### PR TITLE
[eas-cli] Finally fix Windows not-ignoring files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Fix ignoring files in Git repositories on Windows when `requireCommit` is not enabled. ([#2894](https://github.com/expo/eas-cli/pull/2894) by [@sjchmiela](https://github.com/sjchmiela))
+- Fix files not being ignored when creating a tarball on Windows in Git repository in no `requireCommit` mode. ([#2894](https://github.com/expo/eas-cli/pull/2894) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix ignoring files in Git repositories on Windows when `requireCommit` is not enabled. ([#2894](https://github.com/expo/eas-cli/pull/2894) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🧹 Chores
 
 ## [15.0.8](https://github.com/expo/eas-cli/releases/tag/v15.0.8) - 2025-02-09

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -329,10 +329,7 @@ export default class GitClient extends Client {
 
     const easIgnorePath = path.join(rootPath, EASIGNORE_FILENAME);
     if (await fs.exists(easIgnorePath)) {
-      const ignore = await Ignore.createAsync(
-        // eslint-disable-next-line no-underscore-dangle
-        process.env.__NORMALIZE === '1' ? path.normalize(rootPath) : rootPath
-      );
+      const ignore = await Ignore.createAsync(rootPath);
       const wouldNotBeCopiedToClone = ignore.ignores(filePath);
       const wouldBeDeletedFromClone =
         (

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -97,7 +97,7 @@ export async function makeShallowCopyAsync(_src: string, dst: string): Promise<v
   // to the `filter` function in `fs.cp`. We need to ensure that we compare the right paths
   // (both with prefix), otherwise the `relativePath` ends up being wrong and causes no files
   // to be ignored.
-  const src = path.toNamespacedPath(_src);
+  const src = path.toNamespacedPath(path.normalize(_src));
 
   Log.debug('makeShallowCopyAsync', { src, dst });
   const ignore = await Ignore.createAsync(src);

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -93,12 +93,11 @@ export class Ignore {
 }
 
 export async function makeShallowCopyAsync(_src: string, dst: string): Promise<void> {
-  let src = _src;
-
-  // eslint-disable-next-line no-underscore-dangle
-  if (process.env.__NORMALIZE === '1') {
-    src = path.toNamespacedPath(path.normalize(src));
-  }
+  // `node:fs` on Windows adds a namespace prefix (e.g. `\\?\`) to the path provided
+  // to the `filter` function in `fs.cp`. We need to ensure that we compare the right paths
+  // (both with prefix), otherwise the `relativePath` ends up being wrong and causes no files
+  // to be ignored.
+  const src = path.toNamespacedPath(_src);
 
   Log.debug('makeShallowCopyAsync', { src, dst });
   const ignore = await Ignore.createAsync(src);
@@ -109,15 +108,7 @@ export async function makeShallowCopyAsync(_src: string, dst: string): Promise<v
     // Preserve symlinks without re-resolving them to their original targets
     verbatimSymlinks: true,
     filter: (_srcFilePath: string) => {
-      let srcFilePath = _srcFilePath;
-
-      // eslint-disable-next-line no-underscore-dangle
-      if (process.env.__NORMALIZE === '1') {
-        // `node:fs` on Windows adds a namespace prefix (e.g. `\\?\`) to the path.
-        // We need to ensure that we compare the right paths (both with prefix),
-        // otherwise the `relativePath` ends up being wrong and causes no files to be ignored.
-        srcFilePath = path.toNamespacedPath(srcFilePath);
-      }
+      const srcFilePath = path.toNamespacedPath(_srcFilePath);
 
       if (srcFilePath === src) {
         return true;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

With `toNamespacedPath` I was finally able to make ignoring files work properly.

# How

Removed `if (__NORMALIZE)` checks.

# Test Plan

Ran `eas build:inspect` on Windows, confirmed no `node_modules` was copied. Also ran `eas build:inspect` on macOS, worked too.