### PR TITLE
[eas-cli] use correct logic to determine whether artifacts expired in eas build:run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Use correct logic to determine whether artifacts have expired in `eas build:run` command. ([#2931](https://github.com/expo/eas-cli/pull/2931) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [15.0.14](https://github.com/expo/eas-cli/releases/tag/v15.0.14) - 2025-03-06

--- a/packages/eas-cli/src/run/utils.ts
+++ b/packages/eas-cli/src/run/utils.ts
@@ -5,7 +5,7 @@ function isAab(build: BuildFragment): boolean {
 }
 
 function didArtifactsExpire(build: BuildFragment): boolean {
-  return new Date().getTime() - new Date(build.completedAt).getTime() > 30 * 24 * 60 * 60 * 1000; // 30 days
+  return new Date().getTime() > new Date(build.expirationDate).getTime(); // 30 days
 }
 
 export function isRunnableOnSimulatorOrEmulator(build: BuildFragment): boolean {

--- a/packages/eas-cli/src/run/utils.ts
+++ b/packages/eas-cli/src/run/utils.ts
@@ -5,7 +5,7 @@ function isAab(build: BuildFragment): boolean {
 }
 
 function didArtifactsExpire(build: BuildFragment): boolean {
-  return new Date().getTime() > new Date(build.expirationDate).getTime(); // 30 days
+  return new Date().getTime() > new Date(build.expirationDate).getTime();
 }
 
 export function isRunnableOnSimulatorOrEmulator(build: BuildFragment): boolean {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Fixes https://github.com/expo/eas-cli/issues/2919

We indeed use legacy logic for determining whether artifact has expired.

# How

Let's use build.expiredAt

# Test Plan

Tests
