### PR TITLE
[eas-cli] Raise threshold for "big tarball" warning

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -37,6 +37,7 @@ import {
   LocalFile,
   makeProjectMetadataFileAsync,
   makeProjectTarballAsync,
+  maybeWarnAboutProjectTarballSize,
   reviewAndCommitChangesAsync,
 } from './utils/repository';
 import { BuildEvent } from '../analytics/AnalyticsManager';
@@ -275,15 +276,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
         );
         const projectTarball = await makeProjectTarballAsync(ctx.vcsClient);
 
-        if (projectTarball.size > 1024 * 1024 * 100) {
-          Log.warn(
-            `Your project archive is ${formatBytes(
-              projectTarball.size
-            )}. You can reduce its size and the time it takes to upload by excluding files that are unnecessary for the build process in ${chalk.bold(
-              '.easignore'
-            )} file. ${learnMore('https://expo.fyi/eas-build-archive')}`
-          );
-        }
+        maybeWarnAboutProjectTarballSize(projectTarball.size);
 
         if (projectTarball.size > 2 * 1024 * 1024 * 1024) {
           throw new Error('Project archive is too big. Maximum allowed size is 2GB.');

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -35,6 +35,7 @@ import { collectMetadataAsync } from './metadata';
 import { printDeprecationWarnings } from './utils/printBuildInfo';
 import {
   LocalFile,
+  assertProjectTarballSizeDoesNotExceedLimit,
   makeProjectMetadataFileAsync,
   makeProjectTarballAsync,
   maybeWarnAboutProjectTarballSize,
@@ -277,10 +278,7 @@ async function uploadProjectAsync<TPlatform extends Platform>(
         const projectTarball = await makeProjectTarballAsync(ctx.vcsClient);
 
         maybeWarnAboutProjectTarballSize(projectTarball.size);
-
-        if (projectTarball.size > 2 * 1024 * 1024 * 1024) {
-          throw new Error('Project archive is too big. Maximum allowed size is 2GB.');
-        }
+        assertProjectTarballSizeDoesNotExceedLimit(projectTarball.size);
 
         projectTarballPath = projectTarball.path;
         const [bucketKey, { metadataLocation }] = await Promise.all([

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -170,7 +170,7 @@ export async function makeProjectTarballAsync(vcsClient: Client): Promise<LocalF
 }
 
 export function maybeWarnAboutProjectTarballSize(size: number): void {
-  if (size <= 1024 * 1024 * 100) {
+  if (size <= 150 /* MiB */ * 1024 /* KiB */ * 1024 /* B */) {
     return;
   }
 

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import tar from 'tar';
 import { v4 as uuidv4 } from 'uuid';
 
-import Log from '../../log';
+import Log, { learnMore } from '../../log';
 import { ora } from '../../ora';
 import { confirmAsync, promptAsync } from '../../prompts';
 import { formatBytes } from '../../utils/files';
@@ -167,6 +167,20 @@ export async function makeProjectTarballAsync(vcsClient: Client): Promise<LocalF
   }
 
   return { size, path: tarPath };
+}
+
+export function maybeWarnAboutProjectTarballSize(size: number): void {
+  if (size <= 1024 * 1024 * 100) {
+    return;
+  }
+
+  Log.warn(
+    `Your project archive is ${formatBytes(
+      size
+    )}. You can reduce its size and the time it takes to upload by excluding files that are unnecessary for the build process in ${chalk.bold(
+      '.easignore'
+    )} file. ${learnMore('https://expo.fyi/eas-build-archive')}`
+  );
 }
 
 enum ShouldCommitChanges {

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -183,6 +183,20 @@ export function maybeWarnAboutProjectTarballSize(size: number): void {
   );
 }
 
+const MAX_ALLOWED_PROJECT_TARBALL_SIZE =
+  2 /* GiB */ * 1024 /* MiB */ * 1024 /* KiB */ * 1024; /* B */
+export function assertProjectTarballSizeDoesNotExceedLimit(size: number): void {
+  if (size <= MAX_ALLOWED_PROJECT_TARBALL_SIZE) {
+    return;
+  }
+
+  throw new Error(
+    `Project archive is too big. Maximum allowed size is ${formatBytes(
+      MAX_ALLOWED_PROJECT_TARBALL_SIZE
+    )}.`
+  );
+}
+
 enum ShouldCommitChanges {
   Yes,
   ShowDiffFirst,

--- a/packages/eas-cli/src/project/uploadAccountScopedProjectSourceAsync.ts
+++ b/packages/eas-cli/src/project/uploadAccountScopedProjectSourceAsync.ts
@@ -1,7 +1,10 @@
 import chalk from 'chalk';
 import fs from 'node:fs';
 
-import { makeProjectTarballAsync } from '../build/utils/repository';
+import {
+  makeProjectTarballAsync,
+  maybeWarnAboutProjectTarballSize,
+} from '../build/utils/repository';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { AccountUploadSessionType } from '../graphql/generated';
 import Log, { learnMore } from '../log';
@@ -36,15 +39,7 @@ export async function uploadAccountScopedProjectSourceAsync({
     const projectTarball = await makeProjectTarballAsync(vcsClient);
     projectTarballPath = projectTarball.path;
 
-    if (projectTarball.size > 1024 * 1024 * 100) {
-      Log.warn(
-        `Your project archive is ${formatBytes(
-          projectTarball.size
-        )}. You can reduce its size and the time it takes to upload by excluding files that are unnecessary for the build process in ${chalk.bold(
-          '.easignore'
-        )} file. ${learnMore('https://expo.fyi/eas-build-archive')}`
-      );
-    }
+    maybeWarnAboutProjectTarballSize(projectTarball.size);
 
     if (projectTarball.size > 2 * 1024 * 1024 * 1024) {
       throw new Error('Project archive is too big. Maximum allowed size is 2GB.');

--- a/packages/eas-cli/src/project/uploadAccountScopedProjectSourceAsync.ts
+++ b/packages/eas-cli/src/project/uploadAccountScopedProjectSourceAsync.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import fs from 'node:fs';
 
 import {
+  assertProjectTarballSizeDoesNotExceedLimit,
   makeProjectTarballAsync,
   maybeWarnAboutProjectTarballSize,
 } from '../build/utils/repository';
@@ -40,10 +41,7 @@ export async function uploadAccountScopedProjectSourceAsync({
     projectTarballPath = projectTarball.path;
 
     maybeWarnAboutProjectTarballSize(projectTarball.size);
-
-    if (projectTarball.size > 2 * 1024 * 1024 * 1024) {
-      throw new Error('Project archive is too big. Maximum allowed size is 2GB.');
-    }
+    assertProjectTarballSizeDoesNotExceedLimit(projectTarball.size);
 
     const projectArchiveBucketKey = await uploadAccountScopedFileAtPathToGCSAsync(graphqlClient, {
       accountId,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Adding `.git` directory to the tarball makes it bigger. Users notice this warning and want it to be actionable, but currently adding `.git` to `.easignore` does nothing.

# How

For now, raise threshold for warning from 100 MiB to 150 MiB. In the next pull request I'm going to fix `.git` exclusion via `.easignore`.

# Test Plan

CI should pass.