### PR TITLE
[eas-cli] improve applicationIdSuffix error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - Fix `eas fingerprint:compare` URL generation and pretty prints. ([#2909](https://github.com/expo/eas-cli/pull/2909) by [@quinlanj](https://github.com/quinlanj))
 - fix formatFields to handle empty array. ([#2914](https://github.com/expo/eas-cli/pull/2914) by [@quinlanj](https://github.com/quinlanj))
 - fix git diff header in `fingerprint:compare`. ([#2915](https://github.com/expo/eas-cli/pull/2915) by [@quinlanj](https://github.com/quinlanj))
+- improve error message for `applicationIdSuffix`. ([#2924](https://github.com/expo/eas-cli/pull/2924) by [@kadikraman](https://github.com/kadikraman))
 
 ## [15.0.12](https://github.com/expo/eas-cli/releases/tag/v15.0.12) - 2025-02-22
 

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -75,7 +75,9 @@ export async function getApplicationIdFromBareAsync(
       gradleContext.flavor
     );
     if (applicationIdSuffix) {
-      throw new Error('"applicationIdSuffix" in app/build.gradle is not supported, configure the full application ID under productFlavors.');
+      throw new Error(
+        '"applicationIdSuffix" in app/build.gradle is not supported, configure the full application ID under productFlavors.'
+      );
     }
     const applicationId = gradleUtils.resolveConfigValue(
       buildGradle,
@@ -89,7 +91,9 @@ export async function getApplicationIdFromBareAsync(
     const buildGradle = await fs.readFile(buildGradlePath, 'utf8');
     const matchResult = buildGradle.match(/applicationId ['"](.*)['"]/);
     if (buildGradle.match(/applicationIdSuffix/)) {
-      throw new Error('"applicationIdSuffix" in app/build.gradle is not supported, configure the full application ID under productFlavors.');
+      throw new Error(
+        '"applicationIdSuffix" in app/build.gradle is not supported, configure the full application ID under productFlavors.'
+      );
     }
     if (buildGradle.match(/productFlavors/)) {
       throw new AmbiguousApplicationIdError(

--- a/packages/eas-cli/src/project/android/applicationId.ts
+++ b/packages/eas-cli/src/project/android/applicationId.ts
@@ -75,7 +75,7 @@ export async function getApplicationIdFromBareAsync(
       gradleContext.flavor
     );
     if (applicationIdSuffix) {
-      throw new Error('"applicationIdSuffix" in app/build.gradle is not supported.');
+      throw new Error('"applicationIdSuffix" in app/build.gradle is not supported, configure the full application ID under productFlavors.');
     }
     const applicationId = gradleUtils.resolveConfigValue(
       buildGradle,
@@ -89,7 +89,7 @@ export async function getApplicationIdFromBareAsync(
     const buildGradle = await fs.readFile(buildGradlePath, 'utf8');
     const matchResult = buildGradle.match(/applicationId ['"](.*)['"]/);
     if (buildGradle.match(/applicationIdSuffix/)) {
-      throw new Error('"applicationIdSuffix" in app/build.gradle is not supported.');
+      throw new Error('"applicationIdSuffix" in app/build.gradle is not supported, configure the full application ID under productFlavors.');
     }
     if (buildGradle.match(/productFlavors/)) {
       throw new AmbiguousApplicationIdError(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When building bare RN projects with EAS CLI with `applicationIdSuffix`, the CLI will error due to being unable to determine the application ID from the `build.gradle`. The workaround for this is not obvious.

# How

Update the error message to suggest adding the full application ID in `productFlavors` which is the simplest workaround.

# Test Plan

Verified locally.
