### PR TITLE
[eas-cli] fix git diff header in fingerprint:compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Fix `eas fingerprint:compare` URL generation and pretty prints. ([#2909](https://github.com/expo/eas-cli/pull/2909) by [@quinlanj](https://github.com/quinlanj))
 - fix formatFields to handle empty array. ([#2914](https://github.com/expo/eas-cli/pull/2914) by [@quinlanj](https://github.com/quinlanj))
+- fix git diff header in `fingerprint:compare`. ([#2915](https://github.com/expo/eas-cli/pull/2915) by [@quinlanj](https://github.com/quinlanj))
 
 ## [15.0.12](https://github.com/expo/eas-cli/releases/tag/v15.0.12) - 2025-02-22
 

--- a/packages/eas-cli/src/utils/__tests__/fingerprintDiff-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/fingerprintDiff-test.ts
@@ -22,7 +22,7 @@ describe('abridgedDiff', () => {
     abridgedDiff(str1, str2, 1);
 
     const expectedOutput = [
-      'cyan(@@ -2,1 +2,1 @@)',
+      'cyan(@@ -1,3 +1,3 @@)',
       ' gray(Line1)',
       'red(-Line2)',
       'green(+LineX)',
@@ -106,7 +106,7 @@ describe('abridgedDiff', () => {
     abridgedDiff(str1, str2, 1);
 
     const expectedOutput = [
-      'cyan(@@ -3,1 +3,1 @@)',
+      'cyan(@@ -2,3 +2,3 @@)',
       ' gray(Line1)',
       'red(-Line2)',
       'green(+LineX)',

--- a/packages/eas-cli/src/utils/fingerprintDiff.ts
+++ b/packages/eas-cli/src/utils/fingerprintDiff.ts
@@ -52,8 +52,13 @@ export function abridgedDiff(str1: string, str2: string, contextLines: number = 
 
   const flushChunk = (): void => {
     if (currentChunk.length > 0) {
-      const originalRange = `${startOriginal},${removedLines || 0}`;
-      const modifiedRange = `${startModified},${addedLines || 0}`;
+      const contextLines = currentChunkPriorContext.length + currentChunkAfterContext.length;
+      const originalRange = `${(startOriginal ?? 1) - currentChunkPriorContext.length},${
+        contextLines + removedLines
+      }`;
+      const modifiedRange = `${(startModified ?? 1) - currentChunkPriorContext.length},${
+        contextLines + addedLines
+      }`;
       // `git diff` style header
       output.push(chalk.cyan(`@@ -${originalRange} +${modifiedRange} @@`));
       output.push(...currentChunkPriorContext);


### PR DESCRIPTION
# Why

The current git-style diff output in the fingerprint diff utility shows incorrect line numbers in the chunk headers. This affects the readability and accuracy of diff representations when comparing fingerprints.

# How

Updated the chunk header calculation in `fingerprintDiff.ts` to properly account for context lines when determining the line ranges. The fix adjusts both the starting position and total line count by incorporating the context lines in the calculations.

The changes ensure that:
- Starting positions are offset by the number of prior context lines
- Total line counts include both context lines and modified lines
- Default starting position is 1 when undefined

# Test Plan

- [ ] Ran `EXPO_STAGING=1 ~/Documents/eas-cli/packages/eas-cli/bin/run fingerprint:compare 796b89315aeaa4b466aa3ac6c2dcff5cf9ed4c8e d5de1b929c0346251e400eed13205fda4eaf51bf` and ensure diff header is correct