### PR TITLE
[eas-cli] Prevent using non-initialized `Ignore`

### DIFF
--- a/packages/eas-cli/src/vcs/__tests__/local-test.ts
+++ b/packages/eas-cli/src/vcs/__tests__/local-test.ts
@@ -18,8 +18,7 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = new Ignore('/root');
-    await ignore.initIgnoreAsync();
+    const ignore = await Ignore.createAsync('/root');
     expect(ignore.ignores('aaa')).toBe(true);
     expect(ignore.ignores('bbb')).toBe(false);
     expect(ignore.ignores('dir/aaa')).toBe(true);
@@ -36,8 +35,7 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = new Ignore('/root');
-    await ignore.initIgnoreAsync();
+    const ignore = await Ignore.createAsync('/root');
     expect(ignore.ignores('aaa')).toBe(false);
     expect(ignore.ignores('bbb')).toBe(false);
     expect(ignore.ignores('ccc')).toBe(true);
@@ -54,8 +52,7 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = new Ignore('/root');
-    await ignore.initIgnoreAsync();
+    const ignore = await Ignore.createAsync('/root');
     expect(ignore.ignores('aaa')).toBe(true);
     expect(ignore.ignores('bbb')).toBe(false);
     expect(ignore.ignores('node_modules/aaa')).toBe(true);
@@ -72,16 +69,14 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = new Ignore('/root');
-    await ignore.initIgnoreAsync();
+    const ignore = await Ignore.createAsync('/root');
     expect(ignore.ignores('dir/ccc')).toBe(true);
   });
 
   it('ignores .git', async () => {
     vol.fromJSON({}, '/root');
 
-    const ignore = new Ignore('/root');
-    await ignore.initIgnoreAsync();
+    const ignore = await Ignore.createAsync('/root');
     expect(ignore.ignores('.git')).toBe(true);
   });
 
@@ -93,8 +88,7 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = new Ignore('/root');
-    await ignore.initIgnoreAsync();
+    const ignore = await Ignore.createAsync('/root');
     expect(() => ignore.ignores('dir/test')).not.toThrowError();
   });
 });

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -299,8 +299,7 @@ export default class GitClient extends Client {
 
     const easIgnorePath = path.join(rootPath, EASIGNORE_FILENAME);
     if (await fs.exists(easIgnorePath)) {
-      const ignore = new Ignore(rootPath);
-      await ignore.initIgnoreAsync();
+      const ignore = await Ignore.createAsync(rootPath);
       const wouldNotBeCopiedToClone = ignore.ignores(filePath);
       const wouldBeDeletedFromClone =
         (

--- a/packages/eas-cli/src/vcs/clients/noVcs.ts
+++ b/packages/eas-cli/src/vcs/clients/noVcs.ts
@@ -12,8 +12,7 @@ export default class NoVcsClient extends Client {
   }
 
   public override async isFileIgnoredAsync(filePath: string): Promise<boolean> {
-    const ignore = new Ignore(getRootPath());
-    await ignore.initIgnoreAsync();
+    const ignore = await Ignore.createAsync(getRootPath());
     return ignore.ignores(filePath);
   }
 

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -32,7 +32,13 @@ export function getRootPath(): string {
 export class Ignore {
   private ignoreMapping: (readonly [string, SingleFileIgnore])[] = [];
 
-  constructor(private readonly rootDir: string) {}
+  private constructor(private readonly rootDir: string) {}
+
+  static async createAsync(rootDir: string): Promise<Ignore> {
+    const ignore = new Ignore(rootDir);
+    await ignore.initIgnoreAsync();
+    return ignore;
+  }
 
   public async initIgnoreAsync(): Promise<void> {
     const easIgnorePath = path.join(this.rootDir, EASIGNORE_FILENAME);
@@ -75,8 +81,7 @@ export class Ignore {
 }
 
 export async function makeShallowCopyAsync(src: string, dst: string): Promise<void> {
-  const ignore = new Ignore(src);
-  await ignore.initIgnoreAsync();
+  const ignore = await Ignore.createAsync(src);
   await fs.copy(src, dst, {
     filter: (srcFilePath: string) => {
       if (srcFilePath === src) {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`eas-cli@15.0.0-15.0.3` doesn't interpret `.easignore` right because I haven't initialized the `Ignore` class properly.

# How

Make it so it's not possible to use `Ignore` without initializing it.

# Test Plan

Tests should pass.