### PR TITLE
[eas-cli] pass server env when resolving fingerprint runtime version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fixed EAS server environment variables does not pass to `npx expo-updates runtimeversion:resolve` call. ([#2867](https://github.com/expo/eas-cli/pull/2867) by [@kudo](https://github.com/kudo))
+
 ### 🧹 Chores
 
 ## [15.0.0](https://github.com/expo/eas-cli/releases/tag/v15.0.0) - 2025-02-04

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -237,6 +237,10 @@ export default class UpdatePublish extends EasCommand {
       jsonFlag,
     });
 
+    const maybeServerEnv = environment
+      ? { ...(await getServerSideEnvironmentVariablesAsync()), EXPO_NO_DOTENV: '1' }
+      : {};
+
     // build bundle and upload assets for a new publish
     if (!skipBundler) {
       const bundleSpinner = ora().start('Exporting...');
@@ -247,11 +251,7 @@ export default class UpdatePublish extends EasCommand {
           exp,
           platformFlag: requestedPlatform,
           clearCache,
-          extraEnv: {
-            ...(environment
-              ? { ...(await getServerSideEnvironmentVariablesAsync()), EXPO_NO_DOTENV: '1' }
-              : {}),
-          },
+          extraEnv: maybeServerEnv,
         });
         bundleSpinner.succeed('Exported bundle(s)');
       } catch (e) {
@@ -393,7 +393,7 @@ export default class UpdatePublish extends EasCommand {
         ...workflows,
         web: Workflow.UNKNOWN,
       },
-      env: undefined,
+      env: maybeServerEnv,
     });
     const runtimeToPlatformsAndFingerprintInfoMapping =
       getRuntimeToPlatformsAndFingerprintInfoMappingFromRuntimeVersionInfoObjects(


### PR DESCRIPTION
# Why

receiving an issue for a customer who uses eas environment and continuous-deploy-fingerprint github action. they have build variants setup in their app.config.ts. the app id, scheme and some other properties are determined by their `APP_VARIANT` variable. the `APP_VARIANT` is from eas server environment.

when continuous-deploy-fingerprint first calculates fingerprint, it uses `eas env:exec` for the `npx expo-updates fingerprint:generate` call. the `APP_VARIANT` is correctly passed.
then for `eas update` call, it doesn't pass the `APP_VARIANT` env and generates an inconsistent fingerprint.

# How

pass server env to the `getRuntimeVersionInfoObjectsAsync()` (`npx expo-updates runtimeversion:resolve`)

# Test Plan

1. my **app.config.js**

  ```js
  export default ({ config }) => {
    config.android.package = process.env.APP_VARIANT === 'staging' ? 'dev.expo.kudo.ooxx.staging' : 'dev.expo.kudo.ooxx.default';
    return config;
  };
  ```

2. adding `APP_VARIANT=staging` to my eas project
3. running `EXPO_DEBUG=1 eas update -m "update" --branch preview --environment production` to check the `expoConfig` fingerprint source of "android.package" is `dev.expo.kudo.ooxx.staging` or `dev.expo.kudo.ooxx.default'`