### PR TITLE
fix(eas-cli): limit only relevant provisioning profiles being validated with Apple

### DIFF
--- a/packages/eas-cli/src/credentials/ios/appstore/bundleId.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleId.ts
@@ -1,4 +1,4 @@
-import { BundleId, Profile, RequestContext } from '@expo/apple-utils';
+import { BundleId, Profile, ProfileState, RequestContext } from '@expo/apple-utils';
 
 async function getProfilesForBundleIdDangerousAsync(
   context: RequestContext,
@@ -15,7 +15,12 @@ export async function getProfilesForBundleIdAsync(
   context: RequestContext,
   bundleIdentifier: string
 ): Promise<Profile[]> {
-  const profiles = await getProfilesForBundleIdDangerousAsync(context, bundleIdentifier);
+  // Only work with active provisioning profiles, we can't use expired or invalid profiles
+  // Once a profile expired or is marked as invalid, it cannot change back to active, making cache poisoning irrelevant here
+  const profiles = await getProfilesForBundleIdDangerousAsync(context, bundleIdentifier).then(
+    profiles => profiles.filter(profile => profile.attributes.profileState === ProfileState.ACTIVE)
+  );
+
   // users sometimes have a poisoned Apple cache and receive stale data from the API
   // we call an arbitrary method, `getBundleIdAsync` on each profile
   // if it errors, the profile was stale, so we remove it


### PR DESCRIPTION
# Why

Just a tweak to not try to validate already known invalid or expired provisioning profiles.

# How

- We can't request "only valid provisioning profiles" from Apple, so we filter it instead based on the state.
- When we make sure these provisioning profiles are valid, we skip the ones we know are invalid

# Test Plan

- `eas build -p ios` and go through the Apple account flow
- `eas credentials -p ios` and try to manage Apple certificates