### PR TITLE
[eas-cli] Switch update group deletion to be asynchronous

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -1730,6 +1730,22 @@
             "deprecationReason": null
           },
           {
+            "name": "hasBuilds",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "args": [],
@@ -21807,6 +21823,18 @@
             "deprecationReason": null
           },
           {
+            "name": "buildMode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "distribution",
             "description": null,
             "args": [],
@@ -36168,6 +36196,26 @@
             "deprecationReason": null
           },
           {
+            "name": "groups",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "isVerboseFastlaneEnabled",
             "description": null,
             "type": {
@@ -50348,6 +50396,39 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "DeleteUpdateGroupResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "scheduleUpdateGroupDeletion",
+            "description": "Delete an EAS update group in the background",
+            "args": [
+              {
+                "name": "group",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BackgroundJobReceipt",
                 "ofType": null
               }
             },

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -78,6 +78,7 @@
     "qrcode-terminal": "0.12.0",
     "resolve-from": "5.0.0",
     "semver": "7.5.4",
+    "set-interval-async": "3.0.3",
     "slash": "3.0.0",
     "tar": "6.2.1",
     "tar-stream": "3.1.7",

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -131,6 +131,7 @@ export type Account = {
   googleServiceAccountKeys: Array<GoogleServiceAccountKey>;
   /** Android credentials for account */
   googleServiceAccountKeysPaginated: AccountGoogleServiceAccountKeysConnection;
+  hasBuilds: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
   isCurrent: Scalars['Boolean']['output'];
   isDisabled: Scalars['Boolean']['output'];
@@ -3185,6 +3186,7 @@ export enum BuildPriority {
 export type BuildPublicData = {
   __typename?: 'BuildPublicData';
   artifacts: PublicArtifacts;
+  buildMode?: Maybe<BuildMode>;
   distribution?: Maybe<DistributionType>;
   id: Scalars['ID']['output'];
   isForIosSimulator: Scalars['Boolean']['output'];
@@ -5205,6 +5207,7 @@ export type IosSubmissionConfigInput = {
   ascApiKey?: InputMaybe<AscApiKeyInput>;
   ascApiKeyId?: InputMaybe<Scalars['String']['input']>;
   ascAppIdentifier: Scalars['String']['input'];
+  groups?: InputMaybe<Array<Scalars['String']['input']>>;
   isVerboseFastlaneEnabled?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
@@ -7197,6 +7200,8 @@ export type UpdateMutation = {
   __typename?: 'UpdateMutation';
   /** Delete an EAS update group */
   deleteUpdateGroup: DeleteUpdateGroupResult;
+  /** Delete an EAS update group in the background */
+  scheduleUpdateGroupDeletion: BackgroundJobReceipt;
   /** Set code signing info for an update */
   setCodeSigningInfo: Update;
   /** Set rollout percentage for an update */
@@ -7205,6 +7210,11 @@ export type UpdateMutation = {
 
 
 export type UpdateMutationDeleteUpdateGroupArgs = {
+  group: Scalars['ID']['input'];
+};
+
+
+export type UpdateMutationScheduleUpdateGroupDeletionArgs = {
   group: Scalars['ID']['input'];
 };
 
@@ -8870,12 +8880,12 @@ export type AppInfoQueryVariables = Exact<{
 
 export type AppInfoQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, fullName: string } } };
 
-export type DeleteUpdateGroupMutationVariables = Exact<{
+export type ScheduleUpdateGroupDeletionMutationVariables = Exact<{
   group: Scalars['ID']['input'];
 }>;
 
 
-export type DeleteUpdateGroupMutation = { __typename?: 'RootMutation', update: { __typename?: 'UpdateMutation', deleteUpdateGroup: { __typename?: 'DeleteUpdateGroupResult', group: string } } };
+export type ScheduleUpdateGroupDeletionMutation = { __typename?: 'RootMutation', update: { __typename?: 'UpdateMutation', scheduleUpdateGroupDeletion: { __typename?: 'BackgroundJobReceipt', id: string, state: BackgroundJobState, tries: number, willRetry: boolean, resultId?: string | null, resultType: BackgroundJobResultType, resultData?: any | null, errorCode?: string | null, errorMessage?: string | null, createdAt: any, updatedAt: any } } };
 
 export type CreateAndroidAppBuildCredentialsMutationVariables = Exact<{
   androidAppBuildCredentialsInput: AndroidAppBuildCredentialsInput;
@@ -9572,6 +9582,13 @@ export type LatestAppVersionQueryVariables = Exact<{
 
 export type LatestAppVersionQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, latestAppVersionByPlatformAndApplicationIdentifier?: { __typename?: 'AppVersion', id: string, storeVersion: string, buildVersion: string } | null } } };
 
+export type BackgroundJobReceiptByIdQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type BackgroundJobReceiptByIdQuery = { __typename?: 'RootQuery', backgroundJobReceipt: { __typename?: 'BackgroundJobReceiptQuery', byId: { __typename?: 'BackgroundJobReceipt', id: string, state: BackgroundJobState, tries: number, willRetry: boolean, resultId?: string | null, resultType: BackgroundJobResultType, resultData?: any | null, errorCode?: string | null, errorMessage?: string | null, createdAt: any, updatedAt: any } } };
+
 export type ViewBranchQueryVariables = Exact<{
   appId: Scalars['String']['input'];
   name: Scalars['String']['input'];
@@ -9864,6 +9881,8 @@ export type WebhookByIdQuery = { __typename?: 'RootQuery', webhook: { __typename
 export type AccountFragment = { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> };
 
 export type AppFragment = { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null };
+
+export type BackgroundJobReceiptDataFragment = { __typename?: 'BackgroundJobReceipt', id: string, state: BackgroundJobState, tries: number, willRetry: boolean, resultId?: string | null, resultType: BackgroundJobResultType, resultData?: any | null, errorCode?: string | null, errorMessage?: string | null, createdAt: any, updatedAt: any };
 
 export type BuildFragment = { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string }, metrics?: { __typename?: 'BuildMetrics', buildWaitTime?: number | null, buildQueueTime?: number | null, buildDuration?: number | null } | null };
 

--- a/packages/eas-cli/src/graphql/queries/BackgroundJobReceiptQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/BackgroundJobReceiptQuery.ts
@@ -1,0 +1,40 @@
+import gql from 'graphql-tag';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
+import {
+  BackgroundJobReceiptByIdQuery,
+  BackgroundJobReceiptByIdQueryVariables,
+} from '../generated';
+import { BackgroundJobReceiptNode } from '../types/BackgroundJobReceipt';
+
+export const BackgroundJobReceiptQuery = {
+  async byIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    backgroundJobReceiptId: string
+  ): Promise<BackgroundJobReceiptByIdQuery['backgroundJobReceipt']['byId'] | null> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<BackgroundJobReceiptByIdQuery, BackgroundJobReceiptByIdQueryVariables>(
+          gql`
+            query BackgroundJobReceiptById($id: ID!) {
+              backgroundJobReceipt {
+                byId(id: $id) {
+                  id
+                  ...BackgroundJobReceiptData
+                }
+              }
+            }
+            ${BackgroundJobReceiptNode}
+          `,
+          { id: backgroundJobReceiptId },
+          {
+            additionalTypenames: ['BackgroundJobReceipt'],
+          }
+        )
+        .toPromise()
+    );
+
+    return data.backgroundJobReceipt.byId ?? null;
+  },
+};

--- a/packages/eas-cli/src/graphql/types/BackgroundJobReceipt.ts
+++ b/packages/eas-cli/src/graphql/types/BackgroundJobReceipt.ts
@@ -1,0 +1,17 @@
+import gql from 'graphql-tag';
+
+export const BackgroundJobReceiptNode = gql`
+  fragment BackgroundJobReceiptData on BackgroundJobReceipt {
+    id
+    state
+    tries
+    willRetry
+    resultId
+    resultType
+    resultData
+    errorCode
+    errorMessage
+    createdAt
+    updatedAt
+  }
+`;

--- a/packages/eas-cli/src/utils/__tests__/pollForBackgroundJobReceiptAsync-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/pollForBackgroundJobReceiptAsync-test.ts
@@ -1,0 +1,164 @@
+import { instance, mock } from 'ts-mockito';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import {
+  BackgroundJobReceiptDataFragment,
+  BackgroundJobResultType,
+  BackgroundJobState,
+} from '../../graphql/generated';
+import { BackgroundJobReceiptQuery } from '../../graphql/queries/BackgroundJobReceiptQuery';
+import { pollForBackgroundJobReceiptAsync } from '../pollForBackgroundJobReceiptAsync';
+
+jest.mock('../../graphql/queries/BackgroundJobReceiptQuery');
+
+describe(pollForBackgroundJobReceiptAsync, () => {
+  it('returns successful receipt when polling eventually succeeds', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
+
+    const receiptId = '123';
+
+    const backgroundJobReceiptInProgress: BackgroundJobReceiptDataFragment = {
+      id: receiptId,
+      state: BackgroundJobState.InProgress,
+      willRetry: false,
+      tries: 0,
+      resultType: BackgroundJobResultType.Void,
+    } as any;
+
+    const backgroundJobReceiptSuccess: BackgroundJobReceiptDataFragment = {
+      id: receiptId,
+      state: BackgroundJobState.Success,
+      willRetry: false,
+      tries: 0,
+      resultType: BackgroundJobResultType.Void,
+    } as any;
+
+    jest
+      .mocked(BackgroundJobReceiptQuery.byIdAsync)
+      .mockResolvedValueOnce(backgroundJobReceiptInProgress)
+      .mockResolvedValueOnce(backgroundJobReceiptInProgress)
+      .mockResolvedValueOnce(backgroundJobReceiptSuccess);
+
+    const result = await pollForBackgroundJobReceiptAsync(
+      graphqlClient,
+      backgroundJobReceiptInProgress,
+      { pollInterval: 100 }
+    );
+
+    expect(result).toEqual(backgroundJobReceiptSuccess);
+  });
+
+  it('throws error when polling eventually fails', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
+
+    const receiptId = '123';
+
+    const backgroundJobReceiptInProgress: BackgroundJobReceiptDataFragment = {
+      id: receiptId,
+      state: BackgroundJobState.InProgress,
+      willRetry: false,
+      tries: 0,
+      resultType: BackgroundJobResultType.Void,
+    } as any;
+
+    const backgroundJobReceiptFailure: BackgroundJobReceiptDataFragment = {
+      id: receiptId,
+      state: BackgroundJobState.Failure,
+      errorMessage: 'Watch out for falling rocks!',
+      willRetry: false,
+      tries: 0,
+      resultType: BackgroundJobResultType.Void,
+    } as any;
+
+    jest
+      .mocked(BackgroundJobReceiptQuery.byIdAsync)
+      .mockResolvedValueOnce(backgroundJobReceiptInProgress)
+      .mockResolvedValueOnce(backgroundJobReceiptInProgress)
+      .mockResolvedValueOnce(backgroundJobReceiptFailure);
+
+    await expect(
+      pollForBackgroundJobReceiptAsync(graphqlClient, backgroundJobReceiptInProgress, {
+        pollInterval: 100,
+      })
+    ).rejects.toThrow('Background job failed with error: Watch out for falling rocks!');
+  });
+
+  it('succeeds when polling eventually succeeds after a failure with retry', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
+
+    const receiptId = '123';
+
+    const backgroundJobReceiptInProgress: BackgroundJobReceiptDataFragment = {
+      id: receiptId,
+      state: BackgroundJobState.InProgress,
+      willRetry: false,
+      tries: 0,
+      resultType: BackgroundJobResultType.Void,
+    } as any;
+
+    const backgroundJobReceiptFailureWithRetry: BackgroundJobReceiptDataFragment = {
+      id: receiptId,
+      state: BackgroundJobState.Failure,
+      errorMessage: 'Watch out for falling rocks!',
+      willRetry: true,
+      tries: 0,
+      resultType: BackgroundJobResultType.Void,
+    } as any;
+
+    const backgroundJobReceiptInProgress2: BackgroundJobReceiptDataFragment = {
+      id: receiptId,
+      state: BackgroundJobState.InProgress,
+      willRetry: true,
+      tries: 1,
+      resultType: BackgroundJobResultType.Void,
+    } as any;
+
+    const backgroundJobReceiptSuccess: BackgroundJobReceiptDataFragment = {
+      id: receiptId,
+      state: BackgroundJobState.Success,
+      willRetry: true,
+      tries: 1,
+      resultType: BackgroundJobResultType.Void,
+    } as any;
+
+    jest
+      .mocked(BackgroundJobReceiptQuery.byIdAsync)
+      .mockResolvedValueOnce(backgroundJobReceiptInProgress)
+      .mockResolvedValueOnce(backgroundJobReceiptInProgress)
+      .mockResolvedValueOnce(backgroundJobReceiptFailureWithRetry)
+      .mockResolvedValueOnce(backgroundJobReceiptInProgress2)
+      .mockResolvedValueOnce(backgroundJobReceiptSuccess);
+
+    const result = await pollForBackgroundJobReceiptAsync(
+      graphqlClient,
+      backgroundJobReceiptInProgress,
+      { pollInterval: 100 }
+    );
+
+    expect(result).toEqual(backgroundJobReceiptSuccess);
+  });
+
+  it('times out after 90 checks', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
+
+    const receiptId = '123';
+
+    const backgroundJobReceiptInProgress: BackgroundJobReceiptDataFragment = {
+      id: receiptId,
+      state: BackgroundJobState.InProgress,
+      willRetry: false,
+      tries: 0,
+      resultType: BackgroundJobResultType.Void,
+    } as any;
+
+    jest
+      .mocked(BackgroundJobReceiptQuery.byIdAsync)
+      .mockResolvedValue(backgroundJobReceiptInProgress);
+
+    await expect(
+      pollForBackgroundJobReceiptAsync(graphqlClient, backgroundJobReceiptInProgress, {
+        pollInterval: 10,
+      })
+    ).rejects.toThrow('Background job timed out.');
+  });
+});

--- a/packages/eas-cli/src/utils/pollForBackgroundJobReceiptAsync.ts
+++ b/packages/eas-cli/src/utils/pollForBackgroundJobReceiptAsync.ts
@@ -1,0 +1,148 @@
+import { CombinedError } from '@urql/core';
+import { clearIntervalAsync, setIntervalAsync } from 'set-interval-async';
+
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import { BackgroundJobReceiptDataFragment, BackgroundJobState } from '../graphql/generated';
+import { BackgroundJobReceiptQuery } from '../graphql/queries/BackgroundJobReceiptQuery';
+
+export enum BackgroundJobReceiptPollErrorType {
+  NULL_RECEIPT,
+  JOB_FAILED_NO_WILL_RETRY,
+  TIMEOUT,
+}
+
+export type BackgroundJobReceiptPollErrorData =
+  | {
+      errorType: BackgroundJobReceiptPollErrorType.NULL_RECEIPT;
+    }
+  | {
+      errorType: BackgroundJobReceiptPollErrorType.JOB_FAILED_NO_WILL_RETRY;
+      receiptErrorMessage: string | undefined | null;
+    }
+  | {
+      errorType: BackgroundJobReceiptPollErrorType.TIMEOUT;
+    };
+
+export class BackgroundJobReceiptPollError extends Error {
+  readonly errorData: BackgroundJobReceiptPollErrorData;
+
+  constructor(errorData: BackgroundJobReceiptPollErrorData) {
+    super(BackgroundJobReceiptPollError.createErrorMessage(errorData));
+    this.errorData = errorData;
+  }
+
+  static createErrorMessage(errorData: BackgroundJobReceiptPollErrorData): string {
+    switch (errorData.errorType) {
+      case BackgroundJobReceiptPollErrorType.NULL_RECEIPT:
+        return 'Background job receipt was null.';
+      case BackgroundJobReceiptPollErrorType.JOB_FAILED_NO_WILL_RETRY:
+        return `Background job failed with error: ${errorData.receiptErrorMessage}`;
+      case BackgroundJobReceiptPollErrorType.TIMEOUT:
+        return 'Background job timed out.';
+    }
+  }
+}
+
+export type BackgroundJobPollErrorCondition = (error: CombinedError) => {
+  errorIndicatesSuccess: boolean;
+};
+
+async function fetchBackgroundJobReceiptAsync(
+  graphqlClient: ExpoGraphqlClient,
+  receiptId: string
+): Promise<[BackgroundJobReceiptDataFragment | null, CombinedError | null]> {
+  try {
+    return [await BackgroundJobReceiptQuery.byIdAsync(graphqlClient, receiptId), null];
+  } catch (error) {
+    if (error instanceof CombinedError) {
+      return [null, error];
+    }
+    throw error;
+  }
+}
+
+export function pollForBackgroundJobReceiptAsync(
+  graphqlClient: ExpoGraphqlClient,
+  backgroundJobReceipt: BackgroundJobReceiptDataFragment
+): Promise<BackgroundJobReceiptDataFragment>;
+export function pollForBackgroundJobReceiptAsync(
+  graphqlClient: ExpoGraphqlClient,
+  backgroundJobReceipt: BackgroundJobReceiptDataFragment,
+  options?: {
+    onBackgroundJobReceiptPollError?: BackgroundJobPollErrorCondition;
+    pollInterval?: number;
+  }
+): Promise<BackgroundJobReceiptDataFragment | null>;
+export async function pollForBackgroundJobReceiptAsync(
+  graphqlClient: ExpoGraphqlClient,
+  backgroundJobReceipt: BackgroundJobReceiptDataFragment,
+  options?: {
+    onBackgroundJobReceiptPollError?: BackgroundJobPollErrorCondition;
+    pollInterval?: number;
+  }
+): Promise<BackgroundJobReceiptDataFragment | null> {
+  return await new Promise<BackgroundJobReceiptDataFragment | null>((resolve, reject) => {
+    let numChecks = 0;
+    const intervalHandle = setIntervalAsync(
+      async function pollForDeletionFinishedAsync() {
+        function failBackgroundDeletion(error: BackgroundJobReceiptPollError): void {
+          void clearIntervalAsync(intervalHandle);
+          reject(error);
+        }
+
+        const [receipt, error] = await fetchBackgroundJobReceiptAsync(
+          graphqlClient,
+          backgroundJobReceipt.id
+        );
+        if (!receipt) {
+          if (error instanceof CombinedError) {
+            const errorResult = options?.onBackgroundJobReceiptPollError?.(error);
+            if (errorResult?.errorIndicatesSuccess) {
+              void clearIntervalAsync(intervalHandle);
+              resolve(null);
+              return;
+            }
+          }
+          failBackgroundDeletion(
+            new BackgroundJobReceiptPollError({
+              errorType: BackgroundJobReceiptPollErrorType.NULL_RECEIPT,
+            })
+          );
+          return;
+        }
+
+        // job failed and will not retry
+        if (receipt.state === BackgroundJobState.Failure && !receipt.willRetry) {
+          failBackgroundDeletion(
+            new BackgroundJobReceiptPollError({
+              errorType: BackgroundJobReceiptPollErrorType.JOB_FAILED_NO_WILL_RETRY,
+              receiptErrorMessage: receipt.errorMessage,
+            })
+          );
+          return;
+        }
+
+        // all else fails, stop polling after 90 checks. This should only happen if there's an
+        // issue with receipts not setting `willRetry` to false when they fail within a reasonable
+        // amount of time.
+        if (numChecks > 90) {
+          failBackgroundDeletion(
+            new BackgroundJobReceiptPollError({
+              errorType: BackgroundJobReceiptPollErrorType.TIMEOUT,
+            })
+          );
+          return;
+        }
+
+        if (receipt.state === BackgroundJobState.Success) {
+          void clearIntervalAsync(intervalHandle);
+          resolve(receipt);
+          return;
+        }
+
+        numChecks++;
+      },
+      options?.pollInterval ?? 1000
+    );
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12855,6 +12855,11 @@ set-function-name@^2.0.2:
     functions-have-names "^1.2.3"
     has-property-descriptors "^1.0.2"
 
+set-interval-async@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/set-interval-async/-/set-interval-async-3.0.3.tgz#99dd13098eebc2bf1ad0b22e03fe25c516b982c3"
+  integrity sha512-o4DyBv6mko+A9cH3QKek4SAAT5UyJRkfdTi6JHii6ZCKUYFun8SwgBmQrOXd158JOwBQzA+BnO8BvT64xuCaSw==
+
 setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
@@ -13236,16 +13241,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13401,7 +13397,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13421,13 +13417,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -14635,16 +14624,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Equivalent to the Expo website PR (https://github.com/expo/universe/pull/19468) but for the CLI.

We're moving update group deletion to be a background job since it can take so long for large update groups.

# How

Copy polling utility from website, use it here to replace existing update group deletion.

# Test Plan

`neas update:delete 25d8b9c5-6c8a-4069-a13f-0892c2c66203`

See it successfully deletes the update group.

Run new unit test.
