### PR TITLE
Improvements to workflow:validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Improvements to workflow:validate. ([#3165](https://github.com/expo/eas-cli/pull/3165) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -8133,18 +8133,6 @@
             "deprecationReason": null
           },
           {
-            "name": "archiveUrl",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "changelog",
             "description": null,
             "type": {
@@ -24362,18 +24350,6 @@
             "deprecationReason": null
           },
           {
-            "name": "archiveUrl",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "config",
             "description": null,
             "type": {
@@ -25121,18 +25097,6 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "SubmissionArchiveSourceInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "archiveUrl",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -37047,18 +37011,6 @@
           },
           {
             "name": "appleIdUsername",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "archiveUrl",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/packages/eas-cli/src/api.ts
+++ b/packages/eas-cli/src/api.ts
@@ -108,3 +108,7 @@ export function getEASUpdateURL(projectId: string, manifestHostOverride: string 
     return new URL(projectId, `https://u.expo.dev`).href;
   }
 }
+
+export function getExpoApiWorkflowSchemaURL(): string {
+  return getExpoApiBaseUrl() + '/v2/workflows/schema';
+}

--- a/packages/eas-cli/src/commandUtils/workflow/validation.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/validation.ts
@@ -1,0 +1,196 @@
+import { EasJsonAccessor, EasJsonUtils } from '@expo/eas-json';
+import { InvalidEasJsonError, MissingEasJsonError } from '@expo/eas-json/build/errors';
+import { CombinedError } from '@urql/core';
+import * as YAML from 'yaml';
+
+import { AccountFragment } from '../../graphql/generated';
+import { WorkflowRevisionMutation } from '../../graphql/mutations/WorkflowRevisionMutation';
+import Log from '../../log';
+import { createValidator, getReadableErrors } from '../../metadata/utils/ajv';
+import { WorkflowFile } from '../../utils/workflowFile';
+import { ExpoGraphqlClient } from '../context/contextUtils/createGraphqlClient';
+
+export async function validateWorkflowFileAsync(
+  workflowFileContents: { yamlConfig: string; filePath: string },
+  projectDir: string,
+  graphqlClient: ExpoGraphqlClient,
+  projectId: string
+): Promise<void> {
+  const parsedYaml = parsedYamlFromWorkflowContents(workflowFileContents);
+  Log.debug(`Parsed workflow: ${JSON.stringify(parsedYaml, null, 2)}`);
+
+  // Check if the parsed result is empty or null
+  Log.debug(`Validating workflow is not empty...`);
+  validateWorkflowIsNotEmpty(parsedYaml);
+
+  const workflowSchema = await fetchWorkflowSchemaAsync();
+
+  // Check that all job types are valid
+  Log.debug(`Validating workflow job types...`);
+  validateWorkflowJobTypes(parsedYaml, workflowSchema);
+
+  // Check for build jobs that do not match any EAS build profiles
+  Log.debug(`Validating workflow build jobs...`);
+  await validateWorkflowBuildJobsAsync(parsedYaml, projectDir);
+
+  // Check that result passes validation against workflow schema
+  Log.debug(`Validating workflow structure...`);
+  validateWorkflowStructure(parsedYaml, workflowSchema);
+
+  // Check for other errors using the server-side validation
+  Log.debug(`Validating workflow on server...`);
+  await validateWorkflowOnServerAsync(graphqlClient, projectId, workflowFileContents);
+}
+
+export function logWorkflowValidationErrors(
+  error: unknown,
+  account: AccountFragment | undefined,
+  projectName: string | undefined
+): void {
+  if (error instanceof MissingEasJsonError) {
+    throw new Error(
+      'Workflows require a valid eas.json. Please run "eas build:configure" to create it.'
+    );
+  } else if (error instanceof InvalidEasJsonError) {
+    throw new Error(
+      'Workflows require a valid eas.json. Please fix the errors in your eas.json and try again.\n\n' +
+        error.message
+    );
+  } else if (error instanceof YAML.YAMLParseError) {
+    Log.error(`YAML syntax error: ${error.message}`);
+  } else if (error instanceof CombinedError) {
+    WorkflowFile.maybePrintWorkflowFileValidationErrors({
+      error,
+      accountName: account?.name ?? '',
+      projectName: projectName ?? '',
+    });
+
+    throw error;
+  } else if (error instanceof Error) {
+    Log.error(`Error: ${error.message}`);
+  } else {
+    Log.error(`Unexpected error: ${String(error)}`);
+  }
+}
+
+function validateWorkflowIsNotEmpty(parsedYaml: any): void {
+  if (
+    parsedYaml === null ||
+    parsedYaml === undefined ||
+    (typeof parsedYaml === 'object' && Object.keys(parsedYaml).length === 0)
+  ) {
+    throw new Error('YAML file is empty or contains only comments.');
+  }
+}
+
+async function validateWorkflowOnServerAsync(
+  graphqlClient: ExpoGraphqlClient,
+  projectId: string,
+  workflowFileContents: { yamlConfig: string }
+): Promise<void> {
+  await WorkflowRevisionMutation.validateWorkflowYamlConfigAsync(graphqlClient, {
+    appId: projectId,
+    yamlConfig: workflowFileContents.yamlConfig,
+  });
+}
+
+async function validateWorkflowBuildJobsAsync(parsedYaml: any, projectDir: string): Promise<void> {
+  const jobs = jobsFromWorkflow(parsedYaml);
+  const buildJobs = jobs.filter(job => job.value.type === 'build');
+  if (buildJobs.length === 0) {
+    return;
+  }
+  const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
+
+  const buildProfileNames = new Set(
+    easJsonAccessor && (await EasJsonUtils.getBuildProfileNamesAsync(easJsonAccessor))
+  );
+  const invalidBuildJobs = buildJobs.filter(
+    job => !buildProfileNames.has(job.value.params.profile)
+  );
+
+  if (invalidBuildJobs.length > 0) {
+    const invalidBuildProfiles = new Set(invalidBuildJobs.map(job => job.value.params.profile));
+    throw new Error(
+      `The build jobs in this workflow refer to the following build profiles that are not present in your eas.json file: ${[
+        ...invalidBuildProfiles,
+      ].join(', ')}`
+    );
+  }
+}
+
+function validateWorkflowJobTypes(parsedYaml: any, workflowJsonSchema: any): void {
+  const jobs = jobsFromWorkflow(parsedYaml);
+  const jobTypes = jobTypesFromWorkflowSchema(workflowJsonSchema);
+  const invalidJobs = jobs.filter(job => job.value.type && !jobTypes.includes(job.value.type));
+  if (invalidJobs.length > 0) {
+    throw new Error(
+      `The following jobs have invalid types: ${invalidJobs
+        .map(job => job.key)
+        .join(', ')}. Valid types are: ${jobTypes.join(', ')}`
+    );
+  }
+}
+
+function validateWorkflowStructure(parsedYaml: any, workflowJsonSchema: any): void {
+  delete workflowJsonSchema['$schema'];
+
+  const ajv = createValidator();
+  const validate = ajv.compile(workflowJsonSchema);
+  const result = validate(parsedYaml);
+
+  if (!result) {
+    Log.debug(
+      JSON.stringify(
+        {
+          errors: validate.errors,
+        },
+        null,
+        2
+      )
+    );
+    const readableErrors = getReadableErrors(validate.errors ?? []);
+    const processedErrors = new Set<string>();
+    for (const err of readableErrors) {
+      if (err.message) {
+        processedErrors.add(err.message);
+      }
+    }
+    throw new Error([...processedErrors].join('\n'));
+  }
+}
+
+function parsedYamlFromWorkflowContents(workflowFileContents: {
+  yamlConfig: string;
+}): Promise<any> {
+  const parsedYaml = YAML.parse(workflowFileContents.yamlConfig);
+  return parsedYaml;
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+async function fetchWorkflowSchemaAsync(): Promise<any> {
+  const schemaUrl =
+    process.env.EXPO_WORKFLOW_SCHEMA_URL ?? 'https://api.expo.dev/v2/workflows/schema';
+  Log.debug(`Fetching workflow schema from ${schemaUrl}`);
+  const response = await fetch(schemaUrl);
+  if (!response.ok) {
+    throw new Error(`Unable to fetch EAS Workflow schema, received status: ${response.status}`);
+  }
+  const jsonResponse: any = (await response.json()) as any;
+  return jsonResponse.data;
+}
+
+function jobsFromWorkflow(parsedYaml: any): any[] {
+  return Object.entries(parsedYaml?.jobs).flatMap(([key, value]: [string, any]) => {
+    return {
+      key,
+      value,
+    };
+  });
+}
+
+function jobTypesFromWorkflowSchema(workflowJsonSchema: any): string[] {
+  return workflowJsonSchema?.properties?.jobs?.additionalProperties?.anyOf.map(
+    (props: any) => props.properties.type.const
+  );
+}

--- a/packages/eas-cli/src/commands/workflow/run.ts
+++ b/packages/eas-cli/src/commands/workflow/run.ts
@@ -154,8 +154,6 @@ export default class WorkflowRun extends EasCommand {
       if (error instanceof CombinedError) {
         WorkflowFile.maybePrintWorkflowFileValidationErrors({
           error,
-          accountName: account.name,
-          projectName,
         });
 
         throw error;

--- a/packages/eas-cli/src/commands/workflow/validate.ts
+++ b/packages/eas-cli/src/commands/workflow/validate.ts
@@ -1,9 +1,10 @@
-import { CombinedError } from '@urql/core';
-import * as YAML from 'yaml';
-
 import EasCommand from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
-import { WorkflowRevisionMutation } from '../../graphql/mutations/WorkflowRevisionMutation';
+import {
+  logWorkflowValidationErrors,
+  validateWorkflowFileAsync,
+} from '../../commandUtils/workflow/validation';
+import { AccountFragment } from '../../graphql/generated';
 import Log from '../../log';
 import { ora } from '../../ora';
 import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
@@ -27,6 +28,7 @@ export class WorkflowValidate extends EasCommand {
   static override contextDefinition = {
     ...this.ContextOptions.DynamicProjectConfig,
     ...this.ContextOptions.ProjectDir,
+    ...this.ContextOptions.ProjectId,
     ...this.ContextOptions.LoggedIn,
   };
 
@@ -36,67 +38,40 @@ export class WorkflowValidate extends EasCommand {
       flags,
     } = await this.parse(WorkflowValidate);
 
-    const {
-      getDynamicPrivateProjectConfigAsync,
-      loggedIn: { graphqlClient },
-      projectDir,
-    } = await this.getContextAsync(WorkflowValidate, {
-      nonInteractive: flags['non-interactive'],
-      withServerSideEnvironment: null,
-    });
-
-    const {
-      projectId,
-      exp: { slug: projectName },
-    } = await getDynamicPrivateProjectConfigAsync();
-    const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
-
+    let account: AccountFragment | undefined;
+    let projectName: string | undefined;
     const spinner = ora().start('Validating the workflow YAML file…');
-
     try {
+      const {
+        getDynamicPrivateProjectConfigAsync,
+        loggedIn: { graphqlClient },
+        projectDir,
+        projectId,
+      } = await this.getContextAsync(WorkflowValidate, {
+        nonInteractive: flags['non-interactive'],
+        withServerSideEnvironment: null,
+      });
+
+      const {
+        exp: { slug: maybeProjectName },
+      } = await getDynamicPrivateProjectConfigAsync();
+      projectName = maybeProjectName;
+
+      account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
+
       const workflowFileContents = await WorkflowFile.readWorkflowFileContentsAsync({
         projectDir,
         filePath,
       });
       Log.log(`Using workflow file from ${workflowFileContents.filePath}`);
 
-      const parsedYaml = YAML.parse(workflowFileContents.yamlConfig);
-
-      // Check if the parsed result is empty or null
-      if (
-        parsedYaml === null ||
-        parsedYaml === undefined ||
-        (typeof parsedYaml === 'object' && Object.keys(parsedYaml).length === 0)
-      ) {
-        throw new Error('YAML file is empty or contains only comments.');
-      }
-
-      await WorkflowRevisionMutation.validateWorkflowYamlConfigAsync(graphqlClient, {
-        appId: projectId,
-        yamlConfig: workflowFileContents.yamlConfig,
-      });
+      await validateWorkflowFileAsync(workflowFileContents, projectDir, graphqlClient, projectId);
 
       spinner.succeed('Workflow configuration YAML is valid.');
     } catch (error) {
       spinner.fail('Workflow configuration YAML is not valid.');
 
-      if (error instanceof YAML.YAMLParseError) {
-        Log.error(`YAML syntax error: ${error.message}`);
-      } else if (error instanceof CombinedError) {
-        WorkflowFile.maybePrintWorkflowFileValidationErrors({
-          error,
-          accountName: account.name,
-          projectName,
-        });
-
-        throw error;
-      } else if (error instanceof Error) {
-        Log.error(error.message);
-      } else {
-        Log.error(`Unexpected error: ${String(error)}`);
-      }
-
-      throw error;
+      logWorkflowValidationErrors(error, account, projectName);
     }
   }
 }

--- a/packages/eas-cli/src/commands/workflow/validate.ts
+++ b/packages/eas-cli/src/commands/workflow/validate.ts
@@ -4,10 +4,8 @@ import {
   logWorkflowValidationErrors,
   validateWorkflowFileAsync,
 } from '../../commandUtils/workflow/validation';
-import { AccountFragment } from '../../graphql/generated';
 import Log from '../../log';
 import { ora } from '../../ora';
-import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 import { WorkflowFile } from '../../utils/workflowFile';
 
 export class WorkflowValidate extends EasCommand {
@@ -38,12 +36,9 @@ export class WorkflowValidate extends EasCommand {
       flags,
     } = await this.parse(WorkflowValidate);
 
-    let account: AccountFragment | undefined;
-    let projectName: string | undefined;
     const spinner = ora().start('Validating the workflow YAML file…');
     try {
       const {
-        getDynamicPrivateProjectConfigAsync,
         loggedIn: { graphqlClient },
         projectDir,
         projectId,
@@ -51,13 +46,6 @@ export class WorkflowValidate extends EasCommand {
         nonInteractive: flags['non-interactive'],
         withServerSideEnvironment: null,
       });
-
-      const {
-        exp: { slug: maybeProjectName },
-      } = await getDynamicPrivateProjectConfigAsync();
-      projectName = maybeProjectName;
-
-      account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
 
       const workflowFileContents = await WorkflowFile.readWorkflowFileContentsAsync({
         projectDir,
@@ -71,7 +59,7 @@ export class WorkflowValidate extends EasCommand {
     } catch (error) {
       spinner.fail('Workflow configuration YAML is not valid.');
 
-      logWorkflowValidationErrors(error, account, projectName);
+      logWorkflowValidationErrors(error);
     }
   }
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1241,7 +1241,6 @@ export type AndroidSubmissionConfig = {
 
 export type AndroidSubmissionConfigInput = {
   applicationIdentifier?: InputMaybe<Scalars['String']['input']>;
-  archiveUrl?: InputMaybe<Scalars['String']['input']>;
   changelog?: InputMaybe<Scalars['String']['input']>;
   changesNotSentForReview?: InputMaybe<Scalars['Boolean']['input']>;
   googleServiceAccountKeyId?: InputMaybe<Scalars['String']['input']>;
@@ -3566,7 +3565,6 @@ export type CreateAndConfigureRepositoryInput = {
 export type CreateAndroidSubmissionInput = {
   appId: Scalars['ID']['input'];
   archiveSource?: InputMaybe<SubmissionArchiveSourceInput>;
-  archiveUrl?: InputMaybe<Scalars['String']['input']>;
   config: AndroidSubmissionConfigInput;
   submittedBuildId?: InputMaybe<Scalars['ID']['input']>;
 };
@@ -3644,7 +3642,6 @@ export type CreateGitHubRepositorySettingsInput = {
 export type CreateIosSubmissionInput = {
   appId: Scalars['ID']['input'];
   archiveSource?: InputMaybe<SubmissionArchiveSourceInput>;
-  archiveUrl?: InputMaybe<Scalars['String']['input']>;
   config: IosSubmissionConfigInput;
   submittedBuildId?: InputMaybe<Scalars['ID']['input']>;
 };
@@ -5324,7 +5321,6 @@ export type IosSubmissionConfig = {
 export type IosSubmissionConfigInput = {
   appleAppSpecificPassword?: InputMaybe<Scalars['String']['input']>;
   appleIdUsername?: InputMaybe<Scalars['String']['input']>;
-  archiveUrl?: InputMaybe<Scalars['String']['input']>;
   ascApiKey?: InputMaybe<AscApiKeyInput>;
   ascApiKeyId?: InputMaybe<Scalars['String']['input']>;
   ascAppIdentifier: Scalars['String']['input'];

--- a/packages/eas-cli/src/log.ts
+++ b/packages/eas-cli/src/log.ts
@@ -38,7 +38,8 @@ export default class Log {
     if (Log.isDebug) {
       Log.consoleLog(...args);
     } else {
-      nodeDebug(args);
+      Log.updateIsLastLineNewLine(args);
+      nodeDebug(...args);
     }
   }
 

--- a/packages/eas-cli/src/utils/workflowFile.ts
+++ b/packages/eas-cli/src/utils/workflowFile.ts
@@ -2,9 +2,8 @@ import { CombinedError } from '@urql/core';
 import fs from 'fs';
 import path from 'path';
 
-import { getProjectGitHubSettingsUrl } from '../build/utils/url';
 import { WorkflowRevisionMutation } from '../graphql/mutations/WorkflowRevisionMutation';
-import Log, { link } from '../log';
+import Log from '../log';
 
 export namespace WorkflowFile {
   export async function readWorkflowFileContentsAsync({
@@ -39,12 +38,8 @@ export namespace WorkflowFile {
 
   export function maybePrintWorkflowFileValidationErrors({
     error,
-    accountName,
-    projectName,
   }: {
     error: CombinedError;
-    accountName: string;
-    projectName: string;
   }): void {
     const validationErrors = error.graphQLErrors.flatMap(e => {
       return WorkflowRevisionMutation.ValidationErrorExtensionZ.safeParse(e.extensions).data ?? [];
@@ -61,18 +56,6 @@ export namespace WorkflowFile {
           Log.error(`- ${field}: ${fieldErrors.join(', ')}`);
         }
       }
-    }
-
-    const githubNotFoundError = error.graphQLErrors.find(
-      e => e.extensions.errorCode === 'GITHUB_NOT_FOUND_ERROR'
-    );
-    if (githubNotFoundError) {
-      Log.error(`GitHub repository not found. It is currently required to run workflows.`);
-      Log.error(
-        `Please check that the repository exists and that you have access to it. ${link(
-          getProjectGitHubSettingsUrl(accountName, projectName)
-        )}`
-      );
     }
   }
 


### PR DESCRIPTION
# Why

Improve the validation of workflow files:

- Add client-side checks for valid syntax, and compatibility with the user's EAS build profiles
- Make validation usable with future improvements to `workflow:create`

# How

- New `validation.ts` in `commandUtils` with the various validation checks separated cleanly into different functions
- `workflow:validate` command refactored to use the new utility and wrap errors
- The new code reads the workflow schema from `<ExpoAPIBaseURL>/v2/workflows/schema`
- For testing purposes only, a local copy of the schema can be used by setting EXPO_TESTING_WORKFLOW_SCHEMA_PATH
- An existing check in `workflowFile.ts` has been modified to remove the requirement for a Github repository, as that is no longer required to run workflows

# Test Plan

- Tested against different workflow templates, and against workflows in a real project.
- Tested against the www server from the main branch running locally, to verify recent server side changes (e.g. https://github.com/expo/universe/pull/21950)