### PR TITLE
[TINY] SSO Login: print browser url

### DIFF
--- a/packages/eas-cli/src/user/expoSsoLauncher.ts
+++ b/packages/eas-cli/src/user/expoSsoLauncher.ts
@@ -96,6 +96,7 @@ export async function getSessionUsingBrowserAuthFlowAsync({
         );
         const port = address.port;
         const authorizeUrl = buildExpoSsoLoginUrl(port);
+        Log.log(`If the browser won't open, visit this link manually: ${authorizeUrl}`);
         void openBrowserAsync(authorizeUrl);
       });
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why
I'm working in a weird setup where the browser won't launch from cli. This required me to visit the url manually from my browser. To get the url, I had to add a `console.log` to the cli's code directly. Figured this change will make it easier for similar users to login, without exposing sensitive data

# How

Added small `log` call

# Test Plan
Tested manually on the compiled code, not the best