### PR TITLE
[worker] Prevent forwarding HTTP log failures to GCS logstream

### DIFF
--- a/packages/worker/src/__unit__/logger.test.ts
+++ b/packages/worker/src/__unit__/logger.test.ts
@@ -4,6 +4,47 @@ import { Response } from 'node-fetch';
 import fetch from 'node-fetch';
 import z from 'zod';
 
+jest.mock('@expo/build-tools', () => {
+  const actual = jest.requireActual('@expo/build-tools');
+  const { Writable } = jest.requireActual('node:stream');
+
+  class MockGCSLoggerStream extends Writable {
+    public static readonly CompressionMethod = actual.GCSLoggerStream.CompressionMethod;
+    public static readonly instances: MockGCSLoggerStream[] = [];
+
+    public readonly writes: any[] = [];
+
+    constructor(...args: any[]) {
+      super({ objectMode: true });
+      void args;
+      MockGCSLoggerStream.instances.push(this);
+    }
+
+    public async init(): Promise<string> {
+      return 'https://gcs.expo.test/logs';
+    }
+
+    public async cleanUp(): Promise<void> {}
+
+    public _write(
+      chunk: unknown,
+      _encoding: BufferEncoding,
+      callback: (error?: Error | null) => void
+    ): void {
+      this.writes.push(chunk);
+      callback(null);
+    }
+  }
+
+  return {
+    ...actual,
+    GCS: {
+      uploadWithSignedUrl: jest.fn(),
+    },
+    GCSLoggerStream: MockGCSLoggerStream,
+  };
+});
+
 import config from '../config';
 import { createBuildLoggerWithSecretsFilter } from '../logger';
 
@@ -24,19 +65,29 @@ async function waitForStreamFlush(): Promise<void> {
 }
 
 const fetchMock = jest.mocked(fetch);
+const { GCSLoggerStream } = jest.requireMock('@expo/build-tools') as {
+  GCSLoggerStream: {
+    instances: Array<{
+      writes: any[];
+    }>;
+  };
+};
 
 describe('logger', () => {
   const originalHttpBaseUrl = config.loggers.http.baseUrl;
   const originalBuildId = config.buildId;
+  const originalGcsSignedUploadUrlForLogs = config.loggers.gcs.signedUploadUrlForLogs;
 
   beforeEach(() => {
     fetchMock.mockReset();
     fetchMock.mockResolvedValue(new Response('', { status: 200, statusText: 'OK' }));
+    GCSLoggerStream.instances.length = 0;
   });
 
   afterEach(() => {
     config.loggers.http.baseUrl = originalHttpBaseUrl;
     config.buildId = originalBuildId;
+    config.loggers.gcs.signedUploadUrlForLogs = originalGcsSignedUploadUrlForLogs;
   });
 
   it('obfuscates secrets in logs', async () => {
@@ -225,6 +276,38 @@ describe('logger', () => {
     expect(firstAttemptOriginalLog).toBeDefined();
     expect(secondAttemptOriginalLog).toBeDefined();
     expect(secondAttemptOriginalLog).toEqual(firstAttemptOriginalLog);
+  });
+
+  it('does not forward HTTP upload failures to the GCS build log stream', async () => {
+    config.loggers.http.baseUrl = 'https://logs.expo.test/logs/';
+    config.loggers.gcs.signedUploadUrlForLogs = {
+      url: 'https://gcs.expo.test/logs',
+      headers: {},
+    };
+    config.buildId = 'build-id';
+    fetchMock.mockResolvedValue(
+      new Response('upload failed', { status: 500, statusText: 'Internal Server Error' })
+    );
+
+    const { logger, cleanUp } = await createBuildLoggerWithSecretsFilter({
+      robotAccessToken: 'robot-token',
+    });
+
+    logger.info('Actual build log');
+    await cleanUp();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(GCSLoggerStream.instances).toHaveLength(1);
+
+    const gcsLogs = GCSLoggerStream.instances[0].writes;
+    expect(gcsLogs).toEqual(
+      expect.arrayContaining([expect.objectContaining({ msg: 'Actual build log' })])
+    );
+    expect(gcsLogs).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ msg: 'Failed to send logs batch over HTTP' }),
+      ])
+    );
   });
 
   it('drains transformed logs even without explicit output consumer', async () => {

--- a/packages/worker/src/logger.ts
+++ b/packages/worker/src/logger.ts
@@ -152,7 +152,7 @@ export async function createBuildLoggerWithSecretsFilter(secrets: Job['secrets']
       headers: {
         Authorization: `Bearer ${secrets.robotAccessToken}`,
       },
-      logger: buildLogger,
+      logger: defaultLogger,
       bufferRetentionMs: config.loggers.gcs.signedUploadUrlForLogs
         ? Math.max(30_000, config.loggers.gcs.uploadIntervalMs * 2)
         : null,

--- a/packages/worker/src/utils/HttpLogStream.ts
+++ b/packages/worker/src/utils/HttpLogStream.ts
@@ -21,7 +21,7 @@ export default class HttpLogStream extends Writable {
   private readonly buffer: BufferedLogEntry[] = [];
   private readonly url: string;
   private readonly headers: Record<string, string>;
-  private readonly logger?: bunyan;
+  private readonly logger: bunyan;
   private readonly maxBatchBytes: number;
   private readonly bufferRetentionMs: number | null;
   private inFlightRequest: Promise<void> | null = null;
@@ -98,7 +98,7 @@ export default class HttpLogStream extends Writable {
         if (!isCleanup) {
           // Keep logs in memory if upload fails so a later flush can retry.
           this.buffer.unshift(...batch);
-          this.logger?.error({ err }, 'Failed to send logs batch over HTTP');
+          this.logger.error({ err }, 'Failed to send logs batch over HTTP');
         }
       })
       .finally(() => {


### PR DESCRIPTION
Makes sure we don't log "Failed to upload batch of logs" to user-facing log as we did [here](https://staging.expo.dev/accounts/expo-services/projects/worker-system-tests/workflows/019cf7b3-19d6-7b57-bb6f-41d5c63491e3).