### PR TITLE
feat(metadata): add app clips support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [eas-cli] Add missing Apple metadata attributes for age ratings and content descriptions. ([#3584](https://github.com/expo/eas-cli/pull/3584) by [@EvanBacon](https://github.com/EvanBacon))
+- [eas-cli] Add App Clip metadata support to `metadata:push` and `metadata:pull` (default experience action, per-locale subtitle and header image, App Store review invocation URLs). ([#3590](https://github.com/expo/eas-cli/pull/3590) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 
 - [build-tools][eas-cli] Detect iOS Development provisioning profiles and set correct code signing identity instead of treating them as Ad Hoc. ([#3496](https://github.com/expo/eas-cli/pull/3496) by [@qwertey6](https://github.com/qwertey6))
 - [build-tools] Prevent detecting Yarn Modern as Classic based on lockfile ([#3572](https://github.com/expo/eas-cli/pull/3572) by [@kitten](https://github.com/kitten))
 - [eas-cli] Bump `@expo/apple-utils` to `2.1.18` to fix `metadata:push` failing on `ageRatingDeclarations` due to the removed `gamblingAndContests` attribute. ([#3588](https://github.com/expo/eas-cli/pull/3588) by [@EvanBacon](https://github.com/EvanBacon))
+- [eas-cli] Bump `@expo/apple-utils` to `2.1.19` to fix image and video uploads via `metadata:push` getting stuck in `AWAITING_UPLOAD` state. The asset client was inheriting Bearer token injection from the App Store Connect API client, which caused S3 presigned URL uploads to be silently mishandled by Apple's CDN. Fixes screenshots, previews, and App Clip header image uploads. ([#3590](https://github.com/expo/eas-cli/pull/3590) by [@EvanBacon](https://github.com/EvanBacon))
+- [eas-cli] `metadata:pull` now preserves screenshot, video preview, and App Clip header image entries with placeholder paths when the asset is in an unrendered state, so users can recover broken records by replacing the file or removing the entry instead of having entries silently dropped from `store.config.json`. ([#3590](https://github.com/expo/eas-cli/pull/3590) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -43,7 +43,7 @@
     "copy-new-templates": "rimraf build/commandUtils/new/templates && mkdir -p build/commandUtils/new && cp -r src/commandUtils/new/templates build/commandUtils/new"
   },
   "dependencies": {
-    "@expo/apple-utils": "2.1.18",
+    "@expo/apple-utils": "2.1.19",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "55.0.10",
     "@expo/config-plugins": "55.0.7",

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -688,6 +688,118 @@
           }
         }
       },
+      "AppleAppClip": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "App Clip metadata. Only applies to apps that ship an App Clip target.",
+        "properties": {
+          "defaultExperience": {
+            "$ref": "#/definitions/apple/AppleAppClipDefaultExperience",
+            "description": "The default experience for this App Clip. There is exactly one per app."
+          }
+        }
+      },
+      "AppleAppClipDefaultExperience": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Default experience for an App Clip - the configuration shown when invoked without a custom experience.",
+        "properties": {
+          "action": {
+            "enum": ["OPEN", "VIEW", "PLAY"],
+            "description": "Action button shown in the App Clip card."
+          },
+          "releaseWithAppStoreVersion": {
+            "type": "boolean",
+            "description": "Whether to release this default experience alongside the next App Store version."
+          },
+          "reviewDetail": {
+            "$ref": "#/definitions/apple/AppleAppClipReviewDetail",
+            "description": "App Store review information for the App Clip default experience."
+          },
+          "info": {
+            "$ref": "#/definitions/apple/AppleAppClipInfo",
+            "description": "Localized subtitle and header image for the App Clip default experience."
+          }
+        }
+      },
+      "AppleAppClipReviewDetail": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "App Store review detail for an App Clip default experience.",
+        "required": ["invocationUrls"],
+        "properties": {
+          "invocationUrls": {
+            "type": "array",
+            "description": "Invocation URLs that App Review will use to launch the App Clip during review.",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      },
+      "AppleAppClipLocalizedInfo": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Localized subtitle and header image for an App Clip default experience.",
+        "properties": {
+          "subtitle": {
+            "type": "string",
+            "description": "Subtitle shown in the App Clip card. Apple limits this to 43 characters.",
+            "maxLength": 43
+          },
+          "headerImage": {
+            "type": "string",
+            "description": "Relative path (from project root) to the App Clip header image PNG."
+          }
+        }
+      },
+      "AppleAppClipInfo": {
+        "type": "object",
+        "description": "Localized App Clip information, keyed by locale.",
+        "additionalProperties": false,
+        "properties": {
+          "ar-SA": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Arabic" },
+          "ca": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Catalan" },
+          "zh-Hans": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Chinese (Simplified)" },
+          "zh-Hant": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Chinese (Traditional)" },
+          "hr": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Croatian" },
+          "cs": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Czech" },
+          "da": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Danish" },
+          "nl-NL": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Dutch" },
+          "en-AU": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "English (Australia)" },
+          "en-CA": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "English (Canada)" },
+          "en-GB": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "English (U.K.)" },
+          "en-US": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "English (U.S.)" },
+          "fi": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Finnish" },
+          "fr-FR": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "French" },
+          "fr-CA": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "French (Canada)" },
+          "de-DE": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "German" },
+          "el": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Greek" },
+          "he": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Hebrew" },
+          "hi": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Hindi" },
+          "hu": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Hungarian" },
+          "id": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Indonesian" },
+          "it": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Italian" },
+          "ja": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Japanese" },
+          "ko": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Korean" },
+          "ms": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Malay" },
+          "no": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Norwegian" },
+          "pl": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Polish" },
+          "pt-BR": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Portuguese (Brazil)" },
+          "pt-PT": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Portuguese (Portugal)" },
+          "ro": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Romanian" },
+          "ru": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Russian" },
+          "sk": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Slovak" },
+          "es-MX": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Spanish (Mexico)" },
+          "es-ES": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Spanish (Spain)" },
+          "sv": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Swedish" },
+          "th": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Thai" },
+          "tr": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Turkish" },
+          "uk": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Ukrainian" },
+          "vi": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Vietnamese" }
+        }
+      },
       "AppleAgeRatingOverride": {
         "enum": [
           "NONE",
@@ -918,6 +1030,10 @@
         "review": {
           "$ref": "#/definitions/apple/AppleReview",
           "description": "Info for the App Store reviewer"
+        },
+        "appClip": {
+          "$ref": "#/definitions/apple/AppleAppClip",
+          "description": "App Clip metadata. Only applies to apps that ship an App Clip target."
         }
       }
     }

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/reader.test.ts
@@ -176,3 +176,43 @@ describe('getVersion', () => {
     });
   });
 });
+
+describe('getAppClip', () => {
+  it('returns null when no app clip is configured', () => {
+    const reader = new AppleConfigReader({});
+    expect(reader.getAppClip()).toBeNull();
+    expect(reader.getAppClipDefaultExperience()).toBeNull();
+    expect(reader.getAppClipLocales()).toEqual([]);
+  });
+
+  it('returns the configured app clip block', () => {
+    const reader = new AppleConfigReader({
+      appClip: {
+        defaultExperience: {
+          action: 'OPEN',
+          releaseWithAppStoreVersion: true,
+          reviewDetail: { invocationUrls: ['https://example.com/clip'] },
+          info: {
+            'en-US': { subtitle: 'Quick experience', headerImage: 'header.png' },
+            'fr-FR': { subtitle: 'Expérience rapide' },
+          },
+        },
+      },
+    });
+
+    expect(reader.getAppClipDefaultExperience()).toMatchObject({
+      action: 'OPEN',
+      releaseWithAppStoreVersion: true,
+      reviewDetail: { invocationUrls: ['https://example.com/clip'] },
+    });
+    expect(reader.getAppClipLocales().sort()).toEqual(['en-US', 'fr-FR']);
+    expect(reader.getAppClipLocalizedInfo('en-US')).toEqual({
+      subtitle: 'Quick experience',
+      headerImage: 'header.png',
+    });
+    expect(reader.getAppClipLocalizedInfo('fr-FR')).toEqual({
+      subtitle: 'Expérience rapide',
+    });
+    expect(reader.getAppClipLocalizedInfo('de-DE')).toBeNull();
+  });
+});

--- a/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
+++ b/packages/eas-cli/src/metadata/apple/config/__tests__/writer.test.ts
@@ -346,3 +346,72 @@ describe('setReviewDetails', () => {
     });
   });
 });
+
+describe('setAppClipDefaultExperience', () => {
+  it('sets default experience attributes', () => {
+    const writer = new AppleConfigWriter();
+    writer.setAppClipDefaultExperience({
+      action: 'OPEN',
+      releaseWithAppStoreVersion: true,
+    });
+    expect(writer.schema.appClip?.defaultExperience).toMatchObject({
+      action: 'OPEN',
+      releaseWithAppStoreVersion: true,
+    });
+  });
+});
+
+describe('setAppClipReviewDetail', () => {
+  it('sets invocation urls', () => {
+    const writer = new AppleConfigWriter();
+    writer.setAppClipReviewDetail({ invocationUrls: ['https://example.com/clip'] });
+    expect(writer.schema.appClip?.defaultExperience?.reviewDetail).toEqual({
+      invocationUrls: ['https://example.com/clip'],
+    });
+  });
+
+  it('removes review detail when null', () => {
+    const writer = new AppleConfigWriter();
+    writer.setAppClipReviewDetail({ invocationUrls: ['https://example.com/clip'] });
+    writer.setAppClipReviewDetail(null);
+    expect(writer.schema.appClip?.defaultExperience?.reviewDetail).toBeUndefined();
+  });
+
+  it('removes review detail when invocationUrls is empty', () => {
+    const writer = new AppleConfigWriter();
+    writer.setAppClipReviewDetail({ invocationUrls: ['https://example.com/clip'] });
+    writer.setAppClipReviewDetail({ invocationUrls: [] });
+    expect(writer.schema.appClip?.defaultExperience?.reviewDetail).toBeUndefined();
+  });
+});
+
+describe('setAppClipLocalizedInfo', () => {
+  it('writes localized subtitle and header image', () => {
+    const writer = new AppleConfigWriter();
+    writer.setAppClipLocalizedInfo('en-US', {
+      subtitle: 'Quick experience',
+      headerImage: 'store/apple/app-clip/en-US/header.png',
+    });
+    expect(writer.schema.appClip?.defaultExperience?.info?.['en-US']).toEqual({
+      subtitle: 'Quick experience',
+      headerImage: 'store/apple/app-clip/en-US/header.png',
+    });
+  });
+
+  it('omits empty locale entries', () => {
+    const writer = new AppleConfigWriter();
+    writer.setAppClipLocalizedInfo('en-US', { subtitle: 'Quick' });
+    writer.setAppClipLocalizedInfo('en-US', {});
+    expect(writer.schema.appClip?.defaultExperience?.info?.['en-US']).toBeUndefined();
+  });
+
+  it('keeps multiple locales independent', () => {
+    const writer = new AppleConfigWriter();
+    writer.setAppClipLocalizedInfo('en-US', { subtitle: 'Quick' });
+    writer.setAppClipLocalizedInfo('fr-FR', { subtitle: 'Rapide' });
+    expect(writer.schema.appClip?.defaultExperience?.info).toMatchObject({
+      'en-US': { subtitle: 'Quick' },
+      'fr-FR': { subtitle: 'Rapide' },
+    });
+  });
+});

--- a/packages/eas-cli/src/metadata/apple/config/reader.ts
+++ b/packages/eas-cli/src/metadata/apple/config/reader.ts
@@ -16,7 +16,14 @@ import {
 import uniq from '../../../utils/expodash/uniq';
 import { AttributesOf } from '../../utils/asc';
 import { removeDatePrecision } from '../../utils/date';
-import { AppleMetadata, ApplePreviews, AppleScreenshots } from '../types';
+import {
+  AppleAppClip,
+  AppleAppClipDefaultExperience,
+  AppleAppClipLocalizedInfo,
+  AppleMetadata,
+  ApplePreviews,
+  AppleScreenshots,
+} from '../types';
 
 type PartialExcept<T, K extends keyof T> = Pick<T, K> & Partial<Omit<T, K>>;
 
@@ -229,5 +236,25 @@ export class AppleConfigReader {
   /** Get video previews configuration for a specific locale */
   public getPreviews(locale: string): ApplePreviews | null {
     return this.schema.info?.[locale]?.previews ?? null;
+  }
+
+  /** Get the App Clip configuration block, or null if no App Clip is configured. */
+  public getAppClip(): AppleAppClip | null {
+    return this.schema.appClip ?? null;
+  }
+
+  /** Get the App Clip default experience, or null if not configured. */
+  public getAppClipDefaultExperience(): AppleAppClipDefaultExperience | null {
+    return this.schema.appClip?.defaultExperience ?? null;
+  }
+
+  /** Locales that have App Clip default-experience info configured. */
+  public getAppClipLocales(): string[] {
+    return uniq(Object.keys(this.schema.appClip?.defaultExperience?.info ?? {}));
+  }
+
+  /** Get the localized App Clip info (subtitle + header image) for a specific locale. */
+  public getAppClipLocalizedInfo(locale: string): AppleAppClipLocalizedInfo | null {
+    return this.schema.appClip?.defaultExperience?.info?.[locale] ?? null;
   }
 }

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -13,7 +13,14 @@ import {
 } from '@expo/apple-utils';
 
 import { AttributesOf } from '../../utils/asc';
-import { AppleMetadata, ApplePreviews, AppleScreenshots } from '../types';
+import {
+  AppleAppClipDefaultExperience,
+  AppleAppClipLocalizedInfo,
+  AppleAppClipReviewDetail,
+  AppleMetadata,
+  ApplePreviews,
+  AppleScreenshots,
+} from '../types';
 
 /**
  * Serializes the Apple ASC entities into the metadata configuration schema.
@@ -209,6 +216,44 @@ export class AppleConfigWriter {
     this.schema.info = this.schema.info ?? {};
     this.schema.info[locale] = this.schema.info[locale] ?? { title: '' };
     this.schema.info[locale].previews = Object.keys(previews).length > 0 ? previews : undefined;
+  }
+
+  /** Set the App Clip default experience attributes (action, releaseWithAppStoreVersion). */
+  public setAppClipDefaultExperience(
+    attributes: Pick<AppleAppClipDefaultExperience, 'action' | 'releaseWithAppStoreVersion'>
+  ): void {
+    this.schema.appClip = this.schema.appClip ?? {};
+    this.schema.appClip.defaultExperience = {
+      ...this.schema.appClip.defaultExperience,
+      action: attributes.action,
+      releaseWithAppStoreVersion: attributes.releaseWithAppStoreVersion,
+    };
+  }
+
+  /** Set the App Clip App Store review detail (invocation URLs). */
+  public setAppClipReviewDetail(reviewDetail: AppleAppClipReviewDetail | null): void {
+    this.schema.appClip = this.schema.appClip ?? {};
+    this.schema.appClip.defaultExperience = this.schema.appClip.defaultExperience ?? {};
+    if (reviewDetail && reviewDetail.invocationUrls.length > 0) {
+      this.schema.appClip.defaultExperience.reviewDetail = reviewDetail;
+    } else {
+      delete this.schema.appClip.defaultExperience.reviewDetail;
+    }
+  }
+
+  /** Set per-locale App Clip info (subtitle + header image). */
+  public setAppClipLocalizedInfo(locale: string, info: AppleAppClipLocalizedInfo): void {
+    this.schema.appClip = this.schema.appClip ?? {};
+    this.schema.appClip.defaultExperience = this.schema.appClip.defaultExperience ?? {};
+    this.schema.appClip.defaultExperience.info = this.schema.appClip.defaultExperience.info ?? {};
+    if (info.subtitle || info.headerImage) {
+      this.schema.appClip.defaultExperience.info[locale] = {
+        subtitle: optional(info.subtitle ?? null),
+        headerImage: optional(info.headerImage ?? null),
+      };
+    } else {
+      delete this.schema.appClip.defaultExperience.info[locale];
+    }
   }
 }
 

--- a/packages/eas-cli/src/metadata/apple/data.ts
+++ b/packages/eas-cli/src/metadata/apple/data.ts
@@ -1,6 +1,7 @@
 import type { App } from '@expo/apple-utils';
 
 import type { AgeRatingData } from './tasks/age-rating';
+import type { AppClipData } from './tasks/app-clip';
 import type { AppInfoData } from './tasks/app-info';
 import type { AppReviewData } from './tasks/app-review-detail';
 import type { AppVersionData } from './tasks/app-version';
@@ -16,7 +17,8 @@ export type AppleData = { app: App; projectDir: string } & AppInfoData &
   AgeRatingData &
   AppReviewData &
   ScreenshotsData &
-  PreviewsData;
+  PreviewsData &
+  AppClipData;
 
 /**
  * The unprepared partial apple data, used within the `prepareAsync` tasks.

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-clip.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-clip.test.ts
@@ -1,4 +1,11 @@
-import { App, AppClip } from '@expo/apple-utils';
+import {
+  App,
+  AppClip,
+  AppClipAppStoreReviewDetail,
+  AppClipDefaultExperience,
+  AppClipDefaultExperienceLocalization,
+  AppStoreVersion,
+} from '@expo/apple-utils';
 import nock from 'nock';
 
 import { requestContext } from './fixtures/requestContext';
@@ -9,6 +16,31 @@ import { AppClipTask } from '../app-clip';
 
 jest.mock('../../../../ora');
 jest.mock('../../config/writer');
+
+function makeExperience(
+  id: string,
+  attrs: Partial<AppClipDefaultExperience['attributes']> = {}
+): AppClipDefaultExperience {
+  return new AppClipDefaultExperience(requestContext, id, {
+    action: null,
+    ...attrs,
+  } as any);
+}
+
+function makeLocalization(
+  id: string,
+  locale: string,
+  subtitle: string | null = null
+): AppClipDefaultExperienceLocalization {
+  return new AppClipDefaultExperienceLocalization(requestContext, id, {
+    locale,
+    subtitle,
+  } as any);
+}
+
+function makeVersion(id: string): AppStoreVersion {
+  return new AppStoreVersion(requestContext, id, { versionString: '1.0.0' } as any);
+}
 
 const APP_CLIPS_EMPTY_RESPONSE = {
   data: [],
@@ -59,6 +91,101 @@ describe(AppClipTask, () => {
       expect(writer.setAppClipLocalizedInfo).not.toBeCalled();
       expect(writer.setAppClipReviewDetail).not.toBeCalled();
     });
+
+    it('writes from current version experience when present', async () => {
+      const writer = jest.mocked(new AppleConfigWriter());
+      const experience = makeExperience('exp-current', { action: 'PLAY' as any });
+      const localization = makeLocalization('loc-1', 'en-US', 'Quick play');
+
+      await new AppClipTask().downloadAsync({
+        config: writer,
+        context: {
+          appClip: new AppClip(requestContext, 'clip-1', { bundleId: 'com.x.Clip' }),
+          appClipDefaultExperience: experience,
+          appClipTemplateExperience: null,
+          appClipLocalizations: new Map([['en-US', localization]]),
+          appClipHeaderImages: new Map(),
+          appClipReviewDetail: null,
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      expect(writer.setAppClipDefaultExperience).toBeCalledWith(
+        expect.objectContaining({ action: 'PLAY' })
+      );
+      expect(writer.setAppClipLocalizedInfo).toBeCalledWith(
+        'en-US',
+        expect.objectContaining({ subtitle: 'Quick play' })
+      );
+    });
+
+    it('falls back to template experience when current version has none', async () => {
+      // Regression test: when bumping the app version, the new version has no
+      // default experience yet. Pull should still populate config from the
+      // most recent prior experience (the template) so the user has data to
+      // edit, instead of writing nothing.
+      const writer = jest.mocked(new AppleConfigWriter());
+      const template = makeExperience('exp-template', { action: 'OPEN' as any });
+      const localization = makeLocalization('loc-1', 'en-US', 'Old subtitle');
+
+      await new AppClipTask().downloadAsync({
+        config: writer,
+        context: {
+          appClip: new AppClip(requestContext, 'clip-1', { bundleId: 'com.x.Clip' }),
+          appClipDefaultExperience: null,
+          appClipTemplateExperience: template,
+          appClipLocalizations: new Map([['en-US', localization]]),
+          appClipHeaderImages: new Map(),
+          appClipReviewDetail: null,
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      expect(writer.setAppClipDefaultExperience).toBeCalledWith(
+        expect.objectContaining({ action: 'OPEN' })
+      );
+      expect(writer.setAppClipLocalizedInfo).toBeCalledWith(
+        'en-US',
+        expect.objectContaining({ subtitle: 'Old subtitle' })
+      );
+    });
+
+    it('preserves expected local path when header image is not yet downloadable', async () => {
+      // Regression test for the App Clip header image race condition: ASC
+      // hasn't yet rendered the imageAsset (typically right after a fresh
+      // upload), so the download URL is null. We should still preserve the
+      // headerImage path in config so subsequent pushes don't try to delete
+      // the in-progress upload.
+      const writer = jest.mocked(new AppleConfigWriter());
+      const experience = makeExperience('exp-1', { action: 'OPEN' as any });
+      const localization = makeLocalization('loc-1', 'en-US', 'Sub');
+      // Header image with no rendered imageAsset (still processing).
+      const headerImage = {
+        attributes: { fileName: 'header.png', imageAsset: null },
+        getImageAssetUrl: () => null,
+      } as any;
+
+      await new AppClipTask().downloadAsync({
+        config: writer,
+        context: {
+          appClip: new AppClip(requestContext, 'clip-1', { bundleId: 'com.x.Clip' }),
+          appClipDefaultExperience: experience,
+          appClipTemplateExperience: null,
+          appClipLocalizations: new Map([['en-US', localization]]),
+          appClipHeaderImages: new Map([['en-US', headerImage]]),
+          appClipReviewDetail: null,
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      expect(writer.setAppClipLocalizedInfo).toBeCalledWith(
+        'en-US',
+        expect.objectContaining({
+          subtitle: 'Sub',
+          headerImage: 'store/apple/app-clip/en-US/header.png',
+        })
+      );
+    });
   });
 
   describe('uploadAsync', () => {
@@ -102,6 +229,87 @@ describe(AppClipTask, () => {
 
       // No HTTP calls when there's no clip in ASC to update.
       expect(nock.pendingMocks()).toHaveLength(0);
+    });
+
+    it('warns and aborts when no editable app store version is loaded', async () => {
+      const reader = new AppleConfigReader({
+        appClip: { defaultExperience: { action: 'OPEN' } },
+      });
+
+      await new AppClipTask().uploadAsync({
+        config: reader,
+        context: {
+          appClip: new AppClip(requestContext, 'clip-1', { bundleId: 'com.x.Clip' }),
+          version: null,
+          appClipDefaultExperience: null,
+          appClipTemplateExperience: null,
+          appClipLocalizations: new Map(),
+          appClipHeaderImages: new Map(),
+          appClipReviewDetail: null,
+        } as any,
+      });
+
+      expect(nock.pendingMocks()).toHaveLength(0);
+    });
+
+    it('skips PATCH when default experience action already matches config', async () => {
+      // Regression test: Apple rejects PATCHes on `action` once the linked
+      // version is locked (in review/released), so we must skip the call when
+      // nothing changed to avoid spurious failures on round-trip pushes.
+      const reader = new AppleConfigReader({
+        appClip: { defaultExperience: { action: 'PLAY' } },
+      });
+      const existing = makeExperience('exp-current', { action: 'PLAY' as any });
+      // Spy on updateAsync to assert it's not invoked.
+      const updateSpy = jest.spyOn(existing, 'updateAsync');
+
+      await new AppClipTask().uploadAsync({
+        config: reader,
+        context: {
+          app: new App(requestContext, 'app-1', {} as any),
+          appClip: new AppClip(requestContext, 'clip-1', { bundleId: 'com.x.Clip' }),
+          version: makeVersion('ver-1'),
+          appClipDefaultExperience: existing,
+          appClipTemplateExperience: null,
+          appClipLocalizations: new Map(),
+          appClipHeaderImages: new Map(),
+          appClipReviewDetail: null,
+        } as any,
+      });
+
+      expect(updateSpy).not.toBeCalled();
+    });
+
+    it('skips review detail PATCH when invocation URLs already match', async () => {
+      const reader = new AppleConfigReader({
+        appClip: {
+          defaultExperience: {
+            action: 'OPEN',
+            reviewDetail: { invocationUrls: ['https://a.example/', 'https://b.example/'] },
+          },
+        },
+      });
+      const existing = makeExperience('exp-current', { action: 'OPEN' as any });
+      const review = new AppClipAppStoreReviewDetail(requestContext, 'rev-1', {
+        invocationUrls: ['https://a.example/', 'https://b.example/'],
+      } as any);
+      const updateSpy = jest.spyOn(review, 'updateAsync');
+
+      await new AppClipTask().uploadAsync({
+        config: reader,
+        context: {
+          app: new App(requestContext, 'app-1', {} as any),
+          appClip: new AppClip(requestContext, 'clip-1', { bundleId: 'com.x.Clip' }),
+          version: makeVersion('ver-1'),
+          appClipDefaultExperience: existing,
+          appClipTemplateExperience: null,
+          appClipLocalizations: new Map(),
+          appClipHeaderImages: new Map(),
+          appClipReviewDetail: review,
+        } as any,
+      });
+
+      expect(updateSpy).not.toBeCalled();
     });
   });
 });

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-clip.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/app-clip.test.ts
@@ -1,0 +1,107 @@
+import { App, AppClip } from '@expo/apple-utils';
+import nock from 'nock';
+
+import { requestContext } from './fixtures/requestContext';
+import { AppleConfigReader } from '../../config/reader';
+import { AppleConfigWriter } from '../../config/writer';
+import { AppleData, PartialAppleData } from '../../data';
+import { AppClipTask } from '../app-clip';
+
+jest.mock('../../../../ora');
+jest.mock('../../config/writer');
+
+const APP_CLIPS_EMPTY_RESPONSE = {
+  data: [],
+  links: { self: 'https://api.appstoreconnect.apple.com/v1/apps/stub-id/appClips' },
+  meta: { paging: { total: 0, limit: 50 } },
+};
+
+describe(AppClipTask, () => {
+  describe('prepareAsync', () => {
+    it('initializes empty state when the app has no app clips', async () => {
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .get(uri => uri.startsWith(`/v1/${App.type}/stub-id/${AppClip.type}`))
+        .reply(200, APP_CLIPS_EMPTY_RESPONSE);
+
+      const context: PartialAppleData = {
+        app: new App(requestContext, 'stub-id', {} as any),
+        projectDir: '/test/project',
+      };
+
+      await new AppClipTask().prepareAsync({ context });
+
+      expect(context.appClip).toBeNull();
+      expect(context.appClipDefaultExperience).toBeNull();
+      expect(context.appClipLocalizations?.size).toBe(0);
+      expect(context.appClipHeaderImages?.size).toBe(0);
+      expect(context.appClipReviewDetail).toBeNull();
+      expect(scope.isDone()).toBeTruthy();
+    });
+  });
+
+  describe('downloadAsync', () => {
+    it('skips when no default experience is loaded', async () => {
+      const writer = jest.mocked(new AppleConfigWriter());
+
+      await new AppClipTask().downloadAsync({
+        config: writer,
+        context: {
+          appClip: null,
+          appClipDefaultExperience: null,
+          appClipTemplateExperience: null,
+          appClipLocalizations: new Map(),
+          appClipHeaderImages: new Map(),
+          appClipReviewDetail: null,
+        } as any,
+      });
+
+      expect(writer.setAppClipDefaultExperience).not.toBeCalled();
+      expect(writer.setAppClipLocalizedInfo).not.toBeCalled();
+      expect(writer.setAppClipReviewDetail).not.toBeCalled();
+    });
+  });
+
+  describe('uploadAsync', () => {
+    it('skips when no app clip is configured in store config', async () => {
+      const reader = new AppleConfigReader({});
+
+      await new AppClipTask().uploadAsync({
+        config: reader,
+        context: {
+          appClip: null,
+          appClipDefaultExperience: null,
+          appClipTemplateExperience: null,
+          appClipLocalizations: new Map(),
+          appClipHeaderImages: new Map(),
+          appClipReviewDetail: null,
+        } as AppleData,
+      });
+
+      // No HTTP calls should be made when nothing is configured.
+      expect(nock.pendingMocks()).toHaveLength(0);
+    });
+
+    it('warns and aborts when ASC has no app clip but config does', async () => {
+      const reader = new AppleConfigReader({
+        appClip: {
+          defaultExperience: { action: 'OPEN' },
+        },
+      });
+
+      await new AppClipTask().uploadAsync({
+        config: reader,
+        context: {
+          appClip: null,
+          appClipDefaultExperience: null,
+          appClipTemplateExperience: null,
+          appClipLocalizations: new Map(),
+          appClipHeaderImages: new Map(),
+          appClipReviewDetail: null,
+        } as AppleData,
+      });
+
+      // No HTTP calls when there's no clip in ASC to update.
+      expect(nock.pendingMocks()).toHaveLength(0);
+    });
+  });
+});

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/previews.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/previews.test.ts
@@ -219,6 +219,48 @@ describe(PreviewsTask, () => {
         },
       });
     });
+
+    it('preserves entries with placeholder paths when videoUrl is null (broken state)', async () => {
+      // Same regression as for screenshots: previews stuck in AWAITING_UPLOAD
+      // with no rendered videoUrl used to be dropped from config. Now we
+      // preserve the entry so the user can recover.
+      const writer = jest.mocked(new AppleConfigWriter());
+
+      const broken = new AppPreview(requestContext, 'PV_BROKEN', {
+        fileName: 'demo.mp4',
+        fileSize: 12345,
+        videoUrl: null,
+        assetDeliveryState: { state: 'AWAITING_UPLOAD', errors: [], warnings: [] },
+      } as any);
+      jest.spyOn(broken, 'getVideoUrl').mockReturnValue(null);
+
+      const previewTypeMap = new Map<PreviewType, AppPreviewSet>();
+      previewTypeMap.set(
+        PreviewType.IPHONE_67,
+        new AppPreviewSet(requestContext, 'PSET_1', {
+          previewType: PreviewType.IPHONE_67,
+          appPreviews: [broken],
+        } as any)
+      );
+
+      const locale = new AppStoreVersionLocalization(requestContext, 'LOC_1', {
+        locale: 'en-US',
+      } as any);
+
+      await new PreviewsTask().downloadAsync({
+        config: writer,
+        context: {
+          previewSets: new Map([['en-US', previewTypeMap]]),
+          versionLocales: [locale],
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      expect(mockFetch).not.toBeCalled();
+      expect(writer.setPreviews).toBeCalledWith('en-US', {
+        [PreviewType.IPHONE_67]: 'store/apple/preview/en-US/IPHONE_67/demo.mp4',
+      });
+    });
   });
 
   describe('uploadAsync', () => {

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/screenshots.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/screenshots.test.ts
@@ -170,6 +170,95 @@ describe(ScreenshotsTask, () => {
         ],
       });
     });
+
+    it('preserves entries with placeholder paths when imageAsset is null (broken state)', async () => {
+      // Regression test for screenshots stuck in AWAITING_UPLOAD with no
+      // rendered imageAsset. Pull used to drop these from config entirely,
+      // which made it impossible to recover via push (since push only acts on
+      // entries present in config). Now pull writes a placeholder path so the
+      // user can drop in a replacement file or remove the entry to delete the
+      // broken ASC record.
+      const writer = jest.mocked(new AppleConfigWriter());
+
+      const broken = new AppScreenshot(requestContext, 'SS_BROKEN', {
+        fileName: '01.png',
+        fileSize: 599307,
+        imageAsset: null,
+        assetDeliveryState: { state: 'AWAITING_UPLOAD', errors: [], warnings: [] },
+      } as any);
+      // getImageAssetUrl returns null when imageAsset is null.
+      jest.spyOn(broken, 'getImageAssetUrl').mockReturnValue(null);
+
+      const displayTypeMap = new Map<ScreenshotDisplayType, AppScreenshotSet>();
+      const screenshotSet = new AppScreenshotSet(requestContext, 'SET_1', {
+        screenshotDisplayType: ScreenshotDisplayType.APP_IPHONE_67,
+        appScreenshots: [broken],
+      } as any);
+      displayTypeMap.set(ScreenshotDisplayType.APP_IPHONE_67, screenshotSet);
+
+      const screenshotSets = new Map([['en-US', displayTypeMap]]);
+      const locale = new AppStoreVersionLocalization(requestContext, 'LOC_1', {
+        locale: 'en-US',
+      } as any);
+
+      await new ScreenshotsTask().downloadAsync({
+        config: writer,
+        context: {
+          screenshotSets,
+          versionLocales: [locale],
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      // No fetch should have been attempted (URL was null).
+      expect(mockFetch).not.toBeCalled();
+      // Entry should still be present in config with the original filename.
+      expect(writer.setScreenshots).toBeCalledWith('en-US', {
+        [ScreenshotDisplayType.APP_IPHONE_67]: [
+          'store/apple/screenshot/en-US/APP_IPHONE_67/01.png',
+        ],
+      });
+    });
+
+    it('uses index-based fallback filename when fileName is also null', async () => {
+      const writer = jest.mocked(new AppleConfigWriter());
+
+      const broken = new AppScreenshot(requestContext, 'SS_BROKEN', {
+        fileName: null,
+        fileSize: 0,
+        imageAsset: null,
+        assetDeliveryState: { state: 'AWAITING_UPLOAD', errors: [], warnings: [] },
+      } as any);
+      jest.spyOn(broken, 'getImageAssetUrl').mockReturnValue(null);
+
+      const displayTypeMap = new Map<ScreenshotDisplayType, AppScreenshotSet>();
+      displayTypeMap.set(
+        ScreenshotDisplayType.APP_IPAD_PRO_3GEN_129,
+        new AppScreenshotSet(requestContext, 'SET_2', {
+          screenshotDisplayType: ScreenshotDisplayType.APP_IPAD_PRO_3GEN_129,
+          appScreenshots: [broken],
+        } as any)
+      );
+
+      const locale = new AppStoreVersionLocalization(requestContext, 'LOC_1', {
+        locale: 'en-US',
+      } as any);
+
+      await new ScreenshotsTask().downloadAsync({
+        config: writer,
+        context: {
+          screenshotSets: new Map([['en-US', displayTypeMap]]),
+          versionLocales: [locale],
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      expect(writer.setScreenshots).toBeCalledWith('en-US', {
+        [ScreenshotDisplayType.APP_IPAD_PRO_3GEN_129]: [
+          'store/apple/screenshot/en-US/APP_IPAD_PRO_3GEN_129/01.png',
+        ],
+      });
+    });
   });
 
   describe('uploadAsync', () => {

--- a/packages/eas-cli/src/metadata/apple/tasks/app-clip.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-clip.ts
@@ -136,7 +136,10 @@ export class AppClipTask extends AppleTask {
   }
 
   public async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
-    const experience = context.appClipDefaultExperience;
+    // Pull data from the current version's experience when present, otherwise
+    // fall back to the template experience. The localizations and review
+    // detail in `context` were populated from whichever was used.
+    const experience = context.appClipDefaultExperience ?? context.appClipTemplateExperience;
     if (!experience) {
       return;
     }

--- a/packages/eas-cli/src/metadata/apple/tasks/app-clip.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/app-clip.ts
@@ -1,0 +1,519 @@
+import {
+  AppClip,
+  AppClipAppStoreReviewDetail,
+  AppClipDefaultExperience,
+  AppClipDefaultExperienceLocalization,
+  AppClipHeaderImage,
+} from '@expo/apple-utils';
+import chalk from 'chalk';
+import fs from 'fs';
+import path from 'path';
+
+import fetch from '../../../fetch';
+import Log from '../../../log';
+import { logAsync } from '../../utils/log';
+import { AppleTask, TaskDownloadOptions, TaskPrepareOptions, TaskUploadOptions } from '../task';
+
+export type AppClipData = {
+  /** The App Clip resource for the current app, if one exists. */
+  appClip: AppClip | null;
+  /**
+   * The default experience attached to the *current editable* app store
+   * version, if one exists. App Clip default experiences are versioned per
+   * app store version, so this is null when the user has bumped the version
+   * but not yet pushed an App Clip configuration for it.
+   */
+  appClipDefaultExperience: AppClipDefaultExperience | null;
+  /**
+   * The most recent default experience from any other version, used as a
+   * template when creating a new default experience for the current version
+   * (and as the source for `metadata:pull` when the current version has none).
+   */
+  appClipTemplateExperience: AppClipDefaultExperience | null;
+  /** Existing localizations keyed by locale (e.g. `en-US`). */
+  appClipLocalizations: Map<string, AppClipDefaultExperienceLocalization>;
+  /** Existing header images keyed by locale. */
+  appClipHeaderImages: Map<string, AppClipHeaderImage>;
+  /** App Store review detail (invocation URLs), if one exists. */
+  appClipReviewDetail: AppClipAppStoreReviewDetail | null;
+};
+
+/**
+ * Task for managing App Clip metadata (default experience, localized
+ * subtitles + header images, App Store review invocation URLs).
+ *
+ * No-op when the app does not have an App Clip target.
+ */
+export class AppClipTask extends AppleTask {
+  public name = (): string => 'app clip';
+
+  public async prepareAsync({ context }: TaskPrepareOptions): Promise<void> {
+    context.appClip = null;
+    context.appClipDefaultExperience = null;
+    context.appClipTemplateExperience = null;
+    context.appClipLocalizations = new Map();
+    context.appClipHeaderImages = new Map();
+    context.appClipReviewDetail = null;
+
+    const appClips = await context.app.getAppClipsAsync();
+    if (appClips.length === 0) {
+      return;
+    }
+
+    // Apps may have multiple App Clip bundles registered. Pick the first
+    // clip that has any default experiences attached.
+    let chosenClip: AppClip | null = null;
+    let allExperiences: AppClipDefaultExperience[] = [];
+    for (const clip of appClips) {
+      const experiences = await clip.getAppClipDefaultExperiencesAsync();
+      if (experiences.length > 0) {
+        chosenClip = clip;
+        allExperiences = experiences;
+        break;
+      }
+    }
+    chosenClip ??= appClips[0];
+    context.appClip = chosenClip;
+
+    if (allExperiences.length === 0) {
+      return;
+    }
+
+    // App Clip default experiences are versioned per app store version. Find
+    // the experience linked to the current editable version. Fall back to the
+    // first experience as a template (used as the source of truth on pull
+    // when the current version has no experience yet, and as a template when
+    // creating a new experience on push).
+    const currentVersionId = context.version?.id;
+    const currentVersionExperience = currentVersionId
+      ? (allExperiences.find(
+          exp => exp.attributes.releaseWithAppStoreVersion?.id === currentVersionId
+        ) ?? null)
+      : null;
+
+    context.appClipDefaultExperience = currentVersionExperience;
+    // The template is only used when we need to CREATE a new default
+    // experience for the current version on push — pick any other existing
+    // experience (most recent first by sort order). When the current version
+    // already has an experience, no template is needed.
+    context.appClipTemplateExperience = currentVersionExperience
+      ? null
+      : (allExperiences[0] ?? null);
+
+    // Use the current version's experience for downstream data when present;
+    // otherwise fall back to the template so `metadata:pull` still produces a
+    // populated `store.config.json`.
+    const sourceExperience = currentVersionExperience ?? context.appClipTemplateExperience;
+    if (!sourceExperience) {
+      return;
+    }
+
+    const [localizations, reviewDetail] = await Promise.all([
+      sourceExperience.getAppClipDefaultExperienceLocalizationsAsync(),
+      sourceExperience.getAppClipAppStoreReviewDetailAsync(),
+    ]);
+
+    for (const localization of localizations) {
+      context.appClipLocalizations.set(localization.attributes.locale, localization);
+    }
+    context.appClipReviewDetail = reviewDetail;
+
+    // Header images may be missing from the included payload depending on
+    // ASC's whims; fetch any that weren't pre-populated.
+    await Promise.all(
+      localizations.map(async localization => {
+        const included = localization.attributes.appClipHeaderImage;
+        if (included) {
+          context.appClipHeaderImages!.set(localization.attributes.locale, included);
+          return;
+        }
+        const headerImage = await localization.getAppClipHeaderImageAsync();
+        if (headerImage) {
+          context.appClipHeaderImages!.set(localization.attributes.locale, headerImage);
+        }
+      })
+    );
+  }
+
+  public async downloadAsync({ config, context }: TaskDownloadOptions): Promise<void> {
+    const experience = context.appClipDefaultExperience;
+    if (!experience) {
+      return;
+    }
+
+    config.setAppClipDefaultExperience({
+      action: experience.attributes.action ?? undefined,
+      // ASC does not expose `releaseWithAppStoreVersion` directly on the
+      // attributes — it's a relationship. We treat presence of an included
+      // version as `true`. When unset we leave the field undefined so the
+      // serializer omits it.
+      releaseWithAppStoreVersion:
+        experience.attributes.releaseWithAppStoreVersion != null ? true : undefined,
+    });
+
+    const reviewDetail = context.appClipReviewDetail;
+    if (reviewDetail?.attributes.invocationUrls?.length) {
+      config.setAppClipReviewDetail({
+        invocationUrls: reviewDetail.attributes.invocationUrls,
+      });
+    } else {
+      config.setAppClipReviewDetail(null);
+    }
+
+    for (const [locale, localization] of context.appClipLocalizations) {
+      const headerImage = context.appClipHeaderImages.get(locale);
+      let headerImagePath: string | undefined;
+      if (headerImage) {
+        const downloaded = await downloadAppClipHeaderImageAsync(
+          context.projectDir,
+          locale,
+          headerImage
+        );
+        if (downloaded) {
+          headerImagePath = downloaded;
+        } else {
+          // Image exists in ASC but isn't downloadable yet (still processing,
+          // or Apple's CDN hasn't caught up). Preserve the expected local path
+          // so subsequent pushes don't try to delete the in-progress upload.
+          // Filename match in syncAppClipHeaderImageAsync will skip re-upload.
+          const fileName = headerImage.attributes.fileName || 'header.png';
+          headerImagePath = path.join('store', 'apple', 'app-clip', locale, fileName);
+        }
+      }
+      config.setAppClipLocalizedInfo(locale, {
+        subtitle: localization.attributes.subtitle ?? undefined,
+        headerImage: headerImagePath,
+      });
+    }
+  }
+
+  public async uploadAsync({ config, context }: TaskUploadOptions): Promise<void> {
+    const desired = config.getAppClipDefaultExperience();
+    if (!desired) {
+      Log.log(chalk`{dim - Skipped app clip, not configured}`);
+      return;
+    }
+
+    if (!context.appClip) {
+      Log.warn(
+        chalk`{yellow Skipping app clip - no App Clip is registered for this app in App Store Connect}`
+      );
+      return;
+    }
+
+    if (!context.version) {
+      Log.warn(chalk`{yellow Skipping app clip - no editable app store version available}`);
+      return;
+    }
+
+    // App Clip default experiences are versioned per app store version. If
+    // the current editable version doesn't have one yet, create a new one,
+    // optionally cloning the most recent prior experience as a template.
+    let experience = context.appClipDefaultExperience;
+    // We always link the default experience to the current editable version,
+    // regardless of whether the user opted into `releaseWithAppStoreVersion`
+    // — every default experience must belong to a version in ASC.
+    const releaseWithAppStoreVersionId = context.version.id;
+
+    if (!experience) {
+      const appClipId = context.appClip.id;
+      const templateId = context.appClipTemplateExperience?.id;
+      experience = await logAsync(
+        () =>
+          AppClipDefaultExperience.createAsync(context.app.context, {
+            appClipId,
+            releaseWithAppStoreVersionId,
+            appClipDefaultExperienceTemplateId: templateId,
+            attributes: { action: (desired.action as any) ?? null },
+          }),
+        {
+          pending: templateId
+            ? `Creating App Clip default experience for ${chalk.bold(context.version.attributes.versionString)} (cloned from previous version)...`
+            : `Creating App Clip default experience for ${chalk.bold(context.version.attributes.versionString)}...`,
+          success: `Created App Clip default experience for ${chalk.bold(context.version.attributes.versionString)}`,
+          failure: `Failed creating App Clip default experience for ${chalk.bold(context.version.attributes.versionString)}`,
+        }
+      );
+      context.appClipDefaultExperience = experience;
+
+      // Apple cloned the previous experience's localizations + review detail
+      // into the new experience. Re-fetch them so subsequent diff/sync logic
+      // operates on the new resource ids.
+      const [localizations, reviewDetail] = await Promise.all([
+        experience.getAppClipDefaultExperienceLocalizationsAsync(),
+        experience.getAppClipAppStoreReviewDetailAsync(),
+      ]);
+      context.appClipLocalizations = new Map();
+      context.appClipHeaderImages = new Map();
+      for (const localization of localizations) {
+        context.appClipLocalizations.set(localization.attributes.locale, localization);
+        const included = localization.attributes.appClipHeaderImage;
+        if (included) {
+          context.appClipHeaderImages.set(localization.attributes.locale, included);
+        } else {
+          const headerImage = await localization.getAppClipHeaderImageAsync();
+          if (headerImage) {
+            context.appClipHeaderImages.set(localization.attributes.locale, headerImage);
+          }
+        }
+      }
+      context.appClipReviewDetail = reviewDetail;
+    } else {
+      const currentAction = experience.attributes.action ?? null;
+      const desiredAction = (desired.action as any) ?? null;
+      // Apple rejects PATCHes on `action` once the linked app store version is
+      // locked (in review / released). Skip the call when nothing actually
+      // changed to avoid spurious failures on round-trip pushes.
+      if (currentAction !== desiredAction) {
+        const existing = experience;
+        experience = await logAsync(
+          () =>
+            existing.updateAsync({
+              action: desiredAction,
+              releaseWithAppStoreVersionId: desired.releaseWithAppStoreVersion
+                ? (releaseWithAppStoreVersionId ?? null)
+                : null,
+            }),
+          {
+            pending: 'Updating App Clip default experience...',
+            success: 'Updated App Clip default experience',
+            failure: 'Failed updating App Clip default experience',
+          }
+        );
+        context.appClipDefaultExperience = experience;
+      } else {
+        Log.log(chalk`{dim - Skipped App Clip default experience, no changes}`);
+      }
+    }
+
+    // Sync App Store review detail (invocation URLs).
+    const desiredReview = desired.reviewDetail;
+    if (desiredReview && desiredReview.invocationUrls.length > 0) {
+      if (context.appClipReviewDetail) {
+        const currentUrls = context.appClipReviewDetail.attributes.invocationUrls ?? [];
+        const desiredUrls = desiredReview.invocationUrls;
+        const unchanged =
+          currentUrls.length === desiredUrls.length &&
+          currentUrls.every((url, i) => url === desiredUrls[i]);
+        if (!unchanged) {
+          const existingReview = context.appClipReviewDetail;
+          context.appClipReviewDetail = await logAsync(
+            () =>
+              existingReview.updateAsync({
+                invocationUrls: desiredUrls,
+              }),
+            {
+              pending: 'Updating App Clip review invocation URLs...',
+              success: 'Updated App Clip review invocation URLs',
+              failure: 'Failed updating App Clip review invocation URLs',
+            }
+          );
+        }
+      } else {
+        context.appClipReviewDetail = await logAsync(
+          () =>
+            AppClipAppStoreReviewDetail.createAsync(context.app.context, {
+              appClipDefaultExperienceId: experience.id,
+              attributes: { invocationUrls: desiredReview.invocationUrls },
+            }),
+          {
+            pending: 'Creating App Clip review invocation URLs...',
+            success: 'Created App Clip review invocation URLs',
+            failure: 'Failed creating App Clip review invocation URLs',
+          }
+        );
+      }
+    } else if (context.appClipReviewDetail) {
+      await logAsync(() => context.appClipReviewDetail!.deleteAsync(), {
+        pending: 'Removing App Clip review invocation URLs...',
+        success: 'Removed App Clip review invocation URLs',
+        failure: 'Failed removing App Clip review invocation URLs',
+      });
+      context.appClipReviewDetail = null;
+    }
+
+    // Sync localizations: create/update from config, delete locales that
+    // exist in ASC but were removed from the config.
+    const desiredLocales = config.getAppClipLocales();
+    const desiredLocaleSet = new Set(desiredLocales);
+
+    for (const locale of desiredLocales) {
+      const desiredInfo = config.getAppClipLocalizedInfo(locale);
+      if (!desiredInfo) {
+        continue;
+      }
+
+      let localization = context.appClipLocalizations.get(locale);
+      if (!localization) {
+        localization = await logAsync(
+          () =>
+            experience.createAppClipDefaultExperienceLocalizationAsync({
+              locale,
+              subtitle: desiredInfo.subtitle ?? null,
+            }),
+          {
+            pending: `Creating App Clip localization for ${chalk.bold(locale)}...`,
+            success: `Created App Clip localization for ${chalk.bold(locale)}`,
+            failure: `Failed creating App Clip localization for ${chalk.bold(locale)}`,
+          }
+        );
+        context.appClipLocalizations.set(locale, localization);
+      } else if (localization.attributes.subtitle !== (desiredInfo.subtitle ?? null)) {
+        localization = await logAsync(
+          () => localization!.updateAsync({ subtitle: desiredInfo.subtitle ?? null }),
+          {
+            pending: `Updating App Clip localization for ${chalk.bold(locale)}...`,
+            success: `Updated App Clip localization for ${chalk.bold(locale)}`,
+            failure: `Failed updating App Clip localization for ${chalk.bold(locale)}`,
+          }
+        );
+        context.appClipLocalizations.set(locale, localization);
+      }
+
+      // Sync header image.
+      await syncAppClipHeaderImageAsync({
+        projectDir: context.projectDir,
+        localization,
+        existing: context.appClipHeaderImages.get(locale),
+        desiredPath: desiredInfo.headerImage,
+        onUploaded: image => context.appClipHeaderImages.set(locale, image),
+        onDeleted: () => context.appClipHeaderImages.delete(locale),
+      });
+    }
+
+    // Delete localizations no longer in config.
+    for (const [locale, localization] of context.appClipLocalizations) {
+      if (!desiredLocaleSet.has(locale)) {
+        await logAsync(() => localization.deleteAsync(), {
+          pending: `Deleting App Clip localization for ${chalk.bold(locale)}...`,
+          success: `Deleted App Clip localization for ${chalk.bold(locale)}`,
+          failure: `Failed deleting App Clip localization for ${chalk.bold(locale)}`,
+        });
+        context.appClipLocalizations.delete(locale);
+        context.appClipHeaderImages.delete(locale);
+      }
+    }
+  }
+}
+
+/**
+ * Upload, replace, or delete the header image for a single App Clip
+ * localization based on the desired config path.
+ */
+async function syncAppClipHeaderImageAsync({
+  projectDir,
+  localization,
+  existing,
+  desiredPath,
+  onUploaded,
+  onDeleted,
+}: {
+  projectDir: string;
+  localization: AppClipDefaultExperienceLocalization;
+  existing: AppClipHeaderImage | undefined;
+  desiredPath: string | undefined;
+  onUploaded: (image: AppClipHeaderImage) => void;
+  onDeleted: () => void;
+}): Promise<void> {
+  const locale = localization.attributes.locale;
+
+  if (!desiredPath) {
+    if (existing) {
+      await logAsync(() => existing.deleteAsync(), {
+        pending: `Deleting App Clip header image for ${chalk.bold(locale)}...`,
+        success: `Deleted App Clip header image for ${chalk.bold(locale)}`,
+        failure: `Failed deleting App Clip header image for ${chalk.bold(locale)}`,
+      });
+      onDeleted();
+    }
+    return;
+  }
+
+  const absolutePath = path.resolve(projectDir, desiredPath);
+  if (!fs.existsSync(absolutePath)) {
+    Log.warn(chalk`{yellow App Clip header image not found: ${absolutePath}}`);
+    return;
+  }
+
+  const fileName = path.basename(absolutePath);
+
+  // Skip upload if the existing image already has the same filename and is
+  // either fully processed or still being processed (i.e. anything that
+  // isn't AWAITING_UPLOAD or FAILED). Apple does not expose the original
+  // source bytes (only re-rendered copies), so we can't reliably compare
+  // file size or checksum after a round-trip pull — filename is the only
+  // stable identity available.
+  if (
+    existing &&
+    !existing.isAwaitingUpload() &&
+    !existing.isFailed() &&
+    existing.attributes.fileName === fileName
+  ) {
+    return;
+  }
+
+  if (existing) {
+    await logAsync(() => existing.deleteAsync(), {
+      pending: `Replacing App Clip header image for ${chalk.bold(locale)}...`,
+      success: `Removed previous App Clip header image for ${chalk.bold(locale)}`,
+      failure: `Failed removing previous App Clip header image for ${chalk.bold(locale)}`,
+    });
+    onDeleted();
+  }
+
+  const uploaded = await logAsync(
+    () =>
+      AppClipHeaderImage.uploadAsync(localization.context, {
+        id: localization.id,
+        filePath: absolutePath,
+        waitForProcessing: true,
+      }),
+    {
+      pending: `Uploading App Clip header image ${chalk.bold(fileName)} (${locale})...`,
+      success: `Uploaded App Clip header image ${chalk.bold(fileName)} (${locale})`,
+      failure: `Failed uploading App Clip header image ${chalk.bold(fileName)} (${locale})`,
+    }
+  );
+  onUploaded(uploaded);
+}
+
+/**
+ * Download an App Clip header image to the local filesystem.
+ * Returns the relative path to the downloaded file, or null on failure.
+ */
+async function downloadAppClipHeaderImageAsync(
+  projectDir: string,
+  locale: string,
+  headerImage: AppClipHeaderImage
+): Promise<string | null> {
+  const imageUrl = headerImage.getImageAssetUrl({ type: 'png' });
+  if (!imageUrl) {
+    Log.warn(chalk`{yellow Could not get download URL for App Clip header image (${locale})}`);
+    return null;
+  }
+
+  const targetDir = path.join(projectDir, 'store', 'apple', 'app-clip', locale);
+  await fs.promises.mkdir(targetDir, { recursive: true });
+
+  const fileName = headerImage.attributes.fileName || 'header.png';
+  const outputPath = path.join(targetDir, fileName);
+  const relativePath = path.relative(projectDir, outputPath);
+
+  try {
+    const response = await fetch(imageUrl);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const buffer = await response.buffer();
+    await fs.promises.writeFile(outputPath, buffer);
+
+    Log.log(chalk`{dim Downloaded App Clip header image: ${relativePath}}`);
+    return relativePath;
+  } catch (error: any) {
+    Log.warn(
+      chalk`{yellow Failed to download App Clip header image (${locale}): ${error.message}}`
+    );
+    return null;
+  }
+}

--- a/packages/eas-cli/src/metadata/apple/tasks/index.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/index.ts
@@ -1,4 +1,5 @@
 import { AgeRatingTask } from './age-rating';
+import { AppClipTask } from './app-clip';
 import { AppInfoTask } from './app-info';
 import { AppReviewDetailTask } from './app-review-detail';
 import { AppVersionOptions, AppVersionTask } from './app-version';
@@ -21,5 +22,6 @@ export function createAppleTasks({ version }: AppleTaskOptions = {}): AppleTask[
     new AppReviewDetailTask(),
     new ScreenshotsTask(),
     new PreviewsTask(),
+    new AppClipTask(),
   ];
 }

--- a/packages/eas-cli/src/metadata/apple/tasks/previews.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/previews.ts
@@ -89,7 +89,7 @@ export class PreviewsTask extends AppleTask {
         // For now, we only handle the first preview per set (App Store allows up to 3)
         // We can extend this later to support multiple previews
         const preview = previewModels[0];
-        const relativePath = await downloadPreviewAsync(
+        const downloaded = await downloadPreviewAsync(
           context.projectDir,
           localeCode,
           previewType,
@@ -97,16 +97,22 @@ export class PreviewsTask extends AppleTask {
           0
         );
 
-        if (relativePath) {
-          // Include preview frame time code if available
-          if (preview.attributes.previewFrameTimeCode) {
-            previews[previewType] = {
-              path: relativePath,
-              previewFrameTimeCode: preview.attributes.previewFrameTimeCode,
-            };
-          } else {
-            previews[previewType] = relativePath;
-          }
+        // When the download succeeds, write the real path. When it fails
+        // (e.g. the preview is in a broken AWAITING_UPLOAD state with no
+        // rendered videoUrl), preserve the entry in config so the user can
+        // either drop in a replacement file or remove the entry to delete
+        // the broken ASC record.
+        const fileName = preview.attributes.fileName || 'preview.mp4';
+        const relativePath =
+          downloaded || path.join('store', 'apple', 'preview', localeCode, previewType, fileName);
+
+        if (preview.attributes.previewFrameTimeCode) {
+          previews[previewType] = {
+            path: relativePath,
+            previewFrameTimeCode: preview.attributes.previewFrameTimeCode,
+          };
+        } else {
+          previews[previewType] = relativePath;
         }
       }
 

--- a/packages/eas-cli/src/metadata/apple/tasks/screenshots.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/screenshots.ts
@@ -73,20 +73,32 @@ export class ScreenshotsTask extends AppleTask {
           continue;
         }
 
-        // Download screenshots and save to local filesystem
+        // Download screenshots and save to local filesystem. When a screenshot
+        // is in a broken state (AWAITING_UPLOAD with no rendered imageAsset)
+        // the download will fail, but we still preserve the entry pointing at
+        // its expected local path so users can either drop in a replacement
+        // file or remove the entry to delete the broken ASC record.
         const paths: string[] = [];
         for (let i = 0; i < screenshotModels.length; i++) {
           const screenshot = screenshotModels[i];
-          const relativePath = await downloadScreenshotAsync(
+          const downloaded = await downloadScreenshotAsync(
             context.projectDir,
             localeCode,
             displayType,
             screenshot,
             i
           );
-          if (relativePath) {
-            paths.push(relativePath);
+          if (downloaded) {
+            paths.push(downloaded);
+            continue;
           }
+          // Fall back to a placeholder path so the entry isn't lost from
+          // config. Push will detect that the existing screenshot isn't
+          // complete and either re-upload (if a local file exists at this
+          // path) or warn and skip (if it doesn't).
+          const fileName =
+            screenshot.attributes.fileName || `${String(i + 1).padStart(2, '0')}.png`;
+          paths.push(path.join('store', 'apple', 'screenshot', localeCode, displayType, fileName));
         }
 
         if (paths.length > 0) {

--- a/packages/eas-cli/src/metadata/apple/types.ts
+++ b/packages/eas-cli/src/metadata/apple/types.ts
@@ -1,5 +1,6 @@
 import type {
   AgeRatingDeclarationProps,
+  AppClipAction,
   PreviewType,
   ScreenshotDisplayType,
 } from '@expo/apple-utils';
@@ -51,6 +52,38 @@ export interface AppleMetadata {
   /** @deprecated Use screenshots/previews in AppleInfo instead */
   preview?: Record<string, string[]>;
   review?: AppleReview;
+  /** App Clip metadata. Only applies to apps that ship an App Clip target. */
+  appClip?: AppleAppClip;
+}
+
+/** App Clip action enum values from App Store Connect API */
+export type AppleAppClipAction = `${AppClipAction}`;
+
+export interface AppleAppClip {
+  /** The default experience for this App Clip. There is exactly one per app. */
+  defaultExperience?: AppleAppClipDefaultExperience;
+}
+
+export interface AppleAppClipDefaultExperience {
+  /** Action button shown in the App Clip card. Defaults to OPEN if unset. */
+  action?: AppleAppClipAction;
+  /** Whether to release this default experience alongside the next App Store version. */
+  releaseWithAppStoreVersion?: boolean;
+  /** App Store review invocation URLs (used by App Review to launch the clip). */
+  reviewDetail?: AppleAppClipReviewDetail;
+  /** Per-locale subtitle and header image. */
+  info?: Record<AppleLocale, AppleAppClipLocalizedInfo>;
+}
+
+export interface AppleAppClipReviewDetail {
+  invocationUrls: string[];
+}
+
+export interface AppleAppClipLocalizedInfo {
+  /** Subtitle shown in the App Clip card. Apple limits this to 43 characters. */
+  subtitle?: string;
+  /** Relative path (from project root) to the App Clip header image PNG. */
+  headerImage?: string;
 }
 
 // The omited properties are deprecated

--- a/yarn.lock
+++ b/yarn.lock
@@ -2847,12 +2847,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/apple-utils@npm:2.1.18":
-  version: 2.1.18
-  resolution: "@expo/apple-utils@npm:2.1.18"
+"@expo/apple-utils@npm:2.1.19":
+  version: 2.1.19
+  resolution: "@expo/apple-utils@npm:2.1.19"
   bin:
     apple-utils: bin.js
-  checksum: 10c0/4ca2b4b475eba9fd1c2b874e76800c2954a778bff0573c6e6830460d0ae78d5a8883b96ada6856a3eecc90f9c1e65f381a33aeb57b53a86d826cf22aceaa12ee
+  checksum: 10c0/42eb1038bd0906d53b37d830499c7a8ee7ec9f9b9ef4078ff898ca84cb5af1e6ac39d3a392818825151aa2ea237a44698f539b973936733350f314efff020858
   languageName: node
   linkType: hard
 
@@ -10998,7 +10998,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "eas-cli@workspace:packages/eas-cli"
   dependencies:
-    "@expo/apple-utils": "npm:2.1.18"
+    "@expo/apple-utils": "npm:2.1.19"
     "@expo/code-signing-certificates": "npm:0.0.5"
     "@expo/config": "npm:55.0.10"
     "@expo/config-plugins": "npm:55.0.7"


### PR DESCRIPTION
# Why

Add support for basic App Clip metadata in `eas metadata` commands.

# Test Plan

Run with pillar-valley and ensure the data syncs correctly.