### PR TITLE
[eas-cli] Add Sentry reporting to `eas-cli` in EAS

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -68,6 +68,7 @@
     "@oclif/core": "^4.8.3",
     "@oclif/plugin-autocomplete": "^3.2.40",
     "@segment/ajv-human-errors": "^2.1.2",
+    "@sentry/node": "7.77.0",
     "@urql/core": "4.0.11",
     "@urql/exchange-retry": "1.2.0",
     "ajv": "8.11.0",

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -27,7 +27,9 @@ import {
   createAnalyticsAsync,
 } from '../analytics/AnalyticsManager';
 import Log, { link } from '../log';
+import Sentry from '../sentry';
 import SessionManager from '../user/SessionManager';
+import { getActorDisplayName } from '../user/User';
 import { Client } from '../vcs/vcs';
 
 export type ContextInput<
@@ -169,7 +171,6 @@ export default abstract class EasCommand extends Command {
    * It is set up here to ensure a consistent setup.
    */
   private analyticsInternal?: AnalyticsWithOrchestration;
-
   /**
    * Execute the context in the contextDefinition to satisfy command prerequisites.
    */
@@ -230,7 +231,13 @@ export default abstract class EasCommand extends Command {
 
     // this is needed for logEvent call below as it identifies the user in the analytics system
     // if possible
-    await this.sessionManager.getUserAsync();
+    const actor = await this.sessionManager.getUserAsync();
+    if (actor) {
+      Sentry.setUser({
+        id: actor.id,
+        username: getActorDisplayName(actor),
+      });
+    }
 
     this.analytics.logEvent(CommandEvent.ACTION, {
       // id is assigned by oclif in constructor based on the filepath:
@@ -244,11 +251,13 @@ export default abstract class EasCommand extends Command {
   // eslint-disable-next-line async-protect/async-suffix
   override async finally(err: Error): Promise<any> {
     await this.analytics.flushAsync();
+    await Sentry.flush(2000);
     return await super.finally(err);
   }
 
   protected override catch(err: Error): Promise<any> {
-    let baseMessage = `${this.id} command failed.`;
+    const commandId = this.id ?? 'unknown';
+    let baseMessage = `${commandId} command failed.`;
     if (err instanceof EasCommandError) {
       Log.error(err.message);
     } else if (err instanceof CombinedError && err?.graphQLErrors) {
@@ -293,6 +302,17 @@ export default abstract class EasCommand extends Command {
       Log.error(err.message);
     }
     Log.debug(err);
+    Sentry.withScope(scope => {
+      scope.setTag('command', commandId);
+      scope.setTag('error_name', err.name);
+      scope.setExtra('commandId', commandId);
+      scope.setExtra('commandMessage', baseMessage);
+      scope.setExtra('originalMessage', err.message);
+      if (err instanceof CombinedError) {
+        scope.setExtra('graphQLErrorCount', err.graphQLErrors.length);
+      }
+      Sentry.captureException(err);
+    });
     const sanitizedError = new Error(baseMessage);
     sanitizedError.stack = err.stack;
     throw sanitizedError;

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -1,14 +1,20 @@
-import { CombinedError } from '@urql/core';
-import { GraphQLError } from 'graphql/error';
 import { v4 as uuidv4 } from 'uuid';
 
-import { AnalyticsWithOrchestration, createAnalyticsAsync } from '../../analytics/AnalyticsManager';
-import Log from '../../log';
-import SessionManager from '../../user/SessionManager';
-import EasCommand from '../EasCommand';
+import { AnalyticsWithOrchestration } from '../../analytics/AnalyticsManager';
 
 jest.mock('../../user/User');
 jest.mock('../../user/SessionManager');
+jest.mock('../../sentry', () => ({
+  __esModule: true,
+  default: {
+    init: jest.fn(),
+    setTag: jest.fn(),
+    setUser: jest.fn(),
+    withScope: jest.fn(),
+    captureException: jest.fn(),
+    flush: jest.fn(async (): Promise<void> => {}),
+  },
+}));
 jest.mock('../../analytics/AnalyticsManager', () => {
   const { CommandEvent } = jest.requireActual('../../analytics/AnalyticsManager');
   return {
@@ -38,20 +44,22 @@ const analytics: AnalyticsWithOrchestration = {
 
 beforeEach(() => {
   jest.resetAllMocks();
-
-  jest.mocked(createAnalyticsAsync).mockResolvedValue(analytics);
 });
 
 const createTestEasCommand = (): any => {
+  const { createAnalyticsAsync } = jest.requireMock('../../analytics/AnalyticsManager');
+  createAnalyticsAsync.mockResolvedValue(analytics);
+  const EasCommand = require('../EasCommand').default;
+
   class TestEasCommand extends EasCommand {
-    override async runAsync(): Promise<void> {}
+    async runAsync(): Promise<void> {}
   }
 
   TestEasCommand.id = 'testEasCommand'; // normally oclif will assign ids, but b/c this is located outside the commands folder it will not
   return TestEasCommand;
 };
 
-describe(EasCommand.name, () => {
+describe('EasCommand', () => {
   describe('without exceptions', () => {
     // The first test in this suite should have an increased timeout
     // because of the implementation of Command from @oclif/command.
@@ -64,6 +72,7 @@ describe(EasCommand.name, () => {
       const TestEasCommand = createTestEasCommand();
       await TestEasCommand.run();
 
+      const SessionManager = jest.requireMock('../../user/SessionManager').default;
       const sessionManagerSpy = jest.spyOn(SessionManager.prototype, 'getUserAsync');
       expect(sessionManagerSpy).toBeCalledTimes(1);
     }, 60_000);
@@ -72,6 +81,7 @@ describe(EasCommand.name, () => {
       const TestEasCommand = createTestEasCommand();
       await TestEasCommand.run();
 
+      const { createAnalyticsAsync } = jest.requireMock('../../analytics/AnalyticsManager');
       expect(createAnalyticsAsync).toHaveBeenCalled();
     });
 
@@ -80,6 +90,14 @@ describe(EasCommand.name, () => {
       await TestEasCommand.run();
 
       expect(analytics.flushAsync).toHaveBeenCalled();
+    });
+
+    it('flushes Sentry', async () => {
+      const TestEasCommand = createTestEasCommand();
+      await TestEasCommand.run();
+
+      const Sentry = jest.requireMock('../../sentry').default;
+      expect(Sentry.flush).toHaveBeenCalled();
     });
 
     it('logs events', async () => {
@@ -105,8 +123,59 @@ describe(EasCommand.name, () => {
     });
 
     describe('catch', () => {
+      it('captures unexpected errors', async () => {
+        const TestEasCommand = createTestEasCommand();
+        const runAsyncMock = jest.spyOn(TestEasCommand.prototype, 'runAsync');
+        const error = new Error('Unexpected, internal error message');
+        const sentryScope = {
+          setTag: jest.fn(),
+          setExtra: jest.fn(),
+        };
+        const Sentry = jest.requireMock('../../sentry').default;
+        Sentry.withScope.mockImplementation((cb: (scope: typeof sentryScope) => void) => {
+          cb(sentryScope);
+        });
+        runAsyncMock.mockImplementation(() => {
+          throw error;
+        });
+
+        try {
+          await TestEasCommand.run();
+        } catch {}
+
+        expect(sentryScope.setTag).toHaveBeenCalledWith('command', TestEasCommand.id);
+        expect(sentryScope.setTag).toHaveBeenCalledWith('error_name', error.name);
+        expect(sentryScope.setExtra).toHaveBeenCalledWith('commandId', TestEasCommand.id);
+        expect(sentryScope.setExtra).toHaveBeenCalledWith(
+          'commandMessage',
+          `${TestEasCommand.id} command failed.`
+        );
+        expect(sentryScope.setExtra).toHaveBeenCalledWith('originalMessage', error.message);
+        expect(Sentry.captureException).toHaveBeenCalledWith(error);
+      });
+
+      it('captures expected command errors', async () => {
+        const TestEasCommand = createTestEasCommand();
+        const runAsyncMock = jest.spyOn(TestEasCommand.prototype, 'runAsync');
+        const { EasCommandError } = require('../errors');
+        const Sentry = jest.requireMock('../../sentry').default;
+        Sentry.withScope.mockImplementation((cb: (scope: any) => void) => {
+          cb({ setTag: jest.fn(), setExtra: jest.fn() });
+        });
+        runAsyncMock.mockImplementation(() => {
+          throw new EasCommandError('Expected user-facing error');
+        });
+
+        try {
+          await TestEasCommand.run();
+        } catch {}
+
+        expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+      });
+
       it('logs the message', async () => {
         const TestEasCommand = createTestEasCommand();
+        const Log = jest.requireMock('../../log').default;
         const logErrorSpy = jest.spyOn(Log, 'error');
         const logDebugSpy = jest.spyOn(Log, 'debug');
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype, 'runAsync');
@@ -124,9 +193,11 @@ describe(EasCommand.name, () => {
 
       it('logs the cleaned message if needed', async () => {
         const TestEasCommand = createTestEasCommand();
+        const Log = jest.requireMock('../../log').default;
         const logErrorSpy = jest.spyOn(Log, 'error');
         const logDebugSpy = jest.spyOn(Log, 'debug');
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype, 'runAsync');
+        const { CombinedError } = require('@urql/core');
         const graphQLErrors = ['Unexpected GraphQL error message'];
         const error = new CombinedError({ graphQLErrors });
         runAsyncMock.mockImplementation(() => {
@@ -142,9 +213,12 @@ describe(EasCommand.name, () => {
 
       it('logs the cleaned message with request ID if present', async () => {
         const TestEasCommand = createTestEasCommand();
+        const Log = jest.requireMock('../../log').default;
         const logErrorSpy = jest.spyOn(Log, 'error');
         const logDebugSpy = jest.spyOn(Log, 'debug');
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype, 'runAsync');
+        const { CombinedError } = require('@urql/core');
+        const { GraphQLError } = require('graphql/error');
         const graphQLError = new GraphQLError(
           'Unexpected GraphQL error message',
           null,
@@ -174,9 +248,12 @@ describe(EasCommand.name, () => {
 
       it('logs the cleaned messages with request IDs if multiple GraphQL errors present', async () => {
         const TestEasCommand = createTestEasCommand();
+        const Log = jest.requireMock('../../log').default;
         const logErrorSpy = jest.spyOn(Log, 'error');
         const logDebugSpy = jest.spyOn(Log, 'debug');
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype, 'runAsync');
+        const { CombinedError } = require('@urql/core');
+        const { GraphQLError } = require('graphql/error');
         const graphQLErrors = [
           new GraphQLError('Unexpected GraphQL error message', null, null, null, null, null, {
             errorCode: 'UNKNOWN_GRAPHQL_ERROR',
@@ -227,6 +304,7 @@ describe(EasCommand.name, () => {
       it('re-throws the error with a different default base message in case of CombinedError', async () => {
         const TestEasCommand = createTestEasCommand();
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype, 'runAsync');
+        const { CombinedError } = require('@urql/core');
         runAsyncMock.mockImplementation(() => {
           const graphQLErrors = ['Unexpected GraphQL error message'];
           throw new CombinedError({ graphQLErrors });
@@ -242,6 +320,8 @@ describe(EasCommand.name, () => {
       it('re-throws the error with a different default base message in case of CombinedError with multiple GraphQLErrors', async () => {
         const TestEasCommand = createTestEasCommand();
         const runAsyncMock = jest.spyOn(TestEasCommand.prototype, 'runAsync');
+        const { CombinedError } = require('@urql/core');
+        const { GraphQLError } = require('graphql/error');
         runAsyncMock.mockImplementation(() => {
           const graphQLErrors = [
             new GraphQLError('Unexpected GraphQL error message', null, null, null, null, null, {

--- a/packages/eas-cli/src/sentry.ts
+++ b/packages/eas-cli/src/sentry.ts
@@ -1,0 +1,22 @@
+import * as Sentry from '@sentry/node';
+
+import { easCliVersion } from './utils/easCli';
+
+Sentry.init({
+  dsn: process.env.EAS_CLI_SENTRY_DSN,
+  enabled: !!process.env.EAS_CLI_SENTRY_DSN,
+  environment: getSentryEnvironment(),
+  release: easCliVersion ? `eas-cli@${easCliVersion}` : undefined,
+});
+Sentry.setTag('source', 'eas-cli');
+
+function getSentryEnvironment(): string {
+  if (process.env.EXPO_LOCAL) {
+    return 'local';
+  } else if (process.env.EXPO_STAGING) {
+    return 'staging';
+  }
+  return 'production';
+}
+
+export default Sentry;

--- a/packages/worker/src/__unit__/env.test.ts
+++ b/packages/worker/src/__unit__/env.test.ts
@@ -1,0 +1,36 @@
+import { Platform, Workflow } from '@expo/eas-build-job';
+
+import config from '../config';
+import { getBuildEnv } from '../env';
+
+describe(getBuildEnv.name, () => {
+  const originalSentryDsn = config.sentry.dsn;
+
+  afterEach(() => {
+    config.sentry.dsn = originalSentryDsn;
+  });
+
+  it('passes the CLI sentry DSN to worker child processes', () => {
+    config.sentry.dsn = 'https://public@example.ingest.sentry.io/1';
+
+    const env = getBuildEnv({
+      job: {
+        platform: Platform.ANDROID,
+        type: Workflow.MANAGED,
+        builderEnvironment: {
+          env: {},
+        },
+        username: 'expo-user',
+      } as any,
+      projectId: 'project-id',
+      metadata: {
+        buildProfile: 'production',
+        gitCommitHash: 'abc123',
+        username: 'expo-user',
+      } as any,
+      buildId: 'build-id',
+    });
+
+    expect(env.EAS_CLI_SENTRY_DSN).toBe(config.sentry.dsn);
+  });
+});

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -36,6 +36,7 @@ export function getBuildEnv({
   setEnv(env, 'EAS_BUILD', 'true');
   setEnv(env, 'EAS_BUILD_RUNNER', 'eas-build');
   setEnv(env, 'EAS_BUILD_PLATFORM', job.platform);
+  setEnv(env, 'EAS_CLI_SENTRY_DSN', config.sentry.dsn);
   // NPM_CACHE_URL is deprecated
   setEnv(env, 'NPM_CACHE_URL', config.npmCacheUrl);
   setEnv(env, 'NVM_NODEJS_ORG_MIRROR', config.nodeJsCacheUrl);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10858,6 +10858,7 @@ __metadata:
     "@oclif/core": "npm:^4.8.3"
     "@oclif/plugin-autocomplete": "npm:^3.2.40"
     "@segment/ajv-human-errors": "npm:^2.1.2"
+    "@sentry/node": "npm:7.77.0"
     "@tsconfig/node20": "npm:20.1.8"
     "@types/cli-progress": "npm:3.11.5"
     "@types/dateformat": "npm:3.0.1"


### PR DESCRIPTION
## Summary
- add a dedicated `packages/eas-cli/src/sentry.ts` module that initializes `@sentry/node` for eas-cli
- capture command failures from `EasCommand`, including `EasCommandError`, and flush Sentry on exit
- propagate `EAS_CLI_SENTRY_DSN` into the worker child-process environment so worker-run eas-cli commands can report errors too

https://exponent-internal.slack.com/archives/C06EFBQK3B7/p1773432161848589?thread_ts=1773417343.042269&cid=C06EFBQK3B7

## Validation
- `yarn test src/commandUtils/__tests__/EasCommand-test.ts --runInBand`
- `yarn test:unit --runInBand src/__unit__/env.test.ts`
- `yarn build` in `packages/eas-cli`
- `node ./bin/run --version`
- `node ./bin/run --help`
- `node ./bin/run analytics`
- `EAS_CLI_SENTRY_DSN=https://public@example.ingest.us.sentry.io/1 node ./bin/run analytics`

## Manual Sentry Verification
- ran the compiled CLI against the test Sentry project `expo-stanley-test/test-local` with a real DSN
- forced an `EasCommandError` from `eas analytics` and confirmed the CLI failed locally as expected
- verified that Sentry ingested the event and created issue `TEST-LOCAL-1`
- confirmed the event in Sentry at `https://expo-stanley-test.sentry.io/issues/TEST-LOCAL-1`