### PR TITLE
[release] Work around the removal of yarn --silent

### DIFF
--- a/scripts/src/release.sh
+++ b/scripts/src/release.sh
@@ -12,8 +12,10 @@ ROOT_DIR="$( cd "$SCRIPTS_DIR"/.. && pwd )"
 # to @expo/eas-build-job dependency, so the update-local-plugin step is no longer needed.
 # $SCRIPTS_DIR/bin/run update-local-plugin
 
-next_version_bump=$($SCRIPTS_DIR/bin/run next-version)
+next_version_bump=`(cd $SCRIPTS_DIR; node --no-warnings=ExperimentalWarning --loader ts-node/esm src/nextVersion.ts)`
 next_version=${1:-$next_version_bump}
+
+echo "next_version = ${next_version}"
 
 if [[ "$GITHUB_USER" == "Expo CI" && "$GITHUB_EMAIL" == "support+ci@expo.io" && "$INPUT_DRY_RUN" != "true" ]]; then
   echo "Releasing with version $next_version"


### PR DESCRIPTION
# Why

When yarn moved to version 4, they removed the `--silent` flag. Because of this change, any use of yarn to call scripts and get output will also get yarn debugging garbage, and there is no way to suppress it.

The release scripts are mostly ok with this, except for calling the `next-version` script. The output of this script has to be clean for it to be used as input for `lerna version`.

# How

Replaced the yarn call with a direct invocation of the node Typescript source, bypassing yarn.

# Test Plan

Since the `trigger-release.yml` workflow supports a dry run mode, it's safe to modify it to check out a test branch and run the workflow many times to debug the issue.

Once this change is merged, a dry run invocation of the workflow should succeed even if no version string is passed in.