### PR TITLE
[chore] Use `NPM_ACCESS_TOKEN` in steps moving tags between `eas-cli` releases

### DIFF
--- a/.github/workflows/move-eas-build-tag.yml
+++ b/.github/workflows/move-eas-build-tag.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.EXPO_BOT_PAT }}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+      NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
       INPUT_VERSION: ${{ github.event.inputs.version }}
       INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
       INPUT_STAGING_ONLY: ${{ github.event.inputs.staging_only }}
@@ -46,7 +46,7 @@ jobs:
             echo "cmd = $cmd"
             exit 0
           fi
-          echo //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN > ~/.npmrc
+          echo //registry.npmjs.org/:_authToken=$NPM_ACCESS_TOKEN > ~/.npmrc
           $cmd
       - name: Add latest-eas-build tag
         run: |
@@ -60,5 +60,5 @@ jobs:
             echo "Only moving the staging tag, skipping the production tag"
             exit 0
           fi
-          echo //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN > ~/.npmrc
+          echo //registry.npmjs.org/:_authToken=$NPM_ACCESS_TOKEN > ~/.npmrc
           $cmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,12 +176,18 @@ jobs:
       - name: Publish packages to npm
         run: yarn lerna publish from-package --yes --no-verify-access
       - name: Add latest-eas-build-staging tag
+        env:
+          NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
         run: |
           VERSION=$(cat lerna.json | jq -r .version)
+          echo //registry.npmjs.org/:_authToken=$NPM_ACCESS_TOKEN > ~/.npmrc
           npm dist-tag add eas-cli@$VERSION latest-eas-build-staging
       - name: Add latest-eas-build tag
+        env:
+          NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
         run: |
           VERSION=$(cat lerna.json | jq -r .version)
+          echo //registry.npmjs.org/:_authToken=$NPM_ACCESS_TOKEN > ~/.npmrc
           npm dist-tag add eas-cli@$VERSION latest-eas-build
   release-changelog:
     name: Update changelog and publish release


### PR DESCRIPTION
We still need `NPM_ACCESS_TOKEN` despite OIDC for publishing. https://github.com/expo/eas-cli/actions/runs/21363225445/job/61513769796

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d0214f5c832898a83f54ba0a68fd)