### PR TITLE
fix: Skip non-exempt check in non-interactive mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Skip non-exempt check in non-interactive mode.
+- Skip non-exempt check in non-interactive mode. ([#2849](https://github.com/expo/eas-cli/pull/2849) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Skip non-exempt check in non-interactive mode.
+
 ### 🧹 Chores
 
 ## [14.6.0](https://github.com/expo/eas-cli/releases/tag/v14.6.0) - 2025-01-30

--- a/packages/eas-cli/src/project/ios/exemptEncryption.ts
+++ b/packages/eas-cli/src/project/ios/exemptEncryption.ts
@@ -42,6 +42,7 @@ async function configureNonExemptEncryptionAsync({
     Log.warn(
       chalk`${description} is missing {bold ios.infoPlist.ITSAppUsesNonExemptEncryption} boolean. Manual configuration is required in App Store Connect before the app can be tested.`
     );
+    return;
   }
 
   let onlyExemptEncryption = await confirmAsync({


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

- Skip the prompts if the user is running in CI or non-interactive.

# How

How did you build this feature or fix this bug and why?

# Test Plan

- Tests keep working
- `eas build --non-interactive` doesn't hang
