### PR TITLE
[eas-cli] skip syncing capabilities if they don't contain 'enabled' attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- skip syncing capabilities with settings if they don't contain the `enabled` attribute ([#3201](https://github.com/expo/eas-cli/pull/3201) by [@vonovak](https://github.com/vonovak))
+
 ### 🧹 Chores
 
 ## [16.20.0](https://github.com/expo/eas-cli/releases/tag/v16.20.0) - 2025-09-30

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -129,7 +129,7 @@ function getCapabilitiesToEnable(
     const { op } = operation;
 
     if (Log.isDebug) {
-      Log.log(`Will ${op} remote capability: ${key} (${staticCapabilityInfo.name}.`);
+      Log.log(`Will ${op} remote capability: ${key} (${staticCapabilityInfo.name}).`);
     }
     if (op === 'enable') {
       enabledCapabilityNames.push(staticCapabilityInfo.name);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

To fix an `Expected "enabled" attribute in xyz_APPLE_ID_AUTH` error.

This change influences iCloud, data protection and Sign in with Apple capabilities

# How

- add a test case that replicated the prerequisites for the crash

# Test Plan

- green CI