### PR TITLE
[eas-cli] Allow no in dev-client flag for build:download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+Add `--no-dev-client` flag for `build:download` command. ([#2985](https://github.com/expo/eas-cli/pull/2985) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## [16.3.0](https://github.com/expo/eas-cli/releases/tag/v16.3.0) - 2025-04-09
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commands/build/download.ts
+++ b/packages/eas-cli/src/commands/build/download.ts
@@ -29,6 +29,7 @@ export default class Download extends EasCommand {
     }),
     'dev-client': Flags.boolean({
       description: 'Filter only dev-client builds.',
+      allowNo: true,
     }),
     ...EasNonInteractiveAndJsonFlags,
   };


### PR DESCRIPTION
# Why

Users should be able to download non dev-client builds (e.g. builds with `--configuration Release`)

# How

Allow no in dev-client flag for build:download

# Test Plan

Run `easd build:download -p ios --fingerprint "5daec8fdf29fd8023ce92fae92f0e33d2eadac33" --no-dev-client`
