### PR TITLE
[eas cli] Builds: wait before showing the concurrency limit message

### DIFF
--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -485,10 +485,6 @@ async function handleSingleBuildProgressAsync(
     spinner.start('Build is about to start');
   }
 
-  if (statusNewSetAt !== null && build.status !== BuildStatus.New) {
-    statusNewSetAt = null;
-  }
-
   switch (build.status) {
     case BuildStatus.Finished:
       spinner.succeed('Build finished');
@@ -599,10 +595,8 @@ async function handleMultipleBuildsProgressAsync(
       ].includes(build.status)
     ).length === buildCount;
 
-  if (someNew) {
-    statusNewSetAt ??= Date.now();
-  } else {
-    statusNewSetAt = null;
+  if (someNew && statusNewSetAt === null) {
+    statusNewSetAt = Date.now();
   }
 
   if (allSettled) {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

This issue: https://linear.app/expo/issue/ENG-19399/fix-concurrency-upsell-showing-when-running-builds-on-orchestrator

The current behavior is correct for Turtle builds (without orchestrator) – they appeared `IN_QUEUE` as soon as they were created unless the concurrency limit was indeed reached. It's different with the orchestrator – new builds need to be picked up by the "enqueue" task that runs periodically, so they stay in the `NEW` status for a few seconds even if the concurrency limit isn't reached.

# How

Added a grace period (15s) for the "NEW" status display in the CLI. After this times out, the concurrency limit message is shown.

# Test Plan

Tested this with staging backend (it uses the orchestrator):

https://github.com/user-attachments/assets/c85323d9-b115-477c-bb73-ceaf440433e3
