### PR TITLE
[eas-cli] refactor capability syncing

### DIFF
--- a/packages/eas-cli/src/credentials/ios/appstore/capabilityList.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/capabilityList.ts
@@ -1,6 +1,6 @@
 import {
   AppGroup,
-  CapabilityOptionMap,
+  BundleIdCapability,
   CapabilityType,
   CapabilityTypeDataProtectionOption,
   CapabilityTypeOption,
@@ -9,15 +9,8 @@ import {
   MerchantId,
 } from '@expo/apple-utils';
 import { JSONObject, JSONValue } from '@expo/json-file';
+import { invariant } from 'graphql/jsutils/invariant';
 import nullthrows from 'nullthrows';
-
-type GetOptionsMethod<T extends CapabilityType = any> = (
-  entitlement: JSONValue,
-  entitlementsJson: JSONObject,
-  additionalOptions: {
-    usesBroadcastPushNotifications?: boolean;
-  }
-) => CapabilityOptionMap[T];
 
 const validateBooleanOptions = (options: any): boolean => {
   return typeof options === 'boolean';
@@ -50,12 +43,64 @@ const createValidateStringArrayOptions =
 
 const validateDevProdString = createValidateStringOptions(['development', 'production']);
 
-const getBooleanOptions: GetOptionsMethod = entitlement => {
-  return entitlement === true ? CapabilityTypeOption.ON : CapabilityTypeOption.OFF;
+const skipOp = { op: 'skip' } as const;
+const disableOp = { op: 'disable' } as const;
+const enableOp = { op: 'enable', option: CapabilityTypeOption.ON } as const;
+
+type GetSyncOperation = (opts: {
+  existingRemote: BundleIdCapability | null;
+  entitlementValue: JSONValue;
+  entitlements: JSONObject;
+  additionalOptions: {
+    usesBroadcastPushNotifications: boolean;
+  };
+}) => { op: 'enable'; option: JSONValue } | typeof skipOp | typeof disableOp;
+
+const getBooleanSyncOperation: GetSyncOperation = ({ existingRemote, entitlementValue }) => {
+  if (existingRemote) {
+    // If the remote capability exists, we only disable it if the value is false.
+    // Otherwise, we skip it.
+    if ('enabled' in existingRemote.attributes) {
+      return existingRemote.attributes['enabled'] === entitlementValue ? skipOp : disableOp;
+    }
+    return existingRemote.attributes.settings === null ? skipOp : enableOp;
+  } else {
+    return entitlementValue === false ? skipOp : enableOp;
+  }
 };
 
-const getDefinedOptions: GetOptionsMethod = entitlement => {
-  return entitlement ? CapabilityTypeOption.ON : CapabilityTypeOption.OFF;
+const getDefinedValueSyncOperation: GetSyncOperation = ({ existingRemote }) => {
+  if (!existingRemote) {
+    // If the remote capability does not exist, we create it.
+    return enableOp;
+  }
+  return existingRemote.attributes.settings === null ? skipOp : enableOp;
+};
+
+const capabilityWithSettingsSyncOperation: GetSyncOperation = ({
+  existingRemote,
+  entitlementValue,
+}) => {
+  // settings are defined for only a few capabilities: iCloud, data protection and Sign in with Apple
+  // https://developer.apple.com/documentation/appstoreconnectapi/capabilitysetting
+  if (!existingRemote) {
+    return enableOp;
+  }
+  invariant(
+    'enabled' in existingRemote.attributes,
+    `Expected "enabled" attribute in ${existingRemote.id}`
+  );
+  const existingEnabled = existingRemote.attributes.enabled === true;
+  const newOption = entitlementValue ? CapabilityTypeOption.ON : CapabilityTypeOption.OFF;
+
+  // If both are enabled and the existing one has settings, skip the update
+  if (existingEnabled && entitlementValue && existingRemote.attributes.settings) {
+    return skipOp;
+  }
+
+  // If the states don't match, we need to update
+  const newEnabled = newOption === CapabilityTypeOption.ON;
+  return existingEnabled === newEnabled ? skipOp : { op: 'enable', option: newOption };
 };
 
 export type CapabilityClassifier = {
@@ -63,8 +108,8 @@ export type CapabilityClassifier = {
   entitlement: string;
   capability: CapabilityType;
   validateOptions: (options: any) => boolean;
-  getOptions: GetOptionsMethod;
   capabilityIdModel?: typeof MerchantId;
+  getSyncOperation: GetSyncOperation;
   capabilityIdPrefix?: string;
   options?: undefined;
 };
@@ -78,70 +123,70 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     entitlement: 'com.apple.developer.homekit',
     capability: CapabilityType.HOME_KIT,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     name: 'Hotspot',
     entitlement: 'com.apple.developer.networking.HotspotConfiguration',
     capability: CapabilityType.HOT_SPOT,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     name: 'Multipath',
     entitlement: 'com.apple.developer.networking.multipath',
     capability: CapabilityType.MULTIPATH,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     name: 'SiriKit',
     entitlement: 'com.apple.developer.siri',
     capability: CapabilityType.SIRI_KIT,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     name: 'Wireless Accessory Configuration',
     entitlement: 'com.apple.external-accessory.wireless-configuration',
     capability: CapabilityType.WIRELESS_ACCESSORY,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     name: 'Extended Virtual Address Space',
     entitlement: 'com.apple.developer.kernel.extended-virtual-addressing',
     capability: CapabilityType.EXTENDED_VIRTUAL_ADDRESSING,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     name: 'Access WiFi Information',
     entitlement: 'com.apple.developer.networking.wifi-info',
     capability: CapabilityType.ACCESS_WIFI,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     name: 'Associated Domains',
     entitlement: 'com.apple.developer.associated-domains',
     capability: CapabilityType.ASSOCIATED_DOMAINS,
     validateOptions: validateStringArrayOptions,
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     name: 'AutoFill Credential Provider',
     entitlement: 'com.apple.developer.authentication-services.autofill-credential-provider',
     capability: CapabilityType.AUTO_FILL_CREDENTIAL,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     name: 'HealthKit',
     entitlement: 'com.apple.developer.healthkit',
     capability: CapabilityType.HEALTH_KIT,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   //   {
   //     // ?? -- adds UIRequiredDeviceCapabilities gamekit
@@ -150,7 +195,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
   //     entitlement: 'com.apple.developer.game-center',
   //     capability: CapabilityType.GAME_CENTER,
   //     validateOptions: validateBooleanOptions,
-  //     getOptions: getBooleanOptions,
+  //         getSyncOperation: getBooleanSyncOperation,
   //   },
   {
     name: 'App Groups',
@@ -158,7 +203,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     capability: CapabilityType.APP_GROUP,
     // Ex: ['group.CY-A5149AC2-49FC-11E7-B3F3-0335A16FFB8D.com.cydia.Extender']
     validateOptions: validatePrefixedStringArrayOptions('group.'),
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
     capabilityIdModel: AppGroup,
     capabilityIdPrefix: 'group.',
   },
@@ -168,7 +213,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     capability: CapabilityType.APPLE_PAY,
     // Ex: ['merchant.com.example.development']
     validateOptions: validatePrefixedStringArrayOptions('merchant.'),
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
     capabilityIdModel: MerchantId,
     capabilityIdPrefix: 'merchant.',
   },
@@ -178,7 +223,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     capability: CapabilityType.ICLOUD,
     validateOptions: validatePrefixedStringArrayOptions('iCloud.'),
     // Only supports Xcode +6
-    getOptions: getDefinedOptions,
+    getSyncOperation: capabilityWithSettingsSyncOperation,
     capabilityIdModel: CloudContainer,
     capabilityIdPrefix: 'iCloud.',
   },
@@ -187,35 +232,35 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     entitlement: 'com.apple.developer.ClassKit-environment',
     capability: CapabilityType.CLASS_KIT,
     validateOptions: validateDevProdString,
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     name: 'Communication Notifications',
     entitlement: 'com.apple.developer.usernotifications.communication',
     capability: CapabilityType.USER_NOTIFICATIONS_COMMUNICATION,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     name: 'Time Sensitive Notifications',
     entitlement: 'com.apple.developer.usernotifications.time-sensitive',
     capability: CapabilityType.USER_NOTIFICATIONS_TIME_SENSITIVE,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     name: 'Group Activities',
     entitlement: 'com.apple.developer.group-session',
     capability: CapabilityType.GROUP_ACTIVITIES,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     name: 'Family Controls',
     entitlement: 'com.apple.developer.family-controls',
     capability: CapabilityType.FAMILY_CONTROLS,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     // https://developer-mdn.apple.com/documentation/bundleresources/entitlements/com_apple_developer_default-data-protection
@@ -228,18 +273,27 @@ export const CapabilityMapping: CapabilityClassifier[] = [
       'NSFileProtectionNone',
       'NSFileProtectionComplete',
     ]),
-    getOptions(entitlement) {
-      if (entitlement === 'NSFileProtectionComplete') {
-        return CapabilityTypeDataProtectionOption.COMPLETE_PROTECTION;
-      } else if (entitlement === 'NSFileProtectionCompleteUnlessOpen') {
-        return CapabilityTypeDataProtectionOption.PROTECTED_UNLESS_OPEN;
-      } else if (entitlement === 'NSFileProtectionCompleteUntilFirstUserAuthentication') {
-        return CapabilityTypeDataProtectionOption.PROTECTED_UNTIL_FIRST_USER_AUTH;
+    getSyncOperation: ({ existingRemote, entitlementValue: entitlement }) => {
+      const newValue = (() => {
+        if (entitlement === 'NSFileProtectionComplete') {
+          return CapabilityTypeDataProtectionOption.COMPLETE_PROTECTION;
+        } else if (entitlement === 'NSFileProtectionCompleteUnlessOpen') {
+          return CapabilityTypeDataProtectionOption.PROTECTED_UNLESS_OPEN;
+        } else if (entitlement === 'NSFileProtectionCompleteUntilFirstUserAuthentication') {
+          return CapabilityTypeDataProtectionOption.PROTECTED_UNTIL_FIRST_USER_AUTH;
+        }
+        // NSFileProtectionNone isn't documented, not sure how to handle
+        throw new Error(
+          `iOS entitlement "com.apple.developer.default-data-protection" is using unsupported value "${entitlement}"`
+        );
+      })();
+      const enableOp = { op: 'enable', option: newValue } as const;
+      if (!existingRemote) {
+        return enableOp;
       }
-      // NSFileProtectionNone isn't documented, not sure how to handle
-      throw new Error(
-        `iOS entitlement "com.apple.developer.default-data-protection" is using unsupported value "${entitlement}"`
-      );
+      invariant(existingRemote.attributes.settings?.[0].key === 'DATA_PROTECTION_PERMISSION_LEVEL');
+      const oldValue = existingRemote.attributes.settings[0]?.options?.[0]?.key;
+      return oldValue === newValue ? skipOp : enableOp;
     },
   },
   {
@@ -248,7 +302,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     entitlement: 'inter-app-audio',
     capability: CapabilityType.INTER_APP_AUDIO,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     // https://developer-mdn.apple.com/documentation/bundleresources/entitlements/com_apple_developer_networking_networkextension
@@ -267,7 +321,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
       'dns-settings',
       'app-push-provider',
     ]),
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     // https://developer-mdn.apple.com/documentation/bundleresources/entitlements/com_apple_developer_nfc_readersession_formats
@@ -276,7 +330,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     capability: CapabilityType.NFC_TAG_READING,
     // Technically it seems only `TAG` is allowed, but many apps and packages tell users to add `NDEF` as well.
     validateOptions: createValidateStringArrayOptions(['NDEF', 'TAG']),
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     name: 'Personal VPN',
@@ -284,7 +338,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     capability: CapabilityType.PERSONAL_VPN,
     // Ex: ['allow-vpn']
     validateOptions: createValidateStringArrayOptions(['allow-vpn']),
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     // https://developer-mdn.apple.com/documentation/bundleresources/entitlements/com_apple_developer_networking_vpn_api
@@ -293,12 +347,28 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     entitlement: 'aps-environment',
     capability: CapabilityType.PUSH_NOTIFICATIONS,
     validateOptions: validateDevProdString,
-    getOptions(entitlement, _entitlementsJson, { usesBroadcastPushNotifications }) {
-      const option = entitlement ? CapabilityTypeOption.ON : CapabilityTypeOption.OFF;
-      if (option === CapabilityTypeOption.ON && usesBroadcastPushNotifications) {
-        return CapabilityTypePushNotificationsOption.PUSH_NOTIFICATION_FEATURE_BROADCAST;
+    getSyncOperation: ({
+      existingRemote,
+      entitlementValue: entitlement,
+      additionalOptions: { usesBroadcastPushNotifications },
+    }) => {
+      const newOption = (() => {
+        const option = entitlement ? CapabilityTypeOption.ON : CapabilityTypeOption.OFF;
+        if (option === CapabilityTypeOption.ON && usesBroadcastPushNotifications) {
+          return CapabilityTypePushNotificationsOption.PUSH_NOTIFICATION_FEATURE_BROADCAST;
+        }
+        return option;
+      })();
+      const createOp = { op: 'enable', option: newOption } as const;
+      if (!existingRemote) {
+        // If the remote capability does not exist, we create it.
+        return createOp;
       }
-      return option;
+      // For push notifications, we should always update the capability if
+      // - settings are not defined in the existing capability, but usesBroadcastPushNotifications is enabled (we want to add settings for this capability)
+      // - settings are defined in the existing capability, but usesBroadcastPushNotifications is disabled (we want to remove settings for this capability)
+      const noSettingsAttributes = existingRemote.attributes.settings == null;
+      return !noSettingsAttributes === usesBroadcastPushNotifications ? skipOp : createOp;
     },
   },
   {
@@ -307,7 +377,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     capability: CapabilityType.WALLET,
     // Ex: ['$(TeamIdentifierPrefix)*']
     validateOptions: validateStringArrayOptions,
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     name: 'Sign In with Apple',
@@ -315,28 +385,28 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     capability: CapabilityType.APPLE_ID_AUTH,
     // Ex: ['Default']
     validateOptions: createValidateStringArrayOptions(['Default']),
-    getOptions: getDefinedOptions,
+    getSyncOperation: capabilityWithSettingsSyncOperation,
   },
   {
     name: 'Fonts',
     entitlement: 'com.apple.developer.user-fonts',
     capability: CapabilityType.FONT_INSTALLATION,
     validateOptions: createValidateStringArrayOptions(['app-usage', 'system-installation']),
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     name: 'Apple Pay Later Merchandising',
     entitlement: 'com.apple.developer.pay-later-merchandising',
     capability: CapabilityType.APPLE_PAY_LATER_MERCHANDISING,
     validateOptions: createValidateStringArrayOptions(['payinfour-merchandising']),
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     name: 'Sensitive Content Analysis',
     entitlement: 'com.apple.developer.sensitivecontentanalysis.client',
     capability: CapabilityType.SENSITIVE_CONTENT_ANALYSIS,
     validateOptions: createValidateStringArrayOptions(['analysis']),
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     // Not in Xcode
@@ -346,231 +416,231 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     entitlement: 'com.apple.developer.devicecheck.appattest-environment',
     capability: CapabilityType.APP_ATTEST,
     validateOptions: validateDevProdString,
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.coremedia.hls.low-latency',
     name: 'Low Latency HLS',
     capability: CapabilityType.HLS_LOW_LATENCY,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.associated-domains.mdm-managed',
     name: 'MDM Managed Associated Domains',
     capability: CapabilityType.MDM_MANAGED_ASSOCIATED_DOMAINS,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.fileprovider.testing-mode',
     name: 'FileProvider TestingMode',
     capability: CapabilityType.FILE_PROVIDER_TESTING_MODE,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.healthkit.recalibrate-estimates',
     name: 'Recalibrate Estimates',
     capability: CapabilityType.HEALTH_KIT_RECALIBRATE_ESTIMATES,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.maps',
     name: 'Maps',
     capability: CapabilityType.MAPS,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.user-management',
     name: 'TV Services',
     capability: CapabilityType.USER_MANAGEMENT,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.networking.custom-protocol',
     name: 'Custom Network Protocol',
     capability: CapabilityType.NETWORK_CUSTOM_PROTOCOL,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.system-extension.install',
     name: 'System Extension',
     capability: CapabilityType.SYSTEM_EXTENSION_INSTALL,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.push-to-talk',
     name: 'Push to Talk',
     capability: CapabilityType.PUSH_TO_TALK,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.driverkit.transport.usb',
     name: 'DriverKit USB Transport (development)',
     capability: CapabilityType.DRIVER_KIT_USB_TRANSPORT_PUB,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.kernel.increased-memory-limit',
     name: 'Increased Memory Limit',
     capability: CapabilityType.INCREASED_MEMORY_LIMIT,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.driverkit.communicates-with-drivers',
     name: 'Communicates with Drivers',
     capability: CapabilityType.DRIVER_KIT_COMMUNICATES_WITH_DRIVERS,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.media-device-discovery-extension',
     name: 'Media Device Discovery',
     capability: CapabilityType.MEDIA_DEVICE_DISCOVERY,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.driverkit.allow-third-party-userclients',
     name: 'DriverKit Allow Third Party UserClients',
     capability: CapabilityType.DRIVER_KIT_ALLOW_THIRD_PARTY_USER_CLIENTS,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.weatherkit',
     name: 'WeatherKit',
     capability: CapabilityType.WEATHER_KIT,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.on-demand-install-capable',
     name: 'On Demand Install Capable for App Clip Extensions',
     capability: CapabilityType.ON_DEMAND_INSTALL_EXTENSIONS,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.driverkit.family.scsicontroller',
     name: 'DriverKit Family SCSIController (development)',
     capability: CapabilityType.DRIVER_KIT_FAMILY_SCSI_CONTROLLER_PUB,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.driverkit.family.serial',
     name: 'DriverKit Family Serial (development)',
     capability: CapabilityType.DRIVER_KIT_FAMILY_SERIAL_PUB,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.driverkit.family.networking',
     name: 'DriverKit Family Networking (development)',
     capability: CapabilityType.DRIVER_KIT_FAMILY_NETWORKING_PUB,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.driverkit.family.hid.eventservice',
     name: 'DriverKit Family HID EventService (development)',
     capability: CapabilityType.DRIVER_KIT_FAMILY_HID_EVENT_SERVICE_PUB,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.driverkit.family.hid.device',
     name: 'DriverKit Family HID Device (development)',
     capability: CapabilityType.DRIVER_KIT_FAMILY_HID_DEVICE_PUB,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.driverkit',
     name: 'DriverKit for Development',
     capability: CapabilityType.DRIVER_KIT_PUBLIC,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.driverkit.transport.hid',
     name: 'DriverKit Transport HID (development)',
     capability: CapabilityType.DRIVER_KIT_TRANSPORT_HID_PUB,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.driverkit.family.audio',
     name: 'DriverKit Family Audio (development)',
     capability: CapabilityType.DRIVER_KIT_FAMILY_AUDIO_PUB,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.shared-with-you',
     name: 'Shared with You',
     capability: CapabilityType.SHARED_WITH_YOU,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.shared-with-you.collaboration',
     name: 'Messages Collaboration',
     capability: CapabilityType.MESSAGES_COLLABORATION,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.submerged-shallow-depth-and-pressure',
     name: 'Shallow Depth and Pressure',
     capability: CapabilityType.SHALLOW_DEPTH_PRESSURE,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.proximity-reader.identity.display',
     name: 'Tap to Present ID on iPhone (Display Only)',
     capability: CapabilityType.TAP_TO_DISPLAY_ID,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.proximity-reader.payment.acceptance',
     name: 'Tap to Pay on iPhone',
     capability: CapabilityType.TAP_TO_PAY_ON_IPHONE,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.matter.allow-setup-payload',
     name: 'Matter Allow Setup Payload',
     capability: CapabilityType.MATTER_ALLOW_SETUP_PAYLOAD,
     validateOptions: validateBooleanOptions,
-    getOptions: getBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.journal.allow',
     name: 'Journaling Suggestions',
     capability: CapabilityType.JOURNALING_SUGGESTIONS,
     validateOptions: createValidateStringArrayOptions(['suggestions']),
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.managed-app-distribution.install-ui',
     name: 'Managed App Installation UI',
     capability: CapabilityType.MANAGED_APP_INSTALLATION_UI,
     validateOptions: createValidateStringArrayOptions(['managed-app']),
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.networking.slicing.appcategory',
@@ -581,7 +651,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
       'communication-9000',
       'streaming-9001',
     ]),
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   {
     entitlement: 'com.apple.developer.networking.slicing.trafficcategory',
@@ -597,7 +667,7 @@ export const CapabilityMapping: CapabilityClassifier[] = [
       'avstreaming-7',
       'responsiveav-8',
     ]),
-    getOptions: getDefinedOptions,
+    getSyncOperation: getDefinedValueSyncOperation,
   },
   // VMNET
 


### PR DESCRIPTION
# Why

This PR refactors the iOS capability synchronization logic to make it more "linear" and easier to maintain

# How

- Encapsulating capability-specific logic with the capability definition
- Making the operation decision process more explicit and easier to follow

# Test Plan

- green CI
- local tests