### PR TITLE
[worker] Add step-level metrics reporting

### DIFF
--- a/packages/worker/src/config.ts
+++ b/packages/worker/src/config.ts
@@ -107,4 +107,8 @@ export default {
       : process.env.ENVIRONMENT === 'staging'
         ? 'https://staging-api.expo.dev/v2/'
         : 'https://api.expo.dev/v2/',
+  datadog: {
+    apiKey: env<string | null>('WORKER_DD_API_KEY', { defaultValue: null }),
+    site: env<string | null>('WORKER_DD_SITE', { defaultValue: 'datadoghq.com' }),
+  },
 };


### PR DESCRIPTION
# Why

https://github.com/expo/eas-build/pull/656
Add steps metrics reporting.
 
# How

Initialize step metrics reporter if `WORKER_DD_API_KEY` is set.

Still need to update the eas-build package version after package released.

# Test Plan

Tested locally.
