### PR TITLE
[eas-json] Add android sdk-52 image to schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- Add `sdk-52` alias to the list or supported android images. ([#2989](https://github.com/expo/eas-cli/pull/2989) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🧹 Chores
 

--- a/packages/eas-json/schema/eas.schema.json
+++ b/packages/eas-json/schema/eas.schema.json
@@ -243,6 +243,7 @@
               "enum": [
                 "auto",
                 "latest",
+                "sdk-52",
                 "sdk-51",
                 "sdk-50",
                 "sdk-49",
@@ -255,6 +256,7 @@
               "markdownEnumDescriptions": [
                 "When using this option the build image is selected automatically based on the project configuration, detected Expo SDK and React Native versions.",
                 "The latest Android image currently available. It is resolved to `ubuntu-22.04-jdk-17-ndk-r26b`. The `latest` to image mapping will be updated as new images are released.",
+                "The recommended image for SDK 52 builds",
                 "The recommended image for SDK 51 builds",
                 "The recommended image for SDK 50 builds",
                 "The recommended image for SDK 49 builds"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The `sdk-52` label  for Android is [set up on EAS](https://github.com/expo/turtle-v2/blob/c571f3208d27d0d196467e04e989b1a9c9175a81/src/services/launcher/src/workerImages.json#L17) but the alias was not added to the schema.

<img width="1201" alt="Screenshot 2025-04-15 at 13 50 09" src="https://github.com/user-attachments/assets/8c6bd445-fb6f-4ed1-9b2e-285dec68d308" />

# How

Add the `sdk-52` alias to the schema.

# Test Plan

Unsure.