### PR TITLE
[eas-cli] Fix bug in log during update:republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix bug in log during update:republish. ([#3067](https://github.com/expo/eas-cli/pull/3067) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 ## [16.13.0](https://github.com/expo/eas-cli/releases/tag/v16.13.0) - 2025-06-24

--- a/packages/eas-cli/src/commands/update/republish.ts
+++ b/packages/eas-cli/src/commands/update/republish.ts
@@ -138,7 +138,7 @@ export default class UpdateRepublish extends EasCommand {
       );
     }
 
-    if (rawFlags.platform === 'all') {
+    if (rawFlags.platform !== 'all') {
       Log.withTick(`The republished update group will appear only on: ${rawFlags.platform}`);
     } else {
       const platformsFromUpdates = updatesToPublish.map(update => update.platform);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Noticed this condition was inverted during creation of a new related command.

# How

Correct the if statement. It should warn when platform is not `all`.

# Test Plan

Run `neas update:republish --platform ios`, see logged message:

```
$ eas update:republish --platform ios
✔ Find update by branch or channel? › Branch
✔ Select branch from which to choose update › main
✔ Load more update groups? › [Jun 23 11:14 by wschurman, runtimeVersion: 1.0.0] Initial commit

Generated by create-expo-app 3.4.2.
You are republishing an update group that wasn't published for all platforms.
✔ The republished update group will appear on the same platforms it was originally published on: ios
✔ Provide an update message. … Republish "Initial commit

Generated by create-expo-app 3.4.2." - group: 8e1b11be-ef82-4ccd-8294-a4e7075849d1
✔ Republished update group
```