### PR TITLE
[eas-cli] Add non-interactive and json flags to upload command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add `eas upload` command. ([#2932](https://github.com/expo/eas-cli/pull/2932), [#2981](https://github.com/expo/eas-cli/pull/2981), [#2983](https://github.com/expo/eas-cli/pull/2983) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add `eas build:download` command. ([#2982](https://github.com/expo/eas-cli/pull/2982) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -132,6 +132,7 @@ eas --help COMMAND
 * [`eas update:roll-back-to-embedded`](#eas-updateroll-back-to-embedded)
 * [`eas update:rollback`](#eas-updaterollback)
 * [`eas update:view GROUPID`](#eas-updateview-groupid)
+* [`eas upload`](#eas-upload)
 * [`eas webhook:create`](#eas-webhookcreate)
 * [`eas webhook:delete [ID]`](#eas-webhookdelete-id)
 * [`eas webhook:list`](#eas-webhooklist)
@@ -472,6 +473,7 @@ FLAGS
   --dev-client=<value>              Filter only dev-client builds.
   --fingerprint=<value>             (required) Fingerprint hash of the build to run.
   --non-interactive                 Run the command in non-interactive mode.
+  --json                            Enable JSON output, non-JSON messages will be printed to stderr.
   -p, --platform=(ios|android)
 
 DESCRIPTION
@@ -1887,6 +1889,28 @@ DESCRIPTION
 ```
 
 _See code: [packages/eas-cli/src/commands/update/view.ts](https://github.com/expo/eas-cli/blob/v16.2.2/packages/eas-cli/src/commands/update/view.ts)_
+
+## `eas upload`
+
+uploads a local build to EAS
+
+```
+USAGE
+  $ eas upload [-p ios|android] [--build-path <value>] [--fingerprint  <value>]
+
+FLAGS
+  --build-path=<value>              Path to the build artifact.
+  --dev-client=<value>              Filter only dev-client builds.
+  --fingerprint=<value>             Manual fingerprint hash to include in the build.
+  --non-interactive                 Run the command in non-interactive mode.
+  --json                            Enable JSON output, non-JSON messages will be printed to stderr.
+  -p, --platform=(ios|android)
+
+DESCRIPTION
+  upload a local build and generates a sharable link
+```
+
+_See code: [packages/eas-cli/src/commands/build/download.ts](https://github.com/expo/eas-cli/blob/v16.2.2/packages/eas-cli/src/commands/build/download.ts)_
 
 ## `eas webhook:create`
 

--- a/packages/eas-cli/src/commands/upload.ts
+++ b/packages/eas-cli/src/commands/upload.ts
@@ -124,9 +124,11 @@ export default class BuildUpload extends EasCommand {
 
     if (jsonFlag) {
       printJsonOnlyOutput({ url: getBuildLogsUrl(build) });
-    } else {
-      Log.withTick(`Shareable link to the build: ${getBuildLogsUrl(build)}`);
-    }
+      return;
+    } 
+    
+    Log.withTick(`Shareable link to the build: ${getBuildLogsUrl(build)}`);
+    
   }
 
   private async selectPlatformAsync({


### PR DESCRIPTION
# Why

As part of the integration with expo-cli we should support a non-interactive mode when running `eas upload`

# How

 Add non-interactive and json flags to `upload` the command

# Test Plan

### Setup

 create build your app locally using Xcode or Android Studio

### Actions
  - Run `easd upload --non-interactive --platform ios --json`
  - Navigate to http://staging.expo.dev/accounts/gabrieldonadel/projects/fabric-tester/builds/bc7fe643-a5db-40e2-9cac-5362a8601423
  - Observe your local build
