### PR TITLE
[eas-cli] Add command for deleting worker aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Add workflow:view and workflow:logs commands. ([#3090](https://github.com/expo/eas-cli/pull/3090) by [@douglowder](https://github.com/douglowder))
 - Add support for providing inputs to new workflow runs ([#3095](https://github.com/expo/eas-cli/pull/3095) by [@sjchmiela](https://github.com/sjchmiela))
+- Add deploy:alias:delete for deleting worker deployment aliases ([#3107](https://github.com/expo/eas-cli/pull/3107) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -27828,6 +27828,55 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "deleteWorkerDeploymentByIdentifier",
+            "description": null,
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "deploymentIdentifier",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteWorkerDeploymentResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,

--- a/packages/eas-cli/src/commands/deploy/alias/delete.ts
+++ b/packages/eas-cli/src/commands/deploy/alias/delete.ts
@@ -1,0 +1,142 @@
+import chalk from 'chalk';
+
+import EasCommand from '../../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { EasNonInteractiveAndJsonFlags } from '../../../commandUtils/flags';
+import Log from '../../../log';
+import { Ora, ora } from '../../../ora';
+import { toggleConfirmAsync } from '../../../prompts';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+import {
+  deleteWorkerDeploymentAliasAsync,
+  selectWorkerDeploymentAliasOnAppAsync,
+} from '../../../worker/deployment';
+
+interface DeployAliasDeleteFlags {
+  nonInteractive: boolean;
+  json: boolean;
+}
+
+export default class WorkerAliasDelete extends EasCommand {
+  static override description = 'Delete deployment aliases.';
+  static override aliases = ['worker:alias:delete'];
+  static override state = 'preview';
+
+  static override args = [{ name: 'ALIAS_NAME' }];
+  static override flags = {
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.DynamicProjectConfig,
+    ...this.ContextOptions.ProjectDir,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  override async runAsync(): Promise<void> {
+    const {
+      args: { ALIAS_NAME: aliasNameFromArg },
+      flags: rawFlags,
+    } = await this.parse(WorkerAliasDelete);
+    const flags = this.sanitizeFlags(rawFlags);
+
+    if (flags.json) {
+      enableJsonOutput();
+    }
+
+    Log.warn('EAS Hosting is still in preview and subject to changes.');
+
+    const {
+      getDynamicPrivateProjectConfigAsync,
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(WorkerAliasDelete, {
+      nonInteractive: true,
+      withServerSideEnvironment: null,
+    });
+
+    const { projectId } = await getDynamicPrivateProjectConfigAsync();
+    const aliasName = await resolveDeploymentAliasAsync(
+      flags,
+      graphqlClient,
+      projectId,
+      aliasNameFromArg
+    );
+
+    const isProduction = !aliasName;
+
+    if (!flags.nonInteractive) {
+      Log.addNewLineIfNone();
+      Log.warn(
+        isProduction
+          ? `You are about to delete your production alias`
+          : `You are about to delete alias: "${aliasName}"`
+      );
+      Log.newLine();
+      const confirmed = await toggleConfirmAsync({ message: 'Are you sure you wish to proceed?' });
+
+      if (!confirmed) {
+        Log.log('Aborted.');
+        return;
+      }
+    }
+
+    let progress: null | Ora = null;
+    let deleteResult: null | Awaited<ReturnType<typeof deleteWorkerDeploymentAliasAsync>> = null;
+
+    try {
+      progress = ora(chalk`Deleting alias {bold ${aliasName ?? 'production'}}`).start();
+      deleteResult = await deleteWorkerDeploymentAliasAsync({
+        graphqlClient,
+        appId: projectId,
+        aliasName,
+      });
+      progress.text = chalk`Deleted alias {bold ${aliasName ?? 'production'}}`;
+    } catch (error: any) {
+      progress?.fail(chalk`Failed to delete alias {bold ${aliasName ?? 'production'}}`);
+      throw error;
+    }
+
+    progress?.succeed(chalk`Deleted alias {bold ${aliasName ?? 'production'}}`);
+
+    if (flags.json) {
+      printJsonOnlyOutput({
+        aliasName: deleteResult.aliasName,
+        id: deleteResult.id,
+      });
+    }
+  }
+
+  private sanitizeFlags(flags: any): DeployAliasDeleteFlags {
+    return {
+      nonInteractive: flags['non-interactive'],
+      json: flags['json'],
+    };
+  }
+}
+
+async function resolveDeploymentAliasAsync(
+  flags: DeployAliasDeleteFlags,
+  graphqlClient: ExpoGraphqlClient,
+  projectId: string,
+  aliasNameFromArg?: string
+): Promise<string> {
+  if (aliasNameFromArg?.trim()) {
+    return aliasNameFromArg.trim().toLowerCase();
+  }
+
+  if (flags.nonInteractive) {
+    throw new Error('Alias name must be provided in non-interactive mode');
+  }
+
+  const alias = await selectWorkerDeploymentAliasOnAppAsync({
+    graphqlClient,
+    appId: projectId,
+    selectTitle: 'alias to delete',
+  });
+
+  if (!alias) {
+    throw new Error('No aliases found for this project, create aliases with "eas deploy:alias"');
+  }
+
+  return alias.aliasName;
+}

--- a/packages/eas-cli/src/commands/deploy/alias/index.ts
+++ b/packages/eas-cli/src/commands/deploy/alias/index.ts
@@ -1,20 +1,23 @@
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
-import EasCommand from '../../commandUtils/EasCommand';
-import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
-import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import { WorkerDeploymentAliasFragment } from '../../graphql/generated';
-import Log from '../../log';
-import { Ora, ora } from '../../ora';
-import { promptAsync } from '../../prompts';
-import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+import EasCommand from '../../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { EasNonInteractiveAndJsonFlags } from '../../../commandUtils/flags';
+import { WorkerDeploymentAliasFragment } from '../../../graphql/generated';
+import Log from '../../../log';
+import { Ora, ora } from '../../../ora';
+import { promptAsync } from '../../../prompts';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
 import {
   assignWorkerDeploymentAliasAsync,
   assignWorkerDeploymentProductionAsync,
   selectWorkerDeploymentOnAppAsync,
-} from '../../worker/deployment';
-import { formatWorkerDeploymentJson, formatWorkerDeploymentTable } from '../../worker/utils/logs';
+} from '../../../worker/deployment';
+import {
+  formatWorkerDeploymentJson,
+  formatWorkerDeploymentTable,
+} from '../../../worker/utils/logs';
 
 interface DeployAliasFlags {
   nonInteractive: boolean;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4031,6 +4031,7 @@ export type DeploymentsMutation = {
   createSignedDeploymentUrl: DeploymentSignedUrlResult;
   deleteAlias: DeleteAliasResult;
   deleteWorkerDeployment: DeleteWorkerDeploymentResult;
+  deleteWorkerDeploymentByIdentifier: DeleteWorkerDeploymentResult;
 };
 
 
@@ -4055,6 +4056,12 @@ export type DeploymentsMutationDeleteAliasArgs = {
 
 export type DeploymentsMutationDeleteWorkerDeploymentArgs = {
   workerDeploymentId: Scalars['ID']['input'];
+};
+
+
+export type DeploymentsMutationDeleteWorkerDeploymentByIdentifierArgs = {
+  appId: Scalars['ID']['input'];
+  deploymentIdentifier: Scalars['ID']['input'];
 };
 
 export type DiscordUser = {
@@ -10277,6 +10284,14 @@ export type AssignAliasMutationVariables = Exact<{
 
 export type AssignAliasMutation = { __typename?: 'RootMutation', deployments: { __typename?: 'DeploymentsMutation', assignAlias: { __typename?: 'WorkerDeploymentAlias', id: string, aliasName?: any | null, url: string, workerDeployment: { __typename?: 'WorkerDeployment', id: string, url: string, deploymentIdentifier: any, deploymentDomain: string, createdAt: any } } } };
 
+export type DeleteAliasMutationVariables = Exact<{
+  appId: Scalars['ID']['input'];
+  aliasName?: InputMaybe<Scalars['WorkerDeploymentIdentifier']['input']>;
+}>;
+
+
+export type DeleteAliasMutation = { __typename?: 'RootMutation', deployments: { __typename?: 'DeploymentsMutation', deleteAlias: { __typename?: 'DeleteAliasResult', id: string, aliasName?: any | null } } };
+
 export type PaginatedWorkerDeploymentsQueryVariables = Exact<{
   appId: Scalars['String']['input'];
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -10294,3 +10309,14 @@ export type SuggestedDevDomainNameQueryVariables = Exact<{
 
 
 export type SuggestedDevDomainNameQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, suggestedDevDomainName: string } } };
+
+export type PaginatedWorkerDeploymentAliasesQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type PaginatedWorkerDeploymentAliasesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, workerDeploymentAliases: { __typename?: 'WorkerDeploymentAliasesConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ __typename?: 'WorkerDeploymentAliasEdge', cursor: string, node: { __typename?: 'WorkerDeploymentAlias', id: string, aliasName?: any | null, url: string } }> } } } };

--- a/packages/eas-cli/src/worker/deployment.ts
+++ b/packages/eas-cli/src/worker/deployment.ts
@@ -5,7 +5,7 @@ import { DeploymentsMutation } from './mutations';
 import { DeploymentsQuery } from './queries';
 import { EXPO_BASE_DOMAIN } from './utils/logs';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
-import { WorkerDeploymentFragment } from '../graphql/generated';
+import { WorkerDeploymentAliasFragment, WorkerDeploymentFragment } from '../graphql/generated';
 import Log from '../log';
 import { promptAsync } from '../prompts';
 import { memoize } from '../utils/expodash/memoize';
@@ -229,5 +229,44 @@ export async function selectWorkerDeploymentOnAppAsync({
       chalk`${deployment.deploymentIdentifier}{dim  - created at: ${new Date(
         deployment.createdAt
       ).toLocaleString()}}`,
+  });
+}
+
+export async function deleteWorkerDeploymentAliasAsync({
+  graphqlClient,
+  appId,
+  aliasName,
+}: {
+  graphqlClient: ExpoGraphqlClient;
+  appId: string;
+  aliasName: string;
+}): Promise<{ aliasName?: string; id: string }> {
+  return await DeploymentsMutation.deleteAliasAsync(graphqlClient, {
+    appId,
+    aliasName,
+  });
+}
+
+export async function selectWorkerDeploymentAliasOnAppAsync({
+  graphqlClient,
+  appId,
+  selectTitle,
+  pageSize,
+}: {
+  graphqlClient: ExpoGraphqlClient;
+  appId: string;
+  selectTitle?: string;
+  pageSize?: number;
+}): ReturnType<typeof selectPaginatedAsync<WorkerDeploymentAliasFragment>> {
+  return await selectPaginatedAsync({
+    pageSize: pageSize ?? 25,
+    printedType: selectTitle ?? 'worker deployment alias',
+    queryAsync: async queryParams =>
+      await DeploymentsQuery.getAllAliasesPaginatedAsync(graphqlClient, {
+        ...queryParams,
+        appId,
+      }),
+    getTitleAsync: async (alias: WorkerDeploymentAliasFragment) =>
+      chalk`${alias.aliasName ?? 'production'}{dim  - ${alias.url}}`,
   });
 }

--- a/packages/eas-cli/src/worker/mutations.ts
+++ b/packages/eas-cli/src/worker/mutations.ts
@@ -13,6 +13,7 @@ import {
   AssignDevDomainNameMutationVariables,
   CreateDeploymentUrlMutation,
   CreateDeploymentUrlMutationVariables,
+  DeleteAliasResult,
 } from '../graphql/generated';
 
 export const DeploymentsMutation = {
@@ -112,5 +113,30 @@ export const DeploymentsMutation = {
     );
 
     return data.deployments.assignAlias;
+  },
+
+  async deleteAliasAsync(
+    graphqlClient: ExpoGraphqlClient,
+    deleteAliasVariables: { appId: string; aliasName: string }
+  ): Promise<DeleteAliasResult> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation(
+          gql`
+            mutation DeleteAlias($appId: ID!, $aliasName: WorkerDeploymentIdentifier) {
+              deployments {
+                deleteAlias(appId: $appId, aliasName: $aliasName) {
+                  id
+                  aliasName
+                }
+              }
+            }
+          `,
+          deleteAliasVariables
+        )
+        .toPromise()
+    );
+
+    return data.deployments.deleteAlias;
   },
 };


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Part of ENG-16625
Related to https://github.com/expo/eas-cli/pull/3106

Deployments cannot be deleted if they are assigned to an alias, so in order to fully support automating deleting deployments, we also need to support deleting aliases.

# How

- `eas deploy:alias:delete` will show a paginated list of aliases (& can choose one to delete)
- `eas deploy:alias:delete name` will delete alias `name`

# Test Plan

### `eas deploy:alias:delete`

<img width="724" height="242" alt="Screenshot 2025-07-18 at 12 29 53" src="https://github.com/user-attachments/assets/b0840af3-6a30-450d-a7ba-3ff43e54c4bc" />

<img width="813" height="256" alt="Screenshot 2025-07-18 at 12 30 12" src="https://github.com/user-attachments/assets/c68ec6f5-8de0-49ab-bba4-f039c62c28a3" />


### `eas deploy:alias:delete test`
<img width="723" height="251" alt="Screenshot 2025-07-18 at 12 31 37" src="https://github.com/user-attachments/assets/849fd69d-667a-4832-8585-6f13def55a5a" />

