### PR TITLE
Add native server deployments support for EAS Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Better description for update:rollback. ([#3154](https://github.com/expo/eas-cli/pull/3154) by [@douglowder](https://github.com/douglowder))
-- Support native server deployments in EAS Update
+- Support native server deployments in EAS Update ([#3155](https://github.com/expo/eas-cli/pull/3155) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Better description for update:rollback. ([#3154](https://github.com/expo/eas-cli/pull/3154) by [@douglowder](https://github.com/douglowder))
+- Support native server deployments in EAS Update
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eas-cli",
   "description": "EAS command line tool",
-  "version": "16.18.0",
+  "version": "99.0.0",
   "author": "Expo <support@expo.dev>",
   "bin": {
     "eas": "./bin/run"

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eas-cli",
   "description": "EAS command line tool",
-  "version": "99.0.0",
+  "version": "16.18.0",
   "author": "Expo <support@expo.dev>",
   "bin": {
     "eas": "./bin/run"

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -778,7 +778,7 @@ async function readDeployedServerUrlAsync(exp: ExpoConfig, inputDir: string): Pr
     exp.extra ??= {};
     exp.extra.router ??= {};
     exp.extra.router.generatedOrigin = serverUrl;
-    Log.log(`Set origin to ${serverUrl}`);
+    Log.withInfo(`Set origin to ${serverUrl}`);
   } catch (error: any) {
     if (error.code === 'ENOENT') {
       Log.debug('No auto-deployed server URL file found.');

--- a/packages/eas-cli/src/project/publish.ts
+++ b/packages/eas-cli/src/project/publish.ts
@@ -42,6 +42,7 @@ import {
   truncateString as truncateUpdateMessage,
 } from '../update/utils';
 import { PresignedPost, uploadWithPresignedPostWithRetryAsync } from '../uploads';
+import { easCliBin } from '../utils/easCli';
 import {
   expoCommandAsync,
   shouldUseVersionedExpoCLI,
@@ -223,6 +224,11 @@ export async function buildBundlesAsync({
     throw new Error('Could not locate package.json');
   }
 
+  const extendedEnv = {
+    ...extraEnv,
+    __EAS_BIN: easCliBin,
+  };
+
   // Legacy global Expo CLI
   if (!shouldUseVersionedExpoCLI(projectDir, exp)) {
     await expoCommandAsync(
@@ -239,7 +245,7 @@ export async function buildBundlesAsync({
         ...(clearCache ? ['--clear'] : []),
       ],
       {
-        extraEnv,
+        extraEnv: extendedEnv,
       }
     );
     return;
@@ -265,7 +271,7 @@ export async function buildBundlesAsync({
         ...(clearCache ? ['--clear'] : []),
       ],
       {
-        extraEnv,
+        extraEnv: extendedEnv,
       }
     );
     return;
@@ -293,7 +299,7 @@ export async function buildBundlesAsync({
       ...(clearCache ? ['--clear'] : []),
     ],
     {
-      extraEnv,
+      extraEnv: extendedEnv,
     }
   );
 }

--- a/packages/eas-cli/src/utils/easCli.ts
+++ b/packages/eas-cli/src/utils/easCli.ts
@@ -1,3 +1,6 @@
+import { argv } from 'node:process';
+
 const packageJSON = require('../../package.json');
 
 export const easCliVersion: string = packageJSON.version;
+export const easCliBin: string = argv[1];

--- a/packages/eas-cli/src/utils/temporaryPath.ts
+++ b/packages/eas-cli/src/utils/temporaryPath.ts
@@ -1,0 +1,13 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export function getTemporaryPath(): string {
+  return path.join(os.tmpdir(), Math.random().toString(36).substring(2));
+}
+
+export async function safelyDeletePathAsync(value: string): Promise<void> {
+  try {
+    await fs.rm(value, { recursive: true, force: true });
+  } catch {}
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

EAS Currently supports native deployments only for EAS Builds.

# How

This PR relies on Expo CLI changes which deploys API routes for the update during `export`, same as `export:embed` deploys them for native builds.

- https://github.com/expo/expo/pull/39218

`eas update` sets `__EXPO_GENERATED_CONFIG_PATH` which `expo export` writes the generated config into. The deployed URL in this case. This TMP file is created to avoid breaking computed fingerprint. This ensures the new update with will be compatible with the native build or prev update.

This PR also passes it's binary using envs to Expo CLI to ensure the executed deploy command uses the same EAS CLI as the update.

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

```bash
# .env
EXPO_UNSTABLE_DEPLOY_SERVER=true
```

```bash
eas update
```

Example output

```
➜ easd update --channel production --message "test27"
[expo-cli] env: load .env
[expo-cli] env: export EXPO_UNSTABLE_DEPLOY_SERVER
[expo-cli] React Compiler enabled
[expo-cli] Starting Metro Bundler
[expo-cli] λ Bundled 750ms node_modules/expo-router/build/static/getServerManifest.js (999 modules)
[expo-cli] λ Bundled 5ms app/hello+api.ts (1 module)
[expo-cli] › Files (1):
[expo-cli] _expo/routes.json (247 B)
[expo-cli]
[expo-cli] › API routes (1):
[expo-cli] /hello (3.65 kB) (source map (5.46 kB))
[expo-cli]
[expo-cli] Deploying server to link with client
[expo-cli] EAS Hosting is still in preview and subject to changes.
[expo-cli] > Project export: server
[expo-cli] - Preparing project
[expo-cli] - Creating deployment
[expo-cli] ✔ Created deployment
[expo-cli] Server dashboard: https://expo.dev/projects/xxxxxxxx
[expo-cli] Server deployed to: https://expo-vsupdates--xxxxxxxx.expo.app
[expo-cli] iOS node_modules/expo-router/entry.js ░░░░░░░░░░░░░░░░  0.0% (0/1)
[expo-cli] Android node_modules/expo-router/entry.js ░░░░░░░░░░░░░░░░  0.0% (0/1)
[expo-cli] iOS node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░ 99.9% (1281/1281)
[expo-cli] Android node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░ 99.9% (1294/1294)
[expo-cli] Android Bundled 5038ms node_modules/expo-router/entry.js (1294 modules)
[expo-cli] iOS node_modules/expo-router/entry.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░ 99.9% (1281/1281)
[expo-cli] iOS Bundled 7793ms node_modules/expo-router/entry.js (1281 modules)
[expo-cli] Creating asset map
[expo-cli]
[expo-cli] › Assets (36):
[expo-cli] node_modules/expo-router/assets/unmatched.png (4.75 kB)
[expo-cli]
[expo-cli] › android bundles (2):
[expo-cli] _expo/static/js/android/entry-2f1724c2101da188ea611fe10295ff10.hbc (2.21 MB)
[expo-cli] _expo/static/js/android/entry-2f1724c2101da188ea611fe10295ff10.hbc.map (7.36 MB)
[expo-cli]
[expo-cli] › ios bundles (2):
[expo-cli] _expo/static/js/ios/entry-c198586c91d2746e4392264528b56a8c.hbc (2.15 MB)
[expo-cli] _expo/static/js/ios/entry-c198586c91d2746e4392264528b56a8c.hbc.map (7.32 MB)
[expo-cli]
[expo-cli] › Files (4):
[expo-cli] _expo/routes.json (247 B)
[expo-cli] assetmap.json (12.4 kB)
[expo-cli] metadata.json (4.08 kB)
[expo-cli] server-deployment.json (59 B)
[expo-cli]
[expo-cli] › API routes (1):
[expo-cli] /hello (3.65 kB) (source map (5.46 kB))
[expo-cli]
[expo-cli] Exported: dist
✔ Exported bundle(s)
ℹ Set origin to https://expo-vsupdates--xxxxxxxx.expo.app
✔ Uploaded assetmap.json
✔ Uploaded 2 app bundles
✔ Uploading assets skipped - no new assets found
ℹ 31 iOS assets, 32 Android assets (maximum: 2000 total per update). Learn more about asset limits
✔ Computed project fingerprints
✔ Published!

Branch             production
Runtime version    1.0.0
Platform           android, ios
Update group ID    xxxxxxxx
Android update ID  xxxxxxxx
iOS update ID      v
Message            test27
Commit             xxxxxxxx
EAS Dashboard      https://expo.dev/xxxxxxxx
```