### PR TITLE
[build-tools] Classify ASC 90478 as closed version train

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/uploadToAsc.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/uploadToAsc.test.ts
@@ -8,7 +8,12 @@ import {
 describe(isClosedVersionTrainError, () => {
   it('returns true when all errors are closed-version-train codes', () => {
     expect(
-      isClosedVersionTrainError([{ code: '90062' }, { code: '90186' }, { code: '90062' }])
+      isClosedVersionTrainError([
+        { code: '90062' },
+        { code: '90186' },
+        { code: '90478' },
+        { code: '90062' },
+      ])
     ).toBe(true);
   });
 

--- a/packages/build-tools/src/steps/functions/uploadToAsc.ts
+++ b/packages/build-tools/src/steps/functions/uploadToAsc.ts
@@ -305,8 +305,9 @@ export function createUploadToAscBuildFunction(): BuildFunction {
           if (isClosedVersionTrainError(errors)) {
             throw new UserFacingError(
               'EAS_UPLOAD_TO_ASC_CLOSED_VERSION_TRAIN',
-              `Build upload was rejected by App Store Connect because the ${bundleShortVersion} version train is closed. ` +
-                'Bump the iOS app version (CFBundleShortVersionString, e.g. expo.version) to a higher version and submit again.'
+              `Build upload was rejected by App Store Connect because the ${bundleShortVersion} app version is not accepted for new build submissions. ` +
+                'This usually means the version train is closed or lower than a previously approved version. ' +
+                'Bump the iOS app version (CFBundleShortVersionString, e.g. expo.version) to a higher version, then rebuild and submit again.'
             );
           }
           throw new Error(`Build upload (ID: ${buildUploadId}) failed.`);
@@ -325,7 +326,8 @@ function itemizeMessages(messages: { description: string; code: string }[]): str
 
 export function isClosedVersionTrainError(messages: { code: string }[]): boolean {
   return (
-    messages.length > 0 && messages.every(message => ['90062', '90186'].includes(message.code))
+    messages.length > 0 &&
+    messages.every(message => ['90062', '90186', '90478'].includes(message.code))
   );
 }
 


### PR DESCRIPTION
## Why
`submit_ios_from_linux` UNKNOWN_ERROR analysis showed App Store Connect responses that clearly indicate the same version-train failure class but with mixed codes (`90062`, `90186`, `90478`).

Current handling recognizes only `90062` and `90186`, so runs that include `90478` fall back to `UNKNOWN_ERROR`.

## How
- extend `isClosedVersionTrainError` to include ASC code `90478` while keeping strict `.every` matching
- broaden `EAS_UPLOAD_TO_ASC_CLOSED_VERSION_TRAIN` user-facing message to cover both closed train and lower-than-approved version cases
- update unit test to include `90478` in positive closed-train detection

## Examples
Existing `EAS_UPLOAD_TO_ASC_CLOSED_VERSION_TRAIN` runs:
- https://expo.dev/uuid/019cbe83-ac3b-756f-b7ef-447bae5ef4dc
- https://expo.dev/uuid/019cbe66-4f9b-7d95-a35e-06886b646434

Would-be closed-train runs currently persisted as `UNKNOWN_ERROR` (log errors include `90478` with `90062`/`90186`):
- https://expo.dev/uuid/019cbe71-62fa-7fee-9e77-bdc051cc6e8b
- https://expo.dev/uuid/019cbe44-5c75-7211-af66-35fe96a86903

## Test Plan
- `yarn --cwd packages/build-tools jest-unit src/steps/functions/__tests__/uploadToAsc.test.ts`
- `yarn --cwd packages/build-tools typecheck`
- `yarn fmt`
