### PR TITLE
[build] Replace mention of specific plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Reword how paid plans are described ([#3082](https://github.com/expo/eas-cli/pull/3082) by [@ide](https://github.com/ide))
+
 ## [16.13.2](https://github.com/expo/eas-cli/releases/tag/v16.13.2) - 2025-06-27
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -500,11 +500,7 @@ async function handleSingleBuildProgressAsync(
         if (build.priority !== BuildPriority.High) {
           Log.newLine();
           Log.log('Start builds sooner in the priority queue.');
-          Log.log(
-            `Sign up for EAS Production or Enterprise at ${link(
-              formatAccountBillingUrl(accountName)
-            )}`
-          );
+          Log.log(`Sign up for a paid plan at ${link(formatAccountBillingUrl(accountName))}`);
         }
 
         Log.newLine();


### PR DESCRIPTION
Why
===
The message about queuing builds faster mentions the Production and Enterprise plans. The Starter plan is also a good choice.

How
===
This PR changes the message just to say "paid plan" which is simple and understandable.

Test Plan
===
Just automated tests since this is a copy change.
