### PR TITLE
[eas-cli] Allow normalizing root path to fix Windows not ignoring files

### DIFF
--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -329,7 +329,10 @@ export default class GitClient extends Client {
 
     const easIgnorePath = path.join(rootPath, EASIGNORE_FILENAME);
     if (await fs.exists(easIgnorePath)) {
-      const ignore = await Ignore.createAsync(rootPath);
+      const ignore = await Ignore.createAsync(
+        // eslint-disable-next-line no-underscore-dangle
+        process.env.__NORMALIZE === '1' ? path.normalize(rootPath) : rootPath
+      );
       const wouldNotBeCopiedToClone = ignore.ignores(filePath);
       const wouldBeDeletedFromClone =
         (

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -320,7 +320,7 @@ export default class GitClient extends Client {
     let isTracked: boolean;
     try {
       await spawnAsync('git', ['ls-files', '--error-unmatch', filePath], {
-        cwd: this.maybeCwdOverride,
+        cwd: rootPath,
       });
       isTracked = true;
     } catch {

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -92,7 +92,14 @@ export class Ignore {
   }
 }
 
-export async function makeShallowCopyAsync(src: string, dst: string): Promise<void> {
+export async function makeShallowCopyAsync(_src: string, dst: string): Promise<void> {
+  let src = _src;
+
+  // eslint-disable-next-line no-underscore-dangle
+  if (process.env.__NORMALIZE === '1') {
+    src = path.normalize(src);
+  }
+
   Log.debug('makeShallowCopyAsync', { src, dst });
   const ignore = await Ignore.createAsync(src);
   Log.debug('makeShallowCopyAsync ignoreMapping', { ignoreMapping: ignore.ignoreMapping });


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Since v15 files that should be ignored get added to the tarball on Windows.

# How

After adding some debugging I was able to find that `src`, `srcFilePath` don't match on path separators which breaks `ignore.ignores`.

<img width="827" alt="Zrzut ekranu 2025-02-7 o 21 57 02" src="https://github.com/user-attachments/assets/9ed3b166-dbc0-4287-87a1-0009769e0d4d" />

Added `path.normalize` if `__NORMALIZE` is `1`.

---

Also noticed we used wrong `cwd` for is-tracked check.

# Test Plan

Going to release this and test.