### PR TITLE
fix(submit): Fix TestFlight internal group creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix internal TestFlight group creation. ([#2906](https://github.com/expo/eas-cli/pull/2906) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🧹 Chores
 
 ## [15.0.9](https://github.com/expo/eas-cli/releases/tag/v15.0.9) - 2025-02-09

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "2.1.6",
+    "@expo/apple-utils": "2.1.9",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "10.0.6",
     "@expo/config-plugins": "9.0.12",

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureTestFlightGroup.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureTestFlightGroup.ts
@@ -37,8 +37,6 @@ async function ensureInternalGroupAsync(app: App): Promise<BetaGroup> {
         async () => {
           betaGroup = await app.createBetaGroupAsync({
             name: AUTO_GROUP_NAME,
-            publicLinkEnabled: false,
-            publicLinkLimitEnabled: false,
             isInternalGroup: true,
             // Automatically add latest builds to the group without needing to run the command.
             hasAccessToAllBuilds: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@expo/apple-utils@2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.6.tgz#293fafccffd9afa24c9992963d74052558d5c5a1"
-  integrity sha512-6UkfLL/1AIRa082rlh26WG2K5Hzd67c8CIdNlHvrFmMEHlGl1PcVFZoUnNRFEROeTmrXW5/Sv4gJfmLXLTq3cQ==
+"@expo/apple-utils@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.9.tgz#f036709cc0676ed3fc7415da08c5f026f55d54bd"
+  integrity sha512-d3g7uslMS77FfgsNWADJb/rGn8s2L0RfNPIKJLQJNfWtf8PBUnk7Oa1SkPELeVTWP/SHOXUTtxh8gNlXYTVzSQ==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

- Looks like the internal group API changed recently with v3.8.0 https://github.com/EvanBacon/App-Store-Connect-OpenAPI-Spec/pull/25
- We now get an error:
```
Failed to create an internal TestFlight group. This can be done manually in the App Store Connect website.
UnexpectedAppleResponse: The provided entity includes an attribute with an invalid value - Public link limit cannot be applied to internal group
```
- Removing the extra properties may fix this, hard to explicitly verify.

# How

- Ensure the external TestFlight properties are removed when creating an internal group.

# Test Plan

- `easd submit -p ios` -> creates TF internal group without throwing an error.