### PR TITLE
[steps][local-build-plugin] Remove `buildStepInternalId`

### DIFF
--- a/packages/local-build-plugin/src/logger.ts
+++ b/packages/local-build-plugin/src/logger.ts
@@ -86,7 +86,6 @@ class PrettyStream extends Writable {
       'pid',
       'hostname',
       'name',
-      'buildStepInternalId',
       'buildStepId',
       'buildStepDisplayName',
     ]);

--- a/packages/steps/src/BuildStep.ts
+++ b/packages/steps/src/BuildStep.ts
@@ -139,7 +139,6 @@ export class BuildStep extends BuildStepOutputAccessor {
   private readonly outputsDir: string;
   private readonly envsDir: string;
 
-  private readonly internalId: string;
   private readonly inputById: BuildStepInputById;
   protected executed = false;
 
@@ -198,10 +197,7 @@ export class BuildStep extends BuildStepOutputAccessor {
     this.__metricsId = __metricsId;
     this.status = BuildStepStatus.NEW;
 
-    this.internalId = uuidv4();
-
     const logger = ctx.baseLogger.child({
-      buildStepInternalId: this.internalId,
       buildStepId: this.id,
       buildStepDisplayName: this.displayName,
     });

--- a/packages/steps/src/__tests__/BuildStep-test.ts
+++ b/packages/steps/src/__tests__/BuildStep-test.ts
@@ -170,7 +170,6 @@ describe(BuildStep, () => {
       });
       expect(ctx.baseLogger.child).toHaveBeenCalledWith(
         expect.objectContaining({
-          buildStepInternalId: expect.stringMatching(UUID_REGEX),
           buildStepId: 'test1',
           buildStepDisplayName: 'Test step',
         })


### PR DESCRIPTION
## Summary
- remove `buildStepInternalId` emission from `BuildStep`
- stop generating the extra UUID entirely
- drop the now-unused field from local build log sanitization

Just want to make logs smaller.

## Testing
- yarn --cwd packages/steps test --runInBand BuildStep-test.ts
- yarn --cwd packages/steps typecheck
