### PR TITLE
[eas-cli] fix CapabilityModel creation and syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Refactor capabilities syncing to avoid provisioning profiles becoming invalid. ([#3088](https://github.com/expo/eas-cli/pull/3088) by [@vonovak](https://github.com/vonovak))
+
 ### 🧹 Chores
 
 ## [16.15.0](https://github.com/expo/eas-cli/releases/tag/v16.15.0) - 2025-07-10

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/bundleIdCapabilities-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/bundleIdCapabilities-test.ts
@@ -66,6 +66,7 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
       },
     ]);
   });
+
   describe('capabilities with settings', () => {
     const ctx = { providerId: 123195, teamId: 'MyteamId' };
     const capabilities = [
@@ -157,6 +158,25 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
       'com.apple.developer.ubiquity-kvstore-identifier':
         '$(TeamIdentifierPrefix)com.vonovak.edfapp',
     };
+
+    it(`given a nonempty set S of remote capabilities, and a local boolean capability that is disabled and not in S, it does not disable any capability from S`, async () => {
+      // this is for an edge case
+      const bundleId = createMockBundleId('U78L9459DG', capabilities);
+      const result = await syncCapabilitiesForEntitlementsAsync(
+        bundleId,
+        {
+          'com.apple.developer.healthkit': false,
+          ...entitlements,
+        },
+        noBroadcastNotificationOption
+      );
+
+      expect(result).toStrictEqual({
+        enabled: [],
+        disabled: [],
+      });
+      expect(bundleId.updateBundleIdCapabilityAsync).not.toHaveBeenCalled();
+    });
 
     it('does not sync a capability that is already enabled', async () => {
       const bundleId = createMockBundleId('U78L9459DG', capabilities);

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/capabilityIdentifiers-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/capabilityIdentifiers-test.ts
@@ -1,56 +1,61 @@
 import { syncCapabilityIdentifiersForEntitlementsAsync } from '../capabilityIdentifiers';
 
+const mockItems = {
+  merchant: {
+    expo: { id: 'XXX-merch-1', attributes: { identifier: 'merchant.expo' } },
+  },
+  appGroup: {
+    expo: { id: 'XXX-group-1', attributes: { identifier: 'group.expo' } },
+  },
+  cloudContainer: {
+    expo: { id: 'XXX-icloud-1', attributes: { identifier: 'iCloud.expo' } },
+  },
+};
+
 function mockCapabilities(Apple: any): void {
-  Apple.MerchantId.getAsync = jest.fn(() => [
-    {
-      id: 'XXX-merch-1',
+  const mockGetAsync = (existingItems: any[]): jest.Mock =>
+    jest.fn(() => Promise.resolve(existingItems));
+
+  const mockCreateAsync = (newId: string): jest.Mock =>
+    jest.fn((_ctx, { identifier }) => ({
+      id: newId,
       attributes: {
-        identifier: 'merchant.expo',
+        identifier,
       },
-    },
+    }));
+
+  Apple.MerchantId.getAsync = mockGetAsync([mockItems.merchant.expo]);
+
+  Apple.MerchantId.createAsync = mockCreateAsync('XXX-merch-2');
+
+  Apple.AppGroup.getAsync = mockGetAsync([mockItems.appGroup.expo]);
+
+  Apple.AppGroup.createAsync = mockCreateAsync('XXX-group-2');
+
+  Apple.CloudContainer.getAsync = mockGetAsync([mockItems.cloudContainer.expo]);
+
+  Apple.CloudContainer.createAsync = mockCreateAsync('XXX-icloud-2');
+}
+
+function mockCapabilitiesAlreadyCreated(Apple: any): void {
+  Apple.MerchantId.getAsync.mockResolvedValue([
+    mockItems.merchant.expo,
+    { id: 'XXX-merch-2', attributes: { identifier: 'merchant.bacon' } },
   ]);
 
-  Apple.MerchantId.createAsync = jest.fn((_ctx, { identifier }) => ({
-    id: 'XXX-merch-2',
-    attributes: {
-      identifier,
-    },
-  }));
-
-  Apple.AppGroup.getAsync = jest.fn(() => [
-    {
-      id: 'XXX-group-1',
-      attributes: {
-        identifier: 'group.expo',
-      },
-    },
-  ]);
-  Apple.AppGroup.createAsync = jest.fn((_ctx, { identifier }) => ({
-    id: 'XXX-group-2',
-    attributes: {
-      identifier,
-    },
-  }));
-
-  Apple.CloudContainer.getAsync = jest.fn(() => [
-    {
-      id: 'XXX-icloud-1',
-      attributes: {
-        identifier: 'iCloud.expo',
-      },
-    },
+  Apple.AppGroup.getAsync.mockResolvedValue([
+    mockItems.appGroup.expo,
+    { id: 'XXX-group-2', attributes: { identifier: 'group.bacon' } },
   ]);
 
-  Apple.CloudContainer.createAsync = jest.fn((_ctx, { identifier }) => ({
-    id: 'XXX-icloud-2',
-    attributes: {
-      identifier,
-    },
-  }));
+  Apple.CloudContainer.getAsync.mockResolvedValue([
+    mockItems.cloudContainer.expo,
+    { id: 'XXX-icloud-2', attributes: { identifier: 'iCloud.bacon' } },
+  ]);
 }
 
 describe(syncCapabilityIdentifiersForEntitlementsAsync, () => {
-  it(`creates missing capability identifiers`, async () => {
+  it(`creates missing capability identifiers, and once they are created, they are not re-created`, async () => {
     const Apple = require('@expo/apple-utils');
     mockCapabilities(Apple);
 
@@ -60,10 +65,26 @@ describe(syncCapabilityIdentifiersForEntitlementsAsync, () => {
       id: 'XXX',
     } as any;
 
-    await syncCapabilityIdentifiersForEntitlementsAsync(bundleId, {
-      'com.apple.developer.in-app-payments': ['merchant.bacon'],
-      'com.apple.security.application-groups': ['group.bacon'],
-      'com.apple.developer.icloud-container-identifiers': ['iCloud.bacon'],
+    const syncCapabilities = (): Promise<{
+      created: string[];
+      linked: string[];
+    }> =>
+      syncCapabilityIdentifiersForEntitlementsAsync(bundleId, {
+        'com.apple.developer.in-app-payments': ['merchant.bacon'],
+        'com.apple.security.application-groups': ['group.bacon'],
+        'com.apple.developer.icloud-container-identifiers': ['iCloud.bacon'],
+      });
+
+    const result = await syncCapabilities();
+    expect(result).toStrictEqual({
+      created: ['group.bacon', 'merchant.bacon', 'iCloud.bacon'],
+      linked: ['group.bacon', 'merchant.bacon', 'iCloud.bacon'],
+    });
+    mockCapabilitiesAlreadyCreated(Apple);
+    const result2 = await syncCapabilities();
+    expect(result2).toStrictEqual({
+      created: [],
+      linked: [],
     });
 
     // Ensure we create missing ids
@@ -73,6 +94,7 @@ describe(syncCapabilityIdentifiersForEntitlementsAsync, () => {
       // props
       { identifier: 'merchant.bacon' }
     );
+    expect(Apple.MerchantId.createAsync).toHaveBeenCalledTimes(1);
     // Ensure we create missing ids
     expect(Apple.AppGroup.createAsync).toHaveBeenLastCalledWith(
       // auth context
@@ -80,6 +102,7 @@ describe(syncCapabilityIdentifiersForEntitlementsAsync, () => {
       // props
       { identifier: 'group.bacon' }
     );
+    expect(Apple.AppGroup.createAsync).toHaveBeenCalledTimes(1);
     // Ensure we create missing ids
     expect(Apple.CloudContainer.createAsync).toHaveBeenLastCalledWith(
       // auth context
@@ -87,8 +110,8 @@ describe(syncCapabilityIdentifiersForEntitlementsAsync, () => {
       // props
       { identifier: 'iCloud.bacon' }
     );
-
-    expect(bundleId.updateBundleIdCapabilityAsync).toBeCalledWith([
+    expect(Apple.CloudContainer.createAsync).toHaveBeenCalledTimes(1);
+    expect(bundleId.updateBundleIdCapabilityAsync).toHaveBeenLastCalledWith([
       {
         capabilityType: 'APP_GROUPS',
         option: 'ON',
@@ -111,9 +134,10 @@ describe(syncCapabilityIdentifiersForEntitlementsAsync, () => {
         },
       },
     ]);
+    expect(bundleId.updateBundleIdCapabilityAsync).toHaveBeenCalledTimes(1);
   });
 
-  it(`removes local duplicates`, async () => {
+  it(`doesn't perform duplicate CapabilityModel.getAsync calls`, async () => {
     const Apple = require('@expo/apple-utils');
     mockCapabilities(Apple);
     const bundleId = {
@@ -122,28 +146,38 @@ describe(syncCapabilityIdentifiersForEntitlementsAsync, () => {
       id: 'XXX',
     } as any;
 
-    await syncCapabilityIdentifiersForEntitlementsAsync(bundleId, {
+    const result = await syncCapabilityIdentifiersForEntitlementsAsync(bundleId, {
       'com.apple.developer.in-app-payments': ['merchant.expo', 'merchant.expo'],
     });
 
     // Only called once because we remove local duplicates to minimize network requests.
-    expect(Apple.MerchantId.getAsync).toBeCalledTimes(1);
+    expect(Apple.MerchantId.getAsync).toHaveBeenCalledTimes(1);
+    expect(bundleId.updateBundleIdCapabilityAsync).not.toHaveBeenCalled();
+    expect(result).toStrictEqual({
+      created: [],
+      linked: [],
+    });
   });
 
-  it(`creates missing capability identifiers`, async () => {
+  it(`does not create capability identifiers (merchant.expo) when it already exists`, async () => {
     const Apple = require('@expo/apple-utils');
     mockCapabilities(Apple);
     const bundleId = {
       context: {},
       updateBundleIdCapabilityAsync: jest.fn(),
       id: 'XXX',
-    } as any;
+    };
 
-    await syncCapabilityIdentifiersForEntitlementsAsync(bundleId, {
+    const result = await syncCapabilityIdentifiersForEntitlementsAsync(bundleId as any, {
       'com.apple.developer.in-app-payments': ['merchant.expo'],
     });
 
-    expect(Apple.MerchantId.createAsync).not.toBeCalled();
+    expect(Apple.MerchantId.createAsync).not.toHaveBeenCalled();
+    expect(bundleId.updateBundleIdCapabilityAsync).not.toHaveBeenCalled();
+    expect(result).toStrictEqual({
+      created: [],
+      linked: [],
+    });
   });
 
   it(`throws when creating a missing capability that is reserved`, async () => {

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -138,7 +138,7 @@ function getCapabilitiesToEnable(
         capabilityType: staticCapabilityInfo.capability,
         option: operation.option,
       });
-    } else if (op === 'skip') {
+    } else if (op === 'skip' && existingIndex >= 0) {
       // Remove the item from the list of capabilities so we don't disable it in the next step.
       remainingCapabilities.splice(existingIndex, 1);
     }


### PR DESCRIPTION
# Why

The current implementation of capabilities syncing can lead to provisioning profiles becoming invalid. This PR refactors the syncing process to avoid this issue by making the following improvements:

1. Preventing unnecessary creation of capability identifiers that already exist
2. Only updating bundle capabilities when necessary

closes https://github.com/expo/eas-cli/issues/1069
closes https://github.com/expo/eas-cli/issues/1445

# How

I refactored the capability syncing logic to:

- Add test coverage for faulty behaviors. More tests are [up the stack](https://github.com/expo/eas-cli/pull/3086/files#diff-09c5aad6e72a7a336e9783710d3899ff2ea432146929bc07ba8bfec7c7bbd2a8).
- Only create capability identifiers that don't already exist on the server
- Skip updating bundle capabilities when no changes are needed


# Test Plan

`easd` command below is from https://github.com/expo/eas-cli/blob/main/CONTRIBUTING.md#development.

To best test this locally, have an iOS app with 

(1) no capabilities enabled. Enable some capabilities in `app.json` and run prebuild. [iCloud](https://docs.expo.dev/versions/latest/sdk/document-picker/#example-appjson-with-config-plugin), Apple Sign In, app groups, or `"com.apple.developer.default-data-protection": "NSFileProtectionComplete / ..."` are of special interest, but any will do.

OR

(2) a buch of capabilities already enabled

using this app, run `easd build -p ios` TWO times. Confirm that the first build creates new capabilities on your app bundle (https://developer.apple.com/account/resources/identifiers/list) and provisioning profiles (if any). Confirm the second build passes and doesn't require any provisioning profile changes.

Finally, change the capabilities, and again run `easd build -p ios` twice to confirm no capabilities / provisioning profiles are changed on the second run (that's what should happen on the first run).

- green CI
- local tests

