### PR TITLE
Use correct token in release trigger workflow

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -18,7 +18,7 @@ jobs:
     name: Trigger a release
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.EXPO_BOT_PAT }}
       INPUT_VERSION: ${{ github.event.inputs.version }}
       INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
     steps:
@@ -26,6 +26,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.EXPO_BOT_PAT }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
# Why

Release trigger workflow was working correctly otherwise, but was not using the Git token for the Expo bot, so could not push to main.

# How

Modify workflow to use the correct token.

# Test Plan

Just successfully triggered a release, showing that the fix is working.