### PR TITLE
[cli] Temporarily remove warnings when no compatible build found, need to refine the message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- Temporarily remove warnings when no compatible build found, need to refine the message. ([#3182](https://github.com/expo/eas-cli/pull/3182) by [@brentvatne](https://github.com/brentvatne))
+
 ## [16.19.2](https://github.com/expo/eas-cli/releases/tag/v16.19.2) - 2025-09-15
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -367,11 +367,13 @@ export default class UpdatePublish extends EasCommand {
       if (uploadedNormalAssetCount === 0) {
         Log.withTick(`Uploading assets skipped - no new assets found`);
       } else {
-        let message = `Uploaded ${uploadedNormalAssetCount} ${uploadedNormalAssetCount === 1 ? 'asset' : 'assets'
-          }`;
+        let message = `Uploaded ${uploadedNormalAssetCount} ${
+          uploadedNormalAssetCount === 1 ? 'asset' : 'assets'
+        }`;
         if (reusedNormalAssetCount > 0) {
-          message += ` (reused ${reusedNormalAssetCount} ${reusedNormalAssetCount === 1 ? 'asset' : 'assets'
-            })`;
+          message += ` (reused ${reusedNormalAssetCount} ${
+            reusedNormalAssetCount === 1 ? 'asset' : 'assets'
+          })`;
         }
         Log.withTick(message);
       }
@@ -426,12 +428,12 @@ export default class UpdatePublish extends EasCommand {
             ...info,
             expoUpdatesRuntimeFingerprintSource: info.expoUpdatesRuntimeFingerprint
               ? (
-                await maybeUploadFingerprintAsync({
-                  hash: info.runtimeVersion,
-                  fingerprint: info.expoUpdatesRuntimeFingerprint,
-                  graphqlClient,
-                })
-              ).fingerprintSource ?? null
+                  await maybeUploadFingerprintAsync({
+                    hash: info.runtimeVersion,
+                    fingerprint: info.expoUpdatesRuntimeFingerprint,
+                    graphqlClient,
+                  })
+                ).fingerprintSource ?? null
               : null,
           };
         })
@@ -450,11 +452,11 @@ export default class UpdatePublish extends EasCommand {
     const runtimeVersionToRolloutInfoGroup =
       rolloutPercentage !== undefined
         ? await getRuntimeToUpdateRolloutInfoGroupMappingAsync(graphqlClient, {
-          appId: projectId,
-          branchName,
-          rolloutPercentage,
-          runtimeToPlatformsAndFingerprintInfoMapping,
-        })
+            appId: projectId,
+            branchName,
+            rolloutPercentage,
+            runtimeToPlatformsAndFingerprintInfoMapping,
+          })
         : undefined;
 
     const gitCommitHash = await vcsClient.getCommitHashAsync();
@@ -476,11 +478,11 @@ export default class UpdatePublish extends EasCommand {
             : null;
           const localRolloutInfoGroup = rolloutInfoGroupForRuntimeVersion
             ? Object.fromEntries(
-              platforms.map(platform => [
-                platform,
-                rolloutInfoGroupForRuntimeVersion[platform as keyof UpdateRolloutInfoGroup],
-              ])
-            )
+                platforms.map(platform => [
+                  platform,
+                  rolloutInfoGroupForRuntimeVersion[platform as keyof UpdateRolloutInfoGroup],
+                ])
+              )
             : null;
           const transformedFingerprintInfoGroup = Object.entries(fingerprintInfoGroup).reduce(
             (prev, [platform, fingerprintInfo]) => {
@@ -550,7 +552,7 @@ export default class UpdatePublish extends EasCommand {
                   manifestBody,
                   nullthrows(
                     nullthrows(updateGroup.updateInfoGroup)[
-                    newUpdate.platform as keyof UpdateInfoGroup
+                      newUpdate.platform as keyof UpdateInfoGroup
                     ]
                   )
                 );
@@ -632,28 +634,28 @@ export default class UpdatePublish extends EasCommand {
           ...(newIosUpdate ? [{ label: 'iOS update ID', value: newIosUpdate.id }] : []),
           ...(newAndroidUpdate?.rolloutControlUpdate
             ? [
-              {
-                label: 'Android Rollout',
-                value: `${newAndroidUpdate.rolloutPercentage}% (Base update ID: ${newAndroidUpdate.rolloutControlUpdate.id})`,
-              },
-            ]
+                {
+                  label: 'Android Rollout',
+                  value: `${newAndroidUpdate.rolloutPercentage}% (Base update ID: ${newAndroidUpdate.rolloutControlUpdate.id})`,
+                },
+              ]
             : []),
           ...(newIosUpdate?.rolloutControlUpdate
             ? [
-              {
-                label: 'iOS Rollout',
-                value: `${newIosUpdate.rolloutPercentage}% (Base update ID: ${newIosUpdate.rolloutControlUpdate.id})`,
-              },
-            ]
+                {
+                  label: 'iOS Rollout',
+                  value: `${newIosUpdate.rolloutPercentage}% (Base update ID: ${newIosUpdate.rolloutControlUpdate.id})`,
+                },
+              ]
             : []),
           { label: 'Message', value: updateMessage ?? '' },
           ...(gitCommitHash
             ? [
-              {
-                label: 'Commit',
-                value: `${gitCommitHash}${isGitWorkingTreeDirty ? '*' : ''}`,
-              },
-            ]
+                {
+                  label: 'Commit',
+                  value: `${gitCommitHash}${isGitWorkingTreeDirty ? '*' : ''}`,
+                },
+              ]
             : []),
           { label: 'EAS Dashboard', value: updateGroupLink },
         ])
@@ -662,10 +664,10 @@ export default class UpdatePublish extends EasCommand {
       if (isUploadedAssetCountAboveWarningThreshold(uploadedAssetCount, assetLimitPerUpdateGroup)) {
         Log.warn(
           `This update group contains ${uploadedAssetCount} assets and is nearing the server cap of ${assetLimitPerUpdateGroup}.\n` +
-          `${learnMore('https://docs.expo.dev/eas-update/optimize-assets/', {
-            learnMoreMessage: 'Consider optimizing your usage of assets',
-            dim: false,
-          })}.`
+            `${learnMore('https://docs.expo.dev/eas-update/optimize-assets/', {
+              learnMoreMessage: 'Consider optimizing your usage of assets',
+              dim: false,
+            })}.`
         );
         Log.addNewLineIfNone();
       }

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -4,7 +4,7 @@ import { Errors, Flags } from '@oclif/core';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
-import { getExpoWebsiteBaseUrl } from '../../api';
+// import { getExpoWebsiteBaseUrl } from '../../api';
 import { ensureBranchExistsAsync } from '../../branch/queries';
 import { transformFingerprintSource } from '../../build/graphql';
 import { ensureRepoIsCleanAsync } from '../../build/utils/repository';
@@ -24,7 +24,7 @@ import {
   UpdateRolloutInfoGroup,
 } from '../../graphql/generated';
 import { PublishMutation } from '../../graphql/mutations/PublishMutation';
-import { AppQuery } from '../../graphql/queries/AppQuery';
+// import { AppQuery } from '../../graphql/queries/AppQuery';
 import Log, { learnMore, link } from '../../log';
 import { ora } from '../../ora';
 import { RequestedPlatform } from '../../platform';
@@ -38,7 +38,7 @@ import {
   buildUnsortedUpdateInfoGroupAsync,
   collectAssetsAsync,
   filterCollectedAssetsByRequestedPlatforms,
-  findCompatibleBuildsAsync,
+  // findCompatibleBuildsAsync,
   generateEasMetadataAsync,
   getBranchNameForCommandAsync,
   getRuntimeToPlatformsAndFingerprintInfoMappingFromRuntimeVersionInfoObjects,
@@ -367,13 +367,11 @@ export default class UpdatePublish extends EasCommand {
       if (uploadedNormalAssetCount === 0) {
         Log.withTick(`Uploading assets skipped - no new assets found`);
       } else {
-        let message = `Uploaded ${uploadedNormalAssetCount} ${
-          uploadedNormalAssetCount === 1 ? 'asset' : 'assets'
-        }`;
+        let message = `Uploaded ${uploadedNormalAssetCount} ${uploadedNormalAssetCount === 1 ? 'asset' : 'assets'
+          }`;
         if (reusedNormalAssetCount > 0) {
-          message += ` (reused ${reusedNormalAssetCount} ${
-            reusedNormalAssetCount === 1 ? 'asset' : 'assets'
-          })`;
+          message += ` (reused ${reusedNormalAssetCount} ${reusedNormalAssetCount === 1 ? 'asset' : 'assets'
+            })`;
         }
         Log.withTick(message);
       }
@@ -428,12 +426,12 @@ export default class UpdatePublish extends EasCommand {
             ...info,
             expoUpdatesRuntimeFingerprintSource: info.expoUpdatesRuntimeFingerprint
               ? (
-                  await maybeUploadFingerprintAsync({
-                    hash: info.runtimeVersion,
-                    fingerprint: info.expoUpdatesRuntimeFingerprint,
-                    graphqlClient,
-                  })
-                ).fingerprintSource ?? null
+                await maybeUploadFingerprintAsync({
+                  hash: info.runtimeVersion,
+                  fingerprint: info.expoUpdatesRuntimeFingerprint,
+                  graphqlClient,
+                })
+              ).fingerprintSource ?? null
               : null,
           };
         })
@@ -452,11 +450,11 @@ export default class UpdatePublish extends EasCommand {
     const runtimeVersionToRolloutInfoGroup =
       rolloutPercentage !== undefined
         ? await getRuntimeToUpdateRolloutInfoGroupMappingAsync(graphqlClient, {
-            appId: projectId,
-            branchName,
-            rolloutPercentage,
-            runtimeToPlatformsAndFingerprintInfoMapping,
-          })
+          appId: projectId,
+          branchName,
+          rolloutPercentage,
+          runtimeToPlatformsAndFingerprintInfoMapping,
+        })
         : undefined;
 
     const gitCommitHash = await vcsClient.getCommitHashAsync();
@@ -478,11 +476,11 @@ export default class UpdatePublish extends EasCommand {
             : null;
           const localRolloutInfoGroup = rolloutInfoGroupForRuntimeVersion
             ? Object.fromEntries(
-                platforms.map(platform => [
-                  platform,
-                  rolloutInfoGroupForRuntimeVersion[platform as keyof UpdateRolloutInfoGroup],
-                ])
-              )
+              platforms.map(platform => [
+                platform,
+                rolloutInfoGroupForRuntimeVersion[platform as keyof UpdateRolloutInfoGroup],
+              ])
+            )
             : null;
           const transformedFingerprintInfoGroup = Object.entries(fingerprintInfoGroup).reduce(
             (prev, [platform, fingerprintInfo]) => {
@@ -552,7 +550,7 @@ export default class UpdatePublish extends EasCommand {
                   manifestBody,
                   nullthrows(
                     nullthrows(updateGroup.updateInfoGroup)[
-                      newUpdate.platform as keyof UpdateInfoGroup
+                    newUpdate.platform as keyof UpdateInfoGroup
                     ]
                   )
                 );
@@ -594,11 +592,11 @@ export default class UpdatePublish extends EasCommand {
 
     Log.addNewLineIfNone();
 
-    const runtimeToCompatibleBuilds = await Promise.all(
-      runtimeToPlatformsAndFingerprintInfoAndFingerprintSourceMapping.map(obj =>
-        findCompatibleBuildsAsync(graphqlClient, projectId, obj)
-      )
-    );
+    // const runtimeToCompatibleBuilds = await Promise.all(
+    //   runtimeToPlatformsAndFingerprintInfoAndFingerprintSourceMapping.map(obj =>
+    //     findCompatibleBuildsAsync(graphqlClient, projectId, obj)
+    //   )
+    // );
 
     for (const runtime of uniqBy(
       runtimeToPlatformsAndFingerprintInfoMapping,
@@ -634,28 +632,28 @@ export default class UpdatePublish extends EasCommand {
           ...(newIosUpdate ? [{ label: 'iOS update ID', value: newIosUpdate.id }] : []),
           ...(newAndroidUpdate?.rolloutControlUpdate
             ? [
-                {
-                  label: 'Android Rollout',
-                  value: `${newAndroidUpdate.rolloutPercentage}% (Base update ID: ${newAndroidUpdate.rolloutControlUpdate.id})`,
-                },
-              ]
+              {
+                label: 'Android Rollout',
+                value: `${newAndroidUpdate.rolloutPercentage}% (Base update ID: ${newAndroidUpdate.rolloutControlUpdate.id})`,
+              },
+            ]
             : []),
           ...(newIosUpdate?.rolloutControlUpdate
             ? [
-                {
-                  label: 'iOS Rollout',
-                  value: `${newIosUpdate.rolloutPercentage}% (Base update ID: ${newIosUpdate.rolloutControlUpdate.id})`,
-                },
-              ]
+              {
+                label: 'iOS Rollout',
+                value: `${newIosUpdate.rolloutPercentage}% (Base update ID: ${newIosUpdate.rolloutControlUpdate.id})`,
+              },
+            ]
             : []),
           { label: 'Message', value: updateMessage ?? '' },
           ...(gitCommitHash
             ? [
-                {
-                  label: 'Commit',
-                  value: `${gitCommitHash}${isGitWorkingTreeDirty ? '*' : ''}`,
-                },
-              ]
+              {
+                label: 'Commit',
+                value: `${gitCommitHash}${isGitWorkingTreeDirty ? '*' : ''}`,
+              },
+            ]
             : []),
           { label: 'EAS Dashboard', value: updateGroupLink },
         ])
@@ -664,10 +662,10 @@ export default class UpdatePublish extends EasCommand {
       if (isUploadedAssetCountAboveWarningThreshold(uploadedAssetCount, assetLimitPerUpdateGroup)) {
         Log.warn(
           `This update group contains ${uploadedAssetCount} assets and is nearing the server cap of ${assetLimitPerUpdateGroup}.\n` +
-            `${learnMore('https://docs.expo.dev/eas-update/optimize-assets/', {
-              learnMoreMessage: 'Consider optimizing your usage of assets',
-              dim: false,
-            })}.`
+          `${learnMore('https://docs.expo.dev/eas-update/optimize-assets/', {
+            learnMoreMessage: 'Consider optimizing your usage of assets',
+            dim: false,
+          })}.`
         );
         Log.addNewLineIfNone();
       }

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -672,52 +672,56 @@ export default class UpdatePublish extends EasCommand {
         Log.addNewLineIfNone();
       }
 
-      const fingerprintsWithoutCompatibleBuilds = runtimeToCompatibleBuilds.find(
-        ({ runtimeVersion }) => runtimeVersion === runtime.runtimeVersion
-      )?.fingerprintInfoGroupWithCompatibleBuilds;
-      if (fingerprintsWithoutCompatibleBuilds) {
-        const missingBuilds = Object.entries(fingerprintsWithoutCompatibleBuilds).filter(
-          ([_platform, fingerprintInfo]) => !fingerprintInfo.build
-        );
-        if (missingBuilds.length > 0) {
-          const project = await AppQuery.byIdAsync(graphqlClient, projectId);
-          Log.warn('No compatible builds found for the following fingerprints:');
-          for (const [platform, fingerprintInfo] of missingBuilds) {
-            const fingerprintUrl = new URL(
-              `/accounts/${project.ownerAccount.name}/projects/${project.slug}/fingerprints/${fingerprintInfo.fingerprintHash}`,
-              getExpoWebsiteBaseUrl()
-            );
-            Log.warn(
-              formatFields(
-                [
-                  {
-                    label: `${this.prettyPlatform(platform)} fingerprint`,
-                    value: fingerprintInfo.fingerprintHash,
-                  },
-                  { label: 'URL', value: fingerprintUrl.toString() },
-                ],
-                {
-                  labelFormat: label => `    ${chalk.dim(label)}:`,
-                }
-              )
-            );
-            Log.addNewLineIfNone();
-          }
-        }
-      }
+      // NOTE(brentvatne): temporarily disable logging this until we can revisit the formatting
+      // and the logic for it - it's a bit too aggressive right now, and warns even if you're
+      // not using EAS Build
+      //
+      // const fingerprintsWithoutCompatibleBuilds = runtimeToCompatibleBuilds.find(
+      //   ({ runtimeVersion }) => runtimeVersion === runtime.runtimeVersion
+      // )?.fingerprintInfoGroupWithCompatibleBuilds;
+      // if (fingerprintsWithoutCompatibleBuilds) {
+      //   const missingBuilds = Object.entries(fingerprintsWithoutCompatibleBuilds).filter(
+      //     ([_platform, fingerprintInfo]) => !fingerprintInfo.build
+      //   );
+      //   if (missingBuilds.length > 0) {
+      //     const project = await AppQuery.byIdAsync(graphqlClient, projectId);
+      //     Log.warn('No compatible builds found for the following fingerprints:');
+      //     for (const [platform, fingerprintInfo] of missingBuilds) {
+      //       const fingerprintUrl = new URL(
+      //         `/accounts/${project.ownerAccount.name}/projects/${project.slug}/fingerprints/${fingerprintInfo.fingerprintHash}`,
+      //         getExpoWebsiteBaseUrl()
+      //       );
+      //       Log.warn(
+      //         formatFields(
+      //           [
+      //             {
+      //               label: `${this.prettyPlatform(platform)} fingerprint`,
+      //               value: fingerprintInfo.fingerprintHash,
+      //             },
+      //             { label: 'URL', value: fingerprintUrl.toString() },
+      //           ],
+      //           {
+      //             labelFormat: label => `    ${chalk.dim(label)}:`,
+      //           }
+      //         )
+      //       );
+      //       Log.addNewLineIfNone();
+      //     }
+      //   }
+      // }
     }
   }
 
-  private prettyPlatform(updatePlatform: string): string {
-    switch (updatePlatform) {
-      case 'android':
-        return 'Android';
-      case 'ios':
-        return 'iOS';
-      default:
-        return updatePlatform;
-    }
-  }
+  // private prettyPlatform(updatePlatform: string): string {
+  //   switch (updatePlatform) {
+  //     case 'android':
+  //       return 'Android';
+  //     case 'ios':
+  //       return 'iOS';
+  //     default:
+  //       return updatePlatform;
+  //   }
+  // }
 
   private sanitizeFlags(flags: RawUpdateFlags): UpdateFlags {
     const nonInteractive = flags['non-interactive'] ?? false;


### PR DESCRIPTION
# Why

```
Branch             livestream
Runtime version    1.0.0
Platform           android, ios
Update group ID    7d01437f-2960-4efc-bd3b-abfef18c1a09
Android update ID  416bdd21-a78c-4a70-bf3c-4f56d8d8252c
iOS update ID      041ef585-4f7a-49cf-aaeb-9874cf96d2e2
Message            Ready
Commit             f6c1eff71c1030ac500b7f8a13c5a13f4660f539*
EAS Dashboard      https://expo.dev/accounts/brents/projects/hello-updates/updates/7d01437f-2960-4efc-bd3b-abfef18c1a09

No compatible builds found for the following fingerprints:
    iOS fingerprint:  08e0d74c33061720148b4c5cbb0534b357646282
    URL            :  https://expo.dev/accounts/brents/projects/hello-updates/fingerprints/08e0d74c33061720148b4c5cbb0534b357646282

    Android fingerprint:  3876a23c19cd256285dd2f3b6eb3e57933609ec2
    URL                :  https://expo.dev/accounts/brents/projects/hello-updates/fingerprints/3876a23c19cd256285dd2f3b6eb3e57933609ec2
```

I found this to be really noisy on projects that aren't using EAS Build. I think we need to refine this message and figure out when is a good time to show it, since it isn't always relevant.

I'd also like to improve the formatting of it before adding it back (it's inconsistent with other formatting above it, for example)

# How

Temporarily disable, we can discuss further at next sync

# Test Plan

Run `eas update`, verify it doesn't print the message above or cause any problems