### PR TITLE
[eas-cli] Add specific error for WAF block events (EAS Hosting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - upload assetmap.json when publishing update. ([#2994](https://github.com/expo/eas-cli/pull/2994) by [@quinlanj](https://github.com/quinlanj))
+- Add error messages for CDN-level upload errors. ([#2998](https://github.com/expo/eas-cli/pull/2998) by [@kitten](https://github.com/kitten))
 
 ## [16.3.2](https://github.com/expo/eas-cli/releases/tag/v16.3.2) - 2025-04-17
 

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -149,7 +149,6 @@ export async function uploadAsync(params: UploadParams): Promise<UploadResult> {
 
       if (
         response.status === 408 ||
-        response.status === 408 ||
         response.status === 409 ||
         response.status === 429 ||
         (response.status >= 500 && response.status <= 599)

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -138,8 +138,9 @@ export async function uploadAsync(params: UploadParams): Promise<UploadResult> {
           // why a request was blocked by looking up a WAF event via the "Ray ID" here:
           // https://dash.cloudflare.com/e6f39f67f543faa6038768e8f37e4234/expo.app/security/events
           let message = `CDN firewall has aborted the upload with ${response.statusText}.`;
-          if (rayId)
+          if (rayId) {
             message += `\nReport this error quoting Request ID ${rayId}`;
+          }
           return `Upload of "${filePath}" failed: ${message}`;
         } else {
           const json = await response.json().catch(() => null);


### PR DESCRIPTION
# Why

The Cloudflare CDN WAF might block the requests from specific sources when a request contains suspicious contents, a rule has caught the content, or the IP has been rate limited by their bot net protection.

All we can do in this case is:
- Tell the user this has been a CDN-level error
- Quote the Request ID (aka Ray ID) so we can look up the error

Here's an example of what this might look like:
![image](https://github.com/user-attachments/assets/8dce6ce7-eb68-4b7f-a775-da5f99f4735e)


# How

- Add check for `Content-Type: text/html` and output non-JSON error message

# Test Plan

- Tested manually locally
