### PR TITLE
[eas-cli] Fix batch uploads being subject to early-termination issues corrupting multipart upload parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - Refactor capabilities syncing to avoid provisioning profiles becoming invalid. ([#3088](https://github.com/expo/eas-cli/pull/3088) by [@vonovak](https://github.com/vonovak))
+- Avoid corrupted EAS Hosting batch upload bodies and double-check length and checksums while uploading. ([#3103](https://github.com/expo/eas-cli/pull/3103) by [@kitten](https://github.com/kitten))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -1,7 +1,7 @@
 import { parseProjectEnv } from '@expo/env';
 import mime from 'mime';
 import { Gzip, GzipOptions } from 'minizlib';
-import { HashOptions, createHash, randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import fs, { createWriteStream } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -37,11 +37,8 @@ async function createTempWritePathAsync(): Promise<string> {
 }
 
 /** Computes a SHA512 hash for a file */
-async function computeSha512HashAsync(
-  filePath: fs.PathLike,
-  options?: HashOptions
-): Promise<string> {
-  const hash = createHash('sha512', { encoding: 'hex', ...options });
+async function computeSha512HashAsync(filePath: fs.PathLike): Promise<string> {
+  const hash = createHash('sha512', { encoding: 'hex' });
   await pipeline(fs.createReadStream(filePath), hash);
   return `${hash.read()}`;
 }
@@ -94,7 +91,6 @@ async function determineMimeTypeAsync(filePath: string): Promise<string | null> 
 }
 
 interface AssetMapOptions {
-  hashOptions?: HashOptions;
   maxFileSize: number;
 }
 
@@ -119,7 +115,7 @@ export async function collectAssetsAsync(
           `Upload of "${file.normalizedPath}" aborted: File size is greater than the upload limit (>500MB)`
         );
       }
-      const sha512$ = computeSha512HashAsync(file.path, options?.hashOptions);
+      const sha512$ = computeSha512HashAsync(file.path);
       const contentType$ = determineMimeTypeAsync(file.path);
       assets.push({
         normalizedPath: file.normalizedPath,

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -89,12 +89,7 @@ export async function uploadAsync(
         method = 'PATCH';
         url.pathname = '/asset/batch';
         const iterator = createMultipartBodyFromFilesAsync(
-          multipart.map(asset => ({
-            name: asset.sha512,
-            filePath: asset.path,
-            contentType: asset.type,
-            contentLength: asset.size,
-          })),
+          multipart,
           onProgressUpdate
         );
         body = Readable.from(iterator);

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -8,7 +8,11 @@ import { Readable } from 'node:stream';
 import promiseRetry from 'promise-retry';
 
 import { AssetFileEntry } from './assets';
-import { createMultipartBodyFromFilesAsync, createReadStreamAsync, multipartContentType } from './utils/multipart';
+import {
+  createMultipartBodyFromFilesAsync,
+  createReadStreamAsync,
+  multipartContentType,
+} from './utils/multipart';
 
 const MAX_CONCURRENCY = Math.min(10, Math.max(os.availableParallelism() * 2, 20));
 const MAX_RETRIES = 4;
@@ -77,10 +81,7 @@ export async function uploadAsync(
         }
         method = 'POST';
         url.pathname = `/asset/${asset.sha512}`;
-        body = Readable.from(
-          createReadStreamAsync(asset),
-          { objectMode: false },
-        );
+        body = Readable.from(createReadStreamAsync(asset), { objectMode: false });
       } else if ('filePath' in payload) {
         const { filePath } = payload;
         errorPrefix = 'Worker deployment failed';
@@ -91,13 +92,9 @@ export async function uploadAsync(
         headers.set('content-type', multipartContentType);
         method = 'PATCH';
         url.pathname = '/asset/batch';
-        body = Readable.from(
-          createMultipartBodyFromFilesAsync(
-            multipart,
-            onProgressUpdate
-          ),
-          { objectMode: false },
-        );
+        body = Readable.from(createMultipartBodyFromFilesAsync(multipart, onProgressUpdate), {
+          objectMode: false,
+        });
       }
 
       let response: Response;

--- a/packages/eas-cli/src/worker/utils/multipart.ts
+++ b/packages/eas-cli/src/worker/utils/multipart.ts
@@ -21,9 +21,14 @@ const encodeName = (input: string): string => {
 };
 
 async function* createReadStreamAsync(filePath: string): AsyncGenerator<Uint8Array> {
-  for await (const raw of fs.createReadStream(filePath)) {
-    const chunk = raw as Buffer;
-    yield new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+  const handle = await fs.promises.open(filePath);
+  const buffer = Buffer.alloc(4096);
+  try {
+    let bytesRead = 0;
+    while ((bytesRead = (await handle.read(buffer)).bytesRead) > 0)
+      yield new Uint8Array(buffer, buffer.byteOffset, bytesRead);
+  } finally {
+    await handle.close();
   }
 }
 

--- a/packages/eas-cli/src/worker/utils/multipart.ts
+++ b/packages/eas-cli/src/worker/utils/multipart.ts
@@ -1,5 +1,5 @@
-import fs from 'node:fs';
 import { createHash } from 'node:crypto';
+import fs from 'node:fs';
 
 const CRLF = '\r\n';
 const BOUNDARY_HYPHEN_CHARS = '--';
@@ -21,7 +21,9 @@ const encodeName = (input: string): string => {
   });
 };
 
-export async function* createReadStreamAsync(fileEntry: MultipartFileEntry): AsyncGenerator<Uint8Array> {
+export async function* createReadStreamAsync(
+  fileEntry: MultipartFileEntry
+): AsyncGenerator<Uint8Array> {
   let handle: fs.promises.FileHandle | undefined;
   try {
     handle = await fs.promises.open(fileEntry.path);
@@ -35,7 +37,9 @@ export async function* createReadStreamAsync(fileEntry: MultipartFileEntry): Asy
       bytesTotal += output.byteLength;
 
       if (bytesTotal > fileEntry.size) {
-        throw new RangeError(`Asset "${fileEntry.path}" was modified during the upload (length mismatch)`);
+        throw new RangeError(
+          `Asset "${fileEntry.path}" was modified during the upload (length mismatch)`
+        );
       }
 
       if (output.byteLength) {
@@ -45,7 +49,9 @@ export async function* createReadStreamAsync(fileEntry: MultipartFileEntry): Asy
       if (bytesTotal === fileEntry.size) {
         const sha512 = hash.digest('hex');
         if (sha512 !== fileEntry.sha512) {
-          throw new Error(`Asset "${fileEntry.path}" was modified during the upload (checksum mismatch)`);
+          throw new Error(
+            `Asset "${fileEntry.path}" was modified during the upload (checksum mismatch)`
+          );
         }
       }
 
@@ -57,7 +63,9 @@ export async function* createReadStreamAsync(fileEntry: MultipartFileEntry): Asy
     }
 
     if (bytesTotal < fileEntry.size) {
-      throw new RangeError(`Asset "${fileEntry.path}" was modified during the upload (length mismatch)`);
+      throw new RangeError(
+        `Asset "${fileEntry.path}" was modified during the upload (length mismatch)`
+      );
     }
   } finally {
     await handle?.close();


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We're basically using `Readable.from(asyncGenerator)` and `for await (const chunk of fs.createReadStream(filePath))` to read files. However, if the `createReadStream()` ends with an `'end'` event, in some Node.js versions they're subject to an early termination timing bug. When this happens, the file output ends earlier than expected, which causes the upload to become corrupted.

# How

- Switch to `fs.promises.open` and `filehandle.read` to work around async-iterable early termination bug
- Double-check the file's length (from the known size) while uploading
- Double-check the file's checksum (from the computed SHA-512) while uploading
- Use `Readable.from(asyncIterator, { objectMode: false })` to enter binary mode

This ensures that:
- we're now working around the early termination issue
- we're preventing file modifications during uploads from corrupting the upload
- we're properly using the `Readable` buffering and backpressure should work as expected

This issue is likely triggered in only some Node.js (22?) versions when:
- the `createReadStream` starts buffering
- the `Readable` hasn't filled the internal buffer yet
- the `Readable` then receives the `'end'` event discarding the internal buffer and ending early

# Test Plan

- `createReadStreamAsync` is now used for the legacy uploads as well, which should prevent this issue from being inconsistent and tied only to the new protocol (which also enforces the new length and checksum checks)
- While I've been unable to reproduce this locally so far, the new implementation isn't subject to the same code paths, which caused this issue. Because `AsyncGenerator`s don't buffer, the only buffer we're now subject to is `Readable.from`'s
