### PR TITLE
[eas-cli] Fix deleting ignored submodules when archiving project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix `EISDIR` error when archiving project with submodules ignored. ([#2884](https://github.com/expo/eas-cli/pull/2884) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🧹 Chores
 
 ## [15.0.4](https://github.com/expo/eas-cli/releases/tag/v15.0.4) - 2025-02-05

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -210,7 +210,11 @@ export default class GitClient extends Client {
           .filter(file => file !== '');
 
         await Promise.all(
-          cachedFilesWeShouldHaveIgnored.map(file => fs.rm(path.join(destinationPath, file)))
+          cachedFilesWeShouldHaveIgnored.map(file =>
+            // `ls-files` does not go over files within submodules. If submodule is
+            // ignored, it is listed as a single path, so we need to `rm -rf` it.
+            fs.rm(path.join(destinationPath, file), { recursive: true, force: true })
+          )
         );
 
         // Special-case `.git` which `git ls-files` will never consider ignored.


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`git ls-files` returns submodules as a single filepath entry, so `rm` must remove it with `-rf`. Fixes https://github.com/expo/eas-cli/issues/2883.

# How

Added `{ recursive: true, force: true }` to `fs.rm`.

# Test Plan

I tried `easd build:inspect -p android -s archive -o ~/testtest --force` on a repo with a submodule in `.easignore`. It succeeded and the submodule was not included in the folder.