### PR TITLE
[eas-cli] Detect when expo metro config is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Detect when expo metro config is used. ([#2996](https://github.com/expo/eas-cli/pull/2996) by [@kadikraman](https://github.com/kadikraman))
+
 ### 🧹 Chores
 
 - upload assetmap.json when publishing update. ([#2994](https://github.com/expo/eas-cli/pull/2994) by [@quinlanj](https://github.com/quinlanj))

--- a/packages/eas-cli/src/project/metroConfig.ts
+++ b/packages/eas-cli/src/project/metroConfig.ts
@@ -16,10 +16,11 @@ export async function validateMetroConfigForManagedWorkflowAsync(
   }
 
   const metroConfig = await loadConfigAsync(ctx.projectDir);
-  const hasHashAssetFilesPlugin = metroConfig.transformer?.assetPlugins?.find((plugin: string) =>
-    plugin.match(/expo-asset[/|\\]tools[/|\\]hashAssetFiles/)
-  );
-  if (!hasHashAssetFilesPlugin) {
+  
+  // This is a custom property that we inject to ensure cache invalidation between projects.
+  const isExtendingExpoMetroConfig = metroConfig.transformer.hasOwnProperty('_expoRelativeProjectRoot');
+
+  if (!isExtendingExpoMetroConfig) {
     Log.warn(
       `It looks like that you are using a custom ${chalk.bold(
         'metro.config.js'

--- a/packages/eas-cli/src/project/metroConfig.ts
+++ b/packages/eas-cli/src/project/metroConfig.ts
@@ -16,11 +16,18 @@ export async function validateMetroConfigForManagedWorkflowAsync(
   }
 
   const metroConfig = await loadConfigAsync(ctx.projectDir);
-  
-  // This is a custom property that we inject to ensure cache invalidation between projects.
-  const isExtendingExpoMetroConfig = metroConfig.transformer.hasOwnProperty('_expoRelativeProjectRoot');
 
-  if (!isExtendingExpoMetroConfig) {
+  // SDK <50 | plugins whose presence can be used to determine if the config is extending Expo's Metro config
+  const hasHashAssetFilesPlugin = metroConfig.transformer?.assetPlugins?.find((plugin: string) =>
+    plugin.match(/expo-asset[/|\\]tools[/|\\]hashAssetFiles/)
+  );
+
+  // SDK >=51 | this is a custom property that we inject to ensure cache invalidation between projects.
+  const isExtendingExpoMetroConfig = metroConfig.transformer.hasOwnProperty(
+    '_expoRelativeProjectRoot'
+  );
+
+  if (!isExtendingExpoMetroConfig && !hasHashAssetFilesPlugin) {
     Log.warn(
       `It looks like that you are using a custom ${chalk.bold(
         'metro.config.js'


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

After upgrading to SDK 53 I get this warning when running `eas build` even though I'm definitely using the expo metro config.

<img width="1188" alt="Screenshot 2025-04-22 at 20 08 27" src="https://github.com/user-attachments/assets/66a8be17-6068-45c4-a491-1f6ea63304ec" />

# How

Update the check to match that of [Expo Doctor](https://github.com/expo/expo/blob/main/packages/expo-doctor/src/checks/MetroConfigCheck.ts#L20) which does detect this.

# Test Plan

Run `easd build` locally and confirm the warning is no longer shown.