### PR TITLE
[worker] Build worker in production

### DIFF
--- a/.github/workflows/build-and-deploy-worker.yml
+++ b/.github/workflows/build-and-deploy-worker.yml
@@ -92,8 +92,7 @@ jobs:
         id: eas_workflow
         working-directory: packages/worker
         env:
-          EXPO_TOKEN: ${{ secrets.STAGING_EXPO_DEV_EXPO_SERVICES_GITHUB_ROBOT_ACCESS_TOKEN }}
-          EXPO_STAGING: "1"
+          EXPO_TOKEN: ${{ secrets.EXPO_DEV_EXPO_GITHUB_ROBOT_ACCESS_TOKEN }}
         run: |
           # Run workflow and capture output (includes full workflow run with jobs and artifacts)
           WORKFLOW_OUTPUT=$(npx -y eas-cli@latest workflow:run build-worker.yml \

--- a/packages/worker/app.json
+++ b/packages/worker/app.json
@@ -1,11 +1,11 @@
 {
   "expo": {
-    "name": "worker",
-    "slug": "worker-build",
+    "name": "EAS Worker",
+    "slug": "eas-worker",
     "platforms": ["ios"],
     "extra": {
       "eas": {
-        "projectId": "be34d6b1-4242-4cf5-8464-3fdec53ad91c"
+        "projectId": "90798684-1384-4ce4-a73b-9f3fa3e3e368"
       }
     }
   }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Gives us more concurrencies for building worker (which is not a huge problem, but may be nice). Also, IF we botched worker staging, we won't break the whole pipeline (system tests won't let worker deploy to production so worker in production will still work and let us rebuild worker).

# How

Changed app ID and token to expo.dev ones.

# Test Plan

CI ran ok.