### PR TITLE
[build-cache-provider] Read types from @expo/config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Read remote build cache provider types from `@expo/config`. ([#3005](https://github.com/expo/eas-cli/pull/3005) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## [16.3.3](https://github.com/expo/eas-cli/releases/tag/v16.3.3) - 2025-04-24
 
 ### 🐛 Bug fixes

--- a/packages/eas-build-cache-provider/package.json
+++ b/packages/eas-build-cache-provider/package.json
@@ -5,7 +5,7 @@
   "author": "Expo <support@expo.dev>",
   "bugs": "https://github.com/expo/eas-cli/issues",
   "dependencies": {
-    "@expo/config": "10.0.6",
+    "@expo/config": "11.0.6",
     "@babel/code-frame": "7.23.5",
     "@expo/spawn-async": "^1.7.2",
     "chalk": "4.1.2",

--- a/packages/eas-build-cache-provider/src/helpers.ts
+++ b/packages/eas-build-cache-provider/src/helpers.ts
@@ -1,8 +1,5 @@
-import { getPackageJson } from '@expo/config';
+import { getPackageJson, RunOptions } from '@expo/config';
 import { SpawnResult } from '@expo/spawn-async';
-
-// import from '@expo/config';
-type RunOptions = any;
 
 export function isSpawnResultError(obj: any): obj is Error & SpawnResult {
   return (

--- a/packages/eas-build-cache-provider/src/helpers.ts
+++ b/packages/eas-build-cache-provider/src/helpers.ts
@@ -1,4 +1,4 @@
-import { getPackageJson, RunOptions } from '@expo/config';
+import { RunOptions, getPackageJson } from '@expo/config';
 import { SpawnResult } from '@expo/spawn-async';
 
 export function isSpawnResultError(obj: any): obj is Error & SpawnResult {

--- a/packages/eas-build-cache-provider/src/index.ts
+++ b/packages/eas-build-cache-provider/src/index.ts
@@ -1,4 +1,9 @@
-import { Platform } from '@expo/config';
+import {
+  Platform,
+  CalculateFingerprintHashProps,
+  RemoteBuildCachePlugin,
+  RunOptions,
+} from '@expo/config';
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import fs from 'fs-extra';
@@ -6,11 +11,6 @@ import path from 'path';
 
 import { isDevClientBuild, isSpawnResultError } from './helpers';
 import Log from './log';
-
-// import from '@expo/config';
-type CalculateFingerprintHashProps = any;
-type RemoteBuildCachePlugin = any;
-type RunOptions = any;
 
 async function resolveRemoteBuildCacheAsync({
   projectRoot,

--- a/packages/eas-build-cache-provider/src/index.ts
+++ b/packages/eas-build-cache-provider/src/index.ts
@@ -1,6 +1,6 @@
 import {
-  Platform,
   CalculateFingerprintHashProps,
+  Platform,
   RemoteBuildCachePlugin,
   RunOptions,
 } from '@expo/config';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1410,6 +1410,26 @@
     xcode "^3.0.1"
     xml2js "0.6.0"
 
+"@expo/config-plugins@~10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-10.0.0.tgz#5ea58f9c12d1d06b6c43c9fb9e7163bb4954d04f"
+  integrity sha512-VAGMjQoBFKwyXGzVcAptqY68LGx1pZr8c+4e82h6E1elenjeVBt1CBaWHC/kiAw2Akr2nkdUVd85nIaC81m1ow==
+  dependencies:
+    "@expo/config-types" "^53.0.2"
+    "@expo/json-file" "~9.1.3"
+    "@expo/plist" "^0.3.3"
+    "@expo/sdk-runtime-versions" "^1.0.0"
+    chalk "^4.1.2"
+    debug "^4.3.5"
+    getenv "^1.0.0"
+    glob "^10.4.2"
+    resolve-from "^5.0.0"
+    semver "^7.5.4"
+    slash "^3.0.0"
+    slugify "^1.6.6"
+    xcode "^3.0.1"
+    xml2js "0.6.0"
+
 "@expo/config-plugins@~9.0.0":
   version "9.0.9"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-9.0.9.tgz#3765c310c112e200c6715365d6023f6a05b001ed"
@@ -1435,6 +1455,11 @@
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-52.0.1.tgz#327af1b72a3a9d4556f41e083e0e284dd8198b96"
   integrity sha512-vD8ZetyKV7U29lR6+NJohYeoLYTH+eNYXJeNiSOrWCz0witJYY11meMmEnpEaVbN89EfC6uauSUOa6wihtbyPQ==
 
+"@expo/config-types@^53.0.2":
+  version "53.0.3"
+  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-53.0.3.tgz#d083d9b095972e89eee96c41d085feb5b92d2749"
+  integrity sha512-V1e6CiM4TXtGxG/W2Msjp/QOx/vikLo5IUGMvEMjgAglBfGYx3PXfqsUb5aZDt6kqA3bDDwFuZoS5vNm/SYwSg==
+
 "@expo/config@10.0.6":
   version "10.0.6"
   resolved "https://registry.yarnpkg.com/@expo/config/-/config-10.0.6.tgz#85830491bc8cce2af3f19276922a13f5578d2aa8"
@@ -1444,6 +1469,25 @@
     "@expo/config-plugins" "~9.0.10"
     "@expo/config-types" "^52.0.0"
     "@expo/json-file" "^9.0.0"
+    deepmerge "^4.3.1"
+    getenv "^1.0.0"
+    glob "^10.4.2"
+    require-from-string "^2.0.2"
+    resolve-from "^5.0.0"
+    resolve-workspace-root "^2.0.0"
+    semver "^7.6.0"
+    slugify "^1.3.4"
+    sucrase "3.35.0"
+
+"@expo/config@11.0.6":
+  version "11.0.6"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-11.0.6.tgz#934efecf3393e0d47d00cadd511095b2255c3262"
+  integrity sha512-lmBP4kbNFiDLZoxPNuaN/UanFzns0+PxJA1eimOAHa6aFSAHTl48AHozbJ6UARbvig/TVTzLfGpoxv2Ih03iYQ==
+  dependencies:
+    "@babel/code-frame" "~7.10.4"
+    "@expo/config-plugins" "~10.0.0"
+    "@expo/config-types" "^53.0.2"
+    "@expo/json-file" "^9.1.3"
     deepmerge "^4.3.1"
     getenv "^1.0.0"
     glob "^10.4.2"
@@ -1528,6 +1572,14 @@
     json5 "^2.2.3"
     write-file-atomic "^2.3.0"
 
+"@expo/json-file@^9.1.3", "@expo/json-file@~9.1.3":
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-9.1.3.tgz#7e40658345e694c33641cf5750ac08d42cf00c84"
+  integrity sha512-u+5OxD589x+BkR3CerGKshz7OTX23xFAkKWH0Vu2uG0nNrHwAC+RMafvehiP3+xnDrFwuK+oGtZJpg6+fW3bHw==
+  dependencies:
+    "@babel/code-frame" "~7.10.4"
+    json5 "^2.2.3"
+
 "@expo/logger@1.0.117":
   version "1.0.117"
   resolved "https://registry.yarnpkg.com/@expo/logger/-/logger-1.0.117.tgz#31e302656f33dd015fdde89ad803d710a0e5b8a2"
@@ -1584,6 +1636,15 @@
     "@xmldom/xmldom" "~0.7.7"
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
+
+"@expo/plist@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.3.3.tgz#fe2da503d7e6a411161e11c79ecab629c256161d"
+  integrity sha512-tpokZlWbeMm8UwW5311XyEv4tELGysZYkzq+f+LOgi9DRcGPmGPtcQ+aD1dZv4JZkld82AnTUWu0sfWDZdwpNA==
+  dependencies:
+    "@xmldom/xmldom" "^0.8.8"
+    base64-js "^1.2.3"
+    xmlbuilder "^15.1.1"
 
 "@expo/plugin-help@5.1.23":
   version "5.1.23"
@@ -4144,6 +4205,11 @@
     busboy "^1.6.0"
     fast-querystring "^1.1.1"
     tslib "^2.3.1"
+
+"@xmldom/xmldom@^0.8.8":
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
+  integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
 "@xmldom/xmldom@~0.7.7":
   version "0.7.9"
@@ -14757,6 +14823,11 @@ xmlbuilder@^14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-14.0.0.tgz#876b5aec4f05ffd5feb97b0a871c855d16fbeb8c"
   integrity sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==
+
+xmlbuilder@^15.1.1:
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
+  integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
 
 xmlbuilder@^9.0.7, xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
# Why

With `@expo/config`  11.0.6 we can now import remote build cache provider types

# How

Use remote build cache provider types types from @expo/config

# Test Plan

yarn tsc
