### PR TITLE
Add tests for the env commands

### DIFF
--- a/packages/eas-cli/src/commands/env/__tests__/EnvCreate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvCreate.test.ts
@@ -369,4 +369,42 @@ describe(EnvCreate, () => {
       );
     });
   });
+
+  it('accepts development environment when using positional argument', async () => {
+    const command = new EnvCreate(
+      [
+        'development',
+        '--name',
+        'TEST_VAR',
+        '--value',
+        'test-value',
+        '--visibility',
+        'plaintext',
+        '--scope',
+        'project',
+        '--non-interactive',
+      ],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    await command.runAsync();
+
+    expect(EnvironmentVariableMutation.createForAppAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      {
+        name: 'TEST_VAR',
+        value: 'test-value',
+        environments: [EnvironmentVariableEnvironment.Development],
+        visibility: EnvironmentVariableVisibility.Public,
+        type: EnvironmentSecretType.String,
+      },
+      testProjectId
+    );
+  });
 });

--- a/packages/eas-cli/src/commands/env/__tests__/EnvDelete.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvDelete.test.ts
@@ -152,7 +152,11 @@ describe(EnvDelete, () => {
       projectId: projectId,
     });
 
-    // The command should run without throwing an environment validation error
-    await expect(command.runAsync()).resolves.not.toThrow();
+    await command.runAsync();
+
+    expect(EnvironmentVariablesQuery.byAppIdAsync).toHaveBeenCalledWith(graphqlClient, {
+      appId: projectId,
+      environment: EnvironmentVariableEnvironment.Development,
+    });
   });
 });

--- a/packages/eas-cli/src/commands/env/__tests__/EnvDelete.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvDelete.test.ts
@@ -1,7 +1,11 @@
 import { Config } from '@oclif/core';
 
 import { EnvironmentVariableEnvironment } from '../../../build/utils/environment';
-import { EnvironmentVariableScope } from '../../../graphql/generated';
+import { 
+  EnvironmentVariableScope,
+  EnvironmentVariableVisibility,
+  EnvironmentSecretType,
+} from '../../../graphql/generated';
 import { EnvironmentVariableMutation } from '../../../graphql/mutations/EnvironmentVariableMutation';
 import { EnvironmentVariablesQuery } from '../../../graphql/queries/EnvironmentVariablesQuery';
 import Log from '../../../log';
@@ -118,5 +122,37 @@ describe(EnvDelete, () => {
     await expect(command.runAsync()).rejects.toThrowErrorMatchingSnapshot();
 
     expect(EnvironmentVariableMutation.deleteAsync).not.toHaveBeenCalled();
+  });
+
+  it('accepts development environment when using positional argument', async () => {
+    const mockVariable = {
+      id: 'var1',
+      name: 'TEST_VAR_1',
+      value: 'value1',
+      environments: [EnvironmentVariableEnvironment.Development],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
+      type: EnvironmentSecretType.String,
+    };
+
+    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValueOnce([mockVariable]);
+    jest.mocked(EnvironmentVariableMutation.deleteAsync).mockResolvedValueOnce({ id: 'var1' });
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+
+    const command = new EnvDelete(
+      ['development', '--variable-name', 'TEST_VAR_1', '--scope', 'project', '--non-interactive'],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: projectId,
+    });
+
+    // The command should run without throwing an environment validation error
+    await expect(command.runAsync()).resolves.not.toThrow();
   });
 });

--- a/packages/eas-cli/src/commands/env/__tests__/EnvExec.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvExec.test.ts
@@ -1,0 +1,79 @@
+import { Config } from '@oclif/core';
+
+import { EnvironmentVariableEnvironment } from '../../../build/utils/environment';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../credentials/__tests__/fixtures-constants';
+import {
+  EnvironmentSecretType,
+  EnvironmentVariableScope,
+  EnvironmentVariableVisibility,
+} from '../../../graphql/generated';
+import { EnvironmentVariablesQuery } from '../../../graphql/queries/EnvironmentVariablesQuery';
+import Log from '../../../log';
+import EnvExec from '../exec';
+
+jest.mock('../../../graphql/queries/EnvironmentVariablesQuery');
+jest.mock('../../../log');
+
+describe(EnvExec, () => {
+  const graphqlClient = {} as any as ExpoGraphqlClient;
+  const mockConfig = {} as unknown as Config;
+
+  const mockEnvironmentVariables = [
+    {
+      id: 'var1',
+      name: 'EXPO_PUBLIC_API_URL',
+      value: 'https://api.example.com',
+      environments: [EnvironmentVariableEnvironment.Development],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
+      type: EnvironmentSecretType.String,
+    },
+  ];
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+    
+    // Mock GraphQL query
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync)
+      .mockResolvedValue(mockEnvironmentVariables);
+  });
+
+  it('accepts development environment when using positional argument', async () => {
+    const command = new EnvExec(['development', 'echo $EXPO_PUBLIC_API_URL'], mockConfig);
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    await command.runAsync();
+
+    expect(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      {
+        appId: testProjectId,
+        environment: EnvironmentVariableEnvironment.Development,
+      }
+    );
+  });
+
+  it('rejects invalid environment when using positional argument', async () => {
+    const command = new EnvExec(['invalid', 'echo test'], mockConfig);
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    await expect(command.runAsync()).rejects.toThrow(
+      "Invalid environment. Use one of 'production', 'preview', or 'development'."
+    );
+  });
+});

--- a/packages/eas-cli/src/commands/env/__tests__/EnvGet.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvGet.test.ts
@@ -111,4 +111,31 @@ describe(EnvGet, () => {
     expect(promptVariableEnvironmentAsync).toHaveBeenCalled();
     expect(promptVariableNameAsync).toHaveBeenCalled();
   });
+
+  it('accepts development environment when using positional argument', async () => {
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync)
+      .mockResolvedValueOnce(mockVariables);
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+
+    const command = new EnvGet(['development', '--variable-name', 'TEST_VAR_1', '--scope', 'project'], mockConfig);
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    await command.runAsync();
+
+    expect(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      {
+        appId: testProjectId,
+        environment: EnvironmentVariableEnvironment.Development,
+        filterNames: ['TEST_VAR_1'],
+        includeFileContent: true,
+      }
+    );
+  });
 });

--- a/packages/eas-cli/src/commands/env/__tests__/EnvList.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvList.test.ts
@@ -95,6 +95,26 @@ describe(EnvList, () => {
     expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('TEST_VAR_2'));
   });
 
+  it('accepts development environment when using positional argument', async () => {
+    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValueOnce(mockVariables);
+
+    const command = new EnvList(['development'], mockConfig); // Using positional argument
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    await command.runAsync();
+
+    expect(EnvironmentVariablesQuery.byAppIdAsync).toHaveBeenCalledWith(graphqlClient, {
+      appId: testProjectId,
+      environment: EnvironmentVariableEnvironment.Development,
+      includeFileContent: false,
+    });
+  });
+
   it('lists project environment variables including sensitive values', async () => {
     jest
       .mocked(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync)

--- a/packages/eas-cli/src/commands/env/__tests__/EnvPull.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvPull.test.ts
@@ -1,0 +1,385 @@
+import { Config } from '@oclif/core';
+import * as fs from 'fs-extra';
+import path from 'path';
+
+import { EnvironmentVariableEnvironment } from '../../../build/utils/environment';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../credentials/__tests__/fixtures-constants';
+import {
+  EnvironmentSecretType,
+  EnvironmentVariableScope,
+  EnvironmentVariableVisibility,
+} from '../../../graphql/generated';
+import { EnvironmentVariablesQuery } from '../../../graphql/queries/EnvironmentVariablesQuery';
+import Log from '../../../log';
+import { confirmAsync } from '../../../prompts';
+import { EnvironmentVariableWithFileContent } from '../../../graphql/queries/EnvironmentVariablesQuery';
+import EnvPull from '../pull';
+
+jest.mock('../../../graphql/queries/EnvironmentVariablesQuery');
+jest.mock('../../../prompts');
+jest.mock('fs-extra');
+jest.mock('../../../log');
+
+describe(EnvPull, () => {
+  const graphqlClient = {} as any as ExpoGraphqlClient;
+  const mockConfig = {} as unknown as Config;
+  const testProjectDir = '/test/project';
+  const testTargetPath = '.env.local';
+
+  const mockEnvironmentVariables: EnvironmentVariableWithFileContent[] = [
+    {
+      id: 'var1',
+      name: 'EXPO_PUBLIC_API_URL',
+      value: 'https://api.example.com',
+      environments: [EnvironmentVariableEnvironment.Development],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
+      type: EnvironmentSecretType.String,
+    },
+    {
+      id: 'var2',
+      name: 'DATABASE_URL',
+      value: 'postgres://localhost:5432/mydb',
+      environments: [EnvironmentVariableEnvironment.Development],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Sensitive,
+      type: EnvironmentSecretType.String,
+    },
+    {
+      id: 'var3',
+      name: 'SECRET_KEY',
+      value: 'super-secret-key',
+      environments: [EnvironmentVariableEnvironment.Development],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Secret,
+      type: EnvironmentSecretType.String,
+    },
+    {
+      id: 'var4',
+      name: 'CONFIG_FILE',
+      value: 'base64-encoded-file-content',
+      environments: [EnvironmentVariableEnvironment.Development],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
+      type: EnvironmentSecretType.FileBase64,
+      valueWithFileContent: Buffer.from('{"key": "value"}').toString('base64'),
+    },
+  ];
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+    jest.spyOn(Log, 'addNewLineIfNone').mockImplementation(() => {});
+    
+    // Mock fs-extra methods
+    jest.mocked(fs.exists).mockImplementation(() => Promise.resolve(false));
+    jest.mocked(fs.writeFile).mockImplementation(() => Promise.resolve());
+    jest.mocked(fs.mkdir).mockImplementation(() => Promise.resolve());
+    jest.mocked(fs.readFile).mockImplementation(() => Promise.resolve(''));
+    
+    // Mock GraphQL query
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync)
+      .mockResolvedValue(mockEnvironmentVariables);
+  });
+
+  describe('environment validation', () => {
+    it('accepts development environment (case insensitive)', async () => {
+      const command = new EnvPull(['development'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      expect(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync).toHaveBeenCalledWith(
+        graphqlClient,
+        {
+          appId: testProjectId,
+          environment: 'development',
+          includeFileContent: true,
+        }
+      );
+    });
+
+
+    it('rejects invalid environment', async () => {
+      const command = new EnvPull(['invalid'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await expect(command.runAsync()).rejects.toThrow(
+        "Invalid environment. Use one of 'production', 'preview', or 'development'."
+      );
+    });
+  });
+
+  describe('file operations', () => {
+    it('writes environment variables to .env.local file', async () => {
+      const command = new EnvPull(['development'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        testTargetPath,
+        expect.stringContaining('# Environment: development')
+      );
+    });
+
+    it('writes correct environment variable content', async () => {
+      const command = new EnvPull(['development'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      // Find the call that writes to .env.local (not the file variable)
+      const writeFileCalls = jest.mocked(fs.writeFile).mock.calls;
+      const envFileCall = writeFileCalls.find(call => call[0] === testTargetPath);
+      expect(envFileCall).toBeDefined();
+      const fileContent = envFileCall![1] as string;
+
+      // Check that the file contains the expected content
+      expect(fileContent).toContain('# Environment: development');
+      expect(fileContent).toContain('EXPO_PUBLIC_API_URL=https://api.example.com');
+      expect(fileContent).toContain('DATABASE_URL=postgres://localhost:5432/mydb');
+      expect(fileContent).toContain('# SECRET_KEY=***** (secret)');
+    });
+
+    it('handles file variables correctly', async () => {
+      const command = new EnvPull(['development'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      // Should create .eas/.env directory for file variables
+      expect(fs.mkdir).toHaveBeenCalledWith(
+        path.join(testProjectDir, '.eas', '.env'),
+        { recursive: true }
+      );
+
+      // Should write the file content (base64 encoded)
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        path.join(testProjectDir, '.eas', '.env', 'CONFIG_FILE'),
+        Buffer.from('{"key": "value"}').toString('base64'),
+        'base64'
+      );
+
+      // Should include file path in env file
+      const writeFileCalls = jest.mocked(fs.writeFile).mock.calls;
+      const envFileCall = writeFileCalls.find(call => call[0] === testTargetPath);
+      expect(envFileCall).toBeDefined();
+      const fileContent = envFileCall![1] as string;
+      expect(fileContent).toContain('CONFIG_FILE=');
+      expect(fileContent).toContain(path.join(testProjectDir, '.eas', '.env', 'CONFIG_FILE'));
+    });
+
+    it('prompts for overwrite when file exists in interactive mode', async () => {
+      jest.mocked(fs.exists).mockImplementation(() => Promise.resolve(true));
+      jest.mocked(confirmAsync).mockResolvedValue(true);
+
+      const command = new EnvPull(['development'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      expect(confirmAsync).toHaveBeenCalledWith({
+        message: `File ${testTargetPath} already exists. Do you want to overwrite it?`,
+      });
+    });
+
+    it('aborts when user declines overwrite', async () => {
+      jest.mocked(fs.exists).mockImplementation(() => Promise.resolve(true));
+      jest.mocked(confirmAsync).mockResolvedValue(false);
+
+      const command = new EnvPull(['development'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await expect(command.runAsync()).rejects.toThrow(
+        `File ${testTargetPath} already exists.`
+      );
+    });
+  });
+
+  describe('non-interactive mode', () => {
+    it('works in non-interactive mode', async () => {
+      const command = new EnvPull(['development', '--non-interactive'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      expect(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync).toHaveBeenCalledWith(
+        graphqlClient,
+        {
+          appId: testProjectId,
+          environment: 'development',
+          includeFileContent: true,
+        }
+      );
+    });
+
+    it('requires environment in non-interactive mode', async () => {
+      const command = new EnvPull(['--non-interactive'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await expect(command.runAsync()).rejects.toThrow(
+        'The `--environment` flag must be set when running in `--non-interactive` mode.'
+      );
+    });
+  });
+
+  describe('custom target path', () => {
+    it('writes to custom path when specified', async () => {
+      const customPath = '.env.custom';
+      const command = new EnvPull(['development', '--path', customPath], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        customPath,
+        expect.stringContaining('# Environment: development')
+      );
+    });
+  });
+
+  describe('logging', () => {
+    it('logs success message with correct environment', async () => {
+      const command = new EnvPull(['development'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      expect(Log.log).toHaveBeenCalledWith(
+        `Pulled plain text and sensitive environment variables from "development" environment to ${testTargetPath}.`
+      );
+    });
+
+    it('logs secret variables that were skipped', async () => {
+      const command = new EnvPull(['development'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      expect(Log.log).toHaveBeenCalledWith(
+        expect.stringContaining('The following variables have the secret visibility')
+      );
+      expect(Log.log).toHaveBeenCalledWith(
+        expect.stringContaining('SECRET_KEY')
+      );
+    });
+  });
+
+  describe('existing .env.local file handling', () => {
+    it('preserves existing secret values when they exist', async () => {
+      const existingEnvContent = 'SECRET_KEY=existing-secret-value\nOTHER_VAR=other-value';
+      jest.mocked(fs.exists).mockImplementation(() => Promise.resolve(true));
+      jest.mocked(fs.readFile).mockImplementation(() => Promise.resolve(existingEnvContent));
+      jest.mocked(confirmAsync).mockResolvedValue(true);
+
+      const command = new EnvPull(['development'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      // Find the call that writes to .env.local (not the file variable)
+      const writeFileCalls = jest.mocked(fs.writeFile).mock.calls;
+      const envFileCall = writeFileCalls.find(call => call[0] === testTargetPath);
+      expect(envFileCall).toBeDefined();
+      const fileContent = envFileCall![1] as string;
+
+      // Should use existing secret value instead of placeholder
+      expect(fileContent).toContain('SECRET_KEY=existing-secret-value');
+      expect(fileContent).not.toContain('# SECRET_KEY=***** (secret)');
+
+      // Should log that it reused the local value
+      expect(Log.log).toHaveBeenCalledWith(
+        expect.stringContaining('Reused local values for following secrets: SECRET_KEY')
+      );
+    });
+  });
+});

--- a/packages/eas-cli/src/commands/env/__tests__/EnvPush.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvPush.test.ts
@@ -1,0 +1,83 @@
+import { Config } from '@oclif/core';
+import * as fs from 'fs-extra';
+
+import { EnvironmentVariableEnvironment } from '../../../build/utils/environment';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../credentials/__tests__/fixtures-constants';
+import {
+  EnvironmentSecretType,
+  EnvironmentVariableScope,
+  EnvironmentVariableVisibility,
+} from '../../../graphql/generated';
+import { EnvironmentVariableMutation } from '../../../graphql/mutations/EnvironmentVariableMutation';
+import { EnvironmentVariablesQuery } from '../../../graphql/queries/EnvironmentVariablesQuery';
+import Log from '../../../log';
+import EnvPush from '../push';
+
+jest.mock('../../../graphql/mutations/EnvironmentVariableMutation');
+jest.mock('../../../graphql/queries/EnvironmentVariablesQuery');
+jest.mock('fs-extra');
+jest.mock('../../../log');
+
+describe(EnvPush, () => {
+  const graphqlClient = {} as any as ExpoGraphqlClient;
+  const mockConfig = {} as unknown as Config;
+  const testProjectDir = '/test/project';
+  const testEnvPath = '.env.test';
+
+  const mockEnvContent = `EXPO_PUBLIC_API_URL=https://api.example.com
+DATABASE_URL=postgres://localhost:5432/mydb
+SECRET_KEY=super-secret-key`;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+    
+    // Mock fs-extra methods
+    jest.mocked(fs.exists).mockImplementation(() => Promise.resolve(true));
+    jest.mocked(fs.readFile).mockImplementation(() => Promise.resolve(mockEnvContent));
+    
+    // Mock GraphQL queries and mutations
+    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValue([]); // No existing variables
+    jest.mocked(EnvironmentVariableMutation.createForAppAsync).mockResolvedValue({
+      id: 'var1',
+      name: 'EXPO_PUBLIC_API_URL',
+      value: 'https://api.example.com',
+      environments: [EnvironmentVariableEnvironment.Development],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
+      type: EnvironmentSecretType.String,
+    });
+  });
+
+  it('accepts development environment when using positional argument', async () => {
+    const command = new EnvPush(['development', '--path', testEnvPath], mockConfig);
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+      projectDir: testProjectDir,
+    });
+
+    // The command should run without throwing an environment validation error
+    await expect(command.runAsync()).resolves.not.toThrow();
+  });
+
+  it('rejects invalid environment when using positional argument', async () => {
+    const command = new EnvPush(['invalid', '--path', testEnvPath], mockConfig);
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+      projectDir: testProjectDir,
+    });
+
+    await expect(command.runAsync()).rejects.toThrow(
+      "Invalid environment. Use one of 'production', 'preview', or 'development'."
+    );
+  });
+});

--- a/packages/eas-cli/src/commands/env/__tests__/EnvPush.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvPush.test.ts
@@ -53,6 +53,8 @@ SECRET_KEY=super-secret-key`;
   });
 
   it('accepts development environment when using positional argument', async () => {
+    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValueOnce([]);
+
     const command = new EnvPush(['development', '--path', testEnvPath], mockConfig);
 
     // @ts-expect-error
@@ -62,8 +64,13 @@ SECRET_KEY=super-secret-key`;
       projectDir: testProjectDir,
     });
 
-    // The command should run without throwing an environment validation error
-    await expect(command.runAsync()).resolves.not.toThrow();
+    await command.runAsync();
+
+    expect(EnvironmentVariablesQuery.byAppIdAsync).toHaveBeenCalledWith(graphqlClient, {
+      appId: testProjectId,
+      environment: EnvironmentVariableEnvironment.Development,
+      filterNames: ['EXPO_PUBLIC_API_URL', 'DATABASE_URL', 'SECRET_KEY'],
+    });
   });
 
   it('rejects invalid environment when using positional argument', async () => {

--- a/packages/eas-cli/src/commands/env/__tests__/EnvUpdate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvUpdate.test.ts
@@ -6,6 +6,7 @@ import { EnvironmentVariableEnvironment } from '../../../build/utils/environment
 import {
   EnvironmentVariableScope,
   EnvironmentVariableVisibility,
+  EnvironmentSecretType,
 } from '../../../graphql/generated';
 import { EnvironmentVariableMutation } from '../../../graphql/mutations/EnvironmentVariableMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
@@ -161,5 +162,51 @@ describe(EnvUpdate, () => {
     await expect(command.runAsync()).rejects.toThrow(
       'Variable with name NON_EXISTENT_VARIABLE  does not exist on project @testuser/testpp.'
     );
+  });
+
+  it('accepts development environment when using positional argument', async () => {
+    const mockVariable = {
+      id: 'var1',
+      name: 'TEST_VAR_1',
+      value: 'value1',
+      environments: [EnvironmentVariableEnvironment.Development],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
+      type: EnvironmentSecretType.String,
+    };
+
+    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValueOnce([mockVariable]);
+    jest.mocked(EnvironmentVariableMutation.updateAsync).mockResolvedValueOnce(mockVariable);
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+
+    const command = new EnvUpdate(
+      [
+        'development',
+        '--variable-name',
+        'TEST_VAR_1',
+        '--value',
+        'new-value',
+        '--scope',
+        'project',
+        '--non-interactive',
+      ],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: projectId,
+    });
+
+    await command.runAsync();
+
+    expect(EnvironmentVariablesQuery.byAppIdAsync).toHaveBeenCalledWith(graphqlClient, {
+      appId: projectId,
+      environment: EnvironmentVariableEnvironment.Development,
+      filterNames: ['TEST_VAR_1'],
+    });
   });
 });


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Follow-up to https://github.com/expo/eas-cli/pull/3216

Add tests that would have caught this issue.

We did have tests that seemed on the surface like they would have caught this validation error in some commands, e.g. in `env:create`, but the validation logic was only triggered when passing the environment as a positional argument and there was no test for it (so `eas env:create --environment development` had a test, but `eas env:create development` did not - the latter fails).

# How

- [x] add tests for `env:pull`
- [x] add tests for `env:push`
- [x] in all env commands, add a test for the positional argument

# Test Plan

Tests pass 🎉 
