### PR TITLE
[eas-build-job] Add `app_store_connect` event context to `WorkflowInterpolationContext`

### DIFF
--- a/packages/eas-build-job/src/__tests__/common.test.ts
+++ b/packages/eas-build-job/src/__tests__/common.test.ts
@@ -43,10 +43,8 @@ describe('StaticWorkflowInterpolationContextZ', () => {
         name: 'account-name',
       },
       app_store_connect: {
-        event: {
-          app: {
-            id: '1234567890',
-          },
+        app: {
+          id: '1234567890',
         },
       },
     };

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -261,10 +261,8 @@ export const StaticWorkflowInterpolationContextZ = z.object({
   }),
   app_store_connect: z
     .looseObject({
-      event: z.looseObject({
-        app: z.looseObject({
-          id: z.string(),
-        }),
+      app: z.looseObject({
+        id: z.string(),
       }),
     })
     .optional(),


### PR DESCRIPTION
# Why

We're adding support for `on.app_store_connect` trigger in workflows. We need to enable users to access ASC context. This PR adds a basic schema, with just ASC app ID.

# How

Extend `StaticWorkflowInterpolationContextZ` by adding `app_store_connect` schema with just `event` object containing just `app`, with just the `id` property.

# Test Plan

Added unit test.
