### PR TITLE
Support workflow:run from a Git ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- Allow workflow:run to run a workflow from a GitHub ref. ([#3203](https://github.com/expo/eas-cli/pull/3203) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/workflow/run.ts
+++ b/packages/eas-cli/src/commands/workflow/run.ts
@@ -40,6 +40,7 @@
  * ```
  */
 
+import spawnAsync from '@expo/spawn-async';
 import { Flags } from '@oclif/core';
 import { CombinedError } from '@urql/core';
 import chalk from 'chalk';
@@ -55,6 +56,7 @@ import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/creat
 import { EASNonInteractiveFlag, EasJsonOnlyFlag } from '../../commandUtils/flags';
 import {
   WorkflowProjectSourceType,
+  WorkflowRevision,
   WorkflowRunByIdQuery,
   WorkflowRunStatus,
 } from '../../graphql/generated';
@@ -78,7 +80,8 @@ const EXIT_CODES = {
 };
 
 export default class WorkflowRun extends EasCommand {
-  static override description = 'run an EAS workflow';
+  static override description =
+    'run an EAS workflow. The entire local project directory will be packaged and uploaded to EAS servers for the workflow run, unless the --ref flag is used.';
 
   static override args = [{ name: 'file', description: 'Path to the workflow file to run' }];
 
@@ -97,6 +100,11 @@ export default class WorkflowRun extends EasCommand {
       description:
         'Add a parameter in key=value format. Use multiple instances of this flag to set multiple inputs.',
       summary: 'Set workflow inputs',
+    }),
+    ref: Flags.string({
+      description:
+        "The git reference must exist in the project's git repository, and the workflow file must exist at that reference. When this flag is used, the local project is not uploaded; instead, the workflow is run from the exact state of the project at the chosen reference.",
+      summary: 'Git reference to run the workflow on',
     }),
     ...EasJsonOnlyFlag,
   };
@@ -125,26 +133,70 @@ export default class WorkflowRun extends EasCommand {
       withServerSideEnvironment: null,
     });
 
-    let yamlConfig: string;
-    try {
-      const workflowFileContents = await WorkflowFile.readWorkflowFileContentsAsync({
-        projectDir,
-        filePath: args.file,
-      });
-      Log.log(`Using workflow file from ${workflowFileContents.filePath}`);
-      yamlConfig = workflowFileContents.yamlConfig;
-    } catch (err) {
-      Log.error('Failed to read workflow file.');
-
-      throw err;
-    }
-
     const {
       projectId,
       exp: { slug: projectName },
     } = await getDynamicPrivateProjectConfigAsync();
     const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
 
+    let yamlConfig: string;
+    let workflowRunId: string;
+    let workflowRevisionId: string | undefined;
+    let gitRef: string | undefined;
+
+    if (flags.ref) {
+      // Run from git ref
+      const fileName = path.basename(args.file);
+      // Find the real commit, make sure the ref is valid
+      gitRef = (
+        await spawnAsync('git', ['rev-parse', flags.ref], {
+          cwd: projectDir,
+        })
+      ).output[0].trim();
+      if (!gitRef) {
+        throw new Error('Failed to resolve git reference');
+      }
+      Log.log(`Using workflow file ${fileName} at ${gitRef}`);
+      let revisionResult: WorkflowRevision | undefined;
+      try {
+        revisionResult = await WorkflowRevisionMutation.getOrCreateWorkflowRevisionFromGitRefAsync(
+          graphqlClient,
+          {
+            appId: projectId,
+            fileName,
+            gitRef,
+          }
+        );
+      } catch (err) {
+        throw new Error(
+          `Failed to find or create workflow revision for ${fileName} at ${flags.ref}: ${err}`
+        );
+      }
+      Log.debug(`Workflow revision: ${JSON.stringify(revisionResult, null, 2)}`);
+      if (!revisionResult) {
+        throw new Error(
+          `Failed to find or create workflow revision for ${fileName} at ${flags.ref}`
+        );
+      }
+      yamlConfig = revisionResult.yamlConfig;
+      workflowRevisionId = revisionResult.id;
+    } else {
+      // Run from local file
+      try {
+        const workflowFileContents = await WorkflowFile.readWorkflowFileContentsAsync({
+          projectDir,
+          filePath: args.file,
+        });
+        Log.log(`Using workflow file from ${workflowFileContents.filePath}`);
+        yamlConfig = workflowFileContents.yamlConfig;
+      } catch (err) {
+        Log.error('Failed to read workflow file.');
+
+        throw err;
+      }
+    }
+
+    // Validate workflow YAML
     try {
       await WorkflowRevisionMutation.validateWorkflowYamlConfigAsync(graphqlClient, {
         appId: projectId,
@@ -206,80 +258,94 @@ export default class WorkflowRun extends EasCommand {
       path.relative(await vcsClient.getRootPathAsync(), projectDir) || '.'
     );
 
-    try {
-      ({ projectArchiveBucketKey } = await uploadAccountScopedProjectSourceAsync({
-        graphqlClient,
-        vcsClient,
-        accountId: account.id,
-      }));
-
-      if (await fileExistsAsync(easJsonPath)) {
-        ({ fileBucketKey: easJsonBucketKey } = await uploadAccountScopedFileAsync({
-          graphqlClient,
-          accountId: account.id,
-          filePath: easJsonPath,
-          maxSizeBytes: 1024 * 1024,
-        }));
-      } else {
-        Log.warn(
-          `⚠ No ${chalk.bold('eas.json')} found in the project directory. Running ${chalk.bold(
-            'type: build'
-          )} jobs will not work. Run ${chalk.bold(
-            'eas build:configure'
-          )} to configure your project for builds.`
-        );
-      }
-
-      if (await fileExistsAsync(packageJsonPath)) {
-        ({ fileBucketKey: packageJsonBucketKey } = await uploadAccountScopedFileAsync({
-          graphqlClient,
-          accountId: account.id,
-          filePath: packageJsonPath,
-          maxSizeBytes: 1024 * 1024,
-        }));
-      } else {
-        Log.warn(
-          `⚠ No ${chalk.bold(
-            'package.json'
-          )} found in the project directory. It is used to automatically infer best job configuration for your project. You may want to define ${chalk.bold(
-            'image'
-          )} property in your workflow to specify the image to use.`
-        );
-      }
-    } catch (err) {
-      Log.error('Failed to upload project sources.');
-
-      throw err;
-    }
-
-    let workflowRunId: string;
-
-    try {
-      ({ id: workflowRunId } = await WorkflowRunMutation.createWorkflowRunAsync(graphqlClient, {
-        appId: projectId,
-        workflowRevisionInput: {
-          fileName: path.basename(args.file),
-          yamlConfig,
-        },
-        workflowRunInput: {
+    if (gitRef) {
+      // Run from git ref
+      let runResult: { id: string };
+      try {
+        runResult = await WorkflowRunMutation.createWorkflowRunFromGitRefAsync(graphqlClient, {
+          workflowRevisionId: workflowRevisionId ?? '',
+          gitRef,
           inputs,
-          projectSource: {
-            type: WorkflowProjectSourceType.Gcs,
-            projectArchiveBucketKey,
-            easJsonBucketKey,
-            packageJsonBucketKey,
-            projectRootDirectory,
+        });
+      } catch (err) {
+        throw new Error(`Failed to create workflow run: ${err}`);
+      }
+      workflowRunId = runResult.id;
+    } else {
+      // Run from local file
+      try {
+        ({ projectArchiveBucketKey } = await uploadAccountScopedProjectSourceAsync({
+          graphqlClient,
+          vcsClient,
+          accountId: account.id,
+        }));
+
+        if (await fileExistsAsync(easJsonPath)) {
+          ({ fileBucketKey: easJsonBucketKey } = await uploadAccountScopedFileAsync({
+            graphqlClient,
+            accountId: account.id,
+            filePath: easJsonPath,
+            maxSizeBytes: 1024 * 1024,
+          }));
+        } else {
+          Log.warn(
+            `⚠ No ${chalk.bold('eas.json')} found in the project directory. Running ${chalk.bold(
+              'type: build'
+            )} jobs will not work. Run ${chalk.bold(
+              'eas build:configure'
+            )} to configure your project for builds.`
+          );
+        }
+
+        if (await fileExistsAsync(packageJsonPath)) {
+          ({ fileBucketKey: packageJsonBucketKey } = await uploadAccountScopedFileAsync({
+            graphqlClient,
+            accountId: account.id,
+            filePath: packageJsonPath,
+            maxSizeBytes: 1024 * 1024,
+          }));
+        } else {
+          Log.warn(
+            `⚠ No ${chalk.bold(
+              'package.json'
+            )} found in the project directory. It is used to automatically infer best job configuration for your project. You may want to define ${chalk.bold(
+              'image'
+            )} property in your workflow to specify the image to use.`
+          );
+        }
+      } catch (err) {
+        Log.error('Failed to upload project sources.');
+
+        throw err;
+      }
+
+      try {
+        ({ id: workflowRunId } = await WorkflowRunMutation.createWorkflowRunAsync(graphqlClient, {
+          appId: projectId,
+          workflowRevisionInput: {
+            fileName: path.basename(args.file),
+            yamlConfig,
           },
-        },
-      }));
+          workflowRunInput: {
+            inputs,
+            projectSource: {
+              type: WorkflowProjectSourceType.Gcs,
+              projectArchiveBucketKey,
+              easJsonBucketKey,
+              packageJsonBucketKey,
+              projectRootDirectory,
+            },
+          },
+        }));
+      } catch (err) {
+        Log.error('Failed to start the workflow with the API.');
 
-      Log.newLine();
-      Log.log(`See logs: ${link(getWorkflowRunUrl(account.name, projectName, workflowRunId))}`);
-    } catch (err) {
-      Log.error('Failed to start the workflow with the API.');
-
-      throw err;
+        throw err;
+      }
     }
+
+    Log.newLine();
+    Log.log(`See logs: ${link(getWorkflowRunUrl(account.name, projectName, workflowRunId))}`);
 
     if (!flags.wait) {
       if (flags.json) {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -9859,6 +9859,15 @@ export type DeleteWebhookMutationVariables = Exact<{
 
 export type DeleteWebhookMutation = { __typename?: 'RootMutation', webhook: { __typename?: 'WebhookMutation', deleteWebhook: { __typename?: 'DeleteWebhookResult', id: string } } };
 
+export type GetOrCreateWorkflowRevisionFromGitRefMutationVariables = Exact<{
+  appId: Scalars['ID']['input'];
+  fileName: Scalars['String']['input'];
+  gitRef: Scalars['String']['input'];
+}>;
+
+
+export type GetOrCreateWorkflowRevisionFromGitRefMutation = { __typename?: 'RootMutation', workflowRevision: { __typename?: 'WorkflowRevisionMutation', getOrCreateWorkflowRevisionFromGitRef: { __typename?: 'WorkflowRevision', id: string, yamlConfig: string, blobSha: string, commitSha?: string | null, createdAt: any, workflow: { __typename?: 'Workflow', id: string } } } };
+
 export type ValidateWorkflowYamlConfigMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
   yamlConfig: Scalars['String']['input'];
@@ -9875,6 +9884,15 @@ export type CreateWorkflowRunMutationVariables = Exact<{
 
 
 export type CreateWorkflowRunMutation = { __typename?: 'RootMutation', workflowRun: { __typename?: 'WorkflowRunMutation', createWorkflowRun: { __typename?: 'WorkflowRun', id: string } } };
+
+export type CreateWorkflowRunFromGitRefMutationVariables = Exact<{
+  workflowRevisionId: Scalars['ID']['input'];
+  gitRef: Scalars['String']['input'];
+  inputs?: InputMaybe<Scalars['JSONObject']['input']>;
+}>;
+
+
+export type CreateWorkflowRunFromGitRefMutation = { __typename?: 'RootMutation', workflowRun: { __typename?: 'WorkflowRunMutation', createWorkflowRunFromGitRef: { __typename?: 'WorkflowRun', id: string } } };
 
 export type CancelWorkflowRunMutationVariables = Exact<{
   workflowRunId: Scalars['ID']['input'];

--- a/packages/eas-cli/src/graphql/mutations/WorkflowRunMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/WorkflowRunMutation.ts
@@ -5,6 +5,8 @@ import { withErrorHandlingAsync } from '../client';
 import {
   CancelWorkflowRunMutation,
   CancelWorkflowRunMutationVariables,
+  CreateWorkflowRunFromGitRefMutation,
+  CreateWorkflowRunFromGitRefMutationVariables,
   CreateWorkflowRunMutation,
   CreateWorkflowRunMutationVariables,
   WorkflowRevisionInput,
@@ -54,6 +56,53 @@ export namespace WorkflowRunMutation {
     );
     return { id: data.workflowRun.createWorkflowRun.id };
   }
+
+  export async function createWorkflowRunFromGitRefAsync(
+    graphqlClient: ExpoGraphqlClient,
+    {
+      workflowRevisionId,
+      gitRef,
+      inputs,
+    }: {
+      workflowRevisionId: string;
+      gitRef: string;
+      inputs?: Record<string, any>;
+    }
+  ): Promise<{ id: string }> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<
+          CreateWorkflowRunFromGitRefMutation,
+          CreateWorkflowRunFromGitRefMutationVariables
+        >(
+          gql`
+            mutation CreateWorkflowRunFromGitRef(
+              $workflowRevisionId: ID!
+              $gitRef: String!
+              $inputs: JSONObject
+            ) {
+              workflowRun {
+                createWorkflowRunFromGitRef(
+                  workflowRevisionId: $workflowRevisionId
+                  gitRef: $gitRef
+                  inputs: $inputs
+                ) {
+                  id
+                }
+              }
+            }
+          `,
+          {
+            workflowRevisionId,
+            gitRef,
+            inputs,
+          }
+        )
+        .toPromise()
+    );
+    return { id: data.workflowRun.createWorkflowRunFromGitRef.id };
+  }
+
   export async function cancelWorkflowRunAsync(
     graphqlClient: ExpoGraphqlClient,
     {


### PR DESCRIPTION
# Why

Add a `--ref` flag so that `eas workflow:run` can initiate a workflow run from an existing ref in the project's GitHub repository.

- Avoids the need to upload the entire project from a local machine
- Ensures that the workflow starts from a known reference point in the project's source control, with no unexpected local changes

# How

- If the ref flag is set, the run command will ensure that the ref is valid, and that the workflow can be used for that ref (using the new mutation for this from https://github.com/expo/universe/pull/22132)
- If the ref flag is set, the run command starts the run from that ref (using https://github.com/expo/universe/pull/20161)
- If the user chooses ref = HEAD, `git rev-parse` is called to convert that to a commit
- The flow is designed to work the same for running from GitHub ref as running from local, so inputs and waiting for results are supported 

# Test Plan

- Tested in an existing project with workflows with and without inputs
- CI should pass
