### PR TITLE
Add missing env for local builds with latest plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - workflow:run can use --wait and --json together. ([#3239](https://github.com/expo/eas-cli/pull/3239) by [@douglowder](https://github.com/douglowder))
+- Add missing env for local builds with latest plugin. ([#3237](https://github.com/expo/eas-cli/pull/3237) by [@douglowder](https://github.com/douglowder))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -12,7 +12,7 @@
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "10.0.6",
     "@expo/config-plugins": "9.0.12",
-    "@expo/eas-build-job": "1.0.239",
+    "@expo/eas-build-job": "1.0.243",
     "@expo/eas-json": "16.23.0",
     "@expo/env": "^1.0.0",
     "@expo/json-file": "8.3.3",

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -1,13 +1,14 @@
-import { Job, Metadata } from '@expo/eas-build-job';
+import { Job, Metadata, version } from '@expo/eas-build-job';
 import spawnAsync from '@expo/spawn-async';
 import { ChildProcess } from 'child_process';
 import semver from 'semver';
 
+import { getExpoApiBaseUrl } from '../api';
 import Log from '../log';
 import { ora } from '../ora';
 
 const PLUGIN_PACKAGE_NAME = 'eas-cli-local-build-plugin';
-const PLUGIN_PACKAGE_VERSION = '1.0.171';
+const PLUGIN_PACKAGE_VERSION = version; // should match version of @expo/eas-build-job
 
 export enum LocalBuildMode {
   /**
@@ -60,6 +61,7 @@ export async function runLocalBuildAsync(
       ...env,
       ...process.env,
       EAS_LOCAL_BUILD_WORKINGDIR: options.workingdir ?? process.env.EAS_LOCAL_BUILD_WORKINGDIR,
+      __API_SERVER_URL: getExpoApiBaseUrl(),
       ...(options.skipCleanup || options.skipNativeBuild
         ? { EAS_LOCAL_BUILD_SKIP_CLEANUP: '1' }
         : {}),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,10 +1549,10 @@
     semver "^7.6.2"
     zod "^4.1.3"
 
-"@expo/eas-build-job@1.0.239":
-  version "1.0.239"
-  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-1.0.239.tgz#025afd9c3fb9086cbb053ccbc08b7683aa74bbc4"
-  integrity sha512-5P/dQL2S2iEyTvGKOPN95r7cNFW3HgnA4PNqXU0s5ctb10837sMX6/A5XgIg/Ow0SFGZRiP4cK9ZFAiK3m2Ong==
+"@expo/eas-build-job@1.0.243":
+  version "1.0.243"
+  resolved "https://registry.yarnpkg.com/@expo/eas-build-job/-/eas-build-job-1.0.243.tgz#2b390ca1a84b4a4ea06630cf875b96c0954094ab"
+  integrity sha512-wLU9q0pzIKibr4jLMV/U6BYszk5T85p/WmRYUIqH7nhmy2dDUJHz0WlP/i/ZWAsnrHplwidbCZvZGoxwgJsISA==
   dependencies:
     "@expo/logger" "1.0.221"
     joi "^17.13.1"


### PR DESCRIPTION
# Why

Currently, the CLI is using an old version of `eas-cli-local-build-plugin` for builds with `eas build --local`. This is not ideal, as this means that local builds are not using the most recent `build-tools` and other packages.

# How

- Modify `local.ts` so that the version of the plugin matches the version of `@expo/eas-build-job` used by the CLI
- Add some missing environment variables that are required in the most recent releases of `@expo/build-tools`

# Test Plan

- Testing with local builds on my dev machine
- CI should pass