### PR TITLE
Add new Apple metadata attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add missing Apple metadata attributes for age ratings and content descriptions. ([#3584](https://github.com/expo/eas-cli/pull/3584) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -43,7 +43,7 @@
     "copy-new-templates": "rimraf build/commandUtils/new/templates && mkdir -p build/commandUtils/new && cp -r src/commandUtils/new/templates build/commandUtils/new"
   },
   "dependencies": {
-    "@expo/apple-utils": "2.1.16",
+    "@expo/apple-utils": "2.1.17",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "55.0.10",
     "@expo/config-plugins": "55.0.7",

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/ageRatingDeclaration.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/fixtures/ageRatingDeclaration.ts
@@ -34,6 +34,15 @@ export const emptyAdvisory: AgeRatingDeclarationProps = {
   ageRatingOverride: null,
   koreaAgeRatingOverride: null,
   lootBox: null,
+  advertising: null,
+  ageAssurance: null,
+  ageRatingOverrideV2: null,
+  developerAgeRatingInfoUrl: null,
+  gunsOrOtherWeapons: null,
+  healthOrWellnessTopics: null,
+  messagingAndChat: null,
+  parentalControls: null,
+  userGeneratedContent: null,
 };
 
 export const leastRestrictiveAdvisory: AgeRatingDeclarationProps = {
@@ -55,6 +64,15 @@ export const leastRestrictiveAdvisory: AgeRatingDeclarationProps = {
   ageRatingOverride: RatingOverride.NONE,
   koreaAgeRatingOverride: KoreaRatingOverride.NONE,
   lootBox: false,
+  advertising: false,
+  ageAssurance: false,
+  ageRatingOverrideV2: null,
+  developerAgeRatingInfoUrl: null,
+  gunsOrOtherWeapons: Rating.NONE,
+  healthOrWellnessTopics: false,
+  messagingAndChat: false,
+  parentalControls: false,
+  userGeneratedContent: false,
 };
 
 export const mostRestrictiveAdvisory: AgeRatingDeclarationProps = {
@@ -76,6 +94,15 @@ export const mostRestrictiveAdvisory: AgeRatingDeclarationProps = {
   ageRatingOverride: RatingOverride.SEVENTEEN_PLUS,
   koreaAgeRatingOverride: KoreaRatingOverride.NINETEEN_PLUS,
   lootBox: true,
+  advertising: true,
+  ageAssurance: true,
+  ageRatingOverrideV2: null,
+  developerAgeRatingInfoUrl: null,
+  gunsOrOtherWeapons: Rating.FREQUENT_OR_INTENSE,
+  healthOrWellnessTopics: true,
+  messagingAndChat: true,
+  parentalControls: true,
+  userGeneratedContent: true,
 };
 
 export const kidsSixToEightAdvisory: AgeRatingDeclarationProps = {
@@ -97,4 +124,13 @@ export const kidsSixToEightAdvisory: AgeRatingDeclarationProps = {
   ageRatingOverride: RatingOverride.NONE,
   koreaAgeRatingOverride: KoreaRatingOverride.NONE,
   lootBox: false,
+  advertising: false,
+  ageAssurance: false,
+  ageRatingOverrideV2: null,
+  developerAgeRatingInfoUrl: null,
+  gunsOrOtherWeapons: Rating.NONE,
+  healthOrWellnessTopics: false,
+  messagingAndChat: false,
+  parentalControls: false,
+  userGeneratedContent: false,
 };

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -57,6 +57,15 @@ export class AppleConfigReader {
       violenceRealistic: attributes.violenceRealistic ?? Rating.NONE,
       violenceRealisticProlongedGraphicOrSadistic:
         attributes.violenceRealisticProlongedGraphicOrSadistic ?? Rating.NONE,
+      advertising: attributes.advertising ?? false,
+      ageAssurance: attributes.ageAssurance ?? false,
+      ageRatingOverrideV2: attributes.ageRatingOverrideV2 ?? null,
+      developerAgeRatingInfoUrl: attributes.developerAgeRatingInfoUrl ?? null,
+      gunsOrOtherWeapons: attributes.gunsOrOtherWeapons ?? Rating.NONE,
+      healthOrWellnessTopics: attributes.healthOrWellnessTopics ?? false,
+      messagingAndChat: attributes.messagingAndChat ?? false,
+      parentalControls: attributes.parentalControls ?? false,
+      userGeneratedContent: attributes.userGeneratedContent ?? false,
     };
   }
 

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -55,6 +55,15 @@ export class AppleConfigWriter {
       violenceRealistic: attributes.violenceRealistic ?? Rating.NONE,
       violenceRealisticProlongedGraphicOrSadistic:
         attributes.violenceRealisticProlongedGraphicOrSadistic ?? Rating.NONE,
+      advertising: attributes.advertising ?? false,
+      ageAssurance: attributes.ageAssurance ?? false,
+      ageRatingOverrideV2: attributes.ageRatingOverrideV2 ?? null,
+      developerAgeRatingInfoUrl: attributes.developerAgeRatingInfoUrl ?? null,
+      gunsOrOtherWeapons: attributes.gunsOrOtherWeapons ?? Rating.NONE,
+      healthOrWellnessTopics: attributes.healthOrWellnessTopics ?? false,
+      messagingAndChat: attributes.messagingAndChat ?? false,
+      parentalControls: attributes.parentalControls ?? false,
+      userGeneratedContent: attributes.userGeneratedContent ?? false,
     };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2847,12 +2847,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/apple-utils@npm:2.1.16":
-  version: 2.1.16
-  resolution: "@expo/apple-utils@npm:2.1.16"
+"@expo/apple-utils@npm:2.1.17":
+  version: 2.1.17
+  resolution: "@expo/apple-utils@npm:2.1.17"
   bin:
     apple-utils: bin.js
-  checksum: 10c0/9d3915f3f25c32e1f1ab323676cabccc2998046be6f30deebc68a0706836bd50bc5145662fa13441e0283f82c56e50f55002d50dcc43aa78e9fa7327d1676a54
+  checksum: 10c0/644734f4d3e1f781a62786bba7cef7cd6aa7bd1247332fe4701430897631b008b9a81e1805f031601fcfe0fd8403ee53f69d3c263aef3c5cd9fd432baa484739
   languageName: node
   linkType: hard
 
@@ -10998,7 +10998,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "eas-cli@workspace:packages/eas-cli"
   dependencies:
-    "@expo/apple-utils": "npm:2.1.16"
+    "@expo/apple-utils": "npm:2.1.17"
     "@expo/code-signing-certificates": "npm:0.0.5"
     "@expo/config": "npm:55.0.10"
     "@expo/config-plugins": "npm:55.0.7"


### PR DESCRIPTION
Extend AppleConfigReader and AppleConfigWriter to include additional app rating/content fields (advertising, ageAssurance, ageRatingOverrideV2, developerAgeRatingInfoUrl, gunsOrOtherWeapons, healthOrWellnessTopics, messagingAndChat, parentalControls, userGeneratedContent) with sensible defaults (false/null or Rating.NONE). This ensures these attributes are preserved when reading and writing Apple metadata.

<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.

# How

How did you build this feature or fix this bug and why?

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
