### PR TITLE
Reapply "Use auth code flow (#3398)" (#3422)

### DIFF
--- a/packages/eas-cli/src/user/expoBrowserAuthFlowLauncher.ts
+++ b/packages/eas-cli/src/user/expoBrowserAuthFlowLauncher.ts
@@ -1,24 +1,86 @@
 import assert from 'assert';
 import openBrowserAsync from 'better-opn';
+import crypto from 'crypto';
 import http from 'http';
 import { Socket } from 'node:net';
-import querystring from 'querystring';
 
-import { getExpoWebsiteBaseUrl } from '../api';
+import { getExpoApiBaseUrl, getExpoWebsiteBaseUrl } from '../api';
+import fetch from '../fetch';
 import Log from '../log';
+
+const CLIENT_ID = 'eas-cli';
+
+function generateCodeVerifier(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+function generateCodeChallenge(codeVerifier: string): string {
+  return crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+}
+
+function generateState(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+async function exchangeCodeForSessionSecretAsync({
+  code,
+  codeVerifier,
+  redirectUri,
+}: {
+  code: string;
+  codeVerifier: string;
+  redirectUri: string;
+}): Promise<string> {
+  const tokenUrl = `${getExpoApiBaseUrl()}/v2/auth/token`;
+  const response = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+      client_id: CLIENT_ID,
+    }),
+  });
+
+  const result: any = await response.json();
+  const sessionSecret = result?.data?.session_secret;
+  if (!sessionSecret) {
+    throw new Error('Failed to obtain session secret from token exchange.');
+  }
+  return sessionSecret;
+}
 
 export async function getSessionUsingBrowserAuthFlowAsync({ sso = false }): Promise<string> {
   const scheme = 'http';
   const hostname = 'localhost';
-  const path = '/auth/callback';
+  const callbackPath = '/auth/callback';
 
   const expoWebsiteUrl = getExpoWebsiteBaseUrl();
 
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  const state = generateState();
+
+  const buildRedirectUri = (port: number): string =>
+    `${scheme}://${hostname}:${port}${callbackPath}`;
+
   const buildExpoLoginUrl = (port: number, sso: boolean): string => {
-    const params = querystring.stringify({
-      confirm_account: true,
-      app_redirect_uri: `${scheme}://${hostname}:${port}${path}`,
-    });
+    // Note: we avoid URLSearchParams here because better-opn calls encodeURI()
+    // on the URL before passing it to AppleScript, which would double-encode
+    // the percent-encoded values from URLSearchParams.toString().
+    const params = [
+      `client_id=${CLIENT_ID}`,
+      `redirect_uri=${buildRedirectUri(port)}`,
+      `response_type=code`,
+      `code_challenge=${codeChallenge}`,
+      `code_challenge_method=S256`,
+      `state=${state}`,
+      `confirm_account=true`,
+    ].join('&');
     return `${expoWebsiteUrl}${sso ? '/sso-login' : '/login'}?${params}`;
   };
 
@@ -39,22 +101,39 @@ export async function getSessionUsingBrowserAuthFlowAsync({ sso = false }): Prom
             }
           };
 
-          try {
+          const handleRequestAsync = async (): Promise<void> => {
             if (!(request.method === 'GET' && request.url?.includes('/auth/callback'))) {
               throw new Error('Unexpected login response.');
             }
             const url = new URL(request.url, `http:${request.headers.host}`);
-            const sessionSecret = url.searchParams.get('session_secret');
+            const code = url.searchParams.get('code');
+            const returnedState = url.searchParams.get('state');
 
-            if (!sessionSecret) {
-              throw new Error('Request missing session_secret search parameter.');
+            if (!code) {
+              throw new Error('Request missing code search parameter.');
             }
+            if (returnedState !== state) {
+              throw new Error('State mismatch. Possible CSRF attack.');
+            }
+
+            const address = server.address();
+            assert(address !== null && typeof address === 'object');
+            const redirectUri = buildRedirectUri(address.port);
+
+            const sessionSecret = await exchangeCodeForSessionSecretAsync({
+              code,
+              codeVerifier,
+              redirectUri,
+            });
+
             resolve(sessionSecret);
             redirectAndCleanup('success');
-          } catch (error) {
+          };
+
+          handleRequestAsync().catch(error => {
             redirectAndCleanup('error');
             reject(error);
-          }
+          });
         }
       );
 


### PR DESCRIPTION
This reverts the revert commit 0fdf2dd44a36f5a55f14fdb0f2dca6000034c934 (https://github.com/expo/eas-cli/pull/3422), reapplying https://github.com/expo/eas-cli/pull/3398

# Why
`eas` should use OAuth code flow to authenticate with API. This change originally had to be reverted since it didn't support SSO users, but now it does. (See https://app.graphite.com/github/pr/expo/universe/25642)

# How
Re-applying commit. 

# Test Plan
Ran `eas login --sso` against staging. Confirmed things work as expected when:
- SSO user already logged in on website
- Other, non-SSO user already logged in on website
- User not logged in on website
- Independent sign-out behavior (already tested by www)