### PR TITLE
[worker] Add `ITSAppUsesNonExemptEncryption` flag to worker app config

### DIFF
--- a/packages/worker/app.json
+++ b/packages/worker/app.json
@@ -3,6 +3,11 @@
     "name": "EAS Worker",
     "slug": "eas-worker",
     "platforms": ["ios"],
+    "ios": {
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
+    },
     "extra": {
       "eas": {
         "projectId": "90798684-1384-4ce4-a73b-9f3fa3e3e368"


### PR DESCRIPTION
Summary
- add the missing `ITSAppUsesNonExemptEncryption` boolean to `packages/worker/app.json` so the worker app can declare non-exempt encryption usage and avoid iOS config errors

Should fix system tests!