### PR TITLE
Use yarn --version to determine if modern yarn

### DIFF
--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -7,7 +7,7 @@ import { instance, mock, when } from 'ts-mockito';
 
 import { BuildContext } from '../../context';
 import { PackageManager } from '../packageManager';
-import { readEasJsonContents, runExpoCliCommand } from '../project';
+import { isUsingModernYarnVersion, readEasJsonContents, runExpoCliCommand } from '../project';
 
 jest.mock('fs');
 jest.mock('@expo/turtle-spawn', () => ({
@@ -85,5 +85,29 @@ describe(readEasJsonContents, () => {
     await fs.writeFile(easJsonPath, contents);
 
     expect(readEasJsonContents(projectDir)).toBe(contents);
+  });
+});
+
+describe(isUsingModernYarnVersion, () => {
+  const mockSpawn = spawn as jest.Mock;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+  });
+
+  it('returns false for yarn 1.x', async () => {
+    mockSpawn.mockResolvedValue({ stdout: '1.22.22' });
+
+    const result = await isUsingModernYarnVersion('/project');
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true for yarn 4.x', async () => {
+    mockSpawn.mockResolvedValue({ stdout: '4.13.0' });
+
+    const result = await isUsingModernYarnVersion('/project');
+
+    expect(result).toBe(true);
   });
 });

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -8,14 +8,10 @@ import { PackageManager } from '../utils/packageManager';
  * Check if yarn version is 2 or later (modern yarn) by running `yarn --version`
  */
 export async function isUsingModernYarnVersion(projectDir: string): Promise<boolean> {
-  try {
-    const result = await spawn('yarn', ['--version'], { cwd: projectDir, stdio: 'pipe' });
-    const version = result.stdout.trim();
-    const majorVersion = parseInt(version.split('.')[0], 10);
-    return majorVersion >= 2;
-  } catch {
-    return false;
-  }
+  const result = await spawn('yarn', ['--version'], { cwd: projectDir, stdio: 'pipe' });
+  const version = result.stdout.trim();
+  const majorVersion = parseInt(version.split('.')[0], 10);
+  return majorVersion >= 2;
 }
 
 export function runExpoCliCommand({


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`eas-cli` was failing for us in CI because it was using yarn 1 install command parameters when we are using yarn 4. The logic for determining whether `.yarnrc` exists should have worked for us, so I'm not entirely sure why the old logic stopped working. 

# How

On the other hand just asking `yarn` which version it is would work better than trying to infer it from the presence of an rc file. There's nothing else that tries to read the rc file so I think this should be strictly better. 


# Test Plan

- Made sure `yarn --version` returns just a version string for both classic and berry 
- Add a small test to make sure the output is correct while mocking `spawn` 
