### PR TITLE
feat(eas-cli): Implement new batched EAS Hosting asset upload protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Update the EAS Hosting worker deployment progress indicator to use a progress bar for asset uploads instead ([#3099](https://github.com/expo/eas-cli/pull/3099) by [@kitten](https://github.com/kitten))
+
 ## [16.14.1](https://github.com/expo/eas-cli/releases/tag/v16.14.1) - 2025-07-08
 
 ### 🧹 Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Implement new EAS Hosting asset upload protocol, which improves performance by grouping files into batched upload API calls ([#3085](https://github.com/expo/eas-cli/pull/3085) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/deploy/index.ts
+++ b/packages/eas-cli/src/commands/deploy/index.ts
@@ -27,6 +27,8 @@ import {
   getDeploymentUrlFromFullName,
 } from '../../worker/utils/logs';
 
+const MAX_UPLOAD_SIZE = 5e8; // 5MB
+
 const isDirectory = (directoryPath: string): Promise<boolean> =>
   fs.promises
     .stat(directoryPath)
@@ -269,7 +271,8 @@ export default class WorkerDeploy extends EasCommand {
         );
       }
       assetFiles = await WorkerAssets.collectAssetsAsync(
-        projectDist.type === 'server' ? projectDist.clientPath : projectDist.path
+        projectDist.type === 'server' ? projectDist.clientPath : projectDist.path,
+        { maxFileSize: MAX_UPLOAD_SIZE }
       );
       tarPath = await WorkerAssets.packFilesIterableAsync(
         emitWorkerTarballAsync({

--- a/packages/eas-cli/src/commands/deploy/index.ts
+++ b/packages/eas-cli/src/commands/deploy/index.ts
@@ -165,7 +165,6 @@ export default class WorkerDeploy extends EasCommand {
       const { response } = await uploadAsync({
         url: uploadUrl,
         filePath: tarPath,
-        compress: false,
         headers: {
           accept: 'application/json',
         },

--- a/packages/eas-cli/src/commands/deploy/index.ts
+++ b/packages/eas-cli/src/commands/deploy/index.ts
@@ -164,10 +164,8 @@ export default class WorkerDeploy extends EasCommand {
     ): Promise<DeployInProgressParams> {
       const { response } = await uploadAsync({
         url: uploadUrl,
+        method: 'POST',
         filePath: tarPath,
-        headers: {
-          accept: 'application/json',
-        },
       });
       if (response.status === 413) {
         throw new Error(
@@ -206,7 +204,11 @@ export default class WorkerDeploy extends EasCommand {
       const uploadParams = assetFiles.map(asset => {
         const uploadURL = new URL(`/asset/${asset.sha512}`, deployParams.baseURL);
         uploadURL.searchParams.set('token', deployParams.token);
-        return { url: uploadURL.toString(), filePath: asset.path };
+        return {
+          url: uploadURL.toString(),
+          method: 'POST',
+          filePath: asset.path,
+        };
       });
 
       const progress = {

--- a/packages/eas-cli/src/commands/deploy/index.ts
+++ b/packages/eas-cli/src/commands/deploy/index.ts
@@ -32,7 +32,7 @@ import {
   getDeploymentUrlFromFullName,
 } from '../../worker/utils/logs';
 
-const MAX_UPLOAD_SIZE = 5e8; // 5MB
+const MAX_UPLOAD_SIZE = 5e8; // 500MB
 
 const isDirectory = (directoryPath: string): Promise<boolean> =>
   fs.promises

--- a/packages/eas-cli/src/commands/deploy/index.ts
+++ b/packages/eas-cli/src/commands/deploy/index.ts
@@ -167,7 +167,7 @@ export default class WorkerDeploy extends EasCommand {
       const payload = { filePath: tarPath };
       const { response } = await uploadAsync(
         {
-          url: uploadUrl,
+          baseURL: uploadUrl,
           method: 'POST',
         },
         payload
@@ -206,9 +206,9 @@ export default class WorkerDeploy extends EasCommand {
       assetFiles: WorkerAssets.AssetFileEntry[],
       deployParams: DeployInProgressParams
     ): Promise<void> {
-      const uploadURL = new URL('/asset/', deployParams.baseURL);
-      uploadURL.searchParams.set('token', deployParams.token);
-      const uploadInit = { url: uploadURL, method: 'POST' };
+      const baseURL = new URL('/asset/', deployParams.baseURL);
+      const uploadInit = { baseURL, method: 'POST' };
+      uploadInit.baseURL.searchParams.set('token', deployParams.token);
 
       const uploadPayloads = assetFiles.map(asset => ({ asset }));
 

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -118,9 +118,6 @@ export async function collectAssetsAsync(
         throw new Error(
           `Upload of "${file.normalizedPath}" aborted: File size is greater than the upload limit (>500MB)`
         );
-      } else if (file.size === 0) {
-        // We skip all empty files and choose not to upload them
-        continue;
       }
       const sha512$ = computeSha512HashAsync(file.path, options?.hashOptions);
       const contentType$ = determineMimeTypeAsync(file.path);

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -118,6 +118,9 @@ export async function collectAssetsAsync(
         throw new Error(
           `Upload of "${file.normalizedPath}" aborted: File size is greater than the upload limit (>500MB)`
         );
+      } else if (file.size === 0) {
+        // We skip all empty files and choose not to upload them
+        continue;
       }
       const sha512$ = computeSha512HashAsync(file.path, options?.hashOptions);
       const contentType$ = determineMimeTypeAsync(file.path);

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -134,12 +134,22 @@ export async function collectAssetsAsync(
 }
 
 /** Mapping of normalized file paths to a SHA512 hash */
-export type AssetMap = Record<string, string>;
+export type AssetMap = Record<
+  string,
+  | string
+  | {
+      sha512: string;
+      size: number;
+    }
+>;
 
 /** Converts array of asset entries into AssetMap (as sent to deployment-api) */
 export function assetsToAssetsMap(assets: AssetFileEntry[]): AssetMap {
   return assets.reduce((map, entry) => {
-    map[entry.normalizedPath] = entry.sha512;
+    map[entry.normalizedPath] = {
+      sha512: entry.sha512,
+      size: entry.size,
+    };
     return map;
   }, Object.create(null));
 }

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -97,7 +97,7 @@ export async function uploadAsync(
           body,
           headers,
           agent: getAgent(),
-          signal: (init.signal as any),
+          signal: init.signal as any,
         });
       } catch (error) {
         return retry(error);

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -2,14 +2,15 @@ import * as https from 'https';
 import createHttpsProxyAgent from 'https-proxy-agent';
 import fetch, { BodyInit, Headers, HeadersInit, RequestInit, Response } from 'node-fetch';
 import fs from 'node:fs';
+import os from 'node:os';
 import { Readable } from 'node:stream';
 import promiseRetry from 'promise-retry';
 
 import { AssetFileEntry } from './assets';
 import { createMultipartBodyFromFilesAsync, multipartContentType } from './utils/multipart';
 
+const MAX_CONCURRENCY = Math.min(10, Math.max(os.availableParallelism() * 2, 20));
 const MAX_RETRIES = 4;
-const MAX_CONCURRENCY = 10;
 
 export type UploadPayload =
   | { filePath: string }

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -97,8 +97,7 @@ export async function uploadAsync(
           body,
           headers,
           agent: getAgent(),
-          // @ts-expect-error: Internal types don't match
-          signal,
+          signal: (init.signal as any),
         });
       } catch (error) {
         return retry(error);

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -1,7 +1,7 @@
 import * as https from 'https';
 import createHttpsProxyAgent from 'https-proxy-agent';
 import mime from 'mime';
-import fetch, { Headers, HeadersInit, RequestInit, Response } from 'node-fetch';
+import fetch, { Headers, RequestInit, Response } from 'node-fetch';
 import fs, { createReadStream } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
@@ -33,8 +33,7 @@ const getContentTypeAsync = async (filePath: string): Promise<string | null> => 
 export interface UploadParams extends Omit<RequestInit, 'signal' | 'body'> {
   filePath: string;
   url: string;
-  method?: string;
-  headers?: HeadersInit;
+  method: string;
   body?: undefined;
   signal?: AbortSignal;
 }

--- a/packages/eas-cli/src/worker/utils/multipart.ts
+++ b/packages/eas-cli/src/worker/utils/multipart.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs';
+
+const CRLF = '\r\n';
+const BOUNDARY_HYPHEN_CHARS = '--';
+const BOUNDARY_ID = '----formdata-eas-cli';
+const FORM_FOOTER = `${BOUNDARY_HYPHEN_CHARS}${BOUNDARY_ID}${BOUNDARY_HYPHEN_CHARS}${CRLF}${CRLF}`;
+
+const encodeName = (input: string): string => {
+  return input.replace(/["\n\\]/g, (c: string) => {
+    switch (c) {
+      case '\\':
+        return '\\\\';
+      case '"':
+        return '%22';
+      case '\n':
+        return '%0A';
+      default:
+        return `%${c.charCodeAt(0).toString(16).toUpperCase()}`;
+    }
+  });
+};
+
+async function* createReadStreamAsync(filePath: string): AsyncGenerator<Uint8Array> {
+  for await (const raw of fs.createReadStream(filePath)) {
+    const chunk = raw as Buffer;
+    yield new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+  }
+}
+
+const makeFormHeader = (params: {
+  name: string;
+  contentType: string;
+  contentLength: number;
+}): string => {
+  const name = encodeName(params.name);
+  let header = BOUNDARY_HYPHEN_CHARS + BOUNDARY_ID + CRLF;
+  header += `Content-Disposition: form-data; name="${name}"; filename="${name}"`;
+  header += `${CRLF}Content-Type: ${params.contentType}`;
+  header += `${CRLF}Content-Length: ${params.contentLength}`;
+  header += CRLF;
+  header += CRLF;
+  return header;
+};
+
+export interface MultipartFileEntry {
+  name: string;
+  filePath: string;
+  contentType: string;
+}
+
+export const multipartContentType = `multipart/form-data; boundary=${BOUNDARY_ID}`;
+
+export async function* createMultipartBodyFromFilesAsync(
+  entries: MultipartFileEntry[]
+): AsyncGenerator<Uint8Array> {
+  const encoder = new TextEncoder();
+  for await (const entry of entries) {
+    const stats = await fs.promises.stat(entry.filePath);
+    const header = makeFormHeader({
+      name: entry.name,
+      contentType: entry.contentType,
+      contentLength: stats.size,
+    });
+    yield encoder.encode(header);
+    yield* createReadStreamAsync(entry.filePath);
+    yield encoder.encode(CRLF);
+  }
+  yield encoder.encode(FORM_FOOTER);
+}


### PR DESCRIPTION
# Why

This implements the new EAS Hosting asset upload protocol. This should improve parallel asset upload performance by grouping asset uploads into fewer requests. Because some assets can be small, the cost associated with making requests (even in parallel, and even with `keepAlive`) from scratch is likely high and outstrips the performance gains from the parallelization we have.

# How

The new EAS Hosting assets protocol, when active, changes the `/deploy` endpoint to return an `upload` result paramter. This contains batches of SHA-512 arrays. When this parameter is received, `eas-cli` _may_ use this parameter to send the assets as batches instead.

Each batch is encoded as a `multipart/form-data` request payload. The payload contains a non-standard `Content-Length` header for each part, which switches modes in the `deployment-api`, allowing it to complete the upload a little faster.

# Test Plan

- Manually test this against the new protocol in staging
