### PR TITLE
Exposes channel:delete as command

### DIFF
--- a/packages/eas-cli/src/commands/channel/delete.ts
+++ b/packages/eas-cli/src/commands/channel/delete.ts
@@ -16,7 +16,6 @@ import { toggleConfirmAsync } from '../../prompts';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class ChannelDelete extends EasCommand {
-  static override hidden = true;
   static override description = 'Delete a channel';
 
   static override args = [


### PR DESCRIPTION
# Why

Had a user who wanted to delete some channels, but didn't know about the `delete` command due to it being hidden. This PR exposes it.

# Test Plan

Make sure that when you run `easd channel --help`, you see the `delete` command.

<img width="696" height="309" alt="Screenshot 2025-08-22 at 2 52 27 PM" src="https://github.com/user-attachments/assets/39991c8c-157a-4155-b66f-f069cc1280d0" />
