### PR TITLE
Clarify error message regarding ignored files

### DIFF
--- a/packages/eas-cli/src/project/customBuildConfig.ts
+++ b/packages/eas-cli/src/project/customBuildConfig.ts
@@ -37,7 +37,7 @@ export async function validateCustomBuildConfigAsync({
     throw new Error(
       `Custom build configuration file ${chalk.bold(
         relativeConfigPath
-      )} is ignored by your version control system. Remove it from the ignore list to successfully create custom build.`
+      )} is ignored by your version control system or .easignore. Remove it from the ignore list to successfully create custom build.`
     );
   }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I struggled with adding a new workflow within `.eas/build` since I had `build/` in my `.gitignore`. I removed the line but it was still an issue. Turns out I had the same thing in `.easignore`. I think adding this to the error message could be helpful for others

# How

Not tested

