### PR TITLE
Update eas go FYI link

### DIFF
--- a/packages/eas-cli/src/commands/go.ts
+++ b/packages/eas-cli/src/commands/go.ts
@@ -173,7 +173,7 @@ export default class Go extends EasCommand {
   async runAsync(): Promise<void> {
     Log.log(
       chalk.bold(
-        `Creating your personal Expo Go and deploying to TestFlight. ${learnMore('https://expo.fyi/personal-expo-go')}`
+        `Creating your personal Expo Go and deploying to TestFlight. ${learnMore('https://expo.fyi/deploy-expo-go-testflight')}`
       )
     );
 


### PR DESCRIPTION
# Why

I published the FYI page and it ended up having a different URL.

# How

Updated the URL.

# Test Plan

https://expo.fyi/deploy-expo-go-testflight works.