### PR TITLE
feat: add internal TestFlight group to submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Automatically create internal TestFlight group in EAS Submit command. ([#2839](https://github.com/expo/eas-cli/pull/2839) by [@evanbacon](https://github.com/evanbacon))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "2.1.5",
+    "@expo/apple-utils": "2.1.6",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "10.0.6",
     "@expo/config-plugins": "9.0.12",

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -317,7 +317,7 @@ export async function createAppAsync(
   }
 }
 
-function isAppleError(error: any): error is {
+export function isAppleError(error: any): error is {
   data: {
     errors: {
       id: string;

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureTestFlightGroup.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureTestFlightGroup.ts
@@ -1,0 +1,255 @@
+import { App, BetaGroup, Session, User, UserRole } from '@expo/apple-utils';
+
+import Log from '../../../log';
+import { ora } from '../../../ora';
+import { confirmAsync } from '../../../prompts';
+
+const AUTO_GROUP_NAME = 'Team (Expo)';
+
+export async function ensureTestFlightGroupExistsAsync(app: App): Promise<void> {
+  // Ensure the app has an internal TestFlight group with access to all builds and app managers added.
+  // TODO: Should we expose this feature somehow?
+  const max = false;
+
+  const group = await ensureInternalGroupAsync(app);
+
+  const admins = await User.getAsync(
+    app.context,
+    !max
+      ? undefined
+      : // Querying all visible apps for all users can be expensive so we only do it when there's a chance we may need to reconcile.
+        {
+          query: {
+            includes: ['visibleApps'],
+          },
+        }
+  );
+
+  await addAllUsersToInternalGroupAsync(
+    app,
+    group,
+    max ? admins : admins.filter(user => user.attributes.roles?.includes(UserRole.ADMIN)),
+    max
+  );
+}
+
+export async function ensureInternalGroupAsync(app: App): Promise<BetaGroup> {
+  const groups = await app.getBetaGroupsAsync({
+    query: {
+      includes: ['betaTesters'],
+    },
+  });
+
+  let betaGroup = groups.find(group => group.attributes.name === AUTO_GROUP_NAME);
+
+  if (!betaGroup) {
+    const spinner = ora().start('Creating TestFlight group...');
+
+    try {
+      // Apple throw an error if you create the group too quickly after creating the app. We'll retry a few times.
+      await pollRetryAsync(
+        async () => {
+          betaGroup = await app.createBetaGroupAsync({
+            name: AUTO_GROUP_NAME,
+            publicLinkEnabled: false,
+            publicLinkLimitEnabled: false,
+            isInternalGroup: true,
+            // Automatically add latest builds to the group without needing to run the command.
+            hasAccessToAllBuilds: true,
+          });
+        },
+        {
+          shouldRetry(error) {
+            if (isAppleError(error)) {
+              spinner.text = `TestFlight not ready, retrying in 25 seconds...`;
+
+              return error.data.errors.some(
+                error => error.code === 'ENTITY_ERROR.RELATIONSHIP.INVALID'
+              );
+            }
+            return false;
+          },
+        }
+      );
+      spinner.succeed(`TestFlight group created: ${AUTO_GROUP_NAME}`);
+    } catch (error: any) {
+      spinner.fail('Failed to create TestFlight group...');
+
+      throw error;
+    }
+  }
+  if (!betaGroup) {
+    throw new Error('Failed to create internal TestFlight group');
+  }
+
+  // `hasAccessToAllBuilds` is a newer feature that allows the group to automatically have access to all builds. This cannot be patched so we need to recreate the group.
+  if (!betaGroup.attributes.hasAccessToAllBuilds) {
+    if (
+      await confirmAsync({
+        message: 'Regenerate internal TestFlight group to allow automatic access to all builds?',
+      })
+    ) {
+      await BetaGroup.deleteAsync(app.context, { id: betaGroup.id });
+      return await ensureInternalGroupAsync(app);
+    }
+  }
+
+  return betaGroup;
+}
+
+export async function addAllUsersToInternalGroupAsync(
+  app: App,
+  group: BetaGroup,
+  users: User[],
+  shouldAddUsers = true
+): Promise<void> {
+  let emails = users
+    .map(user => ({
+      email: user.attributes.email ?? '',
+      firstName: user.attributes.firstName ?? '',
+      lastName: user.attributes.lastName ?? '',
+    }))
+    .filter(user => user.email);
+
+  if (group.attributes.betaTesters) {
+    emails = emails.filter(user => {
+      return !group.attributes.betaTesters!.find(tester => tester.attributes.email === user.email);
+    });
+  }
+  if (!emails.length) {
+    // No new users to add to the internal group.
+    Log.debug('No new users to add to internal group');
+    return;
+  }
+
+  Log.debug(`Adding ${emails.length} users to internal group: ${group.attributes.name}`);
+  Log.debug(`Users: ${emails.map(user => user.email).join(', ')}`);
+
+  const data = await group.createBulkBetaTesterAssignmentsAsync(emails);
+
+  const needsQualification = data.attributes.betaTesters.filter(tester => {
+    if (tester.assignmentResult === 'NOT_QUALIFIED_FOR_INTERNAL_GROUP') {
+      return true;
+    }
+    return false;
+  });
+
+  // Reconcile users that need qualification (non-admins).
+  if (needsQualification.length) {
+    Log.debug('Some users need to be qualified for internal group.');
+    Log.debug(needsQualification);
+
+    const matchingUsers = users.filter(user => {
+      return needsQualification.find(tester => tester.email === user.attributes.email);
+    });
+
+    if (shouldAddUsers) {
+      Log.debug('Matching users:', matchingUsers);
+
+      await Promise.all(
+        matchingUsers.map(user => {
+          if (!user.attributes.visibleApps) {
+            // Shouldn't happen. But this prevents removing all apps from a user accidentally.
+            throw new Error('User is missing visibleApps attribute');
+          }
+
+          return user.updateAsync(user.attributes, {
+            visibleApps: [...user.attributes.visibleApps!.map(app => app.id), app.id],
+          });
+        })
+      );
+
+      await addAllUsersToInternalGroupAsync(app, group, users, false);
+      return;
+    }
+  }
+
+  const success = data.attributes.betaTesters.every(tester => {
+    if (tester.assignmentResult === 'FAILED') {
+      if (tester.errors && Array.isArray(tester.errors) && tester.errors.length) {
+        if (
+          tester.errors.length === 1 &&
+          tester.errors[0].key === 'Halliday.tester.already.exists'
+        ) {
+          return true;
+        }
+        for (const error of tester.errors) {
+          Log.error(
+            `Error adding user ${tester.email} to TestFlight group "${group.attributes.name}": ${error.key}`
+          );
+        }
+      }
+      return false;
+    }
+    if (tester.assignmentResult === 'NOT_QUALIFIED_FOR_INTERNAL_GROUP') {
+      return false;
+    }
+    return true;
+  });
+
+  if (!success) {
+    const groupUrl = await getTestFlightGroupUrlAsync(group);
+
+    Log.error(
+      `Unable to add all developers to TestFlight internal group "${
+        group.attributes.name
+      }". You can add them manually in App Store Connect. ${groupUrl ?? ''}`
+    );
+  }
+}
+
+async function getTestFlightGroupUrlAsync(group: BetaGroup): Promise<string | null> {
+  if (group.context.providerId) {
+    try {
+      const session = await Session.getSessionForProviderIdAsync(group.context.providerId);
+
+      return `https://appstoreconnect.apple.com/teams/${session.provider.publicProviderId}/apps/6741088859/testflight/groups/${group.id}`;
+    } catch (error) {
+      // Avoid crashing if we can't get the session.
+      Log.debug('Failed to get session for provider ID', error);
+    }
+  }
+  return null;
+}
+
+function isAppleError(error: any): error is {
+  data: {
+    errors: {
+      id: string;
+      status: string;
+      /** 'ENTITY_ERROR.ATTRIBUTE.INVALID.INVALID_CHARACTERS' */
+      code: string;
+      /** 'An attribute value has invalid characters.' */
+      title: string;
+      /** 'App Name contains certain Unicode symbols, emoticons, diacritics, special characters, or private use characters that are not permitted.' */
+      detail: string;
+    }[];
+  };
+} {
+  return 'data' in error && 'errors' in error.data && Array.isArray(error.data.errors);
+}
+
+async function pollRetryAsync<T>(
+  fn: () => Promise<T>,
+  {
+    shouldRetry,
+    retries = 10,
+    // 25 seconds was the minium interval I calculated when measuring against 5 second intervals.
+    interval = 25000,
+  }: { shouldRetry?: (error: Error) => boolean; retries?: number; interval?: number } = {}
+): Promise<T> {
+  let lastError: Error | null = null;
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await fn();
+    } catch (error: any) {
+      if (shouldRetry && !shouldRetry(error)) {
+        throw error;
+      }
+      lastError = error;
+      await new Promise(resolve => setTimeout(resolve, interval));
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-throw-literal
+  throw lastError;
+}

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
@@ -29,6 +29,7 @@ function resolveProfileType(
       return resolveProfileTypeIos(profileClass, isEnterprise);
     case ApplePlatform.TV_OS:
       return resolveProfileTypeAppleTv(profileClass, isEnterprise);
+    case ApplePlatform.VISION_OS:
     case ApplePlatform.MAC_OS:
       throw new Error(`${applePlatform} profiles are not supported`);
   }

--- a/packages/eas-cli/src/project/ios/__tests__/target-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/target-test.ts
@@ -29,7 +29,7 @@ describe(getApplePlatformFromSdkRoot, () => {
   // Update `getApplePlatformFromSdkRoot` to be compatible with new Apple Platforms
   test('all enumerations work with the function', () => {
     expect(Object.values(ApplePlatform).sort()).toEqual(
-      [ApplePlatform.IOS, ApplePlatform.TV_OS, ApplePlatform.MAC_OS].sort()
+      [ApplePlatform.IOS, ApplePlatform.TV_OS, ApplePlatform.MAC_OS, ApplePlatform.VISION_OS].sort()
     );
   });
   test('existing SDKs work with the function', () => {

--- a/packages/eas-cli/src/submit/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submit/ios/AppProduce.ts
@@ -1,4 +1,4 @@
-import { App, RequestContext, Session, User } from '@expo/apple-utils';
+import { App, BetaGroup, RequestContext, Session, User, UserRole } from '@expo/apple-utils';
 import { Platform } from '@expo/eas-build-job';
 import chalk from 'chalk';
 
@@ -10,7 +10,7 @@ import {
 } from '../../credentials/ios/appstore/ensureAppExists';
 import Log from '../../log';
 import { getBundleIdentifierAsync } from '../../project/ios/bundleIdentifier';
-import { promptAsync } from '../../prompts';
+import { confirmAsync, promptAsync } from '../../prompts';
 import { SubmissionContext } from '../context';
 
 interface CreateAppOptions {
@@ -118,9 +118,77 @@ async function createAppStoreConnectAppAsync(
     throw error;
   }
 
+  // Ensure the app has an internal TestFlight group with access to all builds and app managers added.
+  const max = false;
+
+  const group = await ensureInternalGroupAsync(app);
+
+  const admins = await User.getAsync(
+    app.context,
+    !max
+      ? undefined
+      : // Querying all visible apps for all users can be expensive so we only do it when there's a chance we may need to reconcile.
+        {
+          query: {
+            includes: ['visibleApps'],
+          },
+        }
+  );
+
+  await addAllUsersToInternalGroupAsync(
+    app,
+    group,
+    max ? admins : admins.filter(user => user.attributes.roles?.includes(UserRole.ADMIN)),
+    max
+  );
+
   return {
     ascAppIdentifier: app.id,
   };
+}
+
+const AUTO_GROUP_NAME = 'Internal (Expo)';
+
+async function ensureInternalGroupAsync(app: App): Promise<BetaGroup> {
+  const groups = await app.getBetaGroupsAsync({
+    query: {
+      includes: ['betaTesters'],
+    },
+  });
+
+  let betaGroup = groups.find(group => group.attributes.name === AUTO_GROUP_NAME);
+
+  if (!betaGroup) {
+    betaGroup = await app.createBetaGroupAsync({
+      name: AUTO_GROUP_NAME,
+      publicLinkEnabled: false,
+      publicLinkLimitEnabled: false,
+      isInternalGroup: true,
+      // Automatically add latest builds to the group without needing to run the command.
+      hasAccessToAllBuilds: true,
+    });
+  }
+
+  // `hasAccessToAllBuilds` is a newer feature that allows the group to automatically have access to all builds. This cannot be patched so we need to recreate the group.
+  if (!betaGroup.attributes.hasAccessToAllBuilds) {
+    if (
+      await confirmAsync({
+        message: 'Regenerate internal TestFlight group to allow automatic access to all builds?',
+      })
+    ) {
+      await BetaGroup.deleteAsync(app.context, { id: betaGroup.id });
+      return await ensureInternalGroupAsync(app);
+    }
+  }
+
+  if (!betaGroup.attributes.isInternalGroup || !betaGroup.attributes.feedbackEnabled) {
+    await betaGroup.updateAsync({
+      isInternalGroup: true,
+      feedbackEnabled: true,
+    });
+  }
+
+  return betaGroup;
 }
 
 async function promptForAppNameAsync(): Promise<string> {
@@ -131,4 +199,96 @@ async function promptForAppNameAsync(): Promise<string> {
     validate: (val: string) => val !== '' || 'App name cannot be empty!',
   });
   return appName;
+}
+
+async function addAllUsersToInternalGroupAsync(
+  app: App,
+  group: BetaGroup,
+  users: User[],
+  shouldAddUsers = true
+): Promise<void> {
+  let emails = users
+    .map(user => ({
+      email: user.attributes.email ?? '',
+      firstName: user.attributes.firstName ?? '',
+      lastName: user.attributes.lastName ?? '',
+    }))
+    .filter(user => user.email);
+
+  if (group.attributes.betaTesters) {
+    emails = emails.filter(user => {
+      return !group.attributes.betaTesters!.find(tester => tester.attributes.email === user.email);
+    });
+  }
+  if (!emails.length) {
+    // No new users to add to the internal group.
+    Log.debug('No new users to add to internal group');
+    return;
+  }
+
+  Log.debug(`Adding ${emails.length} users to internal group: ${group.attributes.name}`);
+  Log.debug(`Users: ${emails.map(user => user.email).join(', ')}`);
+  const data = await group.createBulkBetaTesterAssignmentsAsync(emails);
+
+  const needsQualification = data.attributes.betaTesters.filter(tester => {
+    if (tester.assignmentResult === 'NOT_QUALIFIED_FOR_INTERNAL_GROUP') {
+      return true;
+    }
+    return false;
+  });
+
+  // Reconcile users that need qualification (non-admins).
+  if (needsQualification.length) {
+    Log.debug('Some users need to be qualified for internal group.');
+    Log.debug(needsQualification);
+
+    const matchingUsers = users.filter(user => {
+      return needsQualification.find(tester => tester.email === user.attributes.email);
+    });
+
+    if (shouldAddUsers) {
+      Log.debug('Matching users:', matchingUsers);
+
+      await Promise.all(
+        matchingUsers.map(user => {
+          if (!user.attributes.visibleApps) {
+            // Shouldn't happen. But this prevents removing all apps from a user accidentally.
+            throw new Error('User is missing visibleApps attribute');
+          }
+
+          return user.updateAsync(user.attributes, {
+            visibleApps: [...user.attributes.visibleApps!.map(app => app.id), app.id],
+          });
+        })
+      );
+
+      await addAllUsersToInternalGroupAsync(app, group, users, false);
+      return;
+    }
+  }
+
+  const success = data.attributes.betaTesters.every(tester => {
+    if (tester.assignmentResult === 'FAILED') {
+      if (tester.errors) {
+        if (
+          tester.errors.length === 1 &&
+          tester.errors[0].key === 'Halliday.tester.already.exists'
+        ) {
+          return true;
+        }
+        for (const error of tester.errors) {
+          Log.error(`Failed to add ${tester.email}: ${error.key}`);
+        }
+      }
+      return false;
+    }
+    if (tester.assignmentResult === 'NOT_QUALIFIED_FOR_INTERNAL_GROUP') {
+      return false;
+    }
+    return true;
+  });
+
+  if (!success) {
+    Log.error('Failed to add all TestFlight users to internal group.');
+  }
 }

--- a/packages/eas-cli/src/submit/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submit/ios/AppProduce.ts
@@ -121,6 +121,7 @@ async function createAppStoreConnectAppAsync(
 
   try {
     // Ensure the app has an internal TestFlight group with access to all builds and app managers added.
+    // TODO: Should we expose this feature somehow?
     const max = false;
 
     const group = await ensureInternalGroupAsync(app);
@@ -146,7 +147,7 @@ async function createAppStoreConnectAppAsync(
   } catch (error: any) {
     // This process is not critical to the app submission so we shouldn't let it fail the entire process.
     Log.error(
-      'Failed to create an internal TestFlight group. This can be done manually in App Store Connect.'
+      'Failed to create an internal TestFlight group. This can be done manually in the App Store Connect website.'
     );
     Log.error(error);
 

--- a/packages/eas-cli/src/submit/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submit/ios/AppProduce.ts
@@ -1,4 +1,4 @@
-import { App, BetaGroup, RequestContext, Session, User, UserRole } from '@expo/apple-utils';
+import { App, RequestContext, Session, User } from '@expo/apple-utils';
 import { Platform } from '@expo/eas-build-job';
 import chalk from 'chalk';
 
@@ -8,10 +8,10 @@ import {
   ensureAppExistsAsync,
   ensureBundleIdExistsWithNameAsync,
 } from '../../credentials/ios/appstore/ensureAppExists';
+import { ensureTestFlightGroupExistsAsync } from '../../credentials/ios/appstore/ensureTestFlightGroup';
 import Log from '../../log';
-import { ora } from '../../ora';
 import { getBundleIdentifierAsync } from '../../project/ios/bundleIdentifier';
-import { confirmAsync, promptAsync } from '../../prompts';
+import { promptAsync } from '../../prompts';
 import { SubmissionContext } from '../context';
 
 interface CreateAppOptions {
@@ -120,137 +120,18 @@ async function createAppStoreConnectAppAsync(
   }
 
   try {
-    // Ensure the app has an internal TestFlight group with access to all builds and app managers added.
-    // TODO: Should we expose this feature somehow?
-    const max = false;
-
-    const group = await ensureInternalGroupAsync(app);
-
-    const admins = await User.getAsync(
-      app.context,
-      !max
-        ? undefined
-        : // Querying all visible apps for all users can be expensive so we only do it when there's a chance we may need to reconcile.
-          {
-            query: {
-              includes: ['visibleApps'],
-            },
-          }
-    );
-
-    await addAllUsersToInternalGroupAsync(
-      app,
-      group,
-      max ? admins : admins.filter(user => user.attributes.roles?.includes(UserRole.ADMIN)),
-      max
-    );
+    await ensureTestFlightGroupExistsAsync(app);
   } catch (error: any) {
     // This process is not critical to the app submission so we shouldn't let it fail the entire process.
     Log.error(
       'Failed to create an internal TestFlight group. This can be done manually in the App Store Connect website.'
     );
     Log.error(error);
-
-    // Debug
-    // throw error;
   }
-
-  // process.exit(0);
 
   return {
     ascAppIdentifier: app.id,
   };
-}
-
-const AUTO_GROUP_NAME = 'Team (Expo)';
-
-async function pollRetryAsync<T>(
-  fn: () => Promise<T>,
-  {
-    shouldRetry,
-    retries = 10,
-    // 25 seconds was the minium interval I calculated when measuring against 5 second intervals.
-    interval = 25000,
-  }: { shouldRetry?: (error: Error) => boolean; retries?: number; interval?: number } = {}
-): Promise<T> {
-  let lastError: Error | null = null;
-  for (let i = 0; i < retries; i++) {
-    try {
-      return await fn();
-    } catch (error: any) {
-      if (shouldRetry && !shouldRetry(error)) {
-        throw error;
-      }
-      lastError = error;
-      await new Promise(resolve => setTimeout(resolve, interval));
-    }
-  }
-  // eslint-disable-next-line @typescript-eslint/no-throw-literal
-  throw lastError;
-}
-
-async function ensureInternalGroupAsync(app: App): Promise<BetaGroup> {
-  const groups = await app.getBetaGroupsAsync({
-    query: {
-      includes: ['betaTesters'],
-    },
-  });
-
-  let betaGroup = groups.find(group => group.attributes.name === AUTO_GROUP_NAME);
-
-  if (!betaGroup) {
-    const spinner = ora().start('Creating TestFlight group...');
-
-    try {
-      // Apple throw an error if you create the group too quickly after creating the app. We'll retry a few times.
-      await pollRetryAsync(
-        async () => {
-          betaGroup = await app.createBetaGroupAsync({
-            name: AUTO_GROUP_NAME,
-            publicLinkEnabled: false,
-            publicLinkLimitEnabled: false,
-            isInternalGroup: true,
-            // Automatically add latest builds to the group without needing to run the command.
-            hasAccessToAllBuilds: true,
-          });
-        },
-        {
-          shouldRetry(error) {
-            if (isAppleError(error)) {
-              spinner.text = `TestFlight not ready, retrying in 25 seconds...`;
-
-              return error.data.errors.some(
-                error => error.code === 'ENTITY_ERROR.RELATIONSHIP.INVALID'
-              );
-            }
-            return false;
-          },
-        }
-      );
-      spinner.succeed(`TestFlight group created: ${AUTO_GROUP_NAME}`);
-    } catch (error: any) {
-      spinner.fail('Failed to create TestFlight group...');
-
-      throw error;
-    }
-  }
-  if (!betaGroup) {
-    throw new Error('Failed to create internal TestFlight group');
-  }
-
-  // `hasAccessToAllBuilds` is a newer feature that allows the group to automatically have access to all builds. This cannot be patched so we need to recreate the group.
-  if (!betaGroup.attributes.hasAccessToAllBuilds) {
-    if (
-      await confirmAsync({
-        message: 'Regenerate internal TestFlight group to allow automatic access to all builds?',
-      })
-    ) {
-      await BetaGroup.deleteAsync(app.context, { id: betaGroup.id });
-      return await ensureInternalGroupAsync(app);
-    }
-  }
-
-  return betaGroup;
 }
 
 async function promptForAppNameAsync(): Promise<string> {
@@ -261,136 +142,4 @@ async function promptForAppNameAsync(): Promise<string> {
     validate: (val: string) => val !== '' || 'App name cannot be empty!',
   });
   return appName;
-}
-
-async function addAllUsersToInternalGroupAsync(
-  app: App,
-  group: BetaGroup,
-  users: User[],
-  shouldAddUsers = true
-): Promise<void> {
-  let emails = users
-    .map(user => ({
-      email: user.attributes.email ?? '',
-      firstName: user.attributes.firstName ?? '',
-      lastName: user.attributes.lastName ?? '',
-    }))
-    .filter(user => user.email);
-
-  if (group.attributes.betaTesters) {
-    emails = emails.filter(user => {
-      return !group.attributes.betaTesters!.find(tester => tester.attributes.email === user.email);
-    });
-  }
-  if (!emails.length) {
-    // No new users to add to the internal group.
-    Log.debug('No new users to add to internal group');
-    return;
-  }
-
-  Log.debug(`Adding ${emails.length} users to internal group: ${group.attributes.name}`);
-  Log.debug(`Users: ${emails.map(user => user.email).join(', ')}`);
-
-  const data = await group.createBulkBetaTesterAssignmentsAsync(emails);
-
-  const needsQualification = data.attributes.betaTesters.filter(tester => {
-    if (tester.assignmentResult === 'NOT_QUALIFIED_FOR_INTERNAL_GROUP') {
-      return true;
-    }
-    return false;
-  });
-
-  // Reconcile users that need qualification (non-admins).
-  if (needsQualification.length) {
-    Log.debug('Some users need to be qualified for internal group.');
-    Log.debug(needsQualification);
-
-    const matchingUsers = users.filter(user => {
-      return needsQualification.find(tester => tester.email === user.attributes.email);
-    });
-
-    if (shouldAddUsers) {
-      Log.debug('Matching users:', matchingUsers);
-
-      await Promise.all(
-        matchingUsers.map(user => {
-          if (!user.attributes.visibleApps) {
-            // Shouldn't happen. But this prevents removing all apps from a user accidentally.
-            throw new Error('User is missing visibleApps attribute');
-          }
-
-          return user.updateAsync(user.attributes, {
-            visibleApps: [...user.attributes.visibleApps!.map(app => app.id), app.id],
-          });
-        })
-      );
-
-      await addAllUsersToInternalGroupAsync(app, group, users, false);
-      return;
-    }
-  }
-
-  const success = data.attributes.betaTesters.every(tester => {
-    if (tester.assignmentResult === 'FAILED') {
-      if (tester.errors && Array.isArray(tester.errors) && tester.errors.length) {
-        if (
-          tester.errors.length === 1 &&
-          tester.errors[0].key === 'Halliday.tester.already.exists'
-        ) {
-          return true;
-        }
-        for (const error of tester.errors) {
-          Log.error(
-            `Error adding user ${tester.email} to TestFlight group "${group.attributes.name}": ${error.key}`
-          );
-        }
-      }
-      return false;
-    }
-    if (tester.assignmentResult === 'NOT_QUALIFIED_FOR_INTERNAL_GROUP') {
-      return false;
-    }
-    return true;
-  });
-
-  if (!success) {
-    const groupUrl = await getTestFlightGroupUrlAsync(group);
-
-    Log.error(
-      `Unable to add all developers to TestFlight internal group "${
-        group.attributes.name
-      }". You can add them manually in App Store Connect. ${groupUrl ?? ''}`
-    );
-  }
-}
-
-async function getTestFlightGroupUrlAsync(group: BetaGroup): Promise<string | null> {
-  if (group.context.providerId) {
-    try {
-      const session = await Session.getSessionForProviderIdAsync(group.context.providerId);
-
-      return `https://appstoreconnect.apple.com/teams/${session.provider.publicProviderId}/apps/6741088859/testflight/groups/${group.id}`;
-    } catch (error) {
-      // Avoid crashing if we can't get the session.
-      Log.debug('Failed to get session for provider ID', error);
-    }
-  }
-  return null;
-}
-
-function isAppleError(error: any): error is {
-  data: {
-    errors: {
-      id: string;
-      status: string;
-      /** 'ENTITY_ERROR.ATTRIBUTE.INVALID.INVALID_CHARACTERS' */
-      code: string;
-      /** 'An attribute value has invalid characters.' */
-      title: string;
-      /** 'App Name contains certain Unicode symbols, emoticons, diacritics, special characters, or private use characters that are not permitted.' */
-      detail: string;
-    }[];
-  };
-} {
-  return 'data' in error && 'errors' in error.data && Array.isArray(error.data.errors);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@expo/apple-utils@2.1.5":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.5.tgz#a947697f10a7ab0f07f2d2fd075efdae9825e85e"
-  integrity sha512-Yy4BWVoViYePwQk8rqvhosolS5MTTMgcsl9Aq3rzJrd1BH8C1V/h6N5xelqo+/V+ww2k8Bom7UTE1NlGcKHxRw==
+"@expo/apple-utils@2.1.6":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.6.tgz#293fafccffd9afa24c9992963d74052558d5c5a1"
+  integrity sha512-6UkfLL/1AIRa082rlh26WG2K5Hzd67c8CIdNlHvrFmMEHlGl1PcVFZoUnNRFEROeTmrXW5/Sv4gJfmLXLTq3cQ==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"
@@ -13233,16 +13233,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13398,7 +13389,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13418,13 +13409,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -14632,16 +14616,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

- During `eas submit -p ios`, automatically create an internal TestFlight group `Internal (Expo)` and add all App Managers to it.
- Assuming that non-exempt encryption is set before the build—`expo.ios.infoPlist.ITSAppUsesNonExemptEncryption` in the app.json—then all app admins will have instant access to new builds from TestFlight.
- This greatly streamlines the time-to-testing for developers.

---

- Should we make this feature opt-in? I feel like it's good enough to just have on by default.
- Should there be comprehensive eas.json config settings for configuring the group and adding other groups? Maybe that's out of scope for this PR?
- External groups require manual assignment which would need to take place after a build and not before it. For this, we'd likely want to run the API calls from the server.

# Test Plan

- In a project with `expo.ios.infoPlist.ITSAppUsesNonExemptEncryption` set:
- `eas build --auto-submit -p ios` -> Group exists in ASC -> App can be installed from TestFlight on iOS for app owners.
- I observed a server issue where you had to wait ~25s after creating the app to create a TestFlight group, this can only be observed by changing the bundle identifier and submitting for the first time (my account has a lot of apps).