### PR TITLE
[eas-build-job] Add missing events support to `app_store_connect` workflows interpolation context

### DIFF
--- a/packages/eas-build-job/src/__tests__/common.test.ts
+++ b/packages/eas-build-job/src/__tests__/common.test.ts
@@ -84,6 +84,232 @@ describe('StaticWorkflowInterpolationContextZ', () => {
     expect(StaticWorkflowInterpolationContextZ.parse(context)).toEqual(context);
   });
 
+  it('accepts app_store_connect context with app_version', () => {
+    const context = {
+      after: {},
+      needs: {},
+      workflow: {
+        id: 'workflow-id',
+        name: 'workflow-name',
+        filename: 'workflow.yml',
+        url: 'https://expo.dev/accounts/example/workflows/workflow-id',
+      },
+      app: {
+        id: 'app-id',
+        slug: 'app-slug',
+      },
+      account: {
+        id: 'account-id',
+        name: 'account-name',
+      },
+      app_store_connect: {
+        app: {
+          id: '1234567890',
+        },
+        app_version: {
+          id: '123e4567-e89b-42d3-a456-426614174000',
+          state: 'ready_for_review',
+        },
+      },
+    };
+
+    expect(StaticWorkflowInterpolationContextZ.parse(context)).toEqual(context);
+  });
+
+  it('rejects invalid app_store_connect app_version state', () => {
+    const context = {
+      after: {},
+      needs: {},
+      workflow: {
+        id: 'workflow-id',
+        name: 'workflow-name',
+        filename: 'workflow.yml',
+        url: 'https://expo.dev/accounts/example/workflows/workflow-id',
+      },
+      app: {
+        id: 'app-id',
+        slug: 'app-slug',
+      },
+      account: {
+        id: 'account-id',
+        name: 'account-name',
+      },
+      app_store_connect: {
+        app: {
+          id: '1234567890',
+        },
+        app_version: {
+          id: '123e4567-e89b-42d3-a456-426614174000',
+          state: 'invalid-state',
+        },
+      },
+    };
+
+    expect(() => StaticWorkflowInterpolationContextZ.parse(context)).toThrow();
+  });
+
+  it('accepts app_store_connect context with external_beta', () => {
+    const context = {
+      after: {},
+      needs: {},
+      workflow: {
+        id: 'workflow-id',
+        name: 'workflow-name',
+        filename: 'workflow.yml',
+        url: 'https://expo.dev/accounts/example/workflows/workflow-id',
+      },
+      app: {
+        id: 'app-id',
+        slug: 'app-slug',
+      },
+      account: {
+        id: 'account-id',
+        name: 'account-name',
+      },
+      app_store_connect: {
+        app: {
+          id: '1234567890',
+        },
+        external_beta: {
+          id: '123e4567-e89b-42d3-a456-426614174000',
+          state: 'beta_approved',
+        },
+      },
+    };
+
+    expect(StaticWorkflowInterpolationContextZ.parse(context)).toEqual(context);
+  });
+
+  it('rejects invalid app_store_connect external_beta state', () => {
+    const context = {
+      after: {},
+      needs: {},
+      workflow: {
+        id: 'workflow-id',
+        name: 'workflow-name',
+        filename: 'workflow.yml',
+        url: 'https://expo.dev/accounts/example/workflows/workflow-id',
+      },
+      app: {
+        id: 'app-id',
+        slug: 'app-slug',
+      },
+      account: {
+        id: 'account-id',
+        name: 'account-name',
+      },
+      app_store_connect: {
+        app: {
+          id: '1234567890',
+        },
+        external_beta: {
+          id: '123e4567-e89b-42d3-a456-426614174000',
+          state: 'invalid-state',
+        },
+      },
+    };
+
+    expect(() => StaticWorkflowInterpolationContextZ.parse(context)).toThrow();
+  });
+
+  it('accepts app_store_connect context with beta_feedback', () => {
+    const context = {
+      after: {},
+      needs: {},
+      workflow: {
+        id: 'workflow-id',
+        name: 'workflow-name',
+        filename: 'workflow.yml',
+        url: 'https://expo.dev/accounts/example/workflows/workflow-id',
+      },
+      app: {
+        id: 'app-id',
+        slug: 'app-slug',
+      },
+      account: {
+        id: 'account-id',
+        name: 'account-name',
+      },
+      app_store_connect: {
+        app: {
+          id: '1234567890',
+        },
+        beta_feedback: {
+          id: 'AD8JvKbr0BK0Cj9OnM6WO6I',
+          type: 'screenshot',
+          url: 'https://api.appstoreconnect.apple.com/v1/betaFeedbackScreenshotSubmissions/AD8JvKbr0BK0Cj9OnM6WO6I',
+        },
+      },
+    };
+
+    expect(StaticWorkflowInterpolationContextZ.parse(context)).toEqual(context);
+  });
+
+  it('rejects app_store_connect beta_feedback without url', () => {
+    const context = {
+      after: {},
+      needs: {},
+      workflow: {
+        id: 'workflow-id',
+        name: 'workflow-name',
+        filename: 'workflow.yml',
+        url: 'https://expo.dev/accounts/example/workflows/workflow-id',
+      },
+      app: {
+        id: 'app-id',
+        slug: 'app-slug',
+      },
+      account: {
+        id: 'account-id',
+        name: 'account-name',
+      },
+      app_store_connect: {
+        app: {
+          id: '1234567890',
+        },
+        beta_feedback: {
+          id: 'AD8JvKbr0BK0Cj9OnM6WO6I',
+          type: 'crash',
+        },
+      },
+    };
+
+    expect(() => StaticWorkflowInterpolationContextZ.parse(context)).toThrow();
+  });
+
+  it('rejects invalid app_store_connect beta_feedback type', () => {
+    const context = {
+      after: {},
+      needs: {},
+      workflow: {
+        id: 'workflow-id',
+        name: 'workflow-name',
+        filename: 'workflow.yml',
+        url: 'https://expo.dev/accounts/example/workflows/workflow-id',
+      },
+      app: {
+        id: 'app-id',
+        slug: 'app-slug',
+      },
+      account: {
+        id: 'account-id',
+        name: 'account-name',
+      },
+      app_store_connect: {
+        app: {
+          id: '1234567890',
+        },
+        beta_feedback: {
+          id: 'AD8JvKbr0BK0Cj9OnM6WO6I',
+          type: 'invalid-type',
+          url: 'https://api.appstoreconnect.apple.com/v1/betaFeedbackScreenshotSubmissions/AD8JvKbr0BK0Cj9OnM6WO6I',
+        },
+      },
+    };
+
+    expect(() => StaticWorkflowInterpolationContextZ.parse(context)).toThrow();
+  });
+
   it('rejects invalid app_store_connect build_upload context', () => {
     const context = {
       after: {},

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -226,6 +226,66 @@ const GitHubContextZ = z.object({
     .optional(),
 });
 
+const AppStoreConnectContextZ = z.looseObject({
+  app: z.looseObject({
+    id: z.string(),
+  }),
+  app_version: z
+    .looseObject({
+      id: z.string(),
+      state: z.enum([
+        'accepted',
+        'developer_rejected',
+        'in_review',
+        'invalid_binary',
+        'metadata_rejected',
+        'pending_apple_release',
+        'pending_developer_release',
+        'prepare_for_submission',
+        'processing_for_distribution',
+        'ready_for_distribution',
+        'ready_for_review',
+        'rejected',
+        'replaced_with_new_version',
+        'waiting_for_export_compliance',
+        'waiting_for_review',
+      ]),
+    })
+    .optional(),
+  build_upload: z
+    .looseObject({
+      id: z.string(),
+      state: z.enum(['awaiting_upload', 'processing', 'failed', 'complete']),
+    })
+    .optional(),
+  external_beta: z
+    .looseObject({
+      id: z.string(),
+      state: z.enum([
+        'processing',
+        'processing_exception',
+        'missing_export_compliance',
+        'ready_for_beta_testing',
+        'in_beta_testing',
+        'expired',
+        'ready_for_beta_submission',
+        'in_export_compliance_review',
+        'waiting_for_beta_review',
+        'in_beta_review',
+        'beta_rejected',
+        'beta_approved',
+      ]),
+    })
+    .optional(),
+  beta_feedback: z
+    .looseObject({
+      id: z.string(),
+      type: z.enum(['crash', 'screenshot']),
+      url: z.string(),
+    })
+    .optional(),
+});
+
 export const StaticWorkflowInterpolationContextZ = z.object({
   after: z.record(
     z.string(),
@@ -259,19 +319,8 @@ export const StaticWorkflowInterpolationContextZ = z.object({
     id: z.string(),
     name: z.string(),
   }),
-  app_store_connect: z
-    .looseObject({
-      app: z.looseObject({
-        id: z.string(),
-      }),
-      build_upload: z
-        .looseObject({
-          id: z.string(),
-          state: z.enum(['awaiting_upload', 'processing', 'failed', 'complete']),
-        })
-        .optional(),
-    })
-    .optional(),
+  // We need to .optional() to support jobs that are not triggered by an App Store Connect event.
+  app_store_connect: AppStoreConnectContextZ.optional(),
 });
 
 export type StaticWorkflowInterpolationContext = z.infer<


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The App Store Connect workflow interpolation context supports `build_upload`, but there are also other event types.

# How

Added basic schema for the remaining event types. Moved the ASC context schema to a separate const, as it grew significantly.

# Test Plan

Added unit tests.
