### PR TITLE
[eas-cli] Add support for uploading for ipa files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Add support for uploading iOS internal distribution local builds. ([#3014](https://github.com/expo/eas-cli/pull/3014) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -38,6 +38,7 @@
     "ajv": "8.11.0",
     "ajv-formats": "2.1.1",
     "better-opn": "3.0.2",
+    "bplist-parser": "^0.3.0",
     "chalk": "4.1.2",
     "cli-progress": "3.12.0",
     "dateformat": "4.6.3",

--- a/packages/eas-cli/src/utils/plist.ts
+++ b/packages/eas-cli/src/utils/plist.ts
@@ -1,5 +1,6 @@
 import { IOSConfig } from '@expo/config-plugins';
 import plist from '@expo/plist';
+import binaryPlist from 'bplist-parser';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -24,4 +25,25 @@ export async function writePlistAsync(
   const contents = plist.build(plistObject);
   await fs.mkdirp(path.dirname(plistPath));
   await fs.writeFile(plistPath, contents);
+}
+
+const CHAR_CHEVRON_OPEN = 60;
+const CHAR_B_LOWER = 98;
+
+export function parseBinaryPlistBuffer(contents: Buffer): any {
+  if (contents[0] === CHAR_CHEVRON_OPEN) {
+    const info = plist.parse(contents.toString());
+    if (Array.isArray(info)) {
+      return info[0];
+    }
+    return info;
+  } else if (contents[0] === CHAR_B_LOWER) {
+    const info = binaryPlist.parseBuffer(contents);
+    if (Array.isArray(info)) {
+      return info[0];
+    }
+    return info;
+  } else {
+    throw new Error(`Cannot parse plist of type byte (0x${contents[0].toString(16)})`);
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4970,6 +4970,13 @@ bplist-parser@0.3.1:
   dependencies:
     big-integer "1.6.x"
 
+bplist-parser@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.3.2.tgz#3ac79d67ec52c4c107893e0237eb787cbacbced7"
+  integrity sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==
+  dependencies:
+    big-integer "1.6.x"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
# Why

A user requests the ability to upload internal distribution builds in our Canny (https://expo.canny.io/feature-requests/p/upload-local-build-to-eas). Although we can't collect the same information as when a build is generated through EAS, we should allow users to upload IPA files.

# How

Add support for uploading IPA files and update the simulator detection logic. In order to determine if an iOS app was built for a simulator, we should read the `DTPlatformName` value from the main `Info.plist`.

# Test Plan

Tested manually with multiple different file formats 
<img width="526" alt="image" src="https://github.com/user-attachments/assets/64666347-b7a8-412e-bcf7-284a0fe8835b" />

