### PR TITLE
Adjust release workflow so Lerna detects version changes

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -23,11 +23,16 @@ jobs:
       INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
       - run: |
-          git fetch origin main
+          # Lerna will not detect changes correctly without having all tags
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          # Checkout the main branch
           git checkout main
           git config --global user.email "support+ci@expo.io"
           git config --global user.name "Expo CI"


### PR DESCRIPTION
# Why

The existing release trigger workflow does not obtain the GItHub history and tags, so that Lerna cannot correctly determine which package versions to bump.

# How

Set `fetch-depth: 0` in the checkout action, and do an explicit fetch of all tags.

# Test Plan

- After merge, a dry run of the release trigger should correctly bump only changed packages.