### PR TITLE
[eas-cli] add update group id for fingerprint:compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Add update support for fingerprint:compare. ([#2850](https://github.com/expo/eas-cli/pull/2850) by [@quinlanj](https://github.com/quinlanj))
+- Add update group id support for fingerprint:compare. ([#2851](https://github.com/expo/eas-cli/pull/2851) by [@quinlanj](https://github.com/quinlanj))
 
 ## [14.7.1](https://github.com/expo/eas-cli/releases/tag/v14.7.1) - 2025-01-31
 


### PR DESCRIPTION
# Why

Add support for users accidentally passing in update group id into `fingerprint:compare` instead of update id.

# How

Added support for handling update group IDs in the fingerprint comparison command by:
- Attempting to fetch updates using the provided ID as an update group ID
- If successful and there's only one update, using that update directly
- If multiple updates exist in the group, prompting the user to select the specific platform/update
- Falling back to the original update ID logic if the group ID lookup fails
- Adding helpful error messages that include the direct URL to find the correct update ID

# Test Plan

- [ ] `EXPO_STAGING=1 ~/Documents/eas-cli/packages/eas-cli/bin/run fingerprint:compare --update-id ed36a46b-6cc7-4f49-88df-e6ffb66f22d2`
- [ ]  `EXPO_STAGING=1 ~/Documents/eas-cli/packages/eas-cli/bin/run fingerprint:compare --update-id ed36a46b-6cc7-4f49-88df-e6ffb66f22d2 --non-interactive`