### PR TITLE
Switch to lowercase in exec and pull

### DIFF
--- a/packages/eas-cli/src/build/utils/environment.ts
+++ b/packages/eas-cli/src/build/utils/environment.ts
@@ -17,7 +17,7 @@ const BuildProfileEnvironmentToEnvironment: Record<Environment, EnvironmentVaria
 
 export function isEnvironment(env: string): env is EnvironmentVariableEnvironment {
   return Object.values(EnvironmentVariableEnvironment).includes(
-    env as EnvironmentVariableEnvironment
+    env.toLowerCase() as EnvironmentVariableEnvironment
   );
 }
 

--- a/packages/eas-cli/src/commands/env/exec.ts
+++ b/packages/eas-cli/src/commands/env/exec.ts
@@ -101,7 +101,7 @@ export default class EnvExec extends EasCommand {
       );
     }
 
-    environment = environment?.toUpperCase();
+    environment = environment?.toLowerCase();
 
     if (!isEnvironment(environment)) {
       throw new Error("Invalid environment. Use one of 'production', 'preview', or 'development'.");

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -49,7 +49,7 @@ export default class EnvPull extends EasCommand {
       flags: { environment: flagEnvironment, path: targetPath, 'non-interactive': nonInteractive },
     } = await this.parse(EnvPull);
 
-    let environment = flagEnvironment?.toUpperCase() ?? argEnvironment?.toUpperCase();
+    let environment = flagEnvironment?.toLowerCase() ?? argEnvironment?.toLowerCase();
 
     if (!environment) {
       environment = await promptVariableEnvironmentAsync({ nonInteractive });


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Resolves https://github.com/expo/eas-cli/issues/3212

I switched to lowercase in https://github.com/expo/eas-cli/pull/3213 but missed exec and pull.

# How

Switched from `toUpperCase` to `toLowerCase` in `exec` and `pull`.
Updated `isEnvironment` validator to support both (both are supported in the api).

> [!NOTE]
> Not adding test here in favour of get this fixed quick, but longer term we need to add tests for these commands. This should have been caught by CI.

# Test Plan

```sh
easd env:pull --environment development
```
