### PR TITLE
[eas-cli] Add `--json` flag to `workflow:run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add `--wait`/`--no-wait` flag to `eas workflow:run`. ([#3012](https://github.com/expo/eas-cli/pull/3012) by [@sjchmiela](https://github.com/sjchmiela))
+- Add `--json` flag to `eas workflow:run`. ([#3013](https://github.com/expo/eas-cli/pull/3013) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/workflow/run.ts
+++ b/packages/eas-cli/src/commands/workflow/run.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import { getWorkflowRunUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
-import { EASNonInteractiveFlag } from '../../commandUtils/flags';
+import { EASNonInteractiveFlag, EasJsonOnlyFlag } from '../../commandUtils/flags';
 import {
   WorkflowProjectSourceType,
   WorkflowRunByIdQuery,
@@ -19,6 +19,7 @@ import { ora } from '../../ora';
 import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 import { uploadAccountScopedFileAsync } from '../../project/uploadAccountScopedFileAsync';
 import { uploadAccountScopedProjectSourceAsync } from '../../project/uploadAccountScopedProjectSourceAsync';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import { sleepAsync } from '../../utils/promise';
 import { WorkflowFile } from '../../utils/workflowFile';
 
@@ -41,6 +42,7 @@ export default class WorkflowRun extends EasCommand {
       description: 'Exit codes: 0 = success, 11 = failure, 12 = canceled, 13 = wait aborted.',
       summary: 'Wait for workflow run to complete',
     }),
+    ...EasJsonOnlyFlag,
   };
 
   static override contextDefinition = {
@@ -52,6 +54,10 @@ export default class WorkflowRun extends EasCommand {
 
   async runAsync(): Promise<void> {
     const { flags, args } = await this.parse(WorkflowRun);
+
+    if (flags.json) {
+      enableJsonOutput();
+    }
 
     const {
       getDynamicPrivateProjectConfigAsync,
@@ -157,6 +163,12 @@ export default class WorkflowRun extends EasCommand {
 
     if (!flags.wait) {
       Log.succeed('Workflow run started successfully.');
+
+      printJsonOnlyOutput({
+        id: workflowRunId,
+        url: getWorkflowRunUrl(account.name, projectName, workflowRunId),
+      });
+
       process.exit(0);
     }
 
@@ -164,6 +176,17 @@ export default class WorkflowRun extends EasCommand {
     const { status } = await waitForWorkflowRunToEndAsync(graphqlClient, {
       workflowRunId,
     });
+
+    if (flags.json) {
+      const workflowRun = await WorkflowRunQuery.withJobsByIdAsync(graphqlClient, workflowRunId, {
+        useCache: false,
+      });
+
+      printJsonOnlyOutput({
+        ...workflowRun,
+        url: getWorkflowRunUrl(account.name, projectName, workflowRunId),
+      });
+    }
 
     if (status === WorkflowRunStatus.Failure) {
       process.exit(EXIT_CODES.WORKFLOW_FAILED);

--- a/packages/eas-cli/src/commands/workflow/run.ts
+++ b/packages/eas-cli/src/commands/workflow/run.ts
@@ -164,10 +164,12 @@ export default class WorkflowRun extends EasCommand {
     if (!flags.wait) {
       Log.succeed('Workflow run started successfully.');
 
-      printJsonOnlyOutput({
-        id: workflowRunId,
-        url: getWorkflowRunUrl(account.name, projectName, workflowRunId),
-      });
+      if (flags.json) {
+        printJsonOnlyOutput({
+          id: workflowRunId,
+          url: getWorkflowRunUrl(account.name, projectName, workflowRunId),
+        });
+      }
 
       process.exit(0);
     }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -10001,6 +10001,13 @@ export type WorkflowRunByIdQueryVariables = Exact<{
 
 export type WorkflowRunByIdQuery = { __typename?: 'RootQuery', workflowRuns: { __typename?: 'WorkflowRunQuery', byId: { __typename?: 'WorkflowRun', id: string, status: WorkflowRunStatus } } };
 
+export type WorkflowRunByIdWithJobsQueryVariables = Exact<{
+  workflowRunId: Scalars['ID']['input'];
+}>;
+
+
+export type WorkflowRunByIdWithJobsQuery = { __typename?: 'RootQuery', workflowRuns: { __typename?: 'WorkflowRunQuery', byId: { __typename?: 'WorkflowRun', id: string, name: string, status: WorkflowRunStatus, createdAt: any, workflow: { __typename?: 'Workflow', id: string, name?: string | null, fileName: string }, jobs: Array<{ __typename?: 'WorkflowJob', id: string, key: string, name: string, type: WorkflowJobType, status: WorkflowJobStatus, outputs: any, createdAt: any }> } } };
+
 export type AccountFragment = { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> };
 
 export type AppFragment = { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', githubRepoOwnerName: string, githubRepoName: string } } | null };

--- a/packages/eas-cli/src/graphql/queries/WorkflowRunQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/WorkflowRunQuery.ts
@@ -2,7 +2,12 @@ import gql from 'graphql-tag';
 
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { withErrorHandlingAsync } from '../client';
-import { WorkflowRunByIdQuery, WorkflowRunByIdQueryVariables } from '../generated';
+import {
+  WorkflowRunByIdQuery,
+  WorkflowRunByIdQueryVariables,
+  WorkflowRunByIdWithJobsQuery,
+  WorkflowRunByIdWithJobsQueryVariables,
+} from '../generated';
 
 export const WorkflowRunQuery = {
   async byIdAsync(
@@ -19,6 +24,52 @@ export const WorkflowRunQuery = {
                 byId(workflowRunId: $workflowRunId) {
                   id
                   status
+                }
+              }
+            }
+          `,
+          { workflowRunId },
+          {
+            requestPolicy: useCache ? 'cache-first' : 'network-only',
+            additionalTypenames: ['WorkflowRun'],
+          }
+        )
+        .toPromise()
+    );
+    return data.workflowRuns.byId;
+  },
+  async withJobsByIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    workflowRunId: string,
+    { useCache = true }: { useCache?: boolean } = {}
+  ): Promise<WorkflowRunByIdWithJobsQuery['workflowRuns']['byId']> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<WorkflowRunByIdWithJobsQuery, WorkflowRunByIdWithJobsQueryVariables>(
+          gql`
+            query WorkflowRunByIdWithJobs($workflowRunId: ID!) {
+              workflowRuns {
+                byId(workflowRunId: $workflowRunId) {
+                  id
+                  name
+                  status
+                  createdAt
+
+                  workflow {
+                    id
+                    name
+                    fileName
+                  }
+
+                  jobs {
+                    id
+                    key
+                    name
+                    type
+                    status
+                    outputs
+                    createdAt
+                  }
                 }
               }
             }


### PR DESCRIPTION
# Why

Affirm asked for this.

# How

Added `--json` flag which is going to print out all useful job information.

# Test Plan

`--wait --json`:
```
{
  "id": "0196c564-5553-70ed-8835-adff6484e8cf",
  "name": "easd.yml",
  "status": "SUCCESS",
  "createdAt": "2025-05-12T16:46:49.171Z",
  "workflow": {
    "id": "48ee38cd-44d3-4359-8b35-d71297545ea5",
    "fileName": "easd.yml"
  },
  "jobs": [
    {
      "id": "0196c564-58c9-75da-a3ef-931c64b756a2",
      "key": "test",
      "name": "test",
      "type": "CUSTOM",
      "status": "SUCCESS",
      "outputs": {},
      "createdAt": "2025-05-12T16:46:50.057Z"
    }
  ],
  "url": "http://expo.test/accounts/stanley/projects/test-local/workflows/0196c564-5553-70ed-8835-adff6484e8cf"
}
```


`--json`:
```
{
  "id": "0196c563-5a25-75e1-9447-e35d82f8fef0",
  "url": "http://expo.test/accounts/stanley/projects/test-local/workflows/0196c563-5a25-75e1-9447-e35d82f8fef0"
}
```