### PR TITLE
Don't show build credits warning bar at 100% usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Don't show build credits warning bar when usage is at 100%. ([#3371](https://github.com/expo/eas-cli/pull/3371) by [@mackenco](https://github.com/mackenco))
+- Hide progress bar in build credits warning when usage reaches 100%. ([#3371](https://github.com/expo/eas-cli/pull/3371) by [@mackenco](https://github.com/mackenco))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/utils/usage/checkForOverages.ts
+++ b/packages/eas-cli/src/utils/usage/checkForOverages.ts
@@ -27,7 +27,7 @@ export async function maybeWarnAboutUsageOveragesAsync({
     }
 
     const percentUsed = calculatePercentUsed(planMetric.value, planMetric.limit);
-    if (percentUsed >= THRESHOLD_PERCENT && percentUsed < 100) {
+    if (percentUsed >= THRESHOLD_PERCENT) {
       const hasFreePlan = subscription.name === 'Free';
       displayOverageWarning({ percentUsed, hasFreePlan, name });
     }
@@ -61,10 +61,12 @@ export function displayOverageWarning({
   hasFreePlan: boolean;
   name: string;
 }): void {
-  Log.warn(
-    chalk.bold(`You've used ${percentUsed}% of your included build credits for this month. `) +
-      createProgressBar(percentUsed)
+  const message = chalk.bold(
+    `You've used ${percentUsed}% of your included build credits for this month.`
   );
+  // Don't show progress bar at 100% - it's redundant when the limit is reached
+  const progressBar = percentUsed < 100 ? ' ' + createProgressBar(percentUsed) : '';
+  Log.warn(message + progressBar);
 
   const billingUrl = `https://expo.dev/accounts/${name}/settings/billing`;
   const warning = hasFreePlan


### PR DESCRIPTION
## What
Hide the build credits warning bar when usage reaches 100%. This was flagged by Brent - it's a little redundant/noisy to show a full progress bar. 

<img width="3010" height="524" alt="image" src="https://github.com/user-attachments/assets/624ac3fc-696d-4dd3-b7e0-095c133eafa8" />

## How
The warning bar alerts users when approaching their limit (85-99%), but at 100% they've already hit it, making the bar redundant

Resolves ENG-19190

## Test plan
- [x] Added test case to verify warning is not shown at 100% usage
- [x] Existing tests pass
