### PR TITLE
[eas-cli] remove hidden flag from  fingerprint:generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Remove hidden flag from `eas fingerprint:generate`. ([#2965](https://github.com/expo/eas-cli/pull/2965) by [@quinlanj](https://github.com/quinlanj))
+
 ## [16.1.0](https://github.com/expo/eas-cli/releases/tag/v16.1.0) - 2025-03-26
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commands/fingerprint/generate.ts
+++ b/packages/eas-cli/src/commands/fingerprint/generate.ts
@@ -16,7 +16,6 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 export default class FingerprintGenerate extends EasCommand {
   static override description = 'generate fingerprints from the current project';
   static override strict = false;
-  static override hidden = true;
 
   static override examples = [
     '$ eas fingerprint:generate  \t # Generate fingerprint in interactive mode',


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Make the `eas fingerprint:generate` command public 

# Test Plan
```
MacBook-Pro-8:sdk-52-test quin$ ~/Documents/eas-cli/packages/eas-cli/bin/run fingerprint --help
See more details with DEBUG=*
compare fingerprints of the current project, builds, and updates

USAGE
  $ eas fingerprint:COMMAND

COMMANDS
  fingerprint:compare   compare fingerprints of the current project, builds, and updates
  fingerprint:generate  generate fingerprints from the current project
```
