### PR TITLE
[chore] Fix Yarn v4 prepack commands

### DIFF
--- a/packages/create-eas-build-function/package.json
+++ b/packages/create-eas-build-function/package.json
@@ -32,7 +32,7 @@
     "build:dev": "ncc build ./src/index.ts -o build/",
     "build": "ncc build ./src/index.ts -o build/ --minify --no-cache --no-source-map-register",
     "typecheck": "tsc",
-    "clean": "rimraf ./build/ *.tsbuildinfo"
+    "clean": "rimraf ./build/ \"*.tsbuildinfo\""
   },
   "dependencies": {
     "@expo/steps": "18.0.2"

--- a/packages/eas-cli/scripts/prepack.js
+++ b/packages/eas-cli/scripts/prepack.js
@@ -2,6 +2,6 @@ const spawn = require('@expo/spawn-async');
 
 (async () => {
   if (!process.env.CLI_SIZE_CHECK) {
-    await spawn('yarn', ['oclif', 'manifest'], { stdio: 'inherit' });
+    await spawn('yarn', ['run', '-T', 'oclif', 'manifest'], { stdio: 'inherit' });
   }
 })();


### PR DESCRIPTION
## Why
Release publish failed in `Publish to npm` for `v18.0.2`.

- `packages/eas-cli/scripts/prepack.js` invoked `yarn oclif manifest`, which fails on Yarn v4 (`Couldn't find a script named \"oclif\"`).
- `packages/create-eas-build-function` `clean` script used an unquoted `*.tsbuildinfo` glob, which fails when no files match.

## How
- Update `packages/eas-cli/scripts/prepack.js` to run `yarn run -T oclif manifest`.
- Quote the tsbuildinfo glob in `packages/create-eas-build-function/package.json`:
  - `rimraf ./build/ "*.tsbuildinfo"`

## Test plan
- `cd packages/eas-cli && mise exec node@20.19.4 -- node ./scripts/prepack.js`
- `cd packages/create-eas-build-function && mise exec node@20.19.4 -- yarn run clean`
- CI
