### PR TITLE
chore(eas-cli): fix support for VisionOS in provisioning profiles and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Fix tests for VisionOS type.
 - Make new autoIncremented builds start at nr 1 by default ([#2828](https://github.com/expo/eas-cli/pull/2828) by [@radoslawkrzemien](https://github.com/radoslawkrzemien))
 
 ## [14.5.0](https://github.com/expo/eas-cli/releases/tag/v14.5.0) - 2025-01-22

--- a/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/provisioningProfile.ts
@@ -30,6 +30,7 @@ function resolveProfileType(
     case ApplePlatform.TV_OS:
       return resolveProfileTypeAppleTv(profileClass, isEnterprise);
     case ApplePlatform.MAC_OS:
+    case ApplePlatform.VISION_OS:
       throw new Error(`${applePlatform} profiles are not supported`);
   }
 }

--- a/packages/eas-cli/src/project/ios/__tests__/target-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/target-test.ts
@@ -29,7 +29,7 @@ describe(getApplePlatformFromSdkRoot, () => {
   // Update `getApplePlatformFromSdkRoot` to be compatible with new Apple Platforms
   test('all enumerations work with the function', () => {
     expect(Object.values(ApplePlatform).sort()).toEqual(
-      [ApplePlatform.IOS, ApplePlatform.TV_OS, ApplePlatform.MAC_OS].sort()
+      [ApplePlatform.IOS, ApplePlatform.TV_OS, ApplePlatform.MAC_OS, ApplePlatform.VISION_OS].sort()
     );
   });
   test('existing SDKs work with the function', () => {


### PR DESCRIPTION

<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Make CI green
