### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,36 @@ When working with this repository follow instructions from CLAUDE.md.
 
 - [./CLAUDE.md](./CLAUDE.md)
 - Before committing, run the formatter on modified files.
+
+## Cursor Cloud specific instructions
+
+### Environment
+
+- **Node.js**: v22+ (provided by nvm in the VM)
+- **Yarn**: 4.12.0 (activated via `corepack enable && corepack install`)
+- The update script runs `corepack enable`, `corepack install`, `yarn install`, and `yarn build` automatically on VM startup.
+
+### Key development commands
+
+All standard commands are documented in [CLAUDE.md](./CLAUDE.md). Quick reference:
+
+| Task         | Command                          |
+| ------------ | -------------------------------- |
+| Install deps | `yarn install`                   |
+| Build all    | `yarn build`                     |
+| Watch mode   | `yarn start`                     |
+| Lint         | `yarn lint`                      |
+| Format check | `yarn fmt:check`                 |
+| Format fix   | `yarn fmt`                       |
+| Typecheck    | `yarn typecheck`                 |
+| Test all     | `yarn test`                      |
+| Test one pkg | `cd packages/<pkg> && yarn test` |
+| Run CLI      | `yarn eas <command>`             |
+
+### Non-obvious caveats
+
+- After `yarn install`, you **must** run `yarn build` before tests or the CLI will work. The build step compiles TypeScript for all packages and cross-package imports rely on the compiled output.
+- The `yarn test` worker process warning about force exit is a known, benign issue — all tests pass.
+- The CLI runs without authentication for most diagnostic/help commands. Commands that interact with the Expo API require `yarn eas login` or `EXPO_TOKEN` env var.
+- No Docker, databases, or external services are needed — all tests are fully mocked.
+- Oxlint reports 7 pre-existing warnings (missing return types in test files and a sort-imports issue). These are not errors.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Why

Set up the Cursor Cloud development environment for this monorepo and document non-obvious caveats for future cloud agents.

# How

Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` with:
- Environment details (Node.js v22+, Yarn 4.12.0 via corepack)
- Quick reference table for key development commands
- Non-obvious caveats discovered during setup (build required before tests, benign worker warning, auth requirements, no external services needed, pre-existing lint warnings)

# Test Plan

Full development environment verified:

[setup_verification.log](https://cursor.com/agents/bc-42aa2423-2324-4a80-912c-4327d4599aca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsetup_verification.log)

- `yarn install` — 2026 packages installed
- `yarn build` — all 13 packages built
- `yarn typecheck` — all 13 packages pass
- `yarn lint` — 0 errors (7 pre-existing warnings)
- `yarn fmt:check` — all 1300 files formatted correctly
- `yarn test` — 179 test suites, 1222 tests passed
- `yarn eas diagnostics` — CLI runs correctly (v18.4.0)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42aa2423-2324-4a80-912c-4327d4599aca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42aa2423-2324-4a80-912c-4327d4599aca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

