### PR TITLE
New workflow to trigger releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: 'eas-cli@${{ env.EAS_CLI_VERSION }}'
+          release_name: ${{ github.ref }}
           draft: true
   build-linux:
     name: Build for Linux
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 20
+          node-version: 22
       - run: yarn install --frozen-lockfile --check-files
       - run: yarn build
       - name: Ensure GraphQL schema and generated code is up-to-date
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 20
+          node-version: 22
       - run: brew install python-setuptools
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 20
+          node-version: 22
       - run: yarn install --frozen-lockfile --check-files
       - run: sudo apt-get install nsis
       - run: yarn build
@@ -158,7 +158,7 @@ jobs:
         with:
           registry-url: 'https://registry.npmjs.org/'
           scope: 'expo'
-          node-version: 20
+          node-version: 22
       - name: Install dependencies
         run: yarn install --frozen-lockfile --check-files
       - name: Build
@@ -191,7 +191,7 @@ jobs:
           token: ${{ secrets.EXPO_BOT_PAT }}
       - uses: actions/setup-node@v2
         with:
-          node-version: 20
+          node-version: 22
       - name: Install dependencies
         working-directory: ./scripts
         run: yarn install --frozen-lockfile --check-files
@@ -211,7 +211,7 @@ jobs:
           git config --global user.email "support+ci@expo.io"
           git config --global user.name "Expo CI"
           git add CHANGELOG.md
-          git commit -m "update CHANGELOG.md"
+          git commit --allow-empty -m "update CHANGELOG.md"
           git push
       - name: Prepare changelog for Slack
         run: |

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -1,0 +1,29 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
+        description: 'Version number for the release'
+
+name: Manually trigger a release
+
+jobs:
+  release:
+    name: Trigger a release
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 22
+      - run: |
+          git fetch
+          git checkout main
+          git config --global user.email "support+ci@expo.io"
+          git config --global user.name "Expo CI"
+          yarn install --frozen-lockfile --check-files
+          yarn build
+          yarn release ${{ github.event.inputs.version }}

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -3,7 +3,7 @@ on:
     inputs:
       version:
         type: string
-        required: true
+        required: false
         description: 'Version number for the release'
 
 name: Manually trigger a release
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      INPUT_VERSION: ${{ github.event.inputs.version }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -26,4 +27,10 @@ jobs:
           git config --global user.name "Expo CI"
           yarn install --frozen-lockfile --check-files
           yarn build
-          yarn release ${{ github.event.inputs.version }}
+          if [[ "$INPUT_VERSION" == "" ]]; then
+            echo "Releasing with default version"
+            yarn release
+          else
+            echo "Releasing with version $INPUT_VERSION"
+            yarn release $INPUT_VERSION
+          fi

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -16,12 +16,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       INPUT_VERSION: ${{ github.event.inputs.version }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
       - run: |
-          git fetch
+          git fetch --depth=1 origin main
           git checkout main
           git config --global user.email "support+ci@expo.io"
           git config --global user.name "Expo CI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Introduce new release process and workflow. ([#3119](https://github.com/expo/eas-cli/pull/3119) by [@douglowder](https://github.com/douglowder))
 - SSO Login: print browser url ([#3113](https://github.com/expo/eas-cli/pull/3113) by [@BackSlasher](https://github.com/BackSlasher))
 
 ## [16.17.2](https://github.com/expo/eas-cli/releases/tag/v16.17.2) - 2025-07-23

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing EAS CLI
 
-1. Invoke the GitHub workflow "Manually trigger a release" (`trigger-release.yml`). The next version is chosen automatically based on the changelog entries. If you want to use different version, pass the version string as an input to the workflow.
+1. Invoke the GitHub workflow ["Manually trigger a release"](https://github.com/expo/eas-cli/actions/workflows/trigger-release.yml). The next version is chosen automatically based on the changelog entries. If you want to use different version, pass the version string as an input to the workflow, in semver format, e.g. "1.2.3"
 2. That's it! GitHub Actions is going to take care of the rest. Watch the #eas-cli Slack channel for a successful release notification.
 
 ## Choosing the next version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing EAS CLI
 
-1. Run `yarn release` in the repository root folder. The next version is chosen automatically based on the changelog entries. If you want to use different version, pass the version string as a positional argument to the command, e.g. `yarn release 1.2.3`.
+1. Invoke the GitHub workflow "Manually trigger a release" (`trigger-release.yml`). The next version is chosen automatically based on the changelog entries. If you want to use different version, pass the version string as an input to the workflow.
 2. That's it! GitHub Actions is going to take care of the rest. Watch the #eas-cli Slack channel for a successful release notification.
 
 ## Choosing the next version

--- a/scripts/src/release.sh
+++ b/scripts/src/release.sh
@@ -2,6 +2,14 @@
 
 set -eo pipefail
 
+GITHUB_USER=`git config get --global user.name`
+GITHUB_EMAIL=`git config get --global user.email`
+
+if [[ "$GITHUB_USER" != "Expo CI" || "$GITHUB_EMAIL" != "support+ci@expo.io" ]]; then
+  echo "This script may only be executed by the Expo CI bot in a GitHub workflow."
+  exit 1
+fi
+
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 ROOT_DIR="$( cd "$SCRIPTS_DIR"/.. && pwd )"
 


### PR DESCRIPTION
# Why

The current release script requires that the user executing the script have permission to push changes to main without any PR requirement or checks.

# How

To allow us to add PR requirements and checks, I have added a manual GitHub workflow so that the existing script is executed by the expo-bot user, which is exempted from PR requirements.

I have also made a few adjustments to the `release.yml` workflow (remove incorrect release name, update Node version to 22).

# Test Plan

- CI should pass
- Try a release after this PR is merged