### PR TITLE
[eas-cli] change launch asset file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - Update upload command to display build info. ([#2990](https://github.com/expo/eas-cli/pull/2990) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- change launch asset file extension. ([#2991](https://github.com/expo/eas-cli/pull/2991) by [@quinlanj](https://github.com/quinlanj))
 
 ## [16.3.1](https://github.com/expo/eas-cli/releases/tag/v16.3.1) - 2025-04-11
 

--- a/packages/eas-cli/src/project/__tests__/publish-test.ts
+++ b/packages/eas-cli/src/project/__tests__/publish-test.ts
@@ -424,7 +424,7 @@ describe(collectAssetsAsync, () => {
     expect(await collectAssetsAsync(inputDir)).toEqual({
       android: {
         launchAsset: {
-          fileExtension: '.bundle',
+          fileExtension: '.js',
           contentType: 'application/javascript',
           path: `${inputDir}/bundles/android.js`,
         },
@@ -432,7 +432,7 @@ describe(collectAssetsAsync, () => {
       },
       ios: {
         launchAsset: {
-          fileExtension: '.bundle',
+          fileExtension: '.js',
           contentType: 'application/javascript',
           path: `${inputDir}/bundles/ios.js`,
         },
@@ -440,7 +440,7 @@ describe(collectAssetsAsync, () => {
       },
       web: {
         launchAsset: {
-          fileExtension: '.bundle',
+          fileExtension: '.js',
           contentType: 'application/javascript',
           path: `${inputDir}/bundles/web.js`,
         },

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -374,7 +374,7 @@ export function filterCollectedAssetsByRequestedPlatforms(
 }
 
 /** Try to load the asset map for logging the names of assets published */
-export async function loadAssetMapAsync(distRoot: string): Promise<AssetMap | null> {
+async function loadAssetMapAsync(distRoot: string): Promise<AssetMap | null> {
   const assetMapPath = path.join(distRoot, 'assetmap.json');
 
   if (!(await fs.pathExists(assetMapPath))) {
@@ -421,7 +421,8 @@ export async function collectAssetsAsync(dir: string): Promise<CollectedAssets> 
   for (const platform of Object.keys(metadata.fileMetadata) as ExpoConfigPlatform[]) {
     collectedAssets[platform] = {
       launchAsset: {
-        fileExtension: '.bundle',
+        // path.extname() returns an empty string when there's no extension so we use || to fall back to .bundle
+        fileExtension: path.extname(metadata.fileMetadata[platform].bundle) || '.bundle',
         contentType: 'application/javascript',
         path: path.resolve(dir, metadata.fileMetadata[platform].bundle),
       },


### PR DESCRIPTION
# Why

This PR changes the file extension detection for launch assets to either `.hbc` or `.js`. If the file extension cannot be determined, we fall back to `.bundle`. It would be great to have this so we can display a UI with someone's update and show whether the bundle is hermes bytecode or js. 

## Documentation
- In [our v1 spec](https://docs.expo.dev/technical-specs/expo-updates-1/#manifest-body), we mention that we dont use the `fileExtension` field for the launch asset:

> launchAsset: A special asset that is the entry point of the application code. The fileExtension field will be ignored for this asset and SHOULD be omitted. 

- In the client code, it doesnt look like we care about the launch asset file extension for [Android updates](https://github.com/expo/expo/blob/177b7e763db899ecb6404441d706215d18508309/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ExpoUpdatesUpdate.kt#L53) and [iOS updates](https://github.com/expo/expo/blob/65bd4188bcffad05394fd81ada883e125b512ee3/packages/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift#L36)

# How

- Made `loadAssetMapAsync` function private by removing the `export` keyword since it's only used internally.
- Updated the `collectAssetsAsync` function to dynamically determine the file extension from the bundle path using `path.extname()`.
- Added a fallback to `.bundle` when `path.extname()` returns an empty string (which happens when there's no extension).

# Test Plan

- [x] tested with hermes and jsengine to confirm we correctly mark `.hbc` and `.js` in common cases
- [x] tested on android and ios, ensured updates are correctly applied 