### PR TITLE
[eas-cli] lowercase urls, add more pretty prints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Narrow amount of data queried for basic update channel operations. ([#2901](https://github.com/expo/eas-cli/pull/2901) by [@wschurman](https://github.com/wschurman))
 - Fix `eas fingerprint:compare` description. ([#2908](https://github.com/expo/eas-cli/pull/2908) by [@quinlanj](https://github.com/quinlanj))
+- Fix `eas fingerprint:compare` URL generation and pretty prints. ([#2909](https://github.com/expo/eas-cli/pull/2909) by [@quinlanj](https://github.com/quinlanj))
 
 ## [15.0.10](https://github.com/expo/eas-cli/releases/tag/v15.0.10) - 2025-02-11
 

--- a/packages/eas-cli/src/commands/fingerprint/compare.ts
+++ b/packages/eas-cli/src/commands/fingerprint/compare.ts
@@ -740,7 +740,7 @@ const PRETTY_CONTENT_ID: Record<string, string> = {
   'expoAutolinkingConfig:android': 'Expo autolinking config (Android)',
   'packageJson:scripts': 'package.json scripts',
   expoConfig: 'Expo app config',
-  'package:react-native': 'React native package.json',
+  'package:react-native': 'React Native package.json',
   'rncoreAutolinkingConfig:ios': 'React Native Community autolinking config (iOS)',
   'rncoreAutolinkingConfig:android': 'React Native Community autolinking config (Android)',
 };

--- a/packages/eas-cli/src/commands/fingerprint/compare.ts
+++ b/packages/eas-cli/src/commands/fingerprint/compare.ts
@@ -238,7 +238,7 @@ export default class FingerprintCompare extends EasCommand {
 
     const project = await AppQuery.byIdAsync(graphqlClient, projectId);
     const fingerprintCompareUrl = new URL(
-      `/accounts/${project.ownerAccount.name}/projects/${project.name}/fingerprints/compare`,
+      `/accounts/${project.ownerAccount.name.toLowerCase()}/projects/${project.name.toLowerCase()}/fingerprints/compare`,
       getExpoWebsiteBaseUrl()
     );
     fingerprintCompareUrl.searchParams.set('a', firstFingerprintInfo.fingerprint.hash);
@@ -528,7 +528,7 @@ async function getFingerprintInfoFromUpdateGroupIdOrUpdateIdAsync(
       const project = await AppQuery.byIdAsync(graphqlClient, projectId);
       const updateUrl =
         getExpoWebsiteBaseUrl() +
-        `/accounts/${project.ownerAccount.name}/projects/${project.name}/updates/${maybeUpdateGroupId}`;
+        `/accounts/${project.ownerAccount.name.toLowerCase()}/projects/${project.name.toLowerCase()}/updates/${maybeUpdateGroupId}`;
       throw new Error(
         `Please pass in your update ID from ${updateUrl} or use interactive mode to select the update ID.`
       );
@@ -739,7 +739,10 @@ const PRETTY_CONTENT_ID: Record<string, string> = {
   'expoAutolinkingConfig:ios': 'Expo autolinking config (iOS)',
   'expoAutolinkingConfig:android': 'Expo autolinking config (Android)',
   'packageJson:scripts': 'package.json scripts',
-  expoConfig: 'Expo config',
+  expoConfig: 'Expo app config',
+  'package:react-native': 'React native package.json',
+  'rncoreAutolinkingConfig:ios': 'React Native Community autolinking config (iOS)',
+  'rncoreAutolinkingConfig:android': 'React Native Community autolinking config (Android)',
 };
 
 function printContentSource({

--- a/packages/eas-cli/src/commands/fingerprint/compare.ts
+++ b/packages/eas-cli/src/commands/fingerprint/compare.ts
@@ -238,7 +238,7 @@ export default class FingerprintCompare extends EasCommand {
 
     const project = await AppQuery.byIdAsync(graphqlClient, projectId);
     const fingerprintCompareUrl = new URL(
-      `/accounts/${project.ownerAccount.name.toLowerCase()}/projects/${project.name.toLowerCase()}/fingerprints/compare`,
+      `/accounts/${project.ownerAccount.name}/projects/${project.slug}/fingerprints/compare`,
       getExpoWebsiteBaseUrl()
     );
     fingerprintCompareUrl.searchParams.set('a', firstFingerprintInfo.fingerprint.hash);
@@ -528,7 +528,7 @@ async function getFingerprintInfoFromUpdateGroupIdOrUpdateIdAsync(
       const project = await AppQuery.byIdAsync(graphqlClient, projectId);
       const updateUrl =
         getExpoWebsiteBaseUrl() +
-        `/accounts/${project.ownerAccount.name.toLowerCase()}/projects/${project.name.toLowerCase()}/updates/${maybeUpdateGroupId}`;
+        `/accounts/${project.ownerAccount.name}/projects/${project.slug}/updates/${maybeUpdateGroupId}`;
       throw new Error(
         `Please pass in your update ID from ${updateUrl} or use interactive mode to select the update ID.`
       );


### PR DESCRIPTION
# Why

The current fingerprint comparison URLs and content identifiers need improvements:
1. URLs should be case-insensitive to match Expo's website behavior
2. Content identifiers need clearer labels and additional React Native specific entries

# How

- Modified URL generation to lowercase account and project names for consistency
- Updated and added new content identifier labels:
  - Renamed "Expo config" to "Expo app config" for clarity
  - Added entries for React Native package.json
  - Added entries for React Native Community autolinking configs

# Test Plan

Ran `eas fingerprint:compare` to ensure:
1. fingerprint comparison URLs work with mixed case account/project names
2. Verify content identifiers display correctly 