### PR TITLE
Add eas-build-cache-provider package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 -- Add `--verbose-logs` flag for `build` command ([#3000](https://github.com/expo/eas-cli/pull/3000) by [@khamilowicz](https://github.com/khamilowicz))
 
+- Add `eas-build-cache-provider` package. ([#3002](https://github.com/expo/eas-cli/pull/3002) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-build-cache-provider/README.md
+++ b/packages/eas-build-cache-provider/README.md
@@ -1,0 +1,3 @@
+# eas-build-cache-provider
+
+A build cache provider plugin for the Expo CLI

--- a/packages/eas-build-cache-provider/package.json
+++ b/packages/eas-build-cache-provider/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "eas-build-cache-provider",
+  "description": "A build cache provider plugin for the Expo CLI",
+  "version": "0.1.0",
+  "author": "Expo <support@expo.dev>",
+  "bugs": "https://github.com/expo/eas-cli/issues",
+  "dependencies": {
+    "@babel/code-frame": "7.23.5",
+    "@expo/config-plugins": "9.0.12",
+    "@expo/spawn-async": "^1.7.2",
+    "chalk": "4.1.2",
+    "fs-extra": "11.2.0",
+    "log-symbols": "4.1.0",
+    "semver": "7.5.2",
+    "terminal-link": "2.1.1",
+    "tslib": "2.4.1"
+  },
+  "devDependencies": {
+    "@tsconfig/node18": "18.2.4",
+    "@types/babel__code-frame": "7.0.3",
+    "@types/fs-extra": "11.0.4",
+    "memfs": "3.4.13",
+    "rimraf": "3.0.2",
+    "typescript": "5.3.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "homepage": "https://github.com/expo/eas-cli",
+  "license": "MIT",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "repository": "expo/eas-cli",
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json",
+    "build-allow-unused": "tsc --project tsconfig.allowUnused.json",
+    "watch": "yarn build --watch --preserveWatchOutput",
+    "watch-allow-unused": "yarn build-allow-unused --watch --preserveWatchOutput",
+    "typecheck": "tsc",
+    "prepack": "yarn rebuild",
+    "rebuild": "rimraf build && yarn build",
+    "test": "jest",
+    "clean": "rimraf build node_modules yarn-error.log"
+  },
+  "files": [
+    "/build"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "volta": {
+    "node": "20.11.0",
+    "yarn": "1.22.21"
+  }
+}

--- a/packages/eas-build-cache-provider/package.json
+++ b/packages/eas-build-cache-provider/package.json
@@ -5,11 +5,13 @@
   "author": "Expo <support@expo.dev>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
+    "@expo/config": "10.0.6",
     "@babel/code-frame": "7.23.5",
-    "@expo/config-plugins": "9.0.12",
     "@expo/spawn-async": "^1.7.2",
     "chalk": "4.1.2",
+    "figures": "3.2.0",
     "fs-extra": "11.2.0",
+    "getenv": "1.0.0",
     "log-symbols": "4.1.0",
     "semver": "7.5.2",
     "terminal-link": "2.1.1",
@@ -19,6 +21,7 @@
     "@tsconfig/node18": "18.2.4",
     "@types/babel__code-frame": "7.0.3",
     "@types/fs-extra": "11.0.4",
+    "@types/getenv": "^1.0.0",
     "memfs": "3.4.13",
     "rimraf": "3.0.2",
     "typescript": "5.3.3"

--- a/packages/eas-build-cache-provider/src/.eslintrc.js
+++ b/packages/eas-build-cache-provider/src/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  extends: ['universe/shared/typescript-analysis'],
+  overrides: [
+    {
+      files: ['*.ts', '*.d.ts'],
+      parserOptions: {
+        project: './packages/eas-build-cache-provider/tsconfig.json',
+      },
+      rules: {
+        '@typescript-eslint/explicit-function-return-type': [
+          'warn',
+          {
+            allowExpressions: true,
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/packages/eas-build-cache-provider/src/helpers.ts
+++ b/packages/eas-build-cache-provider/src/helpers.ts
@@ -1,0 +1,40 @@
+import { getPackageJson } from '@expo/config';
+import { SpawnResult } from '@expo/spawn-async';
+
+type RunOptions = any;
+
+export function isSpawnResultError(obj: any): obj is Error & SpawnResult {
+  return (
+    obj &&
+    'message' in obj &&
+    obj.status !== undefined &&
+    obj.stdout !== undefined &&
+    obj.stderr !== undefined
+  );
+}
+
+export function isDevClientBuild({
+  runOptions,
+  projectRoot,
+}: {
+  runOptions: RunOptions;
+  projectRoot: string;
+}): boolean {
+  if (!hasDirectDevClientDependency(projectRoot)) {
+    return false;
+  }
+
+  if ('variant' in runOptions && runOptions.variant !== undefined) {
+    return runOptions.variant === 'debug';
+  }
+  if ('configuration' in runOptions && runOptions.configuration !== undefined) {
+    return runOptions.configuration === 'Debug';
+  }
+
+  return true;
+}
+
+export function hasDirectDevClientDependency(projectRoot: string): boolean {
+  const { dependencies = {}, devDependencies = {} } = getPackageJson(projectRoot);
+  return !!dependencies['expo-dev-client'] || !!devDependencies['expo-dev-client'];
+}

--- a/packages/eas-build-cache-provider/src/helpers.ts
+++ b/packages/eas-build-cache-provider/src/helpers.ts
@@ -1,6 +1,7 @@
 import { getPackageJson } from '@expo/config';
 import { SpawnResult } from '@expo/spawn-async';
 
+// import from '@expo/config';
 type RunOptions = any;
 
 export function isSpawnResultError(obj: any): obj is Error & SpawnResult {

--- a/packages/eas-build-cache-provider/src/index.ts
+++ b/packages/eas-build-cache-provider/src/index.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import { isDevClientBuild, isSpawnResultError } from './helpers';
 import Log from './log';
 
+// import from '@expo/config';
 type CalculateFingerprintHashProps = any;
 type RemoteBuildCachePlugin = any;
 type RunOptions = any;

--- a/packages/eas-build-cache-provider/src/index.ts
+++ b/packages/eas-build-cache-provider/src/index.ts
@@ -1,4 +1,4 @@
-import { ModPlatform } from '@expo/config-plugins';
+import { Platform } from '@expo/config';
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import fs from 'fs-extra';
@@ -19,7 +19,7 @@ async function resolveRemoteBuildCacheAsync({
   runOptions,
 }: {
   projectRoot: string;
-  platform: ModPlatform;
+  platform: Platform;
   fingerprintHash: string;
   runOptions: RunOptions;
 }): Promise<string | null> {
@@ -75,7 +75,7 @@ async function uploadEASRemoteBuildCacheAsync({
 }: {
   projectRoot: string;
   runOptions: RunOptions;
-  platform: ModPlatform;
+  platform: Platform;
   fingerprintHash: string;
   buildPath?: string;
 }): Promise<string | null> {

--- a/packages/eas-build-cache-provider/src/index.ts
+++ b/packages/eas-build-cache-provider/src/index.ts
@@ -1,0 +1,146 @@
+import { ModPlatform } from '@expo/config-plugins';
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+
+import { isDevClientBuild, isSpawnResultError } from './helpers';
+import Log from './log';
+
+type CalculateFingerprintHashProps = any;
+type RemoteBuildCachePlugin = any;
+type RunOptions = any;
+
+async function resolveRemoteBuildCacheAsync({
+  projectRoot,
+  platform,
+  fingerprintHash,
+  runOptions,
+}: {
+  projectRoot: string;
+  platform: ModPlatform;
+  fingerprintHash: string;
+  runOptions: RunOptions;
+}): Promise<string | null> {
+  const easJsonPath = path.join(projectRoot, 'eas.json');
+  if (!(await fs.exists(easJsonPath))) {
+    Log.debug('eas.json not found, skip checking for remote builds');
+    return null;
+  }
+
+  Log.log(
+    chalk`{whiteBright \u203A} {bold Searching builds with matching fingerprint on EAS servers}`
+  );
+  try {
+    const results = await spawnAsync(
+      'npx',
+      [
+        'eas-cli',
+        'build:download',
+        `--platform=${platform}`,
+        `--fingerprint=${fingerprintHash}`,
+        '--non-interactive',
+        isDevClientBuild({ runOptions, projectRoot }) ? '--dev-client' : '--no-dev-client',
+        '--json',
+      ],
+      {
+        cwd: projectRoot,
+      }
+    );
+
+    Log.log(chalk`{whiteBright \u203A} {bold Successfully downloaded cached build}`);
+    // {
+    //   "path": "/var/folders/03/lppcpcnn61q3mz5ckzmzd8w80000gn/T/eas-cli-nodejs/eas-build-run-cache/c0f9ba9c-0cf1-4c5c-8566-b28b7971050f_22f1bbfa-1c09-4b67-9e4a-721906546b58.app"
+    // }
+    const json = JSON.parse(results.stdout.trim());
+    return json?.path;
+  } catch (error) {
+    Log.debug('eas-cli error:', error);
+    // @TODO(2025-04-11): remove this in a future release
+    if (isSpawnResultError(error) && error.stderr.includes('command build:download not found')) {
+      Log.warn(
+        `To take advantage of remote build cache, upgrade your eas-cli installation to latest.`
+      );
+    }
+    return null;
+  }
+}
+
+async function uploadEASRemoteBuildCacheAsync({
+  projectRoot,
+  platform,
+  fingerprintHash,
+  buildPath,
+}: {
+  projectRoot: string;
+  runOptions: RunOptions;
+  platform: ModPlatform;
+  fingerprintHash: string;
+  buildPath?: string;
+}): Promise<string | null> {
+  const easJsonPath = path.join(projectRoot, 'eas.json');
+  if (!(await fs.exists(easJsonPath))) {
+    Log.debug('eas.json not found, skip uploading builds');
+    return null;
+  }
+
+  try {
+    Log.log(chalk`{whiteBright \u203A} {bold Uploading build to remote cache}`);
+    const results = await spawnAsync(
+      'npx',
+      [
+        'eas-cli',
+        'upload',
+        `--platform=${platform}`,
+        `--fingerprint=${fingerprintHash}`,
+        buildPath ? `--build-path=${buildPath}` : '',
+        '--non-interactive',
+        '--json',
+      ],
+      {
+        cwd: projectRoot,
+      }
+    );
+    // {
+    //   "url": "/var/folders/03/lppcpcnn61q3mz5ckzmzd8w80000gn/T/eas-cli-nodejs/eas-build-run-cache/c0f9ba9c-0cf1-4c5c-8566-b28b7971050f_22f1bbfa-1c09-4b67-9e4a-721906546b58.app"
+    // }
+    const json = JSON.parse(results.stdout.trim());
+    Log.log(chalk`{whiteBright \u203A} {bold Build successfully uploaded: ${json?.url}}`);
+    return json?.url;
+  } catch (error) {
+    Log.debug('eas-cli error:', error);
+  }
+  return null;
+}
+
+async function calculateEASFingerprintHashAsync({
+  projectRoot,
+  platform,
+}: CalculateFingerprintHashProps): Promise<string | null> {
+  // prefer using `eas fingerprint:generate` because it automatically upload sources
+  try {
+    const results = await spawnAsync(
+      'npx',
+      ['eas-cli', 'fingerprint:generate', `--platform=${platform}`, '--json', '--non-interactive'],
+      {
+        cwd: projectRoot,
+      }
+    );
+    // {
+    //   "hash": "203f960b965e154b77dc31c6c42e5582e8d77196"
+    // }
+    const json = JSON.parse(results.stdout.trim());
+    return json?.hash;
+  } catch (error) {
+    Log.debug('eas-cli error:', error);
+  }
+  return null;
+}
+
+const EASRemoteBuildCacheProvider: RemoteBuildCachePlugin = {
+  resolveRemoteBuildCache: resolveRemoteBuildCacheAsync,
+  uploadRemoteBuildCache: uploadEASRemoteBuildCacheAsync,
+  calculateFingerprintHash: calculateEASFingerprintHashAsync,
+};
+
+export default EASRemoteBuildCacheProvider;

--- a/packages/eas-build-cache-provider/src/log.ts
+++ b/packages/eas-build-cache-provider/src/log.ts
@@ -1,0 +1,121 @@
+import chalk from 'chalk';
+import figures from 'figures';
+import { boolish } from 'getenv';
+import logSymbols from 'log-symbols';
+import terminalLink from 'terminal-link';
+
+type Color = (...text: string[]) => string;
+
+export default class Log {
+  public static readonly isDebug = boolish('EXPO_DEBUG', false);
+
+  public static log(...args: any[]): void {
+    Log.consoleLog(...args);
+  }
+
+  public static newLine(): void {
+    Log.consoleLog();
+  }
+
+  public static addNewLineIfNone(): void {
+    if (!Log.isLastLineNewLine) {
+      Log.newLine();
+    }
+  }
+
+  public static error(...args: any[]): void {
+    Log.consoleLog(...Log.withTextColor(args, chalk.red));
+  }
+
+  public static warn(...args: any[]): void {
+    Log.consoleLog(...Log.withTextColor(args, chalk.yellow));
+  }
+
+  public static debug(...args: any[]): void {
+    if (Log.isDebug) {
+      Log.consoleLog(...args);
+    }
+  }
+
+  public static gray(...args: any[]): void {
+    Log.consoleLog(...Log.withTextColor(args, chalk.gray));
+  }
+
+  public static warnDeprecatedFlag(flag: string, message: string): void {
+    Log.warn(`› ${chalk.bold('--' + flag)} flag is deprecated. ${message}`);
+  }
+
+  public static fail(message: string): void {
+    Log.log(`${chalk.red(logSymbols.error)} ${message}`);
+  }
+
+  public static succeed(message: string): void {
+    Log.log(`${chalk.green(logSymbols.success)} ${message}`);
+  }
+
+  public static withTick(...args: any[]): void {
+    Log.consoleLog(chalk.green(figures.tick), ...args);
+  }
+
+  public static withInfo(...args: any[]): void {
+    Log.consoleLog(chalk.green(figures.info), ...args);
+  }
+
+  private static consoleLog(...args: any[]): void {
+    Log.updateIsLastLineNewLine(args);
+    // eslint-disable-next-line no-console
+    console.log(...args);
+  }
+
+  private static withTextColor(args: any[], chalkColor: Color): string[] {
+    return args.map(arg => chalkColor(arg));
+  }
+
+  private static isLastLineNewLine = false;
+  private static updateIsLastLineNewLine(args: any[]): void {
+    if (args.length === 0) {
+      Log.isLastLineNewLine = true;
+    } else {
+      const lastArg = args[args.length - 1];
+      if (typeof lastArg === 'string' && (lastArg === '' || lastArg.match(/[\r\n]$/))) {
+        Log.isLastLineNewLine = true;
+      } else {
+        Log.isLastLineNewLine = false;
+      }
+    }
+  }
+}
+
+/**
+ * Prints a link for given URL, using text if provided, otherwise text is just the URL.
+ * Format links as dim (unless disabled) and with an underline.
+ *
+ * @example https://expo.dev
+ */
+export function link(
+  url: string,
+  { text = url, fallback, dim = true }: { text?: string; dim?: boolean; fallback?: string } = {}
+): string {
+  // Links can be disabled via env variables https://github.com/jamestalmage/supports-hyperlinks/blob/master/index.js
+  const output = terminalLink(text, url, {
+    fallback: () =>
+      fallback ?? (text === url ? chalk.underline(url) : `${text}: ${chalk.underline(url)}`),
+  });
+  return dim ? chalk.dim(output) : output;
+}
+
+/**
+ * Provide a consistent "Learn more" link experience.
+ * Format links as dim (unless disabled) with an underline.
+ *
+ * @example Learn more: https://expo.dev
+ */
+export function learnMore(
+  url: string,
+  {
+    learnMoreMessage: maybeLearnMoreMessage,
+    dim = true,
+  }: { learnMoreMessage?: string; dim?: boolean } = {}
+): string {
+  return link(url, { text: maybeLearnMoreMessage ?? 'Learn more', dim });
+}

--- a/packages/eas-build-cache-provider/tsconfig.build.json
+++ b/packages/eas-build-cache-provider/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig",
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}

--- a/packages/eas-build-cache-provider/tsconfig.json
+++ b/packages/eas-build-cache-provider/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "importHelpers": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "build",
+    "rootDir": "src",
+    "typeRoots": ["../../node_modules/@types", "../../ts-declarations", "./node_modules/@types"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/36314

Given that the cache provider logic is directly tied to eas-cli, there is no reason for this code to live on the expo/expo repo

# How
 
Extract the code from https://github.com/expo/expo/blob/e0128f52abf313f9a8c99460bbab5b8c4e3cc3f9/packages/%40expo/cli/src/utils/remote-build-cache-providers/eas.ts to a separate package

I'll add proper types in a follow-up PR once they are exported by `@expo/config`

# Test Plan

app.json
```json
{
  "expo": {
    "experiments": {
      "remoteBuildCache": {
        "provider": {
          "plugin": "eas-build-cache-provider"
        }
      }
    }
  }
}
```

Run `nexpo run:ios` 
