### PR TITLE
[eas-cli] remove hidden flag from upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Remove hidden flag from `eas upload`. ([#3014](https://github.com/expo/eas-cli/pull/3014) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## [16.13.3](https://github.com/expo/eas-cli/releases/tag/v16.13.3) - 2025-07-01
 
 ### 🐛 Bug fixes
@@ -34,7 +36,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Fix bug in log during update:republish. ([#3067](https://github.com/expo/eas-cli/pull/3067) by [@wschurman](https://github.com/wschurman))
-Fix update group deletion. ([#3069](https://github.com/expo/eas-cli/pull/3069) by [@wschurman](https://github.com/wschurman))
+- Fix update group deletion. ([#3069](https://github.com/expo/eas-cli/pull/3069) by [@wschurman](https://github.com/wschurman))
 
 ## [16.13.0](https://github.com/expo/eas-cli/releases/tag/v16.13.0) - 2025-06-24
 

--- a/packages/eas-cli/src/commands/upload.ts
+++ b/packages/eas-cli/src/commands/upload.ts
@@ -33,7 +33,6 @@ import { createProgressTracker } from '../utils/progress';
 
 export default class BuildUpload extends EasCommand {
   static override description = 'upload a local build and generate a sharable link';
-  static override hidden = true;
 
   static override flags = {
     platform: Flags.enum<Platform.IOS | Platform.ANDROID>({


### PR DESCRIPTION
# Why

Make the `eas upload` command public

# How

remove hidden flag from `upload` command

# Test Plan

Run `easd -h`

<img width="768" alt="image" src="https://github.com/user-attachments/assets/d7e62c7b-f378-4bd9-8c2b-5f63941e7b1a" />
