### PR TITLE
[eas-cli] add `--submit` and `-s` aliases to `--auto-submit` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add `--submit` and `-s` as aliases for `--auto-submit` flag. ([#2846](https://github.com/expo/eas-cli/pull/2846) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -78,10 +78,12 @@ export default class Build extends EasCommand {
       description: 'Clear cache before the build',
     }),
     'auto-submit': Flags.boolean({
+      char: 's',
       default: false,
       description:
         'Submit on build complete using the submit profile with the same name as the build profile',
       exclusive: ['auto-submit-with-profile'],
+      aliases: ['submit'],
     }),
     'auto-submit-with-profile': Flags.string({
       description: 'Submit on build complete using the submit profile with provided name',


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C017N0N99RA/p1738188149992119

# How

add `--submit` and `-s` aliases to `--auto-submit` flag

# Test Plan

test manually
