### PR TITLE
Remove outdated update-local-plugin from release workflow

### DIFF
--- a/scripts/src/release.sh
+++ b/scripts/src/release.sh
@@ -8,7 +8,9 @@ GITHUB_EMAIL=`git config get --global user.email`
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 ROOT_DIR="$( cd "$SCRIPTS_DIR"/.. && pwd )"
 
-$SCRIPTS_DIR/bin/run update-local-plugin
+# Since https://github.com/expo/eas-cli/pull/3237 , the local plugin version is identical
+# to @expo/eas-build-job dependency, so the update-local-plugin step is no longer needed.
+# $SCRIPTS_DIR/bin/run update-local-plugin
 
 next_version_bump=$($SCRIPTS_DIR/bin/run next-version)
 next_version=${1:-$next_version_bump}


### PR DESCRIPTION
# Why

The manual release workflow is broken after #3237, since the local plugin version is no longer hardcoded, but tied to the `@expo/eas-build-job` dependency.

# How

Remove this step from the workflow.

# Test Plan

Workflow should succeed in dry run mode.