### PR TITLE
[eas-cli] Allow any suffix for gradle command build type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+-- Allow non-standard build types in custom gradle command. ([#3000](https://github.com/expo/eas-cli/pull/3003) by [@khamilowicz](https://github.com/khamilowicz))
+
 ## [16.4.0](https://github.com/expo/eas-cli/releases/tag/v16.4.0) - 2025-05-02
 
 ### 🎉 New features

--- a/packages/eas-cli/src/build/android/__tests__/build-test.ts
+++ b/packages/eas-cli/src/build/android/__tests__/build-test.ts
@@ -1,0 +1,26 @@
+import Log from '../../../log';
+import { maybeWarnAboutNonStandardBuildType } from '../build';
+
+const warn = jest.spyOn(Log, 'warn');
+
+describe('maybeWarnAboutNonStandardBuildType', () => {
+  it('should not warn about non-standard build type', () => {
+    const buildProfile = {
+      gradleCommand: ':app:buildRelease',
+    };
+
+    maybeWarnAboutNonStandardBuildType({ buildProfile, buildType: 'release' });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('should warn about non-standard build type', () => {
+    const buildProfile = {
+      gradleCommand: ':app:buildStage',
+    };
+
+    maybeWarnAboutNonStandardBuildType({ buildProfile, buildType: 'stage' });
+
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/project/android/__tests__/gradle-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/gradle-test.ts
@@ -69,7 +69,7 @@ describe(resolveGradleBuildContextAsync, () => {
         } as any,
         vcsClient
       );
-      expect(gradleContext).toEqual({ moduleName: 'app', flavor: 'abc' });
+      expect(gradleContext).toEqual({ moduleName: 'app', flavor: 'abc', buildType: 'release' });
     });
 
     it('returns undefined if build.gradle does not exist', async () => {

--- a/packages/eas-cli/src/project/android/__tests__/gradleUtils-test.ts
+++ b/packages/eas-cli/src/project/android/__tests__/gradleUtils-test.ts
@@ -144,6 +144,12 @@ describe(parseGradleCommand, () => {
     });
     expect(result).toEqual({ moduleName: 'app', flavor: 'example', buildType: 'release' });
   });
+  test('parsing :app:buildExampleStage', async () => {
+    const result = parseGradleCommand(':app:buildExampleStage', {
+      android: { productFlavors: { example: {} } },
+    });
+    expect(result).toEqual({ moduleName: 'app', flavor: 'example', buildType: 'stage' });
+  });
   test('parsing :app:buildExampleDebug when flavor is named with uper-case', async () => {
     const result = parseGradleCommand(':app:buildExampleRelease', {
       android: { productFlavors: { Example: {} } },

--- a/packages/eas-cli/src/project/android/gradle.ts
+++ b/packages/eas-cli/src/project/android/gradle.ts
@@ -9,6 +9,7 @@ import { Client } from '../../vcs/vcs';
 export interface GradleBuildContext {
   moduleName?: string;
   flavor?: string;
+  buildType?: string;
 }
 
 export async function resolveGradleBuildContextAsync(
@@ -32,9 +33,11 @@ export async function resolveGradleBuildContextAsync(
             `Building modules different than "${gradleUtils.DEFAULT_MODULE_NAME}" might result in unexpected behavior.`
           );
         }
+
         return {
           moduleName: parsedGradleCommand?.moduleName ?? gradleUtils.DEFAULT_MODULE_NAME,
           flavor: parsedGradleCommand?.flavor,
+          buildType: parsedGradleCommand?.buildType,
         };
       } else {
         return { moduleName: gradleUtils.DEFAULT_MODULE_NAME };

--- a/packages/eas-cli/src/project/android/gradleUtils.ts
+++ b/packages/eas-cli/src/project/android/gradleUtils.ts
@@ -1,5 +1,6 @@
 import { AndroidConfig } from '@expo/config-plugins';
 import fs from 'fs-extra';
+import getenv from 'getenv';
 import g2js from 'gradle-to-js/lib/parser';
 
 import Log, { learnMore } from '../../log';
@@ -111,9 +112,13 @@ export function parseGradleCommand(cmd: string, buildGradle: AppBuildGradle): Gr
     ? matchResult[3].charAt(0).toLowerCase() + matchResult[3].slice(1)
     : undefined;
 
-  if (buildType && !['debug', 'release'].includes(buildType)) {
+  if (
+    buildType &&
+    !['debug', 'release'].includes(buildType) &&
+    !getenv.boolish('EAS_BUILD_NO_GRADLE_BUILD_TYPE_WARNING', false)
+  ) {
     Log.warn(
-      `Custom gradle command "${cmd}" has non-standard build type: "${buildType}". Expected "release" or "debug". Ensure it is spelled correctly and build.gradle is configured correctly.`
+      `Custom gradle command "${cmd}" has non-standard build type: "${buildType}". Expected "release" or "debug". Ensure it is spelled correctly and build.gradle is configured correctly. To suppress this warning, set EAS_BUILD_NO_GRADLE_BUILD_TYPE_WARNING=true.`
     );
     Log.warn(learnMore('https://developer.android.com/build/build-variants#build-types'));
   }

--- a/packages/eas-cli/src/project/android/gradleUtils.ts
+++ b/packages/eas-cli/src/project/android/gradleUtils.ts
@@ -1,9 +1,6 @@
 import { AndroidConfig } from '@expo/config-plugins';
 import fs from 'fs-extra';
-import getenv from 'getenv';
 import g2js from 'gradle-to-js/lib/parser';
-
-import Log, { learnMore } from '../../log';
 
 // represents gradle command
 // e.g. for `:app:buildExampleDebug` -> { moduleName: app, flavor: example, buildType: debug }
@@ -111,17 +108,6 @@ export function parseGradleCommand(cmd: string, buildGradle: AppBuildGradle): Gr
   const buildType = matchResult[3]
     ? matchResult[3].charAt(0).toLowerCase() + matchResult[3].slice(1)
     : undefined;
-
-  if (
-    buildType &&
-    !['debug', 'release'].includes(buildType) &&
-    !getenv.boolish('EAS_BUILD_NO_GRADLE_BUILD_TYPE_WARNING', false)
-  ) {
-    Log.warn(
-      `Custom gradle command "${cmd}" has non-standard build type: "${buildType}". Expected "release" or "debug". Ensure it is spelled correctly and build.gradle is configured correctly. To suppress this warning, set EAS_BUILD_NO_GRADLE_BUILD_TYPE_WARNING=true.`
-    );
-    Log.warn(learnMore('https://developer.android.com/build/build-variants#build-types'));
-  }
 
   return {
     moduleName,


### PR DESCRIPTION
# Why

[ENG-15618: Support different suffixes of custom gradle commands](https://linear.app/expo/issue/ENG-15618/support-different-suffixes-of-custom-gradle-commands)

Currently when user specifies a custom gradle command that does not end with `*Release` or `*Debug` the command is not parsed correctly. Build type and flavour are not parsed, which causes problems with setting code version and app version down the line.

# How

- Changed the regexp that parses gradle command to be more flexible, allowing any suffix that starts with a capital letter.

# Test Plan

- add a custom gradle command to `eas.json`, for example 
```
 "development": {
      "android": {
        "gradleCommand": ":app:assembleAbcStaging"
      }
    },
```
- add a `buildType` and packageFlavor to `build.gradle` file:
```
productFlavors {  
        abc { // New flavor
            versionCode 3
            versionName "abc"
        }
    }
buildTypes {
        staging {}
        debug {... }
        release {...}
}
```

- start an android build from cli.
- started build should not warn about invalid configuration
- on website, build version should be set to the value assigned in flavour.