### PR TITLE
[worker] Handle non-OK HTTP responses before JSON parsing in upload session

### DIFF
--- a/packages/worker/src/upload.ts
+++ b/packages/worker/src/upload.ts
@@ -331,6 +331,13 @@ async function createUploadSessionAsync(
     throw new Error(`Unexpected response from server (${response.status}): ${textResult.value}`);
   }
 
+  if (!responseResult.value.ok) {
+    const textResult = await asyncResult(responseResult.value.text());
+    throw new Error(
+      `Unexpected response from server (${responseResult.value.status}): ${textResult.ok ? textResult.value : 'Could not read response body'}`
+    );
+  }
+
   const jsonResult = await asyncResult(responseResult.value.json());
   if (!jsonResult.ok) {
     throw new ErrorWithMetadata(`Malformed response from server: ${jsonResult.reason}.`, {


### PR DESCRIPTION
# Why
  - When creating an upload session, if the server (or an intermediate proxy)
    returns a non-OK response with a non-JSON body (e.g. "upstream connect error"),
    the code skipped the `response.ok` check and went straight to `response.json()`,
    producing a confusing `Malformed response from server: FetchError: invalid json
    response body` error with no status code.
  - Add an explicit `response.ok` check before attempting JSON parsing, so the error
    now surfaces the actual HTTP status code and response body.

# How

  - Verified that the existing `responseResult.ok` check (for fetch-level failures)
    is preserved
  - The new `responseResult.value.ok` check catches HTTP-level non-OK responses
    (e.g. 502, 503) that `turtleFetch` passes through due to `shouldThrowOnNotOk: false`

# Test Plan

CI should pass
