### PR TITLE
[eas-cli] Only make EXPO_PUBLIC_ env vars plain text

### DIFF
--- a/packages/eas-cli/src/commands/env/push.ts
+++ b/packages/eas-cli/src/commands/env/push.ts
@@ -246,9 +246,9 @@ export default class EnvPush extends EasCommand {
         name,
         value,
         environments,
-        visibility: name.startsWith('EXPO_SENSITIVE')
-          ? EnvironmentVariableVisibility.Sensitive
-          : EnvironmentVariableVisibility.Public,
+        visibility: name.startsWith('EXPO_PUBLIC_')
+          ? EnvironmentVariableVisibility.Public
+          : EnvironmentVariableVisibility.Sensitive,
       };
     }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Currently, when you `eas env:push`, all env vars will be plain text unless prefixed with `EXPO_SENSITIVE`. This is unexpected, as we don't have any documentation or references to any kind for `EXPO_SENSITIVE` being used for sensitive env vars. Instead the expected and widely documented behaviour is of `EXPO_PUBLIC_` env vars being inlined in frontend code.

Therefore it makes sense to flip this logic so only `EXPO_PUBLIC_` env vars are made plain text, and the rest sensitive.

# How

When uploading bulk env vars, make `EXPO_PUBLIC_` values plain text, and the rest sensitive.

# Test Plan

Uploaded the following file via `easd env:push`

```
# .env.local
EXPO_PUBLIC_SOMETHING=should-be-plain-text
API_KEY=should-be-sensitive
```

The visibility is not as expected:

<img width="741" height="353" alt="Screenshot 2025-07-30 at 10 29 55" src="https://github.com/user-attachments/assets/146d45b5-2c0a-4f91-b1af-f9f4e921421d" />
