### PR TITLE
[eas-cli] Create portable project archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Create portable project archives on all platforms to normalize cross-platform tar metadata and permissions. ([#3234](https://github.com/expo/eas-cli/pull/3234) by [@sjchmiela](https://github.com/sjchmiela))
 - [eas-cli] Remove hardcoded `builderEnvironment.image` override in `eas build:resign`. ([#3661](https://github.com/expo/eas-cli/pull/3661) by [@hSATAC](https://github.com/hSATAC))
 - [eas-cli] Fix `eas update --json` intermittently failing with JSON parse errors during "Computing project fingerprints" by passing `silent: true` to `@expo/fingerprint` to suppress subprocess stdout pollution. ([#3659](https://github.com/expo/eas-cli/pull/3659) by [@Mookiies](https://github.com/Mookiies))
 

--- a/packages/eas-cli/src/build/utils/__tests__/repository.test.ts
+++ b/packages/eas-cli/src/build/utils/__tests__/repository.test.ts
@@ -1,0 +1,75 @@
+import fs from 'fs-extra';
+import path from 'path';
+import * as tar from 'tar';
+
+import { Client } from '../../../vcs/vcs';
+import { makeProjectTarballAsync } from '../repository';
+
+jest.mock('../../../ora', () => ({
+  ora: jest.fn(() => ({
+    fail: jest.fn(),
+    isSpinning: false,
+    start: jest.fn(),
+    succeed: jest.fn(),
+  })),
+}));
+
+class FakeVcsClient extends Client {
+  public async makeShallowCopyAsync(destinationPath: string): Promise<void> {
+    await fs.mkdirp(path.join(destinationPath, 'bin'));
+    await fs.mkdirp(path.join(destinationPath, 'read-only-dir'));
+
+    await fs.writeFile(path.join(destinationPath, 'bin', 'postcheckout.sh'), '#!/bin/sh\necho hi\n');
+    await fs.writeFile(path.join(destinationPath, 'regular-file.txt'), 'regular file\n');
+    await fs.writeFile(path.join(destinationPath, 'read-only-dir', 'child.txt'), 'child file\n');
+
+    await fs.chmod(path.join(destinationPath, 'bin', 'postcheckout.sh'), 0o755);
+    await fs.chmod(path.join(destinationPath, 'regular-file.txt'), 0o644);
+    await fs.chmod(path.join(destinationPath, 'read-only-dir'), 0o555);
+  }
+
+  public async getRootPathAsync(): Promise<string> {
+    return process.cwd();
+  }
+
+  public canGetLastCommitMessage(): boolean {
+    return false;
+  }
+}
+
+describe(makeProjectTarballAsync, () => {
+  it('creates portable project archives while preserving executable files', async () => {
+    const removeAsync = fs.remove.bind(fs);
+    const removeSpy = jest.spyOn(fs, 'remove').mockImplementation(async targetPath => {
+      await fs.chmod(path.join(targetPath.toString(), 'read-only-dir'), 0o755).catch(() => {});
+      await removeAsync(targetPath);
+    });
+    const projectTarball = await makeProjectTarballAsync(new FakeVcsClient());
+    const entries = new Map<string, tar.ReadEntry>();
+
+    try {
+      await tar.list({
+        file: projectTarball.path,
+        onentry: entry => {
+          entries.set(entry.path, entry);
+        },
+      });
+
+      expect(entries.get('project/bin/postcheckout.sh')?.mode).toBe(0o755);
+      expect(entries.get('project/regular-file.txt')?.mode).toBe(0o644);
+      expect(entries.get('project/read-only-dir/')?.mode).toBe(0o755);
+      expect(entries.has('project/read-only-dir/child.txt')).toBe(true);
+
+      for (const entry of entries.values()) {
+        expect(entry.path.startsWith('project/')).toBe(true);
+        expect(entry.uid).toBeUndefined();
+        expect(entry.gid).toBeUndefined();
+        expect(entry.uname).toBe('');
+        expect(entry.gname).toBe('');
+      }
+    } finally {
+      await fs.remove(projectTarball.path);
+      removeSpy.mockRestore();
+    }
+  });
+});

--- a/packages/eas-cli/src/build/utils/repository.ts
+++ b/packages/eas-cli/src/build/utils/repository.ts
@@ -143,9 +143,16 @@ export async function makeProjectTarballAsync(vcsClient: Client): Promise<LocalF
 
   try {
     await vcsClient.makeShallowCopyAsync(shallowClonePath);
-    await tar.create({ cwd: shallowClonePath, file: tarPath, prefix: 'project', gzip: true }, [
-      '.',
-    ]);
+    await tar.create(
+      {
+        cwd: shallowClonePath,
+        file: tarPath,
+        prefix: 'project',
+        gzip: true,
+        portable: true,
+      },
+      ['.']
+    );
   } catch (err) {
     clearTimeout(timer);
     if (spinner.isSpinning) {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Project archives created on one platform can be extracted on another platform with incompatible metadata or mode bits. In particular, Windows read-only directories can be represented as read-only POSIX directories in the tarball, which can make worker extraction fail when child files need to be created.

Using `portable: true` consistently also strips owner/group metadata and avoids making Windows a special case.

Supersedes the approach in #3489 and avoids changing worker extraction as proposed in #3663.

# How

Create project tarballs with `portable: true` on all platforms.

# Test Plan

- `yarn workspace eas-cli test src/build/utils/__tests__/repository.test.ts`
- `yarn workspace eas-cli typecheck`
- `yarn run -T oxfmt CHANGELOG.md packages/eas-cli/src/build/utils/repository.ts packages/eas-cli/src/build/utils/__tests__/repository.test.ts`