### PR TITLE
[eas-cli] Adhere to `.easignore` even if `requireCommit` is `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- Add support for `.easignore` when `requireCommit` is set to `true`.
+  - Up to 15.0.0, if `requireCommit` was `true`, `.easignore` was silently ignored.
+  - Versions 15.0.0-15.0.13 started using `.easignore` to skip files from being bundled into a tarball when `requireCommit` was `true`. This was an unexpected change in behavior.
+  - To clear this up, versions 15.0.13-15.0.15 were erroring if `.easignore` was present when `requireCommit` was `true`.
+  - `eas-cli@16.0.0` formalizes the 15.0.0-15.0.13 behavior by adhering to `.easignore` even when `requireCommit` is set to `true`.
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
-- Add support for `.easignore` when `requireCommit` is set to `true`.
+- Add support for `.easignore` when `requireCommit` is set to `true`. ([#2942](https://github.com/expo/eas-cli/pull/2942) by [@sjchmiela](https://github.com/sjchmiela))
   - Up to 15.0.0, if `requireCommit` was `true`, `.easignore` was silently ignored.
   - Versions 15.0.0-15.0.13 started using `.easignore` to skip files from being bundled into a tarball when `requireCommit` was `true`. This was an unexpected change in behavior.
   - To clear this up, versions 15.0.13-15.0.15 were erroring if `.easignore` was present when `requireCommit` was `true`.
   - `eas-cli@16.0.0` formalizes the 15.0.0-15.0.13 behavior by adhering to `.easignore` even when `requireCommit` is set to `true`.
+  - If you know what you're doing and you want to suppress a warning printed, you can do so by setting `EAS_SUPPRESS_REQUIRE_COMMIT_EASIGNORE_WARNING` environment variable to `true`.
 
 ### 🎉 New features
 

--- a/packages/eas-cli/src/vcs/clients/__tests__/git.test.ts
+++ b/packages/eas-cli/src/vcs/clients/__tests__/git.test.ts
@@ -5,7 +5,6 @@ import path from 'path';
 
 import Log from '../../../log';
 import GitClient from '../git';
-// import getenv from 'getenv';
 
 describe('git', () => {
   describe('GitClient that does not require a commit', () => {

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -3,6 +3,7 @@ import spawnAsync from '@expo/spawn-async';
 import { Errors } from '@oclif/core';
 import chalk from 'chalk';
 import fs from 'fs-extra';
+import { boolish } from 'getenv';
 import path from 'path';
 
 import Log, { learnMore } from '../../log';
@@ -165,17 +166,10 @@ export default class GitClient extends Client {
     const rootPath = await this.getRootPathAsync();
     const sourceEasignorePath = path.join(rootPath, EASIGNORE_FILENAME);
     const doesEasignoreExist = await fs.exists(sourceEasignorePath);
-    if (this.requireCommit && doesEasignoreExist) {
-      Log.error(
-        `".easignore" file is not supported if you also have "requireCommit" set to "true" in "eas.json".`
-      );
-      Log.error(
-        `Remove "${sourceEasignorePath}" and use ".gitignore" instead. ${learnMore(
-          'https://expo.fyi/eas-build-archive'
-        )}`
-      );
-      throw new Error(
-        `Detected ".easignore" file ${sourceEasignorePath} while in "requireCommit = true" mode.`
+    const shouldSuppressWarning = boolish('EAS_SUPPRESS_REQUIRE_COMMIT_EASIGNORE_WARNING', false);
+    if (this.requireCommit && doesEasignoreExist && !shouldSuppressWarning) {
+      Log.warn(
+        `You have "requireCommit: true" in "eas.json" and also ".easignore". If ".easignore" does remove files, note that the repository checked out in EAS will not longer be Git-clean.`
       );
     }
 

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -3,7 +3,7 @@ import spawnAsync from '@expo/spawn-async';
 import { Errors } from '@oclif/core';
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import { boolish } from 'getenv';
+import getenv from 'getenv';
 import path from 'path';
 
 import Log, { learnMore } from '../../log';
@@ -18,6 +18,8 @@ import {
 } from '../git';
 import { EASIGNORE_FILENAME, Ignore, makeShallowCopyAsync } from '../local';
 import { Client } from '../vcs';
+
+let hasWarnedAboutEasignoreInRequireCommit = false;
 
 export default class GitClient extends Client {
   private readonly maybeCwdOverride?: string;
@@ -166,11 +168,14 @@ export default class GitClient extends Client {
     const rootPath = await this.getRootPathAsync();
     const sourceEasignorePath = path.join(rootPath, EASIGNORE_FILENAME);
     const doesEasignoreExist = await fs.exists(sourceEasignorePath);
-    const shouldSuppressWarning = boolish('EAS_SUPPRESS_REQUIRE_COMMIT_EASIGNORE_WARNING', false);
+    const shouldSuppressWarning =
+      hasWarnedAboutEasignoreInRequireCommit ||
+      getenv.boolish('EAS_SUPPRESS_REQUIRE_COMMIT_EASIGNORE_WARNING', false);
     if (this.requireCommit && doesEasignoreExist && !shouldSuppressWarning) {
       Log.warn(
         `You have "requireCommit: true" in "eas.json" and also ".easignore". If ".easignore" does remove files, note that the repository checked out in EAS will not longer be Git-clean.`
       );
+      hasWarnedAboutEasignoreInRequireCommit = true;
     }
 
     let gitRepoUri;


### PR DESCRIPTION
# Why

https://github.com/expo/eas-cli/pull/2925#issuecomment-2710138932

# How

Delete files from `.easignore` even if `requireCommit` is `true`. Instead of erroring, print a warning.

# Test Plan

Adjusted tests.