### PR TITLE
Fix invisible credential prompts in eas go

### DIFF
--- a/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/CreateProvisioningProfile.ts
@@ -64,7 +64,7 @@ export class CreateProvisioningProfile {
   private async maybeGetUserProvidedAsync(
     ctx: CredentialsContext
   ): Promise<ProvisioningProfile | null> {
-    if (ctx.nonInteractive) {
+    if (ctx.nonInteractive || ctx.autoAcceptCredentialReuse) {
       return null;
     }
     const userProvided = await askForUserProvidedAsync(provisioningProfileSchema);

--- a/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/DistributionCertificateUtils.ts
@@ -162,7 +162,7 @@ Remember that Apple Distribution Certificates are not application specific!
 export async function provideOrGenerateDistributionCertificateAsync(
   ctx: CredentialsContext
 ): Promise<DistributionCertificate> {
-  if (!ctx.nonInteractive) {
+  if (!ctx.nonInteractive && !ctx.autoAcceptCredentialReuse) {
     const userProvided = await promptForDistCertAsync(ctx);
     if (userProvided) {
       if (!ctx.appStore.authCtx) {


### PR DESCRIPTION
# Why

`eas go` can get stuck after "Fetched Apple distribution certificates" on first-time setup, requiring the user to press Enter to continue. This happens because credential creation prompts ("Generate a new Apple Distribution Certificate?", "Generate a new Apple Provisioning Profile?") run inside `withSuppressedOutputAsync`, which intercepts `process.stdout.write`. The prompts are invisible but still block on stdin.

Reproduces unreliably because it only occurs when new credentials need to be created (first-time setup or expired certs). If valid credentials already exist, the creation path is never hit.

# How

Skip the "generate or provide your own?" prompt in `CreateProvisioningProfile` and `provideOrGenerateDistributionCertificateAsync` when `ctx.autoAcceptCredentialReuse` is `true`. This is consistent with how other credential actions (`SetUpDistributionCertificate`, `SetUpProvisioningProfile`, `SetUpAscApiKey`) already use this flag to skip interactive prompts.

When `autoAcceptCredentialReuse` is true (the default for `eas go` without `--credentials`), returning `null` from these functions means "auto-generate", which is the desired behavior.

# Test Plan

Existing tests pass. The fix is straightforward: it adds the same `autoAcceptCredentialReuse` guard that other credential actions already use.