### PR TITLE
[eas-cli] Create a project in `new` command

### DIFF
--- a/packages/eas-cli/src/commands/project/new.ts
+++ b/packages/eas-cli/src/commands/project/new.ts
@@ -1,16 +1,25 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
+import nullthrows from 'nullthrows';
 import path from 'path';
 
+import { getProjectDashboardUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
-import Log from '../../log';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { Role } from '../../graphql/generated';
+import { AppMutation } from '../../graphql/mutations/AppMutation';
+import Log, { link } from '../../log';
 import { canAccessRepositoryUsingSshAsync, runGitCloneAsync } from '../../onboarding/git';
 import {
   installDependenciesAsync,
   promptForPackageManagerAsync,
 } from '../../onboarding/installDependencies';
 import { runCommandAsync } from '../../onboarding/runCommand';
-import { promptAsync } from '../../prompts';
+import { ora } from '../../ora';
+import { createOrModifyExpoConfigAsync, getPrivateExpoConfigAsync } from '../../project/expoConfig';
+import { findProjectIdByAccountNameAndSlugNullableAsync } from '../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
+import { Choice, confirmAsync, promptAsync } from '../../prompts';
+import { Actor, getActorUsername } from '../../user/User';
 
 export default class New extends EasCommand {
   static override aliases = ['new'];
@@ -33,11 +42,8 @@ export default class New extends EasCommand {
     } = await this.parse(New);
 
     const {
-      loggedIn: { actor },
+      loggedIn: { actor, graphqlClient },
     } = await this.getContextAsync(New, { nonInteractive: false });
-
-    const githubUsername = 'expo';
-    const githubRepositoryName = 'expo-template-default';
 
     if (actor.__typename === 'Robot') {
       throw new Error(
@@ -50,6 +56,19 @@ export default class New extends EasCommand {
     );
     Log.log(`👋 Welcome to Expo, ${actor.username}!`);
     Log.newLine();
+
+    const targetProjectDirInput =
+      await this.getTargetProjectDirectoryAsync(targetProjectDirFromArgs);
+    const finalTargetProjectDirectory = await this.cloneTemplateAsync(targetProjectDirInput);
+    await this.installProjectDependenciesAsync(finalTargetProjectDirectory);
+    await this.initializeGitRepositoryAsync(finalTargetProjectDirectory);
+    await this.initializeProjectAsync(graphqlClient, actor, finalTargetProjectDirectory);
+
+    Log.log('🎉 We finished creating your new project.');
+    Log.newLine();
+  }
+
+  private async getTargetProjectDirectoryAsync(targetProjectDirFromArgs: string): Promise<string> {
     Log.log(
       `🚚 Let's start by cloning the default Expo template project from GitHub and installing dependencies.`
     );
@@ -65,6 +84,13 @@ export default class New extends EasCommand {
         })
       ).targetProjectDir;
     }
+
+    return targetProjectDirInput;
+  }
+
+  private async cloneTemplateAsync(targetProjectDirInput: string): Promise<string> {
+    const githubUsername = 'expo';
+    const githubRepositoryName = 'expo-template-default';
 
     Log.log(`📂 Cloning the project to ${targetProjectDirInput}`);
     Log.newLine();
@@ -85,6 +111,20 @@ export default class New extends EasCommand {
       cloneMethod,
     });
 
+    return finalTargetProjectDirectory;
+  }
+
+  private async installProjectDependenciesAsync(
+    finalTargetProjectDirectory: string
+  ): Promise<void> {
+    const packageManager = await promptForPackageManagerAsync();
+    await installDependenciesAsync({
+      projectDir: finalTargetProjectDirectory,
+      packageManager,
+    });
+  }
+
+  private async initializeGitRepositoryAsync(finalTargetProjectDirectory: string): Promise<void> {
     await fs.remove(path.join(finalTargetProjectDirectory, '.git'));
     await runCommandAsync({
       cwd: finalTargetProjectDirectory,
@@ -92,19 +132,6 @@ export default class New extends EasCommand {
       args: ['init'],
     });
     Log.log();
-    // TODO - need to create an app
-    // await configureProjectFromBareDefaultExpoTemplateAsync({
-    //   app,
-    //   vcsClient,
-    //   targetDir: finalTargetProjectDirectory,
-    // });
-
-    const packageManager = await promptForPackageManagerAsync();
-    await installDependenciesAsync({
-      projectDir: finalTargetProjectDirectory,
-      packageManager,
-    });
-
     await runCommandAsync({
       cwd: finalTargetProjectDirectory,
       command: 'git',
@@ -116,15 +143,167 @@ export default class New extends EasCommand {
       command: 'git',
       args: ['commit', '-m', 'Initial commit'],
     });
+  }
 
-    Log.log('🎉 We finished creating your new project.');
-    Log.newLine();
+  private async initializeProjectAsync(
+    graphqlClient: ExpoGraphqlClient,
+    actor: Actor,
+    projectDir: string
+  ): Promise<string> {
+    const exp = await getPrivateExpoConfigAsync(projectDir);
+    const existingProjectId = exp.extra?.eas?.projectId;
 
-    Log.log('Configuring project for EAS Build...');
-    await runCommandAsync({
-      cwd: finalTargetProjectDirectory,
-      command: 'eas',
-      args: ['init'],
-    });
+    if (existingProjectId) {
+      Log.succeed(
+        `Project already linked (ID: ${chalk.bold(
+          existingProjectId
+        )}). To re-configure, remove the "extra.eas.projectId" field from your app config.`
+      );
+      return existingProjectId;
+    }
+
+    const allAccounts = actor.accounts;
+    const accountNamesWhereUserHasSufficientPermissionsToCreateApp = new Set(
+      allAccounts
+        .filter(a => a.users.find(it => it.actor.id === actor.id)?.role !== Role.ViewOnly)
+        .map(it => it.name)
+    );
+
+    // if no owner field, ask the user which account they want to use to create/link the project
+    let accountName = exp.owner;
+    if (!accountName) {
+      if (allAccounts.length === 1) {
+        accountName = allAccounts[0].name;
+      } else {
+        const choices = this.getAccountChoices(
+          actor,
+          accountNamesWhereUserHasSufficientPermissionsToCreateApp
+        );
+
+        accountName = (
+          await promptAsync({
+            type: 'select',
+            name: 'account',
+            message: 'Which account should own this project?',
+            choices,
+          })
+        ).account.name;
+      }
+    }
+
+    if (!accountName) {
+      throw new Error('No account selected for project. Canceling.');
+    }
+
+    const projectName = getActorUsername(actor) + '-app';
+    const projectFullName = `@${accountName}/${projectName}`;
+    const existingProjectIdOnServer = await findProjectIdByAccountNameAndSlugNullableAsync(
+      graphqlClient,
+      accountName,
+      projectName
+    );
+
+    if (existingProjectIdOnServer) {
+      const affirmedLink = await confirmAsync({
+        message: `Existing project found: ${projectFullName} (ID: ${existingProjectIdOnServer}). Link this project?`,
+      });
+      if (!affirmedLink) {
+        throw new Error(
+          `Project ID configuration canceled. Re-run the command to select a different account/project.`
+        );
+      }
+
+      await this.saveProjectIdAndLogSuccessAsync(projectDir, existingProjectIdOnServer);
+      return existingProjectIdOnServer;
+    }
+
+    if (!accountNamesWhereUserHasSufficientPermissionsToCreateApp.has(accountName)) {
+      throw new Error(
+        `You don't have permission to create a new project on the ${accountName} account and no matching project already exists on the account.`
+      );
+    }
+
+    const projectDashboardUrl = getProjectDashboardUrl(accountName, projectName);
+    const projectLink = link(projectDashboardUrl, { text: projectFullName });
+
+    const account = nullthrows(allAccounts.find(a => a.name === accountName));
+
+    const spinner = ora(`Creating ${chalk.bold(projectFullName)}`).start();
+    let createdProjectId: string;
+    try {
+      createdProjectId = await AppMutation.createAppAsync(graphqlClient, {
+        accountId: account.id,
+        projectName,
+      });
+      spinner.succeed(`Created ${chalk.bold(projectLink)}`);
+    } catch (err) {
+      spinner.fail();
+      throw err;
+    }
+
+    await this.saveProjectIdAndLogSuccessAsync(projectDir, createdProjectId);
+    return createdProjectId;
+  }
+
+  private async saveProjectIdAndLogSuccessAsync(
+    projectDir: string,
+    projectId: string
+  ): Promise<void> {
+    const exp = await getPrivateExpoConfigAsync(projectDir, { skipPlugins: true });
+    const result = await createOrModifyExpoConfigAsync(
+      projectDir,
+      {
+        extra: { ...exp.extra, eas: { ...exp.extra?.eas, projectId } },
+      },
+      { skipSDKVersionRequirement: true }
+    );
+
+    switch (result.type) {
+      case 'success':
+        Log.withTick(
+          `Project successfully linked (ID: ${chalk.bold(projectId)}) (modified app.json)`
+        );
+        break;
+      case 'fail':
+        throw new Error(result.message);
+      default:
+        throw new Error('Unexpected result type from modifyConfigAsync');
+    }
+  }
+
+  private getAccountChoices(actor: Actor, namesWithSufficientPermissions: Set<string>): Choice[] {
+    const allAccounts = actor.accounts;
+
+    const sortedAccounts =
+      actor.__typename === 'Robot'
+        ? allAccounts
+        : [...allAccounts].sort((a, _b) =>
+            actor.__typename === 'User' ? (a.name === actor.username ? -1 : 1) : 0
+          );
+
+    if (actor.__typename !== 'Robot') {
+      return sortedAccounts.map(account => {
+        const isPersonalAccount = actor.__typename === 'User' && account.name === actor.username;
+        const accountDisplayName = isPersonalAccount
+          ? `${account.name} (personal account)`
+          : account.name;
+        const disabled = !namesWithSufficientPermissions.has(account.name);
+
+        return {
+          title: accountDisplayName,
+          value: { name: account.name },
+          ...(disabled && {
+            disabled: true,
+            description:
+              'You do not have the required permissions to create projects on this account.',
+          }),
+        };
+      });
+    }
+
+    return sortedAccounts.map(account => ({
+      title: account.name,
+      value: { name: account.name },
+    }));
   }
 }

--- a/packages/eas-cli/src/commands/project/new.ts
+++ b/packages/eas-cli/src/commands/project/new.ts
@@ -272,38 +272,26 @@ export default class New extends EasCommand {
   }
 
   private getAccountChoices(actor: Actor, namesWithSufficientPermissions: Set<string>): Choice[] {
-    const allAccounts = actor.accounts;
+    const sortedAccounts = actor.accounts.sort((a, _b) =>
+      actor.__typename === 'User' ? (a.name === actor.username ? -1 : 1) : 0
+    );
 
-    const sortedAccounts =
-      actor.__typename === 'Robot'
-        ? allAccounts
-        : [...allAccounts].sort((a, _b) =>
-            actor.__typename === 'User' ? (a.name === actor.username ? -1 : 1) : 0
-          );
+    return sortedAccounts.map(account => {
+      const isPersonalAccount = actor.__typename === 'User' && account.name === actor.username;
+      const accountDisplayName = isPersonalAccount
+        ? `${account.name} (personal account)`
+        : account.name;
+      const disabled = !namesWithSufficientPermissions.has(account.name);
 
-    if (actor.__typename !== 'Robot') {
-      return sortedAccounts.map(account => {
-        const isPersonalAccount = actor.__typename === 'User' && account.name === actor.username;
-        const accountDisplayName = isPersonalAccount
-          ? `${account.name} (personal account)`
-          : account.name;
-        const disabled = !namesWithSufficientPermissions.has(account.name);
-
-        return {
-          title: accountDisplayName,
-          value: { name: account.name },
-          ...(disabled && {
-            disabled: true,
-            description:
-              'You do not have the required permissions to create projects on this account.',
-          }),
-        };
-      });
-    }
-
-    return sortedAccounts.map(account => ({
-      title: account.name,
-      value: { name: account.name },
-    }));
+      return {
+        title: accountDisplayName,
+        value: { name: account.name },
+        ...(disabled && {
+          disabled: true,
+          description:
+            'You do not have the required permissions to create projects on this account.',
+        }),
+      };
+    });
   }
 }

--- a/packages/eas-cli/src/commands/project/new.ts
+++ b/packages/eas-cli/src/commands/project/new.ts
@@ -119,5 +119,12 @@ export default class New extends EasCommand {
 
     Log.log('🎉 We finished creating your new project.');
     Log.newLine();
+
+    Log.log('Configuring project for EAS Build...');
+    await runCommandAsync({
+      cwd: finalTargetProjectDirectory,
+      command: 'eas',
+      args: ['init'],
+    });
   }
 }

--- a/packages/eas-cli/src/onboarding/installDependencies.ts
+++ b/packages/eas-cli/src/onboarding/installDependencies.ts
@@ -37,13 +37,3 @@ export async function installDependenciesAsync({
     },
   });
 }
-
-export function getLockFileName(packageManager: PackageManager): string {
-  const lockFileNameMap = {
-    yarn: 'yarn.lock',
-    pnpm: 'pnpm-lock.yaml',
-    npm: 'package-lock.json',
-  };
-
-  return lockFileNameMap[packageManager];
-}

--- a/packages/eas-cli/src/onboarding/installDependencies.ts
+++ b/packages/eas-cli/src/onboarding/installDependencies.ts
@@ -37,3 +37,13 @@ export async function installDependenciesAsync({
     },
   });
 }
+
+export function getLockFileName(packageManager: PackageManager): string {
+  const lockFileNameMap = {
+    yarn: 'yarn.lock',
+    pnpm: 'pnpm-lock.yaml',
+    npm: 'package-lock.json',
+  };
+
+  return lockFileNameMap[packageManager];
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Continuing work on the `new` command. So far the command pulls down the starter template, installs dependencies, and adds them to git. Next step is to create a project on Expo and link it to the local project. 

# How

* I started with a lot of the code in `commands/project/init.ts`, but simplified a lot of it. Because we're starting from a fresh template, I pulled out a lot of "checking if there's already a project id locally" type stuff. 
* I updated a lot of the pre-existing functionality in `new.ts` to be a little more modular/have standalone functions. 

# Test Plan

* I added unit tests for all the new code paths 
* If you pull down, and run `[local eas command] new` and follow the prompts, you should end up with 1) a directory containing the template app and 2) a project on Expo corresponding to this template

Example output
```sh
✔ git commit -m Initial commit succeeded

✔ Which account should own this project? › colins-test-org
✔ Created @colins-test-org/mackenco-app
✔ Project successfully linked (ID: 5bdd62f1-7223-4e5e-9dc6-b199323c99be) (modified app.json)
🎉 We finished creating your new project.
```
<img width="472" height="373" alt="Screenshot 2025-09-23 at 2 40 51 PM" src="https://github.com/user-attachments/assets/7c9ee2c6-5d25-45f9-8f40-3e8c89a3e6a8" />
