### PR TITLE
[ci] Pin to older tj-actions/changed-files commit.

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check if CHANGELOG.md was updated
         id: changelog-updated
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@b1ba699b304f2083b602164e06a89b868c84f076
         with:
           files: CHANGELOG.md
       - name: Fail if CHANGELOG.md was not updated and the "no changelog" label is absent


### PR DESCRIPTION
# Why

`tj-actions/changed-files` has been compromised. See discussion [here](https://github.com/tj-actions/changed-files/issues/2463).

# How

Pinned to a uncompromised commit. I've also disabled this workflow for the repo.
