### PR TITLE
[eas-cli] Do not include files deleted in working directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,29 +50,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - run: yarn lint-changelog
 
-  test_windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        node: ['18', '20', '22']
-    name: Test with Node ${{ matrix.node }} on Windows
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node }}
-      - run: yarn install --frozen-lockfile --check-files
-      - run: |
-          git config --global user.email "tester@expo.dev"
-          git config --global user.name "Test"
-      - run: yarn test
-        env:
-          NODE_OPTIONS: --max-old-space-size=8192
-
   notify-slack:
     runs-on: ubuntu-latest
-    needs: [test, test_windows]
+    needs: [test]
     name: Notify Slack
     if: ${{ github.ref == 'refs/heads/main' && always() }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,9 +50,29 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - run: yarn lint-changelog
 
+  test_windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        node: ['18', '20', '22']
+    name: Test with Node ${{ matrix.node }} on Windows
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: yarn install --frozen-lockfile --check-files
+      - run: |
+          git config --global user.email "tester@expo.dev"
+          git config --global user.name "Test"
+      - run: yarn test
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
   notify-slack:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, test_windows]
     name: Notify Slack
     if: ${{ github.ref == 'refs/heads/main' && always() }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix files deleted in working directory not being removed from the project archive when `requireCommit` is false. ([#2900](https://github.com/expo/eas-cli/pull/2900) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🧹 Chores
 
 ## [15.0.9](https://github.com/expo/eas-cli/releases/tag/v15.0.9) - 2025-02-09

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -182,7 +182,19 @@ export default class GitClient extends Client {
       await setGitCaseSensitivityAsync(true, rootPath);
       await spawnAsync(
         'git',
-        ['clone', '--no-hardlinks', '--depth', '1', gitRepoUri, destinationPath],
+        [
+          'clone',
+          // If we do not require a commit, we are going to later
+          // copy the working directory into the destination path,
+          // so we can skip the checkout step (which also adds files
+          // that have been removed in the working directory).
+          this.requireCommit ? null : '--no-checkout',
+          '--no-hardlinks',
+          '--depth',
+          '1',
+          gitRepoUri,
+          destinationPath,
+        ].flatMap(e => e ?? []),
         { cwd: rootPath }
       );
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When we `git clone` the source repository and then copy worktree changes over, we add and modify files. However, we do not _delete_ files that have been deleted in worktree.

# How

When we operate in `requireCommit: false` mode, we add `--no-checkout` to the `git clone` command. This way the destination directory only has `.git` directory when we start copying files over. Thus, files deleted from worktree will not suddenly appear in tarball.

In `requireCommit: true` mode we don't add `--no-checkout`, because we don't copy files.

# Test Plan

Added test. Tested manually.

Side effect of this is that `git status` reports that all files have been deleted and there's a bunch of untracked files (which, `git add`-ed, make the repository appear as the source repo). I don't know how to copy the Git index 1-1…