### PR TITLE
Auto-generate Android keystore in non-interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - Auto-enable `--non-interactive` when `--json` is passed, so users no longer need to specify both flags. ([#3476](https://github.com/expo/eas-cli/pull/3476) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- Auto-generate Android keystore in non-interactive mode instead of throwing an error. ([#3477](https://github.com/expo/eas-cli/pull/3477) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
+++ b/packages/eas-cli/src/credentials/android/actions/BuildCredentialsUtils.ts
@@ -132,10 +132,6 @@ export async function createOrUpdateDefaultAndroidAppBuildCredentialsAsync(
     androidKeystoreId: string;
   }
 ): Promise<AndroidAppBuildCredentialsFragment> {
-  assert(
-    !ctx.nonInteractive,
-    'createOrUpdateDefaultAndroidAppBuildCredentialsAsync must be run in interactive mode'
-  );
   const existingDefaultBuildCredentials =
     await ctx.android.getDefaultAndroidAppBuildCredentialsAsync(ctx.graphqlClient, appLookupParams);
   if (existingDefaultBuildCredentials) {

--- a/packages/eas-cli/src/credentials/android/actions/CreateKeystore.ts
+++ b/packages/eas-cli/src/credentials/android/actions/CreateKeystore.ts
@@ -12,12 +12,13 @@ export class CreateKeystore {
   constructor(private readonly account: AccountFragment) {}
 
   public async runAsync(ctx: CredentialsContext): Promise<AndroidKeystoreFragment> {
-    if (ctx.nonInteractive) {
-      throw new Error(`New keystore cannot be created in non-interactive mode.`);
-    }
-
     const projectId = await ctx.getProjectIdAsync();
-    const keystore = await this.provideOrGenerateAsync(ctx.graphqlClient, ctx.analytics, projectId);
+    const keystore = await this.provideOrGenerateAsync(
+      ctx.graphqlClient,
+      ctx.analytics,
+      projectId,
+      ctx.nonInteractive
+    );
     const keystoreFragment = await ctx.android.createKeystoreAsync(
       ctx.graphqlClient,
       this.account,
@@ -30,13 +31,16 @@ export class CreateKeystore {
   private async provideOrGenerateAsync(
     graphqlClient: ExpoGraphqlClient,
     analytics: Analytics,
-    projectId: string
+    projectId: string,
+    nonInteractive = false
   ): Promise<KeystoreWithType> {
-    const providedKeystore = await askForUserProvidedAsync(keystoreSchema);
-    if (providedKeystore) {
-      const providedKeystoreWithType = getKeystoreWithType(providedKeystore);
-      validateKeystore(providedKeystoreWithType);
-      return providedKeystoreWithType;
+    if (!nonInteractive) {
+      const providedKeystore = await askForUserProvidedAsync(keystoreSchema);
+      if (providedKeystore) {
+        const providedKeystoreWithType = getKeystoreWithType(providedKeystore);
+        validateKeystore(providedKeystoreWithType);
+        return providedKeystoreWithType;
+      }
     }
     return await generateRandomKeystoreAsync(graphqlClient, analytics, projectId);
   }

--- a/packages/eas-cli/src/credentials/android/actions/SetUpBuildCredentials.ts
+++ b/packages/eas-cli/src/credentials/android/actions/SetUpBuildCredentials.ts
@@ -13,7 +13,6 @@ import {
 import Log from '../../../log';
 import { ora } from '../../../ora';
 import { CredentialsContext } from '../../context';
-import { MissingCredentialsNonInteractiveError } from '../../errors';
 import { AppLookupParams } from '../api/GraphqlClient';
 
 interface Options {
@@ -45,11 +44,6 @@ export class SetUpBuildCredentials {
     });
     if (alreadySetupBuildCredentials) {
       return alreadySetupBuildCredentials;
-    }
-    if (ctx.nonInteractive) {
-      throw new MissingCredentialsNonInteractiveError(
-        'Generating a new Keystore is not supported in --non-interactive mode'
-      );
     }
 
     const keystore = await new CreateKeystore(app.account).runAsync(ctx);

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/CreateKeystore-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/CreateKeystore-test.ts
@@ -19,6 +19,7 @@ jest.mock('../../../../graphql/queries/AppQuery');
 describe('CreateKeystore', () => {
   beforeEach(() => {
     jest.mocked(generateRandomKeystoreAsync).mockReset();
+    jest.mocked(askForUserProvidedAsync).mockReset();
     jest.mocked(AppQuery.byIdAsync).mockResolvedValue(testAppQueryByIdResponse);
   });
   it('creates a keystore in Interactive Mode', async () => {
@@ -46,12 +47,17 @@ describe('CreateKeystore', () => {
     );
     expect(generateRandomKeystoreAsync).not.toHaveBeenCalled();
   });
-  it('errors in Non-Interactive Mode', async () => {
+  it('auto-generates keystore in Non-Interactive Mode', async () => {
     const ctx = createCtxMock({ nonInteractive: true });
     const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const createKeystoreAction = new CreateKeystore(appLookupParams.account);
 
-    // fail if users are running in non-interactive mode
-    await expect(createKeystoreAction.runAsync(ctx)).rejects.toThrowError();
+    await createKeystoreAction.runAsync(ctx);
+
+    // expect keystore to be auto-generated without user prompts
+    expect(ctx.android.createKeystoreAsync).toHaveBeenCalled();
+    expect(generateRandomKeystoreAsync).toHaveBeenCalled();
+    // askForUserProvidedAsync should NOT be called in non-interactive mode
+    expect(askForUserProvidedAsync).not.toHaveBeenCalled();
   });
 });

--- a/packages/eas-cli/src/credentials/android/actions/__tests__/SetUpBuildCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/android/actions/__tests__/SetUpBuildCredentials-test.ts
@@ -9,7 +9,6 @@ import {
   testAppQueryByIdResponse,
 } from '../../../__tests__/fixtures-constants';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
-import { MissingCredentialsNonInteractiveError } from '../../../errors';
 import { generateRandomKeystoreAsync } from '../../utils/keystore';
 import { getAppLookupParamsFromContextAsync } from '../BuildCredentialsUtils';
 import { SetUpBuildCredentials } from '../SetUpBuildCredentials';
@@ -59,17 +58,20 @@ describe('SetUpBuildCredentials', () => {
     expect(ctx.android.createKeystoreAsync).toHaveBeenCalled();
     expect(generateRandomKeystoreAsync).toHaveBeenCalled();
   });
-  it('errors in Non-Interactive Mode', async () => {
+  it('auto-generates keystore in Non-Interactive Mode when no credentials exist', async () => {
     const ctx = createCtxMock({
       nonInteractive: true,
       android: {
         ...getNewAndroidApiMock(),
+        createKeystoreAsync: jest.fn(() => testJksAndroidKeystoreFragment),
       },
     });
     const appLookupParams = await getAppLookupParamsFromContextAsync(ctx);
     const setupBuildCredentialsAction = new SetUpBuildCredentials({ app: appLookupParams });
-    await expect(setupBuildCredentialsAction.runAsync(ctx)).rejects.toThrowError(
-      MissingCredentialsNonInteractiveError
-    );
+
+    await setupBuildCredentialsAction.runAsync(ctx);
+
+    expect(ctx.android.createKeystoreAsync).toHaveBeenCalled();
+    expect(generateRandomKeystoreAsync).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Auto-generate Android keystore when running `eas build -p android --non-interactive` without existing credentials
- Previously this threw `MissingCredentialsNonInteractiveError`, breaking CI/CD workflows
- Uses existing `generateRandomKeystoreAsync()` for fully automatic generation

## Test plan
- [x] Run tests: `yarn test src/credentials/android/actions/__tests__/SetUpBuildCredentials-test.ts src/credentials/android/actions/__tests__/CreateKeystore-test.ts`
- [x] Manual test on fresh project: `eas build -p android --non-interactive --profile preview`
- [ ] Verify existing credentials still work without regenerating

🤖 Generated with [Claude Code](https://claude.com/claude-code)