### PR TITLE
[eas-cli][upload] Filter out duplicates and compress apps

### DIFF
--- a/packages/eas-cli/src/commands/upload.ts
+++ b/packages/eas-cli/src/commands/upload.ts
@@ -235,10 +235,7 @@ async function uploadAppArchiveAsync(
     const tarPath = path.join(getTmpDirectory(), `${uuidv4()}.tar.gz`);
     const parentPath = path.dirname(originalPath);
     const folderName = path.basename(originalPath);
-    try {
-      await tar.create({ cwd: parentPath, file: tarPath, gzip: true }, [folderName]);
-    } finally {
-    }
+    await tar.create({ cwd: parentPath, file: tarPath, gzip: true }, [folderName]);
     filePath = tarPath;
   }
   const fileSize = (await fs.stat(filePath)).size;


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/eas-cli/pull/2932
Fixes some of the issues encountered while testing the new upload command 

# How

- Use a Set instead of an array to store app files to ensure no duplicate entries 
- Compress .app files before uploading to GCS 

# Test Plan

 create build your app locally using Xcode or Android Studio

### Actions
  - Run `easd upload`
  - Test both iOS and Android builds
  - Observe local build on expo.dev
