### PR TITLE
[eas-cli] add --open flag to fingerprint:compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Popup website in fingerprint:compare. ([#2859](https://github.com/expo/eas-cli/pull/2859) by [@quinlanj](https://github.com/quinlanj))
 - Fix fingerprint:compare URL. ([#2861](https://github.com/expo/eas-cli/pull/2861) by [@quinlanj](https://github.com/quinlanj))
 - Make less gql calls in fingerprint:compare. ([#2860](https://github.com/expo/eas-cli/pull/2860) by [@quinlanj](https://github.com/quinlanj))
+- Add --open flag to fingerprint:compare. ([#2872](https://github.com/expo/eas-cli/pull/2872) by [@quinlanj](https://github.com/quinlanj))
 
 ## [15.0.3](https://github.com/expo/eas-cli/releases/tag/v15.0.3) - 2025-02-04
 

--- a/packages/eas-cli/src/commands/fingerprint/compare.ts
+++ b/packages/eas-cli/src/commands/fingerprint/compare.ts
@@ -21,7 +21,7 @@ import { AppQuery } from '../../graphql/queries/AppQuery';
 import { BuildQuery } from '../../graphql/queries/BuildQuery';
 import { FingerprintQuery } from '../../graphql/queries/FingerprintQuery';
 import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
-import Log from '../../log';
+import Log, { learnMore } from '../../log';
 import { ora } from '../../ora';
 import { RequestedPlatform } from '../../platform';
 import { maybeUploadFingerprintAsync } from '../../project/maybeUploadFingerprintAsync';
@@ -88,6 +88,9 @@ export default class FingerprintCompare extends EasCommand {
       description: 'Compare the fingerprint with the update with the specified ID',
       multiple: true,
     }),
+    open: Flags.boolean({
+      description: 'Open the fingerprint comparison in the browser',
+    }),
     ...EasNonInteractiveAndJsonFlags,
   };
 
@@ -106,6 +109,7 @@ export default class FingerprintCompare extends EasCommand {
       'non-interactive': nonInteractive,
       'build-id': buildIds,
       'update-id': updateIds,
+      open,
     } = flags;
     const [buildId1, buildId2] = buildIds ?? [];
     const [updateId1, updateId2] = updateIds ?? [];
@@ -239,6 +243,16 @@ export default class FingerprintCompare extends EasCommand {
     );
     fingerprintCompareUrl.searchParams.set('a', firstFingerprintInfo.fingerprint.hash);
     fingerprintCompareUrl.searchParams.set('b', secondFingerprintInfo.fingerprint.hash);
+
+    if (!open) {
+      Log.newLine();
+      Log.withInfo(
+        `💡 Use the --open flag to view the comparison in the browser. ${learnMore(
+          fingerprintCompareUrl.toString()
+        )}`
+      );
+      return;
+    }
     await openBrowserAsync(fingerprintCompareUrl.toString());
   }
 }


### PR DESCRIPTION
# Why
Followup from https://github.com/expo/eas-cli/commit/7f46baeb21125e1708c9f79610c08cc8acb04b4a#r152099396

Add a new `--open` flag to the `eas fingerprint compare` command to provide users with the option to automatically open fingerprint comparisons in their browser. This improves the user experience by eliminating the need to manually copy and paste URLs.

# output

<img width="1552" alt="Screenshot 2025-02-04 at 12 44 35 PM" src="https://github.com/user-attachments/assets/bb46e96e-bbdc-453e-af2f-7aeee3e60f9a" />

# How

- Added a new boolean flag `open` to the command options
- When the flag is not used, display a helpful message suggesting the use of the flag
- When the flag is used, automatically open the comparison URL in the browser
- Added a link to learn more about fingerprint comparisons in the info message

# Test Plan
ran `eas fingerprint compare` with and without `--open`
