### PR TITLE
[eas-cli] Add `groups` to the output of `submit:internal`

### DIFF
--- a/packages/eas-cli/src/commands/submit/internal.ts
+++ b/packages/eas-cli/src/commands/submit/internal.ts
@@ -115,6 +115,7 @@ export default class SubmitInternal extends EasCommand {
       const configInput: z.input<typeof SubmissionConfig.Ios.SchemaZ> = {
         ascAppIdentifier: iosConfig.ascAppIdentifier,
         isVerboseFastlaneEnabled: iosConfig.isVerboseFastlaneEnabled ?? undefined,
+        groups: iosConfig.groups ?? undefined,
         ...(ascApiKeyJson
           ? { ascApiJsonKey: ascApiKeyJson }
           : {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Since https://linear.app/expo/issue/ENG-14634/add-support-for-groups-option-in-fastlane-pilot-call we support passing `--groups` parameter to `eas submit` and configuring submission profile with `groups` parameter ("undocumentedly").

I need to add support for this property to `submit:internal`. We're going to source the `groups` to pass to `fastlane pilot` from either:
- submit profile (this pull request adds this)
- or workflow config (in which case we'll don't use this output).

# How

Added `groups` output to the `submit:internal` JSON object. We're going to parse it in https://github.com/expo/universe/blob/5dcea35fb50bf9fc8e3ae4ffe445f958bb5789e6/server/www/src/data/entities/workflow/job/WorkflowSubmitJob.ts#L192-L200.

# Test Plan

Ran `easd submit:internal --id 60a2d86a-b6d8-4ba2-b7dd-bf05bdd78791 --platform ios` in a test project of mine after adding submit profile like

```
  "submit": {
    "production": {
      "ios": {
        "ascAppId": "6769090000",
        "groups": ["family", "friends"]
      }
    }
  }
```

<img width="253" alt="Zrzut ekranu 2025-06-25 o 17 39 22" src="https://github.com/user-attachments/assets/584e1bea-a905-4ba3-a68e-5df4a4d3477e" />

