### PR TITLE
[eas-cli] Add tests for eas env:push --force

### DIFF
--- a/packages/eas-cli/src/commands/env/__tests__/EnvPush.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvPush.test.ts
@@ -12,12 +12,14 @@ import {
 import { EnvironmentVariableMutation } from '../../../graphql/mutations/EnvironmentVariableMutation';
 import { EnvironmentVariablesQuery } from '../../../graphql/queries/EnvironmentVariablesQuery';
 import Log from '../../../log';
+import { confirmAsync } from '../../../prompts';
 import EnvPush from '../push';
 
 jest.mock('../../../graphql/mutations/EnvironmentVariableMutation');
 jest.mock('../../../graphql/queries/EnvironmentVariablesQuery');
 jest.mock('fs-extra');
 jest.mock('../../../log');
+jest.mock('../../../prompts');
 
 describe(EnvPush, () => {
   const graphqlClient = {} as any as ExpoGraphqlClient;
@@ -26,12 +28,14 @@ describe(EnvPush, () => {
   const testEnvPath = '.env.test';
 
   const mockEnvContent = `EXPO_PUBLIC_API_URL=https://api.example.com
-DATABASE_URL=postgres://localhost:5432/mydb
+VARIABLE_NAME=variable value
 SECRET_KEY=super-secret-key`;
 
   beforeEach(() => {
     jest.resetAllMocks();
     jest.spyOn(Log, 'log').mockImplementation(() => {});
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    jest.spyOn(Log, 'error').mockImplementation(() => {});
 
     // Mock fs-extra methods
     jest.mocked(fs.exists).mockImplementation(() => Promise.resolve(true));
@@ -39,17 +43,10 @@ SECRET_KEY=super-secret-key`;
 
     // Mock GraphQL queries and mutations
     jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValue([]); // No existing variables
-    jest.mocked(EnvironmentVariableMutation.createForAppAsync).mockResolvedValue({
-      id: 'var1',
-      name: 'EXPO_PUBLIC_API_URL',
-      value: 'https://api.example.com',
-      environments: [EnvironmentVariableEnvironment.Development],
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      scope: EnvironmentVariableScope.Project,
-      visibility: EnvironmentVariableVisibility.Public,
-      type: EnvironmentSecretType.String,
-    });
+    jest
+      .mocked(EnvironmentVariableMutation.createBulkEnvironmentVariablesForAppAsync)
+      .mockResolvedValue(true);
+    jest.mocked(confirmAsync).mockResolvedValue(true);
   });
 
   it('accepts development environment when using positional argument', async () => {
@@ -69,7 +66,7 @@ SECRET_KEY=super-secret-key`;
     expect(EnvironmentVariablesQuery.byAppIdAsync).toHaveBeenCalledWith(graphqlClient, {
       appId: testProjectId,
       environment: EnvironmentVariableEnvironment.Development,
-      filterNames: ['EXPO_PUBLIC_API_URL', 'DATABASE_URL', 'SECRET_KEY'],
+      filterNames: ['EXPO_PUBLIC_API_URL', 'VARIABLE_NAME', 'SECRET_KEY'],
     });
   });
 
@@ -86,5 +83,193 @@ SECRET_KEY=super-secret-key`;
     await expect(command.runAsync()).rejects.toThrow(
       "Invalid environment. Use one of 'production', 'preview', or 'development'."
     );
+  });
+
+  describe('--force option', () => {
+    it('automatically overrides existing variables without confirmation when --force is used', async () => {
+      const existingVariable = {
+        id: 'var1',
+        name: 'VARIABLE_NAME',
+        value: 'old variable value',
+        environments: [EnvironmentVariableEnvironment.Development],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        scope: EnvironmentVariableScope.Project,
+        visibility: EnvironmentVariableVisibility.Sensitive,
+        type: EnvironmentSecretType.String,
+      };
+
+      jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValue([existingVariable]);
+
+      const command = new EnvPush(['development', '--path', testEnvPath, '--force'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      // Should not call confirmAsync for existing variables
+      expect(confirmAsync).not.toHaveBeenCalled();
+
+      // Should log that force flag is being used
+      expect(Log.log).toHaveBeenCalledWith(
+        'Using --force flag: automatically overriding existing variables.'
+      );
+
+      // Should call the mutation with overwrite flag
+      expect(
+        EnvironmentVariableMutation.createBulkEnvironmentVariablesForAppAsync
+      ).toHaveBeenCalledWith(
+        graphqlClient,
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'VARIABLE_NAME',
+            value: 'variable value',
+            environments: [EnvironmentVariableEnvironment.Development],
+            overwrite: true,
+          }),
+        ]),
+        testProjectId
+      );
+    });
+
+    it('automatically overrides sensitive variables without confirmation when --force is used', async () => {
+      const existingSensitiveVariable = {
+        id: 'var1',
+        name: 'SECRET_KEY',
+        value: 'old-secret-key',
+        environments: [EnvironmentVariableEnvironment.Development],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        scope: EnvironmentVariableScope.Project,
+        visibility: EnvironmentVariableVisibility.Sensitive,
+        type: EnvironmentSecretType.String,
+      };
+
+      jest
+        .mocked(EnvironmentVariablesQuery.byAppIdAsync)
+        .mockResolvedValue([existingSensitiveVariable]);
+
+      const command = new EnvPush(['development', '--path', testEnvPath, '--force'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      // Should not call confirmAsync for sensitive variables
+      expect(confirmAsync).not.toHaveBeenCalled();
+
+      // Should log that force flag is being used for sensitive variables
+      expect(Log.log).toHaveBeenCalledWith(
+        'Using --force flag: automatically overriding sensitive variables.'
+      );
+
+      // Should call the mutation with overwrite flag
+      expect(
+        EnvironmentVariableMutation.createBulkEnvironmentVariablesForAppAsync
+      ).toHaveBeenCalledWith(
+        graphqlClient,
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'SECRET_KEY',
+            value: 'super-secret-key',
+            environments: [EnvironmentVariableEnvironment.Development],
+            overwrite: true,
+          }),
+        ]),
+        testProjectId
+      );
+    });
+
+    it('logs appropriate messages when using --force flag', async () => {
+      const existingVariable = {
+        id: 'var1',
+        name: 'VARIABLE_NAME',
+        value: 'old variable value',
+        environments: [EnvironmentVariableEnvironment.Development],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        scope: EnvironmentVariableScope.Project,
+        visibility: EnvironmentVariableVisibility.Sensitive,
+        type: EnvironmentSecretType.String,
+      };
+
+      jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValue([existingVariable]);
+
+      const command = new EnvPush(['development', '--path', testEnvPath, '--force'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      // Should log both force messages
+      expect(Log.log).toHaveBeenCalledWith(
+        'Using --force flag: automatically overriding existing variables.'
+      );
+      expect(Log.log).toHaveBeenCalledWith(
+        'Using --force flag: automatically overriding sensitive variables.'
+      );
+    });
+
+    it('still prompts for confirmation when --force is not used', async () => {
+      const existingVariable = {
+        id: 'var1',
+        name: 'VARIABLE_NAME',
+        value: 'old variable value',
+        environments: [EnvironmentVariableEnvironment.Development],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        scope: EnvironmentVariableScope.Project,
+        visibility: EnvironmentVariableVisibility.Sensitive,
+        type: EnvironmentSecretType.String,
+      };
+
+      jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValue([existingVariable]);
+      jest.mocked(confirmAsync).mockResolvedValue(true);
+
+      const command = new EnvPush(['development', '--path', testEnvPath], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      // Should call confirmAsync for both existing variables and sensitive variables
+      expect(confirmAsync).toHaveBeenCalledTimes(2);
+      expect(confirmAsync).toHaveBeenCalledWith({
+        message:
+          'The VARIABLE_NAME environment variable already exists in development environment. Do you want to override it?',
+      });
+      expect(confirmAsync).toHaveBeenCalledWith({
+        message:
+          'You are about to overwrite sensitive variables.\n- VARIABLE_NAME\n Do you want to continue?',
+      });
+
+      // Should not log force messages
+      expect(Log.log).not.toHaveBeenCalledWith(
+        'Using --force flag: automatically overriding existing variables.'
+      );
+      expect(Log.log).not.toHaveBeenCalledWith(
+        'Using --force flag: automatically overriding sensitive variables.'
+      );
+    });
   });
 });


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We introduced a new `--force` option to `eas env:push`.

# How

Add tests to cover new logic in https://github.com/expo/eas-cli/pull/3135

# Test Plan

Tests pass 🎉 
