### PR TITLE
[eas-cli] fix broken docs links

### DIFF
--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -86,7 +86,7 @@ export default class MetadataPull extends EasCommand {
 - Update the ${chalk.bold(relativePath)} file to prepare the app information.
 - Run ${chalk.bold('eas submit')} or manually upload a new app version to the app stores.
 - Once the app is uploaded, run ${chalk.bold('eas metadata:push')} to sync the store config.
-- ${learnMore('https://docs.expo.dev/eas-metadata/introduction/')}`);
+- ${learnMore('https://docs.expo.dev/eas/metadata/')}`);
     } catch (error: any) {
       handleMetadataError(error);
     }

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -227,7 +227,7 @@ async function generateDistributionCertificateAsync(
           `✅  Distribution Certificates can be revoked with no side effects for App Store builds.`
         )
       );
-      Log.log(learnMore('https://docs.expo.dev/distribution/app-signing/#summary'));
+      Log.log(learnMore('https://docs.expo.dev/app-signing/app-credentials/#summary'));
       Log.newLine();
 
       const { distCertsToRevoke } = await promptAsync({

--- a/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
@@ -76,7 +76,7 @@ async function generatePushKeyAsync(ctx: CredentialsContext): Promise<PushKey> {
       }
 
       Log.log(chalk.grey(`⚠️  Revoking a Push Key will affect other apps that rely on it`));
-      Log.log(learnMore('https://docs.expo.dev/distribution/app-signing/#push-notification-keys'));
+      Log.log(learnMore('https://docs.expo.dev/app-signing/app-credentials/#push-notification-keys'));
       Log.log();
 
       const { pushKeysToRevoke } = await promptAsync({

--- a/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/PushKeyUtils.ts
@@ -76,7 +76,9 @@ async function generatePushKeyAsync(ctx: CredentialsContext): Promise<PushKey> {
       }
 
       Log.log(chalk.grey(`⚠️  Revoking a Push Key will affect other apps that rely on it`));
-      Log.log(learnMore('https://docs.expo.dev/app-signing/app-credentials/#push-notification-keys'));
+      Log.log(
+        learnMore('https://docs.expo.dev/app-signing/app-credentials/#push-notification-keys')
+      );
       Log.log();
 
       const { pushKeysToRevoke } = await promptAsync({


### PR DESCRIPTION
# Why

Some doc links in the eas-cli output are missing. When user clicks those links they show 404 pages instead of useful instructions.

# How

 Replace broken links with correct ones.

# Test Plan

Visit links to verify.