### PR TITLE
[eas-cli] Fix update group deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix bug in log during update:republish. ([#3067](https://github.com/expo/eas-cli/pull/3067) by [@wschurman](https://github.com/wschurman))
+Fix update group deletion. ([#3069](https://github.com/expo/eas-cli/pull/3069) by [@wschurman](https://github.com/wschurman))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/update/delete.ts
+++ b/packages/eas-cli/src/commands/update/delete.ts
@@ -79,7 +79,7 @@ export default class UpdateDelete extends EasCommand {
     }
 
     if (!nonInteractive) {
-      const shouldAbort = await confirmAsync({
+      const shouldContinue = await confirmAsync({
         message:
           `🚨${chalk.red('CAUTION')}🚨\n\n` +
           `${chalk.yellow(`This will delete all of the updates in group "${group}".`)} ${chalk.red(
@@ -87,10 +87,10 @@ export default class UpdateDelete extends EasCommand {
           )}\n\n` +
           `If you want to revert to a previous publish, you should use 'update --republish' targeted at the last working update group instead.\n\n` +
           `An update group should only be deleted in an emergency like an accidental publish of a secret. In this case user 'update --republish' to revert to the last working update group first and then proceed with the deletion. Deleting an update group when it is the latest publish can lead to inconsistent caching behavior by clients.\n\n` +
-          `Would you like to abort?`,
+          `Would you like to continue?`,
       });
 
-      if (shouldAbort) {
+      if (!shouldContinue) {
         Log.log('Aborted.');
         return;
       }

--- a/packages/eas-cli/src/graphql/queries/BackgroundJobReceiptQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/BackgroundJobReceiptQuery.ts
@@ -30,6 +30,7 @@ export const BackgroundJobReceiptQuery = {
           { id: backgroundJobReceiptId },
           {
             additionalTypenames: ['BackgroundJobReceipt'],
+            requestPolicy: 'network-only',
           }
         )
         .toPromise()


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Update group background job polling (and all background job polling in the CLI) is broken due to query caching in the client. Not sure why this worked when I added it as the caching has been present for a while.

# How

Disable cache for the poll request.

This also inverts the confirmation on `update:delete` to be affirmative as most of our other confirm questions are (default to yes). The reason for this change is that I found it non-intuitive while testing this to have "yes" cancel the command. I think the reason we use to have this inverted is it was dangerous, but IMO it's already enough intent by running the command to just have the default be yes. Happy to revert this back if reviewers disagree.

# Test Plan

```
eas update
neas update:delete <update_group>
```

See it now works.