### PR TITLE
[worker] Enable `COCOAPODS_PARALLEL_CODE_SIGN` for iOS builds

### DIFF
--- a/packages/local-build-plugin/src/build.ts
+++ b/packages/local-build-plugin/src/build.ts
@@ -41,6 +41,7 @@ export async function buildAsync(job: BuildJob, metadata: Metadata): Promise<voi
         EAS_BUILD_ANDROID_VERSION_NAME: job.version?.versionName,
       }),
       ...(job.platform === Platform.IOS && {
+        COCOAPODS_PARALLEL_CODE_SIGN: 'true',
         EAS_BUILD_IOS_BUILD_NUMBER: job.version?.buildNumber,
         EAS_BUILD_IOS_APP_VERSION: job.version?.appVersion,
       }),

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -52,6 +52,7 @@ export function getBuildEnv({
   if (runnerPlatform === Platform.IOS) {
     setEnv(env, 'EAS_BUILD_COCOAPODS_CACHE_URL', config.cocoapodsCacheUrl);
     setEnv(env, 'COMPILER_INDEX_STORE_ENABLE', 'NO');
+    setEnv(env, 'COCOAPODS_PARALLEL_CODE_SIGN', 'true');
 
     if (job.builderEnvironment?.env?.EAS_USE_CACHE === '1') {
       setEnv(env, 'USE_CCACHE', '1');


### PR DESCRIPTION
### Motivation
- Enable CocoaPods parallel code signing to speed up iOS builds (notably for projects with dynamic libraries) and keep worker and local build plugin environments consistent.

### Description
- Set `COCOAPODS_PARALLEL_CODE_SIGN=true` in the worker iOS build environment (`packages/worker/src/env.ts`) and add the same variable to the local build plugin iOS env construction (`packages/local-build-plugin/src/build.ts`).

### Testing
- Ran `yarn workspace @expo/worker test`, which failed in this environment due to missing module resolution for `@expo/build-tools` in the worker test setup.
- Ran `yarn workspace eas-cli-local-build-plugin test`, which succeeded (no tests found, exited 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a33872ec6c8328a3d8818a4f63a84c)