### PR TITLE
[eas-cli] Narrow amount of data queried for basic update channel operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Narrow amount of data queried for basic update channel operations. ([#2901](https://github.com/expo/eas-cli/pull/2901) by [@wschurman](https://github.com/wschurman))
+
 ## [15.0.10](https://github.com/expo/eas-cli/releases/tag/v15.0.10) - 2025-02-11
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -60915,12 +60915,6 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "GITHUB",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "GITHUB_PULL_REQUEST_OPENED",
             "description": null,
             "isDeprecated": false,

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -289,7 +289,7 @@ export async function doesChannelExistAsync(
   { appId, channelName }: { appId: string; channelName: string }
 ): Promise<boolean> {
   try {
-    await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+    await ChannelQuery.viewUpdateChannelBasicInfoAsync(graphqlClient, {
       appId,
       channelName,
     });

--- a/packages/eas-cli/src/commands/channel/delete.ts
+++ b/packages/eas-cli/src/commands/channel/delete.ts
@@ -52,7 +52,7 @@ export default class ChannelDelete extends EasCommand {
 
     let channelId, channelName;
     if (nameArg) {
-      const { id, name } = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      const { id, name } = await ChannelQuery.viewUpdateChannelBasicInfoAsync(graphqlClient, {
         appId: projectId,
         channelName: nameArg,
       });

--- a/packages/eas-cli/src/commands/channel/edit.ts
+++ b/packages/eas-cli/src/commands/channel/edit.ts
@@ -94,7 +94,7 @@ export default class ChannelEdit extends EasCommand {
     }
 
     const existingChannel = args.name
-      ? await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      ? await ChannelQuery.viewUpdateChannelBasicInfoAsync(graphqlClient, {
           appId: projectId,
           channelName: args.name,
         })

--- a/packages/eas-cli/src/commands/channel/pause.ts
+++ b/packages/eas-cli/src/commands/channel/pause.ts
@@ -86,7 +86,7 @@ export default class ChannelPause extends EasCommand {
     }
 
     const existingChannel = args.name
-      ? await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      ? await ChannelQuery.viewUpdateChannelBasicInfoAsync(graphqlClient, {
           appId: projectId,
           channelName: args.name,
         })

--- a/packages/eas-cli/src/commands/channel/resume.ts
+++ b/packages/eas-cli/src/commands/channel/resume.ts
@@ -86,7 +86,7 @@ export default class ChannelResume extends EasCommand {
     }
 
     const existingChannel = args.name
-      ? await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+      ? await ChannelQuery.viewUpdateChannelBasicInfoAsync(graphqlClient, {
           appId: projectId,
           channelName: args.name,
         })

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -8570,7 +8570,6 @@ export enum WorkflowRunStatus {
 }
 
 export enum WorkflowRunTriggerEventType {
-  Github = 'GITHUB',
   GithubPullRequestOpened = 'GITHUB_PULL_REQUEST_OPENED',
   GithubPullRequestReopened = 'GITHUB_PULL_REQUEST_REOPENED',
   GithubPullRequestSynchronize = 'GITHUB_PULL_REQUEST_SYNCHRONIZE',
@@ -9473,6 +9472,14 @@ export type ViewBuildsOnAppQueryVariables = Exact<{
 
 
 export type ViewBuildsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, builds: Array<{ __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string }, metrics?: { __typename?: 'BuildMetrics', buildWaitTime?: number | null, buildQueueTime?: number | null, buildDuration?: number | null } | null }> } } };
+
+export type ViewUpdateChannelBasicInfoOnAppQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+  channelName: Scalars['String']['input'];
+}>;
+
+
+export type ViewUpdateChannelBasicInfoOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } | null } } };
 
 export type ViewUpdateChannelOnAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

As we've added more features, we've added more fetched data to the default fragments (UpdateFragment). But a lot of callsites don't need all the data. This PR adds a new basic query for getting just the basic info (similar to other query below).

# How

Add new query, replace callsites that can be replaces (rely on tsc to tell me)

# Test Plan

`yarn tsc`
