### PR TITLE
eas build:dev command will correctly use passed build profile

### DIFF
--- a/packages/eas-cli/src/commands/build/dev.ts
+++ b/packages/eas-cli/src/commands/build/dev.ts
@@ -115,6 +115,7 @@ export default class BuildDev extends EasCommand {
       projectId,
       platform,
       fingerprint,
+      profile: buildProfile.profileName,
     });
     if (builds.length !== 0) {
       const build = builds[0];
@@ -137,6 +138,7 @@ export default class BuildDev extends EasCommand {
       graphqlClient,
       projectId,
       platform,
+      profile: buildProfile.profileName,
     });
     if (
       previousBuildsForSelectedProfile.length > 0 &&
@@ -307,11 +309,13 @@ export default class BuildDev extends EasCommand {
     projectId,
     platform,
     fingerprint,
+    profile,
   }: {
     graphqlClient: ExpoGraphqlClient;
     projectId: string;
     platform: Platform;
     fingerprint?: { hash: string };
+    profile?: string;
   }): Promise<BuildFragment[]> {
     return await BuildQuery.viewBuildsOnAppAsync(graphqlClient, {
       appId: projectId,
@@ -322,6 +326,7 @@ export default class BuildDev extends EasCommand {
         simulator: platform === Platform.IOS ? true : undefined,
         distribution: platform === Platform.ANDROID ? DistributionType.Internal : undefined,
         developmentClient: true,
+        buildProfile: profile,
       },
       offset: 0,
       limit: 1,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
`/changelog-entry bug-fix eas build:dev command will correctly use passed build profile`

# Why

I tried to use eas dev:build with --build-profile parameter, but I got eas build with different profile

# How

I tested locally that changes in this branch fixes the problem for my case

# Test Plan

I have run following command (easd linked to locally build eas-cli, as described in CONTRIBUTING.md)
```
EXPO_DEBUG=1 easd build:dev -e preview -p android
```
