### PR TITLE
[eas-cli] Allow skipping version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Add `EAS_SKIP_CLI_VERSION_CHECK` allowing us to skip `eas-cli` version check (against `eas.json#version`). ([#3041](https://github.com/expo/eas-cli/pull/3041) by [@sjchmiela](https://github.com/sjchmiela))
+
 ## [16.7.0](https://github.com/expo/eas-cli/releases/tag/v16.7.0) - 2025-05-29
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/findProjectDirAndVerifyProjectSetupAsync-test.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/findProjectDirAndVerifyProjectSetupAsync-test.ts
@@ -1,6 +1,10 @@
 import { vol } from 'memfs';
 
-import { findProjectRootAsync } from '../findProjectDirAndVerifyProjectSetupAsync';
+import { easCliVersion } from '../../../../utils/easCli';
+import {
+  findProjectDirAndVerifyProjectSetupAsync,
+  findProjectRootAsync,
+} from '../findProjectDirAndVerifyProjectSetupAsync';
 
 jest.mock('@expo/config');
 jest.mock('fs');
@@ -58,5 +62,56 @@ describe(findProjectRootAsync, () => {
     );
     const projectRoot = await findProjectRootAsync({ cwd: '/app/src' });
     expect(projectRoot).toBe('/app');
+  });
+});
+
+describe(findProjectDirAndVerifyProjectSetupAsync, () => {
+  it('throws if the CLI version is not satisfied', async () => {
+    vol.fromJSON(
+      {
+        './eas.json': JSON.stringify({ cli: { version: '1.0.0' } }),
+        './package.json': JSON.stringify({}),
+      },
+      '/app'
+    );
+    await expect(findProjectDirAndVerifyProjectSetupAsync({ cwd: '/app' })).rejects.toThrow(
+      new RegExp(
+        `^You are on eas-cli@${easCliVersion} which does not satisfy the CLI version constraint defined in eas.json \\(1.0.0\\)`,
+        's'
+      )
+    );
+
+    process.env.EAS_SKIP_CLI_VERSION_CHECK = 'true';
+    await expect(findProjectDirAndVerifyProjectSetupAsync({ cwd: '/app' })).resolves.not.toThrow();
+    delete process.env.EAS_SKIP_CLI_VERSION_CHECK;
+
+    await expect(findProjectDirAndVerifyProjectSetupAsync({ cwd: '/app' })).rejects.toThrow(
+      new RegExp(
+        `^You are on eas-cli@${easCliVersion} which does not satisfy the CLI version constraint defined in eas.json \\(1.0.0\\)`,
+        's'
+      )
+    );
+  });
+
+  it('does not throw if the CLI version is satisfied', async () => {
+    vol.fromJSON(
+      {
+        './eas.json': JSON.stringify({ cli: { version: '>= 1.0.0' } }),
+        './package.json': JSON.stringify({}),
+      },
+      '/app'
+    );
+    await expect(findProjectDirAndVerifyProjectSetupAsync({ cwd: '/app' })).resolves.not.toThrow();
+  });
+
+  it('does not throw if there is no version', async () => {
+    vol.fromJSON(
+      {
+        './eas.json': JSON.stringify({}),
+        './package.json': JSON.stringify({}),
+      },
+      '/app'
+    );
+    await expect(findProjectDirAndVerifyProjectSetupAsync({ cwd: '/app' })).resolves.not.toThrow();
   });
 });

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
@@ -2,6 +2,7 @@ import { EasJsonAccessor, EasJsonUtils } from '@expo/eas-json';
 import * as PackageManagerUtils from '@expo/package-manager';
 import chalk from 'chalk';
 import fs from 'fs-extra';
+import getenv from 'getenv';
 import path from 'path';
 import pkgDir from 'pkg-dir';
 import semver from 'semver';
@@ -13,7 +14,14 @@ import { resolveVcsClient } from '../../../vcs';
 async function applyCliConfigAsync(projectDir: string): Promise<void> {
   const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
   const config = await EasJsonUtils.getCliConfigAsync(easJsonAccessor);
-  if (config?.version && !semver.satisfies(easCliVersion, config.version)) {
+
+  const shouldSkipVersionCheck = getenv.boolish('EAS_SKIP_CLI_VERSION_CHECK', false);
+
+  if (
+    !shouldSkipVersionCheck &&
+    config?.version &&
+    !semver.satisfies(easCliVersion, config.version)
+  ) {
     throw new Error(
       `You are on eas-cli@${easCliVersion} which does not satisfy the CLI version constraint defined in eas.json (${
         config.version

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/findProjectDirAndVerifyProjectSetupAsync.ts
@@ -120,8 +120,12 @@ let ranEnsureEasCliIsNotInDependencies = false;
  *
  * @deprecated Should not be used outside of context functions.
  */
-export async function findProjectDirAndVerifyProjectSetupAsync(): Promise<string> {
-  const projectDir = await findProjectRootAsync();
+export async function findProjectDirAndVerifyProjectSetupAsync({
+  cwd,
+}: {
+  cwd?: string;
+} = {}): Promise<string> {
+  const projectDir = await findProjectRootAsync({ cwd });
   await applyCliConfigAsync(projectDir);
   if (!ranEnsureEasCliIsNotInDependencies) {
     ranEnsureEasCliIsNotInDependencies = true;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://exponent-internal.slack.com/archives/C089ED313PV/p1748545207578949?thread_ts=1748543276.564549&cid=C089ED313PV

# How

Added support for `EAS_SKIP_CLI_VERSION_CHECK` environment variable.

# Test Plan

Added tests.