### PR TITLE
[eas-cli] Fix `.git` x `.easignore` interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fixed `.git` being always unexpectedly removed if you had `requireCommit: true` and `.easignore` present. ([#2925](https://github.com/expo/eas-cli/pull/2925) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🧹 Chores
 
 - Fix `eas fingerprint:compare` URL generation and pretty prints. ([#2909](https://github.com/expo/eas-cli/pull/2909) by [@quinlanj](https://github.com/quinlanj))

--- a/packages/eas-cli/src/vcs/__tests__/local-test.ts
+++ b/packages/eas-cli/src/vcs/__tests__/local-test.ts
@@ -18,7 +18,7 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = await Ignore.createAsync('/root');
+    const ignore = await Ignore.createForCopyingAsync('/root');
     expect(ignore.ignores('aaa')).toBe(true);
     expect(ignore.ignores('bbb')).toBe(false);
     expect(ignore.ignores('dir/aaa')).toBe(true);
@@ -35,7 +35,7 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = await Ignore.createAsync('/root');
+    const ignore = await Ignore.createForCopyingAsync('/root');
     expect(ignore.ignores('aaa')).toBe(false);
     expect(ignore.ignores('bbb')).toBe(false);
     expect(ignore.ignores('ccc')).toBe(true);
@@ -52,7 +52,7 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = await Ignore.createAsync('/root');
+    const ignore = await Ignore.createForCopyingAsync('/root');
     expect(ignore.ignores('aaa')).toBe(true);
     expect(ignore.ignores('bbb')).toBe(false);
     expect(ignore.ignores('node_modules/aaa')).toBe(true);
@@ -69,15 +69,35 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = await Ignore.createAsync('/root');
+    const ignore = await Ignore.createForCopyingAsync('/root');
     expect(ignore.ignores('dir/ccc')).toBe(true);
   });
 
-  it('ignores .git', async () => {
+  it('ignores .git if copying', async () => {
     vol.fromJSON({}, '/root');
 
-    const ignore = await Ignore.createAsync('/root');
+    const ignore = await Ignore.createForCopyingAsync('/root');
     expect(ignore.ignores('.git')).toBe(true);
+  });
+  describe('for checking', () => {
+    it('does not necessarily ignore .git', async () => {
+      vol.fromJSON({}, '/root');
+
+      const ignore = await Ignore.createForCheckingAsync('/root');
+      expect(ignore.ignores('.git')).toBe(false);
+    });
+
+    it('ignores .git if present in .easignore', async () => {
+      vol.fromJSON(
+        {
+          '.easignore': '.git\n',
+        },
+        '/root'
+      );
+
+      const ignore = await Ignore.createForCheckingAsync('/root');
+      expect(ignore.ignores('.git')).toBe(true);
+    });
   });
 
   it('does not throw an error if there is a trailing backslash in the gitignore', async () => {
@@ -88,7 +108,7 @@ describe(Ignore, () => {
       '/root'
     );
 
-    const ignore = await Ignore.createAsync('/root');
+    const ignore = await Ignore.createForCopyingAsync('/root');
     expect(() => ignore.ignores('dir/test')).not.toThrowError();
   });
 });

--- a/packages/eas-cli/src/vcs/clients/__tests__/git.test.ts
+++ b/packages/eas-cli/src/vcs/clients/__tests__/git.test.ts
@@ -205,4 +205,20 @@ describe('git', () => {
       fs.stat(path.join(requireCommitClone, 'new-tracked-file.txt'))
     ).resolves.not.toThrow();
   });
+
+  it('does not allow .easignore if requireCommit is true', async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+    await spawnAsync('git', ['init'], { cwd: repoRoot });
+    const vcs = new GitClient({
+      requireCommit: true,
+      maybeCwdOverride: repoRoot,
+    });
+
+    await fs.writeFile(`${repoRoot}/.easignore`, '*easignored*\n');
+
+    await spawnAsync('git', ['add', '.'], { cwd: repoRoot });
+    await spawnAsync('git', ['commit', '-m', 'tmp commit'], { cwd: repoRoot });
+
+    await expect(vcs.makeShallowCopyAsync(repoRoot)).rejects.toThrow('Detected ".easignore" file');
+  });
 });

--- a/packages/eas-cli/src/vcs/clients/__tests__/git.test.ts
+++ b/packages/eas-cli/src/vcs/clients/__tests__/git.test.ts
@@ -157,6 +157,42 @@ describe('git', () => {
       await expect(vcs.makeShallowCopyAsync(repoCloneIgnored)).resolves.not.toThrow();
       await expect(fs.stat(path.join(repoCloneIgnored, 'results'))).rejects.toThrow('ENOENT');
     });
+
+    it('if .git is present in .easignore', async () => {
+      const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+      await spawnAsync('git', ['init'], { cwd: repoRoot });
+      const vcs = new GitClient({
+        requireCommit: false,
+        maybeCwdOverride: repoRoot,
+      });
+
+      await fs.writeFile(`${repoRoot}/.easignore`, '.git\n');
+
+      await spawnAsync('git', ['add', '.'], { cwd: repoRoot });
+      await spawnAsync('git', ['commit', '-m', 'temp commit'], { cwd: repoRoot });
+
+      const repoClone = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+      await expect(vcs.makeShallowCopyAsync(repoClone)).resolves.not.toThrow();
+      await expect(fs.stat(path.join(repoClone, '.git'))).rejects.toThrow('ENOENT');
+    });
+
+    it('if .git is not present in .easignore', async () => {
+      const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+      await spawnAsync('git', ['init'], { cwd: repoRoot });
+      const vcs = new GitClient({
+        requireCommit: false,
+        maybeCwdOverride: repoRoot,
+      });
+
+      await fs.writeFile(`${repoRoot}/.easignore`, '');
+
+      await spawnAsync('git', ['add', '.'], { cwd: repoRoot });
+      await spawnAsync('git', ['commit', '-m', 'temp commit'], { cwd: repoRoot });
+
+      const repoClone = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+      await expect(vcs.makeShallowCopyAsync(repoClone)).resolves.not.toThrow();
+      await expect(fs.readdir(path.join(repoClone, '.git'))).resolves.toBeDefined();
+    });
   });
 
   it('does not include files that have been removed in the working directory', async () => {

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -163,6 +163,21 @@ export default class GitClient extends Client {
     }
 
     const rootPath = await this.getRootPathAsync();
+    const sourceEasignorePath = path.join(rootPath, EASIGNORE_FILENAME);
+    const doesEasignoreExist = await fs.exists(sourceEasignorePath);
+    if (this.requireCommit && doesEasignoreExist) {
+      Log.error(
+        `".easignore" file is not supported if you also have "requireCommit" set to "true" in "eas.json".`
+      );
+      Log.error(
+        `Remove "${sourceEasignorePath}" and use ".gitignore" instead. ${learnMore(
+          'https://expo.fyi/eas-build-archive'
+        )}`
+      );
+      throw new Error(
+        `Detected ".easignore" file ${sourceEasignorePath} while in "requireCommit = true" mode.`
+      );
+    }
 
     let gitRepoUri;
     if (process.platform === 'win32') {

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -253,7 +253,9 @@ export default class GitClient extends Client {
         );
 
         // Special-case `.git` which `git ls-files` will never consider ignored.
-        const ignore = await Ignore.createAsync(rootPath);
+        // We don't want to ignore anything by default. We want to know what does
+        // the user want to ignore.
+        const ignore = await Ignore.createForCheckingAsync(rootPath);
         if (ignore.ignores('.git')) {
           await fs.rm(path.join(destinationPath, '.git'), { recursive: true, force: true });
           Log.debug('deleted .git', {
@@ -356,7 +358,7 @@ export default class GitClient extends Client {
 
     const easIgnorePath = path.join(rootPath, EASIGNORE_FILENAME);
     if (await fs.exists(easIgnorePath)) {
-      const ignore = await Ignore.createAsync(rootPath);
+      const ignore = await Ignore.createForCheckingAsync(rootPath);
       const wouldNotBeCopiedToClone = ignore.ignores(filePath);
       const wouldBeDeletedFromClone =
         (

--- a/packages/eas-cli/src/vcs/clients/noVcs.ts
+++ b/packages/eas-cli/src/vcs/clients/noVcs.ts
@@ -12,7 +12,7 @@ export default class NoVcsClient extends Client {
   }
 
   public override async isFileIgnoredAsync(filePath: string): Promise<boolean> {
-    const ignore = await Ignore.createAsync(getRootPath());
+    const ignore = await Ignore.createForCheckingAsync(getRootPath());
     return ignore.ignores(filePath);
   }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Thanks to [a conversation on Bluesky](https://bsky.app/profile/sjchmiela.bsky.social/post/3lj6k2xo7rk2g) it turned out [this check](https://github.com/expo/eas-cli/blob/3a434940eb44dfa8dddc42af055793134ca9016f/packages/eas-cli/src/vcs/clients/git.ts#L255-L257) is invalid (always true), because `Ignore` has `DEFAULT_IGNORE`, so even if a user had no `.git` in `.easignore`, especially if they had `requireCommit: true`, `.git` would be removed.

# How

- Added a check to disallow `.easignore` if one has `requireCommit: true`.
- Changed logic around `Ignore` so we have separate `createForCopying` (ignores `.git` and `node_modules` always) and `createForChecking` (does not ignore anything by default). I don't like it, but it should work and is the best of what I could come up with without further refactoring.

# Test Plan

Added more tests.