### PR TITLE
[eas-cli] Add eas preview:go command

### DIFF
--- a/packages/eas-cli/src/commands/preview/go.ts
+++ b/packages/eas-cli/src/commands/preview/go.ts
@@ -1,0 +1,22 @@
+import EasCommand from '../../commandUtils/EasCommand';
+import omit from '../../utils/expodash/omit';
+import UpdatePublish from '../update';
+
+export default class PreviewGo extends EasCommand {
+  static override description = 'Publish an update that is compatible with Expo Go';
+
+  static override flags = omit(UpdatePublish.flags, ['source-maps', 'no-bytecode']);
+
+  static override args = UpdatePublish.args;
+
+  static override contextDefinition = UpdatePublish.contextDefinition;
+
+  static override hidden = true; // hidden for now until feature is settled
+
+  override async runAsync(): Promise<void> {
+    await this.parse(PreviewGo); // validation only
+
+    const newArgv = [...this.argv, '--source-maps', 'inline', '--no-bytecode'];
+    await UpdatePublish.run(newArgv, this.config);
+  }
+}

--- a/packages/eas-cli/src/utils/expodash/__tests__/omit-test.ts
+++ b/packages/eas-cli/src/utils/expodash/__tests__/omit-test.ts
@@ -1,0 +1,21 @@
+import omit from '../omit';
+
+describe(omit, () => {
+  it('omits specified keys from an object', () => {
+    const original = { a: 1, b: 2, c: 3 };
+    const result = omit(original, ['b', 'c']);
+    expect(result).toEqual({ a: 1 });
+  });
+
+  it('returns the same object if no keys are specified', () => {
+    const original = { a: 1, b: 2, c: 3 };
+    const result = omit(original, []);
+    expect(result).toEqual(original);
+  });
+
+  it('handles non-existent keys gracefully', () => {
+    const original = { a: 1, b: 2, c: 3 };
+    const result = omit(original, ['d', 'e'] as any);
+    expect(result).toEqual(original);
+  });
+});

--- a/packages/eas-cli/src/utils/expodash/omit.ts
+++ b/packages/eas-cli/src/utils/expodash/omit.ts
@@ -1,0 +1,10 @@
+export default function omit<T extends object, K extends keyof T>(
+  obj: T,
+  keys: readonly K[]
+): Omit<T, K> {
+  const newObj = { ...obj };
+  for (const key of keys) {
+    delete newObj[key];
+  }
+  return newObj as Omit<T, K>;
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This adds a new command `eas preview:go` that is the same as `eas update` but hardcodes the flags added in #3339.

# How

Add new command that composes the other but hardcodes the argv.

# Test Plan

`eas preview:go` (works, does update)

```
$ neas preview:go --source-maps false
Unexpected arguments: --source-maps, false
See more help with --help
```
