### PR TITLE
[eas-cli] add 'account-creation-requires-phone-number' capability

### DIFF
--- a/packages/eas-cli/src/credentials/ios/appstore/capabilityList.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/capabilityList.ts
@@ -682,6 +682,13 @@ export const CapabilityMapping: CapabilityClassifier[] = [
     ]),
     getSyncOperation: getDefinedValueSyncOperation,
   },
+  {
+    entitlement: 'com.apple.developer.authentication-services.account-creation-requires-phone-number',
+    name: 'Account Creation Requires Phone Number',
+    capability: CapabilityType.ACCOUNT_CREATION_REQUIRES_PHONE_NUMBER,
+    validateOptions: validateBooleanOptions,
+    getSyncOperation: getBooleanSyncOperation,
+  },
   // VMNET
 
   // These don't appear to have entitlements, so it's unclear how we can automatically enable / disable them at this time.


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I want to manage as many capabilities as possible in my app.config.json, including `com.apple.developer.authentication-services.account-creation-requires-phone-number`
Managing a white-label app, I don't want to update every single App ID manually (3 envs * 5 clients).

# How

1. Added entry to `eas-cli`'s `capabilityList`
2. **NOT DONE** add the new value to the private lib `@expo/apple-utils`'s `CapabilityType` enum
3. **NOT DONE** release new `@expo/apple-utils` version and upgrade it in `eas-cli`


# Test Plan

Local testing: capability was properly added to App Identifier


# Extra toughts

I would be happy to add more missing capabilities (102 listed on apple website, but only 69 in this repo), once this PR is reviewed and merged