### PR TITLE
Revert "Use auth code flow (#3398)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Revert authorization code flow with PKCE for browser-based login. ([#3422](https://github.com/expo/eas-cli/pull/3422) by [@byronkarlen](https://github.com/byronkarlen))
+
 ### 🧹 Chores
 
 ## [18.0.3](https://github.com/expo/eas-cli/releases/tag/v18.0.3) - 2026-02-20


### PR DESCRIPTION
# Why
This reverts commit 1604b7bc20f2b3705a8c4dab3f17a9806d3f8a6d. (PR https://github.com/expo/eas-cli/pull/3398)

`eas login --sso` is broken.

# How

How did you build this feature or fix this bug and why?

# Test Plan
Ran `eas login -sso` successfully against staging. Used the uuid suffix with stub-idp to avoid signup flow.