### PR TITLE
[eas-cli] update: add warning if no build exists with fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Remove hidden flag from `eas fingerprint:generate`. ([#2965](https://github.com/expo/eas-cli/pull/2965) by [@quinlanj](https://github.com/quinlanj))
 - Refactor `eas update` command to improve code readability. ([#2976](https://github.com/expo/eas-cli/pull/2976) by [@quinlanj](https://github.com/quinlanj))
+- `eas update`: add warning if no build exists with fingerprint. ([#2977](https://github.com/expo/eas-cli/pull/2977) by [@quinlanj](https://github.com/quinlanj))
 
 ## [16.1.0](https://github.com/expo/eas-cli/releases/tag/v16.1.0) - 2025-03-26
 

--- a/packages/eas-cli/src/commandUtils/builds.ts
+++ b/packages/eas-cli/src/commandUtils/builds.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 
+import { ExpoGraphqlClient } from './context/contextUtils/createGraphqlClient';
 import {
   AppPlatform,
   Build,
@@ -8,7 +9,6 @@ import {
   BuildStatus,
   InputMaybe,
 } from '../graphql/generated';
-import { ExpoGraphqlClient } from './context/contextUtils/createGraphqlClient';
 import { BuildQuery } from '../graphql/queries/BuildQuery';
 import { RequestedPlatform, appPlatformEmojis } from '../platform';
 

--- a/packages/eas-cli/src/commandUtils/builds.ts
+++ b/packages/eas-cli/src/commandUtils/builds.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 
-import { ExpoGraphqlClient } from './context/contextUtils/createGraphqlClient';
 import {
   AppPlatform,
   Build,
@@ -9,6 +8,7 @@ import {
   BuildStatus,
   InputMaybe,
 } from '../graphql/generated';
+import { ExpoGraphqlClient } from './context/contextUtils/createGraphqlClient';
 import { BuildQuery } from '../graphql/queries/BuildQuery';
 import { RequestedPlatform, appPlatformEmojis } from '../platform';
 
@@ -43,6 +43,7 @@ export async function fetchBuildsAsync({
     platform?: RequestedPlatform;
     profile?: string;
     hasFingerprint?: boolean;
+    fingerprintHash?: string;
   };
 }): Promise<BuildFragment[]> {
   let builds: BuildFragment[];
@@ -55,6 +56,9 @@ export async function fetchBuildsAsync({
   }
   if (filters?.hasFingerprint) {
     queryFilters['hasFingerprint'] = filters.hasFingerprint;
+  }
+  if (filters?.fingerprintHash) {
+    queryFilters['fingerprintHash'] = filters.fingerprintHash;
   }
   if (!filters?.statuses) {
     builds = await BuildQuery.viewBuildsOnAppAsync(graphqlClient, {

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -17,6 +17,7 @@ import { isModernExpoUpdatesCLIWithRuntimeVersionCommandSupportedAsync } from '.
 import { resolveRuntimeVersionUsingCLIAsync } from './resolveRuntimeVersionAsync';
 import { selectBranchOnAppAsync } from '../branch/queries';
 import { getDefaultBranchNameAsync } from '../branch/utils';
+import { fetchBuildsAsync } from '../commandUtils/builds';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { PaginatedQueryOptions } from '../commandUtils/pagination';
 import { FingerprintOptions, createFingerprintsByKeyAsync } from '../fingerprint/cli';
@@ -53,7 +54,6 @@ import groupBy from '../utils/expodash/groupBy';
 import mapMapAsync from '../utils/expodash/mapMapAsync';
 import uniqBy from '../utils/expodash/uniqBy';
 import { Client } from '../vcs/vcs';
-import { fetchBuildsAsync } from '../commandUtils/builds';
 
 // update publish does not currently support web
 export type UpdatePublishPlatform = 'ios' | 'android';


### PR DESCRIPTION
# Why

When publishing updates, users need to know if there are compatible builds for their fingerprints. This PR prints this information at the end of `eas update` to warn users, if they have updates being published that don't have corresponding builds, causing potential compatibility issues.

<img width="1536" alt="Screenshot 2025-04-01 at 5 09 12 PM" src="https://github.com/user-attachments/assets/400ac0d9-c39e-4aee-9793-465c6acb634e" />


# How

Added functionality to check for compatible builds when publishing updates:

1. Enhanced `fetchBuildsAsync` to support filtering by `fingerprintHash`
2. Implemented `findCompatibleBuildsAsync` to find builds matching fingerprints
3. Added warnings in the update publish command when no compatible builds are found for fingerprints
4. Included links to the fingerprint details on the Expo website for easier debugging

# Test Plan

Run `eas update` with a fingerprint that doesn't have a compatible build