### PR TITLE
[build-tools] Remove cache support check in restoreCache for build jobs

### DIFF
--- a/packages/build-tools/src/steps/functions/restoreCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreCache.ts
@@ -58,11 +58,6 @@ export function createRestoreCacheFunction(): BuildFunction {
       const { logger } = stepsCtx;
 
       try {
-        if (stepsCtx.global.staticContext.job.platform) {
-          logger.error('Caches are not supported in build jobs yet.');
-          return;
-        }
-
         const paths = z
           .array(z.string())
           .parse(((inputs.path.value ?? '') as string).split(/[\r\n]+/))


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I am exploring applying new forms of caching to speed up Build times. This check limits me from restoring cache in build jobs. I believe this check was added before we supported the two routers 

# How

Remove the early-return guard that prevented `eas/restore_cache` from running in build jobs (when `job.platform` is set). downloadCacheAsync already expects the job.platform
