### PR TITLE
[eas-cli] Always sync update configuration with eas update:configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Make `eas update:configure` re-apply configuration from app.json /app.config.js when run multiple times.
+- Make `eas update:configure` re-apply configuration from app.json /app.config.js when run multiple times. ([#2957](https://github.com/expo/eas-cli/pull/2957) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Make `eas update:configure` re-apply configuration from app.json /app.config.js when run multiple times.
+
 ### 🧹 Chores
 
 ## [16.0.0](https://github.com/expo/eas-cli/releases/tag/v16.0.0) - 2025-03-19

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -54,6 +54,7 @@ export default class UpdateConfigure extends EasCommand {
       platform: flags['platform'],
       vcsClient,
       env: undefined,
+      forceNativeConfigSync: true,
     });
 
     await ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir);

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -409,15 +409,13 @@ export async function ensureEASUpdateIsConfiguredAsync({
       workflows,
     });
 
-  if (projectChanged || !hasExpoUpdates) {
-    await ensureEASUpdateIsConfiguredNativelyAsync(vcsClient, {
-      exp: expWithUpdates,
-      projectDir,
-      platform,
-      workflows,
-      env,
-    });
-  }
+  await ensureEASUpdateIsConfiguredNativelyAsync(vcsClient, {
+    exp: expWithUpdates,
+    projectDir,
+    platform,
+    workflows,
+    env,
+  });
 
   if (projectChanged) {
     Log.addNewLineIfNone();

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -371,6 +371,7 @@ export async function ensureEASUpdateIsConfiguredAsync({
   vcsClient,
   platform,
   env,
+  forceNativeConfigSync,
 }: {
   exp: ExpoConfig;
   projectId: string;
@@ -378,6 +379,7 @@ export async function ensureEASUpdateIsConfiguredAsync({
   vcsClient: Client;
   platform: RequestedPlatform | null;
   env: Env | undefined;
+  forceNativeConfigSync?: boolean;
 }): Promise<void> {
   const hasExpoUpdates = isExpoUpdatesInstalledOrAvailable(
     projectDir,
@@ -409,13 +411,15 @@ export async function ensureEASUpdateIsConfiguredAsync({
       workflows,
     });
 
-  await ensureEASUpdateIsConfiguredNativelyAsync(vcsClient, {
-    exp: expWithUpdates,
-    projectDir,
-    platform,
-    workflows,
-    env,
-  });
+  if (forceNativeConfigSync || projectChanged || !hasExpoUpdates) {
+    await ensureEASUpdateIsConfiguredNativelyAsync(vcsClient, {
+      exp: expWithUpdates,
+      projectDir,
+      platform,
+      workflows,
+      env,
+    });
+  }
 
   if (projectChanged) {
     Log.addNewLineIfNone();


### PR DESCRIPTION
# Why

We sync updates config from app.json/config.js when we run `eas build` but not when running `eas update:configure`.

# How

- Always sync native config from app.json/config.js when running `eas update:configure`, even when already set up. This is a safe change
- Do not sync native config when running `eas update`

# Test Plan

Create a project, configure updates with `eas update:configure`, run prebuild. Change updates configuration in app.json, run `eas update:configure` again - it should sync the changes to the native directories. Change updates configuration in app.json, run `eas update` - it should not sync changes.