### PR TITLE
[eas-cli] add support for build profiles in fingerprint generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add environment flag to `eas fingerprint:generate`([#2951](https://github.com/expo/eas-cli/pull/2951) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- Add environment flag to `eas fingerprint:generate`([#2951](https://github.com/expo/eas-cli/pull/2951) by [@quinlanj](https://github.com/quinlanj))
+- Add environment flag to `eas fingerprint:generate`. ([#2951](https://github.com/expo/eas-cli/pull/2951) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/fingerprint/compare.ts
+++ b/packages/eas-cli/src/commands/fingerprint/compare.ts
@@ -757,7 +757,7 @@ function isJSON(str: string): boolean {
   }
 }
 
-export async function selectBuildToCompareAsync(
+async function selectBuildToCompareAsync(
   graphqlClient: ExpoGraphqlClient,
   projectId: string,
   projectDisplayName: string,

--- a/packages/eas-cli/src/commands/fingerprint/generate.ts
+++ b/packages/eas-cli/src/commands/fingerprint/generate.ts
@@ -75,13 +75,9 @@ export default class FingerprintGenerate extends EasCommand {
       platform = await selectRequestedPlatformAsync();
     }
 
-    let env: Env | undefined;
-    if (environment) {
-      env = environment
-        ? { ...(await getServerSideEnvironmentVariablesAsync()), EXPO_NO_DOTENV: '1' }
-        : {};
-    }
-
+    const env = environment
+      ? { ...(await getServerSideEnvironmentVariablesAsync()), EXPO_NO_DOTENV: '1' }
+      : undefined;
     const fingerprint = await getFingerprintInfoFromLocalProjectForPlatformsAsync(
       graphqlClient,
       projectDir,

--- a/packages/eas-cli/src/commands/fingerprint/generate.ts
+++ b/packages/eas-cli/src/commands/fingerprint/generate.ts
@@ -1,4 +1,3 @@
-import { Env } from '@expo/eas-build-job';
 import { Flags } from '@oclif/core';
 
 import { getExpoWebsiteBaseUrl } from '../../api';

--- a/packages/eas-cli/src/fingerprint/cli.ts
+++ b/packages/eas-cli/src/fingerprint/cli.ts
@@ -104,19 +104,20 @@ async function createFingerprintWithoutLoggingAsync(
     fingerprintOptions.debug = true;
   }
 
-  return await withTemporaryEnv(options.env ?? {}, () =>
+  return await withTemporaryEnvAsync(options.env ?? {}, () =>
     Fingerprint.createFingerprintAsync(projectDir, fingerprintOptions)
   );
 }
 
-function withTemporaryEnv(envVars: Env, fn: () => Promise<any>): Promise<any> {
+async function withTemporaryEnvAsync(envVars: Env, fn: () => Promise<any>): Promise<any> {
   const originalEnv = { ...process.env };
-
   Object.assign(process.env, envVars);
 
-  return fn().finally(() => {
+  try {
+    return await fn();
+  } finally {
     process.env = originalEnv;
-  });
+  }
 }
 
 /**

--- a/packages/eas-cli/src/fingerprint/cli.ts
+++ b/packages/eas-cli/src/fingerprint/cli.ts
@@ -103,8 +103,20 @@ async function createFingerprintWithoutLoggingAsync(
   if (options.debug) {
     fingerprintOptions.debug = true;
   }
-  // eslint-disable-next-line @typescript-eslint/return-await
-  return await Fingerprint.createFingerprintAsync(projectDir, fingerprintOptions);
+
+  return await withTemporaryEnv(options.env ?? {}, () =>
+    Fingerprint.createFingerprintAsync(projectDir, fingerprintOptions)
+  );
+}
+
+function withTemporaryEnv(envVars: Env, fn: () => Promise<any>): Promise<any> {
+  const originalEnv = { ...process.env };
+
+  Object.assign(process.env, envVars);
+
+  return fn().finally(() => {
+    process.env = originalEnv;
+  });
 }
 
 /**

--- a/packages/eas-cli/src/fingerprint/utils.ts
+++ b/packages/eas-cli/src/fingerprint/utils.ts
@@ -15,7 +15,8 @@ export async function getFingerprintInfoFromLocalProjectForPlatformsAsync(
   projectDir: string,
   projectId: string,
   vcsClient: Client,
-  platforms: AppPlatform[]
+  platforms: AppPlatform[],
+  { env }: { env?: Record<string, string> } = {}
 ): Promise<Fingerprint> {
   const workflows = await resolveWorkflowPerPlatformAsync(projectDir, vcsClient);
   const optionsFromWorkflow = getFingerprintOptionsFromWorkflow(platforms, workflows);
@@ -24,7 +25,7 @@ export async function getFingerprintInfoFromLocalProjectForPlatformsAsync(
     ...optionsFromWorkflow,
     platforms: platforms.map(appPlatformToString),
     debug: true,
-    env: undefined,
+    env,
   });
   if (!projectFingerprint) {
     throw new Error('Project fingerprints can only be computed for projects with SDK 52 or higher');
@@ -45,6 +46,7 @@ export async function getFingerprintInfoFromLocalProjectForPlatformsAsync(
 
   return projectFingerprint;
 }
+
 function getFingerprintOptionsFromWorkflow(
   platforms: AppPlatform[],
   workflowsByPlatform: Record<Platform, Workflow>


### PR DESCRIPTION
# How you can help

This is my current understanding of how a build profile can affect a project's fingerprint. @szdziedzic and @sjchmiela, please let me know if it is correct, or if there are any nuances I am missing!

- A fingerprint contains the [following components](https://staging.expo.dev/accounts/quintest110/projects/staging-sdk-52/fingerprints/653b4ea74e6e03eda64fa4815e8a1dd8430b57ba) which we use to determine compatibility at an app's native layer
- In `eas.json`, we have a bunch of build profiles which define a bunch of parameters like build machine types, update channels, etc. However, it is the set of environment variables produced (specifying build profile parameter as input) which ultimately affects the fingerprint. **Is there any other way a build profile can affect a fingerprint?** 

For example, I can define the TEST env var to differ based on the build profile that is chosen:
<img width="930" alt="Screenshot 2025-03-18 at 3 33 58 PM" src="https://github.com/user-attachments/assets/7b6132e5-4a09-4183-ac41-566c715360e9" />

Next, I configure my `app.config.js` to determine the bundleIdentifier based on the `TEST` env var:
```
function getBundleIdentifier() {
  if (process.env.TEST === "production") {
    return "com.quintest110.stagingsdk52.production";
  } else if (process.env.TEST === "development") {
    return "com.quintest110.stagingsdk52.development";
  } else if (process.env.TEST === "preview") {
    return "com.quintest110.stagingsdk52.preview";
  }
  return "com.quintest110.stagingsdk52";
}
```

Since the fingerprint relies on the app config, I can see the fingerprint is changed when I run `eas fingerprint:generate -p ios --profile production` vs `eas fingerprint:generate -p ios --profile development` [here](https://staging.expo.dev/accounts/quintest110/projects/staging-sdk-52/fingerprints/compare/4424134ca5d1f07725826b3a5a504eba2e570379/081bce3372dff93836ff55c0344b896aebaf97ef) 

# Why
This PR adds support for build profiles in `eas fingeprint:generate` by allowing the user to pass in the `--profile` flag. 

# How
After a build profile is chosen, the cli takes the generated Env and temporarily sets those env vars while calculating the fingerprint

# Tests

- [ ] Different fingerprints with expected diffs are generated with `eas fingerprint:generate -p ios --profile production` vs `eas fingerprint:generate -p ios --profile development` [here](https://staging.expo.dev/accounts/quintest110/projects/staging-sdk-52/fingerprints/compare/4424134ca5d1f07725826b3a5a504eba2e570379/081bce3372dff93836ff55c0344b896aebaf97ef) 
