### PR TITLE
[build-tools] Disable Android emulator window transitions

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts
@@ -35,14 +35,15 @@ const mockedSpawn = jest.mocked(spawn);
 const mockedRetryAsync = jest.mocked(retryAsync);
 const mockedAndroidUtils = jest.mocked(AndroidEmulatorUtils);
 
-function createStep(callInputs?: Record<string, unknown>) {
+function createStep(callInputs?: Record<string, unknown>, envOverrides?: NodeJS.ProcessEnv) {
   const logger = createMockLogger();
   const fn = createStartAndroidEmulatorBuildFunction();
   const globalCtx = createGlobalContextMock({ logger });
-  globalCtx.updateEnv({ HOME: '/home/expo', ANDROID_HOME: '/android/home' });
-  return fn.createBuildStepFromFunctionCall(globalCtx, {
+  globalCtx.updateEnv({ HOME: '/home/expo', ANDROID_HOME: '/android/home', ...envOverrides });
+  const step = fn.createBuildStepFromFunctionCall(globalCtx, {
     callInputs,
   });
+  return Object.assign(step, { logger });
 }
 
 function createStartResult(serialId: string) {
@@ -58,6 +59,7 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
     mockedAndroidUtils.getAvailableDevicesAsync.mockResolvedValue([]);
     mockedAndroidUtils.createAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.cloneAsync.mockResolvedValue(undefined);
+    mockedAndroidUtils.startAsync.mockResolvedValue(createStartResult('emulator-default'));
     mockedAndroidUtils.waitForReadyAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.disableWindowAndTransitionAnimationsAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.deleteAsync.mockResolvedValue(undefined);
@@ -199,5 +201,15 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
       })
     );
     expect(mockedAndroidUtils.deleteAsync).toHaveBeenCalledTimes(3);
+  });
+
+  it('skips animation scale adjustments when opt out env var is disabled', async () => {
+    const step = createStep(undefined, {
+      ANDROID_EMULATOR_ADJUST_ANIMATION_SCALE: 'false',
+    });
+
+    await step.executeAsync();
+
+    expect(mockedAndroidUtils.disableWindowAndTransitionAnimationsAsync).not.toHaveBeenCalled();
   });
 });

--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -57,6 +57,15 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
       const systemImagePackage = `${inputs.system_image_package.value}`;
       // We can cast because allowedValueTypeName validated this is a string.
       const deviceIdentifier = inputs.device_identifier.value as AndroidDeviceName | undefined;
+      const shouldAdjustAnimationScale =
+        env.ANDROID_EMULATOR_ADJUST_ANIMATION_SCALE !== 'false' &&
+        env.ANDROID_EMULATOR_ADJUST_ANIMATION_SCALE !== '0';
+
+      if (!shouldAdjustAnimationScale) {
+        logger.info(
+          'Skipping Android emulator animation scale adjustments because $ANDROID_EMULATOR_ADJUST_ANIMATION_SCALE is disabled.'
+        );
+      }
 
       logger.info('Making sure system image is installed');
       await retryAsync(
@@ -107,11 +116,13 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
               timeoutMs,
               logger,
             });
-            await AndroidEmulatorUtils.disableWindowAndTransitionAnimationsAsync({
-              env,
-              logger,
-              serialId: attemptSerialId,
-            });
+            if (shouldAdjustAnimationScale) {
+              await AndroidEmulatorUtils.disableWindowAndTransitionAnimationsAsync({
+                env,
+                logger,
+                serialId: attemptSerialId,
+              });
+            }
             logger.info(`${deviceName} is ready.`);
 
             serialId = attemptSerialId;
@@ -196,11 +207,13 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
                   timeoutMs,
                   logger,
                 });
-                await AndroidEmulatorUtils.disableWindowAndTransitionAnimationsAsync({
-                  env,
-                  logger,
-                  serialId: cloneSerialId,
-                });
+                if (shouldAdjustAnimationScale) {
+                  await AndroidEmulatorUtils.disableWindowAndTransitionAnimationsAsync({
+                    env,
+                    logger,
+                    serialId: cloneSerialId,
+                  });
+                }
 
                 logger.info(`${cloneIdentifier} is ready.`);
               } catch (err) {

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -400,16 +400,6 @@ export namespace AndroidEmulatorUtils {
     env: NodeJS.ProcessEnv;
     logger: bunyan;
   }): Promise<void> {
-    const shouldDisableWindowAndTransitionAnimations =
-      env.ANDROID_EMULATOR_ADJUST_ANIMATION_SCALE !== 'false' &&
-      env.ANDROID_EMULATOR_ADJUST_ANIMATION_SCALE !== '0';
-    if (!shouldDisableWindowAndTransitionAnimations) {
-      logger.info(
-        'Skipping Android emulator animation scale adjustments because $ANDROID_EMULATOR_ADJUST_ANIMATION_SCALE is disabled.'
-      );
-      return;
-    }
-
     logger.info('Disabling Android emulator window animations.');
     try {
       await spawn(

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -161,24 +161,6 @@ describe('AndroidEmulatorUtils', () => {
       );
     });
 
-    it('skips animation scale adjustments when opt out env var is disabled', async () => {
-      const logger = createMockLogger();
-
-      await AndroidEmulatorUtils.disableWindowAndTransitionAnimationsAsync({
-        serialId: 'emulator-5554' as any,
-        env: {
-          ...process.env,
-          ANDROID_EMULATOR_ADJUST_ANIMATION_SCALE: 'false',
-        },
-        logger,
-      });
-
-      expect(logger.info).toHaveBeenCalledWith(
-        'Skipping Android emulator animation scale adjustments because $ANDROID_EMULATOR_ADJUST_ANIMATION_SCALE is disabled.'
-      );
-      expect(mockedSpawn).not.toHaveBeenCalled();
-    });
-
     it('logs and swallows failures when disabling animations', async () => {
       const logger = createMockLogger();
       mockedSpawn


### PR DESCRIPTION
## Summary
- disable Android emulator window and transition animation scales once the emulator is booted and ready
- apply the setting for the initial emulator and any cloned emulator instances used by the start step
- add unit coverage for the new adb settings commands and the startup orchestration

## Why
Maestro test runs already avoid the emulator boot animation, but Android window and transition animations still run after boot. Those system animations add avoidable UI transition latency and can introduce test flake without affecting in-app animator timing.

See https://bsky.app/profile/rdperottoni.bsky.social/post/3mfnhnt77mk2f.

## Validation
- `yarn fmt packages/build-tools/src/utils/AndroidEmulatorUtils.ts packages/build-tools/src/steps/functions/startAndroidEmulator.ts packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts`
- `yarn --cwd packages/build-tools jest-unit -- runInBand src/steps/functions/__tests__/startAndroidEmulator.test.ts src/utils/__tests__/AndroidEmulatorUtils.test.ts`
