### PR TITLE
[eas-cli] Fix `.easignore` behavior for `GitClient`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: yarn install --frozen-lockfile --check-files
       - run: yarn typecheck
+      - run: |
+          git config --global user.email "tester@expo.dev"
+          git config --global user.name "Test"
       - run: yarn test
         if: ${{ !matrix.coverage }}
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fixed `GitClient` not respecting `.easignore` file. ([#2873](https://github.com/expo/eas-cli/pull/2873) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🧹 Chores
 
 - Popup website in fingerprint:compare. ([#2859](https://github.com/expo/eas-cli/pull/2859) by [@quinlanj](https://github.com/quinlanj))

--- a/packages/eas-cli/src/vcs/clients/__tests__/git.test.ts
+++ b/packages/eas-cli/src/vcs/clients/__tests__/git.test.ts
@@ -1,0 +1,138 @@
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import GitClient from '../git';
+
+describe('git', () => {
+  let repoRoot: string;
+  beforeAll(async () => {
+    repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+    await spawnAsync('git', ['init'], { cwd: repoRoot });
+  });
+
+  afterAll(async () => {
+    await fs.rm(repoRoot, { recursive: true, force: true });
+  });
+
+  describe('GitClient that does not require a commit', () => {
+    let vcs: GitClient;
+
+    beforeAll(async () => {
+      vcs = new GitClient({
+        requireCommit: false,
+        maybeCwdOverride: repoRoot,
+      });
+    });
+
+    describe('isFileIgnoredAsync', () => {
+      const testFiles = [
+        { commit: true, gitignore: true, easignore: true },
+        { commit: true, gitignore: true, easignore: false },
+        { commit: true, gitignore: false, easignore: true },
+        { commit: true, gitignore: false, easignore: false },
+        { commit: false, gitignore: true, easignore: true },
+        { commit: false, gitignore: true, easignore: false },
+        { commit: false, gitignore: false, easignore: true },
+        { commit: false, gitignore: false, easignore: false },
+      ].map(combo => {
+        const filename = `${combo.commit ? 'tracked' : 'new'}-${
+          combo.gitignore ? 'gitignored' : 'gitnonignored'
+        }-${combo.easignore ? 'easignored' : 'easnonignored'}.txt`;
+        return { ...combo, filename };
+      });
+
+      async function setupTestFiles(): Promise<void> {
+        await Promise.all(
+          testFiles.map(async file => {
+            const content = `File that is ${Object.values(file).join(', ')}`;
+            await fs.writeFile(`${repoRoot}/${file.filename}`, content);
+          })
+        );
+
+        // Commit the "committed" files
+        await spawnAsync('git', ['add', '*tracked*.txt'], { cwd: repoRoot });
+        await spawnAsync('git', ['commit', '-m', 'test setup'], { cwd: repoRoot });
+      }
+
+      beforeAll(async () => {
+        await setupTestFiles();
+      });
+
+      describe('with only .easignore', () => {
+        beforeAll(async () => {
+          await fs.writeFile(`${repoRoot}/.easignore`, '*easignored*\n');
+        });
+
+        afterAll(async () => {
+          await fs.rm(`${repoRoot}/.easignore`);
+        });
+
+        it.each(testFiles.filter(file => file.easignore))(
+          '$filename should be ignored',
+          async file => {
+            expect(await vcs.isFileIgnoredAsync(file.filename)).toBe(true);
+          }
+        );
+
+        it.each(testFiles.filter(file => !file.easignore))(
+          '$filename should not be ignored',
+          async file => {
+            expect(await vcs.isFileIgnoredAsync(file.filename)).toBe(false);
+          }
+        );
+      });
+
+      describe('with only .gitignore', () => {
+        beforeAll(async () => {
+          await fs.writeFile(`${repoRoot}/.gitignore`, '*gitignored*\n');
+        });
+
+        afterAll(async () => {
+          await fs.rm(`${repoRoot}/.gitignore`);
+        });
+
+        it.each(testFiles.filter(file => file.gitignore && !file.commit))(
+          '$filename should be ignored',
+          async file => {
+            expect(await vcs.isFileIgnoredAsync(file.filename)).toBe(true);
+          }
+        );
+
+        it.each(testFiles.filter(file => !file.gitignore || file.commit))(
+          '$filename should not be ignored',
+          async file => {
+            expect(await vcs.isFileIgnoredAsync(file.filename)).toBe(false);
+          }
+        );
+      });
+
+      describe('with both .gitignore and .easignore', () => {
+        beforeAll(async () => {
+          await fs.writeFile(`${repoRoot}/.gitignore`, '*gitignored*\n');
+          await fs.writeFile(`${repoRoot}/.easignore`, '*easignored*\n');
+        });
+
+        afterAll(async () => {
+          await fs.rm(`${repoRoot}/.gitignore`);
+          await fs.rm(`${repoRoot}/.easignore`);
+        });
+
+        it.each(testFiles.filter(file => file.easignore))(
+          '$filename should be ignored',
+          async file => {
+            expect(await vcs.isFileIgnoredAsync(file.filename)).toBe(true);
+          }
+        );
+
+        it.each(testFiles.filter(file => !file.easignore))(
+          '$filename should not be ignored',
+          async file => {
+            expect(await vcs.isFileIgnoredAsync(file.filename)).toBe(false);
+          }
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

If you had an `.easignore`, `isFileIgnoredAsync` was always thinking all files are NOT ignored which was causing it to think all builds are in `.GENERIC` mode (with native code) which was not true, because ACTUALLY the files WERE ignored.

All mostly because of forgotten `ignore.initIgnoreAsync()`…

# How

Added `ignore.initIgnoreAsync()`. Also realized whether the file is tracked / not-tracked may affect how actually is it going to behave, so added it to the mix.

# Test Plan

Added tests that I think test all cases.