### PR TITLE
[eas-cli] upload assetmap.json when publishing update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- upload assetmap.json when publishing update. ([#2994](https://github.com/expo/eas-cli/pull/2994) by [@quinlanj](https://github.com/quinlanj))
+
 ## [16.3.2](https://github.com/expo/eas-cli/releases/tag/v16.3.2) - 2025-04-17
 
 ### 🧹 Chores

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -17066,6 +17066,105 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "AssetMapGroup",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "android",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AssetMapSourceInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ios",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AssetMapSourceInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "web",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AssetMapSourceInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AssetMapSourceInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "bucketKey",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AssetMapSourceType",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AssetMapSourceType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "GCS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "AssetMetadataResult",
         "description": null,
@@ -17855,6 +17954,33 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AverageMetrics",
+        "description": null,
+        "fields": [
+          {
+            "name": "averageDownloadSize",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -40515,12 +40641,6 @@
             "deprecationReason": null
           },
           {
-            "name": "S3",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "URL",
             "description": null,
             "isDeprecated": false,
@@ -40701,6 +40821,18 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "assetMapGroup",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AssetMapGroup",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "awaitingCodeSigningInfo",
             "description": null,
@@ -48550,6 +48682,18 @@
             "deprecationReason": null
           },
           {
+            "name": "assetMapUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "awaitingCodeSigningInfo",
             "description": null,
             "args": [],
@@ -50465,6 +50609,22 @@
         "description": null,
         "fields": [
           {
+            "name": "averageMetrics",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AverageMetrics",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "cumulativeMetrics",
             "description": null,
             "args": [
@@ -50587,8 +50747,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use scheduleUpdateGroupDeletion instead"
           },
           {
             "name": "scheduleUpdateGroupDeletion",
@@ -51232,6 +51392,12 @@
           },
           {
             "name": "EAS_SUBMIT_GCS_APP_ARCHIVE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EAS_UPDATE_ASSETS_METADATA",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -59764,13 +59930,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "ContinentCode",
-                "ofType": null
-              }
+              "kind": "ENUM",
+              "name": "ContinentCode",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -61332,6 +61494,12 @@
           },
           {
             "name": "REQUIRE_APPROVAL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SLACK",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2550,6 +2550,21 @@ export type AscApiKeyInput = {
   keyP8: Scalars['String']['input'];
 };
 
+export type AssetMapGroup = {
+  android?: InputMaybe<AssetMapSourceInput>;
+  ios?: InputMaybe<AssetMapSourceInput>;
+  web?: InputMaybe<AssetMapSourceInput>;
+};
+
+export type AssetMapSourceInput = {
+  bucketKey?: InputMaybe<Scalars['String']['input']>;
+  type?: InputMaybe<AssetMapSourceType>;
+};
+
+export enum AssetMapSourceType {
+  Gcs = 'GCS'
+}
+
 export type AssetMetadataResult = {
   __typename?: 'AssetMetadataResult';
   status: AssetMetadataStatus;
@@ -2667,6 +2682,11 @@ export enum AuthProviderIdentifier {
   OneLogin = 'ONE_LOGIN',
   StubIdp = 'STUB_IDP'
 }
+
+export type AverageMetrics = {
+  __typename?: 'AverageMetrics';
+  averageDownloadSize: Scalars['Int']['output'];
+};
 
 export type BackgroundJobReceipt = {
   __typename?: 'BackgroundJobReceipt';
@@ -5818,7 +5838,6 @@ export enum ProjectArchiveSourceType {
   Gcs = 'GCS',
   Git = 'GIT',
   None = 'NONE',
-  S3 = 'S3',
   Url = 'URL'
 }
 
@@ -5849,6 +5868,7 @@ export type PublicArtifacts = {
 };
 
 export type PublishUpdateGroupInput = {
+  assetMapGroup?: InputMaybe<AssetMapGroup>;
   awaitingCodeSigningInfo?: InputMaybe<Scalars['Boolean']['input']>;
   branchId: Scalars['String']['input'];
   environment?: InputMaybe<EnvironmentVariableEnvironment>;
@@ -6965,6 +6985,7 @@ export type Update = ActivityTimelineProjectActivity & {
   activityTimestamp: Scalars['DateTime']['output'];
   actor?: Maybe<Actor>;
   app: App;
+  assetMapUrl?: Maybe<Scalars['String']['output']>;
   awaitingCodeSigningInfo: Scalars['Boolean']['output'];
   branch: UpdateBranch;
   branchId: Scalars['ID']['output'];
@@ -7206,6 +7227,7 @@ export type UpdateInfoGroup = {
 
 export type UpdateInsights = {
   __typename?: 'UpdateInsights';
+  averageMetrics: AverageMetrics;
   cumulativeMetrics: CumulativeMetrics;
   id: Scalars['ID']['output'];
   totalUniqueUsers: Scalars['Int']['output'];
@@ -7223,7 +7245,10 @@ export type UpdateInsightsTotalUniqueUsersArgs = {
 
 export type UpdateMutation = {
   __typename?: 'UpdateMutation';
-  /** Delete an EAS update group */
+  /**
+   * Delete an EAS update group
+   * @deprecated Use scheduleUpdateGroupDeletion instead
+   */
   deleteUpdateGroup: DeleteUpdateGroupResult;
   /** Delete an EAS update group in the background */
   scheduleUpdateGroupDeletion: BackgroundJobReceipt;
@@ -7333,6 +7358,7 @@ export enum UploadSessionType {
   /** @deprecated Use EAS_SUBMIT_GCS_APP_ARCHIVE instead. */
   EasSubmitAppArchive = 'EAS_SUBMIT_APP_ARCHIVE',
   EasSubmitGcsAppArchive = 'EAS_SUBMIT_GCS_APP_ARCHIVE',
+  EasUpdateAssetsMetadata = 'EAS_UPDATE_ASSETS_METADATA',
   EasUpdateFingerprint = 'EAS_UPDATE_FINGERPRINT'
 }
 
@@ -8434,7 +8460,7 @@ export type WorkerDeploymentRequestsCacheStatusEdge = {
 
 export type WorkerDeploymentRequestsContinentEdge = {
   __typename?: 'WorkerDeploymentRequestsContinentEdge';
-  continent: ContinentCode;
+  continent?: Maybe<ContinentCode>;
   node: WorkerDeploymentRequestsAggregationNode;
 };
 
@@ -8617,6 +8643,7 @@ export enum WorkflowJobType {
   GetBuild = 'GET_BUILD',
   MaestroTest = 'MAESTRO_TEST',
   RequireApproval = 'REQUIRE_APPROVAL',
+  Slack = 'SLACK',
   Submission = 'SUBMISSION',
   Update = 'UPDATE'
 }
@@ -9465,6 +9492,16 @@ export type CreateKeystoreGenerationUrlMutationVariables = Exact<{ [key: string]
 
 export type CreateKeystoreGenerationUrlMutation = { __typename?: 'RootMutation', keystoreGenerationUrl: { __typename?: 'KeystoreGenerationUrlMutation', createKeystoreGenerationUrl: { __typename?: 'KeystoreGenerationUrl', id: string, url: string } } };
 
+export type CreateLocalBuildMutationVariables = Exact<{
+  appId: Scalars['ID']['input'];
+  jobInput: LocalBuildJobInput;
+  artifactSource: LocalBuildArchiveSourceInput;
+  metadata?: InputMaybe<BuildMetadataInput>;
+}>;
+
+
+export type CreateLocalBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createLocalBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string }, metrics?: { __typename?: 'BuildMetrics', buildWaitTime?: number | null, buildQueueTime?: number | null, buildDuration?: number | null } | null } } } };
+
 export type GetSignedUploadMutationVariables = Exact<{
   contentTypes: Array<Scalars['String']['input']> | Scalars['String']['input'];
 }>;
@@ -9494,16 +9531,6 @@ export type SetRolloutPercentageMutationVariables = Exact<{
 
 
 export type SetRolloutPercentageMutation = { __typename?: 'RootMutation', update: { __typename?: 'UpdateMutation', setRolloutPercentage: { __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, rolloutPercentage?: number | null, actor?: { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string } | null, fingerprint?: { __typename?: 'Fingerprint', id: string, hash: string, debugInfoUrl?: string | null, source?: { __typename?: 'FingerprintSource', type: FingerprintSourceType, bucketKey: string, isDebugFingerprint?: boolean | null } | null } | null } } };
-
-export type CreateLocalBuildMutationVariables = Exact<{
-  appId: Scalars['ID']['input'];
-  jobInput: LocalBuildJobInput;
-  artifactSource: LocalBuildArchiveSourceInput;
-  metadata?: InputMaybe<BuildMetadataInput>;
-}>;
-
-
-export type CreateLocalBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createLocalBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string }, metrics?: { __typename?: 'BuildMetrics', buildWaitTime?: number | null, buildQueueTime?: number | null, buildDuration?: number | null } | null } } } };
 
 export type CreateAndroidSubmissionMutationVariables = Exact<{
   appId: Scalars['ID']['input'];

--- a/packages/eas-cli/src/project/maybeUploadAssetMapAsync.ts
+++ b/packages/eas-cli/src/project/maybeUploadAssetMapAsync.ts
@@ -1,0 +1,53 @@
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import { AssetMapSourceInput, AssetMapSourceType, UploadSessionType } from '../graphql/generated';
+import Log from '../log';
+import { uploadFileAtPathToGCSAsync } from '../uploads';
+import { formatBytes } from '../utils/files';
+import { createProgressTracker } from '../utils/progress';
+
+export async function maybeUploadAssetMapAsync(
+  distRoot: string,
+  graphqlClient: ExpoGraphqlClient
+): Promise<AssetMapSourceInput | null> {
+  const assetMapPath = path.join(distRoot, 'assetmap.json');
+
+  if (!(await fs.pathExists(assetMapPath))) {
+    return null;
+  }
+
+  let gcsBucketKey = undefined;
+  const fileStat = await fs.promises.stat(assetMapPath);
+  try {
+    gcsBucketKey = await uploadFileAtPathToGCSAsync(
+      graphqlClient,
+      UploadSessionType.EasUpdateAssetsMetadata,
+      assetMapPath,
+      createProgressTracker({
+        total: fileStat.size,
+        message: ratio =>
+          `Uploading assetmap.json (${formatBytes(fileStat.size * ratio)} / ${formatBytes(
+            fileStat.size
+          )})`,
+        completedMessage: (duration: string) => `Uploaded assetmap.json ${chalk.dim(duration)}`,
+      })
+    );
+  } catch (err: any) {
+    let errMessage = 'Failed to upload assetmap to EAS';
+
+    if (err.message) {
+      errMessage += `\n\nReason: ${err.message}`;
+    }
+
+    Log.warn(errMessage);
+    return null;
+  }
+
+  return {
+    type: AssetMapSourceType.Gcs,
+    bucketKey: gcsBucketKey,
+  };
+}

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -94,7 +94,7 @@ type UpdateInfoGroup = {
 };
 
 // Partial copy of `@expo/dev-server` `BundleAssetWithFileHashes`
-type AssetMap = Record<
+export type AssetMap = Record<
   string,
   {
     httpServerLocation: string;


### PR DESCRIPTION
# Why

This PR uploads the asset map produced by metro when a user runs `eas update`

# How

- Added new GraphQL schema types for asset maps: `AssetMapGroup`, `AssetMapSourceInput`, and `AssetMapSourceType`
- Created a new function `maybeUploadAssetMapAsync` to handle uploading asset map files to GCS
- Updated the update publish command to collect and upload asset maps alongside other assets
- Added support for including asset map information in the update group publishing process
- Added a new upload session type `EAS_UPDATE_ASSETS_METADATA` for asset map uploads
- Added `assetMapUrl` field to the Update type to expose the asset map URL
- Added `averageMetrics` to UpdateInsights with `averageDownloadSize` field

# Test Plan

- [ ] ran `eas update` in staging and verified source in postgres