### PR TITLE
chore: include available profiles in 'Missing build profile' error

### DIFF
--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -611,7 +611,7 @@ test('valid eas.json with missing profile', async () => {
   const accessor = EasJsonAccessor.fromProjectPath('/project');
   const promise = EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'debug');
   await expect(promise).rejects.toThrowError(
-    'Missing build profile in eas.json: "debug". Available profiles: "[production]"'
+    'Missing build profile in eas.json: "debug". Available profiles: ["production"]'
   );
 });
 
@@ -636,7 +636,7 @@ test('empty json', async () => {
   const accessor = EasJsonAccessor.fromProjectPath('/project');
   const promise = EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'production');
   await expect(promise).rejects.toThrowError(
-    'Missing build profile in eas.json: "production". Available profiles: "[]"'
+    'Missing build profile in eas.json: "production". Available profiles: []'
   );
 });
 

--- a/packages/eas-json/src/__tests__/buildProfiles-test.ts
+++ b/packages/eas-json/src/__tests__/buildProfiles-test.ts
@@ -610,7 +610,9 @@ test('valid eas.json with missing profile', async () => {
 
   const accessor = EasJsonAccessor.fromProjectPath('/project');
   const promise = EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'debug');
-  await expect(promise).rejects.toThrowError('Missing build profile in eas.json: debug');
+  await expect(promise).rejects.toThrowError(
+    'Missing build profile in eas.json: "debug". Available profiles: "[production]"'
+  );
 });
 
 test('invalid eas.json when using wrong buildType', async () => {
@@ -633,7 +635,9 @@ test('empty json', async () => {
 
   const accessor = EasJsonAccessor.fromProjectPath('/project');
   const promise = EasJsonUtils.getBuildProfileAsync(accessor, Platform.ANDROID, 'production');
-  await expect(promise).rejects.toThrowError('Missing build profile in eas.json: production');
+  await expect(promise).rejects.toThrowError(
+    'Missing build profile in eas.json: "production". Available profiles: "[]"'
+  );
 });
 
 test('invalid semver value', async () => {

--- a/packages/eas-json/src/build/resolver.ts
+++ b/packages/eas-json/src/build/resolver.ts
@@ -46,10 +46,14 @@ function resolveProfile({
   const profile = easJson.build?.[profileName];
   if (!profile) {
     if (depth === 0) {
-      throw new MissingProfileError(`Missing build profile in eas.json: ${profileName}`);
+      throw new MissingProfileError(
+        `Missing build profile in eas.json: "${profileName}". Available profiles: "[${Object.keys(
+          easJson.build ?? {}
+        ).join(', ')}]"`
+      );
     } else {
       throw new MissingParentProfileError(
-        `Extending non-existent build profile in eas.json: ${profileName}`
+        `Extending non-existent build profile in eas.json: "${profileName}"`
       );
     }
   }

--- a/packages/eas-json/src/build/resolver.ts
+++ b/packages/eas-json/src/build/resolver.ts
@@ -47,9 +47,11 @@ function resolveProfile({
   if (!profile) {
     if (depth === 0) {
       throw new MissingProfileError(
-        `Missing build profile in eas.json: "${profileName}". Available profiles: "[${Object.keys(
+        `Missing build profile in eas.json: "${profileName}". Available profiles: [${Object.keys(
           easJson.build ?? {}
-        ).join(', ')}]"`
+        )
+          .map(profile => `"${profile}"`)
+          .join(', ')}]`
       );
     } else {
       throw new MissingParentProfileError(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7703,7 +7703,7 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
 
-form-data@4.0.4, form-data@^4.0.0, form-data@^4.0.4:
+form-data@^4.0.0, form-data@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==


### PR DESCRIPTION
# Why

When a user tries to build with a non-existent profile, the error message could be a bit better by showing the available profiles.

# How

Updated the `MissingProfileError` message in `packages/eas-json/src/build/resolver.ts` to include a list of available profiles in the error message.

# Test Plan

- added a test case
