### PR TITLE
[eas-cli] print no vcs warning only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Print warning for `NoVcsClient` only once. ([#2863](https://github.com/expo/eas-cli/pull/2863) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 - Add update support for fingerprint:compare. ([#2850](https://github.com/expo/eas-cli/pull/2850) by [@quinlanj](https://github.com/quinlanj))

--- a/packages/eas-cli/src/vcs/index.ts
+++ b/packages/eas-cli/src/vcs/index.ts
@@ -7,14 +7,19 @@ import { Client } from './vcs';
 
 const NO_VCS_WARNING = `Using EAS CLI without version control system is not recommended, use this mode only if you know what you are doing.`;
 
+let wasNoVcsWarningPrinted = false;
+
 export function resolveVcsClient(requireCommit: boolean = false): Client {
   if (process.env.EAS_NO_VCS) {
     if (process.env.NODE_ENV !== 'test') {
-      // This log might be printed before cli arguments are evaluated,
-      // so it needs to go to stderr in case command is run in JSON
-      // only mode.
-      // eslint-disable-next-line no-console
-      console.error(chalk.yellow(NO_VCS_WARNING));
+      if (!wasNoVcsWarningPrinted) {
+        // This log might be printed before cli arguments are evaluated,
+        // so it needs to go to stderr in case command is run in JSON
+        // only mode.
+        // eslint-disable-next-line no-console
+        console.error(chalk.yellow(NO_VCS_WARNING));
+        wasNoVcsWarningPrinted = true;
+      }
     }
     return new NoVcsClient();
   }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C017N0N99RA/p1738630158821649

# How

Print warn message only once

# Test Plan

Tests
