### PR TITLE
[eas-cli] no warning in update:configure when no build profiles

### DIFF
--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -305,20 +305,22 @@ async function ensureEASUpdateIsConfiguredNativelyAsync(
 export async function ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir: string): Promise<void> {
   const easJsonPath = EasJsonAccessor.formatEasJsonPath(projectDir);
 
+  // Skip if eas.json doesn't exist.
   if (!(await fs.pathExists(easJsonPath))) {
-    Log.warn(
-      `EAS Build is not configured. If you'd like to use EAS Build with EAS Update, run ${chalk.bold(
-        'eas build:configure'
-      )}.`
-    );
     return;
   }
 
+  // Add channel to all build profiles.
   try {
     const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
     await easJsonAccessor.readRawJsonAsync();
 
     easJsonAccessor.patch(easJsonRawObject => {
+      // If there are no build profiles then we are done.
+      if (!easJsonRawObject.build) {
+        return easJsonRawObject;
+      }
+
       const easBuildProfilesWithChannels = Object.keys(easJsonRawObject.build).reduce(
         (acc, profileNameKey) => {
           const buildProfile = easJsonRawObject.build[profileNameKey];


### PR DESCRIPTION
# Why

I was writing some instructions for testing an updates feature and when I ran `eas update:configure` in the project it threw a TypeError:

```
eas update:configure
💡 The following process will configure your project to use EAS Update. These changes only apply to your local project files and you can safely revert them at any time.
✔ Overwrote updates.url "https://u.expo.dev/69109f5f-9770-496f-b74f-c85277aa217d" with "https://updates-test-proxy.expo.app/69109f5f-9770-496f-b74f-c85277aa217d"

All builds of your app going forward will be eligible to receive updates published with EAS Update.

We were not able to configure eas.json. Error: TypeError: Cannot convert undefined or null to object.

🎉 Your app is configured to use EAS Update!

- Learn more about other capabilities of EAS Update: https://docs.expo.dev/eas-update/introduction/
```

It seems we assume that if you have an **eas.json** then you must be using EAS Build, but that is no longer a valid assumption (you may be using it for just submit, or for configuring the CLI for update).

# How

Bail out when no `build` key rather than erroring. Remove warning about running `eas build:configure` when no **eas.json** is present.

# Test Plan

Ran it locally, no type error printed.