### PR TITLE
[eas-cli] cache downloaded app archives in eas build:dev

### DIFF
--- a/packages/eas-cli/src/commands/build/dev.ts
+++ b/packages/eas-cli/src/commands/build/dev.ts
@@ -8,7 +8,7 @@ import {
   ensureProjectConfiguredAsync,
 } from '../../build/configure';
 import { evaluateConfigWithEnvVarsAsync } from '../../build/evaluateConfigWithEnvVarsAsync';
-import { runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
+import { downloadAndRunAsync, runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import { ensureRepoIsCleanAsync } from '../../build/utils/repository';
 import EasCommand from '../../commandUtils/EasCommand';
 import { BuildStatus, DistributionType } from '../../graphql/generated';
@@ -18,8 +18,6 @@ import Log from '../../log';
 import { RequestedPlatform } from '../../platform';
 import { resolveWorkflowAsync } from '../../project/workflow';
 import { confirmAsync, promptAsync } from '../../prompts';
-import { runAsync } from '../../run/run';
-import { downloadAndMaybeExtractAppAsync } from '../../utils/download';
 import { createFingerprintAsync } from '../../utils/fingerprintCli';
 import { ProfileData, getProfilesAsync } from '../../utils/profiles';
 import { Client } from '../../vcs/vcs';
@@ -129,11 +127,7 @@ export default class BuildDev extends EasCommand {
       );
 
       if (build.artifacts?.applicationArchiveUrl) {
-        const buildPath = await downloadAndMaybeExtractAppAsync(
-          build.artifacts.applicationArchiveUrl,
-          build.platform
-        );
-        await runAsync(buildPath, build.platform);
+        await downloadAndRunAsync(build);
         return;
       } else {
         Log.warn('Artifacts for this build expired. New build will be started.');

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -1,7 +1,6 @@
 import { Errors, Flags } from '@oclif/core';
 import assert from 'assert';
 import { pathExists } from 'fs-extra';
-import path from 'path';
 
 import { getLatestBuildAsync, listAndSelectBuildOnAppAsync } from '../../build/queries';
 import EasCommand from '../../commandUtils/EasCommand';
@@ -17,13 +16,12 @@ import Log from '../../log';
 import { appPlatformDisplayNames } from '../../platform';
 import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
-import { RunArchiveFlags, runAsync } from '../../run/run';
+import { RunArchiveFlags, getEasBuildRunCachedAppPath, runAsync } from '../../run/run';
 import { isRunnableOnSimulatorOrEmulator } from '../../run/utils';
 import {
   downloadAndMaybeExtractAppAsync,
   extractAppFromLocalArchiveAsync,
 } from '../../utils/download';
-import { getEasBuildRunCacheDirectoryPath } from '../../utils/paths';
 
 interface RawRunFlags {
   latest?: boolean;
@@ -243,17 +241,6 @@ async function maybeGetBuildAsync(
   } else {
     return null;
   }
-}
-
-function getEasBuildRunCachedAppPath(
-  projectId: string,
-  buildId: string,
-  platform: AppPlatform
-): string {
-  return path.join(
-    getEasBuildRunCacheDirectoryPath(),
-    `${projectId}_${buildId}.${platform === AppPlatform.Ios ? 'app' : 'apk'}`
-  );
 }
 
 async function getPathToSimulatorBuildAppAsync(

--- a/packages/eas-cli/src/run/run.ts
+++ b/packages/eas-cli/src/run/run.ts
@@ -1,6 +1,9 @@
+import path from 'path';
+
 import { runAppOnAndroidEmulatorAsync } from './android/run';
 import { runAppOnIosSimulatorAsync } from './ios/run';
 import { AppPlatform } from '../graphql/generated';
+import { getEasBuildRunCacheDirectoryPath } from '../utils/paths';
 
 export interface RunArchiveFlags {
   latest?: boolean;
@@ -18,4 +21,15 @@ export async function runAsync(
   } else {
     await runAppOnAndroidEmulatorAsync(simulatorBuildPath);
   }
+}
+
+export function getEasBuildRunCachedAppPath(
+  projectId: string,
+  buildId: string,
+  platform: AppPlatform
+): string {
+  return path.join(
+    getEasBuildRunCacheDirectoryPath(),
+    `${projectId}_${buildId}.${platform === AppPlatform.Ios ? 'app' : 'apk'}`
+  );
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We don't need to redownload app every single time in `eas build:dev`. We can cache it locally. This functionality already exists for `eas build:run`.

# How

Use caching the same way we do for `eas build:run`

# Test Plan

Tested manually
