### PR TITLE
[worker] Copy `bin` directory too

### DIFF
--- a/packages/worker/package.sh
+++ b/packages/worker/package.sh
@@ -40,6 +40,9 @@ copy_package() {
     cp "$src/tsconfig.build.json" "$dst/tsconfig.build.json"
   fi
   cp -r "$src/src" "$dst/src"
+  if [[ -d "$src/bin" ]]; then
+    cp -r "$src/bin" "$dst/bin"
+  fi
 }
 
 cp "$ROOT_DIR/yarn.lock" $target_root_dir


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://staging.expo.dev/accounts/expo-services/projects/worker-system-tests/builds/59628168-4fe6-4cef-981a-fb74527c47ed

# How

Added copying of missing `bin`.

# Test Plan

Merge and observe system tests.