### PR TITLE
feat(eas-cli): Ensure non-exempt encryption status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Prompt to set non-exempt encryption status for the iOS app to support faster store submissions. ([#2843](https://github.com/expo/eas-cli/pull/2843) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/__mocks__/fs.ts
+++ b/packages/eas-cli/__mocks__/fs.ts
@@ -12,3 +12,6 @@ if (process.env.TMPDIR) {
 (fs.realpath as any).native = jest.fn();
 
 module.exports = fs;
+
+// Ensure requiring node:fs returns the mock too. This is needed for expo/config and expo/json-file.
+jest.mock('node:fs', () => fs);

--- a/packages/eas-cli/src/build/ios/build.ts
+++ b/packages/eas-cli/src/build/ios/build.ts
@@ -10,6 +10,7 @@ import { IosCredentials } from '../../credentials/ios/types';
 import { BuildParamsInput } from '../../graphql/generated';
 import { BuildMutation, BuildResult } from '../../graphql/mutations/BuildMutation';
 import { ensureBundleIdentifierIsDefinedForManagedProjectAsync } from '../../project/ios/bundleIdentifier';
+import { ensureNonExemptEncryptionIsDefinedForManagedProjectAsync } from '../../project/ios/exemptEncryption';
 import { resolveXcodeBuildContextAsync } from '../../project/ios/scheme';
 import { findApplicationTarget, resolveTargetsAsync } from '../../project/ios/target';
 import { BuildRequestSender, JobData, prepareBuildRequestForPlatformAsync } from '../build';
@@ -28,6 +29,7 @@ export async function createIosContextAsync(
 
   if (ctx.workflow === Workflow.MANAGED) {
     await ensureBundleIdentifierIsDefinedForManagedProjectAsync(ctx);
+    await ensureNonExemptEncryptionIsDefinedForManagedProjectAsync(ctx);
   }
 
   checkNodeEnvVariable(ctx);

--- a/packages/eas-cli/src/project/ios/__tests__/exemptEncryption-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/exemptEncryption-test.ts
@@ -1,0 +1,234 @@
+import { getConfig } from '@expo/config';
+import { vol } from 'memfs';
+
+import * as prompts from '../../../prompts';
+import { ensureNonExemptEncryptionIsDefinedForManagedProjectAsync } from '../exemptEncryption';
+
+jest.mock('fs');
+jest.mock('../../../prompts');
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+  vol.reset();
+});
+
+test('prompts non-exempt encryption is not used', async () => {
+  const projectRoot = '/project';
+  vol.fromJSON(
+    {
+      'package.json': JSON.stringify({}),
+      'app.json': JSON.stringify({
+        expo: {
+          name: 'myproject',
+          slug: 'myproject',
+        },
+      }),
+    },
+    projectRoot
+  );
+
+  jest.mocked(prompts.confirmAsync).mockReset().mockResolvedValueOnce(true);
+
+  await ensureNonExemptEncryptionIsDefinedForManagedProjectAsync({
+    projectDir: projectRoot,
+    exp: getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp,
+    nonInteractive: false,
+  });
+
+  expect(getConfig(projectRoot, { skipSDKVersionRequirement: true }).rootConfig).toEqual({
+    expo: {
+      ios: {
+        infoPlist: {
+          ITSAppUsesNonExemptEncryption: false,
+        },
+      },
+      name: 'myproject',
+      slug: 'myproject',
+    },
+  });
+});
+
+test('does not prompt if the value is already set', async () => {
+  const projectRoot = '/project';
+  vol.fromJSON(
+    {
+      'package.json': JSON.stringify({}),
+      'app.json': JSON.stringify({
+        name: 'myproject',
+        slug: 'myproject',
+        ios: {
+          infoPlist: {
+            ITSAppUsesNonExemptEncryption: false,
+          },
+        },
+      }),
+    },
+    projectRoot
+  );
+
+  // Reset but no mock values.
+  jest.mocked(prompts.confirmAsync).mockReset();
+
+  await ensureNonExemptEncryptionIsDefinedForManagedProjectAsync({
+    projectDir: projectRoot,
+    exp: getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp,
+    nonInteractive: false,
+  });
+
+  expect(prompts.confirmAsync).toHaveBeenCalledTimes(0);
+
+  expect(getConfig(projectRoot, { skipSDKVersionRequirement: true }).rootConfig).toEqual({
+    ios: {
+      infoPlist: {
+        ITSAppUsesNonExemptEncryption: false,
+      },
+    },
+    name: 'myproject',
+    slug: 'myproject',
+  });
+});
+
+test('prompts non-exempt encryption in CI', async () => {
+  const projectRoot = '/project';
+  vol.fromJSON(
+    {
+      'package.json': JSON.stringify({}),
+      'app.json': JSON.stringify({
+        expo: {
+          name: 'myproject',
+          slug: 'myproject',
+        },
+      }),
+    },
+    projectRoot
+  );
+
+  // Reset but no mock values.
+  jest.mocked(prompts.confirmAsync).mockReset();
+
+  await ensureNonExemptEncryptionIsDefinedForManagedProjectAsync({
+    projectDir: projectRoot,
+    exp: getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp,
+    nonInteractive: false,
+  });
+
+  expect(getConfig(projectRoot, { skipSDKVersionRequirement: true }).rootConfig).toEqual({
+    expo: {
+      ios: {
+        infoPlist: {
+          ITSAppUsesNonExemptEncryption: false,
+        },
+      },
+      name: 'myproject',
+      slug: 'myproject',
+    },
+  });
+});
+
+test('prompts non-exempt encryption is not used but app.config.js', async () => {
+  const projectRoot = '/project';
+  vol.fromJSON(
+    {
+      'package.json': JSON.stringify({}),
+      'app.config.js':
+        `module.exports = ` +
+        JSON.stringify({
+          expo: {
+            name: 'myproject',
+            slug: 'myproject',
+          },
+        }),
+    },
+    projectRoot
+  );
+
+  jest.mocked(prompts.confirmAsync).mockReset().mockResolvedValueOnce(true);
+
+  await ensureNonExemptEncryptionIsDefinedForManagedProjectAsync({
+    projectDir: projectRoot,
+    exp: getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp,
+    nonInteractive: false,
+  });
+
+  // Not set.
+  expect(getConfig(projectRoot, { skipSDKVersionRequirement: true }).rootConfig).toEqual({});
+});
+
+test('prompts non-exempt encryption is used', async () => {
+  const projectRoot = '/project';
+  vol.fromJSON(
+    {
+      'package.json': JSON.stringify({}),
+      'app.json': JSON.stringify({
+        expo: {
+          name: 'myproject',
+          slug: 'myproject',
+        },
+      }),
+    },
+    projectRoot
+  );
+
+  jest
+    .mocked(prompts.confirmAsync)
+    .mockReset()
+    .mockResolvedValueOnce(false)
+    // Are you sure?
+    .mockResolvedValueOnce(true);
+
+  await ensureNonExemptEncryptionIsDefinedForManagedProjectAsync({
+    projectDir: projectRoot,
+    exp: getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp,
+    nonInteractive: false,
+  });
+
+  expect(prompts.confirmAsync).toHaveBeenCalledTimes(2);
+
+  expect(getConfig(projectRoot, { skipSDKVersionRequirement: true }).rootConfig).toEqual({
+    expo: {
+      name: 'myproject',
+      slug: 'myproject',
+    },
+  });
+});
+
+test('prompts non-exempt encryption is used but backed out', async () => {
+  const projectRoot = '/project';
+  vol.fromJSON(
+    {
+      'package.json': JSON.stringify({}),
+      'app.json': JSON.stringify({
+        expo: {
+          name: 'myproject',
+          slug: 'myproject',
+        },
+      }),
+    },
+    projectRoot
+  );
+
+  jest
+    .mocked(prompts.confirmAsync)
+    .mockReset()
+    .mockResolvedValueOnce(false)
+    // Are you sure?
+    .mockResolvedValueOnce(false);
+
+  await ensureNonExemptEncryptionIsDefinedForManagedProjectAsync({
+    projectDir: projectRoot,
+    exp: getConfig(projectRoot, { skipSDKVersionRequirement: true }).exp,
+    nonInteractive: false,
+  });
+
+  expect(getConfig(projectRoot, { skipSDKVersionRequirement: true }).rootConfig).toEqual({
+    expo: {
+      name: 'myproject',
+      slug: 'myproject',
+      ios: {
+        infoPlist: {
+          ITSAppUsesNonExemptEncryption: false,
+        },
+      },
+    },
+  });
+});

--- a/packages/eas-cli/src/project/ios/exemptEncryption.ts
+++ b/packages/eas-cli/src/project/ios/exemptEncryption.ts
@@ -1,10 +1,4 @@
-import {
-  ExpoConfig,
-  getConfigFilePaths,
-  getProjectConfigDescription,
-  modifyConfigAsync,
-} from '@expo/config';
-import assert from 'assert';
+import { ExpoConfig, getProjectConfigDescription, modifyConfigAsync } from '@expo/config';
 import chalk from 'chalk';
 
 import Log, { learnMore } from '../../log';
@@ -43,24 +37,12 @@ async function configureNonExemptEncryptionAsync({
   exp: ExpoConfig;
   nonInteractive: boolean;
 }): Promise<void> {
-  const paths = getConfigFilePaths(projectDir);
   const description = getProjectConfigDescription(projectDir);
   if (nonInteractive) {
     Log.warn(
       chalk`${description} is missing {bold ios.infoPlist.ITSAppUsesNonExemptEncryption} boolean. Manual configuration is required in App Store Connect before the app can be tested.`
     );
   }
-
-  if (paths.dynamicConfigPath) {
-    Log.warn(
-      chalk`${description} is missing {bold ios.infoPlist.ITSAppUsesNonExemptEncryption} boolean and it cannot be updated automatically. You will need to configure non-exempt encryption status in App Store Connect for this build. {dim Learn more: ${learnMore(
-        'https://developer.apple.com/documentation/Security/complying-with-encryption-export-regulations'
-      )}}`
-    );
-    return;
-  }
-
-  assert(paths.staticConfigPath, 'app.json must exist');
 
   let onlyExemptEncryption = await confirmAsync({
     message: `iOS app only uses standard/exempt encryption? ${chalk.dim(
@@ -126,7 +108,7 @@ async function configureNonExemptEncryptionAsync({
       },
     };
 
-    Log.log(chalk.cyan(`Add the following to your Expo config`));
+    Log.log(chalk.cyan(`Add the following to ${description}:`));
     Log.log();
     Log.log(JSON.stringify(edits, null, 2));
     Log.log();

--- a/packages/eas-cli/src/project/ios/exemptEncryption.ts
+++ b/packages/eas-cli/src/project/ios/exemptEncryption.ts
@@ -1,0 +1,176 @@
+import { ExpoConfig, getConfigFilePaths } from '@expo/config';
+import { IOSConfig } from '@expo/config-plugins';
+import { getInfoPlistPathFromPbxproj } from '@expo/config-plugins/build/ios/utils/getInfoPlistPath';
+import { Platform, Workflow } from '@expo/eas-build-job';
+import plist from '@expo/plist';
+import assert from 'assert';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'node:path';
+
+import { readAppJson } from '../../build/utils/appJson';
+import Log, { learnMore } from '../../log';
+import { promptAsync } from '../../prompts';
+import { Client } from '../../vcs/vcs';
+import { getProjectConfigDescription } from '../projectUtils';
+import { resolveWorkflowAsync } from '../workflow';
+
+/** Non-exempt encryption must be set on every build in App Store Connect, we move it to before the build process to attempt only setting it once for the entire life-cycle of the project. */
+export async function ensureNonExemptEncryptionIsDefinedForManagedProjectAsync({
+  projectDir,
+  exp,
+  vcsClient,
+  nonInteractive,
+}: {
+  projectDir: string;
+  exp: ExpoConfig;
+  vcsClient: Client;
+  nonInteractive: boolean;
+}): Promise<void> {
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
+  assert(workflow === Workflow.MANAGED, 'This function should be called only for managed projects');
+
+  try {
+    await getNonExemptEncryptionAsync(projectDir, exp, vcsClient);
+  } catch {
+    await configureNonExemptEncryptionAsync({
+      projectDir,
+      exp,
+      nonInteractive,
+    });
+  }
+}
+
+export class AmbiguousNonExemptEncryptionError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Could not resolve non-exempt encryption setting.');
+  }
+}
+
+export async function getNonExemptEncryptionAsync(
+  projectDir: string,
+  exp: ExpoConfig,
+  vcsClient: Client,
+  xcodeContext?: { targetName?: string; buildConfiguration?: string }
+): Promise<void> {
+  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
+
+  if (workflow === Workflow.GENERIC) {
+    const xcodeProject = IOSConfig.XcodeUtils.getPbxproj(projectDir);
+
+    const infoPlistBuildProperty = getInfoPlistPathFromPbxproj(xcodeProject);
+    if (!infoPlistBuildProperty) {
+      throw new Error('Info.plist file linked to Xcode project does not exist');
+    }
+
+    //: [root]/myapp/ios/MyApp/Info.plist
+    const infoPlistPath = path.join(
+      //: myapp/ios
+      projectDir,
+      'ios',
+      //: MyApp/Info.plist
+      infoPlistBuildProperty
+    );
+    if (!(await fs.promises.stat(infoPlistPath))) {
+      throw new Error(`Info.plist file linked to Xcode project does not exist: ${infoPlistPath}`);
+    }
+    const infoPlist = plist.parse(await fs.promises.readFile(infoPlistPath, 'utf8'));
+
+    const nonExemptEncryption = infoPlist['ITSAppUsesNonExemptEncryption'];
+    const buildConfigurationDesc =
+      xcodeContext?.targetName && xcodeContext?.buildConfiguration
+        ? ` (target = ${xcodeContext.targetName}, build configuration = ${xcodeContext.buildConfiguration})`
+        : '';
+    assert(
+      nonExemptEncryption !== undefined,
+      `Could not read non-exempt encryption setting from Xcode project${buildConfigurationDesc}.`
+    );
+    return nonExemptEncryption;
+  } else {
+    const appUsesNonExemptEncryption = exp.ios?.infoPlist?.ITSAppUsesNonExemptEncryption;
+
+    if (appUsesNonExemptEncryption == null) {
+      throw new Error(
+        `Specify "ios.infoPlist.ITSAppUsesNonExemptEncryption" in ${getProjectConfigDescription(
+          projectDir
+        )} and run this command again.`
+      );
+    }
+    return appUsesNonExemptEncryption;
+  }
+}
+
+async function configureNonExemptEncryptionAsync({
+  projectDir,
+  exp,
+  nonInteractive,
+}: {
+  projectDir: string;
+  exp: ExpoConfig;
+  nonInteractive: boolean;
+}): Promise<void> {
+  if (nonInteractive) {
+    Log.warn(
+      `Set "ios.infoPlist.ITSAppUsesNonExemptEncryption" in the app config to release Apple builds faster. Setting to false and continuing.`
+    );
+  }
+
+  const paths = getConfigFilePaths(projectDir);
+  if (paths.dynamicConfigPath) {
+    Log.warn(
+      chalk`"ios.infoPlist.ITSAppUsesNonExemptEncryption" is not defined in your app.config.js and it cannot be updated programmatically. Add the value manually or select it in the App Store after every build. {dim Learn more: ${learnMore(
+        'https://developer.apple.com/documentation/Security/complying-with-encryption-export-regulations'
+      )}`
+    );
+    return;
+  }
+
+  assert(paths.staticConfigPath, 'app.json must exist');
+
+  Log.addNewLineIfNone();
+  Log.log(
+    `${chalk.bold(`📝  Does your app use custom encryption?`)} ${chalk.dim(
+      learnMore(
+        'https://developer.apple.com/documentation/Security/complying-with-encryption-export-regulations'
+      )
+    )}`
+  );
+
+  const { onlyExemptEncryption } = await promptAsync({
+    name: 'onlyExemptEncryption',
+    type: 'confirm',
+    message: `iOS app only uses standard/exempt encryption? Selecting 'No' will require annual self-classification reports for the US government.`,
+    // message: `Does your app use non-exempt encryption?`,
+    initial: true,
+  });
+
+  const rawStaticConfig = readAppJson(paths.staticConfigPath);
+
+  const ITSAppUsesNonExemptEncryption = !onlyExemptEncryption;
+  if (rawStaticConfig.expo) {
+    rawStaticConfig.expo = {
+      ...rawStaticConfig.expo,
+      ios: {
+        ...rawStaticConfig.expo?.ios,
+        infoPlist: {
+          ...rawStaticConfig.expo?.ios?.infoPlist,
+          ITSAppUsesNonExemptEncryption,
+        },
+      },
+    };
+  } else {
+    rawStaticConfig.ios = {
+      ...rawStaticConfig.ios,
+      infoPlist: {
+        ...rawStaticConfig.ios?.infoPlist,
+        ITSAppUsesNonExemptEncryption,
+      },
+    };
+  }
+  await fs.writeJson(paths.staticConfigPath, rawStaticConfig, { spaces: 2 });
+
+  exp.ios = {
+    ...exp.ios,
+    infoPlist: { ...exp.ios?.infoPlist, ITSAppUsesNonExemptEncryption },
+  };
+}

--- a/packages/eas-cli/src/project/ios/exemptEncryption.ts
+++ b/packages/eas-cli/src/project/ios/exemptEncryption.ts
@@ -1,7 +1,7 @@
 import {
   ExpoConfig,
-  getProjectConfigDescription,
   getConfigFilePaths,
+  getProjectConfigDescription,
   modifyConfigAsync,
 } from '@expo/config';
 import assert from 'assert';

--- a/packages/eas-cli/src/project/ios/exemptEncryption.ts
+++ b/packages/eas-cli/src/project/ios/exemptEncryption.ts
@@ -61,7 +61,7 @@ async function configureNonExemptEncryptionAsync({
 
     if (!confirm) {
       Log.warn(
-        `Set "ios.infoPlist.ITSAppUsesNonExemptEncryption" in the app config to release Apple builds faster. Setting to false and continuing.`
+        chalk`Set {bold ios.infoPlist.ITSAppUsesNonExemptEncryption} in ${description} to release Apple builds faster.`
       );
       onlyExemptEncryption = true;
     }

--- a/packages/eas-cli/src/project/ios/exemptEncryption.ts
+++ b/packages/eas-cli/src/project/ios/exemptEncryption.ts
@@ -1,102 +1,36 @@
-import { ExpoConfig, getConfigFilePaths } from '@expo/config';
-import { IOSConfig } from '@expo/config-plugins';
-import { getInfoPlistPathFromPbxproj } from '@expo/config-plugins/build/ios/utils/getInfoPlistPath';
-import { Platform, Workflow } from '@expo/eas-build-job';
-import plist from '@expo/plist';
+import {
+  ExpoConfig,
+  getProjectConfigDescription,
+  getConfigFilePaths,
+  modifyConfigAsync,
+} from '@expo/config';
 import assert from 'assert';
 import chalk from 'chalk';
-import fs from 'fs-extra';
-import path from 'node:path';
 
-import { readAppJson } from '../../build/utils/appJson';
 import Log, { learnMore } from '../../log';
-import { promptAsync } from '../../prompts';
-import { Client } from '../../vcs/vcs';
-import { getProjectConfigDescription } from '../projectUtils';
-import { resolveWorkflowAsync } from '../workflow';
+import { confirmAsync } from '../../prompts';
 
 /** Non-exempt encryption must be set on every build in App Store Connect, we move it to before the build process to attempt only setting it once for the entire life-cycle of the project. */
 export async function ensureNonExemptEncryptionIsDefinedForManagedProjectAsync({
   projectDir,
   exp,
-  vcsClient,
   nonInteractive,
 }: {
   projectDir: string;
   exp: ExpoConfig;
-  vcsClient: Client;
   nonInteractive: boolean;
 }): Promise<void> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
-  assert(workflow === Workflow.MANAGED, 'This function should be called only for managed projects');
+  // TODO: We could add bare workflow support in the future.
+  // TODO: We could add wizard support for non-exempt encryption in the future.
 
-  try {
-    await getNonExemptEncryptionAsync(projectDir, exp, vcsClient);
-  } catch {
+  if (exp.ios?.infoPlist?.ITSAppUsesNonExemptEncryption == null) {
     await configureNonExemptEncryptionAsync({
       projectDir,
       exp,
       nonInteractive,
     });
-  }
-}
-
-export class AmbiguousNonExemptEncryptionError extends Error {
-  constructor(message?: string) {
-    super(message ?? 'Could not resolve non-exempt encryption setting.');
-  }
-}
-
-export async function getNonExemptEncryptionAsync(
-  projectDir: string,
-  exp: ExpoConfig,
-  vcsClient: Client,
-  xcodeContext?: { targetName?: string; buildConfiguration?: string }
-): Promise<void> {
-  const workflow = await resolveWorkflowAsync(projectDir, Platform.IOS, vcsClient);
-
-  if (workflow === Workflow.GENERIC) {
-    const xcodeProject = IOSConfig.XcodeUtils.getPbxproj(projectDir);
-
-    const infoPlistBuildProperty = getInfoPlistPathFromPbxproj(xcodeProject);
-    if (!infoPlistBuildProperty) {
-      throw new Error('Info.plist file linked to Xcode project does not exist');
-    }
-
-    //: [root]/myapp/ios/MyApp/Info.plist
-    const infoPlistPath = path.join(
-      //: myapp/ios
-      projectDir,
-      'ios',
-      //: MyApp/Info.plist
-      infoPlistBuildProperty
-    );
-    if (!(await fs.promises.stat(infoPlistPath))) {
-      throw new Error(`Info.plist file linked to Xcode project does not exist: ${infoPlistPath}`);
-    }
-    const infoPlist = plist.parse(await fs.promises.readFile(infoPlistPath, 'utf8'));
-
-    const nonExemptEncryption = infoPlist['ITSAppUsesNonExemptEncryption'];
-    const buildConfigurationDesc =
-      xcodeContext?.targetName && xcodeContext?.buildConfiguration
-        ? ` (target = ${xcodeContext.targetName}, build configuration = ${xcodeContext.buildConfiguration})`
-        : '';
-    assert(
-      nonExemptEncryption !== undefined,
-      `Could not read non-exempt encryption setting from Xcode project${buildConfigurationDesc}.`
-    );
-    return nonExemptEncryption;
   } else {
-    const appUsesNonExemptEncryption = exp.ios?.infoPlist?.ITSAppUsesNonExemptEncryption;
-
-    if (appUsesNonExemptEncryption == null) {
-      throw new Error(
-        `Specify "ios.infoPlist.ITSAppUsesNonExemptEncryption" in ${getProjectConfigDescription(
-          projectDir
-        )} and run this command again.`
-      );
-    }
-    return appUsesNonExemptEncryption;
+    Log.debug(`ITSAppUsesNonExemptEncryption is defined in the app config.`);
   }
 }
 
@@ -109,45 +43,36 @@ async function configureNonExemptEncryptionAsync({
   exp: ExpoConfig;
   nonInteractive: boolean;
 }): Promise<void> {
+  const paths = getConfigFilePaths(projectDir);
+  const description = getProjectConfigDescription(projectDir);
   if (nonInteractive) {
     Log.warn(
-      `Set "ios.infoPlist.ITSAppUsesNonExemptEncryption" in the app config to release Apple builds faster. Setting to false and continuing.`
+      chalk`${description} is missing {bold ios.infoPlist.ITSAppUsesNonExemptEncryption} boolean. Manual configuration is required in App Store Connect before the app can be tested.`
     );
   }
 
-  const paths = getConfigFilePaths(projectDir);
   if (paths.dynamicConfigPath) {
     Log.warn(
-      chalk`"ios.infoPlist.ITSAppUsesNonExemptEncryption" is not defined in your app.config.js and it cannot be updated programmatically. Add the value manually or select it in the App Store after every build. {dim Learn more: ${learnMore(
+      chalk`${description} is missing {bold ios.infoPlist.ITSAppUsesNonExemptEncryption} boolean and it cannot be updated automatically. You will need to configure non-exempt encryption status in App Store Connect for this build. {dim Learn more: ${learnMore(
         'https://developer.apple.com/documentation/Security/complying-with-encryption-export-regulations'
-      )}`
+      )}}`
     );
     return;
   }
 
   assert(paths.staticConfigPath, 'app.json must exist');
 
-  Log.addNewLineIfNone();
-  Log.log(
-    `${chalk.bold(`📝  Does your app use custom encryption?`)} ${chalk.dim(
+  let onlyExemptEncryption = await confirmAsync({
+    message: `iOS app only uses standard/exempt encryption? ${chalk.dim(
       learnMore(
         'https://developer.apple.com/documentation/Security/complying-with-encryption-export-regulations'
       )
-    )}`
-  );
-
-  let { onlyExemptEncryption } = await promptAsync({
-    name: 'onlyExemptEncryption',
-    type: 'confirm',
-    message: `iOS app only uses standard/exempt encryption? `,
-    // message: `Does your app use non-exempt encryption?`,
+    )}`,
     initial: true,
   });
 
   if (!onlyExemptEncryption) {
-    const { confirm } = await promptAsync({
-      name: 'confirm',
-      type: 'confirm',
+    const confirm = await confirmAsync({
       message: `Are you sure your app uses non-exempt encryption? Selecting 'Yes' will require annual self-classification reports for the US government.`,
       initial: true,
     });
@@ -163,34 +88,47 @@ async function configureNonExemptEncryptionAsync({
   const ITSAppUsesNonExemptEncryption = !onlyExemptEncryption;
 
   // Only set this value if the answer is no, this enables developers to see the more in-depth prompt in App Store Connect. They can set the value manually in the app.json to avoid the EAS prompt in subsequent builds.
-  if (ITSAppUsesNonExemptEncryption === false) {
-    const rawStaticConfig = readAppJson(paths.staticConfigPath);
-
-    if (rawStaticConfig.expo) {
-      rawStaticConfig.expo = {
-        ...rawStaticConfig.expo,
-        ios: {
-          ...rawStaticConfig.expo?.ios,
-          infoPlist: {
-            ...rawStaticConfig.expo?.ios?.infoPlist,
-            ITSAppUsesNonExemptEncryption,
-          },
-        },
-      };
-    } else {
-      rawStaticConfig.ios = {
-        ...rawStaticConfig.ios,
+  if (ITSAppUsesNonExemptEncryption) {
+    Log.warn(
+      `You'll need to manually configure the encryption status in App Store Connect before your build can be tested.`
+    );
+    return;
+  }
+  // NOTE: Is is it possible to assert that the config needs to be modifiable before building the app?
+  const modification = await modifyConfigAsync(
+    projectDir,
+    {
+      ios: {
+        ...(exp.ios ?? {}),
         infoPlist: {
-          ...rawStaticConfig.ios?.infoPlist,
+          ...(exp.ios?.infoPlist ?? {}),
           ITSAppUsesNonExemptEncryption,
         },
-      };
+      },
+    },
+    {
+      skipSDKVersionRequirement: true,
     }
-    await fs.writeJson(paths.staticConfigPath, rawStaticConfig, { spaces: 2 });
+  );
 
-    exp.ios = {
-      ...exp.ios,
-      infoPlist: { ...exp.ios?.infoPlist, ITSAppUsesNonExemptEncryption },
+  if (modification.type !== 'success') {
+    Log.log();
+    if (modification.type === 'warn') {
+      // The project is using a dynamic config, give the user a helpful log and bail out.
+      Log.log(chalk.yellow(modification.message));
+    }
+
+    const edits = {
+      ios: {
+        infoPlist: {
+          ITSAppUsesNonExemptEncryption,
+        },
+      },
     };
+
+    Log.log(chalk.cyan(`Add the following to your Expo config`));
+    Log.log();
+    Log.log(JSON.stringify(edits, null, 2));
+    Log.log();
   }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Apple requires the non-exempt encryption status be defined on every build before it can be submitted to TestFlight or app review. We can use the Info.plist flag to only ask users one time and reuse that answer for every build. This is a better version of https://github.com/expo/expo/pull/34487

Prompting in the CLI saves users six clicks in App Store Connect for every iOS build.

# How

I copied the bundle identifier prompting logic to a new function for setting non-exempt encryption, made it more optional, and added it to `eas build -p ios`.

If the user indicates that they use non-exempt encryption then we won't write anything this will enable them to see the in-depth warnings in ASC about this option. They can still skip the prompt by manually adding the value to their app.json.

# Test Plan

- Run `eas build -p ios` -> prompted "app uses standard encryption?" -> enter / Y -> app builds and doesn't ask again.
- Unit tests for all conditions.