### PR TITLE
feat(cli): add flag to prevent uploading server sourcemaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - Auto-enable `--non-interactive` when `--json` is passed, so users no longer need to specify both flags. ([#3476](https://github.com/expo/eas-cli/pull/3476) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Auto-generate Android keystore in non-interactive mode instead of throwing an error. ([#3477](https://github.com/expo/eas-cli/pull/3477) by [@EvanBacon](https://github.com/EvanBacon))
+- Add `--source-maps` flag to prevent uploading server sourcemaps ([#3478](https://github.com/expo/eas-cli/pull/3478) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/deploy/index.ts
+++ b/packages/eas-cli/src/commands/deploy/index.ts
@@ -52,6 +52,7 @@ interface DeployFlags {
   deploymentIdentifier?: string;
   exportDir: string;
   dryRun: boolean;
+  sourceMaps: boolean;
 }
 
 interface RawDeployFlags {
@@ -63,6 +64,7 @@ interface RawDeployFlags {
   id?: string;
   'export-dir': string;
   'dry-run': boolean;
+  'source-maps': boolean;
 }
 
 interface UploadAssetBatchInstruction {
@@ -106,6 +108,11 @@ export default class WorkerDeploy extends EasCommand {
       description: 'Outputs a tarball of the new deployment instead of uploading it.',
       default: false,
     }),
+    'source-maps': Flags.boolean({
+      description: 'Include source maps in the deployment.',
+      default: true,
+      allowNo: true,
+    }),
     ...EASEnvironmentFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -146,7 +153,9 @@ export default class WorkerDeploy extends EasCommand {
       yield ['assets.json', JSON.stringify(params.assetMap)];
       yield ['manifest.json', JSON.stringify(params.manifest)];
       if (projectDist.type === 'server' && projectDist.serverPath) {
-        const workerFiles = WorkerAssets.listWorkerFilesAsync(projectDist.serverPath);
+        const workerFiles = WorkerAssets.listWorkerFilesAsync(projectDist.serverPath, {
+          skipSourceMaps: !flags.sourceMaps,
+        });
         for await (const workerFile of workerFiles) {
           yield [`server/${workerFile.normalizedPath}`, workerFile.data];
         }
@@ -453,6 +462,7 @@ export default class WorkerDeploy extends EasCommand {
       exportDir: flags['export-dir'],
       environment: flags['environment'],
       dryRun: flags['dry-run'],
+      sourceMaps: flags['source-maps'],
     };
   }
 }

--- a/packages/eas-cli/src/worker/assets.ts
+++ b/packages/eas-cli/src/worker/assets.ts
@@ -232,8 +232,14 @@ interface WorkerFileEntry {
 }
 
 /** Reads worker files while normalizing sourcemaps and providing normalized paths */
-export async function* listWorkerFilesAsync(workerPath: string): AsyncGenerator<WorkerFileEntry> {
+export async function* listWorkerFilesAsync(
+  workerPath: string,
+  options?: { skipSourceMaps?: boolean }
+): AsyncGenerator<WorkerFileEntry> {
   for await (const file of listFilesRecursively(workerPath)) {
+    if (options?.skipSourceMaps && file.normalizedPath.endsWith('.map')) {
+      continue;
+    }
     yield {
       normalizedPath: file.normalizedPath,
       path: file.path,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

EAS Hosting has a 10MB (gzipped) size limit, and we've had user requests to add a way to disable uploading source maps as a way to keep under this limit.

# How

Added a `--source-maps` boolean flag to the `eas deploy` command, and have it default to `true`. When the flag is `false`, source maps for both client and server assets are skipped.

# Test Plan

1. Create a new Expo project that has SSR/API routes/middleware
2. Ran `eas deploy --dry-run` and verified the tarball contains `.map` files
3. Ran `eas deploy --dry-run --no-source-maps` and verified the tarball does not contain `*.map` files
