### PR TITLE
Allow exit from credentials command

### DIFF
--- a/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
+++ b/packages/eas-cli/src/credentials/manager/SelectPlatform.ts
@@ -3,7 +3,7 @@ import { ManageIos } from './ManageIos';
 import { Analytics } from '../../analytics/AnalyticsManager';
 import { DynamicConfigContextFn } from '../../commandUtils/context/DynamicProjectConfigContextField';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
-import { selectPlatformAsync } from '../../platform';
+import { selectPlatformWithExitOptionAsync } from '../../platform';
 import { Actor } from '../../user/User';
 import { Client } from '../../vcs/vcs';
 import { CredentialsContextProjectInfo } from '../context';
@@ -20,7 +20,7 @@ export class SelectPlatform {
   ) {}
 
   async runAsync(): Promise<void> {
-    const platform = await selectPlatformAsync(this.flagPlatform, true /* allowExit */);
+    const platform = await selectPlatformWithExitOptionAsync(this.flagPlatform);
 
     if (platform === 'ios') {
       await new ManageIos(this, process.cwd()).runAsync();

--- a/packages/eas-cli/src/platform.ts
+++ b/packages/eas-cli/src/platform.ts
@@ -48,7 +48,14 @@ export async function selectRequestedPlatformAsync(platform?: string): Promise<R
   return requestedPlatform;
 }
 
-export async function selectPlatformAsync(
+export async function selectPlatformWithExitOptionAsync(platform?: string): Promise<Platform> {
+  return await selectPlatformInternalAsync(platform, true);
+}
+export async function selectPlatformAsync(platform?: string): Promise<Platform> {
+  return await selectPlatformInternalAsync(platform, false);
+}
+
+async function selectPlatformInternalAsync(
   platform?: string,
   allowExit?: boolean
 ): Promise<Platform> {
@@ -69,11 +76,7 @@ export async function selectPlatformAsync(
     type: 'select',
     message: 'Select platform',
     name: 'resolvedPlatform',
-    choices: [
-      { title: 'Android', value: Platform.ANDROID },
-      { title: 'iOS', value: Platform.IOS },
-      { title: 'Exit', value: 'Exit' },
-    ],
+    choices: platformChoices,
   });
   if (result.resolvedPlatform === 'Exit') {
     Log.addNewLineIfNone();


### PR DESCRIPTION
# Why

The command `eas credentials` does not provide a way to exit other than control-C, if no platform flag is passed in.

# How

Add an "Exit" choice to the platform prompt.

# Test Plan

Tested locally.