### PR TITLE
[eas-cli] align text of messages from build and workflow:run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Align text of messages from `build` and `workflow:run`. ([#3061](https://github.com/expo/eas-cli/pull/3061) by [@douglowder](https://github.com/douglowder))
+
 ### 🧹 Chores
 
 ## [16.12.0](https://github.com/expo/eas-cli/releases/tag/v16.12.0) - 2025-06-20

--- a/packages/eas-cli/src/build/utils/printBuildInfo.ts
+++ b/packages/eas-cli/src/build/utils/printBuildInfo.ts
@@ -43,14 +43,14 @@ const errorCodeToErrorMessageOverride: Record<string, (build: BuildFragment) => 
 
 export function printLogsUrls(builds: BuildFragment[]): void {
   if (builds.length === 1) {
-    Log.log(`Build details: ${link(getBuildLogsUrl(builds[0]))}`);
+    Log.log(`See logs: ${link(getBuildLogsUrl(builds[0]))}`);
   } else {
     builds.forEach(build => {
       const logsUrl = getBuildLogsUrl(build);
       Log.log(
-        `${appPlatformEmojis[build.platform]} ${
+        `See ${appPlatformEmojis[build.platform]} ${
           appPlatformDisplayNames[build.platform]
-        } build details: ${link(logsUrl)}`
+        } logs: ${link(logsUrl)}`
       );
     });
   }

--- a/packages/eas-cli/src/commands/workflow/run.ts
+++ b/packages/eas-cli/src/commands/workflow/run.ts
@@ -195,7 +195,7 @@ export default class WorkflowRun extends EasCommand {
     }
 
     if (!flags.wait) {
-      Log.succeed('Workflow run started successfully.');
+      // Log.succeed('Workflow run started successfully.');
 
       if (flags.json) {
         printJsonOnlyOutput({

--- a/packages/eas-cli/src/commands/workflow/run.ts
+++ b/packages/eas-cli/src/commands/workflow/run.ts
@@ -195,8 +195,6 @@ export default class WorkflowRun extends EasCommand {
     }
 
     if (!flags.wait) {
-      // Log.succeed('Workflow run started successfully.');
-
       if (flags.json) {
         printJsonOnlyOutput({
           id: workflowRunId,


### PR DESCRIPTION
# Why

The two commands should print the same text when returning the URL for the run logs, and not have unnecessary messages.

# Test Plan

CI should pass