### PR TITLE
[eas-cli] change push notification confirmation message

### DIFF
--- a/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
+++ b/packages/eas-cli/src/credentials/ios/IosCredentialsProvider.ts
@@ -98,9 +98,7 @@ export default class IosCredentialsProvider {
     const setupPushKeyAction = new SetUpPushKey(appLookupParams);
     const isPushKeySetup = await setupPushKeyAction.isPushKeySetupAsync(ctx);
     if (isPushKeySetup) {
-      Log.succeed(
-        `Push Notifications setup for ${app.projectName}: ${applicationTarget.bundleIdentifier}`
-      );
+      Log.succeed(`Push Notifications are set up`);
       return null;
     }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why
Change the confirmation message for push notification key:

Firstly, "Push Notifications setup for app-name: bundle id" should say "set up" (verb), not "setup" (noun). That is, unless the value of `bundleId` was the value of a push notification setup, which doesn't make sense.

Secondly, the message contains information which is already printed in the row right before it, so it's redundant.

<img width="823" alt="Screenshot 2025-07-04 at 11 48 42" src="https://github.com/user-attachments/assets/dbe30b21-2ff2-49d2-8f85-e4e1f0d0a5bc" />

# How

How did you build this feature or fix this bug and why?

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
