### PR TITLE
[worker] Downgrade project dependency reporting errors to warnings

### DIFF
--- a/packages/worker/src/external/analytics.ts
+++ b/packages/worker/src/external/analytics.ts
@@ -82,6 +82,7 @@ export async function logProjectDependenciesAsync(
     });
   } catch (error: any) {
     sentry.handleError('Failed to report project dependencies metrics', error, {
+      level: 'warning',
       tags: {
         errorCode: 'FAILED_TO_REPORT_PROJECT_DEPENDENCIES_EVENT',
       },


### PR DESCRIPTION
## Summary
- mark `FAILED_TO_REPORT_PROJECT_DEPENDENCIES_EVENT` as a Sentry warning instead of an error
- reduce noise from non-critical analytics failures in worker project dependency reporting

## Testing
- Not run (not requested)