### PR TITLE
Lower instead of uppercase environment

### DIFF
--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -323,14 +323,14 @@ export default class EnvCreate extends EasCommand {
 
     value = environmentFilePath ? await fs.readFile(environmentFilePath, 'base64') : value;
 
-    if (environment && !isEnvironment(environment.toUpperCase())) {
+    if (environment && !isEnvironment(environment.toLowerCase())) {
       throw new Error("Invalid environment. Use one of 'production', 'preview', or 'development'.");
     }
 
     let newEnvironments = environments
       ? environments
       : environment
-        ? [environment.toUpperCase() as EnvironmentVariableEnvironment]
+        ? [environment.toLowerCase() as EnvironmentVariableEnvironment]
         : undefined;
 
     if (!newEnvironments) {

--- a/packages/eas-cli/src/commands/env/delete.ts
+++ b/packages/eas-cli/src/commands/env/delete.ts
@@ -166,8 +166,7 @@ export default class EnvDelete extends EasCommand {
         : EnvironmentVariableScope.Project;
 
     if (environment) {
-      environment = environment.toUpperCase();
-
+      environment = environment.toLowerCase();
       if (!isEnvironment(environment)) {
         throw new Error(
           "Invalid environment. Use one of 'production', 'preview', or 'development'."

--- a/packages/eas-cli/src/commands/env/get.ts
+++ b/packages/eas-cli/src/commands/env/get.ts
@@ -156,7 +156,7 @@ export default class EnvGet extends EasCommand {
         ? EnvironmentVariableScope.Shared
         : EnvironmentVariableScope.Project;
     if (environment) {
-      environment = environment.toUpperCase();
+      environment = environment.toLowerCase();
       if (!isEnvironment(environment)) {
         throw new Error(
           "Invalid environment. Use one of 'production', 'preview', or 'development'."

--- a/packages/eas-cli/src/commands/env/list.ts
+++ b/packages/eas-cli/src/commands/env/list.ts
@@ -180,14 +180,14 @@ export default class EnvList extends EasCommand {
     flags: RawListFlags,
     { environment }: { environment?: string }
   ): ListFlags {
-    if (environment && !isEnvironment(environment.toUpperCase())) {
+    if (environment && !isEnvironment(environment.toLowerCase())) {
       throw new Error("Invalid environment. Use one of 'production', 'preview', or 'development'.");
     }
 
     const environments = flags.environment
       ? flags.environment
       : environment
-        ? [environment.toUpperCase() as EnvironmentVariableEnvironment]
+        ? [environment.toLowerCase() as EnvironmentVariableEnvironment]
         : undefined;
 
     return {

--- a/packages/eas-cli/src/commands/env/push.ts
+++ b/packages/eas-cli/src/commands/env/push.ts
@@ -199,13 +199,13 @@ export default class EnvPush extends EasCommand {
     flags: { path: string; environment: EnvironmentVariableEnvironment[] | undefined },
     { environment }: Record<string, string>
   ): { environment?: EnvironmentVariableEnvironment[]; path: string } {
-    if (environment && !isEnvironment(environment.toUpperCase())) {
+    if (environment && !isEnvironment(environment.toLowerCase())) {
       throw new Error("Invalid environment. Use one of 'production', 'preview', or 'development'.");
     }
 
     const environments =
       flags.environment ??
-      (environment ? [environment.toUpperCase() as EnvironmentVariableEnvironment] : undefined);
+      (environment ? [environment.toLowerCase() as EnvironmentVariableEnvironment] : undefined);
 
     return {
       ...flags,

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -226,7 +226,7 @@ export default class EnvUpdate extends EasCommand {
         : EnvironmentVariableScope.Project;
 
     if (environment) {
-      environment = environment.toUpperCase();
+      environment = environment.toLowerCase();
       if (!isEnvironment(environment)) {
         throw new Error(
           "Invalid environment. Use one of 'production', 'preview', or 'development'."


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Resolves https://github.com/expo/eas-cli/issues/3210

Partially introduced by https://github.com/expo/eas-cli/pull/3208 which was merged to fix https://discord.com/channels/695411232856997968/1309202098591633458/1425100393179906118

# How

The environment name was `.toUpperCase()` in order to conform with the legacy requirement of needing to pass in `DEVELOPMENT`, `PREVIEW` or `PRODUCTION`. The enum we replaced it with in https://github.com/expo/eas-cli/pull/3208 is using lowercase values.

Replacing `.toUpperCase()`  with `.toLowerCase()`  - could just remove `.toUpperCase()` but will keep it to play it safe (in case someone is passing in uppercase values which would have used to work.


# Test Plan

The following commands should work:

```
# create
easd env:create development --name "TEEEST" --value "VALUE" --visibility plaintext --force --non-interactive --scope project

# get
easd env:get development --variable-name "TEEEST" --non-interactive
```