### PR TITLE
[eas-cli] Improve unauthorized error for `eas deploy --prod`

### DIFF
--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -72,3 +72,12 @@ export function getProjectGitHubSettingsUrl(accountName: string, projectName: st
     getExpoWebsiteBaseUrl()
   ).toString();
 }
+
+export function getHostingDeploymentsUrl(accountName: string, projectName: string): string {
+  return new URL(
+    `/accounts/${encodeURIComponent(accountName)}/projects/${encodeURIComponent(
+      projectName
+    )}/hosting/deployments`,
+    getExpoWebsiteBaseUrl()
+  ).toString();
+}

--- a/packages/eas-cli/src/commands/deploy/index.ts
+++ b/packages/eas-cli/src/commands/deploy/index.ts
@@ -5,11 +5,13 @@ import chalk from 'chalk';
 import fs from 'node:fs';
 import * as path from 'node:path';
 
+import { getHostingDeploymentsUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
 import { EASEnvironmentFlag, EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { EnvironmentVariableEnvironment } from '../../graphql/generated';
-import Log from '../../log';
+import Log, { link } from '../../log';
 import { ora } from '../../ora';
+import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import { createProgressTracker } from '../../utils/progress';
 import * as WorkerAssets from '../../worker/assets';
@@ -121,7 +123,10 @@ export default class WorkerDeploy extends EasCommand {
     } = await this.getContextAsync(WorkerDeploy, { ...flags, withServerSideEnvironment: null });
 
     const projectDist = await resolveExportedProjectAsync(flags, projectDir);
-    const { projectId } = await getDynamicPrivateProjectConfigAsync();
+    const { projectId, exp } = await getDynamicPrivateProjectConfigAsync();
+
+    const projectName = exp.slug;
+    const accountName = (await getOwnerAccountForProjectIdAsync(graphqlClient, projectId)).name;
 
     logExportedProjectInfo(projectDist);
 
@@ -315,7 +320,14 @@ export default class WorkerDeploy extends EasCommand {
         throw new Error(
           `You have specified the new deployment should be a production deployment, but a production domain has not been set up yet for this app.\n\nRun ${chalk.bold(
             'eas deploy --prod'
-          )} as an app admin on your machine to set up a production domain and then try again.`
+          )} as an app admin on your machine or promote an existing deployment to production on the ${link(
+            getHostingDeploymentsUrl(accountName, projectName),
+            {
+              dim: false,
+              text: 'Hosting Dashboard',
+              fallback: `Hosting Dashboard (${getHostingDeploymentsUrl(accountName, projectName)})`,
+            }
+          )} to set up a production domain and then try again.`
         );
       }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When we move Workflows to scoped token which has at most DEVELOPER permission, `type: deploy, prod: true` jobs will fail with an ominous

```
You don't have the required permissions to perform this operation.

This can sometimes happen if you are logged in as incorrect user.
Run eas whoami to check the username you are logged in as.
Run eas login to change the account.

Original error message: Entity not authorized: AppDevDomainNameEntity[00000000-0000-0000-0000-000000000000] (viewer = ScopedAccountActorViewerContext[16d62ef3-a219-47ca-936b-89958f6cb1f8], action = CREATE, ruleIndex = -1)
Request ID: 863a1317-882b-4cab-b8f2-c5f5d63b6f29

```

# How

Special-cased the `--prod` && `AppDevDomainEntity` && `CREATE` && `UNAUTHORIZED_ERROR` error.

Not sure if we should call out "as an app admin" in the error message. Open to suggestions.

# Test Plan

Ran `eas deploy --prod` as a developer-permission-only user. I've updated message in code since taking the screenshot.

<img width="836" alt="Zrzut ekranu 2025-03-28 o 21 21 02" src="https://github.com/user-attachments/assets/fc3a8b08-ae2f-4630-9e88-ccb48151d3e2" />
