### PR TITLE
[build-tools] Increase ASC build processing wait timeout

### DIFF
--- a/packages/build-tools/src/steps/functions/uploadToAsc.ts
+++ b/packages/build-tools/src/steps/functions/uploadToAsc.ts
@@ -234,7 +234,7 @@ export function createUploadToAscBuildFunction(): BuildFunction {
 
       stepsCtx.logger.info('Checking build upload status...');
       const waitingForBuildStartedAt = Date.now();
-      while (Date.now() - waitingForBuildStartedAt < 10 * 60 * 1000 /* 10 minutes */) {
+      while (Date.now() - waitingForBuildStartedAt < 30 * 60 * 1000 /* 30 minutes */) {
         const {
           data: {
             attributes: { state },


### PR DESCRIPTION
## Summary
- extend the `upload_to_asc` build status polling window from 10 minutes to 30 minutes so slowly processed builds have time to reach TestFlight
- keep the rest of the polling logic and `wait_for_processing` default untouched
