### PR TITLE
[ENG-17052][build-tools] Add `working_directory` input to `eas/build` function group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Add missing Apple metadata attributes for age ratings and content descriptions. ([#3584](https://github.com/expo/eas-cli/pull/3584) by [@EvanBacon](https://github.com/EvanBacon))
 - [eas-cli] Add App Clip metadata support to `metadata:push` and `metadata:pull` (default experience action, per-locale subtitle and header image, App Store review invocation URLs). ([#3590](https://github.com/expo/eas-cli/pull/3590) by [@EvanBacon](https://github.com/EvanBacon))
+- [build-tools] Add `working_directory` input to `eas/build` function group for custom builds. ([#3582](https://github.com/expo/eas-cli/pull/3582) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/packages/build-tools/src/steps/functionGroups/__tests__/build.test.ts
+++ b/packages/build-tools/src/steps/functionGroups/__tests__/build.test.ts
@@ -1,0 +1,177 @@
+import { BuildJob, Platform } from '@expo/eas-build-job';
+
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { CustomBuildContext } from '../../../customBuildContext';
+import { createEasBuildBuildFunctionGroup } from '../build';
+
+function createMockBuildToolsContext(
+  overrides: Partial<{
+    platform: Platform;
+    simulator: boolean;
+    buildCredentials: Record<string, unknown>;
+  }> = {}
+): CustomBuildContext<BuildJob> {
+  return {
+    job: {
+      platform: overrides.platform ?? Platform.ANDROID,
+      simulator: overrides.simulator ?? false,
+      secrets: overrides.buildCredentials
+        ? { buildCredentials: overrides.buildCredentials }
+        : undefined,
+    },
+  } as unknown as CustomBuildContext<BuildJob>;
+}
+
+describe(createEasBuildBuildFunctionGroup, () => {
+  describe('working_directory input', () => {
+    it('does not set working directory on steps when not provided (Android)', () => {
+      const buildToolsContext = createMockBuildToolsContext({ platform: Platform.ANDROID });
+      const functionGroup = createEasBuildBuildFunctionGroup(buildToolsContext);
+      const globalCtx = createGlobalContextMock({ logger: createMockLogger() });
+
+      const steps = functionGroup.createBuildStepsFromFunctionGroupCall(globalCtx);
+
+      for (const step of steps) {
+        // Without working_directory, only installPods would have a relative dir (iOS only).
+        // On Android, no step should have a relative working directory.
+        expect(step.ctx.relativeWorkingDirectory).toBeUndefined();
+      }
+    });
+
+    it('sets working directory on all steps except checkout (Android)', () => {
+      const buildToolsContext = createMockBuildToolsContext({ platform: Platform.ANDROID });
+      const functionGroup = createEasBuildBuildFunctionGroup(buildToolsContext);
+      const globalCtx = createGlobalContextMock({ logger: createMockLogger() });
+
+      const steps = functionGroup.createBuildStepsFromFunctionGroupCall(globalCtx, {
+        callInputs: { working_directory: './my-app' },
+      });
+
+      const checkoutStep = steps.find(s => s.displayName === 'Checkout');
+      expect(checkoutStep).toBeDefined();
+      expect(checkoutStep!.ctx.relativeWorkingDirectory).toBeUndefined();
+
+      const nonCheckoutSteps = steps.filter(s => s.displayName !== 'Checkout');
+      expect(nonCheckoutSteps.length).toBeGreaterThan(0);
+      for (const step of nonCheckoutSteps) {
+        expect(step.ctx.relativeWorkingDirectory).toBe('./my-app');
+      }
+    });
+
+    it('sets working directory on all steps except checkout (iOS simulator)', () => {
+      const buildToolsContext = createMockBuildToolsContext({
+        platform: Platform.IOS,
+        simulator: true,
+      });
+      const functionGroup = createEasBuildBuildFunctionGroup(buildToolsContext);
+      const globalCtx = createGlobalContextMock({ logger: createMockLogger() });
+
+      const steps = functionGroup.createBuildStepsFromFunctionGroupCall(globalCtx, {
+        callInputs: { working_directory: './my-app' },
+      });
+
+      const checkoutStep = steps.find(s => s.displayName === 'Checkout');
+      expect(checkoutStep).toBeDefined();
+      expect(checkoutStep!.ctx.relativeWorkingDirectory).toBeUndefined();
+
+      const nonCheckoutSteps = steps.filter(s => s.displayName !== 'Checkout');
+      expect(nonCheckoutSteps.length).toBeGreaterThan(0);
+      for (const step of nonCheckoutSteps) {
+        expect(step.ctx.relativeWorkingDirectory).toBeDefined();
+        expect(step.ctx.relativeWorkingDirectory).toContain('my-app');
+      }
+    });
+
+    it('sets working directory on all steps except checkout (iOS with credentials)', () => {
+      const buildToolsContext = createMockBuildToolsContext({
+        platform: Platform.IOS,
+        buildCredentials: { test: {} },
+      });
+      const functionGroup = createEasBuildBuildFunctionGroup(buildToolsContext);
+      const globalCtx = createGlobalContextMock({ logger: createMockLogger() });
+
+      const steps = functionGroup.createBuildStepsFromFunctionGroupCall(globalCtx, {
+        callInputs: { working_directory: './my-app' },
+      });
+
+      const checkoutStep = steps.find(s => s.displayName === 'Checkout');
+      expect(checkoutStep).toBeDefined();
+      expect(checkoutStep!.ctx.relativeWorkingDirectory).toBeUndefined();
+
+      const nonCheckoutSteps = steps.filter(s => s.displayName !== 'Checkout');
+      expect(nonCheckoutSteps.length).toBeGreaterThan(0);
+      for (const step of nonCheckoutSteps) {
+        expect(step.ctx.relativeWorkingDirectory).toBeDefined();
+        expect(step.ctx.relativeWorkingDirectory).toContain('my-app');
+      }
+    });
+
+    it('composes working directory with installPods step-level ./ios dir (iOS)', () => {
+      const buildToolsContext = createMockBuildToolsContext({
+        platform: Platform.IOS,
+        simulator: true,
+      });
+      const functionGroup = createEasBuildBuildFunctionGroup(buildToolsContext);
+      const globalCtx = createGlobalContextMock({ logger: createMockLogger() });
+
+      const steps = functionGroup.createBuildStepsFromFunctionGroupCall(globalCtx, {
+        callInputs: { working_directory: './my-app' },
+      });
+
+      const installPodsStep = steps.find(s => s.displayName === 'Install Pods');
+      expect(installPodsStep).toBeDefined();
+      expect(installPodsStep!.ctx.relativeWorkingDirectory).toBe('my-app/ios');
+    });
+
+    it('uses ./ios for installPods when no working_directory provided (iOS)', () => {
+      const buildToolsContext = createMockBuildToolsContext({
+        platform: Platform.IOS,
+        simulator: true,
+      });
+      const functionGroup = createEasBuildBuildFunctionGroup(buildToolsContext);
+      const globalCtx = createGlobalContextMock({ logger: createMockLogger() });
+
+      const steps = functionGroup.createBuildStepsFromFunctionGroupCall(globalCtx);
+
+      const installPodsStep = steps.find(s => s.displayName === 'Install Pods');
+      expect(installPodsStep).toBeDefined();
+      expect(installPodsStep!.ctx.relativeWorkingDirectory).toBe('./ios');
+    });
+
+    it('sets working directory on all steps except checkout (Android with credentials)', () => {
+      const buildToolsContext = createMockBuildToolsContext({
+        platform: Platform.ANDROID,
+        buildCredentials: { test: {} },
+      });
+      const functionGroup = createEasBuildBuildFunctionGroup(buildToolsContext);
+      const globalCtx = createGlobalContextMock({ logger: createMockLogger() });
+
+      const steps = functionGroup.createBuildStepsFromFunctionGroupCall(globalCtx, {
+        callInputs: { working_directory: './my-app' },
+      });
+
+      const checkoutStep = steps.find(s => s.displayName === 'Checkout');
+      expect(checkoutStep).toBeDefined();
+      expect(checkoutStep!.ctx.relativeWorkingDirectory).toBeUndefined();
+
+      const nonCheckoutSteps = steps.filter(s => s.displayName !== 'Checkout');
+      expect(nonCheckoutSteps.length).toBeGreaterThan(0);
+      for (const step of nonCheckoutSteps) {
+        expect(step.ctx.relativeWorkingDirectory).toBe('./my-app');
+      }
+    });
+  });
+
+  it('throws for generic jobs (no platform)', () => {
+    const buildToolsContext = {
+      job: { platform: undefined },
+    } as unknown as CustomBuildContext<BuildJob>;
+    const functionGroup = createEasBuildBuildFunctionGroup(buildToolsContext);
+    const globalCtx = createGlobalContextMock({ logger: createMockLogger() });
+
+    expect(() => functionGroup.createBuildStepsFromFunctionGroupCall(globalCtx)).toThrow(
+      'Build function group is not supported in generic jobs.'
+    );
+  });
+});

--- a/packages/build-tools/src/steps/functionGroups/build.ts
+++ b/packages/build-tools/src/steps/functionGroups/build.ts
@@ -1,5 +1,12 @@
 import { BuildJob, Platform } from '@expo/eas-build-job';
-import { BuildFunctionGroup, BuildStep, BuildStepGlobalContext } from '@expo/steps';
+import {
+  BuildFunctionGroup,
+  BuildStep,
+  BuildStepGlobalContext,
+  BuildStepInput,
+  BuildStepInputValueTypeName,
+} from '@expo/steps';
+import path from 'path';
 
 import { shouldUseEagerBundle } from '../../common/eagerBundle';
 import { CustomBuildContext } from '../../customBuildContext';
@@ -30,6 +37,7 @@ import { createSetUpNpmrcBuildFunction } from '../functions/useNpmToken';
 interface HelperFunctionsInput {
   globalCtx: BuildStepGlobalContext;
   buildToolsContext: CustomBuildContext<BuildJob>;
+  workingDirectory?: string;
 }
 
 export function createEasBuildBuildFunctionGroup(
@@ -38,17 +46,30 @@ export function createEasBuildBuildFunctionGroup(
   return new BuildFunctionGroup({
     namespace: 'eas',
     id: 'build',
-    createBuildStepsFromFunctionGroupCall: globalCtx => {
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'working_directory',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+    ],
+    createBuildStepsFromFunctionGroupCall: (globalCtx, { inputs }) => {
+      const workingDirectory = inputs.working_directory?.getValue({
+        interpolationContext: globalCtx.getInterpolationContext(),
+      }) as string | undefined;
+
       if (buildToolsContext.job.platform === Platform.IOS) {
         if (buildToolsContext.job.simulator) {
           return createStepsForIosSimulatorBuild({
             globalCtx,
             buildToolsContext,
+            workingDirectory,
           });
         } else {
           return createStepsForIosBuildWithCredentials({
             globalCtx,
             buildToolsContext,
+            workingDirectory,
           });
         }
       } else if (buildToolsContext.job.platform === Platform.ANDROID) {
@@ -56,11 +77,13 @@ export function createEasBuildBuildFunctionGroup(
           return createStepsForAndroidBuildWithoutCredentials({
             globalCtx,
             buildToolsContext,
+            workingDirectory,
           });
         } else {
           return createStepsForAndroidBuildWithCredentials({
             globalCtx,
             buildToolsContext,
+            workingDirectory,
           });
         }
       }
@@ -73,16 +96,19 @@ export function createEasBuildBuildFunctionGroup(
 function createStepsForIosSimulatorBuild({
   globalCtx,
   buildToolsContext,
+  workingDirectory,
 }: HelperFunctionsInput): BuildStep[] {
   const calculateEASUpdateRuntimeVersion =
     calculateEASUpdateRuntimeVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
       id: 'calculate_eas_update_runtime_version',
+      workingDirectory,
     });
   const installPods = createInstallPodsBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
-    workingDirectory: './ios',
+    workingDirectory: workingDirectory ? path.join(workingDirectory, './ios') : './ios',
   });
   const configureEASUpdate =
     configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
       callInputs: {
         throw_if_not_configured: false,
         resolved_eas_update_runtime_version:
@@ -91,6 +117,7 @@ function createStepsForIosSimulatorBuild({
     });
   const runFastlane = runFastlaneFunction().createBuildStepFromFunctionCall(globalCtx, {
     id: 'run_fastlane',
+    workingDirectory,
     callInputs: {
       resolved_eas_update_runtime_version:
         '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
@@ -98,18 +125,26 @@ function createStepsForIosSimulatorBuild({
   });
   return [
     createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
-    createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx),
-    createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
+    createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
     createResolveBuildConfigBuildFunction(buildToolsContext).createBuildStepFromFunctionCall(
-      globalCtx
+      globalCtx,
+      { workingDirectory }
     ),
-    createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
     calculateEASUpdateRuntimeVersion,
     installPods,
     configureEASUpdate,
     ...(shouldUseEagerBundle(globalCtx.staticContext.metadata)
       ? [
           eagerBundleBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+            workingDirectory,
             callInputs: {
               resolved_eas_update_runtime_version:
                 '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
@@ -117,29 +152,35 @@ function createStepsForIosSimulatorBuild({
           }),
         ]
       : []),
-    generateGymfileFromTemplateFunction().createBuildStepFromFunctionCall(globalCtx),
+    generateGymfileFromTemplateFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
     runFastlane,
     createFindAndUploadBuildArtifactsBuildFunction(
       buildToolsContext
-    ).createBuildStepFromFunctionCall(globalCtx),
+    ).createBuildStepFromFunctionCall(globalCtx, { workingDirectory }),
   ];
 }
 
 function createStepsForIosBuildWithCredentials({
   globalCtx,
   buildToolsContext,
+  workingDirectory,
 }: HelperFunctionsInput): BuildStep[] {
   const evictUsedBefore = new Date();
 
   const resolveAppleTeamIdFromCredentials =
     resolveAppleTeamIdFromCredentialsFunction().createBuildStepFromFunctionCall(globalCtx, {
       id: 'resolve_apple_team_id_from_credentials',
+      workingDirectory,
     });
   const calculateEASUpdateRuntimeVersion =
     calculateEASUpdateRuntimeVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
       id: 'calculate_eas_update_runtime_version',
+      workingDirectory,
     });
   const prebuildStep = createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+    workingDirectory,
     callInputs: {
       apple_team_id: '${ steps.resolve_apple_team_id_from_credentials.apple_team_id }',
     },
@@ -147,16 +188,18 @@ function createStepsForIosBuildWithCredentials({
   const restoreCache = createRestoreBuildCacheFunction().createBuildStepFromFunctionCall(
     globalCtx,
     {
+      workingDirectory,
       callInputs: {
         platform: Platform.IOS,
       },
     }
   );
   const installPods = createInstallPodsBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
-    workingDirectory: './ios',
+    workingDirectory: workingDirectory ? path.join(workingDirectory, './ios') : './ios',
   });
   const configureEASUpdate =
     configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
       callInputs: {
         throw_if_not_configured: false,
         resolved_eas_update_runtime_version:
@@ -166,6 +209,7 @@ function createStepsForIosBuildWithCredentials({
   const generateGymfile = generateGymfileFromTemplateFunction().createBuildStepFromFunctionCall(
     globalCtx,
     {
+      workingDirectory,
       callInputs: {
         credentials: '${ eas.job.secrets.buildCredentials }',
       },
@@ -173,6 +217,7 @@ function createStepsForIosBuildWithCredentials({
   );
   const runFastlane = runFastlaneFunction().createBuildStepFromFunctionCall(globalCtx, {
     id: 'run_fastlane',
+    workingDirectory,
     callInputs: {
       resolved_eas_update_runtime_version:
         '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
@@ -181,6 +226,7 @@ function createStepsForIosBuildWithCredentials({
   const saveCache = createSaveBuildCacheFunction(evictUsedBefore).createBuildStepFromFunctionCall(
     globalCtx,
     {
+      workingDirectory,
       callInputs: {
         platform: Platform.IOS,
       },
@@ -188,10 +234,15 @@ function createStepsForIosBuildWithCredentials({
   );
   return [
     createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
-    createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx),
-    createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
+    createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
     createResolveBuildConfigBuildFunction(buildToolsContext).createBuildStepFromFunctionCall(
-      globalCtx
+      globalCtx,
+      { workingDirectory }
     ),
     resolveAppleTeamIdFromCredentials,
     prebuildStep,
@@ -199,11 +250,16 @@ function createStepsForIosBuildWithCredentials({
     calculateEASUpdateRuntimeVersion,
     installPods,
     configureEASUpdate,
-    configureIosCredentialsFunction().createBuildStepFromFunctionCall(globalCtx),
-    configureIosVersionFunction().createBuildStepFromFunctionCall(globalCtx),
+    configureIosCredentialsFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
+    configureIosVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
     ...(shouldUseEagerBundle(globalCtx.staticContext.metadata)
       ? [
           eagerBundleBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+            workingDirectory,
             callInputs: {
               resolved_eas_update_runtime_version:
                 '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
@@ -215,24 +271,29 @@ function createStepsForIosBuildWithCredentials({
     runFastlane,
     createFindAndUploadBuildArtifactsBuildFunction(
       buildToolsContext
-    ).createBuildStepFromFunctionCall(globalCtx),
+    ).createBuildStepFromFunctionCall(globalCtx, { workingDirectory }),
     saveCache,
-    createCacheStatsBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createCacheStatsBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
   ];
 }
 
 function createStepsForAndroidBuildWithoutCredentials({
   globalCtx,
   buildToolsContext,
+  workingDirectory,
 }: HelperFunctionsInput): BuildStep[] {
   const evictUsedBefore = new Date();
 
   const calculateEASUpdateRuntimeVersion =
     calculateEASUpdateRuntimeVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
       id: 'calculate_eas_update_runtime_version',
+      workingDirectory,
     });
   const configureEASUpdate =
     configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
       callInputs: {
         throw_if_not_configured: false,
         resolved_eas_update_runtime_version:
@@ -242,6 +303,7 @@ function createStepsForAndroidBuildWithoutCredentials({
   const restoreCache = createRestoreBuildCacheFunction().createBuildStepFromFunctionCall(
     globalCtx,
     {
+      workingDirectory,
       callInputs: {
         platform: Platform.ANDROID,
       },
@@ -249,6 +311,7 @@ function createStepsForAndroidBuildWithoutCredentials({
   );
   const runGradle = runGradleFunction().createBuildStepFromFunctionCall(globalCtx, {
     id: 'run_gradle',
+    workingDirectory,
     callInputs: {
       resolved_eas_update_runtime_version:
         '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
@@ -257,6 +320,7 @@ function createStepsForAndroidBuildWithoutCredentials({
   const saveCache = createSaveBuildCacheFunction(evictUsedBefore).createBuildStepFromFunctionCall(
     globalCtx,
     {
+      workingDirectory,
       callInputs: {
         platform: Platform.ANDROID,
       },
@@ -264,18 +328,26 @@ function createStepsForAndroidBuildWithoutCredentials({
   );
   return [
     createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
-    createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx),
-    createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
+    createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
     createResolveBuildConfigBuildFunction(buildToolsContext).createBuildStepFromFunctionCall(
-      globalCtx
+      globalCtx,
+      { workingDirectory }
     ),
-    createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
     restoreCache,
     calculateEASUpdateRuntimeVersion,
     configureEASUpdate,
     ...(shouldUseEagerBundle(globalCtx.staticContext.metadata)
       ? [
           eagerBundleBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+            workingDirectory,
             callInputs: {
               resolved_eas_update_runtime_version:
                 '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
@@ -286,24 +358,29 @@ function createStepsForAndroidBuildWithoutCredentials({
     runGradle,
     createFindAndUploadBuildArtifactsBuildFunction(
       buildToolsContext
-    ).createBuildStepFromFunctionCall(globalCtx),
+    ).createBuildStepFromFunctionCall(globalCtx, { workingDirectory }),
     saveCache,
-    createCacheStatsBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createCacheStatsBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
   ];
 }
 
 function createStepsForAndroidBuildWithCredentials({
   globalCtx,
   buildToolsContext,
+  workingDirectory,
 }: HelperFunctionsInput): BuildStep[] {
   const evictUsedBefore = new Date();
 
   const calculateEASUpdateRuntimeVersion =
     calculateEASUpdateRuntimeVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
       id: 'calculate_eas_update_runtime_version',
+      workingDirectory,
     });
   const configureEASUpdate =
     configureEASUpdateIfInstalledFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
       callInputs: {
         throw_if_not_configured: false,
         resolved_eas_update_runtime_version:
@@ -313,6 +390,7 @@ function createStepsForAndroidBuildWithCredentials({
   const restoreCache = createRestoreBuildCacheFunction().createBuildStepFromFunctionCall(
     globalCtx,
     {
+      workingDirectory,
       callInputs: {
         platform: Platform.ANDROID,
       },
@@ -320,6 +398,7 @@ function createStepsForAndroidBuildWithCredentials({
   );
   const runGradle = runGradleFunction().createBuildStepFromFunctionCall(globalCtx, {
     id: 'run_gradle',
+    workingDirectory,
     callInputs: {
       resolved_eas_update_runtime_version:
         '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
@@ -328,6 +407,7 @@ function createStepsForAndroidBuildWithCredentials({
   const saveCache = createSaveBuildCacheFunction(evictUsedBefore).createBuildStepFromFunctionCall(
     globalCtx,
     {
+      workingDirectory,
       callInputs: {
         platform: Platform.ANDROID,
       },
@@ -335,21 +415,33 @@ function createStepsForAndroidBuildWithCredentials({
   );
   return [
     createCheckoutBuildFunction().createBuildStepFromFunctionCall(globalCtx),
-    createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx),
-    createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createSetUpNpmrcBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
+    createInstallNodeModulesBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
     createResolveBuildConfigBuildFunction(buildToolsContext).createBuildStepFromFunctionCall(
-      globalCtx
+      globalCtx,
+      { workingDirectory }
     ),
-    createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createPrebuildBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
     restoreCache,
     calculateEASUpdateRuntimeVersion,
     configureEASUpdate,
-    injectAndroidCredentialsFunction().createBuildStepFromFunctionCall(globalCtx),
-    configureAndroidVersionFunction().createBuildStepFromFunctionCall(globalCtx),
+    injectAndroidCredentialsFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
+    configureAndroidVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
     runGradle,
     ...(shouldUseEagerBundle(globalCtx.staticContext.metadata)
       ? [
           eagerBundleBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+            workingDirectory,
             callInputs: {
               resolved_eas_update_runtime_version:
                 '${ steps.calculate_eas_update_runtime_version.resolved_eas_update_runtime_version }',
@@ -359,8 +451,10 @@ function createStepsForAndroidBuildWithCredentials({
       : []),
     createFindAndUploadBuildArtifactsBuildFunction(
       buildToolsContext
-    ).createBuildStepFromFunctionCall(globalCtx),
+    ).createBuildStepFromFunctionCall(globalCtx, { workingDirectory }),
     saveCache,
-    createCacheStatsBuildFunction().createBuildStepFromFunctionCall(globalCtx),
+    createCacheStatsBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      workingDirectory,
+    }),
   ];
 }

--- a/packages/build-tools/tsconfig.json
+++ b/packages/build-tools/tsconfig.json
@@ -11,6 +11,7 @@
     "composite": true,
     "rootDir": "./src",
     "outDir": "./dist",
+    "types": ["jest", "node"],
     "plugins": [
       {
         "name": "gql.tada/ts-plugin",


### PR DESCRIPTION
# Why

To support custom build workflows that check out a repository, create a new Expo app inside it, and then build that app, we need a way to override the working directory for the `eas/build` function group. 

# How

Added `working_directory` as an optional input to the `eas/build` function group via `inputProviders`. When provided, it's propagated to all build steps except `eas/checkout` (which doesn't use workingDirectory - it operates on `projectSourceDirectory/projectTargetDirectory` directly).

For steps that already define their own relative working directory (e.g. `installPods` with`./ios`), the directories are composed using `path.join` - so `working_directory: ./my-app` with `./ios` results in `my-app/ios`.

# Test plan

Add automated tests.

Test manually with

```yml
name: Build

on:
  workflow_dispatch:
    inputs:
      platform:
        description: 'The platform to build for.'
        type: choice
        required: true
        options:
          - android
          - ios
      profile:
        description: 'The build profile to use'
        type: string
        required: false
        default: production
      message:
        description: 'Custom message attached to the build'
        type: string
        required: false

jobs:
  build_ios:
    name: Build iOS
    type: build
    params:
      platform: ${{ inputs.platform }}
      profile: ${{ inputs.profile }}
      message: ${{ inputs.message }}
    env:
      JAVA_HOME: /opt/homebrew/opt/openjdk@17
      ANDROID_HOME: /Users/szdziedzic/Library/Android/sdk
    steps:
      - uses: eas/checkout

      - run: npx create-expo-app@latest local-testing --template blank
        name: Create Expo app in subdirectory

      - run: cd local-testing && npx -y eas-cli@latest init --id 294b6e21-a144-483b-9f94-56ffa25905f4 --non-interactive
        name: Configure EAS project

      - uses: eas/build
        with:
          working_directory: ./local-testing
```
<img width="868" height="806" alt="Screenshot 2026-04-08 at 17 43 47" src="https://github.com/user-attachments/assets/8d8a78b9-a838-487b-a991-a226c6c45f5d" />
