### PR TITLE
[eas-cli] Implement workflow:cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add workflow:cancel. ([#3048](https://github.com/expo/eas-cli/pull/3048) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commandUtils/workflows.ts
+++ b/packages/eas-cli/src/commandUtils/workflows.ts
@@ -1,0 +1,37 @@
+import { WorkflowRunFragment, WorkflowRunStatus } from '../graphql/generated';
+
+export type WorkflowRunResult = {
+  id: string;
+  status: string;
+  gitCommitMessage: string | null;
+  gitCommitHash: string | null;
+  startedAt: string;
+  finishedAt: string;
+  workflowId: string;
+  workflowName: string | null;
+  workflowFileName: string;
+};
+
+export function processWorkflowRuns(runs: WorkflowRunFragment[]): WorkflowRunResult[] {
+  return runs.map(run => {
+    const finishedAt = run.status === WorkflowRunStatus.InProgress ? null : run.updatedAt;
+    return {
+      id: run.id,
+      status: run.status,
+      gitCommitMessage: run.gitCommitMessage?.split('\n')[0] ?? null,
+      gitCommitHash: run.gitCommitHash ?? null,
+      startedAt: run.createdAt,
+      finishedAt,
+      workflowId: run.workflow.id,
+      workflowName: run.workflow.name ?? null,
+      workflowFileName: run.workflow.fileName,
+    };
+  });
+}
+export type WorkflowResult = {
+  id: string;
+  name?: string | null | undefined;
+  fileName: string;
+  createdAt: string;
+  updatedAt: string;
+};

--- a/packages/eas-cli/src/commands/workflow/cancel.ts
+++ b/packages/eas-cli/src/commands/workflow/cancel.ts
@@ -1,0 +1,47 @@
+import { Flags } from '@oclif/core';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import { WorkflowRunMutation } from '../../graphql/mutations/WorkflowRunMutation';
+import Log from '../../log';
+
+export default class WorkflowRunCancel extends EasCommand {
+  static override description =
+    'cancel a workflow run. You can only cancel runs that are in progress or waiting for action.';
+
+  static override args = [
+    { name: 'id', description: 'ID of the workflow run to cancel', required: true },
+  ];
+
+  static override flags = {
+    all: Flags.boolean({
+      description: 'If present, all workflow runs that are IN_PROCESS will be canceled.',
+      required: false,
+    }),
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectId,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags, args } = await this.parse(WorkflowRunCancel);
+    const {
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(WorkflowRunCancel, {
+      nonInteractive: true,
+    });
+
+    const workflowRunId = args.id;
+    const all = flags.all ?? false;
+
+    await WorkflowRunMutation.cancelWorkflowRunAsync(graphqlClient, {
+      workflowRunId,
+    });
+
+    Log.addNewLineIfNone();
+    Log.log(`Flag --all was set to ${all}.`);
+    Log.log(`Workflow run ${workflowRunId} has been canceled.`);
+    Log.addNewLineIfNone();
+  }
+}

--- a/packages/eas-cli/src/commands/workflow/cancel.ts
+++ b/packages/eas-cli/src/commands/workflow/cancel.ts
@@ -23,7 +23,7 @@ export default class WorkflowRunCancel extends EasCommand {
       projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(WorkflowRunCancel, {
-      nonInteractive: true,
+      nonInteractive,
     });
 
     // Custom parsing of argv
@@ -34,6 +34,10 @@ export default class WorkflowRunCancel extends EasCommand {
         workflowRunIds.add(token);
       });
     } else {
+      if (nonInteractive) {
+        throw new Error('Must supply workflow run IDs as arguments when in non-interactive mode`);
+      }
+
       // Run the workflow run list query and select runs to cancel
       const queryResult = await AppQuery.byIdWorkflowRunsFilteredByStatusAsync(
         graphqlClient,

--- a/packages/eas-cli/src/commands/workflow/list.ts
+++ b/packages/eas-cli/src/commands/workflow/list.ts
@@ -1,17 +1,10 @@
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasJsonOnlyFlag } from '../../commandUtils/flags';
+import { WorkflowResult } from '../../commandUtils/workflows';
 import { AppQuery } from '../../graphql/queries/AppQuery';
 import Log from '../../log';
 import formatFields from '../../utils/formatFields';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
-
-type WorkflowResult = {
-  id: string;
-  name?: string | null | undefined;
-  fileName: string;
-  createdAt: string;
-  updatedAt: string;
-};
 
 export default class WorkflowList extends EasCommand {
   static override description = 'List workflows for the current project';

--- a/packages/eas-cli/src/commands/workflow/runs.ts
+++ b/packages/eas-cli/src/commands/workflow/runs.ts
@@ -3,41 +3,13 @@ import { Flags } from '@oclif/core';
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasJsonOnlyFlag } from '../../commandUtils/flags';
 import { getLimitFlagWithCustomValues } from '../../commandUtils/pagination';
+import { processWorkflowRuns } from '../../commandUtils/workflows';
 import { WorkflowRunFragment, WorkflowRunStatus } from '../../graphql/generated';
 import { AppQuery } from '../../graphql/queries/AppQuery';
 import { WorkflowRunQuery } from '../../graphql/queries/WorkflowRunQuery';
 import Log from '../../log';
 import formatFields from '../../utils/formatFields';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
-
-export type WorkflowRunResult = {
-  id: string;
-  status: string;
-  gitCommitMessage: string | null;
-  gitCommitHash: string | null;
-  startedAt: string;
-  finishedAt: string;
-  workflowId: string;
-  workflowName: string | null;
-  workflowFileName: string;
-};
-
-function processWorkflowRuns(runs: WorkflowRunFragment[]): WorkflowRunResult[] {
-  return runs.map(run => {
-    const finishedAt = run.status === WorkflowRunStatus.InProgress ? null : run.updatedAt;
-    return {
-      id: run.id,
-      status: run.status,
-      gitCommitMessage: run.gitCommitMessage ?? null,
-      gitCommitHash: run.gitCommitHash ?? null,
-      startedAt: run.createdAt,
-      finishedAt,
-      workflowId: run.workflow.id,
-      workflowName: run.workflow.name ?? null,
-      workflowFileName: run.workflow.fileName,
-    };
-  });
-}
 
 export default class WorkflowRunList extends EasCommand {
   static override description =

--- a/packages/eas-cli/src/commands/workflow/runs.ts
+++ b/packages/eas-cli/src/commands/workflow/runs.ts
@@ -10,7 +10,7 @@ import Log from '../../log';
 import formatFields from '../../utils/formatFields';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
-type WorkflowRunResult = {
+export type WorkflowRunResult = {
   id: string;
   status: string;
   gitCommitMessage: string | null;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -9743,6 +9743,13 @@ export type CreateWorkflowRunMutationVariables = Exact<{
 
 export type CreateWorkflowRunMutation = { __typename?: 'RootMutation', workflowRun: { __typename?: 'WorkflowRunMutation', createWorkflowRun: { __typename?: 'WorkflowRun', id: string } } };
 
+export type CancelWorkflowRunMutationVariables = Exact<{
+  workflowRunId: Scalars['ID']['input'];
+}>;
+
+
+export type CancelWorkflowRunMutation = { __typename?: 'RootMutation', workflowRun: { __typename?: 'WorkflowRunMutation', cancelWorkflowRun: { __typename?: 'WorkflowRun', id: string } } };
+
 export type AppByIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];
 }>;

--- a/packages/eas-cli/src/graphql/mutations/WorkflowRunMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/WorkflowRunMutation.ts
@@ -3,6 +3,8 @@ import gql from 'graphql-tag';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { withErrorHandlingAsync } from '../client';
 import {
+  CancelWorkflowRunMutation,
+  CancelWorkflowRunMutationVariables,
   CreateWorkflowRunMutation,
   CreateWorkflowRunMutationVariables,
   WorkflowRevisionInput,
@@ -51,5 +53,32 @@ export namespace WorkflowRunMutation {
         .toPromise()
     );
     return { id: data.workflowRun.createWorkflowRun.id };
+  }
+  export async function cancelWorkflowRunAsync(
+    graphqlClient: ExpoGraphqlClient,
+    {
+      workflowRunId,
+    }: {
+      workflowRunId: string;
+    }
+  ): Promise<void> {
+    await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CancelWorkflowRunMutation, CancelWorkflowRunMutationVariables>(
+          gql`
+            mutation CancelWorkflowRun($workflowRunId: ID!) {
+              workflowRun {
+                cancelWorkflowRun(workflowRunId: $workflowRunId) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            workflowRunId,
+          }
+        )
+        .toPromise()
+    );
   }
 }


### PR DESCRIPTION
# Why

Allow user to cancel one or more workflow runs, as requested in @jonsamp 's [workflow CLI design document](https://www.notion.so/expo/EAS-CLI-workflow-commands-8bc5ccc4f9f949c8adfec1347817113c).

The CLI will print a separate message (success or error message) for each workflow run ID that it attempts to cancel.

```bash
$ eas workflow:cancel --help
Cancel one or more workflow runs. If no workflow run IDs are provided, you will be prompted to select IN_PROGRESS runs to cancel.

USAGE
  $ eas workflow:cancel [--non-interactive]

FLAGS
  --non-interactive  Run the command in non-interactive mode.

DESCRIPTION
  Cancel one or more workflow runs. If no workflow run IDs are provided, you will be prompted to select IN_PROGRESS runs
  to cancel.

```

Example:

```bash
$ eas workflow:cancel
? Select IN_PROGRESS workflow runs to cancel ›  
Instructions:
    ↑/↓: Highlight option
    ←/→/[space]: Toggle selection
    a: Toggle all
    enter/return: Complete answer
◯   01975c6b-3ec2-73ca-b117-987b434056e7 - updates-e2e-enabled.yml, Publish packages, 2025-06-11T00:37:01.762Z
◯   01975c67-7950-74a8-8771-6e2abdd28a82 - updates-e2e-enabled.yml, sync changelog (#37353), 2025-06-11T00:32:54.608Z
◯   01975c66-1c3c-784b-8c4a-f7f95414dbf4 - updates-e2e-enabled.yml, bump expo-image versions, 2025-06-11T00:31:25.244Z
```
# How

- Added a new mutation to cancel a single workflow run by ID
- Added the new command

# Test Plan

- CI should pass

