### PR TITLE
[eas-cli] Add Convex connect command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add `eas integrations:convex` commands to manage Convex integrations for EAS projects. ([#3575](https://github.com/expo/eas-cli/pull/3575) by [@fiberjw](https://github.com/fiberjw))
+
 ### 🐛 Bug fixes
 
 - [eas-cli] Remove hardcoded `builderEnvironment.image` override in `eas build:resign`. ([#3661](https://github.com/expo/eas-cli/pull/3661) by [@hSATAC](https://github.com/hSATAC))

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -25489,6 +25489,18 @@
             "deprecationReason": null
           },
           {
+            "name": "resolvedImage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "resourceClass",
             "description": "The builder resource class requested by the developer",
             "args": [],
@@ -25603,7 +25615,7 @@
               "ofType": null
             },
             "isDeprecated": true,
-            "deprecationReason": "Check logs instead."
+            "deprecationReason": "Use 'resolvedImage' for the concrete image the build runs on."
           },
           {
             "name": "status",
@@ -29827,6 +29839,83 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ConvexProjectMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "deleteConvexProject",
+            "description": null,
+            "args": [
+              {
+                "name": "convexProjectId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "setupConvexProject",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SetupConvexProjectInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SetupConvexProjectResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ConvexTeamConnection",
         "description": null,
         "fields": [
@@ -29848,6 +29937,38 @@
           },
           {
             "name": "convexTeamIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "convexTeamName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "convexTeamSlug",
             "description": null,
             "args": [],
             "type": {
@@ -29890,6 +30011,30 @@
                 "name": "ID",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "invitedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "invitedEmail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -55703,6 +55848,22 @@
             "deprecationReason": null
           },
           {
+            "name": "convexProject",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ConvexProjectMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "convexTeamConnection",
             "description": null,
             "args": [],
@@ -60002,6 +60163,152 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "SetupConvexProjectInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "convexTeamConnectionId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deploymentRegion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectName",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SetupConvexProjectResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "convexDeploymentName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "convexDeploymentUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "convexProject",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ConvexProject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deployKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "SizeBreakdownCategory",
         "description": null,
@@ -62055,6 +62362,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "includedAgentCreditsInCents",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               }
             },

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -202,7 +202,7 @@
         "description": "manage project and account environment variables"
       },
       "integrations": {
-        "description": "manage service connections"
+        "description": "manage third-party service integrations"
       },
       "metadata": {
         "description": "manage store configuration"

--- a/packages/eas-cli/src/commandUtils/__tests__/convex-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/convex-test.ts
@@ -1,0 +1,126 @@
+import {
+  confirmRecentConvexInviteAsync,
+  formatConvexProject,
+  formatConvexTeam,
+  formatConvexTeamConnection,
+  getConvexProjectDashboardUrl,
+  getConvexTeamDashboardUrl,
+} from '../convex';
+import {
+  ConvexProjectData,
+  ConvexTeamConnectionData,
+} from '../../graphql/types/ConvexTeamConnection';
+import Log from '../../log';
+import { confirmAsync } from '../../prompts';
+
+jest.mock('../../log');
+jest.mock('../../prompts');
+
+describe('Convex command utilities', () => {
+  const mockConnection: ConvexTeamConnectionData = {
+    id: 'connection-1',
+    convexTeamIdentifier: 'team-123',
+    convexTeamName: 'Test Team',
+    convexTeamSlug: 'test team',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    invitedAt: '2024-01-02T00:00:00.000Z',
+    invitedEmail: 'user@example.com',
+  };
+
+  const mockProject: ConvexProjectData = {
+    id: 'convex-project-1',
+    convexProjectIdentifier: 'project-123',
+    convexProjectName: 'Test Project',
+    convexProjectSlug: 'test project',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    convexTeamConnection: mockConnection,
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+  });
+
+  it('builds encoded Convex dashboard URLs', () => {
+    expect(getConvexTeamDashboardUrl(mockConnection)).toBe(
+      'https://dashboard.convex.dev/t/test%20team'
+    );
+    expect(getConvexProjectDashboardUrl(mockProject)).toBe(
+      'https://dashboard.convex.dev/t/test%20team/test%20project'
+    );
+  });
+
+  it('formats team and project metadata with invite details', () => {
+    expect(formatConvexTeam(mockConnection)).toBe('Test Team / test team');
+    expect(formatConvexTeamConnection(mockConnection)).toContain('Test Team / test team');
+    expect(formatConvexTeamConnection(mockConnection)).not.toContain('team-123');
+    expect(formatConvexTeamConnection(mockConnection)).not.toContain('connection-1');
+    expect(formatConvexTeamConnection(mockConnection)).toContain('user@example.com');
+    expect(formatConvexTeamConnection(mockConnection)).toContain('2024-01-02T00:00:00.000Z');
+    expect(formatConvexProject(mockProject)).toContain('project-123');
+    expect(formatConvexProject(mockProject)).not.toContain('convex-project-1');
+    expect(formatConvexProject(mockProject)).toContain('Test Team / test team');
+    expect(formatConvexProject(mockProject)).not.toContain('team-123');
+  });
+
+  it('does not prompt when the previous invite timestamp is invalid', async () => {
+    await expect(
+      confirmRecentConvexInviteAsync(
+        { ...mockConnection, invitedAt: 'not-a-date' },
+        { nonInteractive: false }
+      )
+    ).resolves.toBe(true);
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt when the previous invite is old', async () => {
+    await expect(
+      confirmRecentConvexInviteAsync(
+        {
+          ...mockConnection,
+          invitedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+        },
+        { nonInteractive: false }
+      )
+    ).resolves.toBe(true);
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+
+  it('prompts before resending a recent invite in interactive mode', async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+
+    await expect(
+      confirmRecentConvexInviteAsync(
+        {
+          ...mockConnection,
+          invitedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        },
+        { nonInteractive: false }
+      )
+    ).resolves.toBe(false);
+
+    expect(confirmAsync).toHaveBeenCalledWith({
+      message: expect.stringContaining('Are you sure you want to send another invite?'),
+    });
+  });
+
+  it('warns and proceeds for recent invites in non-interactive mode', async () => {
+    await expect(
+      confirmRecentConvexInviteAsync(
+        {
+          ...mockConnection,
+          invitedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        },
+        { nonInteractive: true }
+      )
+    ).resolves.toBe(true);
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('non-interactive mode'));
+  });
+});

--- a/packages/eas-cli/src/commandUtils/convex.ts
+++ b/packages/eas-cli/src/commandUtils/convex.ts
@@ -1,0 +1,83 @@
+import chalk from 'chalk';
+
+import { ConvexProjectData, ConvexTeamConnectionData } from '../graphql/types/ConvexTeamConnection';
+import Log, { link } from '../log';
+import { confirmAsync } from '../prompts';
+
+const CONVEX_DASHBOARD_HOST = 'https://dashboard.convex.dev';
+const RECENT_INVITE_THRESHOLD_MS = 60 * 60 * 1000;
+
+export function getConvexTeamDashboardUrl(connection: ConvexTeamConnectionData): string {
+  return `${CONVEX_DASHBOARD_HOST}/t/${encodeURIComponent(connection.convexTeamSlug)}`;
+}
+
+export function getConvexProjectDashboardUrl(project: ConvexProjectData): string {
+  return `${getConvexTeamDashboardUrl(project.convexTeamConnection)}/${encodeURIComponent(
+    project.convexProjectSlug
+  )}`;
+}
+
+export function formatConvexTeam(connection: ConvexTeamConnectionData): string {
+  return `${connection.convexTeamName} / ${connection.convexTeamSlug}`;
+}
+
+export function formatConvexTeamConnection(connection: ConvexTeamConnectionData): string {
+  const lines = [
+    `${chalk.bold('Team')}: ${formatConvexTeam(connection)}`,
+    `${chalk.bold('Dashboard')}: ${link(getConvexTeamDashboardUrl(connection), { dim: false })}`,
+  ];
+
+  if (connection.invitedEmail) {
+    lines.push(`${chalk.bold('Invited email')}: ${connection.invitedEmail}`);
+  }
+  if (connection.invitedAt) {
+    lines.push(`${chalk.bold('Invited at')}: ${connection.invitedAt}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function formatConvexProject(project: ConvexProjectData): string {
+  return [
+    `${chalk.bold('Name')}: ${project.convexProjectName}`,
+    `${chalk.bold('Slug')}: ${project.convexProjectSlug}`,
+    `${chalk.bold('Identifier')}: ${project.convexProjectIdentifier}`,
+    `${chalk.bold('Team')}: ${formatConvexTeam(project.convexTeamConnection)}`,
+    `${chalk.bold('Dashboard')}: ${link(getConvexProjectDashboardUrl(project), { dim: false })}`,
+  ].join('\n');
+}
+
+export function logNoConvexTeams(accountName: string): void {
+  Log.warn(`No Convex team is linked to account ${chalk.bold(accountName)} on EAS.`);
+}
+
+export function logNoConvexProject(projectName: string): void {
+  Log.warn(`No Convex project is linked to Expo app ${chalk.bold(projectName)} on EAS.`);
+}
+
+export async function confirmRecentConvexInviteAsync(
+  connection: ConvexTeamConnectionData,
+  { nonInteractive }: { nonInteractive: boolean }
+): Promise<boolean> {
+  const invitedAt = connection.invitedAt ? new Date(connection.invitedAt) : null;
+  if (!invitedAt || Number.isNaN(invitedAt.getTime())) {
+    return true;
+  }
+
+  const timeSinceInviteMs = Date.now() - invitedAt.getTime();
+  if (timeSinceInviteMs >= RECENT_INVITE_THRESHOLD_MS) {
+    return true;
+  }
+
+  const previousInvite = `A Convex team invite was already sent${connection.invitedEmail ? ` to ${connection.invitedEmail}` : ''} at ${connection.invitedAt}.`;
+  if (nonInteractive) {
+    Log.warn(
+      `${previousInvite} Sending another invite because this command is running in non-interactive mode.`
+    );
+    return true;
+  }
+
+  return await confirmAsync({
+    message: `${previousInvite} Are you sure you want to send another invite?`,
+  });
+}

--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/connect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/connect.test.ts
@@ -1,0 +1,293 @@
+import spawnAsync from '@expo/spawn-async';
+import * as fs from 'fs-extra';
+
+import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../../credentials/__tests__/fixtures-constants';
+import { ConvexMutation } from '../../../../graphql/mutations/ConvexMutation';
+import { ConvexQuery } from '../../../../graphql/queries/ConvexQuery';
+import {
+  ConvexTeamConnectionData,
+  SetupConvexProjectResultData,
+} from '../../../../graphql/types/ConvexTeamConnection';
+import Log from '../../../../log';
+import { getOwnerAccountForProjectIdAsync } from '../../../../project/projectUtils';
+import { confirmAsync, promptAsync, selectAsync } from '../../../../prompts';
+import { Actor } from '../../../../user/User';
+import IntegrationsConvexConnect from '../connect';
+
+jest.mock('../../../../graphql/queries/ConvexQuery');
+jest.mock('../../../../graphql/mutations/ConvexMutation');
+jest.mock('../../../../project/projectUtils');
+jest.mock('../../../../prompts');
+jest.mock('@expo/spawn-async');
+jest.mock('fs-extra');
+jest.mock('../../../../log');
+jest.mock('../../../../ora', () => ({
+  ora: () => ({
+    start: jest.fn().mockReturnThis(),
+    succeed: jest.fn().mockReturnThis(),
+    fail: jest.fn().mockReturnThis(),
+  }),
+}));
+
+describe(IntegrationsConvexConnect, () => {
+  const graphqlClient = {} as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+  const testProjectDir = '/test/project';
+  const testAccountId = 'test-account-id';
+  const testAccountName = 'testuser';
+
+  const mockActor: Actor = {
+    __typename: 'User',
+    id: 'test-user-id',
+    username: testAccountName,
+    email: 'user@example.com',
+    featureGates: {},
+    isExpoAdmin: false,
+    primaryAccount: {
+      id: testAccountId,
+      name: testAccountName,
+      ownerUserActor: null,
+      users: [],
+    },
+    preferences: { onboarding: null },
+    accounts: [],
+  };
+
+  const mockRobotActor: Actor = {
+    __typename: 'Robot',
+    id: 'robot-1',
+    featureGates: {},
+    isExpoAdmin: false,
+    accounts: [],
+  };
+
+  const mockAccount = {
+    id: testAccountId,
+    name: testAccountName,
+    ownerUserActor: { id: 'test-user-id', username: testAccountName },
+    users: [{ role: 'OWNER' as any, actor: { id: 'test-user-id' } }],
+  };
+
+  const mockConnection: ConvexTeamConnectionData = {
+    id: 'connection-1',
+    convexTeamIdentifier: 'team-123',
+    convexTeamName: 'Test Team',
+    convexTeamSlug: 'test-team',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    invitedAt: null,
+    invitedEmail: null,
+  };
+
+  const mockSetupResult: SetupConvexProjectResultData = {
+    convexDeploymentName: 'happy-otter-123',
+    convexDeploymentUrl: 'https://happy-otter-123.convex.cloud',
+    deployKey: 'dev:happy-otter-123|abc123token',
+    convexProject: {
+      id: 'convex-project-1',
+      convexProjectIdentifier: 'project-123',
+      convexProjectName: 'testapp',
+      convexProjectSlug: 'testapp',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      convexTeamConnection: mockConnection,
+    },
+  };
+
+  function createCommand(argv: string[], actor: Actor = mockActor): IntegrationsConvexConnect {
+    const command = new IntegrationsConvexConnect(argv, mockConfig);
+    jest.spyOn(command as any, 'getContextAsync').mockReturnValue({
+      privateProjectConfig: {
+        projectId: testProjectId,
+        exp: { name: 'testapp', slug: 'testapp' },
+        projectDir: testProjectDir,
+      },
+      loggedIn: { graphqlClient, actor },
+    } as never);
+    return command;
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    jest.spyOn(Log, 'withTick').mockImplementation(() => {});
+    jest.spyOn(Log, 'addNewLineIfNone').mockImplementation(() => {});
+    jest.spyOn(Log, 'newLine').mockImplementation(() => {});
+
+    jest.mocked(fs.pathExists).mockResolvedValue(false as never);
+    jest.mocked(fs.writeFile).mockResolvedValue(undefined as never);
+    jest.mocked(fs.readFile).mockResolvedValue('' as never);
+    jest.mocked(spawnAsync).mockResolvedValue({} as never);
+
+    jest.mocked(getOwnerAccountForProjectIdAsync).mockResolvedValue(mockAccount as any);
+    jest.mocked(selectAsync).mockResolvedValue('aws-us-east-1');
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+    jest.mocked(promptAsync).mockImplementation(async (params: any) => ({
+      [params.name]: params.initial,
+    }));
+    jest.mocked(ConvexMutation.createConvexTeamConnectionAsync).mockResolvedValue(mockConnection);
+    jest.mocked(ConvexMutation.setupConvexProjectAsync).mockResolvedValue(mockSetupResult);
+    jest.mocked(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).mockResolvedValue(true);
+  });
+
+  it('creates a Convex team and project with the new mutation shape', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([]);
+
+    await createCommand([]).runAsync();
+
+    expect(ConvexMutation.createConvexTeamConnectionAsync).toHaveBeenCalledWith(graphqlClient, {
+      accountId: testAccountId,
+      deploymentRegion: 'aws-us-east-1',
+      convexTeamName: testAccountName,
+    });
+    expect(ConvexMutation.setupConvexProjectAsync).toHaveBeenCalledWith(graphqlClient, {
+      appId: testProjectId,
+      convexTeamConnectionId: 'connection-1',
+      deploymentRegion: 'aws-us-east-1',
+      projectName: 'testapp',
+    });
+    expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      { convexTeamConnectionId: 'connection-1' }
+    );
+    expect(spawnAsync).toHaveBeenCalledWith('npx', ['expo', 'install', 'convex'], {
+      cwd: testProjectDir,
+      stdio: 'inherit',
+    });
+  });
+
+  it('uses an existing Convex team connection', async () => {
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection]);
+
+    await createCommand(['--region', 'aws-eu-west-1']).runAsync();
+
+    expect(ConvexMutation.createConvexTeamConnectionAsync).not.toHaveBeenCalled();
+    expect(ConvexMutation.setupConvexProjectAsync).toHaveBeenCalledWith(graphqlClient, {
+      appId: testProjectId,
+      convexTeamConnectionId: 'connection-1',
+      deploymentRegion: 'aws-eu-west-1',
+      projectName: 'testapp',
+    });
+    expect(spawnAsync).toHaveBeenCalledWith('npx', ['expo', 'install', 'convex'], {
+      cwd: testProjectDir,
+      stdio: 'inherit',
+    });
+  });
+
+  it('does not create a Convex team if installing the Convex package fails first', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([]);
+    jest.mocked(spawnAsync).mockRejectedValue(new Error('install failed') as never);
+
+    await expect(createCommand([]).runAsync()).rejects.toThrow('install failed');
+
+    expect(ConvexMutation.createConvexTeamConnectionAsync).not.toHaveBeenCalled();
+    expect(ConvexMutation.setupConvexProjectAsync).not.toHaveBeenCalled();
+  });
+
+  it('skips the verified email invite when the actor has no email', async () => {
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection]);
+
+    await createCommand([], mockRobotActor).runAsync();
+
+    expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Could not determine your verified email address')
+    );
+    expect(Log.warn).not.toHaveBeenCalledWith(expect.stringContaining('Convex dashboard'));
+  });
+
+  it('logs the error when sending a verified email invite fails', async () => {
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection]);
+    jest
+      .mocked(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync)
+      .mockRejectedValue(new Error('Convex invite service unavailable'));
+
+    await createCommand([]).runAsync();
+
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to send Convex team invitation to user@example.com')
+    );
+    expect(Log.warn).toHaveBeenCalledWith('Convex invite service unavailable');
+    expect(Log.warn).not.toHaveBeenCalledWith(expect.stringContaining('Convex dashboard'));
+  });
+
+  it('asks before resending a recent team invite for an existing connection', async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([
+      {
+        ...mockConnection,
+        invitedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        invitedEmail: 'user@example.com',
+      },
+    ]);
+
+    await createCommand([]).runAsync();
+
+    expect(confirmAsync).toHaveBeenCalledWith({
+      message: expect.stringContaining('Are you sure you want to send another invite?'),
+    });
+    expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith('Skipped sending Convex team invitation.');
+  });
+
+  it('writes the deploy key and Convex URL to .env.local', async () => {
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection]);
+
+    await createCommand([]).runAsync();
+
+    const envPath = `${testProjectDir}/.env.local`;
+    const writeCall = jest.mocked(fs.writeFile).mock.calls.find(call => call[0] === envPath);
+    expect(writeCall?.[1]).toContain('CONVEX_DEPLOY_KEY=dev:happy-otter-123|abc123token');
+    expect(writeCall?.[1]).toContain('EXPO_PUBLIC_CONVEX_URL=https://happy-otter-123.convex.cloud');
+  });
+
+  it('prompts before overwriting existing Convex .env.local values', async () => {
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection]);
+    jest.mocked(fs.pathExists).mockResolvedValue(true as never);
+    jest.mocked(fs.readFile).mockResolvedValue('CONVEX_DEPLOY_KEY=old-key\n' as never);
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+
+    await createCommand([]).runAsync();
+
+    expect(confirmAsync).toHaveBeenCalledWith({
+      message: expect.stringContaining('already contains CONVEX_DEPLOY_KEY'),
+    });
+  });
+
+  it('uses defaults in non-interactive mode', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([]);
+
+    await createCommand(['--non-interactive']).runAsync();
+
+    expect(selectAsync).not.toHaveBeenCalled();
+    expect(promptAsync).not.toHaveBeenCalled();
+    expect(ConvexMutation.createConvexTeamConnectionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({
+        deploymentRegion: 'aws-us-east-1',
+        convexTeamName: testAccountName,
+      })
+    );
+    expect(ConvexMutation.setupConvexProjectAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({
+        appId: testProjectId,
+        deploymentRegion: 'aws-us-east-1',
+        projectName: 'testapp',
+      })
+    );
+  });
+});

--- a/packages/eas-cli/src/commands/integrations/convex/connect.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/connect.ts
@@ -1,0 +1,350 @@
+import spawnAsync from '@expo/spawn-async';
+import { Flags } from '@oclif/core';
+import chalk from 'chalk';
+import dotenv from 'dotenv';
+import * as fs from 'fs-extra';
+import path from 'path';
+
+import EasCommand from '../../../commandUtils/EasCommand';
+import { confirmRecentConvexInviteAsync, formatConvexTeam } from '../../../commandUtils/convex';
+import { EASNonInteractiveFlag } from '../../../commandUtils/flags';
+import { ConvexMutation } from '../../../graphql/mutations/ConvexMutation';
+import { ConvexQuery } from '../../../graphql/queries/ConvexQuery';
+import { ConvexTeamConnectionData } from '../../../graphql/types/ConvexTeamConnection';
+import Log from '../../../log';
+import { ora } from '../../../ora';
+import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
+import { confirmAsync, promptAsync, selectAsync } from '../../../prompts';
+import { Actor } from '../../../user/User';
+
+const CONVEX_REGIONS = [
+  { title: 'US East (aws-us-east-1)', value: 'aws-us-east-1' },
+  { title: 'EU West (aws-eu-west-1)', value: 'aws-eu-west-1' },
+];
+
+const DEFAULT_REGION = 'aws-us-east-1';
+
+export default class IntegrationsConvexConnect extends EasCommand {
+  static override description = 'connect Convex to your Expo project';
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+  };
+
+  static override flags = {
+    ...EASNonInteractiveFlag,
+    region: Flags.string({
+      description: 'Convex deployment region (e.g. aws-us-east-1, aws-eu-west-1)',
+      options: CONVEX_REGIONS.map(r => r.value),
+    }),
+    'team-name': Flags.string({
+      description: 'Name for the new Convex team (defaults to EAS account name)',
+    }),
+    'project-name': Flags.string({
+      description: 'Name for the Convex project (defaults to app slug)',
+    }),
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      flags: {
+        region: regionFlag,
+        'team-name': teamNameFlag,
+        'project-name': projectNameFlag,
+        'non-interactive': nonInteractive,
+      },
+    } = await this.parse(IntegrationsConvexConnect);
+
+    const {
+      privateProjectConfig: { projectId, exp, projectDir },
+      loggedIn: { graphqlClient, actor },
+    } = await this.getContextAsync(IntegrationsConvexConnect, {
+      nonInteractive,
+      withServerSideEnvironment: null,
+    });
+
+    const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
+
+    // 1. Check for existing Convex team connections
+    const existingConnections = await ConvexQuery.getConvexTeamConnectionsByAccountIdAsync(
+      graphqlClient,
+      account.id
+    );
+
+    const region = await this.resolveRegionAsync(regionFlag, nonInteractive);
+    let connection: ConvexTeamConnectionData | null = null;
+    let teamName: string | null = null;
+
+    if (existingConnections.length === 0) {
+      // 2a. No connection - resolve a team name and create it after local package install succeeds
+      teamName = await this.resolveTeamNameAsync(teamNameFlag, account.name, nonInteractive);
+    } else if (existingConnections.length === 1) {
+      // 2b. Single existing connection
+      connection = existingConnections[0];
+      Log.withTick(`Using existing Convex team ${chalk.bold(formatConvexTeam(connection))}`);
+    } else {
+      // 2c. Multiple connections - prompt to select
+      connection = await this.selectConnectionAsync(existingConnections, nonInteractive);
+    }
+
+    // 3. Resolve project name before project setup mutation
+    const projectName = await this.resolveProjectNameAsync(
+      projectNameFlag,
+      exp.slug,
+      nonInteractive
+    );
+
+    // 4. Install the Convex package before creating new server-side resources
+    await this.installConvexPackageAsync(projectDir);
+
+    if (!connection) {
+      const spinner = ora('Creating Convex team').start();
+      try {
+        connection = await ConvexMutation.createConvexTeamConnectionAsync(graphqlClient, {
+          accountId: account.id,
+          deploymentRegion: region,
+          convexTeamName: teamName ?? account.name,
+        });
+        spinner.succeed(`Created Convex team ${chalk.bold(formatConvexTeam(connection))}`);
+      } catch (error) {
+        spinner.fail('Failed to create Convex team');
+        throw error;
+      }
+    }
+
+    // 5. Set up Convex project
+    const spinner = ora('Setting up Convex project').start();
+    let setupResult;
+    try {
+      setupResult = await ConvexMutation.setupConvexProjectAsync(graphqlClient, {
+        appId: projectId,
+        convexTeamConnectionId: connection.id,
+        deploymentRegion: region,
+        projectName,
+      });
+      spinner.succeed(
+        `Created Convex project ${chalk.bold(projectName)} with deployment ${chalk.bold(setupResult.convexDeploymentName)}`
+      );
+    } catch (error) {
+      spinner.fail('Failed to set up Convex project');
+      throw error;
+    }
+
+    // 6. Send team invite (non-fatal)
+    await this.sendTeamInviteAsync(graphqlClient, connection, actor, { nonInteractive });
+
+    // 7. Write deploy key and URL to .env.local
+    await this.writeEnvLocalAsync(
+      projectDir,
+      setupResult.deployKey,
+      setupResult.convexDeploymentUrl,
+      nonInteractive
+    );
+
+    // 8. Success message
+    Log.addNewLineIfNone();
+    Log.log(chalk.green('Convex is ready!'));
+    Log.newLine();
+    Log.log('Next steps:');
+    Log.log(`  1. Start the Convex dev server: ${chalk.cyan('npx convex dev')}`);
+    Log.newLine();
+    if (this.getActorEmail(actor)) {
+      Log.log(
+        `Check your email for an invitation to join your Convex team. Accept it for full dashboard access.`
+      );
+    }
+  }
+
+  private async resolveRegionAsync(
+    flagValue: string | undefined,
+    nonInteractive: boolean
+  ): Promise<string> {
+    if (flagValue) {
+      return flagValue;
+    }
+    if (nonInteractive) {
+      return DEFAULT_REGION;
+    }
+    return await selectAsync('Select a Convex deployment region', CONVEX_REGIONS);
+  }
+
+  private async resolveTeamNameAsync(
+    flagValue: string | undefined,
+    accountName: string,
+    nonInteractive: boolean
+  ): Promise<string> {
+    if (flagValue) {
+      return flagValue;
+    }
+    if (nonInteractive) {
+      return accountName;
+    }
+    const { teamName } = await promptAsync({
+      type: 'text',
+      name: 'teamName',
+      message: 'Convex team name',
+      initial: accountName,
+      validate: (value: string) => (value.trim() ? true : 'Team name cannot be empty'),
+    });
+    return teamName;
+  }
+
+  private async resolveProjectNameAsync(
+    flagValue: string | undefined,
+    slug: string,
+    nonInteractive: boolean
+  ): Promise<string> {
+    if (flagValue) {
+      return flagValue;
+    }
+    if (nonInteractive) {
+      return slug;
+    }
+    const { projectName } = await promptAsync({
+      type: 'text',
+      name: 'projectName',
+      message: 'Convex project name',
+      initial: slug,
+      validate: (value: string) => (value.trim() ? true : 'Project name cannot be empty'),
+    });
+    return projectName;
+  }
+
+  private async selectConnectionAsync(
+    connections: ConvexTeamConnectionData[],
+    nonInteractive: boolean
+  ): Promise<ConvexTeamConnectionData> {
+    if (nonInteractive) {
+      return connections[0];
+    }
+    const choices = connections.map(c => ({
+      title: `${formatConvexTeam(c)} (created ${new Date(c.createdAt).toLocaleDateString()})`,
+      value: c,
+    }));
+    return await selectAsync('Select a Convex team connection', choices);
+  }
+
+  private getActorEmail(actor: Actor): string | null {
+    return actor.__typename === 'User' ? actor.email : null;
+  }
+
+  private async sendTeamInviteAsync(
+    graphqlClient: Parameters<typeof ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync>[0],
+    connection: ConvexTeamConnectionData,
+    actor: Actor,
+    { nonInteractive }: { nonInteractive: boolean }
+  ): Promise<void> {
+    const email = this.getActorEmail(actor);
+    if (!email) {
+      Log.warn(
+        `Could not determine your verified email address, so no Convex team invitation was sent. Run ${chalk.cyan(
+          'eas integrations:convex:team:invite'
+        )} after signing in with a user account.`
+      );
+      return;
+    }
+
+    if (!(await confirmRecentConvexInviteAsync(connection, { nonInteractive }))) {
+      Log.warn('Skipped sending Convex team invitation.');
+      return;
+    }
+
+    try {
+      await ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync(graphqlClient, {
+        convexTeamConnectionId: connection.id,
+      });
+      Log.withTick(`Sent Convex team invitation to ${chalk.bold(email)}`);
+    } catch (error) {
+      Log.warn(
+        `Failed to send Convex team invitation to ${email}. Run ${chalk.cyan(
+          'eas integrations:convex:team:invite'
+        )} to retry.`
+      );
+      Log.warn(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  private async installConvexPackageAsync(projectDir: string): Promise<void> {
+    Log.newLine();
+    Log.log(`Running ${chalk.bold('npx expo install convex')}`);
+    Log.newLine();
+
+    try {
+      await spawnAsync('npx', ['expo', 'install', 'convex'], {
+        cwd: projectDir,
+        stdio: 'inherit',
+      });
+      Log.withTick(`Installed the ${chalk.bold('convex')} npm package`);
+    } catch (error) {
+      Log.warn(
+        `Failed to install the ${chalk.bold('convex')} npm package. Run ${chalk.cyan(
+          'npx expo install convex'
+        )} from your project directory, then run ${chalk.cyan('npx convex dev')}.`
+      );
+      throw error;
+    }
+  }
+
+  private async writeEnvLocalAsync(
+    projectDir: string,
+    deployKey: string,
+    convexUrl: string,
+    nonInteractive: boolean
+  ): Promise<void> {
+    const envPath = path.join(projectDir, '.env.local');
+    let existingContent: Record<string, string> = {};
+    let rawContent = '';
+
+    if (await fs.pathExists(envPath)) {
+      rawContent = await fs.readFile(envPath, 'utf8');
+      existingContent = dotenv.parse(rawContent);
+
+      if (existingContent.CONVEX_DEPLOY_KEY && !nonInteractive) {
+        const overwrite = await confirmAsync({
+          message: `.env.local already contains CONVEX_DEPLOY_KEY. Overwrite Convex values?`,
+        });
+        if (!overwrite) {
+          Log.log('Skipping .env.local update. Deploy key:');
+          Log.log(`  CONVEX_DEPLOY_KEY=${deployKey}`);
+          Log.log(`  EXPO_PUBLIC_CONVEX_URL=${convexUrl}`);
+          return;
+        }
+      }
+    }
+
+    const updatedContent = this.mergeEnvContent(rawContent, {
+      CONVEX_DEPLOY_KEY: deployKey,
+      EXPO_PUBLIC_CONVEX_URL: convexUrl,
+    });
+
+    await fs.writeFile(envPath, updatedContent);
+    Log.withTick(`Wrote Convex config to ${chalk.bold('.env.local')}`);
+  }
+
+  private mergeEnvContent(rawContent: string, newVars: Record<string, string>): string {
+    let content = rawContent;
+    const keysToAdd: Record<string, string> = { ...newVars };
+
+    for (const [key, value] of Object.entries(newVars)) {
+      // Replace existing line if present
+      const regex = new RegExp(`^${key}=.*$`, 'm');
+      if (regex.test(content)) {
+        content = content.replace(regex, `${key}=${value}`);
+        delete keysToAdd[key];
+      }
+    }
+
+    // Append any keys that weren't already in the file
+    const remaining = Object.entries(keysToAdd);
+    if (remaining.length > 0) {
+      if (content.length > 0 && !content.endsWith('\n')) {
+        content += '\n';
+      }
+      for (const [key, value] of remaining) {
+        content += `${key}=${value}\n`;
+      }
+    }
+
+    return content;
+  }
+}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3616,6 +3616,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   releaseChannel?: Maybe<Scalars['String']['output']>;
   requiredPackageManager?: Maybe<Scalars['String']['output']>;
   resolvedEnvironment?: Maybe<Scalars['EnvironmentVariableEnvironment']['output']>;
+  resolvedImage?: Maybe<Scalars['String']['output']>;
   /**
    * The builder resource class requested by the developer
    * @deprecated Use resourceClassDisplayName instead
@@ -3629,7 +3630,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   /** @deprecated Use 'runtime' field instead. */
   runtimeVersion?: Maybe<Scalars['String']['output']>;
   sdkVersion?: Maybe<Scalars['String']['output']>;
-  /** @deprecated Check logs instead. */
+  /** @deprecated Use 'resolvedImage' for the concrete image the build runs on. */
   selectedImage?: Maybe<Scalars['String']['output']>;
   status: BuildStatus;
   submissions: Array<Submission>;
@@ -4231,12 +4232,32 @@ export type ConvexProject = {
   updatedAt: Scalars['DateTime']['output'];
 };
 
+export type ConvexProjectMutation = {
+  __typename?: 'ConvexProjectMutation';
+  deleteConvexProject: Scalars['ID']['output'];
+  setupConvexProject: SetupConvexProjectResult;
+};
+
+
+export type ConvexProjectMutationDeleteConvexProjectArgs = {
+  convexProjectId: Scalars['ID']['input'];
+};
+
+
+export type ConvexProjectMutationSetupConvexProjectArgs = {
+  input: SetupConvexProjectInput;
+};
+
 export type ConvexTeamConnection = {
   __typename?: 'ConvexTeamConnection';
   account: Account;
   convexTeamIdentifier: Scalars['String']['output'];
+  convexTeamName: Scalars['String']['output'];
+  convexTeamSlug: Scalars['String']['output'];
   createdAt: Scalars['DateTime']['output'];
   id: Scalars['ID']['output'];
+  invitedAt?: Maybe<Scalars['DateTime']['output']>;
+  invitedEmail?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
 };
 
@@ -7836,6 +7857,7 @@ export type RootMutation = {
   build: BuildMutation;
   /** Mutations that create, update, and delete Build Annotations */
   buildAnnotation: BuildAnnotationMutation;
+  convexProject: ConvexProjectMutation;
   convexTeamConnection: ConvexTeamConnectionMutation;
   customDomain: CustomDomainMutation;
   deployments: DeploymentsMutation;
@@ -8434,6 +8456,21 @@ export type SentryProjectMutationDeleteSentryProjectArgs = {
   sentryProjectId: Scalars['ID']['input'];
 };
 
+export type SetupConvexProjectInput = {
+  appId: Scalars['ID']['input'];
+  convexTeamConnectionId: Scalars['ID']['input'];
+  deploymentRegion?: InputMaybe<Scalars['String']['input']>;
+  projectName: Scalars['String']['input'];
+};
+
+export type SetupConvexProjectResult = {
+  __typename?: 'SetupConvexProjectResult';
+  convexDeploymentName: Scalars['String']['output'];
+  convexDeploymentUrl: Scalars['String']['output'];
+  convexProject: ConvexProject;
+  deployKey: Scalars['String']['output'];
+};
+
 export type SizeBreakdownCategory = {
   __typename?: 'SizeBreakdownCategory';
   assetCount: Scalars['Int']['output'];
@@ -8750,6 +8787,7 @@ export type SubscriptionDetails = {
   endedAt?: Maybe<Scalars['DateTime']['output']>;
   futureSubscription?: Maybe<FutureSubscription>;
   id: Scalars['ID']['output'];
+  includedAgentCreditsInCents: Scalars['Int']['output'];
   isDowngrading?: Maybe<Scalars['Boolean']['output']>;
   meteredBillingStatus: MeteredBillingStatus;
   name?: Maybe<Scalars['String']['output']>;
@@ -11904,6 +11942,41 @@ export type RetryIosBuildMutationVariables = Exact<{
 
 export type RetryIosBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', retryIosBuild: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, logFiles: Array<string>, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, fingerprint?: { __typename?: 'Fingerprint', id: string, hash: string } | null, initiatingActor?: { __typename: 'PartnerActor', id: string, displayName: string } | { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string }, metrics?: { __typename?: 'BuildMetrics', buildWaitTime?: number | null, buildQueueTime?: number | null, buildDuration?: number | null } | null } } };
 
+export type CreateConvexTeamConnectionMutationVariables = Exact<{
+  convexTeamConnectionData: CreateConvexTeamConnectionInput;
+}>;
+
+
+export type CreateConvexTeamConnectionMutation = { __typename?: 'RootMutation', convexTeamConnection: { __typename?: 'ConvexTeamConnectionMutation', createConvexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } };
+
+export type DeleteConvexTeamConnectionMutationVariables = Exact<{
+  convexTeamConnectionId: Scalars['ID']['input'];
+}>;
+
+
+export type DeleteConvexTeamConnectionMutation = { __typename?: 'RootMutation', convexTeamConnection: { __typename?: 'ConvexTeamConnectionMutation', deleteConvexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } };
+
+export type SetupConvexProjectMutationVariables = Exact<{
+  input: SetupConvexProjectInput;
+}>;
+
+
+export type SetupConvexProjectMutation = { __typename?: 'RootMutation', convexProject: { __typename?: 'ConvexProjectMutation', setupConvexProject: { __typename?: 'SetupConvexProjectResult', convexDeploymentName: string, convexDeploymentUrl: string, deployKey: string, convexProject: { __typename?: 'ConvexProject', id: string, convexProjectIdentifier: string, convexProjectName: string, convexProjectSlug: string, createdAt: any, updatedAt: any, convexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } } } };
+
+export type DeleteConvexProjectMutationVariables = Exact<{
+  convexProjectId: Scalars['ID']['input'];
+}>;
+
+
+export type DeleteConvexProjectMutation = { __typename?: 'RootMutation', convexProject: { __typename?: 'ConvexProjectMutation', deleteConvexProject: string } };
+
+export type SendConvexTeamInviteToVerifiedEmailMutationVariables = Exact<{
+  input: SendConvexTeamInviteToVerifiedEmailInput;
+}>;
+
+
+export type SendConvexTeamInviteToVerifiedEmailMutation = { __typename?: 'RootMutation', convexTeamConnection: { __typename?: 'ConvexTeamConnectionMutation', sendConvexTeamInviteToVerifiedEmail: boolean } };
+
 export type CreateDeviceRunSessionMutationVariables = Exact<{
   deviceRunSessionInput: CreateDeviceRunSessionInput;
 }>;
@@ -12385,6 +12458,20 @@ export type ViewUpdateChannelsPaginatedOnAppQueryVariables = Exact<{
 
 export type ViewUpdateChannelsPaginatedOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, channelsPaginated: { __typename?: 'AppChannelsConnection', edges: Array<{ __typename?: 'AppChannelEdge', cursor: string, node: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
+export type ConvexTeamConnectionsByAccountIdQueryVariables = Exact<{
+  accountId: Scalars['String']['input'];
+}>;
+
+
+export type ConvexTeamConnectionsByAccountIdQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byId: { __typename?: 'Account', id: string, convexTeamConnections: Array<{ __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null }> } } };
+
+export type ConvexProjectByAppIdQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+}>;
+
+
+export type ConvexProjectByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, convexProject?: { __typename?: 'ConvexProject', id: string, convexProjectIdentifier: string, convexProjectName: string, convexProjectSlug: string, createdAt: any, updatedAt: any, convexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } | null } } };
+
 export type DeviceRunSessionByIdQueryVariables = Exact<{
   deviceRunSessionId: Scalars['ID']['input'];
 }>;
@@ -12671,6 +12758,12 @@ export type BuildFragment = { __typename?: 'Build', id: string, status: BuildSta
 export type BuildWithSubmissionsFragment = { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, logFiles: Array<string>, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, submissions: Array<{ __typename?: 'Submission', id: string, status: SubmissionStatus, platform: AppPlatform, logFiles: Array<string>, app: { __typename?: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, androidConfig?: { __typename?: 'AndroidSubmissionConfig', applicationIdentifier?: string | null, track: string, releaseStatus?: SubmissionAndroidReleaseStatus | null, rollout?: number | null } | null, iosConfig?: { __typename?: 'IosSubmissionConfig', ascAppIdentifier: string, appleIdUsername?: string | null } | null, error?: { __typename?: 'SubmissionError', errorCode?: string | null, message?: string | null } | null }>, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, fingerprint?: { __typename?: 'Fingerprint', id: string, hash: string } | null, initiatingActor?: { __typename: 'PartnerActor', id: string, displayName: string } | { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string }, metrics?: { __typename?: 'BuildMetrics', buildWaitTime?: number | null, buildQueueTime?: number | null, buildDuration?: number | null } | null };
 
 export type BuildWithFingerprintFragment = { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, logFiles: Array<string>, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, fingerprint?: { __typename?: 'Fingerprint', id: string, hash: string, debugInfoUrl?: string | null, builds: { __typename?: 'AppBuildsConnection', edges: Array<{ __typename?: 'AppBuildEdge', node: { __typename?: 'Build', platform: AppPlatform, id: string } }> }, updates: { __typename?: 'AppUpdatesConnection', edges: Array<{ __typename?: 'AppUpdateEdge', node: { __typename?: 'Update', id: string, platform: string } }> } } | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'PartnerActor', id: string, displayName: string } | { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string }, metrics?: { __typename?: 'BuildMetrics', buildWaitTime?: number | null, buildQueueTime?: number | null, buildDuration?: number | null } | null };
+
+export type ConvexTeamConnectionFragment = { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null };
+
+export type ConvexProjectFragment = { __typename?: 'ConvexProject', id: string, convexProjectIdentifier: string, convexProjectName: string, convexProjectSlug: string, createdAt: any, updatedAt: any, convexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } };
+
+export type SetupConvexProjectResultFragment = { __typename?: 'SetupConvexProjectResult', convexDeploymentName: string, convexDeploymentUrl: string, deployKey: string, convexProject: { __typename?: 'ConvexProject', id: string, convexProjectIdentifier: string, convexProjectName: string, convexProjectSlug: string, createdAt: any, updatedAt: any, convexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } };
 
 export type EnvironmentSecretFragment = { __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any };
 

--- a/packages/eas-cli/src/graphql/mutations/ConvexMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/ConvexMutation.ts
@@ -1,0 +1,196 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
+import {
+  CreateConvexTeamConnectionInput,
+  SendConvexTeamInviteToVerifiedEmailInput,
+  SetupConvexProjectInput,
+} from '../generated';
+import {
+  ConvexProjectFragmentNode,
+  ConvexTeamConnectionData,
+  ConvexTeamConnectionFragmentNode,
+  SetupConvexProjectResultData,
+  SetupConvexProjectResultFragmentNode,
+} from '../types/ConvexTeamConnection';
+
+type CreateConvexTeamConnectionMutation = {
+  convexTeamConnection: {
+    createConvexTeamConnection: ConvexTeamConnectionData;
+  };
+};
+
+type CreateConvexTeamConnectionMutationVariables = {
+  convexTeamConnectionData: CreateConvexTeamConnectionInput;
+};
+
+type DeleteConvexTeamConnectionMutation = {
+  convexTeamConnection: {
+    deleteConvexTeamConnection: ConvexTeamConnectionData;
+  };
+};
+
+type DeleteConvexTeamConnectionMutationVariables = {
+  convexTeamConnectionId: string;
+};
+
+type SetupConvexProjectMutation = {
+  convexProject: {
+    setupConvexProject: SetupConvexProjectResultData;
+  };
+};
+
+type SetupConvexProjectMutationVariables = {
+  input: SetupConvexProjectInput;
+};
+
+type DeleteConvexProjectMutation = {
+  convexProject: {
+    deleteConvexProject: string;
+  };
+};
+
+type DeleteConvexProjectMutationVariables = {
+  convexProjectId: string;
+};
+
+type SendConvexTeamInviteToVerifiedEmailMutation = {
+  convexTeamConnection: {
+    sendConvexTeamInviteToVerifiedEmail: boolean;
+  };
+};
+
+type SendConvexTeamInviteToVerifiedEmailMutationVariables = {
+  input: SendConvexTeamInviteToVerifiedEmailInput;
+};
+
+export const ConvexMutation = {
+  async createConvexTeamConnectionAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: CreateConvexTeamConnectionInput
+  ): Promise<ConvexTeamConnectionData> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreateConvexTeamConnectionMutation, CreateConvexTeamConnectionMutationVariables>(
+          gql`
+            mutation CreateConvexTeamConnection(
+              $convexTeamConnectionData: CreateConvexTeamConnectionInput!
+            ) {
+              convexTeamConnection {
+                createConvexTeamConnection(
+                  convexTeamConnectionData: $convexTeamConnectionData
+                ) {
+                  id
+                  ...ConvexTeamConnectionFragment
+                }
+              }
+            }
+            ${print(ConvexTeamConnectionFragmentNode)}
+          `,
+          { convexTeamConnectionData: input }
+        )
+        .toPromise()
+    );
+    return data.convexTeamConnection.createConvexTeamConnection;
+  },
+
+  async deleteConvexTeamConnectionAsync(
+    graphqlClient: ExpoGraphqlClient,
+    convexTeamConnectionId: string
+  ): Promise<ConvexTeamConnectionData> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<DeleteConvexTeamConnectionMutation, DeleteConvexTeamConnectionMutationVariables>(
+          gql`
+            mutation DeleteConvexTeamConnection($convexTeamConnectionId: ID!) {
+              convexTeamConnection {
+                deleteConvexTeamConnection(
+                  convexTeamConnectionId: $convexTeamConnectionId
+                ) {
+                  id
+                  ...ConvexTeamConnectionFragment
+                }
+              }
+            }
+            ${print(ConvexTeamConnectionFragmentNode)}
+          `,
+          { convexTeamConnectionId }
+        )
+        .toPromise()
+    );
+    return data.convexTeamConnection.deleteConvexTeamConnection;
+  },
+
+  async setupConvexProjectAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: SetupConvexProjectInput
+  ): Promise<SetupConvexProjectResultData> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<SetupConvexProjectMutation, SetupConvexProjectMutationVariables>(
+          gql`
+            mutation SetupConvexProject($input: SetupConvexProjectInput!) {
+              convexProject {
+                setupConvexProject(input: $input) {
+                  ...SetupConvexProjectResultFragment
+                }
+              }
+            }
+            ${print(ConvexTeamConnectionFragmentNode)}
+            ${print(ConvexProjectFragmentNode)}
+            ${print(SetupConvexProjectResultFragmentNode)}
+          `,
+          { input }
+        )
+        .toPromise()
+    );
+    return data.convexProject.setupConvexProject;
+  },
+
+  async deleteConvexProjectAsync(
+    graphqlClient: ExpoGraphqlClient,
+    convexProjectId: string
+  ): Promise<string> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<DeleteConvexProjectMutation, DeleteConvexProjectMutationVariables>(
+          gql`
+            mutation DeleteConvexProject($convexProjectId: ID!) {
+              convexProject {
+                deleteConvexProject(convexProjectId: $convexProjectId)
+              }
+            }
+          `,
+          { convexProjectId }
+        )
+        .toPromise()
+    );
+    return data.convexProject.deleteConvexProject;
+  },
+
+  async sendConvexTeamInviteToVerifiedEmailAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: SendConvexTeamInviteToVerifiedEmailInput
+  ): Promise<boolean> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<
+          SendConvexTeamInviteToVerifiedEmailMutation,
+          SendConvexTeamInviteToVerifiedEmailMutationVariables
+        >(
+          gql`
+            mutation SendConvexTeamInviteToVerifiedEmail($input: SendConvexTeamInviteToVerifiedEmailInput!) {
+              convexTeamConnection {
+                sendConvexTeamInviteToVerifiedEmail(input: $input)
+              }
+            }
+          `,
+          { input }
+        )
+        .toPromise()
+    );
+    return data.convexTeamConnection.sendConvexTeamInviteToVerifiedEmail;
+  },
+};

--- a/packages/eas-cli/src/graphql/queries/ConvexQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ConvexQuery.ts
@@ -1,0 +1,102 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
+import {
+  ConvexProjectData,
+  ConvexProjectFragmentNode,
+  ConvexTeamConnectionData,
+  ConvexTeamConnectionFragmentNode,
+} from '../types/ConvexTeamConnection';
+
+type ConvexTeamConnectionsByAccountIdQuery = {
+  account: {
+    byId: {
+      id: string;
+      convexTeamConnections: ConvexTeamConnectionData[];
+    };
+  };
+};
+
+type ConvexTeamConnectionsByAccountIdQueryVariables = {
+  accountId: string;
+};
+
+type ConvexProjectByAppIdQuery = {
+  app: {
+    byId: {
+      id: string;
+      convexProject?: ConvexProjectData | null;
+    };
+  };
+};
+
+type ConvexProjectByAppIdQueryVariables = {
+  appId: string;
+};
+
+export const ConvexQuery = {
+  async getConvexTeamConnectionsByAccountIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    accountId: string
+  ): Promise<ConvexTeamConnectionData[]> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<
+          ConvexTeamConnectionsByAccountIdQuery,
+          ConvexTeamConnectionsByAccountIdQueryVariables
+        >(
+          gql`
+            query ConvexTeamConnectionsByAccountId($accountId: String!) {
+              account {
+                byId(accountId: $accountId) {
+                  id
+                  convexTeamConnections {
+                    id
+                    ...ConvexTeamConnectionFragment
+                  }
+                }
+              }
+            }
+            ${print(ConvexTeamConnectionFragmentNode)}
+          `,
+          { accountId }
+        )
+        .toPromise()
+    );
+
+    return data.account.byId.convexTeamConnections;
+  },
+
+  async getConvexProjectByAppIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    appId: string
+  ): Promise<ConvexProjectData | null> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<ConvexProjectByAppIdQuery, ConvexProjectByAppIdQueryVariables>(
+          gql`
+            query ConvexProjectByAppId($appId: String!) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  convexProject {
+                    id
+                    ...ConvexProjectFragment
+                  }
+                }
+              }
+            }
+            ${print(ConvexTeamConnectionFragmentNode)}
+            ${print(ConvexProjectFragmentNode)}
+          `,
+          { appId },
+          { additionalTypenames: ['App', 'ConvexProject'] }
+        )
+        .toPromise()
+    );
+
+    return data.app.byId.convexProject ?? null;
+  },
+};

--- a/packages/eas-cli/src/graphql/types/ConvexTeamConnection.ts
+++ b/packages/eas-cli/src/graphql/types/ConvexTeamConnection.ts
@@ -1,0 +1,74 @@
+import gql from 'graphql-tag';
+
+import { ConvexProject, ConvexTeamConnection, SetupConvexProjectResult } from '../generated';
+
+export type ConvexTeamConnectionData = Pick<
+  ConvexTeamConnection,
+  | 'id'
+  | 'convexTeamIdentifier'
+  | 'convexTeamName'
+  | 'convexTeamSlug'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'invitedAt'
+  | 'invitedEmail'
+>;
+
+export type ConvexProjectData = Pick<
+  ConvexProject,
+  | 'id'
+  | 'convexProjectIdentifier'
+  | 'convexProjectName'
+  | 'convexProjectSlug'
+  | 'createdAt'
+  | 'updatedAt'
+> & {
+  convexTeamConnection: ConvexTeamConnectionData;
+};
+
+export type SetupConvexProjectResultData = Pick<
+  SetupConvexProjectResult,
+  'convexDeploymentName' | 'convexDeploymentUrl' | 'deployKey'
+> & {
+  convexProject: ConvexProjectData;
+};
+
+export const ConvexTeamConnectionFragmentNode = gql`
+  fragment ConvexTeamConnectionFragment on ConvexTeamConnection {
+    id
+    convexTeamIdentifier
+    convexTeamName
+    convexTeamSlug
+    createdAt
+    updatedAt
+    invitedAt
+    invitedEmail
+  }
+`;
+
+export const ConvexProjectFragmentNode = gql`
+  fragment ConvexProjectFragment on ConvexProject {
+    id
+    convexProjectIdentifier
+    convexProjectName
+    convexProjectSlug
+    createdAt
+    updatedAt
+    convexTeamConnection {
+      id
+      ...ConvexTeamConnectionFragment
+    }
+  }
+`;
+
+export const SetupConvexProjectResultFragmentNode = gql`
+  fragment SetupConvexProjectResultFragment on SetupConvexProjectResult {
+    convexDeploymentName
+    convexDeploymentUrl
+    deployKey
+    convexProject {
+      id
+      ...ConvexProjectFragment
+    }
+  }
+`;


### PR DESCRIPTION
# Why
Expo is integrating with Convex so users can provision an EAS-linked Convex backend from the EAS CLI.

# How
Adds `eas integrations:convex:connect`, which installs `convex`, creates or reuses an EAS-side Convex team link, sets up the app project, sends a verified-email invite with recent-resend confirmation, writes `CONVEX_DEPLOY_KEY` and `EXPO_PUBLIC_CONVEX_URL` to `.env.local`, and points users at `npx convex dev`.

This PR also includes the generated GraphQL types, Convex GraphQL helpers, shared Convex formatting/prompt utilities, and the changelog entry for the stack.

# Test Plan
Local E2E rerun after updating Convex team output formatting.

Commands run (with `REPO=/Users/fiberjw/Developer/expo/eas-cli`):
```sh
cd packages/eas-cli && yarn build
npx create-expo-app@latest /tmp/eas-convex-e2e-3575-fmt --yes
cd /tmp/eas-convex-e2e-3575-fmt
$REPO/packages/eas-cli/bin/run init --non-interactive --force
$REPO/packages/eas-cli/bin/run integrations:convex:connect --non-interactive --project-name e2e3575fmt
```

Output/verification:
```text
yarn build exited 0
✅ Your project is ready!
✔ Created @fiberjw/eas-convex-e2e-3575-fmt
✔ Project successfully linked (ID: 56a35c21-e0a0-4423-a3bd-070cd5440370)
✔ Installed the convex npm package
✔ Created Convex team fiberjw's team (Expo) / fiberjw-1d252 (Convex ID: 478547)
- Setting up Convex project
Too many Convex project setup attempts. Try again later.
Request ID: 89cc010c-e894-49df-9214-85f60d7bb334
```

The project setup API is temporarily throttled for about an hour, so the full successful connect flow could not be rerun after the formatting change. The EAS-side team link created by this blocked run was removed afterward.
