### PR TITLE
[eas-cli] Further no longer require owner field for SDK >= 53 or canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Further no longer require owner field for SDK >= 53 or canary. ([#3017](https://github.com/expo/eas-cli/pull/3017) by [@wschurman](https://github.com/wschurman))
+
 ## [16.6.1](https://github.com/expo/eas-cli/releases/tag/v16.6.1) - 2025-05-14
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/build/android/prepareJob.ts
+++ b/packages/eas-cli/src/build/android/prepareJob.ts
@@ -12,7 +12,7 @@ import slash from 'slash';
 
 import { AndroidCredentials } from '../../credentials/android/AndroidCredentialsProvider';
 import { getCustomBuildConfigPathForJob } from '../../project/customBuildConfig';
-import { getUsername } from '../../project/projectUtils';
+import { getUsernameForBuildMetadataAndBuildJob } from '../../project/projectUtils';
 import { BuildContext } from '../context';
 
 interface JobData {
@@ -29,7 +29,7 @@ export async function prepareJobAsync(
   ctx: BuildContext<Platform.ANDROID>,
   jobData: JobData
 ): Promise<Android.Job> {
-  const username = getUsername(ctx.exp, ctx.user);
+  const username = getUsernameForBuildMetadataAndBuildJob(ctx.user);
   const buildProfile: BuildProfile<Platform.ANDROID> = ctx.buildProfile;
   const projectRootDirectory =
     slash(path.relative(await ctx.vcsClient.getRootPathAsync(), ctx.projectDir)) || '.';

--- a/packages/eas-cli/src/build/ios/prepareJob.ts
+++ b/packages/eas-cli/src/build/ios/prepareJob.ts
@@ -14,7 +14,7 @@ import slash from 'slash';
 import { IosCredentials, TargetCredentials } from '../../credentials/ios/types';
 import { IosJobSecretsInput } from '../../graphql/generated';
 import { getCustomBuildConfigPathForJob } from '../../project/customBuildConfig';
-import { getUsername } from '../../project/projectUtils';
+import { getUsernameForBuildMetadataAndBuildJob } from '../../project/projectUtils';
 import { BuildContext } from '../context';
 
 interface JobData {
@@ -32,7 +32,7 @@ export async function prepareJobAsync(
   ctx: BuildContext<Platform.IOS>,
   jobData: JobData
 ): Promise<Ios.Job> {
-  const username = getUsername(ctx.exp, ctx.user);
+  const username = getUsernameForBuildMetadataAndBuildJob(ctx.user);
   const buildProfile: BuildProfile<Platform.IOS> = ctx.buildProfile;
   const projectRootDirectory =
     slash(path.relative(await ctx.vcsClient.getRootPathAsync(), ctx.projectDir)) || '.';

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -9,7 +9,10 @@ import { maybeResolveVersionsAsync as maybeResolveIosVersionsAsync } from './ios
 import { LocalBuildMode } from './local';
 import { BuildDistributionType } from './types';
 import Log from '../log';
-import { getUsername, isExpoUpdatesInstalled } from '../project/projectUtils';
+import {
+  getUsernameForBuildMetadataAndBuildJob,
+  isExpoUpdatesInstalled,
+} from '../project/projectUtils';
 import { readChannelSafelyAsync as readAndroidChannelSafelyAsync } from '../update/android/UpdatesModule';
 import { readChannelSafelyAsync as readIosChannelSafelyAsync } from '../update/ios/UpdatesModule';
 import { easCliVersion } from '../utils/easCli';
@@ -48,7 +51,7 @@ export async function collectMetadataAsync<T extends Platform>(
       ctx.localBuildOptions.localBuildMode === LocalBuildMode.INTERNAL
         ? false
         : await ctx.vcsClient.hasUncommittedChangesAsync(),
-    username: getUsername(ctx.exp, ctx.user),
+    username: getUsernameForBuildMetadataAndBuildJob(ctx.user),
     message: ctx.message,
     ...(ctx.platform === Platform.IOS && {
       iosEnterpriseProvisioning: resolveIosEnterpriseProvisioning(

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/getProjectIdAsync.ts
@@ -180,7 +180,7 @@ export async function validateOrSetProjectIdAsync({
 
   Log.warn('EAS project not configured.');
 
-  const getAccountNameForEASProjectSync = (exp: ExpoConfig, user: Actor): string => {
+  const getDefaultAccountNameForEASProject = (exp: ExpoConfig, user: Actor): string => {
     if (exp.owner) {
       return exp.owner;
     }
@@ -191,7 +191,7 @@ export async function validateOrSetProjectIdAsync({
         return user.username;
       case 'Robot':
         throw new Error(
-          'The "owner" manifest property is required when using robot users. See: https://docs.expo.dev/versions/latest/config/app/#owner'
+          'Must configure EAS project by running "eas init" before using a robot user to manage the project.'
         );
     }
   };
@@ -199,7 +199,7 @@ export async function validateOrSetProjectIdAsync({
   const projectId = await fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync(
     graphqlClient,
     {
-      accountName: getAccountNameForEASProjectSync(exp, actor),
+      accountName: getDefaultAccountNameForEASProject(exp, actor),
       projectName: exp.slug,
     },
     {

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -13,19 +13,13 @@ import Log, { learnMore } from '../log';
 import { Actor } from '../user/User';
 import { expoCommandAsync } from '../utils/expoCli';
 
-export function getUsername(exp: ExpoConfig, user: Actor): string | undefined {
+export function getUsernameForBuildMetadataAndBuildJob(user: Actor): string | undefined {
   switch (user.__typename) {
     case 'User':
       return user.username;
     case 'SSOUser':
       return user.username;
     case 'Robot':
-      // owner field is necessary to run `expo prebuild`
-      if (!exp.owner) {
-        throw new Error(
-          'The "owner" manifest property is required when using robot users. See: https://docs.expo.dev/versions/latest/config/app/#owner'
-        );
-      }
       // robot users don't have usernames
       return undefined;
   }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Part 2 of #2835. Missed some cases in that one.

Essentially the `username` field is supplied in EAS build jobs and in the build metadata. It is only used for an environment variable which is known to be undefined for robots: https://docs.expo.dev/eas/environment-variables/#:~:text=learn%20more)-,EAS_BUILD_USERNAME,-%3A%20the%20username%20of

# How

This makes two changes:
1. If project ID is not set and a command is run that needs to generate it, it must be run as a human actor (to know which account to set it to). getAccountNameForEASProject in that path now throws if `eas init` has not yet been run (projectId is not yet set) and a robot is running the command.
2. This removes the overloaded function responsibility of `getUsername` (used by build and build metadata). Previously this function was responsible for preventing a prebuild error it seems. This PR updates it to just get the username or return undefined for robots.

# Test Plan

Run `neas build` as a robot with a project that has a eas project ID is SDK 53 and see it no longer throws an error.