### PR TITLE
[eas-cli][ENG-13286] Add --verbose-logs option to `eas build` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+-- Add `--verbose-logs` flag for `build` command ([#3000](https://github.com/expo/eas-cli/pull/3000) by [@khamilowicz](https://github.com/khamilowicz))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -78,7 +78,10 @@ export async function prepareJobAsync(
       bun: buildProfile.bun,
       yarn: buildProfile.yarn,
       ndk: buildProfile.ndk,
-      env: buildProfile.env,
+      env: {
+        ...buildProfile.env,
+        ...(ctx.isVerboseLoggingEnabled ? { EAS_VERBOSE: '1' } : {}),
+      },
     },
     cache: {
       ...cacheDefaults,

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -63,5 +63,6 @@ export interface BuildContext<T extends Platform> {
   vcsClient: Client;
   loggerLevel?: LoggerLevel;
   repack: boolean;
+  isVerboseLoggingEnabled: boolean;
   env: Record<string, string>;
 }

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -43,6 +43,7 @@ export async function createBuildContextAsync<T extends Platform>({
   buildLoggerLevel,
   freezeCredentials,
   repack,
+  isVerboseLoggingEnabled,
   env,
 }: {
   buildProfileName: string;
@@ -65,6 +66,7 @@ export async function createBuildContextAsync<T extends Platform>({
   buildLoggerLevel?: LoggerLevel;
   freezeCredentials: boolean;
   repack: boolean;
+  isVerboseLoggingEnabled: boolean;
   env: Record<string, string>;
 }): Promise<BuildContext<T>> {
   const { exp, projectId } = await getDynamicPrivateProjectConfigAsync({
@@ -151,6 +153,7 @@ export async function createBuildContextAsync<T extends Platform>({
     requiredPackageManager,
     loggerLevel: buildLoggerLevel,
     repack,
+    isVerboseLoggingEnabled,
     env,
   };
   if (platform === Platform.ANDROID) {

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -72,7 +72,10 @@ export async function prepareJobAsync(
       bundler: buildProfile.bundler,
       cocoapods: buildProfile.cocoapods,
       fastlane: buildProfile.fastlane,
-      env: buildProfile.env,
+      env: {
+        ...buildProfile.env,
+        ...(ctx.isVerboseLoggingEnabled ? { EAS_VERBOSE: '1' } : {}),
+      },
     },
     cache: {
       ...cacheDefaults,

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -98,6 +98,7 @@ export interface BuildFlags {
   buildLoggerLevel?: LoggerLevel;
   freezeCredentials: boolean;
   repack: boolean;
+  isVerboseLoggingEnabled?: boolean;
 }
 
 export async function runBuildAndSubmitAsync({
@@ -401,6 +402,7 @@ async function prepareAndStartBuildAsync({
     buildLoggerLevel: flags.buildLoggerLevel ?? (Log.isDebug ? LoggerLevel.DEBUG : undefined),
     freezeCredentials: flags.freezeCredentials,
     repack: flags.repack,
+    isVerboseLoggingEnabled: flags.isVerboseLoggingEnabled ?? false,
     env,
   });
 

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -37,6 +37,7 @@ interface RawBuildFlags {
   message?: string;
   'build-logger-level'?: LoggerLevel;
   'freeze-credentials': boolean;
+  'verbose-logs'?: boolean;
   repack: boolean;
 }
 
@@ -117,6 +118,10 @@ export default class Build extends EasCommand {
       default: false,
       hidden: true,
       description: 'Use the golden dev client build repack flow as it works for onboarding',
+    }),
+    'verbose-logs': Flags.boolean({
+      default: false,
+      description: 'Use verbose logs for the build process',
     }),
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -238,6 +243,7 @@ export default class Build extends EasCommand {
       message,
       buildLoggerLevel: flags['build-logger-level'],
       freezeCredentials: flags['freeze-credentials'],
+      isVerboseLoggingEnabled: flags['verbose-logs'],
       repack: flags.repack,
     };
   }


### PR DESCRIPTION
### **3000th PR 🎉** 

# Why

[ENG-13286: Provide an option for EAS Build that indicates we should use the verbose logging version of the install command](https://linear.app/expo/issue/ENG-13286/provide-an-option-for-eas-build-that-indicates-we-should-use-the)

User should be able to easily enable verbose logs for build phase for easier debugging.

# How

- added `--verbose-logs` option to `eas build` command
- flag is sent as an additional `EAS_BUILD_ENABLE_VERBOSE_LOGGING` variable

# Test Plan

- start a build command with a flag `--verbose-logs`
- js package manager, `pod install` and `gradlew` should run in verbose mode

# Deploy

1. https://github.com/expo/eas-build/pull/527
2. https://github.com/expo/eas-cli/pull/3000