### PR TITLE
chore: bump expo/apple-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Bump `@expo/apple-utils` to use async JWT API. ([#2973](https://github.com/expo/eas-cli/pull/2973) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove hidden flag from `eas fingerprint:generate`. ([#2965](https://github.com/expo/eas-cli/pull/2965) by [@quinlanj](https://github.com/quinlanj))
 
 ## [16.1.0](https://github.com/expo/eas-cli/releases/tag/v16.1.0) - 2025-03-26

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/apple-utils": "2.1.11",
+    "@expo/apple-utils": "2.1.12",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "10.0.6",
     "@expo/config-plugins": "9.0.12",

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureTestFlightGroup.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureTestFlightGroup.ts
@@ -65,7 +65,7 @@ async function ensureInternalGroupAsync({
         {
           shouldRetry(error) {
             if (isAppleError(error)) {
-              spinner.text = `TestFlight not ready, retrying in 25 seconds...`;
+              spinner.text = `TestFlight still preparing, retrying in 10 seconds...`;
 
               return error.data.errors.some(
                 error => error.code === 'ENTITY_ERROR.RELATIONSHIP.INVALID'
@@ -199,9 +199,10 @@ async function pollRetryAsync<T>(
   fn: () => Promise<T>,
   {
     shouldRetry,
-    retries = 10,
+    retries = 15,
     // 25 seconds was the minium interval I calculated when measuring against 5 second intervals.
-    interval = 25000,
+    // Switching to 10 seconds to account for days where Apple APIs are faster.
+    interval = 10000,
   }: { shouldRetry?: (error: Error) => boolean; retries?: number; interval?: number } = {}
 ): Promise<T> {
   let lastError: Error | null = null;

--- a/packages/eas-cli/src/metadata/download.ts
+++ b/packages/eas-cli/src/metadata/download.ts
@@ -8,7 +8,7 @@ import { createAppleTasks } from './apple/tasks';
 import { getAppStoreAuthAsync } from './auth';
 import { createAppleWriter, getStaticConfigFilePath } from './config/resolve';
 import { MetadataDownloadError, MetadataValidationError } from './errors';
-import { subscribeTelemetry } from './utils/telemetry';
+import { subscribeTelemetryAsync } from './utils/telemetry';
 import { Analytics, MetadataEvent } from '../analytics/AnalyticsManager';
 import { CredentialsContext } from '../credentials/context';
 import Log from '../log';
@@ -51,7 +51,7 @@ export async function downloadMetadataAsync({
     profile,
   });
 
-  const { unsubscribeTelemetry, executionId } = subscribeTelemetry(
+  const { unsubscribeTelemetry, executionId } = await subscribeTelemetryAsync(
     analytics,
     MetadataEvent.APPLE_METADATA_DOWNLOAD,
     { app, auth }

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -7,7 +7,7 @@ import { getAppStoreAuthAsync } from './auth';
 import { createAppleReader, loadConfigAsync } from './config/resolve';
 import { MetadataConfig } from './config/schema';
 import { MetadataUploadError, MetadataValidationError, logMetadataValidationError } from './errors';
-import { subscribeTelemetry } from './utils/telemetry';
+import { subscribeTelemetryAsync } from './utils/telemetry';
 import { Analytics, MetadataEvent } from '../analytics/AnalyticsManager';
 import { CredentialsContext } from '../credentials/context';
 import Log from '../log';
@@ -38,7 +38,7 @@ export async function uploadMetadataAsync({
     profile,
   });
 
-  const { unsubscribeTelemetry, executionId } = subscribeTelemetry(
+  const { unsubscribeTelemetry, executionId } = await subscribeTelemetryAsync(
     analytics,
     MetadataEvent.APPLE_METADATA_UPLOAD,
     { app, auth }

--- a/packages/eas-cli/src/metadata/utils/__tests__/telemetry.test.ts
+++ b/packages/eas-cli/src/metadata/utils/__tests__/telemetry.test.ts
@@ -1,8 +1,8 @@
 import { App } from '@expo/apple-utils';
 
-import { TelemetryContext, makeDataScrubber } from '../telemetry';
+import { TelemetryContext, makeDataScrubberAsync } from '../telemetry';
 
-describe(makeDataScrubber, () => {
+describe(makeDataScrubberAsync, () => {
   const stub: TelemetryContext = {
     // Only the App ID is considered to be sensitive
     app: new App({} as any, 'SECRET_APP_ID', {} as any),
@@ -18,25 +18,31 @@ describe(makeDataScrubber, () => {
     } as any,
   };
 
-  it('scrubs the app.id', () => {
-    expect(makeDataScrubber(stub)('some text SECRET_APP_ID')).toBe('some text {APPLE_APP_ID}');
+  it('scrubs the app.id', async () => {
+    expect((await makeDataScrubberAsync(stub))('some text SECRET_APP_ID')).toBe(
+      'some text {APPLE_APP_ID}'
+    );
   });
 
-  it('scrubs the auth.username', () => {
-    expect(makeDataScrubber(stub)('some text SECRET_USERNAME')).toBe('some text {APPLE_USERNAME}');
+  it('scrubs the auth.username', async () => {
+    expect((await makeDataScrubberAsync(stub))('some text SECRET_USERNAME')).toBe(
+      'some text {APPLE_USERNAME}'
+    );
   });
 
-  it('scrubs the auth.password', () => {
-    expect(makeDataScrubber(stub)('SECRET_PASSWORD')).toBe('{APPLE_PASSWORD}');
+  it('scrubs the auth.password', async () => {
+    expect((await makeDataScrubberAsync(stub))('SECRET_PASSWORD')).toBe('{APPLE_PASSWORD}');
   });
 
-  it('scrubs the auth.context.token', () => {
-    expect(makeDataScrubber(stub)('some text SECRET_TOKEN')).toBe('some text {APPLE_TOKEN}');
+  it('scrubs the auth.context.token', async () => {
+    expect((await makeDataScrubberAsync(stub))('some text SECRET_TOKEN')).toBe(
+      'some text {APPLE_TOKEN}'
+    );
   });
 
-  it('scrubs the auth.context.token when using token instances', () => {
+  it('scrubs the auth.context.token when using token instances', async () => {
     const token = { getToken: () => 'SECRET_TOKEN_INSTANCE' } as any;
-    const scrubber = makeDataScrubber({
+    const scrubber = await makeDataScrubberAsync({
       ...stub,
       auth: {
         ...stub.auth,
@@ -50,29 +56,31 @@ describe(makeDataScrubber, () => {
     expect(scrubber('some text SECRET_TOKEN_INSTANCE')).toBe('some text {APPLE_TOKEN}');
   });
 
-  it('scrubs the auth.context.teamId', () => {
-    expect(makeDataScrubber(stub)('SECRET_TEAM_ID')).toBe('{APPLE_TEAM_ID}');
+  it('scrubs the auth.context.teamId', async () => {
+    expect((await makeDataScrubberAsync(stub))('SECRET_TEAM_ID')).toBe('{APPLE_TEAM_ID}');
   });
 
-  it('scrubs the auth.context.teamId', () => {
-    expect(makeDataScrubber(stub)('some provider 1337')).toBe('some provider {APPLE_PROVIDER_ID}');
+  it('scrubs the auth.context.teamId', async () => {
+    expect((await makeDataScrubberAsync(stub))('some provider 1337')).toBe(
+      'some provider {APPLE_PROVIDER_ID}'
+    );
   });
 
-  it('scrubber returns string representation of falsy values', () => {
-    const scrubber = makeDataScrubber(stub);
+  it('scrubber returns string representation of falsy values', async () => {
+    const scrubber = await makeDataScrubberAsync(stub);
     expect(scrubber(null)).toBe('null');
     expect(scrubber(undefined)).toBe('undefined');
     expect(scrubber(false)).toBe('false');
   });
 
-  it('scrubs multiple sensitive values at once', () => {
-    expect(makeDataScrubber(stub)('SECRET_TOKEN SECRET_USERNAME SECRET_PASSWORD')).toBe(
-      '{APPLE_TOKEN} {APPLE_USERNAME} {APPLE_PASSWORD}'
-    );
+  it('scrubs multiple sensitive values at once', async () => {
+    expect(
+      (await makeDataScrubberAsync(stub))('SECRET_TOKEN SECRET_USERNAME SECRET_PASSWORD')
+    ).toBe('{APPLE_TOKEN} {APPLE_USERNAME} {APPLE_PASSWORD}');
   });
 
-  it('scrubs json and transforms it to string', () => {
-    const scrubber = makeDataScrubber(stub);
+  it('scrubs json and transforms it to string', async () => {
+    const scrubber = await makeDataScrubberAsync(stub);
     expect(scrubber({ foo: 'bar' })).toBe('{"foo":"bar"}');
     expect(scrubber({ value: 'SECRET_APP_ID' })).toBe('{"value":"{APPLE_APP_ID}"}');
   });

--- a/packages/eas-cli/src/metadata/utils/telemetry.ts
+++ b/packages/eas-cli/src/metadata/utils/telemetry.ts
@@ -107,7 +107,7 @@ async function getAuthTokenStringAsync(auth: TelemetryContext['auth']): Promise<
   }
 
   if (typeof auth.context.token === 'object') {
-    return auth.context.token.getToken();
+    return await auth.context.token.getToken();
   }
 
   return auth.context.token;

--- a/packages/eas-cli/src/metadata/utils/telemetry.ts
+++ b/packages/eas-cli/src/metadata/utils/telemetry.ts
@@ -14,18 +14,18 @@ export type TelemetryContext = {
  * When providing the app and auth info, we can scrub that data from the telemetry.
  * Returns an execution ID to group all events of a single run together, and a unsubscribe function.
  */
-export function subscribeTelemetry(
+export async function subscribeTelemetryAsync(
   analytics: Analytics,
   event: MetadataEvent,
   options: TelemetryContext
-): {
+): Promise<{
   /** Unsubscribe the telemetry from all apple-utils events */
   unsubscribeTelemetry: () => void;
   /** The unique id added to all telemetry events from a single execution */
   executionId: string;
-} {
+}> {
   const executionId = uuidv4();
-  const scrubber = makeDataScrubber(options);
+  const scrubber = await makeDataScrubberAsync(options);
   const { interceptors } = getRequestClient();
 
   const responseInterceptorId = interceptors.response.use(
@@ -68,8 +68,11 @@ export function subscribeTelemetry(
 }
 
 /** Exposed for testing */
-export function makeDataScrubber({ app, auth }: TelemetryContext): <T>(data: T) => string {
-  const token = getAuthTokenString(auth);
+export async function makeDataScrubberAsync({
+  app,
+  auth,
+}: TelemetryContext): Promise<<T>(data: T) => string> {
+  const token = await getAuthTokenStringAsync(auth);
   const patterns: Record<string, RegExp | null> = {
     APPLE_APP_ID: new RegExp(app.id, 'gi'),
     APPLE_USERNAME: auth.username ? new RegExp(auth.username, 'gi') : null,
@@ -98,7 +101,7 @@ export function makeDataScrubber({ app, auth }: TelemetryContext): <T>(data: T) 
   };
 }
 
-function getAuthTokenString(auth: TelemetryContext['auth']): string | null {
+async function getAuthTokenStringAsync(auth: TelemetryContext['auth']): Promise<string | null> {
   if (!auth.context?.token) {
     return null;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1367,10 +1367,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@expo/apple-utils@2.1.11":
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.11.tgz#4cd4552ba8f589bd8f3f5fdf7622d8ea94ac58f7"
-  integrity sha512-rfwTPGlyFXhtCSdaKUOEu277tFfL3ulkL3tJKx6/TnRg1nK40a748VBTQZ8CczRrlpU49egJRYvjXBt/M11wWA==
+"@expo/apple-utils@2.1.12":
+  version "2.1.12"
+  resolved "https://registry.yarnpkg.com/@expo/apple-utils/-/apple-utils-2.1.12.tgz#9c40a6294820e59d8b1a677318dccb1ccefc5b00"
+  integrity sha512-ugpL2URxNFxIRw943AIpX3dcvL5rhNCumpL8XTosYqZPyQQ7JRLVNd1m8FNyPg3pmFrz8M4tSucY2pt2ATuKOA==
 
 "@expo/bunyan@^4.0.0":
   version "4.0.0"
@@ -13236,16 +13236,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13401,7 +13392,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13421,13 +13412,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -14635,16 +14619,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

- Switch to new JWT API which is technically breaking.
- Clean up warning message for TestFlight.

# Test Plan

`easd build -p ios --submit`