### PR TITLE
[eas-cli] suggest using eas build:dev when using simulator/emulator dev client configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Suggest using `eas build:dev` for matching configurations. ([#2929](https://github.com/expo/eas-cli/pull/2929) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [15.0.13](https://github.com/expo/eas-cli/releases/tag/v15.0.13) - 2025-03-04
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -122,6 +122,7 @@ export async function runBuildAndSubmitAsync({
   envOverride?: Env;
 }): Promise<{
   buildIds: string[];
+  buildProfiles?: ProfileData<'build'>[];
 }> {
   await vcsClient.ensureRepoExistsAsync();
   await ensureRepoIsCleanAsync(vcsClient, flags.nonInteractive);
@@ -348,6 +349,7 @@ export async function runBuildAndSubmitAsync({
   }
   return {
     buildIds: startedBuilds.map(({ build }) => build.id),
+    buildProfiles,
   };
 }
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -311,9 +311,9 @@ export default class Build extends EasCommand {
         return true;
       })
     ) {
-      Log.addNewLineIfNone();
+      Log.newLine();
       Log.log(
-        `🔎 You are using a build configuration that could benefit from using ${chalk.bold(
+        `🔎 TIP: You are using a build configuration that could benefit from using ${chalk.bold(
           'eas build:dev'
         )} command. Run it to install and run cached development build, or create a new one if a compatible build doesn't exist yet.`
       );

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -1,5 +1,5 @@
 import { Platform } from '@expo/eas-build-job';
-import { EasJsonAccessor, EasJsonUtils, ResourceClass } from '@expo/eas-json';
+import { BuildProfile, EasJsonAccessor, EasJsonUtils, ResourceClass } from '@expo/eas-json';
 import { LoggerLevel } from '@expo/logger';
 import { Errors, Flags } from '@oclif/core';
 import chalk from 'chalk';
@@ -17,6 +17,7 @@ import { RequestedPlatform, selectRequestedPlatformAsync } from '../../platform'
 import { selectAsync } from '../../prompts';
 import uniq from '../../utils/expodash/uniq';
 import { enableJsonOutput } from '../../utils/json';
+import { ProfileData } from '../../utils/profiles';
 import { maybeWarnAboutEasOutagesAsync } from '../../utils/statuspageService';
 
 interface RawBuildFlags {
@@ -160,7 +161,7 @@ export default class Build extends EasCommand {
 
     const flagsWithPlatform = await this.ensurePlatformSelectedAsync(flags);
 
-    await runBuildAndSubmitAsync({
+    const { buildProfiles } = await runBuildAndSubmitAsync({
       graphqlClient,
       analytics,
       vcsClient,
@@ -168,6 +169,11 @@ export default class Build extends EasCommand {
       flags: flagsWithPlatform,
       actor,
       getDynamicPrivateProjectConfigAsync,
+    });
+
+    this.maybeSuggestUsingEasBuildDev({
+      buildProfiles,
+      nonInteractive: flags.nonInteractive,
     });
   }
 
@@ -267,6 +273,51 @@ export default class Build extends EasCommand {
       ...flags,
       requestedPlatform,
     };
+  }
+
+  private maybeSuggestUsingEasBuildDev({
+    buildProfiles,
+    nonInteractive,
+  }: {
+    buildProfiles: ProfileData<'build'>[] | undefined;
+    nonInteractive: boolean;
+  }): void {
+    // suggest using eas build:dev if the build configuration results in simulator/emulator dev client build
+    if (
+      !nonInteractive &&
+      !process.env.CI &&
+      buildProfiles?.some(({ profile, platform }) => {
+        if (profile.developmentClient !== true) {
+          return false;
+        }
+        if (profile.distribution !== 'internal') {
+          return false;
+        }
+
+        if (platform === Platform.IOS) {
+          const iosProfile = profile as BuildProfile<Platform.IOS>;
+          if (iosProfile.simulator !== true && iosProfile.withoutCredentials !== true) {
+            return false;
+          }
+        } else {
+          const androidProfile = profile as BuildProfile<Platform.ANDROID>;
+          if (
+            androidProfile.distribution !== 'internal' &&
+            androidProfile.withoutCredentials !== true
+          ) {
+            return false;
+          }
+        }
+        return true;
+      })
+    ) {
+      Log.addNewLineIfNone();
+      Log.log(
+        `🔎 You are using a build configuration that could benefit from using ${chalk.bold(
+          'eas build:dev'
+        )} command. Run it to install and run cached development build, or create a new one if a compatible build doesn't exist yet.`
+      );
+    }
   }
 }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Suggest using `eas build:dev` if one runs `eas build` resulting in simulator/emulator dev client build.

# How

Add log to suggest using `eas build:dev`

# Test Plan

Tests