### PR TITLE
Sync GraphQL schema and generated code with server schema

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -2007,6 +2007,30 @@
             "deprecationReason": null
           },
           {
+            "name": "ssoAllowedAuthProviders",
+            "description": "Allowed SSO providers for this account",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "AuthProviderIdentifier",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ssoConfiguration",
             "description": "SSO configuration for this account",
             "args": [],
@@ -4162,6 +4186,55 @@
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "AccountSSOConfigurationData",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AccountSSOConfiguration",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateAccountSSOConfigurationClientSecret",
+            "description": "Update just the client secret of an AccountSSOConfiguration",
+            "args": [
+              {
+                "name": "clientSecret",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
                     "ofType": null
                   }
                 },
@@ -18619,6 +18692,12 @@
         "interfaces": null,
         "enumValues": [
           {
+            "name": "AMAZON_FEDERATE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "GENERIC",
             "description": null,
             "isDeprecated": false,
@@ -20072,8 +20151,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Check logs instead."
           },
           {
             "name": "status",
@@ -21623,6 +21702,18 @@
             "deprecationReason": null
           },
           {
+            "name": "projectMetadataFile",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectMetadataFileInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "reactNativeVersion",
             "description": null,
             "type": {
@@ -21696,18 +21787,6 @@
           },
           {
             "name": "sdkVersion",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "selectedImage",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -41267,6 +41346,49 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProjectMetadataFileInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "bucketKey",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProjectArchiveSourceType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -63216,6 +63338,12 @@
           },
           {
             "name": "SUBMISSION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TESTFLIGHT",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -161,6 +161,8 @@ export type Account = {
   sentryInstallation?: Maybe<SentryInstallation>;
   /** Snacks associated with this account */
   snacks: Array<Snack>;
+  /** Allowed SSO providers for this account */
+  ssoAllowedAuthProviders: Array<AuthProviderIdentifier>;
   /** SSO configuration for this account */
   ssoConfiguration?: Maybe<AccountSsoConfiguration>;
   /** Subscription info visible to members that have VIEWER role */
@@ -696,6 +698,8 @@ export type AccountSsoConfigurationMutation = {
   deleteAccountSSOConfiguration: DeleteAccountSsoConfigurationResult;
   /** Update an AccountSSOConfiguration */
   updateAccountSSOConfiguration: AccountSsoConfiguration;
+  /** Update just the client secret of an AccountSSOConfiguration */
+  updateAccountSSOConfigurationClientSecret: AccountSsoConfiguration;
 };
 
 
@@ -712,6 +716,12 @@ export type AccountSsoConfigurationMutationDeleteAccountSsoConfigurationArgs = {
 
 export type AccountSsoConfigurationMutationUpdateAccountSsoConfigurationArgs = {
   accountSSOConfigurationData: AccountSsoConfigurationData;
+  id: Scalars['ID']['input'];
+};
+
+
+export type AccountSsoConfigurationMutationUpdateAccountSsoConfigurationClientSecretArgs = {
+  clientSecret: Scalars['String']['input'];
   id: Scalars['ID']['input'];
 };
 
@@ -2782,6 +2792,7 @@ export enum AuthProtocolType {
 }
 
 export enum AuthProviderIdentifier {
+  AmazonFederate = 'AMAZON_FEDERATE',
   Generic = 'GENERIC',
   GoogleWs = 'GOOGLE_WS',
   MsEntraId = 'MS_ENTRA_ID',
@@ -2947,6 +2958,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   /** @deprecated Use 'runtime' field instead. */
   runtimeVersion?: Maybe<Scalars['String']['output']>;
   sdkVersion?: Maybe<Scalars['String']['output']>;
+  /** @deprecated Check logs instead. */
   selectedImage?: Maybe<Scalars['String']['output']>;
   status: BuildStatus;
   submissions: Array<Submission>;
@@ -3143,6 +3155,7 @@ export type BuildMetadataInput = {
   iosEnterpriseProvisioning?: InputMaybe<BuildIosEnterpriseProvisioning>;
   isGitWorkingTreeDirty?: InputMaybe<Scalars['Boolean']['input']>;
   message?: InputMaybe<Scalars['String']['input']>;
+  projectMetadataFile?: InputMaybe<ProjectMetadataFileInput>;
   reactNativeVersion?: InputMaybe<Scalars['String']['input']>;
   releaseChannel?: InputMaybe<Scalars['String']['input']>;
   requiredPackageManager?: InputMaybe<Scalars['String']['input']>;
@@ -3150,7 +3163,6 @@ export type BuildMetadataInput = {
   runWithNoWaitFlag?: InputMaybe<Scalars['Boolean']['input']>;
   runtimeVersion?: InputMaybe<Scalars['String']['input']>;
   sdkVersion?: InputMaybe<Scalars['String']['input']>;
-  selectedImage?: InputMaybe<Scalars['String']['input']>;
   simulator?: InputMaybe<Scalars['Boolean']['input']>;
   trackingContext?: InputMaybe<Scalars['JSONObject']['input']>;
   username?: InputMaybe<Scalars['String']['input']>;
@@ -5918,6 +5930,11 @@ export enum ProjectArchiveSourceType {
   None = 'NONE',
   Url = 'URL'
 }
+
+export type ProjectMetadataFileInput = {
+  bucketKey: Scalars['String']['input'];
+  type: ProjectArchiveSourceType;
+};
 
 export type ProjectPublicData = {
   __typename?: 'ProjectPublicData';
@@ -8871,6 +8888,7 @@ export enum WorkflowJobType {
   RequireApproval = 'REQUIRE_APPROVAL',
   Slack = 'SLACK',
   Submission = 'SUBMISSION',
+  Testflight = 'TESTFLIGHT',
   Update = 'UPDATE'
 }
 


### PR DESCRIPTION
# Why

Sync up the schema to reflect recent additions to the server GraphQL schema

# How

`yarn --cwd packages/eas-cli verify-graphql-code`, then inspect changes in schema and generated code.

# Test Plan

CI should pass