### PR TITLE
[eas-cli] add environment support for fingerprint:compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add environment flag to `eas fingerprint:compare`. ([#2954](https://github.com/expo/eas-cli/pull/2954) by [@quinlanj](https://github.com/quinlanj))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commandUtils/context/ServerSideEnvironmentVariablesContextField.ts
+++ b/packages/eas-cli/src/commandUtils/context/ServerSideEnvironmentVariablesContextField.ts
@@ -5,7 +5,7 @@ import { getProjectIdAsync } from './contextUtils/getProjectIdAsync';
 import { loadServerSideEnvironmentVariablesAsync } from './contextUtils/loadServerSideEnvironmentVariablesAsync';
 import { getPublicExpoConfigAsync } from '../../project/expoConfig';
 
-type GetServerSideEnvironmentVariablesFn = (
+export type GetServerSideEnvironmentVariablesFn = (
   maybeEnv?: Record<string, string>
 ) => Promise<Record<string, string>>;
 

--- a/packages/eas-cli/src/commands/fingerprint/generate.ts
+++ b/packages/eas-cli/src/commands/fingerprint/generate.ts
@@ -74,6 +74,9 @@ export default class FingerprintGenerate extends EasCommand {
       platform = await selectRequestedPlatformAsync();
     }
 
+    if (environment) {
+      Log.log(`🔧 Using environment: ${environment}`);
+    }
     const env = environment
       ? { ...(await getServerSideEnvironmentVariablesAsync()), EXPO_NO_DOTENV: '1' }
       : undefined;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Add environment support for `eas fingerprint:compare`, similar to https://github.com/expo/eas-cli/pull/2951 . 

# Test Plan

- [ ] Interactive mode picks up environment: `EXPO_STAGING=1 ~/Documents/eas-cli/packages/eas-cli/bin/run fingerprint:compare --environment production`
- [ ] Specified flags are picked up: `EXPO_STAGING=1 ~/Documents/eas-cli/packages/eas-cli/bin/run fingerprint:compare --environment production 141250064aa05217358003c179d5a5d57c6a5b4b`
