### PR TITLE
[build-tools] Add eas/report_maestro_test_results build function

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -53,6 +53,7 @@
     "@urql/core": "^6.0.1",
     "bplist-parser": "0.3.2",
     "fast-glob": "^3.3.2",
+    "fast-xml-parser": "^4.4.1",
     "fs-extra": "^11.2.0",
     "gql.tada": "^1.8.13",
     "joi": "^17.13.1",

--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -10,6 +10,7 @@ import {
 } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { BuildRuntimePlatform, ExternalBuildContextProvider } from '@expo/steps';
+import { Client } from '@urql/core';
 import assert from 'assert';
 import path from 'path';
 
@@ -53,6 +54,7 @@ export class CustomBuildContext<TJob extends Job = Job> implements ExternalBuild
   public readonly startTime: Date;
 
   public readonly logger: bunyan;
+  public readonly graphqlClient: Client;
   public readonly runtimeApi: BuilderRuntimeApi;
   public job: TJob;
   public metadata?: Metadata;
@@ -65,6 +67,7 @@ export class CustomBuildContext<TJob extends Job = Job> implements ExternalBuild
     this.metadata = buildCtx.metadata;
 
     this.logger = buildCtx.logger.child({ phase: BuildPhase.CUSTOM });
+    this.graphqlClient = buildCtx.graphqlClient;
     this.projectSourceDirectory = path.join(buildCtx.workingdir, 'temporary-custom-build');
     this.projectTargetDirectory = path.join(buildCtx.workingdir, 'build');
     this.defaultWorkingDirectory = buildCtx.getReactNativeProjectDirectory();

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -21,6 +21,7 @@ import { createInternalEasMaestroTestFunction } from './functions/internalMaestr
 import { createPrebuildBuildFunction } from './functions/prebuild';
 import { createReadIpaInfoBuildFunction } from './functions/readIpaInfo';
 import { createRepackBuildFunction } from './functions/repack';
+import { createReportMaestroTestResultsFunction } from './functions/reportMaestroTestResults';
 import { resolveAppleTeamIdFromCredentialsFunction } from './functions/resolveAppleTeamIdFromCredentials';
 import { createResolveBuildConfigBuildFunction } from './functions/resolveBuildConfig';
 import {
@@ -81,6 +82,8 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createUploadToAscBuildFunction(),
 
     createInternalEasMaestroTestFunction(ctx),
+
+    createReportMaestroTestResultsFunction(ctx),
   ];
 
   if (ctx.hasBuildJob()) {

--- a/packages/build-tools/src/steps/functions/__tests__/internalMaestroTest.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/internalMaestroTest.test.ts
@@ -1,0 +1,98 @@
+import { spawnAsync } from '@expo/steps';
+import { vol } from 'memfs';
+import os from 'os';
+
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { IosSimulatorUtils } from '../../../utils/IosSimulatorUtils';
+import { findMaestroPathsFlowsToExecuteAsync } from '../../../utils/findMaestroPathsFlowsToExecuteAsync';
+import { createInternalEasMaestroTestFunction } from '../internalMaestroTest';
+
+jest.mock('@expo/steps', () => ({
+  ...jest.requireActual('@expo/steps'),
+  spawnAsync: jest.fn(),
+}));
+
+jest.mock('../../../utils/IosSimulatorUtils');
+jest.mock('../../../utils/AndroidEmulatorUtils');
+jest.mock('../../../utils/findMaestroPathsFlowsToExecuteAsync');
+
+const mockedSpawnAsync = jest.mocked(spawnAsync);
+const mockedIosUtils = jest.mocked(IosSimulatorUtils);
+const mockedFindFlows = jest.mocked(findMaestroPathsFlowsToExecuteAsync);
+
+describe(createInternalEasMaestroTestFunction, () => {
+  const mockUploadArtifact = jest.fn();
+
+  beforeEach(() => {
+    vol.mkdirSync(os.tmpdir(), { recursive: true });
+
+    mockedSpawnAsync.mockResolvedValue(undefined as any);
+    mockUploadArtifact.mockResolvedValue({ artifactId: null });
+
+    mockedIosUtils.getAvailableDevicesAsync.mockResolvedValue([
+      { name: 'iPhone 15', udid: 'test-udid-123' } as any,
+    ]);
+    mockedIosUtils.cloneAsync.mockResolvedValue(undefined as any);
+    mockedIosUtils.startAsync.mockResolvedValue({ udid: 'cloned-udid' } as any);
+    mockedIosUtils.waitForReadyAsync.mockResolvedValue(undefined as any);
+    mockedIosUtils.collectLogsAsync.mockResolvedValue({ outputPath: '/tmp/logs.txt' } as any);
+    mockedIosUtils.deleteAsync.mockResolvedValue(undefined as any);
+
+    mockedFindFlows.mockResolvedValue(['/project/.maestro/home.yml']);
+  });
+
+  function createStep(overrides?: { callInputs?: Record<string, unknown> }) {
+    const ctx = {
+      runtimeApi: { uploadArtifact: mockUploadArtifact },
+    };
+    const fn = createInternalEasMaestroTestFunction(ctx as any);
+    return fn.createBuildStepFromFunctionCall(
+      createGlobalContextMock({
+        logger: createMockLogger(),
+      }),
+      {
+        callInputs: {
+          platform: 'ios',
+          flow_paths: JSON.stringify(['.maestro']),
+          ...overrides?.callInputs,
+        },
+      }
+    );
+  }
+
+  it('sets junit_report_directory output when output_format is junit', async () => {
+    const step = createStep({
+      callInputs: { output_format: 'junit' },
+    });
+    await step.executeAsync();
+
+    const junitDir = step.getOutputValueByName('junit_report_directory');
+    expect(junitDir).toMatch(/maestro-reports-/);
+  });
+
+  it('does not set junit_report_directory output when output_format is not junit', async () => {
+    const step = createStep();
+    await step.executeAsync();
+
+    const junitDir = step.getOutputValueByName('junit_report_directory');
+    expect(junitDir).toBeUndefined();
+  });
+
+  it('does not set junit_report_directory when function throws before reaching output code', async () => {
+    mockedIosUtils.getAvailableDevicesAsync.mockResolvedValue([]);
+
+    const step = createStep({
+      callInputs: { output_format: 'junit' },
+    });
+
+    try {
+      await step.executeAsync();
+    } catch {
+      // Expected - no booted device found
+    }
+
+    const junitDir = step.getOutputValueByName('junit_report_directory');
+    expect(junitDir).toBeUndefined();
+  });
+});

--- a/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
@@ -1,0 +1,594 @@
+import { vol } from 'memfs';
+
+import {
+  parseFlowMetadata,
+  parseJUnitTestCases,
+  parseMaestroResults,
+} from '../maestroResultParser';
+
+describe(parseFlowMetadata, () => {
+  it('parses valid ai-*.json', async () => {
+    vol.fromJSON({
+      '/tests/2026-01-28_055409/ai-home.json': JSON.stringify({
+        flow_name: 'home',
+        flow_file_path: '/Users/expo/workingdir/build/.maestro/home.yml',
+      }),
+    });
+
+    const result = await parseFlowMetadata('/tests/2026-01-28_055409/ai-home.json');
+    expect(result).toEqual({
+      flow_name: 'home',
+      flow_file_path: '/Users/expo/workingdir/build/.maestro/home.yml',
+    });
+  });
+
+  it('returns null when flow_name is missing', async () => {
+    vol.fromJSON({
+      '/tests/2026-01-28_055409/ai-home.json': JSON.stringify({
+        flow_file_path: '/Users/expo/workingdir/build/.maestro/home.yml',
+      }),
+    });
+
+    const result = await parseFlowMetadata('/tests/2026-01-28_055409/ai-home.json');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when flow_file_path is missing', async () => {
+    vol.fromJSON({
+      '/tests/2026-01-28_055409/ai-home.json': JSON.stringify({
+        flow_name: 'home',
+      }),
+    });
+
+    const result = await parseFlowMetadata('/tests/2026-01-28_055409/ai-home.json');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for invalid JSON', async () => {
+    vol.fromJSON({
+      '/tests/2026-01-28_055409/ai-home.json': 'not json',
+    });
+
+    const result = await parseFlowMetadata('/tests/2026-01-28_055409/ai-home.json');
+    expect(result).toBeNull();
+  });
+});
+
+describe(parseMaestroResults, () => {
+  it('parses JUnit results and enriches with ai-*.json metadata', async () => {
+    vol.fromJSON({
+      // JUnit XML (primary data)
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="2" failures="1">',
+        '    <testcase id="home" name="home" classname="home" time="10.5" status="SUCCESS"/>',
+        '    <testcase id="login" name="login" classname="login" time="5.0" status="ERROR">',
+        '      <failure>Tap failed</failure>',
+        '    </testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+      // Debug output (for flow_file_path)
+      '/tests/2026-01-28_055409/ai-home.json': JSON.stringify({
+        flow_name: 'home',
+        flow_file_path: '/root/project/.maestro/home.yml',
+      }),
+      '/tests/2026-01-28_055409/ai-login.json': JSON.stringify({
+        flow_name: 'login',
+        flow_file_path: '/root/project/.maestro/login.yml',
+      }),
+    });
+
+    const results = await parseMaestroResults('/junit', '/tests', '/root/project');
+    expect(results).toHaveLength(2);
+    expect(results).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'home',
+          path: '.maestro/home.yml',
+          status: 'passed',
+          errorMessage: null,
+          duration: 10500,
+          retryCount: 0,
+          tags: [],
+          properties: {},
+        },
+        {
+          name: 'login',
+          path: '.maestro/login.yml',
+          status: 'failed',
+          errorMessage: 'Tap failed',
+          duration: 5000,
+          retryCount: 0,
+          tags: [],
+          properties: {},
+        },
+      ])
+    );
+  });
+
+  it('calculates retryCount from timestamp directory occurrences', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+      // Two timestamp dirs = 1 retry
+      '/tests/2026-01-28_055409/ai-home.json': JSON.stringify({
+        flow_name: 'home',
+        flow_file_path: '/root/project/.maestro/home.yml',
+      }),
+      '/tests/2026-01-28_055420/ai-home.json': JSON.stringify({
+        flow_name: 'home',
+        flow_file_path: '/root/project/.maestro/home.yml',
+      }),
+    });
+
+    const results = await parseMaestroResults('/junit', '/tests', '/root/project');
+    expect(results[0].retryCount).toBe(1);
+  });
+
+  it('uses flow name as fallback path when ai-*.json not found', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+      // No ai-*.json files
+    });
+
+    const results = await parseMaestroResults('/junit', '/tests', '/root/project');
+    expect(results[0].path).toBe('home');
+    expect(results[0].retryCount).toBe(0);
+  });
+
+  it('returns empty array when no JUnit files found', async () => {
+    vol.fromJSON({
+      '/junit/.gitkeep': '',
+      '/tests/2026-01-28_055409/ai-home.json': JSON.stringify({
+        flow_name: 'home',
+        flow_file_path: '/root/project/.maestro/home.yml',
+      }),
+    });
+
+    const results = await parseMaestroResults('/junit', '/tests', '/root/project');
+    expect(results).toEqual([]);
+  });
+
+  it('extracts tags from JUnit properties and separates from other properties', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS">',
+        '      <properties>',
+        '        <property name="env" value="staging"/>',
+        '        <property name="tags" value="e2e, smoke"/>',
+        '      </properties>',
+        '    </testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+      '/tests/2026-01-28_055409/ai-home.json': JSON.stringify({
+        flow_name: 'home',
+        flow_file_path: '/root/project/.maestro/home.yml',
+      }),
+    });
+
+    const results = await parseMaestroResults('/junit', '/tests', '/root/project');
+    expect(results[0].tags).toEqual(['e2e', 'smoke']);
+    expect(results[0].properties).toEqual({ env: 'staging' });
+  });
+
+  it('handles reuse_devices=true (junit_report_directory == tests_directory)', async () => {
+    vol.fromJSON({
+      // Same directory for both JUnit and debug output
+      '/maestro-tests/android-maestro-junit.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+      '/maestro-tests/2026-01-28_055409/ai-home.json': JSON.stringify({
+        flow_name: 'home',
+        flow_file_path: '/root/project/.maestro/home.yml',
+      }),
+    });
+
+    const results = await parseMaestroResults('/maestro-tests', '/maestro-tests', '/root/project');
+    expect(results).toEqual([
+      expect.objectContaining({
+        name: 'home',
+        path: '.maestro/home.yml',
+        status: 'passed',
+      }),
+    ]);
+  });
+
+  it('handles reuse_devices=false (separate junit_report_directory)', async () => {
+    vol.fromJSON({
+      // JUnit in temp dir (per-flow files)
+      '/tmp/maestro-reports-abc123/junit-report-flow-1.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+      '/tmp/maestro-reports-abc123/junit-report-flow-2.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="1">',
+        '    <testcase id="login" name="login" classname="login" time="5.0" status="ERROR">',
+        '      <failure>Failed</failure>',
+        '    </testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+      // Debug output in default location
+      '/tests/2026-01-28_055409/ai-home.json': JSON.stringify({
+        flow_name: 'home',
+        flow_file_path: '/root/project/.maestro/home.yml',
+      }),
+      '/tests/2026-01-28_055409/ai-login.json': JSON.stringify({
+        flow_name: 'login',
+        flow_file_path: '/root/project/.maestro/login.yml',
+      }),
+    });
+
+    const results = await parseMaestroResults(
+      '/tmp/maestro-reports-abc123',
+      '/tests',
+      '/root/project'
+    );
+    expect(results).toHaveLength(2);
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'home', path: '.maestro/home.yml', status: 'passed' }),
+        expect.objectContaining({ name: 'login', path: '.maestro/login.yml', status: 'failed' }),
+      ])
+    );
+  });
+
+  it('uses raw path when flow_file_path is outside project_root', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+      '/tests/2026-01-28_055409/ai-home.json': JSON.stringify({
+        flow_name: 'home',
+        flow_file_path: '/somewhere/else/.maestro/home.yml',
+      }),
+    });
+
+    const results = await parseMaestroResults('/junit', '/tests', '/root/project');
+    expect(results[0].path).toBe('/somewhere/else/.maestro/home.yml');
+  });
+
+  it('filters out non-timestamp directories when scanning debug output', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+      '/tests/2026-01-28_055409/ai-home.json': JSON.stringify({
+        flow_name: 'home',
+        flow_file_path: '/root/project/.maestro/home.yml',
+      }),
+      '/tests/not-a-timestamp/ai-home.json': JSON.stringify({
+        flow_name: 'home',
+        flow_file_path: '/root/project/.maestro/home.yml',
+      }),
+    });
+
+    const results = await parseMaestroResults('/junit', '/tests', '/root/project');
+    // Only 1 occurrence (not-a-timestamp dir should be ignored)
+    expect(results[0].retryCount).toBe(0);
+  });
+});
+
+describe(parseJUnitTestCases, () => {
+  it('parses a single testcase with SUCCESS status', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" device="emulator-5554" tests="1" failures="0" time="10.5">',
+        '    <testcase id="home" name="home" classname="home" time="10.5" status="SUCCESS">',
+        '    </testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results).toEqual([
+      {
+        name: 'home',
+        status: 'passed',
+        duration: 10500,
+        errorMessage: null,
+        tags: [],
+        properties: {},
+      },
+    ]);
+  });
+
+  it('parses a failed testcase with failure message', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="1">',
+        '    <testcase id="login" name="login" classname="login" time="5.0" status="ERROR">',
+        '      <failure>Element not visible</failure>',
+        '    </testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results).toEqual([
+      {
+        name: 'login',
+        status: 'failed',
+        duration: 5000,
+        errorMessage: 'Element not visible',
+        tags: [],
+        properties: {},
+      },
+    ]);
+  });
+
+  it('extracts properties from testcase', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS">',
+        '      <properties>',
+        '        <property name="env" value="staging"/>',
+        '        <property name="priority" value="high"/>',
+        '      </properties>',
+        '    </testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results[0].properties).toEqual({ env: 'staging', priority: 'high' });
+  });
+
+  it('extracts tags from "tags" property as comma-separated values', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS">',
+        '      <properties>',
+        '        <property name="tags" value="smoke, critical, auth"/>',
+        '        <property name="priority" value="high"/>',
+        '      </properties>',
+        '    </testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results[0].tags).toEqual(['smoke', 'critical', 'auth']);
+    expect(results[0].properties).toEqual({ priority: 'high' });
+  });
+
+  it('returns empty tags when no "tags" property exists (older Maestro)', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS">',
+        '      <properties>',
+        '        <property name="priority" value="high"/>',
+        '      </properties>',
+        '    </testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results[0].tags).toEqual([]);
+    expect(results[0].properties).toEqual({ priority: 'high' });
+  });
+
+  it('parses multiple testcases across multiple testsuites (shards)', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" device="emulator-5554" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS"/>',
+        '  </testsuite>',
+        '  <testsuite name="Test Suite" device="emulator-5556" tests="1" failures="1">',
+        '    <testcase id="login" name="login" classname="login" time="5.0" status="ERROR">',
+        '      <failure>Tap failed</failure>',
+        '    </testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results).toHaveLength(2);
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'home', status: 'passed' }),
+        expect.objectContaining({ name: 'login', status: 'failed', errorMessage: 'Tap failed' }),
+      ])
+    );
+  });
+
+  it('parses multiple JUnit XML files in the same directory', async () => {
+    vol.fromJSON({
+      '/junit/junit-report-flow-1.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+      '/junit/junit-report-flow-2.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="1">',
+        '    <testcase id="login" name="login" classname="login" time="5.0" status="ERROR">',
+        '      <failure>Tap failed</failure>',
+        '    </testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results).toHaveLength(2);
+  });
+
+  it('handles missing time attribute (defaults to 0)', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" status="SUCCESS"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results[0].duration).toBe(0);
+  });
+
+  it('handles invalid time attribute (defaults to 0)', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="not_a_number" status="SUCCESS"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results[0].duration).toBe(0);
+  });
+
+  it('uses @_status attribute for pass/fail (not <failure> presence)', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="1">',
+        '    <testcase id="home" name="home" classname="home" time="5.0" status="ERROR"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results[0].status).toBe('failed');
+    expect(results[0].errorMessage).toBeNull();
+  });
+
+  it('extracts error message from <error> element', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="1">',
+        '    <testcase id="home" name="home" classname="home" time="5.0" status="ERROR">',
+        '      <error>Runtime exception occurred</error>',
+        '    </testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results[0].status).toBe('failed');
+    expect(results[0].errorMessage).toBe('Runtime exception occurred');
+  });
+
+  it('returns empty array when directory does not exist', async () => {
+    const results = await parseJUnitTestCases('/nonexistent');
+    expect(results).toEqual([]);
+  });
+
+  it('returns empty array when no XML files found', async () => {
+    vol.fromJSON({ '/junit/.gitkeep': '' });
+    const results = await parseJUnitTestCases('/junit');
+    expect(results).toEqual([]);
+  });
+
+  it('skips invalid XML files gracefully', async () => {
+    vol.fromJSON({
+      '/junit/bad.xml': 'not xml at all',
+      '/junit/good.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results).toEqual([expect.objectContaining({ name: 'home', status: 'passed' })]);
+  });
+
+  it('handles testcase with no properties element', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+    expect(results[0].properties).toEqual({});
+  });
+});

--- a/packages/build-tools/src/steps/functions/__tests__/reportMaestroTestResults.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/reportMaestroTestResults.test.ts
@@ -1,0 +1,273 @@
+import { Client } from '@urql/core';
+import { vol } from 'memfs';
+
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { createReportMaestroTestResultsFunction } from '../reportMaestroTestResults';
+
+const JUNIT_PASS = [
+  '<?xml version="1.0"?>',
+  '<testsuites>',
+  '  <testsuite name="Test Suite" tests="1" failures="0">',
+  '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS"/>',
+  '  </testsuite>',
+  '</testsuites>',
+].join('\n');
+
+const JUNIT_FAIL = [
+  '<?xml version="1.0"?>',
+  '<testsuites>',
+  '  <testsuite name="Test Suite" tests="1" failures="1">',
+  '    <testcase id="home" name="home" classname="home" time="5.0" status="ERROR">',
+  '      <failure>Tap failed</failure>',
+  '    </testcase>',
+  '  </testsuite>',
+  '</testsuites>',
+].join('\n');
+
+const FLOW_AI = JSON.stringify({
+  flow_name: 'home',
+  flow_file_path: '/root/project/.maestro/home.yml',
+});
+
+describe(createReportMaestroTestResultsFunction, () => {
+  let mockMutationFn: jest.Mock;
+  let mockGraphqlClient: Client;
+
+  beforeEach(() => {
+    mockMutationFn = jest.fn();
+    mockGraphqlClient = {
+      mutation: jest.fn().mockReturnValue({
+        toPromise: mockMutationFn,
+      }),
+    } as unknown as Client;
+  });
+
+  function createStep(overrides?: {
+    callInputs?: Record<string, unknown>;
+    staticContextContent?: Record<string, unknown>;
+    env?: Record<string, string>;
+  }) {
+    const ctx = { graphqlClient: mockGraphqlClient };
+    const fn = createReportMaestroTestResultsFunction(ctx as any);
+    const globalCtx = createGlobalContextMock({
+      logger: createMockLogger(),
+      projectTargetDirectory: '/root/project',
+      staticContextContent: {
+        expoApiServerURL: 'https://api.expo.test',
+        job: { secrets: { robotAccessToken: 'test-token' } },
+        ...overrides?.staticContextContent,
+      },
+    });
+    globalCtx.updateEnv(overrides?.env ?? { __WORKFLOW_JOB_ID: 'job-uuid-123' });
+    return fn.createBuildStepFromFunctionCall(globalCtx, {
+      callInputs: {
+        junit_report_directory: '/junit',
+        tests_directory: '/tests',
+        ...overrides?.callInputs,
+      },
+    });
+  }
+
+  it('parses JUnit results and calls GraphQL mutation', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': JUNIT_PASS,
+      '/tests/2026-01-28_055409/ai-home.json': FLOW_AI,
+    });
+
+    mockMutationFn.mockResolvedValue({
+      data: {
+        workflowDeviceTestCaseResult: {
+          createWorkflowDeviceTestCaseResults: [{ id: 'id-1' }],
+        },
+      },
+    });
+
+    await createStep().executeAsync();
+
+    expect(mockGraphqlClient.mutation).toHaveBeenCalledTimes(1);
+    const [, variables] = (mockGraphqlClient.mutation as jest.Mock).mock.calls[0];
+    expect(variables.input.workflowJobId).toBe('job-uuid-123');
+    expect(variables.input.testCaseResults).toEqual([
+      expect.objectContaining({
+        name: 'home',
+        path: '.maestro/home.yml',
+        status: 'PASSED',
+        errorMessage: null,
+        duration: 10000,
+        retryCount: 0,
+        properties: {},
+      }),
+    ]);
+  });
+
+  it('sends tags and properties from JUnit XML', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="1" failures="0">',
+        '    <testcase id="home" name="home" classname="home" time="10.0" status="SUCCESS">',
+        '      <properties>',
+        '        <property name="testCaseId" value="TC-001"/>',
+        '        <property name="priority" value="high"/>',
+        '        <property name="tags" value="e2e"/>',
+        '      </properties>',
+        '    </testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+      '/tests/2026-01-28_055409/ai-home.json': FLOW_AI,
+    });
+
+    mockMutationFn.mockResolvedValue({
+      data: {
+        workflowDeviceTestCaseResult: {
+          createWorkflowDeviceTestCaseResults: [{ id: 'id-1' }],
+        },
+      },
+    });
+
+    await createStep().executeAsync();
+
+    const [, variables] = (mockGraphqlClient.mutation as jest.Mock).mock.calls[0];
+    expect(variables.input.testCaseResults[0].tags).toEqual(['e2e']);
+    expect(variables.input.testCaseResults[0].properties).toEqual({
+      testCaseId: 'TC-001',
+      priority: 'high',
+    });
+  });
+
+  it('reports failed flow with correct status and errorMessage', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': JUNIT_FAIL,
+      '/tests/2026-01-28_055409/ai-home.json': FLOW_AI,
+    });
+
+    mockMutationFn.mockResolvedValue({
+      data: {
+        workflowDeviceTestCaseResult: {
+          createWorkflowDeviceTestCaseResults: [{ id: 'id-1' }],
+        },
+      },
+    });
+
+    await createStep().executeAsync();
+
+    const [, variables] = (mockGraphqlClient.mutation as jest.Mock).mock.calls[0];
+    expect(variables.input.testCaseResults[0]).toEqual(
+      expect.objectContaining({
+        status: 'FAILED',
+        errorMessage: 'Tap failed',
+        duration: 5000,
+      })
+    );
+  });
+
+  // robotAccessToken guard removed — Generic.JobZ requires robotAccessToken (z.string(),
+  // not optional), so it's always present in workflow jobs. graphqlClient is already
+  // initialized with the token in BuildContext constructor.
+
+  it('skips report when junit_report_directory is empty string (upstream step failed)', async () => {
+    const step = createStep({
+      callInputs: { junit_report_directory: '' },
+    });
+    await step.executeAsync();
+    expect(mockGraphqlClient.mutation).not.toHaveBeenCalled();
+  });
+
+  it('skips report when __WORKFLOW_JOB_ID env is not set', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': JUNIT_PASS,
+      '/tests/2026-01-28_055409/ai-home.json': FLOW_AI,
+    });
+
+    const step = createStep({ env: {} });
+    await step.executeAsync();
+    expect(mockGraphqlClient.mutation).not.toHaveBeenCalled();
+  });
+
+  it('skips report when no JUnit files found', async () => {
+    const step = createStep();
+    await step.executeAsync();
+    expect(mockGraphqlClient.mutation).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when GraphQL returns error', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': JUNIT_PASS,
+      '/tests/2026-01-28_055409/ai-home.json': FLOW_AI,
+    });
+
+    mockMutationFn.mockResolvedValue({
+      error: { message: 'Something went wrong' },
+    });
+
+    await createStep().executeAsync();
+  });
+
+  it('does not throw when mutation rejects', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': JUNIT_PASS,
+      '/tests/2026-01-28_055409/ai-home.json': FLOW_AI,
+    });
+
+    mockMutationFn.mockRejectedValue(new Error('Network error'));
+
+    await createStep().executeAsync();
+  });
+
+  it('skips report when duplicate testcase names found', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="2" failures="0">',
+        '    <testcase id="login" name="login" classname="login" time="10.0" status="SUCCESS"/>',
+        '    <testcase id="login" name="login" classname="login" time="5.0" status="SUCCESS"/>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+      '/tests/2026-01-28_055409/ai-login.json': JSON.stringify({
+        flow_name: 'login',
+        flow_file_path: '/root/project/.maestro/login.yml',
+      }),
+    });
+
+    await createStep().executeAsync();
+    expect(mockGraphqlClient.mutation).not.toHaveBeenCalled();
+  });
+
+  it('uses default directories when inputs are not provided', async () => {
+    vol.fromJSON({
+      '/home/expo/.maestro/tests/report.xml': JUNIT_PASS,
+      '/home/expo/.maestro/tests/2026-01-28_055409/ai-home.json': FLOW_AI,
+    });
+
+    const ctx = { graphqlClient: mockGraphqlClient };
+    const fn = createReportMaestroTestResultsFunction(ctx as any);
+    const globalCtx = createGlobalContextMock({
+      logger: createMockLogger(),
+      projectTargetDirectory: '/root/project',
+      staticContextContent: {
+        expoApiServerURL: 'https://api.expo.test',
+        job: { secrets: { robotAccessToken: 'test-token' } },
+      },
+    });
+    globalCtx.updateEnv({ __WORKFLOW_JOB_ID: 'job-uuid-123', HOME: '/home/expo' });
+
+    mockMutationFn.mockResolvedValue({
+      data: {
+        workflowDeviceTestCaseResult: {
+          createWorkflowDeviceTestCaseResults: [{ id: 'id-1' }],
+        },
+      },
+    });
+
+    const step = fn.createBuildStepFromFunctionCall(globalCtx, {
+      callInputs: {},
+    });
+    await step.executeAsync();
+    expect(mockGraphqlClient.mutation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/build-tools/src/steps/functions/internalMaestroTest.ts
+++ b/packages/build-tools/src/steps/functions/internalMaestroTest.ts
@@ -81,6 +81,10 @@ export function createInternalEasMaestroTestFunction(ctx: CustomBuildContext): B
         id: 'test_reports_artifact_id',
         required: false,
       }),
+      BuildStepOutput.createProvider({
+        id: 'junit_report_directory',
+        required: false,
+      }),
     ],
     fn: async (stepCtx, { inputs: _inputs, env, outputs }) => {
       // inputs come in form of { value: unknown }. Here we parse them into a typed and validated object.
@@ -346,6 +350,10 @@ export function createInternalEasMaestroTestFunction(ctx: CustomBuildContext): B
         } catch (err) {
           stepCtx.logger.error({ err }, 'Failed to upload reports.');
         }
+      }
+
+      if (output_format === 'junit') {
+        outputs.junit_report_directory.set(maestroReportsDir);
       }
 
       const generatedDeviceLogs = await fs.promises.readdir(deviceLogsDir);

--- a/packages/build-tools/src/steps/functions/maestroResultParser.ts
+++ b/packages/build-tools/src/steps/functions/maestroResultParser.ts
@@ -1,0 +1,264 @@
+import { XMLParser } from 'fast-xml-parser';
+import fs from 'fs/promises';
+import path from 'path';
+import { z } from 'zod';
+
+export interface MaestroFlowResult {
+  name: string;
+  path: string;
+  status: 'passed' | 'failed';
+  errorMessage: string | null;
+  duration: number; // milliseconds
+  retryCount: number;
+  tags: string[];
+  properties: Record<string, string>;
+}
+
+// Maestro's TestDebugReporter creates timestamped directories, e.g. "2024-06-15_143022"
+const TIMESTAMP_DIR_PATTERN = /^\d{4}-\d{2}-\d{2}_\d{6}$/;
+
+export function extractFlowKey(filename: string, prefix: string): string | null {
+  const match = filename.match(new RegExp(`^${prefix}-(.+)\\.json$`));
+  return match?.[1] ?? null;
+}
+
+export interface JUnitTestCaseResult {
+  name: string;
+  status: 'passed' | 'failed';
+  duration: number; // milliseconds
+  errorMessage: string | null;
+  tags: string[];
+  properties: Record<string, string>;
+}
+
+const xmlParser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  // Ensure single-element arrays are always arrays
+  isArray: name => ['testsuite', 'testcase', 'property'].includes(name),
+});
+
+export async function parseJUnitTestCases(junitDirectory: string): Promise<JUnitTestCaseResult[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(junitDirectory);
+  } catch {
+    return [];
+  }
+
+  const xmlFiles = entries.filter(f => f.endsWith('.xml'));
+  if (xmlFiles.length === 0) {
+    return [];
+  }
+
+  const results: JUnitTestCaseResult[] = [];
+
+  for (const xmlFile of xmlFiles) {
+    try {
+      const content = await fs.readFile(path.join(junitDirectory, xmlFile), 'utf-8');
+      const parsed = xmlParser.parse(content);
+
+      const testsuites = parsed?.testsuites?.testsuite;
+      if (!Array.isArray(testsuites)) {
+        continue;
+      }
+
+      for (const suite of testsuites) {
+        const testcases = suite?.testcase;
+        if (!Array.isArray(testcases)) {
+          continue;
+        }
+
+        for (const tc of testcases) {
+          const name = tc['@_name'];
+          if (!name) {
+            continue;
+          }
+
+          const timeStr = tc['@_time'];
+          const timeSeconds = timeStr ? parseFloat(timeStr) : 0;
+          const duration = Number.isFinite(timeSeconds) ? Math.round(timeSeconds * 1000) : 0;
+
+          // Use @_status as primary indicator (more robust than checking <failure> presence)
+          const status: 'passed' | 'failed' = tc['@_status'] === 'SUCCESS' ? 'passed' : 'failed';
+          // Extract error message from <failure> or <error> elements
+          const failureText =
+            tc.failure != null
+              ? typeof tc.failure === 'string'
+                ? tc.failure
+                : (tc.failure?.['#text'] ?? null)
+              : null;
+          const errorText =
+            tc.error != null
+              ? typeof tc.error === 'string'
+                ? tc.error
+                : (tc.error?.['#text'] ?? null)
+              : null;
+          const errorMessage: string | null = failureText ?? errorText ?? null;
+
+          // Extract properties
+          const rawProperties: { '@_name': string; '@_value': string }[] =
+            tc.properties?.property ?? [];
+          const properties: Record<string, string> = {};
+
+          for (const prop of rawProperties) {
+            const propName = prop['@_name'];
+            const value = prop['@_value'];
+            if (typeof propName !== 'string' || typeof value !== 'string') {
+              continue;
+            }
+            properties[propName] = value;
+          }
+
+          // Extract tags from "tags" property (Maestro 2.2.0+, comma-separated)
+          const tagsValue = properties['tags'];
+          const tags: string[] = tagsValue
+            ? tagsValue
+                .split(',')
+                .map(t => t.trim())
+                .filter(Boolean)
+            : [];
+          delete properties['tags'];
+
+          results.push({ name, status, duration, errorMessage, tags, properties });
+        }
+      }
+    } catch {
+      // Skip malformed XML files
+      continue;
+    }
+  }
+
+  return results;
+}
+
+const FlowMetadataFileSchema = z.object({
+  flow_name: z.string(),
+  flow_file_path: z.string(),
+});
+
+type FlowMetadata = z.output<typeof FlowMetadataFileSchema>;
+
+/**
+ * Parses an `ai-*.json` file produced by Maestro's TestDebugReporter.
+ *
+ * The file contains:
+ * - `flow_name`: derived from the YAML `config.name` field if present, otherwise
+ *   the flow filename without extension.
+ *   See: https://github.com/mobile-dev-inc/Maestro/blob/c0e95fd/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt#L70
+ * - `flow_file_path`: absolute path to the original flow YAML file.
+ * - `outputs`: screenshot defect data (unused here).
+ *
+ * Filename format: `ai-(flowName).json` where `/` in flowName is replaced with `_`.
+ * See: https://github.com/mobile-dev-inc/Maestro/blob/c0e95fd/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt#L67
+ */
+export async function parseFlowMetadata(filePath: string): Promise<FlowMetadata | null> {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    const data = JSON.parse(content);
+    return FlowMetadataFileSchema.parse(data);
+  } catch {
+    return null;
+  }
+}
+
+export async function parseMaestroResults(
+  junitDirectory: string,
+  testsDirectory: string,
+  projectRoot: string
+): Promise<MaestroFlowResult[]> {
+  // 1. Parse JUnit XML files (primary source)
+  const junitResults = await parseJUnitTestCases(junitDirectory);
+  if (junitResults.length === 0) {
+    return [];
+  }
+
+  // 2. Parse ai-*.json from debug output for flow_file_path + retryCount
+  const flowPathMap = new Map<string, string>(); // flowName → flowFilePath
+  const flowOccurrences = new Map<string, number>(); // flowName → count
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(testsDirectory);
+  } catch {
+    entries = [];
+  }
+
+  const timestampDirs = entries.filter(name => TIMESTAMP_DIR_PATTERN.test(name)).sort();
+
+  for (const dir of timestampDirs) {
+    const dirPath = path.join(testsDirectory, dir);
+    let files: string[];
+    try {
+      files = await fs.readdir(dirPath);
+    } catch {
+      continue;
+    }
+
+    for (const file of files) {
+      const flowKey = extractFlowKey(file, 'ai');
+      if (!flowKey) {
+        continue;
+      }
+
+      const metadata = await parseFlowMetadata(path.join(dirPath, file));
+      if (!metadata) {
+        continue;
+      }
+
+      // Track latest path (last timestamp dir wins)
+      flowPathMap.set(metadata.flow_name, metadata.flow_file_path);
+
+      // Count occurrences for retryCount
+      flowOccurrences.set(metadata.flow_name, (flowOccurrences.get(metadata.flow_name) ?? 0) + 1);
+    }
+  }
+
+  // 3. Merge: JUnit results + ai-*.json metadata
+  const results: MaestroFlowResult[] = [];
+
+  for (const junit of junitResults) {
+    const flowFilePath = flowPathMap.get(junit.name);
+    const relativePath = flowFilePath
+      ? await relativizePathAsync(flowFilePath, projectRoot)
+      : junit.name; // fallback: use flow name if ai-*.json not found
+
+    const occurrences = flowOccurrences.get(junit.name) ?? 0;
+    const retryCount = Math.max(0, occurrences - 1);
+
+    results.push({
+      name: junit.name,
+      path: relativePath,
+      status: junit.status,
+      errorMessage: junit.errorMessage,
+      duration: junit.duration,
+      retryCount,
+      tags: junit.tags,
+      properties: junit.properties,
+    });
+  }
+
+  return results;
+}
+
+async function relativizePathAsync(flowFilePath: string, projectRoot: string): Promise<string> {
+  if (!path.isAbsolute(flowFilePath)) {
+    return flowFilePath;
+  }
+
+  // Resolve symlinks (e.g., /tmp -> /private/tmp on macOS) for consistent comparison
+  let resolvedRoot = projectRoot;
+  let resolvedFlow = flowFilePath;
+  try {
+    resolvedRoot = await fs.realpath(projectRoot);
+  } catch {}
+  try {
+    resolvedFlow = await fs.realpath(flowFilePath);
+  } catch {}
+
+  const relative = path.relative(resolvedRoot, resolvedFlow);
+  if (relative.startsWith('..')) {
+    return flowFilePath;
+  }
+  return relative;
+}

--- a/packages/build-tools/src/steps/functions/reportMaestroTestResults.ts
+++ b/packages/build-tools/src/steps/functions/reportMaestroTestResults.ts
@@ -1,0 +1,120 @@
+import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
+import { graphql } from 'gql.tada';
+
+import { MaestroFlowResult, parseMaestroResults } from './maestroResultParser';
+import { CustomBuildContext } from '../../customBuildContext';
+
+const CREATE_MUTATION = graphql(`
+  mutation CreateWorkflowDeviceTestCaseResults($input: CreateWorkflowDeviceTestCaseResultsInput!) {
+    workflowDeviceTestCaseResult {
+      createWorkflowDeviceTestCaseResults(input: $input) {
+        id
+      }
+    }
+  }
+`);
+
+const FLOW_STATUS_TO_TEST_CASE_RESULT_STATUS: Record<string, 'PASSED' | 'FAILED' | undefined> = {
+  passed: 'PASSED',
+  failed: 'FAILED',
+} satisfies Record<MaestroFlowResult['status'], 'PASSED' | 'FAILED'>;
+
+export function createReportMaestroTestResultsFunction(ctx: CustomBuildContext): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'report_maestro_test_results',
+    name: 'Report Maestro Test Results',
+    __metricsId: 'eas/report_maestro_test_results',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'junit_report_directory',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        defaultValue: '${{ env.HOME }}/.maestro/tests',
+      }),
+      BuildStepInput.createProvider({
+        id: 'tests_directory',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        defaultValue: '${{ env.HOME }}/.maestro/tests',
+      }),
+    ],
+    fn: async (stepsCtx, { inputs }) => {
+      const { logger } = stepsCtx;
+      const workflowJobId = stepsCtx.global.env.__WORKFLOW_JOB_ID;
+      if (!workflowJobId) {
+        logger.info('Not running in a workflow job, skipping test results report');
+        return;
+      }
+      const junitDirectory = (inputs.junit_report_directory.value as string | undefined) ?? '';
+      if (!junitDirectory) {
+        logger.info('No JUnit directory provided, skipping test results report');
+        return;
+      }
+      const testsDirectory = inputs.tests_directory.value as string;
+
+      const flowResults = await parseMaestroResults(
+        junitDirectory,
+        testsDirectory,
+        stepsCtx.workingDirectory
+      );
+      if (flowResults.length === 0) {
+        logger.info('No maestro test results found, skipping report');
+        return;
+      }
+
+      // Maestro allows overriding flow names via config, so different flow files can share
+      // the same name. JUnit XML only contains names (not file paths), making it impossible
+      // to map duplicates back to their original flow files. Skip and let the user fix it.
+      const names = flowResults.map(r => r.name);
+      const duplicates = names.filter((n, i) => names.indexOf(n) !== i);
+      if (duplicates.length > 0) {
+        logger.error(
+          `Duplicate test case names found in JUnit output: ${[...new Set(duplicates)].join(
+            ', '
+          )}. Skipping report. Ensure each Maestro flow has a unique name.`
+        );
+        return;
+      }
+
+      try {
+        const testCaseResults = flowResults.flatMap(f => {
+          const status = FLOW_STATUS_TO_TEST_CASE_RESULT_STATUS[f.status];
+          if (!status) {
+            return [];
+          }
+          return [
+            {
+              name: f.name,
+              path: f.path,
+              status,
+              errorMessage: f.errorMessage,
+              duration: f.duration,
+              retryCount: f.retryCount,
+              tags: f.tags,
+              properties: f.properties,
+            },
+          ];
+        });
+
+        const result = await ctx.graphqlClient
+          .mutation(CREATE_MUTATION, {
+            input: {
+              workflowJobId,
+              testCaseResults,
+            },
+          })
+          .toPromise();
+
+        if (result.error) {
+          logger.error({ error: result.error }, 'GraphQL error creating test case results');
+          return;
+        }
+
+        logger.info(`Reported ${testCaseResults.length} test case result(s).`);
+      } catch (error) {
+        logger.error({ err: error }, 'Failed to create test case results');
+      }
+    },
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,6 +2055,7 @@ __metadata:
     bplist-parser: "npm:0.3.2"
     bunyan: "npm:^1.8.15"
     fast-glob: "npm:^3.3.2"
+    fast-xml-parser: "npm:^4.4.1"
     fs-extra: "npm:^11.2.0"
     gql.tada: "npm:^1.8.13"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
# Why

Maestro test jobs produce per-flow results on the build worker (pass/fail, duration, error messages, retries), but this data is lost after the job finishes.

We want to persist these as `WorkflowDeviceTestCaseResult` records to surface test outcomes in the dashboard.

# How

Add a new `eas/report_maestro_test_results` build function that:
  1. Parses JUnit XML reports from the `junit_report_directory` (primary data source)
  2. Enriches with flow file paths from Maestro's `ai-*.json` debug output in `tests_directory`
  3. Calls the `createWorkflowDeviceTestCaseResults` GraphQL mutation via `gql.tada` + `graphqlClient`

Key details:
  - JUnit XML as primary data source — `ai-*.json` only used for `flow_file_path` mapping and retry count
  - `junit_report_directory` added as output on `eas/__maestro_test` (set when `output_format=junit`) and as optional input on `eas/report_maestro_test_results`
  - Retry detection by counting occurrences of the same flow across timestamp directories (works for both `reuse_devices: true` and `false` patterns)
  - Duplicate testcase name detection — skips report when Maestro config-level name collisions make flow-to-file mapping ambiguous
  - Path relativization uses `fs.realpath` to handle symlinks (`/tmp` → `/private/tmp` on macOS)
  - Best-effort reporting — errors are logged but never fail the build step
  - `graphqlClient` exposed on `CustomBuildContext` for step functions to use
  - 39 unit tests covering JUnit parsing, flow metadata, retry detection, properties/tags, duplicate detection, and error resilience

# Test Plan

- Automation tests
- Manual test locally with https://github.com/expo/universe/pull/24814