### PR TITLE
[ENG-14822][steps] Coerce env in steps to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [steps] Coerce numeric env values to strings in workflow step configuration. ([#3583](https://github.com/expo/eas-cli/pull/3583) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools][eas-cli] Detect iOS Development provisioning profiles and set correct code signing identity instead of treating them as Ad Hoc. ([#3496](https://github.com/expo/eas-cli/pull/3496) by [@qwertey6](https://github.com/qwertey6))
 - [build-tools] Prevent detecting Yarn Modern as Classic based on lockfile ([#3572](https://github.com/expo/eas-cli/pull/3572) by [@kitten](https://github.com/kitten))
 

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -188,7 +188,12 @@ const BuildFunctionCallSchema = Joi.object({
   name: Joi.string(),
   workingDirectory: Joi.string(),
   shell: Joi.string(),
-  env: Joi.object().pattern(Joi.string(), Joi.string().allow('')),
+  env: Joi.object().pattern(
+    Joi.string(),
+    Joi.alternatives()
+      .try(Joi.number().strict(), Joi.string().allow(''))
+      .custom(value => String(value))
+  ),
   if: Joi.string(),
   timeout_minutes: Joi.number().positive(),
   // Internal field for metrics collection. Not documented publicly.

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -258,7 +258,7 @@ describe(validateConfig, () => {
 
           expect(() => {
             validateConfig(BuildConfigSchema, buildConfig);
-          }).toThrowError(/"build.steps\[0\].run.env.ENV1" must be a string/);
+          }).toThrowError(/"build.steps\[0\].run.env.ENV1" must be one of \[number, string\]/);
         });
         test('invalid env type', () => {
           const buildConfig = {
@@ -278,7 +278,48 @@ describe(validateConfig, () => {
 
           expect(() => {
             validateConfig(BuildConfigSchema, buildConfig);
-          }).toThrowError(/"build.steps\[0\].run.env.ENV1" must be a string/);
+          }).toThrowError(/"build.steps\[0\].run.env.ENV1" must be one of \[number, string\]/);
+        });
+        test('env number coerced to string', () => {
+          const buildConfig = {
+            build: {
+              steps: [
+                {
+                  run: {
+                    command: 'echo 123',
+                    env: {
+                      HOMEBREW_NO_AUTO_UPDATE: 1,
+                    },
+                  },
+                },
+              ],
+            },
+          };
+
+          const config = validateConfig(BuildConfigSchema, buildConfig);
+          assert(isBuildStepCommandRun(config.build.steps[0]));
+          expect(config.build.steps[0].run.env).toEqual({ HOMEBREW_NO_AUTO_UPDATE: '1' });
+        });
+        test('numeric-like string env value is not coerced', () => {
+          const buildConfig = {
+            build: {
+              steps: [
+                {
+                  run: {
+                    command: 'echo 123',
+                    env: {
+                      PORT: '001',
+                      SCALE: '1e3',
+                    },
+                  },
+                },
+              ],
+            },
+          };
+
+          const config = validateConfig(BuildConfigSchema, buildConfig);
+          assert(isBuildStepCommandRun(config.build.steps[0]));
+          expect(config.build.steps[0].run.env).toEqual({ PORT: '001', SCALE: '1e3' });
         });
         test('valid timeout_minutes', () => {
           const buildConfig = {
@@ -471,6 +512,36 @@ describe(validateConfig, () => {
             validateConfig(BuildConfigSchema, buildConfig);
           }).not.toThrowError();
         });
+        test('call with env number coerced to string', () => {
+          const buildConfig = {
+            build: {
+              steps: [
+                {
+                  say_hi: {
+                    env: {
+                      HOMEBREW_NO_AUTO_UPDATE: 1,
+                      PORT: 3000,
+                      VERBOSE: 'true',
+                    },
+                  },
+                },
+              ],
+            },
+            functions: {
+              say_hi: {
+                command: 'echo "Hi!"',
+              },
+            },
+          };
+
+          const config = validateConfig(BuildConfigSchema, buildConfig);
+          const step = config.build.steps[0] as BuildStepFunctionCall;
+          expect(step['say_hi'].env).toEqual({
+            HOMEBREW_NO_AUTO_UPDATE: '1',
+            PORT: '3000',
+            VERBOSE: 'true',
+          });
+        });
         test('call with if statement', () => {
           const buildConfig = {
             build: {
@@ -518,7 +589,7 @@ describe(validateConfig, () => {
 
           expect(() => {
             validateConfig(BuildConfigSchema, buildConfig);
-          }).toThrowError(/"build.steps\[0\].say_hi.env.ENV1" must be a string/);
+          }).toThrowError(/"build.steps\[0\].say_hi.env.ENV1" must be one of \[number, string\]/);
         });
         test('invalid env structure', () => {
           const buildConfig = {
@@ -544,7 +615,7 @@ describe(validateConfig, () => {
 
           expect(() => {
             validateConfig(BuildConfigSchema, buildConfig);
-          }).toThrowError(/"build.steps\[0\].say_hi.env.ENV1" must be a string/);
+          }).toThrowError(/"build.steps\[0\].say_hi.env.ENV1" must be one of \[number, string\]/);
         });
         test('call with inputs boolean', () => {
           const buildConfig = {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Passing numeric values in workflow step `env` (e.g. `env: { HOMEBREW_NO_AUTO_UPDATE: 1 }`) results in a validation error because env values are required to be strings. YAML naturally parses unquoted numbers as numeric types, so users hit this unexpectedly.

# How

Updated the Joi env validation schema in `BuildFunctionCallSchema` to accept both numbers and strings via `Joi.alternatives().try(Joi.number(), Joi.string().allow(''))`, with a `.custom()` callback that coerces numbers to strings via `String(value)`. This matches the coercion pattern used elsewhere in the codebase (e.g. `stringLike` in eas-cli).

Booleans and objects are still rejected — booleans because YAML accepts both `True` and `true` (coercing would lose casing), and objects because they aren't valid env values.

# Test Plan

- Updated existing error message assertions to match the new `"must be one of [number, string]"` validation message.
- Added two new test cases verifying that numeric env values are coerced to strings for both `run` commands and function calls.
- All 290 tests in the steps package pass.