### PR TITLE
[eas-cli] Add `projectRootDirectory` to `workflow:run` payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fixed monorepo support in `workflow:run` if a project is not connected to a GitHub repository. ([#3058](https://github.com/expo/eas-cli/pull/3058) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🧹 Chores
 
 ## [16.10.1](https://github.com/expo/eas-cli/releases/tag/v16.10.1) - 2025-06-13

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -62594,6 +62594,12 @@
             "deprecationReason": null
           },
           {
+            "name": "REPACK",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "REQUIRE_APPROVAL",
             "description": null,
             "isDeprecated": false,
@@ -62661,6 +62667,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectRootDirectory",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/packages/eas-cli/src/commands/workflow/run.ts
+++ b/packages/eas-cli/src/commands/workflow/run.ts
@@ -3,6 +3,7 @@ import { CombinedError } from '@urql/core';
 import chalk from 'chalk';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import slash from 'slash';
 
 import { getWorkflowRunUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
@@ -115,6 +116,10 @@ export default class WorkflowRun extends EasCommand {
     const easJsonPath = path.join(projectDir, 'eas.json');
     const packageJsonPath = path.join(projectDir, 'package.json');
 
+    const projectRootDirectory = slash(
+      path.relative(await vcsClient.getRootPathAsync(), projectDir) || '.'
+    );
+
     try {
       ({ projectArchiveBucketKey } = await uploadAccountScopedProjectSourceAsync({
         graphqlClient,
@@ -176,6 +181,7 @@ export default class WorkflowRun extends EasCommand {
             projectArchiveBucketKey,
             easJsonBucketKey,
             packageJsonBucketKey,
+            projectRootDirectory,
           },
         },
       }));

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -8772,6 +8772,7 @@ export enum WorkflowJobType {
   GetBuild = 'GET_BUILD',
   MaestroCloud = 'MAESTRO_CLOUD',
   MaestroTest = 'MAESTRO_TEST',
+  Repack = 'REPACK',
   RequireApproval = 'REQUIRE_APPROVAL',
   Slack = 'SLACK',
   Submission = 'SUBMISSION',
@@ -8782,6 +8783,7 @@ export type WorkflowProjectSourceInput = {
   easJsonBucketKey?: InputMaybe<Scalars['String']['input']>;
   packageJsonBucketKey?: InputMaybe<Scalars['String']['input']>;
   projectArchiveBucketKey: Scalars['String']['input'];
+  projectRootDirectory?: InputMaybe<Scalars['String']['input']>;
   type: WorkflowProjectSourceType;
 };
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

[exponent-internal.slack.com/archives/C06EFBQK3B7/p1750180529429209](https://exponent-internal.slack.com/archives/C06EFBQK3B7/p1750180529429209)

# How

Copied what we do for builds — https://github.com/expo/eas-cli/blob/b0522484afdbc7c80c7da84c724480ade8f16f55/packages/eas-cli/src/build/ios/prepareJob.ts#L37-L38 — and added `projectRootDirectory` to workflow runs.

I hoped there's a `node:path` method that would do what `slash` does, but I found none and Cursor did not know of one either.

# Test Plan

Tested end to end with https://github.com/expo/universe/pull/20644.