### PR TITLE
[eas-cli] fix formatFields to handle empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Fix `eas fingerprint:compare` URL generation and pretty prints. ([#2909](https://github.com/expo/eas-cli/pull/2909) by [@quinlanj](https://github.com/quinlanj))
+- fix formatFields to handle empty array. ([#2914](https://github.com/expo/eas-cli/pull/2914) by [@quinlanj](https://github.com/quinlanj))
 
 ## [15.0.12](https://github.com/expo/eas-cli/releases/tag/v15.0.12) - 2025-02-22
 

--- a/packages/eas-cli/src/utils/formatFields.ts
+++ b/packages/eas-cli/src/utils/formatFields.ts
@@ -10,6 +10,10 @@ export default function formatFields(
   fields: FormatFieldsItem[],
   options: FormatFieldsOptions = { labelFormat: chalk.dim }
 ): string {
+  if (fields.length === 0) {
+    return '';
+  }
+
   const columnWidth = fields.reduce((a, b) => (a.label.length > b.label.length ? a : b)).label
     .length;
 


### PR DESCRIPTION
# Why

When formatting fields with an empty array, the code would attempt to find the maximum label length, causing an error when reducing an empty array (`Reduce of empty array with no initial value`). This needs to be fixed to handle empty arrays gracefully.

# How

Added an early return statement that checks if the input fields array is empty, returning an empty string before attempting to calculate the column width.

# Test Plan

- [ ] Ran into the empty array case by running `EXPO_STAGING=1 ~/Documents/eas-cli/packages/eas-cli/bin/run fingerprint:compare 796b89315aeaa4b466aa3ac6c2dcff5cf9ed4c8e d5de1b929c0346251e400eed13205fda4eaf51bf`
