### PR TITLE
[eas-cli] skip creation of testflight group when there are already exisitng testflight groups + allow to opt out of the behavior by setting env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Narrow amount of data queried for basic update channel operations. ([#2901](https://github.com/expo/eas-cli/pull/2901) by [@wschurman](https://github.com/wschurman))
 - Fix `eas fingerprint:compare` description. ([#2908](https://github.com/expo/eas-cli/pull/2908) by [@quinlanj](https://github.com/quinlanj))
+- Skip auto-creation of TestFlight group when there are already exisitng TestFlight groups and allow to opt out of the behavior by setting `EAS_NO_AUTO_TESTFLIGHT_SETUP` env var. ([#2856](https://github.com/expo/eas-cli/pull/2856) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [15.0.10](https://github.com/expo/eas-cli/releases/tag/v15.0.10) - 2025-02-11
 

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureTestFlightGroup.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureTestFlightGroup.ts
@@ -13,8 +13,8 @@ const AUTO_GROUP_NAME = 'Team (Expo)';
  * This allows users to instantly access their builds from TestFlight after it finishes processing.
  */
 export async function ensureTestFlightGroupExistsAsync(app: App): Promise<void> {
-  if (process.env.EXPO_SKIP_TESTFLIGHT_SETUP) {
-    Log.debug('EXPO_SKIP_TESTFLIGHT_SETUP is set, skipping TestFlight setup');
+  if (process.env.EAS_NO_AUTO_TESTFLIGHT_SETUP) {
+    Log.debug('EAS_NO_AUTO_TESTFLIGHT_SETUP is set, skipping TestFlight setup');
     return;
   }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C014YHUJUMN/p1738577486565949?thread_ts=1738574914.864689&cid=C014YHUJUMN

# How

If there are any existing testflight groups skip the creation of the `Team (Expo)` group.

Allow to opt out of the creation y setting `EXPO_SKIP_TESTFLIGHT_SETUP=1`

# Test Plan

Tests
