### PR TITLE
[eas-cli] Pass through the updates version to setUpdatesConfigAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Pass through the updates version to setUpdatesConfigAsync
+- Pass through the updates version to `setUpdatesConfigAsync`, which expects it in order to determine which field values to use. ([#2934](https://github.com/expo/eas-cli/pull/2934) by [@brentvatne](https://github.com/brentvatne)).
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Pass through the updates version to setUpdatesConfigAsync
+
 ### 🧹 Chores
 
 ## [15.0.14](https://github.com/expo/eas-cli/releases/tag/v15.0.14) - 2025-03-06

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -88,7 +88,7 @@ export function isUsingEASUpdate(exp: ExpoConfig, projectId: string): boolean {
   return exp.updates?.url === getEASUpdateURL(projectId);
 }
 
-async function getExpoUpdatesPackageVersionIfInstalledAsync(
+export async function getExpoUpdatesPackageVersionIfInstalledAsync(
   projectDir: string
 ): Promise<string | null> {
   const maybePackageJson = resolveFrom.silent(projectDir, 'expo-updates/package.json');

--- a/packages/eas-cli/src/update/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/android/UpdatesModule.ts
@@ -3,7 +3,10 @@ import { AndroidConfig, AndroidManifest, XML } from '@expo/config-plugins';
 import { Env, Workflow } from '@expo/eas-build-job';
 
 import { RequestedPlatform } from '../../platform';
-import { getExpoUpdatesPackageVersionIfInstalledAsync, isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from '../../project/projectUtils';
+import {
+  getExpoUpdatesPackageVersionIfInstalledAsync,
+  isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync,
+} from '../../project/projectUtils';
 import { expoUpdatesCommandAsync } from '../../utils/expoUpdatesCli';
 import { ensureValidVersions } from '../utils';
 

--- a/packages/eas-cli/src/update/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/android/UpdatesModule.ts
@@ -3,7 +3,7 @@ import { AndroidConfig, AndroidManifest, XML } from '@expo/config-plugins';
 import { Env, Workflow } from '@expo/eas-build-job';
 
 import { RequestedPlatform } from '../../platform';
-import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from '../../project/projectUtils';
+import { getExpoUpdatesPackageVersionIfInstalledAsync, isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from '../../project/projectUtils';
 import { expoUpdatesCommandAsync } from '../../utils/expoUpdatesCli';
 import { ensureValidVersions } from '../utils';
 
@@ -32,13 +32,16 @@ export async function syncUpdatesConfigurationAsync({
     return;
   }
 
+  const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(projectDir);
+
   // sync AndroidManifest.xml
   const androidManifestPath = await AndroidConfig.Paths.getAndroidManifestAsync(projectDir);
   const androidManifest = await getAndroidManifestAsync(projectDir);
   const updatedAndroidManifest = await AndroidConfig.Updates.setUpdatesConfigAsync(
     projectDir,
     exp,
-    androidManifest
+    androidManifest,
+    expoUpdatesPackageVersion
   );
   await AndroidConfig.Manifest.writeAndroidManifestAsync(
     androidManifestPath,

--- a/packages/eas-cli/src/update/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/ios/UpdatesModule.ts
@@ -43,7 +43,7 @@ export async function syncUpdatesConfigurationAsync({
     projectDir,
     exp,
     expoPlist,
-    expoUpdatesPackageVersion,
+    expoUpdatesPackageVersion
   );
   await writeExpoPlistAsync(vcsClient, projectDir, updatedExpoPlist);
 }

--- a/packages/eas-cli/src/update/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/ios/UpdatesModule.ts
@@ -3,7 +3,10 @@ import { IOSConfig } from '@expo/config-plugins';
 import { Env, Workflow } from '@expo/eas-build-job';
 
 import { RequestedPlatform } from '../../platform';
-import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from '../../project/projectUtils';
+import {
+  getExpoUpdatesPackageVersionIfInstalledAsync,
+  isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync,
+} from '../../project/projectUtils';
 import { expoUpdatesCommandAsync } from '../../utils/expoUpdatesCli';
 import { readPlistAsync, writePlistAsync } from '../../utils/plist';
 import { Client } from '../../vcs/vcs';
@@ -33,12 +36,14 @@ export async function syncUpdatesConfigurationAsync({
     return;
   }
 
+  const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(projectDir);
   const expoPlist = await readExpoPlistAsync(projectDir);
   // TODO(wschurman): this dependency needs to be updated for fingerprint
   const updatedExpoPlist = await IOSConfig.Updates.setUpdatesConfigAsync(
     projectDir,
     exp,
-    expoPlist
+    expoPlist,
+    expoUpdatesPackageVersion,
   );
   await writeExpoPlistAsync(vcsClient, projectDir, updatedExpoPlist);
 }


### PR DESCRIPTION
# Why

When we set updates config, the behavior will be different depending on whether there is an expo-updates package version that is passed in: https://github.com/expo/expo/blob/62af2e5c947ef53e004c3ced6f1973895f474abc/packages/%40expo/config-plugins/src/utils/Updates.ts#L157-L162 - this currently makes it so using `ON_ERROR_RECOVERY` will never work. Additionally, a fix will be required in the config plugins package to actually support `ERROR_RECOVERY_ONLY` - which was added but no conditional branch was ever made for it in the config plugin: https://github.com/expo/expo/blob/62af2e5c947ef53e004c3ced6f1973895f474abc/packages/%40expo/config-plugins/src/utils/Updates.ts#L153-L171

# How

Pass through expo-updates pkg version