### PR TITLE
[build-tools] Handle ASC missing purpose strings as user-facing error

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/uploadToAsc.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/uploadToAsc.test.ts
@@ -1,4 +1,9 @@
-import { isClosedVersionTrainError, isInvalidBundleIdentifierError } from '../uploadToAsc';
+import {
+  isClosedVersionTrainError,
+  isInvalidBundleIdentifierError,
+  isMissingPurposeStringError,
+  parseMissingUsageDescriptionKeys,
+} from '../uploadToAsc';
 
 describe(isClosedVersionTrainError, () => {
   it('returns true when all errors are closed-version-train codes', () => {
@@ -31,5 +36,57 @@ describe(isInvalidBundleIdentifierError, () => {
 
   it('returns false when there are no errors', () => {
     expect(isInvalidBundleIdentifierError([])).toBe(false);
+  });
+});
+
+describe(isMissingPurposeStringError, () => {
+  it('returns true when all errors are missing-purpose-string codes', () => {
+    expect(isMissingPurposeStringError([{ code: '90683' }, { code: '90683' }])).toBe(true);
+  });
+
+  it('returns false when any other error code is present', () => {
+    expect(isMissingPurposeStringError([{ code: '90683' }, { code: '90054' }])).toBe(false);
+  });
+
+  it('returns false when there are no errors', () => {
+    expect(isMissingPurposeStringError([])).toBe(false);
+  });
+});
+
+describe(parseMissingUsageDescriptionKeys, () => {
+  it('extracts missing UsageDescription keys from ASC messages', () => {
+    expect(
+      parseMissingUsageDescriptionKeys([
+        {
+          description:
+            'The Info.plist file should contain a NSPhotoLibraryUsageDescription key with a user-facing purpose string. (90683)',
+        },
+        {
+          description:
+            'The Info.plist file should contain a NSCameraUsageDescription key with a user-facing purpose string. (90683)',
+        },
+      ])
+    ).toEqual(['NSPhotoLibraryUsageDescription', 'NSCameraUsageDescription']);
+  });
+
+  it('deduplicates repeated keys', () => {
+    expect(
+      parseMissingUsageDescriptionKeys([
+        {
+          description:
+            'The Info.plist file should contain a NSCameraUsageDescription key with a user-facing purpose string. (90683)',
+        },
+        {
+          description:
+            'The Info.plist file should contain a NSCameraUsageDescription key with a user-facing purpose string. (90683)',
+        },
+      ])
+    ).toEqual(['NSCameraUsageDescription']);
+  });
+
+  it('returns an empty array when no usage description key is present', () => {
+    expect(
+      parseMissingUsageDescriptionKeys([{ description: 'Some other upload validation error.' }])
+    ).toEqual([]);
   });
 });

--- a/packages/build-tools/src/steps/functions/uploadToAsc.ts
+++ b/packages/build-tools/src/steps/functions/uploadToAsc.ts
@@ -282,6 +282,26 @@ export function createUploadToAscBuildFunction(): BuildFunction {
                 'If you selected the right app, you may want to select a different build to upload (or rebuild with a different profile).'
             );
           }
+          if (isMissingPurposeStringError(errors)) {
+            const missingUsageDescriptionKeys = parseMissingUsageDescriptionKeys(errors);
+            throw new UserFacingError(
+              'EAS_UPLOAD_TO_ASC_MISSING_PURPOSE_STRING',
+              `Build upload was rejected by App Store Connect because Info.plist is missing one or more privacy purpose strings.\n\n` +
+                `${
+                  missingUsageDescriptionKeys.length > 0
+                    ? `Missing keys reported by App Store Connect:\n- ${missingUsageDescriptionKeys.join(
+                        '\n- '
+                      )}\n\n`
+                    : ''
+                }` +
+                'Add the missing keys with clear user-facing explanations, then rebuild and submit again.\n' +
+                'If you use Continuous Native Generation (CNG), update `ios.infoPlist` in app.json/app.config.js.\n' +
+                'If you do not use CNG, update your app target Info.plist directly.',
+              {
+                docsUrl: 'https://docs.expo.dev/guides/permissions/#ios',
+              }
+            );
+          }
           if (isClosedVersionTrainError(errors)) {
             throw new UserFacingError(
               'EAS_UPLOAD_TO_ASC_CLOSED_VERSION_TRAIN',
@@ -313,6 +333,23 @@ export function isInvalidBundleIdentifierError(messages: { code: string }[]): bo
   return (
     messages.length > 0 && messages.every(message => ['90054', '90055'].includes(message.code))
   );
+}
+
+export function isMissingPurposeStringError(messages: { code: string }[]): boolean {
+  return messages.length > 0 && messages.every(message => message.code === '90683');
+}
+
+export function parseMissingUsageDescriptionKeys(messages: { description: string }[]): string[] {
+  const usageDescriptionKeyRegex = /\b(\w+UsageDescription)\b/g;
+  const keys = new Set<string>();
+  for (const message of messages) {
+    const matches = message.description.matchAll(usageDescriptionKeyRegex);
+    for (const match of matches) {
+      keys.add(match[1]);
+    }
+  }
+
+  return [...keys];
 }
 
 async function uploadChunksAsync({


### PR DESCRIPTION
## Why
Uploads to App Store Connect can fail with code `90683` when required `*UsageDescription` privacy keys are missing in `Info.plist`.

Without dedicated handling this ends up as a generic upload failure, even though ASC already returns structured details that can guide the user.

## How
- add ASC error recognition for `90683` in `uploadToAsc` failed-state handling
- throw a specific `UserFacingError` with code `EAS_UPLOAD_TO_ASC_MISSING_PURPOSE_STRING`
- parse ASC error descriptions to extract and list missing `*UsageDescription` keys
- provide concrete remediation for both CNG (`ios.infoPlist`) and non-CNG (`Info.plist`) workflows
- set `docsUrl` on the user-facing error to Expo permissions docs
- add unit tests for detection and missing-key parsing helpers

## Test Plan
- `yarn --cwd packages/build-tools jest-unit src/steps/functions/__tests__/uploadToAsc.test.ts`
- `yarn --cwd packages/build-tools typecheck`
- `yarn fmt`