### PR TITLE
[eas-cli] Add build:download command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add `eas build:download` command. ([#2982](https://github.com/expo/eas-cli/pull/2982) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -70,6 +70,7 @@ eas --help COMMAND
 * [`eas build:configure`](#eas-buildconfigure)
 * [`eas build:delete [BUILD_ID]`](#eas-builddelete-build_id)
 * [`eas build:dev`](#eas-builddev)
+* [`eas build:download`](#eas-buildddownload)
 * [`eas build:inspect`](#eas-buildinspect)
 * [`eas build:list`](#eas-buildlist)
 * [`eas build:resign`](#eas-buildresign)
@@ -458,6 +459,25 @@ DESCRIPTION
 ```
 
 _See code: [packages/eas-cli/src/commands/build/dev.ts](https://github.com/expo/eas-cli/blob/v16.2.2/packages/eas-cli/src/commands/build/dev.ts)_
+
+## `eas build:download`
+
+download dev client simulator/emulator build with matching fingerprint
+
+```
+USAGE
+  $ eas build:download [-p ios|android] [-e <value>]
+
+FLAGS
+  --fingerprint=<value>             (required) Fingerprint hash of the build to run
+  --non-interactive                 Run the command in non-interactive mode.
+  -p, --platform=(ios|android)
+
+DESCRIPTION
+  download dev client simulator/emulator build with matching fingerprint
+```
+
+_See code: [packages/eas-cli/src/commands/build/download.ts](https://github.com/expo/eas-cli/blob/v16.2.2/packages/eas-cli/src/commands/build/download.ts)_
 
 ## `eas build:inspect`
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -70,7 +70,7 @@ eas --help COMMAND
 * [`eas build:configure`](#eas-buildconfigure)
 * [`eas build:delete [BUILD_ID]`](#eas-builddelete-build_id)
 * [`eas build:dev`](#eas-builddev)
-* [`eas build:download`](#eas-buildddownload)
+* [`eas build:download`](#eas-builddownload)
 * [`eas build:inspect`](#eas-buildinspect)
 * [`eas build:list`](#eas-buildlist)
 * [`eas build:resign`](#eas-buildresign)
@@ -462,19 +462,20 @@ _See code: [packages/eas-cli/src/commands/build/dev.ts](https://github.com/expo/
 
 ## `eas build:download`
 
-download dev client simulator/emulator build with matching fingerprint
+download a simulator/emulator build with matching fingerprint
 
 ```
 USAGE
   $ eas build:download [-p ios|android] [-e <value>]
 
 FLAGS
-  --fingerprint=<value>             (required) Fingerprint hash of the build to run
+  --dev-client=<value>              Filter only dev-client builds.
+  --fingerprint=<value>             (required) Fingerprint hash of the build to run.
   --non-interactive                 Run the command in non-interactive mode.
   -p, --platform=(ios|android)
 
 DESCRIPTION
-  download dev client simulator/emulator build with matching fingerprint
+  download a simulator/emulator build with matching fingerprint
 ```
 
 _See code: [packages/eas-cli/src/commands/build/download.ts](https://github.com/expo/eas-cli/blob/v16.2.2/packages/eas-cli/src/commands/build/download.ts)_

--- a/packages/eas-cli/src/commands/build/download.ts
+++ b/packages/eas-cli/src/commands/build/download.ts
@@ -1,0 +1,131 @@
+import { Platform } from '@expo/eas-build-job';
+import { Errors, Flags } from '@oclif/core';
+import chalk from 'chalk';
+import { pathExists } from 'fs-extra';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { AppPlatform, BuildFragment, BuildStatus, DistributionType } from '../../graphql/generated';
+import { BuildQuery } from '../../graphql/queries/BuildQuery';
+import Log from '../../log';
+import { promptAsync } from '../../prompts';
+import { getEasBuildRunCachedAppPath } from '../../run/run';
+import { downloadAndMaybeExtractAppAsync } from '../../utils/download';
+import { printJsonOnlyOutput } from '../../utils/json';
+
+export default class Download extends EasCommand {
+  static override description = 'download builds for a given fingerprint hash';
+
+  static override flags = {
+    fingerprint: Flags.string({
+      description: 'Fingerprint hash of the build to download',
+      required: true,
+    }),
+    platform: Flags.enum<Platform.IOS | Platform.ANDROID>({
+      char: 'p',
+      options: [Platform.IOS, Platform.ANDROID],
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+    ...this.ContextOptions.ProjectId,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(Download);
+
+    const selectedPlatform = await resolvePlatformAsync(flags.platform);
+
+    const {
+      loggedIn: { graphqlClient },
+      projectId,
+    } = await this.getContextAsync(Download, {
+      nonInteractive: false,
+    });
+
+    const build = await this.getBuildAsync(
+      graphqlClient,
+      projectId,
+      selectedPlatform,
+      flags.fingerprint
+    );
+    const buildPath = await this.getPathToBuildAppAsync(build, selectedPlatform);
+    if (flags.json) {
+      const jsonResults: { path?: string } = {};
+      if (buildPath) {
+        jsonResults.path = buildPath;
+      }
+      printJsonOnlyOutput(jsonResults);
+    } else {
+      Log.log(`Build downloaded at ${chalk.bold(buildPath)}`);
+    }
+  }
+
+  private async getBuildAsync(
+    graphqlClient: ExpoGraphqlClient,
+    projectId: string,
+    platform: AppPlatform,
+    fingerprintHash: string
+  ): Promise<BuildFragment> {
+    const builds = await BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
+      appId: projectId,
+      filter: {
+        platform,
+        fingerprintHash,
+        status: BuildStatus.Finished,
+        simulator: platform === AppPlatform.Ios ? true : undefined,
+        distribution: platform === AppPlatform.Android ? DistributionType.Internal : undefined,
+        developmentClient: true,
+      },
+      offset: 0,
+      limit: 1,
+    });
+    if (builds.length === 0) {
+      throw new Errors.CLIError(
+        `No builds available for ${platform} with fingerprint hash ${fingerprintHash}`
+      );
+    }
+
+    Log.succeed(`🎯 Found successful build with matching fingerprint on EAS servers.`);
+    return builds[0];
+  }
+
+  async getPathToBuildAppAsync(build: BuildFragment, platform: AppPlatform): Promise<string> {
+    const cachedAppPath = getEasBuildRunCachedAppPath(build.project.id, build.id, platform);
+    if (await pathExists(cachedAppPath)) {
+      Log.newLine();
+      Log.log(`Using cached app...`);
+      return cachedAppPath;
+    }
+
+    if (!build.artifacts?.applicationArchiveUrl) {
+      throw new Error('Build does not have an application archive url');
+    }
+
+    return await downloadAndMaybeExtractAppAsync(
+      build.artifacts.applicationArchiveUrl,
+      platform,
+      cachedAppPath
+    );
+  }
+}
+
+async function resolvePlatformAsync(platform?: string): Promise<AppPlatform> {
+  if (platform && Object.values(AppPlatform).includes(platform.toUpperCase() as AppPlatform)) {
+    return platform.toUpperCase() as AppPlatform;
+  }
+
+  const { selectedPlatform } = await promptAsync({
+    type: 'select',
+    message: 'Select platform',
+    name: 'selectedPlatform',
+    choices: [
+      { title: 'Android', value: AppPlatform.Android },
+      { title: 'iOS', value: AppPlatform.Ios },
+    ],
+  });
+  return selectedPlatform;
+}


### PR DESCRIPTION
# Why

We want to introduce a feature in `expo-cli` to allow users to download remote builds instead of always building locally if there is an available build with a matching fingerprint. For this "cache" layer to work we need a way to download EAS builds through eas-cli 

# How

Introduce a new `build:download`command

# Test Plan

### Setup

 create a couple of builds on expo.dev

### Actions
  - Run `easd build:download --platform [ios|android] --fingerprint [hash]`
  - Check if the build was downloaded correctly
  
### Test Reproduction (Screenshots/Videos/Terminal Output)

<img width="1211" alt="image" src="https://github.com/user-attachments/assets/8ca3f4f4-0342-4415-8f4b-c748f4901eec" />

