### PR TITLE
refactor(eas-cli): Remove `npx expo` invocations and config/entitlements fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Prevent `npx` invocations that can be unreliable and fail when retrieving entitlements or project configs ([#3282](https://github.com/expo/eas-cli/pull/3282) by [@kitten](https://github.com/kitten))
+
 ### 🧹 Chores
 
 ## [18.13.0](https://github.com/expo/eas-cli/releases/tag/v18.13.0) - 2026-05-14

--- a/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
+++ b/packages/eas-cli/src/commandUtils/context/contextUtils/__tests__/getProjectIdAsync-test.ts
@@ -74,7 +74,10 @@ describe(getProjectIdAsync, () => {
     );
 
     jest.mocked(findProjectRootAsync).mockResolvedValue('/app');
-    jest.mocked(isExpoInstalled).mockReturnValue(true);
+
+    // NOTE(@kitten): Updating this test is easiest by letting it fallback to `@expo/config`
+    // This isn't a great solution, but the test is pretty involved
+    jest.mocked(isExpoInstalled).mockReturnValue(false);
   });
 
   it('gets the project ID from app config if exists', async () => {

--- a/packages/eas-cli/src/commandUtils/new/__tests__/commands.test.ts
+++ b/packages/eas-cli/src/commandUtils/new/__tests__/commands.test.ts
@@ -1,12 +1,14 @@
 import { canAccessRepositoryUsingSshAsync, runGitCloneAsync } from '../../../onboarding/git';
 import { installDependenciesAsync } from '../../../onboarding/installDependencies';
 import { runCommandAsync } from '../../../onboarding/runCommand';
+import { expoCommandAsync } from '../../../utils/expoCli';
 import {
   cloneTemplateAsync,
   initializeGitRepositoryAsync,
   installProjectDependenciesAsync,
 } from '../commands';
 
+jest.mock('../../../utils/expoCli');
 jest.mock('../../../onboarding/git');
 jest.mock('../../../onboarding/runCommand');
 jest.mock('../../../onboarding/installDependencies');
@@ -79,21 +81,11 @@ describe('commands', () => {
         packageManager: 'npm',
       });
 
-      expect(runCommandAsync).toHaveBeenCalledWith({
-        cwd: projectDir,
-        command: 'npx',
-        args: ['expo', 'install', 'expo-updates'],
-        showOutput: false,
-        showSpinner: false,
-      });
-
-      expect(runCommandAsync).toHaveBeenCalledWith({
-        cwd: projectDir,
-        command: 'npx',
-        args: ['expo', 'install', '@expo/metro-runtime'],
-        showOutput: false,
-        showSpinner: false,
-      });
+      expect(expoCommandAsync).toHaveBeenCalledWith(
+        projectDir,
+        ['install', 'expo-updates', '@expo/metro-runtime'],
+        { silent: true }
+      );
     });
   });
 

--- a/packages/eas-cli/src/commandUtils/new/commands.ts
+++ b/packages/eas-cli/src/commandUtils/new/commands.ts
@@ -7,6 +7,7 @@ import { canAccessRepositoryUsingSshAsync, runGitCloneAsync } from '../../onboar
 import { PackageManager, installDependenciesAsync } from '../../onboarding/installDependencies';
 import { runCommandAsync } from '../../onboarding/runCommand';
 import { ora } from '../../ora';
+import { expoCommandAsync } from '../../utils/expoCli';
 
 export async function cloneTemplateAsync(targetProjectDir: string): Promise<string> {
   const githubUsername = 'expo';
@@ -48,16 +49,8 @@ export async function installProjectDependenciesAsync(
   });
 
   const dependencies = ['expo-updates', '@expo/metro-runtime'];
-  for (const dependency of dependencies) {
-    spinner.text = `Installing ${chalk.bold(dependency)}`;
-    await runCommandAsync({
-      cwd: projectDir,
-      command: 'npx',
-      args: ['expo', 'install', dependency],
-      showOutput: false,
-      showSpinner: false,
-    });
-  }
+  spinner.text = `Installing ${dependencies.map(dep => chalk.bold(dep)).join(', ')}`;
+  await expoCommandAsync(projectDir, ['install', ...dependencies], { silent: true });
   spinner.succeed(`Installed project dependencies`);
 }
 

--- a/packages/eas-cli/src/commands/project/__tests__/init.test.ts
+++ b/packages/eas-cli/src/commands/project/__tests__/init.test.ts
@@ -95,7 +95,10 @@ function mockTestProject(options: {
     graphqlClient,
     authenticationInfo: { accessToken: null, sessionSecret: '1234' },
   });
-  jest.mocked(isExpoInstalled).mockReturnValue(true);
+
+  // NOTE(@kitten): Updating this test is easiest by letting it fallback to `@expo/config`
+  // This isn't a great solution, but the test is pretty involved
+  jest.mocked(isExpoInstalled).mockReturnValue(false);
 }
 
 const commandOptions = getMockOclifConfig({ root: '/test-project' });

--- a/packages/eas-cli/src/commands/project/onboarding.ts
+++ b/packages/eas-cli/src/commands/project/onboarding.ts
@@ -36,6 +36,7 @@ import { ExpoConfigOptions, getPrivateExpoConfigAsync } from '../../project/expo
 import { promptAsync } from '../../prompts';
 import { Actor } from '../../user/User';
 import { easCliVersion } from '../../utils/easCli';
+import { expoCommandAsync } from '../../utils/expoCli';
 import GitClient from '../../vcs/clients/git';
 
 export default class Onboarding extends EasCommand {
@@ -205,23 +206,12 @@ export default class Onboarding extends EasCommand {
     });
 
     if (!app.githubRepository) {
-      await runCommandAsync({
-        cwd: finalTargetProjectDirectory,
-        command: 'npx',
-        args: ['expo', 'install', 'expo-updates'],
-      });
-      Log.log();
-      await runCommandAsync({
-        cwd: finalTargetProjectDirectory,
-        command: 'npx',
-        args: ['expo', 'install', 'expo-insights'],
-      });
-      Log.log();
-      await runCommandAsync({
-        cwd: finalTargetProjectDirectory,
-        command: 'npx',
-        args: ['expo', 'install', 'expo-dev-client'],
-      });
+      await expoCommandAsync(finalTargetProjectDirectory, [
+        'install',
+        'expo-updates',
+        'expo-insights',
+        'expo-dev-client',
+      ]);
       Log.log();
     }
     await vcsClient.trackFileAsync('package-lock.json');

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -1,12 +1,12 @@
 import { ExpoConfig, getConfig, getConfigFilePaths, modifyConfigAsync } from '@expo/config';
 import { Env } from '@expo/eas-build-job';
-import spawnAsync from '@expo/spawn-async';
 import fs from 'fs-extra';
 import Joi from 'joi';
 import path from 'path';
 
 import { isExpoInstalled } from './projectUtils';
 import Log from '../log';
+import { spawnExpoCommand } from '../utils/expoCli';
 
 export type PublicExpoConfig = Omit<
   ExpoConfig,
@@ -57,15 +57,11 @@ async function getExpoConfigInternalAsync(
     let exp: ExpoConfig;
     if (isExpoInstalled(projectDir)) {
       try {
-        const { stdout } = await spawnAsync(
-          'npx',
-          ['expo', 'config', '--json', ...(opts.isPublicConfig ? ['--type', 'public'] : [])],
-
+        const { stdout } = await spawnExpoCommand(
+          projectDir,
+          ['config', '--json', ...(opts.isPublicConfig ? ['--type', 'public'] : [])],
           {
-            cwd: projectDir,
             env: {
-              ...process.env,
-              ...opts.env,
               EXPO_NO_DOTENV: '1',
             },
           }

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -1,9 +1,9 @@
 import { ExportedConfig, IOSConfig, compileModsAsync } from '@expo/config-plugins';
 import { JSONObject } from '@expo/json-file';
 import { getPrebuildConfigAsync } from '@expo/prebuild-config';
-import spawnAsync from '@expo/spawn-async';
 
 import Log from '../../log';
+import { spawnExpoCommand } from '../../utils/expoCli';
 import { readPlistAsync } from '../../utils/plist';
 import { Client } from '../../vcs/vcs';
 import { hasIgnoredIosProjectAsync } from '../workflow';
@@ -30,24 +30,17 @@ export async function getManagedApplicationTargetEntitlementsAsync(
 
     let expWithMods: ExportedConfig;
     try {
-      const { stdout } = await spawnAsync(
-        'npx',
-        ['expo', 'config', '--json', '--type', 'introspect'],
-
-        {
-          cwd: projectDir,
-          env: {
-            ...process.env,
-            ...env,
-            EXPO_NO_DOTENV: '1',
-          },
-        }
-      );
+      const { stdout } = await spawnExpoCommand(projectDir, [
+        'config',
+        '--json',
+        '--type',
+        'introspect',
+      ]);
       expWithMods = JSON.parse(stdout);
     } catch (err: any) {
       if (!wasExpoConfigPluginsWarnPrinted) {
         Log.warn(
-          `Failed to read the app config from the project using "npx expo config" command: ${err.message}.`
+          `Failed to read the app config from the project using "expo config" command: ${err.message}.`
         );
         Log.warn('Falling back to the version of "@expo/config" shipped with the EAS CLI.');
         wasExpoConfigPluginsWarnPrinted = true;

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -60,7 +60,7 @@ export async function resolveManagedProjectTargetsAsync({
   );
   const applicationTargetEntitlements = await getManagedApplicationTargetEntitlementsAsync(
     projectDir,
-    env ?? {},
+    env ?? {}
   );
   const appExtensions: UserDefinedTarget[] =
     exp.extra?.eas?.build?.experimental?.ios?.appExtensions ?? [];

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -61,7 +61,6 @@ export async function resolveManagedProjectTargetsAsync({
   const applicationTargetEntitlements = await getManagedApplicationTargetEntitlementsAsync(
     projectDir,
     env ?? {},
-    vcsClient
   );
   const appExtensions: UserDefinedTarget[] =
     exp.extra?.eas?.build?.experimental?.ios?.appExtensions ?? [];


### PR DESCRIPTION
See: https://exponent-internal.slack.com/archives/C017N0N99RA/p1758469493137929
Resolves: https://github.com/expo/expo/issues/40227

# Why

> [!NOTE]
> There's still a lot of leftover reliance on `@expo/config` (outdated), `@expo/prebuild-config`, and some other internals, which are prone to failing and not being updated. A lot of them don't have replacement code paths that are obvious but stood out to @byCedric when implementing some Launch features and replicating/replacing some logic from `eas-cli`

All invocations of `npx` are prone to failure and unnecessary:
- `npx expo install` is redundant if we can invoke the Expo CLI directly (which forks if needed automatically)
- `npx expo config --json` is unreliable, if npx adds additional output to the standard output. It also can fail if there's a global provider of `expo`, another `expo` in the npm-resolved `PATH`, or for various other reasons
- the same applies to the entitlements call

Additionally, we have a few fallbacks that are invalid. The entitlements fallback doesn't work and replaces the failed `npx expo config` command with obscure output, failing to also print its `Log.warn`s in some cases, which are confusing.

The `@expo/config` fallback has to be left in place currently as there's no prerequisite of `expo` being installed (which there should be) for `getExpoConfigInternalAsync` to be invokable. The check for `isExpoInstalled` is also faulty as it doesn't resolve `expo` but instead checks the `package.json`, but to keep this PR leaner, this isn't addressed here.

The fallbacks are generally for older versions of the SDK which are now unsupported.

# How

- Replace all `npx expo` invocations with a direct `expo` CLI invocation (code already existed for this)
- Remove entitlements and config error fallbacks, which were confusing

# Test Plan

Most of these changes are speculative and untested right now.
