### PR TITLE
[eas-cli] Fix graphql codegen to look in all directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Remove unreleased `link` and `unlink` commands from `eas env`. ([#3092](https://github.com/expo/eas-cli/pull/3092) by [@kadikraman](https://github.com/kadikraman))
 - Add new CI to verify GraphQL generation. ([#3093](https://github.com/expo/eas-cli/pull/3093) by [@douglowder](https://github.com/douglowder))
+- Update GraphQL generation to look in all src directories. ([#3097](https://github.com/expo/eas-cli/pull/3097) by [@wschurman](https://github.com/wschurman))
 
 ## [16.13.4](https://github.com/expo/eas-cli/releases/tag/v16.13.4) - 2025-07-04
 

--- a/packages/eas-cli/graphql-codegen.yml
+++ b/packages/eas-cli/graphql-codegen.yml
@@ -1,14 +1,7 @@
 overwrite: true
 schema: 'https://staging-api.expo.dev/graphql'
 documents:
-  - 'src/graphql/**/!(*.d).{ts,tsx}'
-  - 'src/credentials/ios/api/graphql/**/!(*.d).{ts,tsx}'
-  - 'src/credentials/android/api/graphql/**/!(*.d).{ts,tsx}'
-  - 'src/commands/**/*.ts'
-  - 'src/branch/**/*.ts'
-  - 'src/channel/**/*.ts'
-  - 'src/worker/**/*.ts'
-  - 'src/update/**/*.ts'
+  - 'src/**/!(*.d).ts'
 generates:
   src/graphql/generated.ts:
     plugins:

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -10193,6 +10193,11 @@ export type ScheduleUpdateGroupDeletionMutationVariables = Exact<{
 
 export type ScheduleUpdateGroupDeletionMutation = { __typename?: 'RootMutation', update: { __typename?: 'UpdateMutation', scheduleUpdateGroupDeletion: { __typename?: 'BackgroundJobReceipt', id: string, state: BackgroundJobState, tries: number, willRetry: boolean, resultId?: string | null, resultType: BackgroundJobResultType, resultData?: any | null, errorCode?: string | null, errorMessage?: string | null, createdAt: any, updatedAt: any } } };
 
+export type MeUserActorQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type MeUserActorQuery = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null };
+
 export type WorkerDeploymentFragment = { __typename?: 'WorkerDeployment', id: string, url: string, deploymentIdentifier: any, deploymentDomain: string, createdAt: any };
 
 export type WorkerDeploymentAliasFragment = { __typename?: 'WorkerDeploymentAlias', id: string, aliasName?: any | null, url: string };

--- a/packages/eas-cli/src/user/fetchUser.ts
+++ b/packages/eas-cli/src/user/fetchUser.ts
@@ -1,6 +1,8 @@
 import gql from 'graphql-tag';
 
 import { createGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../graphql/client';
+import { MeUserActorQuery, MeUserActorQueryVariables } from '../graphql/generated';
 
 export async function fetchUserAsync({
   sessionSecret,
@@ -8,26 +10,30 @@ export async function fetchUserAsync({
   sessionSecret: string;
 }): Promise<{ id: string; username: string }> {
   const graphqlClient = createGraphqlClient({ accessToken: null, sessionSecret });
-  const result = await graphqlClient
-    .query(
-      gql`
-        query UserQuery {
-          meUserActor {
-            id
-            username
+  const result = await withErrorHandlingAsync(
+    graphqlClient
+      .query<MeUserActorQuery, MeUserActorQueryVariables>(
+        gql`
+          query MeUserActorQuery {
+            meUserActor {
+              id
+              username
+            }
           }
-        }
-      `,
-      {},
-      {
-        additionalTypenames: [] /* UserQuery has immutable fields */,
-      }
-    )
-    .toPromise();
+        `,
+        {},
+        { additionalTypenames: ['UserActor'] }
+      )
+      .toPromise()
+  );
 
-  const { data } = result;
+  const meUserActor = result.meUserActor;
+  if (!meUserActor) {
+    throw new Error('Failed to fetch user data after login.');
+  }
+
   return {
-    id: data.meUserActor.id,
-    username: data.meUserActor.username,
+    id: meUserActor.id,
+    username: meUserActor.username,
   };
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

While creating a previous PR, I moved a graphql query into a directory not explicitly specified in `graphql-codegen.yml`. It took me a while to figure out what was going on (only error was `tsc`).

To avoid other devs running into this, just generate it for all files in src.

# How

1. Update paths
2. Fix `fetchUserAsync` to be typed and have a unique query name.

# Test Plan

```
neas logout
neas login
neas whoami
```