### PR TITLE
Make sure quotes in json are escaped

### DIFF
--- a/packages/eas-cli/src/utils/json.ts
+++ b/packages/eas-cli/src/utils/json.ts
@@ -33,6 +33,8 @@ function sanitizeValue(value: any): unknown {
       }
     });
     return result;
+  } else if (value && typeof value === 'string') {
+    return JSON.stringify(value);
   } else {
     return value;
   }


### PR DESCRIPTION

<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I'm seeing issues when I run `eas build:list --json` because git commit messages are included in the result but git commit messages sometimes contain quotes. These aren't escaped and so I am seeing invalid json in the output that looks like this:

```json
{
\\...
"gitCommitMessage": "Changed some "stuff""
}
```

# How

I've changed this so that string values (only) are escaped using `JSON.stringify`.


# Test Plan

I'd love to include tests for this but I couldn't see an appropriate test file to add them to. Considering that I would test this like this:

1. Create a build for a commit that contains a commit message with double quotes in it
2. Run `eas build:list --json --non-interactive` and confirm that the `gitCommitMessage` is there but has the double quotes escaped
3. Try parsing the json using `jq '.[]' to confirm that it's valid json (the json should be output by jq and there should be no parsing error`