### PR TITLE
[eas-cli] Add requestId to ApiV2Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add requestId to ApiV2Error. ([#2941](https://github.com/expo/eas-cli/pull/2941) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 - Use correct logic to determine whether artifacts have expired in `eas build:run` command. ([#2931](https://github.com/expo/eas-cli/pull/2931) by [@szdziedzic](https://github.com/szdziedzic))

--- a/packages/eas-cli/src/ApiV2Error.ts
+++ b/packages/eas-cli/src/ApiV2Error.ts
@@ -6,6 +6,7 @@ export class ApiV2Error extends Error {
   readonly expoApiV2ErrorDetails?: JSONValue;
   readonly expoApiV2ErrorServerStack?: string;
   readonly expoApiV2ErrorMetadata?: object;
+  readonly expoApiV2ErrorRequestId?: string;
 
   constructor(response: {
     message: string;
@@ -13,11 +14,13 @@ export class ApiV2Error extends Error {
     stack?: string;
     details?: JSONValue;
     metadata?: object;
+    requestId?: string;
   }) {
     super(response.message);
     this.expoApiV2ErrorCode = response.code;
     this.expoApiV2ErrorDetails = response.details;
     this.expoApiV2ErrorServerStack = response.stack;
     this.expoApiV2ErrorMetadata = response.metadata;
+    this.expoApiV2ErrorRequestId = response.requestId;
   }
 }

--- a/packages/eas-cli/src/__tests__/api-test.ts
+++ b/packages/eas-cli/src/__tests__/api-test.ts
@@ -16,6 +16,7 @@ describe(ApiV2Client, () => {
             stack: 'line 1: hello',
             details: { who: 'world' },
             metadata: { an: 'object' },
+            requestId: 'request-id',
           },
         ],
       });
@@ -37,6 +38,7 @@ describe(ApiV2Client, () => {
     expect(error.expoApiV2ErrorDetails).toEqual({ who: 'world' });
     expect(error.expoApiV2ErrorMetadata).toEqual({ an: 'object' });
     expect(error.expoApiV2ErrorServerStack).toEqual('line 1: hello');
+    expect(error.expoApiV2ErrorRequestId).toEqual('request-id');
   });
 
   it('does not convert non-APIv2 error to ApiV2Error', async () => {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

To better attribute reported errors to our internal API sentry, we need the request ID. This is already logged for graphql errors by EasCommand (done long ago in #1924) but we didn't have anything similar for ApiV2Error.

Closes ENG-15209.

# How

Add field.

# Test Plan

```
$ EXPO_DEBUG=1 neas login
✔ Email or username …<fake>
✔ Password … **********
Your username, email, or password was incorrect.
ApiV2Error: Your username, email, or password was incorrect. {
  expoApiV2ErrorCode: 'AUTHENTICATION_ERROR',
  expoApiV2ErrorDetails: undefined,
  expoApiV2ErrorServerStack: undefined,
  expoApiV2ErrorMetadata: undefined,
  expoApiV2ErrorRequestId: '9280b16a-9dc5-4271-8fbf-695995c4b673'
}
    Error: account:login command failed.
```
