### PR TITLE
[eas-cli] amend fingerprint compare url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Fix `eas fingerprint:compare` URL generation and pretty prints. ([#2909](https://github.com/expo/eas-cli/pull/2909) by [@quinlanj](https://github.com/quinlanj))
 - fix formatFields to handle empty array. ([#2914](https://github.com/expo/eas-cli/pull/2914) by [@quinlanj](https://github.com/quinlanj))
 - fix git diff header in `fingerprint:compare`. ([#2915](https://github.com/expo/eas-cli/pull/2915) by [@quinlanj](https://github.com/quinlanj))
+- amend fingerprint compare url. ([#2923](https://github.com/expo/eas-cli/pull/2923) by [@quinlanj](https://github.com/quinlanj))
 
 ## [15.0.12](https://github.com/expo/eas-cli/releases/tag/v15.0.12) - 2025-02-22
 

--- a/packages/eas-cli/src/commands/fingerprint/compare.ts
+++ b/packages/eas-cli/src/commands/fingerprint/compare.ts
@@ -238,11 +238,9 @@ export default class FingerprintCompare extends EasCommand {
 
     const project = await AppQuery.byIdAsync(graphqlClient, projectId);
     const fingerprintCompareUrl = new URL(
-      `/accounts/${project.ownerAccount.name}/projects/${project.slug}/fingerprints/compare`,
+      `/accounts/${project.ownerAccount.name}/projects/${project.slug}/fingerprints/compare/${firstFingerprintInfo.fingerprint.hash}/${secondFingerprintInfo.fingerprint.hash}`,
       getExpoWebsiteBaseUrl()
     );
-    fingerprintCompareUrl.searchParams.set('a', firstFingerprintInfo.fingerprint.hash);
-    fingerprintCompareUrl.searchParams.set('b', secondFingerprintInfo.fingerprint.hash);
 
     if (!open) {
       Log.newLine();


### PR DESCRIPTION
# before merging

- [x] land https://github.com/expo/universe/pull/18898

# Why

Updates the fingerprint comparison URL structure to use path parameters instead of query parameters, making it consistent with the new URL format on the Expo website.

# How

Modified the URL construction in the fingerprint comparison command to include the fingerprint hashes directly in the path instead of as search parameters. The new format follows the pattern:
`/accounts/{account}/projects/{project}/fingerprints/compare/{firstHash}/{secondHash}`

# Test Plan

Ran `fingerprint:compare` with and without the `--open` flag

Example:
```bash
$ eas fingerprint compare first-hash second-hash
# Should generate URL: /accounts/user/projects/app/fingerprints/compare/first-hash/second-hash
```