### PR TITLE
[eas-cli] Support excluding `.git` via `.easignore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Fixed `GitClient` not respecting `.easignore` file. ([#2873](https://github.com/expo/eas-cli/pull/2873) by [@sjchmiela](https://github.com/sjchmiela))
 - Fix symlink support in `makeShallowCopyAsync`. ([#2874](https://github.com/expo/eas-cli/pull/2874) by [@sjchmiela](https://github.com/sjchmiela))
+- Allow excluding `.git` directory from project archive by adding it to `.easignore`. ([#2879](https://github.com/expo/eas-cli/pull/2879) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🧹 Chores
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Currently it's not possible to exclude `.git` from being uploaded in project tarball.

# How

In `makeShallowCopyAsync()` we first clone the repository, then we delete files ignored by `.easignore` and then we copy working directory over.

The "delete files ignored by `.easignore`" step is governed by `git ls-files --exclude-from=.easignore`. `git ls-files` is never going to consider `.git` directory to be excluded, even if specified in `.easignore`, so we need to special-case the `.git` directory and remove it manually if specified.

# Test Plan

Added `.git` to a test `.easignore`, ran `eas build:inspect` and confirmed the copied directory did _not_ contain `.git` folder.