### PR TITLE
[eas-cli] Skip `makeShallowCopyAsync` if `requireCommit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Do not copy files over onto a cloned Git repository when packing the project archive if `requireCommit` is true. ([#2885](https://github.com/expo/eas-cli/pull/2885) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🧹 Chores
 
 ## [15.0.4](https://github.com/expo/eas-cli/releases/tag/v15.0.4) - 2025-02-05

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -223,10 +223,15 @@ export default class GitClient extends Client {
       await setGitCaseSensitivityAsync(isCaseSensitive, rootPath);
     }
 
-    // After we create the shallow Git copy, we copy the files
-    // again. This way we include the changed and untracked files
-    // (`git clone` only copies the committed changes).
-    await makeShallowCopyAsync(rootPath, destinationPath);
+    if (!this.requireCommit) {
+      // After we create the shallow Git copy, we copy the files
+      // again. This way we include the changed and untracked files
+      // (`git clone` only copies the committed changes).
+      //
+      // We only do this if `requireCommit` is false because `requireCommit: true`
+      // setups expect no changes in files (e.g. locked files should remain locked).
+      await makeShallowCopyAsync(rootPath, destinationPath);
+    }
   }
 
   public override async getCommitHashAsync(): Promise<string | undefined> {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`requireCommit: true` setups expect worktree to be clean (e.g. encrypted files to be locked).

# How

Made it so if `requireCommit` is true we don't copy files over.

# Test Plan

I have enabled `git-crypt` in my test repository, added a secret file, ran `easd build:inspect -p android -s archive -o ~/test-production --force`. The clone did contain secret file in plaintext.

Then I enabled `requireCommit: true` and repeated the command. The clone did contain the file encrypted.