### PR TITLE
[eas-json] Allow extending with multiple build and submit profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Allow extending with multiple build and submit profiles ([#2987](https://github.com/expo/eas-cli/pull/2987) by [@khamilowicz](https://github.com/khamilowicz))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -379,6 +379,54 @@ test('valid profile with extension chain not exceeding 5', async () => {
   });
 });
 
+test('valid profile with extensions list', async () => {
+  await fs.writeJson('/project/eas.json', {
+    build: {
+      base: {
+        node: '12.0.0',
+      },
+      extension1: {
+        extends: ['base', 'extension2', 'extension3'],
+        credentialsSource: 'remote',
+        env: {
+          SOME_ENV: 'ext1',
+        },
+      },
+      extension2: {
+        distribution: 'store',
+        node: '14.0.0',
+      },
+      extension3: {
+        distribution: 'internal',
+        node: '15.0.0',
+        config: 'extension3.yml',
+        env: {
+          SOME_ENV: 'ext1',
+          OTHER_ENV: 'ext3',
+        },
+      },
+    },
+  });
+
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
+  const extendedProfile1 = await EasJsonUtils.getBuildProfileAsync(
+    accessor,
+    Platform.ANDROID,
+    'extension1'
+  );
+
+  expect(extendedProfile1).toEqual({
+    credentialsSource: 'remote',
+    distribution: 'store',
+    node: '12.0.0',
+    config: 'extension3.yml',
+    env: {
+      SOME_ENV: 'ext1',
+      OTHER_ENV: 'ext3',
+    },
+  });
+});
+
 test('valid profile with extension chain exceeding 5 - too long', async () => {
   await fs.writeJson('/project/eas.json', {
     build: {

--- a/packages/eas-json/src/__tests__/submitProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/submitProfiles-test.ts
@@ -169,6 +169,57 @@ test('ios config with ascApiKey fields set to env var', async () => {
   }
 });
 
+test('valid profile with extensions list', async () => {
+  await fs.writeJson('/project/eas.json', {
+    submit: {
+      base: {
+        ios: {
+          appleId: 'some@email.com',
+          ascAppId: '1223423523',
+          appleTeamId: 'AB32CZE81A',
+        },
+      },
+      extension1: {
+        extends: ['base', 'extension2', 'extension3'],
+        ios: {
+          ascApiKeyId: 'AB32CZE81F',
+          appleTeamId: 'AB32CZE81F',
+        },
+      },
+      extension2: {
+        ios: {
+          ascApiKeyPath: './path-ABCD.p8',
+          appleTeamId: 'AB32CZE81E',
+          ascAppId: '123',
+        },
+      },
+      extension3: {
+        ios: {
+          appleTeamId: 'AB32CZE81G',
+          ascApiKeyIssuerId: '2af70a7a-2ac5-44d4-924e-ae97a7ca9333',
+        },
+      },
+    },
+  });
+
+  const accessor = EasJsonAccessor.fromProjectPath('/project');
+  const extendedProfile1 = await EasJsonUtils.getSubmitProfileAsync(
+    accessor,
+    Platform.IOS,
+    'extension1'
+  );
+
+  expect(extendedProfile1).toEqual({
+    language: 'en-US',
+    appleId: 'some@email.com',
+    ascAppId: '1223423523',
+    appleTeamId: 'AB32CZE81F',
+    ascApiKeyPath: './path-ABCD.p8',
+    ascApiKeyIssuerId: '2af70a7a-2ac5-44d4-924e-ae97a7ca9333',
+    ascApiKeyId: 'AB32CZE81F',
+  });
+});
+
 test('valid profile with extension chain not exceeding 5', async () => {
   await fs.writeJson('/project/eas.json', {
     submit: {

--- a/packages/eas-json/src/build/resolver.ts
+++ b/packages/eas-json/src/build/resolver.ts
@@ -54,14 +54,20 @@ function resolveProfile({
     }
   }
 
-  const { extends: baseProfileName, ...rest } = profile;
-  if (baseProfileName) {
-    const baseProfile = resolveProfile({
-      easJson,
-      profileName: baseProfileName,
-      depth: depth + 1,
-    });
-    return mergeProfiles(baseProfile, rest);
+  let { extends: baseProfileNames, ...rest } = profile;
+  if (baseProfileNames) {
+    if (!Array.isArray(baseProfileNames)) {
+      baseProfileNames = [baseProfileNames];
+    }
+
+    return baseProfileNames.reduce((mergedProfile, baseProfileName) => {
+      const currentProfile = resolveProfile({
+        easJson,
+        profileName: baseProfileName,
+        depth: depth + 1,
+      });
+      return mergeProfiles(currentProfile, mergedProfile);
+    }, rest);
   } else {
     return rest;
   }

--- a/packages/eas-json/src/build/schema.ts
+++ b/packages/eas-json/src/build/schema.ts
@@ -141,7 +141,7 @@ const IosBuildProfileSchema = PlatformBuildProfileSchema.concat(
 
 export const BuildProfileSchema = CommonBuildProfileSchema.concat(
   Joi.object({
-    extends: Joi.string(),
+    extends: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string())),
     android: AndroidBuildProfileSchema,
     ios: IosBuildProfileSchema,
   })

--- a/packages/eas-json/src/build/types.ts
+++ b/packages/eas-json/src/build/types.ts
@@ -122,7 +122,7 @@ export type BuildProfile<TPlatform extends Platform = Platform> = TPlatform exte
   : IosBuildProfile;
 
 export interface EasJsonBuildProfile extends Partial<CommonBuildProfile> {
-  extends?: string;
+  extends?: string | string[];
   [Platform.ANDROID]?: Partial<AndroidBuildProfile>;
   [Platform.IOS]?: Partial<IosBuildProfile>;
 }

--- a/packages/eas-json/src/submit/resolver.ts
+++ b/packages/eas-json/src/submit/resolver.ts
@@ -64,16 +64,22 @@ function resolveProfile<T extends Platform>({
     }
   }
 
-  const { extends: baseProfileName, ...rest } = profile;
+  let { extends: baseProfileNames, ...rest } = profile;
   const platformProfile = rest[platform] as SubmitProfile<T> | undefined;
-  if (baseProfileName) {
-    const baseProfile = resolveProfile({
-      easJson,
-      platform,
-      profileName: baseProfileName,
-      depth: depth + 1,
-    });
-    return mergeProfiles(baseProfile, platformProfile);
+  if (baseProfileNames) {
+    if (!Array.isArray(baseProfileNames)) {
+      baseProfileNames = [baseProfileNames];
+    }
+
+    return baseProfileNames.reduce((mergedProfile, baseProfileName) => {
+      const currentProfile = resolveProfile({
+        easJson,
+        platform,
+        profileName: baseProfileName,
+        depth: depth + 1,
+      });
+      return mergeProfiles(currentProfile, mergedProfile);
+    }, platformProfile);
   } else {
     return platformProfile;
   }

--- a/packages/eas-json/src/submit/schema.ts
+++ b/packages/eas-json/src/submit/schema.ts
@@ -75,7 +75,7 @@ export const ResolvedIosSubmitProfileSchema = Joi.object({
 });
 
 export const UnresolvedSubmitProfileSchema = Joi.object({
-  extends: Joi.string(),
+  extends: Joi.alternatives(Joi.string(), Joi.array().items(Joi.string())),
   android: AndroidSubmitProfileSchema,
   ios: UnresolvedIosSubmitProfileSchema,
 });

--- a/packages/eas-json/src/submit/types.ts
+++ b/packages/eas-json/src/submit/types.ts
@@ -52,7 +52,7 @@ export type SubmitProfile<TPlatform extends Platform = Platform> =
   TPlatform extends Platform.ANDROID ? AndroidSubmitProfile : IosSubmitProfile;
 
 export interface EasJsonSubmitProfile {
-  extends?: string;
+  extends?: string | string[];
   [Platform.ANDROID]?: AndroidSubmitProfile;
   [Platform.IOS]?: IosSubmitProfile;
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

[ENG-14628: Add ability to extend multiple build profiles in eas.json](https://linear.app/expo/issue/ENG-14628/add-ability-to-extend-multiple-build-profiles-in-easjson)

https://github.com/expo/eas-cli/issues/2664

It would be beneficial for users to be able to create more granular build profiles and then compose them into their specific use cases. This can be achieved by allowing specifying multiple profiles that are used for extending current profile:

```
{
   "build": {
        "parent1": {},
        "parent2": {},
        "development": {
            "extends": ["parent1", "parent2"]
        }
    }
}
```

# How

- Allow extending profiles with multiple parents
- The order of parents determines the precedence of profiles' configs.

# Test Plan

Added tests.

Manual testing:

One of the ways to test this feature is to create an `iOS` build using a `eas.json` file with a similar content: 

``` "build": {
    "test": {
      "env": {
        "THIS_IS": "test"
      },
    },
    "base": {
      "env": {
        "THIS_IS": "base"
      },
    },
    "development": {
      "extends": [
        "test",
        "base"
      ],
      "env": {
        "THIS_IS": "development"
      },
    },
 }
```

2. Test for various combinations of `extends` and the environment variable presence. Verify in logs which variable is used for which combination.
3. The precedence should be the following:
- variable defined in the current profile (`development`)
- variable defined in the first specified parent
- variable defined in the second specified parent

