### PR TITLE
[chore] Fix `pretarball-ci` script

### DIFF
--- a/packages/eas-cli/scripts/pretarball-ci.sh
+++ b/packages/eas-cli/scripts/pretarball-ci.sh
@@ -24,7 +24,7 @@ rewrite_deps() {
     KEY="${package%%:*}"
     DIR="${package##*:}"
 
-    # Determine the relative path
+    # Determine the relative path. If IS_EAS_CLI we go one level deeper because oclif builds in `tmp` in current directory.
     if [[ "$IS_EAS_CLI" == "true" ]]; then
       REL_PATH="file:../../../$DIR"
     else


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When oclif is building tarballs with executables it does so in a directory separate from the monorepo which requires us to change `eas-cli` dependencies from the monorepo to `file`.

# How

Asked Gemini to update the script to include all local dependencies of `eas-cli`.

Or… we can land https://github.com/expo/eas-cli/pull/3361 …

# Test Plan

Release should pass. Validated locally. (Hmm but on CI it failed? Will see.)

Ok, so size failed because it ran on `main` which is broken because it lacks this pull request.

<img width="944" height="1031" alt="Zrzut ekranu 2026-02-5 o 19 05 41" src="https://github.com/user-attachments/assets/1134493c-bbdb-4f08-85d6-07e59fa28750" />
