### PR TITLE
[cli] Remove environment requirement for update:configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Remove --environment flag requirement for update:configure. ([#3440](https://github.com/expo/eas-cli/pull/3440) by [@douglowder](https://github.com/douglowder))
+
 ### 🧹 Chores
 
 ## [18.0.6](https://github.com/expo/eas-cli/releases/tag/v18.0.6) - 2026-02-27

--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -67,6 +67,15 @@ export const EasJsonOnlyFlag = {
 export const EasUpdateEnvironmentFlag = {
   environment: Flags.string({
     description:
+      'Environment to use for the server-side defined EAS environment variables during command execution, e.g. "production", "preview", "development".',
+    required: false,
+    default: undefined,
+  }),
+};
+
+export const EasUpdateEnvironmentRequiredFlag = {
+  environment: Flags.string({
+    description:
       'Environment to use for the server-side defined EAS environment variables during command execution, e.g. "production", "preview", "development". Required for projects using Expo SDK 55 or greater.',
     required: false,
     default: undefined,

--- a/packages/eas-cli/src/commands/update/configure.ts
+++ b/packages/eas-cli/src/commands/update/configure.ts
@@ -11,7 +11,6 @@ import {
   ensureEASUpdateIsConfiguredAsync,
   ensureEASUpdateIsConfiguredInEasJsonAsync,
 } from '../../update/configure';
-import { assertEnvironmentFlagForSdk55OrGreater } from '../../update/utils';
 
 export default class UpdateConfigure extends EasCommand {
   static override description = 'configure the project to support EAS Update';
@@ -41,11 +40,6 @@ export default class UpdateConfigure extends EasCommand {
     } = await this.getContextAsync(UpdateConfigure, {
       nonInteractive: flags['non-interactive'],
       withServerSideEnvironment: flags['environment'] ?? null,
-    });
-
-    assertEnvironmentFlagForSdk55OrGreater({
-      sdkVersion: exp.sdkVersion,
-      environment: flags['environment'],
     });
 
     Log.log(

--- a/packages/eas-cli/src/commands/update/index.ts
+++ b/packages/eas-cli/src/commands/update/index.ts
@@ -8,7 +8,10 @@ import { ensureBranchExistsAsync } from '../../branch/queries';
 import { ensureRepoIsCleanAsync } from '../../build/utils/repository';
 import { getUpdateGroupUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
-import { EasNonInteractiveAndJsonFlags, EasUpdateEnvironmentFlag } from '../../commandUtils/flags';
+import {
+  EasNonInteractiveAndJsonFlags,
+  EasUpdateEnvironmentRequiredFlag,
+} from '../../commandUtils/flags';
 import { assertEnvironmentFlagForSdk55OrGreater } from '../../update/utils';
 import { getPaginatedQueryOptions } from '../../commandUtils/pagination';
 import fetch from '../../fetch';
@@ -191,7 +194,7 @@ export default class UpdatePublish extends EasCommand {
       description: `File containing the PEM-encoded private key corresponding to the certificate in expo-updates' configuration. Defaults to a file named "private-key.pem" in the certificate's directory. Only relevant if you are using code signing: https://docs.expo.dev/eas-update/code-signing/`,
       required: false,
     }),
-    ...EasUpdateEnvironmentFlag,
+    ...EasUpdateEnvironmentRequiredFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
 


### PR DESCRIPTION
# Why

This adjusts the change in #3418 that added a requirement for the `--environment` flag in `eas update` for SDK 55 and greater.

The requirement should not have applied to the `update:configure` subcommand. This PR removes the requirement there.

# How

Remove the check in `configure.ts`, and adjust flag descriptions.

# Test Plan

Existing tests should pass.