### PR TITLE
[eas-cli] add rollout flag to update:republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Add support for manifest host and asset host overriding for EAS Update. ([#3021](https://github.com/expo/eas-cli/pull/3021) by [@wschurman](https://github.com/wschurman))
+- Add rollout flag to update:republish. ([#3029](https://github.com/expo/eas-cli/pull/3029) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/update/republish.ts
+++ b/packages/eas-cli/src/commands/update/republish.ts
@@ -31,6 +31,7 @@ type UpdateRepublishRawFlags = {
   'private-key-path'?: string;
   'non-interactive': boolean;
   json?: boolean;
+  'rollout-percentage'?: number;
 };
 
 type UpdateRepublishFlags = {
@@ -44,6 +45,7 @@ type UpdateRepublishFlags = {
   privateKeyPath?: string;
   nonInteractive: boolean;
   json: boolean;
+  rolloutPercentage?: number;
 };
 
 export default class UpdateRepublish extends EasCommand {
@@ -85,6 +87,12 @@ export default class UpdateRepublish extends EasCommand {
     'private-key-path': Flags.string({
       description: `File containing the PEM-encoded private key corresponding to the certificate in expo-updates' configuration. Defaults to a file named "private-key.pem" in the certificate's directory. Only relevant if you are using code signing: https://docs.expo.dev/eas-update/code-signing/`,
       required: false,
+    }),
+    'rollout-percentage': Flags.integer({
+      description: `Percentage of users this update should be immediately available to. Users not in the rollout will be served the previous latest update on the branch, even if that update is itself being rolled out. The specified number must be an integer between 1 and 100. When not specified, this defaults to 100.`,
+      required: false,
+      min: 0,
+      max: 100,
     }),
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -163,6 +171,7 @@ export default class UpdateRepublish extends EasCommand {
       updateMessage,
       codeSigningInfo,
       json: flags.json,
+      rolloutPercentage: flags.rolloutPercentage,
     });
   }
 
@@ -191,6 +200,7 @@ export default class UpdateRepublish extends EasCommand {
       platform,
       updateMessage: rawFlags.message,
       privateKeyPath,
+      rolloutPercentage: rawFlags['rollout-percentage'],
       json: rawFlags.json ?? false,
       nonInteractive,
     };


### PR DESCRIPTION
# Why

Add support for specifying a rollout percentage when republishing updates using the `eas update:republish` command. This allows for gradual rollouts of a known good update (previously tested on a separate branch, no need to rebuild) 

# How

- Added a new `--rollout-percentage` flag to the `eas update republish` command that accepts an integer between 1 and 100
- When specified, the update will only be available to the specified percentage of users
- Users not in the rollout will be served the previous latest update on the branch
- Extracted `getUpdateRolloutInfoGroupAsync` from `getRuntimeToUpdateRolloutInfoGroupMappingAsync` to make it reusable
- Updated the output to display rollout information when applicable

# Test Plan

- Ran ` eas-dev update:republish --group 90fb267a-119a-4206-b72c-d168e9889ddf --rollout-percentage 20`
<img width="632" alt="Screenshot 2025-05-23 at 12 42 27 PM" src="https://github.com/user-attachments/assets/ba3eabc3-609f-4a91-9980-c3dbdef2d45e" />
<img width="1279" alt="Screenshot 2025-05-23 at 12 42 35 PM" src="https://github.com/user-attachments/assets/aca208c3-bfea-4604-8360-430a3d55cd36" />

Republished update: https://expo.dev/accounts/quinlanj/projects/appjs25-update-workshop-code/updates/3d839063-dbea-4c2f-9140-f27d1f2898c6

- made sure original `eas update rollout-percentage` still works