### PR TITLE
[eas-cli] Bump @expo/apple-utils to 2.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools][eas-cli] Detect iOS Development provisioning profiles and set correct code signing identity instead of treating them as Ad Hoc. ([#3496](https://github.com/expo/eas-cli/pull/3496) by [@qwertey6](https://github.com/qwertey6))
 - [build-tools] Prevent detecting Yarn Modern as Classic based on lockfile ([#3572](https://github.com/expo/eas-cli/pull/3572) by [@kitten](https://github.com/kitten))
-- [eas-cli] Bump `@expo/apple-utils` to `2.1.18` to fix `metadata:push` failing on `ageRatingDeclarations` due to the removed `gamblingAndContests` attribute. ([#3585](https://github.com/expo/eas-cli/pull/3585) by [@EvanBacon](https://github.com/EvanBacon))
+- [eas-cli] Bump `@expo/apple-utils` to `2.1.18` to fix `metadata:push` failing on `ageRatingDeclarations` due to the removed `gamblingAndContests` attribute. ([#3588](https://github.com/expo/eas-cli/pull/3588) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools][eas-cli] Detect iOS Development provisioning profiles and set correct code signing identity instead of treating them as Ad Hoc. ([#3496](https://github.com/expo/eas-cli/pull/3496) by [@qwertey6](https://github.com/qwertey6))
 - [build-tools] Prevent detecting Yarn Modern as Classic based on lockfile ([#3572](https://github.com/expo/eas-cli/pull/3572) by [@kitten](https://github.com/kitten))
+- [eas-cli] Bump `@expo/apple-utils` to `2.1.18` to fix `metadata:push` failing on `ageRatingDeclarations` due to the removed `gamblingAndContests` attribute. ([#3585](https://github.com/expo/eas-cli/pull/3585) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -43,7 +43,7 @@
     "copy-new-templates": "rimraf build/commandUtils/new/templates && mkdir -p build/commandUtils/new && cp -r src/commandUtils/new/templates build/commandUtils/new"
   },
   "dependencies": {
-    "@expo/apple-utils": "2.1.17",
+    "@expo/apple-utils": "2.1.18",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "55.0.10",
     "@expo/config-plugins": "55.0.7",

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -515,6 +515,57 @@
           "lootBox": {
             "type": "boolean",
             "description": "Does your app contain purchasable loot boxes? These virtual containers provide players with in-game items, including functional cards or cosmetic modifications, based on random chance."
+          },
+          "advertising": {
+            "type": "boolean",
+            "description": "Does your app display advertising?"
+          },
+          "ageAssurance": {
+            "type": "boolean",
+            "description": "Does your app implement age assurance mechanisms?"
+          },
+          "ageRatingOverrideV2": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/definitions/apple/AppleAgeRatingOverrideV2"
+              }
+            ],
+            "description": "Override the age rating using the V2 rating system. Allows setting a more granular age rating than the auto-calculated value."
+          },
+          "developerAgeRatingInfoUrl": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "string",
+                "format": "uri"
+              }
+            ],
+            "description": "URL to additional developer-provided information about the app's age rating."
+          },
+          "gunsOrOtherWeapons": {
+            "$ref": "#/definitions/apple/AppleRating",
+            "description": "Does the app contain depictions of guns or other weapons?"
+          },
+          "healthOrWellnessTopics": {
+            "type": "boolean",
+            "description": "Does your app contain health or wellness topics?"
+          },
+          "messagingAndChat": {
+            "type": "boolean",
+            "description": "Does your app contain messaging or chat functionality?"
+          },
+          "parentalControls": {
+            "type": "boolean",
+            "description": "Does your app implement parental controls?"
+          },
+          "userGeneratedContent": {
+            "type": "boolean",
+            "description": "Does your app contain or display user-generated content?"
           }
         }
       },
@@ -649,6 +700,16 @@
           "NONE",
           "FIFTEEN_PLUS",
           "NINETEEN_PLUS"
+        ]
+      },
+      "AppleAgeRatingOverrideV2": {
+        "enum": [
+          "NONE",
+          "NINE_PLUS",
+          "THIRTEEN_PLUS",
+          "SIXTEEN_PLUS",
+          "EIGHTEEN_PLUS",
+          "UNRATED"
         ]
       }
     },

--- a/packages/eas-cli/src/commands/metadata/CLAUDE.md
+++ b/packages/eas-cli/src/commands/metadata/CLAUDE.md
@@ -1,0 +1,11 @@
+# CLAUDE.md - metadata commands
+
+`metadata:push` validates `store.config.json` against `packages/eas-cli/schema/metadata-0.json`. The schema can drift from the apple config reader/writer, and when it does `metadata:pull` happily writes fields that `metadata:push` then rejects — and the failure looks like the user's fault.
+
+**Whenever you touch `src/metadata/apple/config/{reader,writer}.ts`, update `metadata-0.json` in the same change.** For new advisory fields:
+
+- Add the property under `definitions.apple.AppleAdvisory.properties`.
+- For enums from `@expo/apple-utils`, add a matching `Apple<Name>` enum definition with the exact string values and reference it via `$ref`. Wrap in `oneOf` with `{ "type": "null" }` if the writer ever persists `null`.
+- Don't add to `required` — that breaks existing user configs. Optional with a sensible default in the writer is the convention.
+
+The drift is caught by `src/metadata/apple/config/__tests__/writer.test.ts` ("writer output for ... passes JSON schema validation"). If you change apple-utils types or fixtures, that test will tell you exactly what the schema is missing.

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -6,6 +6,7 @@ import path from 'path';
 
 import { ensureProjectConfiguredAsync } from '../../build/configure';
 import EasCommand from '../../commandUtils/EasCommand';
+import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { CredentialsContext } from '../../credentials/context';
 import Log, { learnMore } from '../../log';
 import { downloadMetadataAsync } from '../../metadata/download';
@@ -21,10 +22,7 @@ export default class MetadataPull extends EasCommand {
       description:
         'Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.',
     }),
-    'non-interactive': Flags.boolean({
-      default: false,
-      description: 'Run the command in non-interactive mode.',
-    }),
+    ...EASNonInteractiveFlag,
   };
 
   static override contextDefinition = {

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -4,6 +4,7 @@ import { Flags } from '@oclif/core';
 
 import { ensureProjectConfiguredAsync } from '../../build/configure';
 import EasCommand from '../../commandUtils/EasCommand';
+import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { CredentialsContext } from '../../credentials/context';
 import Log, { learnMore } from '../../log';
 import { handleMetadataError } from '../../metadata/errors';
@@ -19,10 +20,7 @@ export default class MetadataPush extends EasCommand {
       description:
         'Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.',
     }),
-    'non-interactive': Flags.boolean({
-      default: false,
-      description: 'Run the command in non-interactive mode.',
-    }),
+    ...EASNonInteractiveFlag,
   };
 
   static override contextDefinition = {

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -12,6 +12,7 @@ import { nameAndDemoReviewDetails, nameOnlyReviewDetails } from './fixtures/appS
 import { automaticRelease, manualRelease, scheduledRelease } from './fixtures/appStoreVersion';
 import { dutchVersion, englishVersion } from './fixtures/appStoreVersionLocalization';
 import { phasedRelease } from './fixtures/appStoreVersionPhasedRelease';
+import { validateConfig } from '../../../config/validate';
 import { AppleConfigWriter } from '../writer';
 
 describe('toSchema', () => {
@@ -41,6 +42,22 @@ describe('setAgeRating', () => {
     const writer = new AppleConfigWriter();
     writer.setAgeRating(mostRestrictiveAdvisory);
     expect(writer.schema.advisory).toMatchObject(mostRestrictiveAdvisory);
+  });
+
+  // Drift guard: every advisory field that the writer emits must be allowed by
+  // metadata-0.json. If you add a field to writer.ts (or apple-utils surfaces a
+  // new one upstream), update the schema in the same change. Without this
+  // test, the drift only shows up at `metadata:push` time as a confusing
+  // validation error against the user's freshly pulled config.
+  it.each([
+    ['emptyAdvisory', emptyAdvisory],
+    ['leastRestrictiveAdvisory', leastRestrictiveAdvisory],
+    ['mostRestrictiveAdvisory', mostRestrictiveAdvisory],
+    ['kidsSixToEightAdvisory', kidsSixToEightAdvisory],
+  ])('writer output for %s passes JSON schema validation', (_name, advisory) => {
+    const writer = new AppleConfigWriter();
+    writer.setAgeRating(advisory);
+    expect(validateConfig(writer.toSchema())).toEqual([]);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2847,12 +2847,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/apple-utils@npm:2.1.17":
-  version: 2.1.17
-  resolution: "@expo/apple-utils@npm:2.1.17"
+"@expo/apple-utils@npm:2.1.18":
+  version: 2.1.18
+  resolution: "@expo/apple-utils@npm:2.1.18"
   bin:
     apple-utils: bin.js
-  checksum: 10c0/644734f4d3e1f781a62786bba7cef7cd6aa7bd1247332fe4701430897631b008b9a81e1805f031601fcfe0fd8403ee53f69d3c263aef3c5cd9fd432baa484739
+  checksum: 10c0/4ca2b4b475eba9fd1c2b874e76800c2954a778bff0573c6e6830460d0ae78d5a8883b96ada6856a3eecc90f9c1e65f381a33aeb57b53a86d826cf22aceaa12ee
   languageName: node
   linkType: hard
 
@@ -10998,7 +10998,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "eas-cli@workspace:packages/eas-cli"
   dependencies:
-    "@expo/apple-utils": "npm:2.1.17"
+    "@expo/apple-utils": "npm:2.1.18"
     "@expo/code-signing-certificates": "npm:0.0.5"
     "@expo/config": "npm:55.0.10"
     "@expo/config-plugins": "npm:55.0.7"


### PR DESCRIPTION
# Why

`eas metadata:push` was failing in the age-rating phase against real apps with:

```
✖ Failed to update age rating declaration
The provided entity includes an unknown attribute - 'gamblingAndContests' is not an attribute on the resource 'ageRatingDeclarations'
```

Apple removed `gamblingAndContests` from the App Store Connect API (replaced by `gambling` + `contests`), but the published `@expo/apple-utils@2.1.17` runtime still defaulted and sent that attribute on every `AgeRatingDeclaration.updateAsync` call.

Verified end-to-end against `pillar-valley`:

- **Before** (`2.1.17`): `✖ Failed to update age rating declaration` → command exits with the error above.
- **After** (`2.1.18`): `✔ Updated age rating declaration` → `🎉 Store configuration is synced with the app stores.`

# Test Plan

- [x] `yarn install` resolves cleanly to `2.1.18`.
- [x] Ran `eas metadata:push --non-interactive` against `pillar-valley` (real App Store Connect sync). All phases pass, including `✔ Updated age rating declaration`.
- [ ] CI on this PR.
