### PR TITLE
Enable manual testing of changelog GitHub workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,7 @@
 name: CHANGELOG.md PR check
 
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - opened


### PR DESCRIPTION
# Why

There have been failures recently with the GitHub CHANGELOG check. Adjusting the workflow so that it can be manually tested.

# How

Add `workflow_dispatch:`

# Test Plan

CI should pass