### PR TITLE
[eas-cli] popup website in fingerprint:compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Add update support for fingerprint:compare. ([#2850](https://github.com/expo/eas-cli/pull/2850) by [@quinlanj](https://github.com/quinlanj))
 - Add update group id support for fingerprint:compare. ([#2851](https://github.com/expo/eas-cli/pull/2851) by [@quinlanj](https://github.com/quinlanj))
 - Add better interactive support for fingerprint:compare. ([#2854](https://github.com/expo/eas-cli/pull/2854) by [@quinlanj](https://github.com/quinlanj))
+- Popup website in fingerprint:compare. ([#2859](https://github.com/expo/eas-cli/pull/2859) by [@quinlanj](https://github.com/quinlanj))
 
 ## [14.7.1](https://github.com/expo/eas-cli/releases/tag/v14.7.1) - 2025-01-31
 

--- a/packages/eas-cli/src/commands/fingerprint/compare.ts
+++ b/packages/eas-cli/src/commands/fingerprint/compare.ts
@@ -235,12 +235,9 @@ export default class FingerprintCompare extends EasCommand {
       return;
     }
 
-    const [accountName, project] = await Promise.all([
-      (await getOwnerAccountForProjectIdAsync(graphqlClient, projectId)).name,
-      AppQuery.byIdAsync(graphqlClient, projectId),
-    ]);
+    const project = await AppQuery.byIdAsync(graphqlClient, projectId);
     const fingerprintCompareUrl = new URL(
-      `/accounts/${accountName}/projects/${project.name}/fingerprint/compare`,
+      `/accounts/${project.ownerAccount.name}/projects/${project.name}/fingerprint/compare`,
       getExpoWebsiteBaseUrl()
     );
     fingerprintCompareUrl.searchParams.set('a', firstFingerprintInfo.fingerprint.hash);

--- a/packages/eas-cli/src/commands/fingerprint/compare.ts
+++ b/packages/eas-cli/src/commands/fingerprint/compare.ts
@@ -1,5 +1,6 @@
 import { Platform, Workflow } from '@expo/eas-build-job';
 import { Flags } from '@oclif/core';
+import openBrowserAsync from 'better-opn';
 import chalk from 'chalk';
 
 import { getExpoWebsiteBaseUrl } from '../../api';
@@ -229,6 +230,22 @@ export default class FingerprintCompare extends EasCommand {
     for (const diff of contentDiffs) {
       printContentDiff(diff);
     }
+
+    if (nonInteractive) {
+      return;
+    }
+
+    const [accountName, project] = await Promise.all([
+      (await getOwnerAccountForProjectIdAsync(graphqlClient, projectId)).name,
+      AppQuery.byIdAsync(graphqlClient, projectId),
+    ]);
+    const fingerprintCompareUrl = new URL(
+      `/accounts/${accountName}/projects/${project.name}/fingerprint/compare`,
+      getExpoWebsiteBaseUrl()
+    );
+    fingerprintCompareUrl.searchParams.set('a', firstFingerprintInfo.fingerprint.hash);
+    fingerprintCompareUrl.searchParams.set('b', secondFingerprintInfo.fingerprint.hash);
+    await openBrowserAsync(fingerprintCompareUrl.toString());
   }
 }
 


### PR DESCRIPTION
# Why

When comparing fingerprints diffs in the CLI, popup the website window for a better viewing experience in interactive mode. 


https://github.com/user-attachments/assets/a16febfe-ac1f-4170-9667-294e3be823ea



# How

Added functionality to automatically open the web-based fingerprint comparison tool in the browser after displaying the CLI output. This provides users with a more comprehensive and interactive way to analyze differences between fingerprints.

The browser only opens when running in interactive mode, preserving the existing behavior for CI/CD environments.

# Test Plan

- [ ] ran `fingerprint:compare` with differing hashes