### PR TITLE
Limit worker workflow to dependency-impacting changes

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -3,22 +3,80 @@ name: worker
 on:
   push:
     branches: [main]
-    paths:
-      - "packages/worker/**"
-      - .github/workflows/worker.yml
-      - .github/workflows/build-and-deploy-worker.yml
   pull_request:
-    paths:
-      - "packages/worker/**"
-      - .github/workflows/worker.yml
-      - .github/workflows/build-and-deploy-worker.yml
 
 concurrency:
   group: worker-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      run_worker: ${{ steps.changes.outputs.run_worker }}
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: volta-cli/action@5c175f92dea6f48441c436471e6479dbc192e194 # v4
+
+      - run: yarn install --frozen-lockfile --check-files
+
+      - id: changes
+        name: Determine worker dependency changes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+          fi
+
+          if git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+            CHANGED_FILES="$(git diff --name-only "$BASE_SHA" "${{ github.sha }}")"
+          else
+            CHANGED_FILES="$(git diff --name-only --root "${{ github.sha }}")"
+          fi
+
+          ROOT_DIR="$(git rev-parse --show-toplevel)"
+          DEP_DIRS="$(yarn --silent lerna list --include-dependencies --scope @expo/worker --parsable)"
+          RELEVANT_PREFIXES=(
+            "packages/worker/"
+            ".github/workflows/worker.yml"
+            ".github/workflows/build-and-deploy-worker.yml"
+          )
+
+          while IFS= read -r dir; do
+            [[ -z "$dir" ]] && continue
+            # Lerna may emit absolute paths; normalize to repo-relative for git diff matching.
+            if [[ "$dir" == "$ROOT_DIR"* ]]; then
+              dir="${dir#"$ROOT_DIR"/}"
+            else
+              # Some environments emit paths like ./packages/...
+              dir="${dir#./}"
+            fi
+            RELEVANT_PREFIXES+=("${dir}/")
+          done <<< "$DEP_DIRS"
+
+          RUN_WORKER=false
+          while IFS= read -r file; do
+            for prefix in "${RELEVANT_PREFIXES[@]}"; do
+              if [[ "$file" == "$prefix"* || "$file" == "$prefix" ]]; then
+                RUN_WORKER=true
+                break 2
+              fi
+            done
+          done <<< "$CHANGED_FILES"
+
+          echo "run_worker=$RUN_WORKER" >> "$GITHUB_OUTPUT"
+
   worker-checks:
+    if: needs.changes.outputs.run_worker == 'true'
+    needs:
+      - changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
@@ -36,7 +94,9 @@ jobs:
         run: yarn test:integration
 
   worker-build:
+    if: needs.changes.outputs.run_worker == 'true'
     needs:
+      - changes
       - worker-checks
     uses: ./.github/workflows/build-and-deploy-worker.yml
     secrets: inherit
@@ -44,16 +104,18 @@ jobs:
       environment: ${{ github.ref == 'refs/heads/main' && 'staging' || '' }}
 
   system-tests-staging:
-    if: github.ref == 'refs/heads/main' && !failure() && !cancelled()
+    if: github.ref == 'refs/heads/main' && !failure() && !cancelled() && needs.changes.outputs.run_worker == 'true'
     needs:
+      - changes
       - worker-build
       - worker-checks
     uses: ./.github/workflows/worker-system-tests.yml
     secrets: inherit
 
   deploy-worker-production:
-    if: github.ref == 'refs/heads/main' && !failure() && !cancelled()
+    if: github.ref == 'refs/heads/main' && !failure() && !cancelled() && needs.changes.outputs.run_worker == 'true'
     needs:
+      - changes
       - system-tests-staging
     uses: ./.github/workflows/build-and-deploy-worker.yml
     secrets: inherit
@@ -63,8 +125,9 @@ jobs:
   notify-slack:
     runs-on: ubuntu-latest
     needs:
+      - changes
       - deploy-worker-production
-    if: github.ref == 'refs/heads/main' && always() && !cancelled()
+    if: github.ref == 'refs/heads/main' && always() && !cancelled() && needs.changes.outputs.run_worker == 'true'
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 


### PR DESCRIPTION
Summary
- add a `changes` job that computes whether worker deps or workflow configs changed using Lerna’s dependency list so downstream worker jobs only run when needed
- gate all worker builds, tests, deployments, and Slack notifications on the new flag so CI skips when unrelated files change
Testing
- Not run (not requested)