### PR TITLE
fix: respect .gitignore negation patterns when copying project files

### DIFF
--- a/packages/eas-cli/src/vcs/__tests__/local-test.ts
+++ b/packages/eas-cli/src/vcs/__tests__/local-test.ts
@@ -136,9 +136,9 @@ describe(Ignore, () => {
       );
 
       const ignore = await Ignore.createForCopyingAsync('/root');
-      expect(ignore.ignores('.eas/build')).toBe(false);
+      expect(ignore.ignores('.eas/build/')).toBe(false);
       expect(ignore.ignores('.eas/build/foo.txt')).toBe(false);
-      expect(ignore.ignores('.eas/other')).toBe(true);
+      expect(ignore.ignores('.eas/other/')).toBe(true);
       expect(ignore.ignores('.eas/other.txt')).toBe(true);
     });
 
@@ -154,7 +154,7 @@ describe(Ignore, () => {
       expect(ignore.ignores('.eas/build/foo.txt')).toBe(true);
     });
 
-    it('known limitation: a file whose name matches a directory negation pattern is incorrectly un-ignored', async () => {
+    it('does not un-ignore a file whose name matches a directory negation pattern', async () => {
       vol.fromJSON(
         {
           '.gitignore': 'build\n!build/\n',
@@ -163,7 +163,8 @@ describe(Ignore, () => {
       );
 
       const ignore = await Ignore.createForCopyingAsync('/root');
-      expect(ignore.ignores('build')).toBe(false); // known incorrect behavior
+      expect(ignore.ignores('build')).toBe(true);
+      expect(ignore.ignores('build/')).toBe(false);
     });
   });
 });

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -16,7 +16,6 @@ const GITIGNORE_FILENAME = '.gitignore';
  * Inconsistencies with git behavior:
  * - if parent .gitignore has ignore rule and child has exception to that rule,
  *   file will still be ignored,
- * - !dir/ patterns may incorrectly un-ignore a file with the same name,
  * - node_modules is always ignored,
  * - if .easignore exists, .gitignore files are not used.
  */
@@ -93,13 +92,6 @@ node_modules
       const result = ignore.test(slicedPath);
       if (result.ignored) ignored = true;
       else if (result.unignored) ignored = false;
-      // fs.cp omits trailing slashes from directory paths, but patterns like !dir/ need one.
-      // Re-test with a slash to catch directory negations. Only unignored is applied here
-      // to avoid treating a file named "build" as ignored just because "build/" is a pattern.
-      if (!slicedPath.endsWith('/')) {
-        const resultWithSlash = ignore.test(`${slicedPath}/`);
-        if (resultWithSlash.unignored) ignored = false;
-      }
     }
     return ignored;
   }
@@ -127,7 +119,10 @@ export async function makeShallowCopyAsync(_src: string, dst: string): Promise<v
         return true;
       }
       const relativePath = path.relative(src, srcFilePath);
-      const shouldCopyTheItem = !ignore.ignores(relativePath);
+
+      // Append a trailing slash for directories so patterns like !dir/ match correctly.
+      const isDirectory = fsExtra.lstatSync(srcFilePath).isDirectory();
+      const shouldCopyTheItem = !ignore.ignores(isDirectory ? `${relativePath}/` : relativePath);
 
       Log.debug(shouldCopyTheItem ? 'copying' : 'skipping', {
         src,


### PR DESCRIPTION
# Why
`.gitignore` negation patterns (e.g. `.eas/*` + `!.eas/build/`) were not being respected when copying project files. Once a file or directory was marked as ignored, there was no way for a negation rule in the same `.gitignore` to un-ignore it. This also affected `.gitignore` files inside dot-directories (e.g. `.eas/.gitignore`), which were never discovered at all.

 # How

1. **Negation support** - switched `ignores()` from an early-return loop to accumulating state. It now uses `ignore.test()` instead of `ignore.ignores()` to get both `ignored` and `unignored` signals, so a negation rule in the same `.gitignore` instance can override an earlier positive rule.

2. **Dot-directory discovery** - added `dot: true` to the `fast-glob` call that finds `.gitignore` files, so files like `.eas/.gitignore` are picked up.

3. **Directory negation patterns** - `node:fs` omits trailing slashes from directory paths, so patterns like `!build/` never matched. The filter now calls `lstatSync` to detect directories and appends a trailing slash before passing the path to `ignores()`, which correctly distinguishes `!build/` (directory) from a file named `build`.
 
# Test Plan
Automated tests added in `packages/eas-cli/src/vcs/__tests__/local-test.ts` covering:
- negation patterns un-ignoring a directory and its contents in the same `.gitignore`
- the no-negation baseline still ignoring correctly
- `!build/` not incorrectly un-ignoring a file named `build`
- `.gitignore` files inside dot-directories being picked up

To verify manually, add `.eas/*` and `!.eas/build/` to your project's `.gitignore` and run a build. The `.eas/build/` directory should be included in the uploaded archive.