### PR TITLE
[eas-cli] fix: When warning about usage overages, the build profile's env was not applied before evaluating config

### DIFF
--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -52,6 +52,7 @@ import {
 import { checkExpoSdkIsSupportedAsync } from '../project/expoSdk';
 import { validateMetroConfigForManagedWorkflowAsync } from '../project/metroConfig';
 import {
+  getOwnerAccountForProjectIdAsync,
   isExpoUpdatesInstalledAsDevDependency,
   isExpoUpdatesInstalledOrAvailable,
   isUsingEASUpdate,
@@ -78,6 +79,7 @@ import { downloadAndMaybeExtractAppAsync } from '../utils/download';
 import { truthy } from '../utils/expodash/filter';
 import { printJsonOnlyOutput } from '../utils/json';
 import { ProfileData, getProfilesAsync } from '../utils/profiles';
+import { maybeWarnAboutUsageOveragesAsync } from '../utils/usage/checkForOverages';
 import { Client } from '../vcs/vcs';
 
 let metroConfigValidated = false;
@@ -408,6 +410,14 @@ async function prepareAndStartBuildAsync({
     whatToTest: flags.whatToTest,
     env,
   });
+
+  if (flags.localBuildOptions.localBuildMode) {
+    const account = await getOwnerAccountForProjectIdAsync(graphqlClient, buildCtx.projectId);
+    await maybeWarnAboutUsageOveragesAsync({
+      graphqlClient,
+      accountId: account.id,
+    });
+  }
 
   if (moreBuilds) {
     Log.newLine();

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -14,13 +14,11 @@ import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { StatuspageServiceName } from '../../graphql/generated';
 import Log, { link } from '../../log';
 import { RequestedPlatform, selectRequestedPlatformAsync } from '../../platform';
-import { getOwnerAccountForProjectIdAsync } from '../../project/projectUtils';
 import { selectAsync } from '../../prompts';
 import uniq from '../../utils/expodash/uniq';
 import { enableJsonOutput } from '../../utils/json';
 import { ProfileData } from '../../utils/profiles';
 import { maybeWarnAboutEasOutagesAsync } from '../../utils/statuspageService';
-import { maybeWarnAboutUsageOveragesAsync } from '../../utils/usage/checkForOverages';
 
 interface RawBuildFlags {
   platform?: string;
@@ -163,13 +161,6 @@ export default class Build extends EasCommand {
           ? [StatuspageServiceName.EasBuild, StatuspageServiceName.EasSubmit]
           : [StatuspageServiceName.EasBuild]
       );
-
-      const { projectId } = await getDynamicPrivateProjectConfigAsync();
-      const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
-      await maybeWarnAboutUsageOveragesAsync({
-        graphqlClient,
-        accountId: account.id,
-      });
     }
 
     const flagsWithPlatform = await this.ensurePlatformSelectedAsync(flags);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

#3236 was recently merged, adding a check for the EAS account's build usage and issuing a warning before running a build. It introduced a bug: it evaluates the project's config to get the EAS projectId, but it doesn't apply the `env` from the build profile beforehand. All other code that reads the config will first

This created an issue in my CI builds where I am pinned to the latest CLI version. Because my `app.config.ts` depends on certain values being set in the environment (and throws if they aren't): this caused the entire build command to fail. It seems sensible to keep the previous behaviour where `eas build` will always apply `env` from the relevant build profile before evaluating `app.config.ts`.

# How

Move the code that issues the warning to deeper within the runBuildAndSubmitAsync flow, after the build profile has been read, and the `env` from that profile is available and used when evaluating the project config.

# Test Plan

The test added in #3236 is still passing, and this PR removes the problematic behaviour (evaluating the project config without applying env from the build profile).