### PR TITLE
[eas-cli] Use Git to resolve root path in no-VCS mode

### DIFF
--- a/packages/eas-cli/src/vcs/clients/__tests__/noVcs.test.ts
+++ b/packages/eas-cli/src/vcs/clients/__tests__/noVcs.test.ts
@@ -1,0 +1,44 @@
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import NoVcsClient from '../noVcs';
+
+describe('noVcs', () => {
+  describe('NoVcsClient', () => {
+    let vcs: NoVcsClient;
+    let repoRoot: string;
+    let globalEasProjectRoot: string | undefined;
+
+    afterAll(async () => {
+      await fs.rm(repoRoot, { recursive: true, force: true });
+      process.env.EAS_PROJECT_ROOT = globalEasProjectRoot;
+    });
+
+    beforeAll(async () => {
+      repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+
+      vcs = new NoVcsClient({ cwdOverride: repoRoot });
+      globalEasProjectRoot = process.env.EAS_PROJECT_ROOT;
+      delete process.env.EAS_PROJECT_ROOT;
+    });
+
+    it('should return the current working directory when not in Git repository', async () => {
+      expect(await vcs.getRootPathAsync()).toBe(process.cwd());
+    });
+
+    it('should return the Git root when in Git repository', async () => {
+      await spawnAsync('git', ['init'], { cwd: repoRoot });
+      expect(await fs.realpath(await vcs.getRootPathAsync())).toBe(await fs.realpath(repoRoot));
+    });
+
+    it('should return the project root when EAS_PROJECT_ROOT is set', async () => {
+      process.env.EAS_PROJECT_ROOT = 'project-root';
+      expect(await vcs.getRootPathAsync()).toBe(path.resolve(process.cwd(), 'project-root'));
+
+      process.env.EAS_PROJECT_ROOT = '/app';
+      expect(await vcs.getRootPathAsync()).toBe('/app');
+    });
+  });
+});

--- a/packages/eas-cli/src/vcs/clients/noVcs.ts
+++ b/packages/eas-cli/src/vcs/clients/noVcs.ts
@@ -1,18 +1,53 @@
-import { Ignore, getRootPath, makeShallowCopyAsync } from '../local';
+import spawnAsync from '@expo/spawn-async';
+import path from 'path';
+
+import Log from '../../log';
+import { Ignore, makeShallowCopyAsync } from '../local';
 import { Client } from '../vcs';
 
 export default class NoVcsClient extends Client {
+  private readonly cwdOverride?: string;
+
+  constructor(options: { cwdOverride?: string } = {}) {
+    super();
+    this.cwdOverride = options.cwdOverride;
+  }
+
   public async getRootPathAsync(): Promise<string> {
-    return getRootPath();
+    // Honor `EAS_PROJECT_ROOT` if it is set.
+    if (process.env.EAS_PROJECT_ROOT) {
+      const rootPath = process.env.EAS_PROJECT_ROOT;
+      // `path.resolve()` will return `rootPath` if it is absolute
+      // (which is what we want).
+      return path.resolve(process.cwd(), rootPath);
+    }
+
+    // If `EAS_PROJECT_ROOT` is not set, try to get the root path from Git.
+    try {
+      return (
+        await spawnAsync('git', ['rev-parse', '--show-toplevel'], {
+          cwd: this.cwdOverride,
+        })
+      ).stdout.trim();
+    } catch (err) {
+      Log.warn(`Failed to get Git root path with \`git rev-parse --show-toplevel\`.`, err);
+      Log.warn('Falling back to using current working directory as project root.');
+      Log.warn(
+        'You can set `EAS_PROJECT_ROOT` environment variable to let eas-cli know where your project is located.'
+      );
+
+      return process.cwd();
+    }
   }
 
   public async makeShallowCopyAsync(destinationPath: string): Promise<void> {
-    const srcPath = getRootPath();
+    const srcPath = path.normalize(await this.getRootPathAsync());
     await makeShallowCopyAsync(srcPath, destinationPath);
   }
 
   public override async isFileIgnoredAsync(filePath: string): Promise<boolean> {
-    const ignore = await Ignore.createAsync(getRootPath());
+    const rootPath = path.normalize(await this.getRootPathAsync());
+    const ignore = await Ignore.createAsync(rootPath);
     return ignore.ignores(filePath);
   }
 

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -14,14 +14,6 @@ const DEFAULT_IGNORE = `
 node_modules
 `;
 
-export function getRootPath(): string {
-  const rootPath = process.env.EAS_PROJECT_ROOT ?? process.cwd();
-  if (!path.isAbsolute(rootPath)) {
-    return path.resolve(process.cwd(), rootPath);
-  }
-  return rootPath;
-}
-
 /**
  * Ignore wraps the 'ignore' package to support multiple .gitignore files
  * in subdirectories.


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I was thinking we can offer `EAS_NO_VCS=1` as a simple escape hatch for people that are getting weird Git-related issues. One of them may be an old version of Git that does not support our `git clone` properly.

# How

In `getRootPath` of no-VCS mode, return first of those values (in order):
- `EAS_PROJECT_ROOT`
- Git root path
- `process.cwd()`

# Test Plan

Added a basic test.