### PR TITLE
[build-tools] Add ASC invalid bundle ID user-facing error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,9 +296,11 @@ export EXPO_DEBUG=1     # Enable debug logging
 
 ### Validation
 
-All changes should be validated with TypeScript and the linter before committing:
+All changes should be validated before committing. At minimum run package-level tests (e.g. `jest-unit`)
+for touched code, then run type checks/linting and format the repo:
 
 ```bash
+yarn fmt            # Apply Oxfmt formatting
 yarn typecheck      # Validate TypeScript types
 yarn lint           # Run Oxlint
 yarn fmt:check      # Run Oxfmt format check

--- a/packages/build-tools/src/steps/functions/__tests__/uploadToAsc.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/uploadToAsc.test.ts
@@ -21,11 +21,7 @@ describe(isClosedVersionTrainError, () => {
 describe(isInvalidBundleIdentifierError, () => {
   it('returns true when all errors are invalid-bundle-id codes', () => {
     expect(
-      isInvalidBundleIdentifierError([
-        { code: '90054' },
-        { code: '90055' },
-        { code: '90055' },
-      ])
+      isInvalidBundleIdentifierError([{ code: '90054' }, { code: '90055' }, { code: '90055' }])
     ).toBe(true);
   });
 

--- a/packages/build-tools/src/steps/functions/uploadToAsc.ts
+++ b/packages/build-tools/src/steps/functions/uploadToAsc.ts
@@ -105,7 +105,9 @@ export function createUploadToAscBuildFunction(): BuildFunction {
 
       const client = new AscApiClient({ token, logger: stepsCtx.logger });
 
-      stepsCtx.logger.info('Reading App information...');
+      stepsCtx.logger.info(
+        `Reading App information for Apple app identifier: ${appleAppIdentifier}...`
+      );
       const appResponse = await AscApiUtils.getAppInfoAsync({ client, appleAppIdentifier });
       const ascAppBundleIdentifier = appResponse.data.attributes.bundleId;
       stepsCtx.logger.info(
@@ -266,7 +268,9 @@ export function createUploadToAscBuildFunction(): BuildFunction {
         if (state.state === 'FAILED') {
           if (isInvalidBundleIdentifierError(errors)) {
             const ipaInfoResult = await asyncResult(readIpaInfoAsync(ipaPath));
-            const ipaBundleIdentifier = ipaInfoResult.ok ? ipaInfoResult.value.bundleIdentifier : null;
+            const ipaBundleIdentifier = ipaInfoResult.ok
+              ? ipaInfoResult.value.bundleIdentifier
+              : null;
 
             throw new UserFacingError(
               'EAS_UPLOAD_TO_ASC_INVALID_BUNDLE_ID',


### PR DESCRIPTION
## Why
Some App Store Connect uploads currently end up as generic failures even when ASC returns explicit bundle identifier mismatch validation ([`90054`](https://expo.dev/accounts/dobrokruh/projects/dobrokruh/job-runs/019cb865-ef97-71d1-9137-f6ae4c05d94d)/[`90055`](https://expo.dev/accounts/central-studio/projects/hfc-fuels/job-runs/019cb882-1550-7801-9b4b-9647e1bce364)). We want a user-facing error that explains the mismatch and shows both identifiers so users can quickly determine whether they selected the wrong app or the wrong build profile/build.

## How
- add `isInvalidBundleIdentifierError` detector in `uploadToAsc` for ASC error codes `90054`/`90055`
- when matched, throw `UserFacingError` with code `EAS_UPLOAD_TO_ASC_INVALID_BUNDLE_ID`
- include both identifiers in message:
  - IPA bundle identifier (best-effort read via `readIpaInfoAsync`)
  - selected ASC app bundle identifier
- provide remediation covering both paths:
  - wrong selected app identifier in submit profile
  - wrong build selected / rebuild with different profile
- use `asyncResult` for best-effort IPA introspection (no nested catch needed)
- add unit tests for invalid bundle-id detector

## Test Plan
- `yarn --cwd packages/build-tools jest-unit src/steps/functions/__tests__/uploadToAsc.test.ts`
- `yarn --cwd packages/build-tools typecheck`