### PR TITLE
[build-tools] Differentiate between Yarn Classic/Modern based on lockfile contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Prevent detecting Yarn Modern as Classic based on lockfile ([#3572](https://github.com/expo/eas-cli/pull/3572) by [@kitten](https://github.com/kitten))
+
 ### 🧹 Chores
 
 ## [18.5.0](https://github.com/expo/eas-cli/releases/tag/v18.5.0) - 2026-04-02

--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -2,17 +2,23 @@ import { ExpoConfig } from '@expo/config';
 import { Android } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 import fs from 'fs-extra';
+import { vol } from 'memfs';
 import path from 'path';
+import { Readable } from 'stream';
 import { instance, mock, when } from 'ts-mockito';
 
 import { BuildContext } from '../../context';
-import { PackageManager } from '../packageManager';
-import { readEasJsonContents, runExpoCliCommand } from '../project';
+import { PackageManager, findPackagerRootDir } from '../packageManager';
+import { isUsingModernYarnVersion, readEasJsonContents, runExpoCliCommand } from '../project';
 
 jest.mock('fs');
 jest.mock('@expo/turtle-spawn', () => ({
   __esModule: true,
   default: jest.fn(),
+}));
+jest.mock('../packageManager', () => ({
+  ...jest.requireActual('../packageManager'),
+  findPackagerRootDir: jest.fn((dir: string) => dir),
 }));
 
 describe(runExpoCliCommand, () => {
@@ -72,6 +78,61 @@ describe(runExpoCliCommand, () => {
       void runExpoCliCommand({ args: ['doctor'], options: {}, packageManager: ctx.packageManager });
       expect(spawn).toHaveBeenCalledWith('bun', ['expo', 'doctor'], expect.any(Object));
     });
+  });
+});
+
+describe(isUsingModernYarnVersion, () => {
+  const projectDir = '/project';
+  const mockedFindPackagerRootDir = findPackagerRootDir as jest.MockedFunction<
+    typeof findPackagerRootDir
+  >;
+
+  beforeEach(() => {
+    mockedFindPackagerRootDir.mockReturnValue(projectDir);
+    jest.spyOn(fs, 'createReadStream').mockImplementation(((
+      filePath: string,
+      options?: { start?: number; end?: number }
+    ) => {
+      const content = fs.readFileSync(filePath, 'utf8');
+      const start = options?.start ?? 0;
+      const end = options?.end != null ? options.end + 1 : content.length;
+      return Readable.from(Buffer.from(content.slice(start, end)));
+    }) as any);
+  });
+
+  it('returns true when .yarnrc.yml exists in project directory', async () => {
+    vol.fromJSON({ [path.join(projectDir, '.yarnrc.yml')]: '' });
+    expect(await isUsingModernYarnVersion(projectDir)).toBe(true);
+  });
+
+  it('returns true when .yarnrc.yml exists in workspace root directory', async () => {
+    const workspaceRoot = '/workspace-root';
+    mockedFindPackagerRootDir.mockReturnValue(workspaceRoot);
+    vol.fromJSON({ [path.join(workspaceRoot, '.yarnrc.yml')]: '' });
+    expect(await isUsingModernYarnVersion(projectDir)).toBe(true);
+  });
+
+  it('returns false when no .yarnrc.yml and no yarn.lock exist', async () => {
+    vol.fromJSON({ [projectDir]: null });
+    expect(await isUsingModernYarnVersion(projectDir)).toBe(false);
+  });
+
+  it('returns false when yarn.lock contains classic v1 header', async () => {
+    vol.fromJSON({ [path.join(projectDir, 'yarn.lock')]: '# yarn lockfile v1\n' });
+    expect(await isUsingModernYarnVersion(projectDir)).toBe(false);
+  });
+
+  it('returns true when yarn.lock does not contain classic v1 header', async () => {
+    vol.fromJSON({ [path.join(projectDir, 'yarn.lock')]: '__metadata:\n  version: 8\n' });
+    expect(await isUsingModernYarnVersion(projectDir)).toBe(true);
+  });
+
+  it('returns true when .yarnrc.yml exists even with classic yarn.lock', async () => {
+    vol.fromJSON({
+      [path.join(projectDir, '.yarnrc.yml')]: '',
+      [path.join(projectDir, 'yarn.lock')]: '# yarn lockfile v1\n',
+    });
+    expect(await isUsingModernYarnVersion(projectDir)).toBe(true);
   });
 });
 

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -4,13 +4,43 @@ import path from 'path';
 
 import { PackageManager, findPackagerRootDir } from '../utils/packageManager';
 
+async function readFirstChars(filePath: string, chars: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Uint8Array[] = [];
+    const stream = fs.createReadStream(filePath, {
+      start: 0,
+      end: chars - 1,
+    });
+    stream.on('error', reject);
+    stream.on('data', chunk => {
+      chunks.push(chunk as Uint8Array);
+    });
+    stream.on('end', () => {
+      resolve(Buffer.concat(chunks).toString('utf8'));
+    });
+  });
+}
+
 /**
- * check if .yarnrc.yml exists in the project dir or in the workspace root dir
+ * check if .yarnrc.yml exists in the project dir or in the workspace root dir,
+ * or if the `yarn.lock` file is classic one, not a modern one
  */
 export async function isUsingModernYarnVersion(projectDir: string): Promise<boolean> {
+  const rootDir = findPackagerRootDir(projectDir);
   const yarnrcPath = path.join(projectDir, '.yarnrc.yml');
   const yarnrcRootPath = path.join(findPackagerRootDir(projectDir), '.yarnrc.yml');
-  return (await fs.pathExists(yarnrcPath)) || (await fs.pathExists(yarnrcRootPath));
+  if ((await fs.pathExists(yarnrcPath)) || (await fs.pathExists(yarnrcRootPath))) {
+    return true;
+  }
+
+  const yarnlockPath = path.join(rootDir, 'yarn.lock');
+  if (!(await fs.pathExists(yarnlockPath))) {
+    return false;
+  }
+
+  // The yarn.lock file is for Yarn Classic, not Modern, if it contains "# yarn lockfile v1"
+  const startOfLockfile = await readFirstChars(yarnlockPath, 100);
+  return /yarn lockfile v1/i.test(startOfLockfile);
 }
 
 export function runExpoCliCommand({

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -40,7 +40,7 @@ export async function isUsingModernYarnVersion(projectDir: string): Promise<bool
 
   // The yarn.lock file is for Yarn Classic, not Modern, if it contains "# yarn lockfile v1"
   const startOfLockfile = await readFirstChars(yarnlockPath, 100);
-  return /yarn lockfile v1/i.test(startOfLockfile);
+  return !/yarn lockfile v1/i.test(startOfLockfile);
 }
 
 export function runExpoCliCommand({


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Resolves #3571

Yarn Modern does not accept `--production false`.

# How

Detect Yarn Classic based on `yarn lockfile v1` in the lockfile start.

# Test Plan
