### PR TITLE
[worker] Build and use single tarball

### DIFF
--- a/.github/workflows/build-and-deploy-worker.yml
+++ b/.github/workflows/build-and-deploy-worker.yml
@@ -45,7 +45,7 @@ jobs:
 
           echo "worker_exists=true" >> "$GITHUB_OUTPUT"
 
-  build-workers:
+  build:
     runs-on: ubuntu-latest
     needs:
       - setup
@@ -57,7 +57,7 @@ jobs:
 
       - uses: volta-cli/action@5c175f92dea6f48441c436471e6479dbc192e194 # v4
 
-      - name: Start EAS Workflow to build worker tarballs
+      - name: Start EAS Workflow to build worker tarball
         id: eas_workflow
         working-directory: packages/worker
         env:
@@ -134,37 +134,22 @@ jobs:
 
           # Extract artifact download URLs from workflow output
           # Artifacts are in jobs[].artifacts[] for custom jobs
-          DOWNLOAD_IOS_URL=$(echo "$VIEW_OUTPUT" | jq -r '
+          DOWNLOAD_URL=$(echo "$VIEW_OUTPUT" | jq -r '
             .jobs[]
             | .artifacts[]?
-            | select(.name == "worker-ios-tarball")
+            | select(.name == "worker-tarball")
             | .downloadUrl
           ' | head -1)
 
-          DOWNLOAD_ANDROID_URL=$(echo "$VIEW_OUTPUT" | jq -r '
-            .jobs[]
-            | .artifacts[]?
-            | select(.name == "worker-android-tarball")
-            | .downloadUrl
-          ' | head -1)
-
-          if [ -z "$DOWNLOAD_IOS_URL" ] || [ "$DOWNLOAD_IOS_URL" = "null" ]; then
-            echo "Error: Could not find iOS artifact download URL"
-            echo "$VIEW_OUTPUT" | jq .
-            exit 1
-          fi
-
-          if [ -z "$DOWNLOAD_ANDROID_URL" ] || [ "$DOWNLOAD_ANDROID_URL" = "null" ]; then
-            echo "Error: Could not find Android artifact download URL"
+          if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
+            echo "Error: Could not find artifact download URL"
             echo "$VIEW_OUTPUT" | jq .
             exit 1
           fi
 
           # Mask the download URLs
-          echo "::add-mask::$DOWNLOAD_IOS_URL"
-          echo "::add-mask::$DOWNLOAD_ANDROID_URL"
-          echo "download_ios_url=$DOWNLOAD_IOS_URL" >> "$GITHUB_OUTPUT"
-          echo "download_android_url=$DOWNLOAD_ANDROID_URL" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::$DOWNLOAD_URL"
+          echo "download_url=$DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
 
       - name: Cancel EAS workflow on GitHub cancellation
         if: cancelled()
@@ -184,16 +169,14 @@ jobs:
       - name: Upload worker tarballs to GCP
         if: github.ref == 'refs/heads/main' || inputs.environment != ''
         run: |
-          IOS_GCP_TARBALL="worker-ios-sha1-$GITHUB_SHA.tar.gz"
-          ANDROID_GCP_TARBALL="worker-android-sha1-$GITHUB_SHA.tar.gz"
-          curl -L "${{ steps.eas_artifacts.outputs.download_ios_url }}" | gsutil cp - gs://eas-build-worker-tarballs/$IOS_GCP_TARBALL
-          curl -L "${{ steps.eas_artifacts.outputs.download_android_url }}" | gsutil cp - gs://eas-build-worker-tarballs/$ANDROID_GCP_TARBALL
+          GCP_TARBALL="worker-sha1-$GITHUB_SHA.tar.gz"
+          curl -L "${{ steps.eas_artifacts.outputs.download_url }}" | gsutil cp - gs://eas-build-worker-tarballs/$GCP_TARBALL
 
   deploy:
     runs-on: ubuntu-latest
     needs:
       - setup
-      - build-workers
+      - build
     if: (!failure() && !cancelled() && inputs.environment != '')
     permissions:
       id-token: write
@@ -205,8 +188,8 @@ jobs:
       - name: Promote worker to ${{ inputs.environment }}
         run: |
           for platform in android ios; do
-            GCP_TARBALL="worker-$platform-sha1-$GITHUB_SHA.tar.gz"
-            WORKER_STAGING_TARBALL="worker-$platform-${{ inputs.environment }}.tar.gz"
+            GCP_TARBALL="worker-sha1-$GITHUB_SHA.tar.gz"
+            WORKER_ENVIRONMENT_TARBALL="worker-$platform-${{ inputs.environment }}.tar.gz"
 
-            gsutil cp gs://eas-build-worker-tarballs/$GCP_TARBALL gs://eas-build-worker-tarballs/$WORKER_STAGING_TARBALL
+            gsutil cp gs://eas-build-worker-tarballs/$GCP_TARBALL gs://eas-build-worker-tarballs/$WORKER_ENVIRONMENT_TARBALL
           done

--- a/packages/worker/.eas/workflows/build-worker.yml
+++ b/packages/worker/.eas/workflows/build-worker.yml
@@ -1,30 +1,19 @@
-name: Build Worker
-
 on:
   workflow_dispatch: {}
 
 jobs:
-  build_worker_tarballs:
-    name: Build Worker Tarballs
+  build_worker_tarball:
+    name: Build and Upload
     runs_on: macos-medium
     image: latest
     steps:
       - uses: eas/checkout
 
-      - name: Build iOS worker tarball
-        run: ./package.sh worker-ios.tar.gz ios
+      - name: Build worker tarball
+        run: ./package.sh worker.tar.gz
 
-      - name: Build Android worker tarball
-        run: ./package.sh worker-android.tar.gz android
-
-      - name: Upload iOS worker tarball as artifact
+      - name: Upload worker tarball as artifact
         uses: eas/upload_artifact
         with:
-          name: worker-ios-tarball
-          path: packages/worker/worker-ios.tar.gz
-
-      - name: Upload Android worker tarball as artifact
-        uses: eas/upload_artifact
-        with:
-          name: worker-android-tarball
-          path: packages/worker/worker-android.tar.gz
+          name: worker-tarball
+          path: packages/worker/worker.tar.gz

--- a/packages/worker/package.sh
+++ b/packages/worker/package.sh
@@ -7,12 +7,11 @@ ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../.. && pwd )"
 WORKER_DIR=$( dirname "${BASH_SOURCE[0]}" )
 
 OUTPUT_FILE=$1
-PLATFORM=$2
 
-if [[ -z "$OUTPUT_FILE" || -z "$PLATFORM" ]]; then
-  echo "Please specify the output file and target platform (.tar.gz)"
-  echo "Usage: ./package.sh OUTPUT_FILE (ios|android)"
-  echo "Example: ./package.sh worker.tar.gz ios"
+if [[ -z "$OUTPUT_FILE" ]]; then
+  echo "Please specify the output file (.tar.gz)"
+  echo "Usage: ./package.sh OUTPUT_FILE"
+  echo "Example: ./package.sh worker.tar.gz"
   exit -1
 fi
 
@@ -51,20 +50,19 @@ yarn install --silent --production=true
 rm -rf tsconfig.json tsconfig.build.json
 popd >/dev/null 2>&1
 
-if [[ "$PLATFORM" == "ios" ]]; then
-  # build plugin
-  pushd "$ROOT_DIR/packages/expo-cocoapods-proxy" >/dev/null 2>&1
-  if command -v brew &> /dev/null; then
-    eval "$(brew shellenv)"
-  else
-    echo "Error: brew command not found in PATH. Please ensure Homebrew is installed and in your PATH." >&2
-    exit 1
-  fi
-  bundle install
-  gem build expo-cocoapods-proxy.gemspec
-  mv expo-cocoapods-proxy-*.gem "$target_worker_dir/expo-cocoapods-proxy.gem"
-  popd >/dev/null 2>&1
+# build plugin
+pushd "$ROOT_DIR/packages/expo-cocoapods-proxy" >/dev/null 2>&1
+if command -v brew &> /dev/null; then
+  eval "$(brew shellenv)"
+else
+  echo "Error: brew command not found in PATH. Please ensure Homebrew is installed and in your PATH." >&2
+  exit 1
 fi
+bundle install
+gem build expo-cocoapods-proxy.gemspec
+mv expo-cocoapods-proxy-*.gem "$target_worker_dir/expo-cocoapods-proxy.gem"
+popd >/dev/null 2>&1
+
 rm -rf $target_root_dir/.volta/
 
 # Create backward-compatible symlink for orchestrator


### PR DESCRIPTION
@hSATAC rightly noticed Android and iOS tarballs are not that different (iOS is Android + gem and the gem only weighs 0.1 MB).

We still use `worker-android-staging.tar.gz` and `worker-ios-staging.tar.gz` (this requires changes to Launcher and the Orchestrator), but commit deployments use a no-platform `worker-SHA.tar.gz`.