### PR TITLE
feat(metadata): allow up to 3 previews per device type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Add missing Apple metadata attributes for age ratings and content descriptions. ([#3584](https://github.com/expo/eas-cli/pull/3584) by [@EvanBacon](https://github.com/EvanBacon))
 - [eas-cli] Add App Clip metadata support to `metadata:push` and `metadata:pull` (default experience action, per-locale subtitle and header image, App Store review invocation URLs). ([#3590](https://github.com/expo/eas-cli/pull/3590) by [@EvanBacon](https://github.com/EvanBacon))
+- [eas-cli] Allow up to 3 video previews per device type in `metadata:push` and `metadata:pull`. Each preview type now accepts an array of preview configs in addition to the existing single-config form (which remains supported for backwards compatibility). ([@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -328,7 +328,7 @@
           },
           "previews": {
             "type": "object",
-            "description": "Video previews for this locale, organized by display type (e.g., IPHONE_67, IPAD_PRO_129)",
+            "description": "Video previews for this locale, organized by display type (e.g., IPHONE_67, IPAD_PRO_129). Each device type accepts a single preview config (string or object) or an array of up to 3 preview configs.",
             "additionalProperties": {
               "oneOf": [
                 {
@@ -348,6 +348,31 @@
                   },
                   "required": ["path"],
                   "additionalProperties": false
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string",
+                            "description": "Video file path (relative to project root)"
+                          },
+                          "previewFrameTimeCode": {
+                            "type": "string",
+                            "description": "Optional preview frame time code (e.g., '00:05:00' for 5 seconds)"
+                          }
+                        },
+                        "required": ["path"],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
                 }
               ]
             }

--- a/packages/eas-cli/src/metadata/apple/config/writer.ts
+++ b/packages/eas-cli/src/metadata/apple/config/writer.ts
@@ -211,11 +211,42 @@ export class AppleConfigWriter {
       Object.keys(screenshots).length > 0 ? screenshots : undefined;
   }
 
-  /** Set video previews for a specific locale */
+  /**
+   * Set video previews for a specific locale.
+   *
+   * Accepts either the legacy single-config form or the multi-preview array form
+   * for each preview type. When an array contains exactly one entry, it is
+   * unwrapped to the legacy single-object form for stable, minimal config diffs.
+   */
   public setPreviews(locale: string, previews: ApplePreviews): void {
     this.schema.info = this.schema.info ?? {};
     this.schema.info[locale] = this.schema.info[locale] ?? { title: '' };
-    this.schema.info[locale].previews = Object.keys(previews).length > 0 ? previews : undefined;
+
+    if (Object.keys(previews).length === 0) {
+      this.schema.info[locale].previews = undefined;
+      return;
+    }
+
+    const normalized: ApplePreviews = {};
+    for (const [previewType, value] of Object.entries(previews)) {
+      if (value == null) {
+        continue;
+      }
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          continue;
+        }
+        if (value.length === 1) {
+          normalized[previewType as keyof ApplePreviews] = value[0];
+        } else {
+          normalized[previewType as keyof ApplePreviews] = value;
+        }
+      } else {
+        normalized[previewType as keyof ApplePreviews] = value;
+      }
+    }
+
+    this.schema.info[locale].previews = Object.keys(normalized).length > 0 ? normalized : undefined;
   }
 
   /** Set the App Clip default experience attributes (action, releaseWithAppStoreVersion). */

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/previews.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/previews.test.ts
@@ -354,6 +354,17 @@ describe(PreviewsTask, () => {
       // Mock AppPreview.uploadAsync to avoid real file access
       jest.spyOn(AppPreview, 'uploadAsync').mockResolvedValue(newPreview);
 
+      // Mock AppPreviewSet.infoAsync for the reorder step
+      jest.spyOn(AppPreviewSet, 'infoAsync').mockResolvedValue(
+        new AppPreviewSet(requestContext, 'NEW_PSET_1', {
+          previewType: PreviewType.IPHONE_67,
+          appPreviews: [newPreview],
+        } as any)
+      );
+
+      const reorderMock = jest.fn().mockResolvedValue([]);
+      AppPreviewSet.prototype.reorderPreviewsAsync = reorderMock;
+
       const previewSets = new Map();
       previewSets.set('en-US', new Map());
 
@@ -375,6 +386,214 @@ describe(PreviewsTask, () => {
           waitForProcessing: true,
         })
       );
+      // Single preview, current order matches: reorder should be skipped.
+      expect(reorderMock).not.toHaveBeenCalled();
+    });
+
+    it('uploads multiple previews when configured as an array', async () => {
+      const config = new AppleConfigReader({
+        info: {
+          'en-US': {
+            title: 'My App',
+            previews: {
+              IPHONE_67: [
+                './previews/intro.mp4',
+                { path: './previews/features.mp4', previewFrameTimeCode: '00:02:00' },
+                './previews/outro.mp4',
+              ],
+            },
+          },
+        },
+      });
+
+      const locale = new AppStoreVersionLocalization(requestContext, 'LOC_1', {
+        locale: 'en-US',
+      } as any);
+
+      const intro = new AppPreview(requestContext, 'NEW_PV_INTRO', {
+        fileName: 'intro.mp4',
+        fileSize: 10240,
+        previewFrameTimeCode: null,
+        assetDeliveryState: { state: 'COMPLETE', errors: [], warnings: [] },
+      } as any);
+      const features = new AppPreview(requestContext, 'NEW_PV_FEATURES', {
+        fileName: 'features.mp4',
+        fileSize: 10240,
+        previewFrameTimeCode: '00:02:00',
+        assetDeliveryState: { state: 'COMPLETE', errors: [], warnings: [] },
+      } as any);
+      const outro = new AppPreview(requestContext, 'NEW_PV_OUTRO', {
+        fileName: 'outro.mp4',
+        fileSize: 10240,
+        previewFrameTimeCode: null,
+        assetDeliveryState: { state: 'COMPLETE', errors: [], warnings: [] },
+      } as any);
+
+      const scope = nock('https://api.appstoreconnect.apple.com')
+        .post(`/v1/${AppPreviewSet.type}`)
+        .reply(201, {
+          data: {
+            id: 'NEW_PSET_1',
+            type: AppPreviewSet.type,
+            attributes: {
+              previewType: PreviewType.IPHONE_67,
+              appPreviews: [],
+            },
+          },
+        });
+
+      const uploadSpy = jest
+        .spyOn(AppPreview, 'uploadAsync')
+        .mockResolvedValueOnce(intro)
+        .mockResolvedValueOnce(features)
+        .mockResolvedValueOnce(outro);
+
+      // After upload Apple returns the previews in upload order, which already matches config.
+      jest.spyOn(AppPreviewSet, 'infoAsync').mockResolvedValue(
+        new AppPreviewSet(requestContext, 'NEW_PSET_1', {
+          previewType: PreviewType.IPHONE_67,
+          appPreviews: [intro, features, outro],
+        } as any)
+      );
+
+      const reorderMock = jest.fn().mockResolvedValue([]);
+      AppPreviewSet.prototype.reorderPreviewsAsync = reorderMock;
+
+      const previewSets = new Map();
+      previewSets.set('en-US', new Map());
+
+      await new PreviewsTask().uploadAsync({
+        config,
+        context: {
+          previewSets,
+          versionLocales: [locale],
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      expect(scope.isDone()).toBeTruthy();
+      expect(uploadSpy).toHaveBeenCalledTimes(3);
+      expect(uploadSpy).toHaveBeenNthCalledWith(
+        1,
+        requestContext,
+        expect.objectContaining({ filePath: '/test/project/previews/intro.mp4' })
+      );
+      expect(uploadSpy).toHaveBeenNthCalledWith(
+        2,
+        requestContext,
+        expect.objectContaining({
+          filePath: '/test/project/previews/features.mp4',
+          previewFrameTimeCode: '00:02:00',
+        })
+      );
+      expect(uploadSpy).toHaveBeenNthCalledWith(
+        3,
+        requestContext,
+        expect.objectContaining({ filePath: '/test/project/previews/outro.mp4' })
+      );
+      // Order already matches config order, no reorder call expected.
+      expect(reorderMock).not.toHaveBeenCalled();
+    });
+
+    it('reorders previews when ASC order differs from config order', async () => {
+      const config = new AppleConfigReader({
+        info: {
+          'en-US': {
+            title: 'My App',
+            previews: {
+              IPHONE_67: ['./previews/a.mp4', './previews/b.mp4'],
+            },
+          },
+        },
+      });
+
+      const locale = new AppStoreVersionLocalization(requestContext, 'LOC_1', {
+        locale: 'en-US',
+      } as any);
+
+      // Both previews already exist (matching filename + size), so no upload happens.
+      const previewA = new AppPreview(requestContext, 'PV_A', {
+        fileName: 'a.mp4',
+        fileSize: 10240,
+        previewFrameTimeCode: null,
+        assetDeliveryState: { state: 'COMPLETE', errors: [], warnings: [] },
+      } as any);
+      const previewB = new AppPreview(requestContext, 'PV_B', {
+        fileName: 'b.mp4',
+        fileSize: 10240,
+        previewFrameTimeCode: null,
+        assetDeliveryState: { state: 'COMPLETE', errors: [], warnings: [] },
+      } as any);
+
+      const previewTypeMap = new Map<PreviewType, AppPreviewSet>();
+      // ASC reports them in [b, a] order — config wants [a, b].
+      previewTypeMap.set(
+        PreviewType.IPHONE_67,
+        new AppPreviewSet(requestContext, 'PSET_1', {
+          previewType: PreviewType.IPHONE_67,
+          appPreviews: [previewB, previewA],
+        } as any)
+      );
+
+      jest.spyOn(AppPreview, 'uploadAsync').mockResolvedValue(previewA);
+
+      jest.spyOn(AppPreviewSet, 'infoAsync').mockResolvedValue(
+        new AppPreviewSet(requestContext, 'PSET_1', {
+          previewType: PreviewType.IPHONE_67,
+          appPreviews: [previewB, previewA],
+        } as any)
+      );
+
+      const reorderMock = jest.fn().mockResolvedValue([]);
+      AppPreviewSet.prototype.reorderPreviewsAsync = reorderMock;
+
+      const previewSets = new Map();
+      previewSets.set('en-US', previewTypeMap);
+
+      await new PreviewsTask().uploadAsync({
+        config,
+        context: {
+          previewSets,
+          versionLocales: [locale],
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      expect(AppPreview.uploadAsync).not.toHaveBeenCalled();
+      expect(reorderMock).toHaveBeenCalledWith({ appPreviews: ['PV_A', 'PV_B'] });
+    });
+
+    it('skips a preview type whose array is empty', async () => {
+      const config = new AppleConfigReader({
+        info: {
+          'en-US': {
+            title: 'My App',
+            previews: {
+              IPHONE_67: [],
+            },
+          },
+        },
+      });
+
+      const locale = new AppStoreVersionLocalization(requestContext, 'LOC_1', {
+        locale: 'en-US',
+      } as any);
+
+      jest.spyOn(AppPreview, 'uploadAsync');
+
+      const previewSets = new Map();
+      previewSets.set('en-US', new Map());
+
+      await new PreviewsTask().uploadAsync({
+        config,
+        context: {
+          previewSets,
+          versionLocales: [locale],
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      expect(AppPreview.uploadAsync).not.toHaveBeenCalled();
     });
 
     it('uploads new preview with object config including previewFrameTimeCode', async () => {
@@ -420,6 +639,16 @@ describe(PreviewsTask, () => {
       // Mock AppPreview.uploadAsync to avoid real file access
       jest.spyOn(AppPreview, 'uploadAsync').mockResolvedValue(newPreview);
 
+      jest.spyOn(AppPreviewSet, 'infoAsync').mockResolvedValue(
+        new AppPreviewSet(requestContext, 'NEW_PSET_1', {
+          previewType: PreviewType.IPHONE_67,
+          appPreviews: [newPreview],
+        } as any)
+      );
+
+      const reorderMock = jest.fn().mockResolvedValue([]);
+      AppPreviewSet.prototype.reorderPreviewsAsync = reorderMock;
+
       const previewSets = new Map();
       previewSets.set('en-US', new Map());
 
@@ -442,6 +671,69 @@ describe(PreviewsTask, () => {
           previewFrameTimeCode: '00:05:00',
         })
       );
+    });
+  });
+
+  describe('downloadAsync (multi-preview)', () => {
+    it('emits an array when there are multiple previews in a set', async () => {
+      const writer = jest.mocked(new AppleConfigWriter());
+
+      const previews = [
+        new AppPreview(requestContext, 'PV_1', {
+          fileName: 'intro.mp4',
+          fileSize: 10240,
+          previewFrameTimeCode: null,
+          videoUrl: 'https://example.com/intro.mp4',
+          assetDeliveryState: { state: 'COMPLETE', errors: [], warnings: [] },
+        } as any),
+        new AppPreview(requestContext, 'PV_2', {
+          fileName: 'features.mp4',
+          fileSize: 10240,
+          previewFrameTimeCode: '00:01:00',
+          videoUrl: 'https://example.com/features.mp4',
+          assetDeliveryState: { state: 'COMPLETE', errors: [], warnings: [] },
+        } as any),
+      ];
+
+      jest.spyOn(previews[0], 'getVideoUrl').mockReturnValue('https://example.com/intro.mp4');
+      jest.spyOn(previews[1], 'getVideoUrl').mockReturnValue('https://example.com/features.mp4');
+
+      const previewTypeMap = new Map<PreviewType, AppPreviewSet>();
+      previewTypeMap.set(
+        PreviewType.IPHONE_67,
+        new AppPreviewSet(requestContext, 'PSET_1', {
+          previewType: PreviewType.IPHONE_67,
+          appPreviews: previews,
+        } as any)
+      );
+
+      const locale = new AppStoreVersionLocalization(requestContext, 'LOC_1', {
+        locale: 'en-US',
+      } as any);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        buffer: () => Promise.resolve(Buffer.from('fake-video-data')),
+      });
+
+      await new PreviewsTask().downloadAsync({
+        config: writer,
+        context: {
+          previewSets: new Map([['en-US', previewTypeMap]]),
+          versionLocales: [locale],
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      expect(writer.setPreviews).toBeCalledWith('en-US', {
+        [PreviewType.IPHONE_67]: [
+          'store/apple/preview/en-US/IPHONE_67/intro.mp4',
+          {
+            path: 'store/apple/preview/en-US/IPHONE_67/features.mp4',
+            previewFrameTimeCode: '00:01:00',
+          },
+        ],
+      });
     });
   });
 });

--- a/packages/eas-cli/src/metadata/apple/tasks/previews.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/previews.ts
@@ -22,17 +22,33 @@ export type PreviewsData = {
   previewSets: PreviewSetsMap;
 };
 
-/**
- * Normalize preview config to always return an object with path and optional previewFrameTimeCode.
- */
-function normalizePreviewConfig(config: ApplePreviewConfig): {
+/** Normalized preview entry used internally by the upload pipeline. */
+type NormalizedPreviewConfig = {
   path: string;
   previewFrameTimeCode?: string;
-} {
+};
+
+/**
+ * Normalize a single preview config into an object form with path and optional previewFrameTimeCode.
+ */
+function normalizePreviewConfig(config: ApplePreviewConfig): NormalizedPreviewConfig {
   if (typeof config === 'string') {
     return { path: config };
   }
   return config;
+}
+
+/**
+ * Normalize the value stored in `ApplePreviews[previewType]` (which can be a single
+ * config OR an array of configs) into an array of normalized configs.
+ */
+function normalizePreviewConfigs(
+  value: ApplePreviewConfig | ApplePreviewConfig[]
+): NormalizedPreviewConfig[] {
+  if (Array.isArray(value)) {
+    return value.map(normalizePreviewConfig);
+  }
+  return [normalizePreviewConfig(value)];
 }
 
 /**
@@ -86,34 +102,44 @@ export class PreviewsTask extends AppleTask {
           continue;
         }
 
-        // For now, we only handle the first preview per set (App Store allows up to 3)
-        // We can extend this later to support multiple previews
-        const preview = previewModels[0];
-        const downloaded = await downloadPreviewAsync(
-          context.projectDir,
-          localeCode,
-          previewType,
-          preview,
-          0
-        );
+        // Download all previews in this set, preserving order. Mirrors how
+        // screenshots are handled: when a preview is in a broken state
+        // (AWAITING_UPLOAD with no rendered videoUrl) the download will fail,
+        // but we still preserve the entry pointing at its expected local path
+        // so users can either drop in a replacement file or remove the entry
+        // to delete the broken ASC record.
+        const entries: ApplePreviewConfig[] = [];
+        for (let i = 0; i < previewModels.length; i++) {
+          const preview = previewModels[i];
+          const downloaded = await downloadPreviewAsync(
+            context.projectDir,
+            localeCode,
+            previewType,
+            preview,
+            i
+          );
 
-        // When the download succeeds, write the real path. When it fails
-        // (e.g. the preview is in a broken AWAITING_UPLOAD state with no
-        // rendered videoUrl), preserve the entry in config so the user can
-        // either drop in a replacement file or remove the entry to delete
-        // the broken ASC record.
-        const fileName = preview.attributes.fileName || 'preview.mp4';
-        const relativePath =
-          downloaded || path.join('store', 'apple', 'preview', localeCode, previewType, fileName);
+          const fileName = preview.attributes.fileName || `${String(i + 1).padStart(2, '0')}.mp4`;
+          const relativePath =
+            downloaded || path.join('store', 'apple', 'preview', localeCode, previewType, fileName);
 
-        if (preview.attributes.previewFrameTimeCode) {
-          previews[previewType] = {
-            path: relativePath,
-            previewFrameTimeCode: preview.attributes.previewFrameTimeCode,
-          };
-        } else {
-          previews[previewType] = relativePath;
+          if (preview.attributes.previewFrameTimeCode) {
+            entries.push({
+              path: relativePath,
+              previewFrameTimeCode: preview.attributes.previewFrameTimeCode,
+            });
+          } else {
+            entries.push(relativePath);
+          }
         }
+
+        if (entries.length === 0) {
+          continue;
+        }
+
+        // For backwards compatibility with existing single-preview configs,
+        // emit the legacy single-object form when there's exactly one entry.
+        previews[previewType] = entries.length === 1 ? entries[0] : entries;
       }
 
       if (Object.keys(previews).length > 0) {
@@ -146,8 +172,13 @@ export class PreviewsTask extends AppleTask {
         continue;
       }
 
-      for (const [previewType, previewConfig] of Object.entries(previews)) {
-        if (!previewConfig) {
+      for (const [previewType, previewValue] of Object.entries(previews)) {
+        if (!previewValue) {
+          continue;
+        }
+
+        const normalized = normalizePreviewConfigs(previewValue);
+        if (normalized.length === 0) {
           continue;
         }
 
@@ -155,7 +186,7 @@ export class PreviewsTask extends AppleTask {
           context.projectDir,
           localization,
           previewType as PreviewType,
-          normalizePreviewConfig(previewConfig),
+          normalized,
           context.previewSets.get(localeCode)
         );
       }
@@ -164,23 +195,20 @@ export class PreviewsTask extends AppleTask {
 }
 
 /**
- * Sync a preview set - upload new preview, delete old one if changed.
+ * Sync a preview set against the configured previews.
+ *
+ * Mirrors the screenshots task: keeps unchanged previews (matched by filename
+ * + size + completion state), uploads any new/changed previews, deletes
+ * removed entries, and finally reorders the set to match config order.
  */
 async function syncPreviewSetAsync(
   projectDir: string,
   localization: AppStoreVersionLocalization,
   previewType: PreviewType,
-  previewConfig: { path: string; previewFrameTimeCode?: string },
+  previewConfigs: NormalizedPreviewConfig[],
   existingSets: Map<PreviewType, AppPreviewSet> | undefined
 ): Promise<void> {
   const locale = localization.attributes.locale;
-  const absolutePath = path.resolve(projectDir, previewConfig.path);
-  const fileName = path.basename(absolutePath);
-
-  if (!fs.existsSync(absolutePath)) {
-    Log.warn(chalk`{yellow Video preview not found: ${absolutePath}}`);
-    return;
-  }
 
   // Get or create the preview set
   let previewSet = existingSets?.get(previewType);
@@ -201,62 +229,127 @@ async function syncPreviewSetAsync(
 
   const existingPreviews = previewSet.attributes.appPreviews || [];
 
-  // Check if we need to update (different filename, size, or no existing preview)
-  const existingPreview = existingPreviews.find(p => p.attributes.fileName === fileName);
-  const localSize = fs.statSync(absolutePath).size;
-
-  if (
-    existingPreview &&
-    existingPreview.isComplete() &&
-    existingPreview.attributes.fileSize === localSize
-  ) {
-    // Preview with same filename exists, check if we need to update preview frame time code
-    if (
-      previewConfig.previewFrameTimeCode &&
-      existingPreview.attributes.previewFrameTimeCode !== previewConfig.previewFrameTimeCode
-    ) {
-      await logAsync(
-        () =>
-          existingPreview.updateAsync({
-            previewFrameTimeCode: previewConfig.previewFrameTimeCode,
-          }),
-        {
-          pending: `Updating preview frame time code for ${chalk.bold(fileName)} (${locale})...`,
-          success: `Updated preview frame time code for ${chalk.bold(fileName)} (${locale})`,
-          failure: `Failed updating preview frame time code for ${chalk.bold(fileName)} (${locale})`,
-        }
-      );
-    }
-    Log.log(chalk`{dim Preview ${fileName} already exists, skipping upload}`);
-    return;
-  }
-
-  // Delete existing previews that don't match
+  // Build a map of existing previews by filename for comparison.
+  const existingByFilename = new Map<string, AppPreview>();
   for (const preview of existingPreviews) {
-    if (preview.attributes.fileName !== fileName) {
-      await logAsync(() => preview.deleteAsync(), {
-        pending: `Deleting old preview ${chalk.bold(preview.attributes.fileName)} (${locale})...`,
-        success: `Deleted old preview ${chalk.bold(preview.attributes.fileName)} (${locale})`,
-        failure: `Failed deleting old preview ${chalk.bold(preview.attributes.fileName)} (${locale})`,
-      });
-    }
+    existingByFilename.set(preview.attributes.fileName, preview);
   }
 
-  // Upload new preview
-  await logAsync(
-    () =>
-      AppPreview.uploadAsync(localization.context, {
-        id: previewSet!.id,
-        filePath: absolutePath,
-        waitForProcessing: true,
-        previewFrameTimeCode: previewConfig.previewFrameTimeCode,
-      }),
-    {
-      pending: `Uploading video preview ${chalk.bold(fileName)} (${locale})...`,
-      success: `Uploaded video preview ${chalk.bold(fileName)} (${locale})`,
-      failure: `Failed uploading video preview ${chalk.bold(fileName)} (${locale})`,
+  // Track which previews to keep (by id), and which configs need uploading.
+  const keptPreviewIds = new Set<string>();
+  type UploadEntry = {
+    absolutePath: string;
+    fileName: string;
+    previewFrameTimeCode?: string;
+  };
+  const toUpload: UploadEntry[] = [];
+
+  for (const previewConfig of previewConfigs) {
+    const absolutePath = path.resolve(projectDir, previewConfig.path);
+    const fileName = path.basename(absolutePath);
+
+    const existing = existingByFilename.get(fileName);
+    const localSize = fs.existsSync(absolutePath) ? fs.statSync(absolutePath).size : null;
+
+    if (
+      existing &&
+      existing.isComplete() &&
+      (localSize === null || existing.attributes.fileSize === localSize)
+    ) {
+      keptPreviewIds.add(existing.id);
+      existingByFilename.delete(fileName);
+
+      // If only the previewFrameTimeCode changed, patch it in place.
+      if (
+        previewConfig.previewFrameTimeCode &&
+        existing.attributes.previewFrameTimeCode !== previewConfig.previewFrameTimeCode
+      ) {
+        await logAsync(
+          () =>
+            existing.updateAsync({
+              previewFrameTimeCode: previewConfig.previewFrameTimeCode,
+            }),
+          {
+            pending: `Updating preview frame time code for ${chalk.bold(fileName)} (${locale})...`,
+            success: `Updated preview frame time code for ${chalk.bold(fileName)} (${locale})`,
+            failure: `Failed updating preview frame time code for ${chalk.bold(fileName)} (${locale})`,
+          }
+        );
+      } else {
+        Log.log(chalk`{dim Preview ${fileName} already exists, skipping upload}`);
+      }
+      continue;
     }
-  );
+
+    toUpload.push({
+      absolutePath,
+      fileName,
+      previewFrameTimeCode: previewConfig.previewFrameTimeCode,
+    });
+  }
+
+  // Delete previews that are no longer in config.
+  for (const preview of existingByFilename.values()) {
+    await logAsync(() => preview.deleteAsync(), {
+      pending: `Deleting old preview ${chalk.bold(preview.attributes.fileName)} (${locale})...`,
+      success: `Deleted old preview ${chalk.bold(preview.attributes.fileName)} (${locale})`,
+      failure: `Failed deleting old preview ${chalk.bold(preview.attributes.fileName)} (${locale})`,
+    });
+  }
+
+  // Upload new previews.
+  for (const entry of toUpload) {
+    if (!fs.existsSync(entry.absolutePath)) {
+      Log.warn(chalk`{yellow Video preview not found: ${entry.absolutePath}}`);
+      continue;
+    }
+
+    const newPreview = await logAsync(
+      () =>
+        AppPreview.uploadAsync(localization.context, {
+          id: previewSet!.id,
+          filePath: entry.absolutePath,
+          waitForProcessing: true,
+          previewFrameTimeCode: entry.previewFrameTimeCode,
+        }),
+      {
+        pending: `Uploading video preview ${chalk.bold(entry.fileName)} (${locale})...`,
+        success: `Uploaded video preview ${chalk.bold(entry.fileName)} (${locale})`,
+        failure: `Failed uploading video preview ${chalk.bold(entry.fileName)} (${locale})`,
+      }
+    );
+
+    keptPreviewIds.add(newPreview.id);
+  }
+
+  // Reorder previews to match config order (mirrors screenshots).
+  if (keptPreviewIds.size > 0) {
+    const refreshedSet = await AppPreviewSet.infoAsync(localization.context, {
+      id: previewSet.id,
+    });
+    const refreshedPreviews = refreshedSet.attributes.appPreviews || [];
+    const previewsByFilename = new Map<string, AppPreview>();
+    for (const p of refreshedPreviews) {
+      previewsByFilename.set(p.attributes.fileName, p);
+    }
+
+    const orderedIds: string[] = [];
+    for (const previewConfig of previewConfigs) {
+      const fileName = path.basename(previewConfig.path);
+      const preview = previewsByFilename.get(fileName);
+      if (preview) {
+        orderedIds.push(preview.id);
+      }
+    }
+
+    const currentIds = refreshedPreviews.map(p => p.id);
+    if (
+      orderedIds.length > 0 &&
+      (orderedIds.length !== currentIds.length || orderedIds.some((id, i) => id !== currentIds[i]))
+    ) {
+      await previewSet.reorderPreviewsAsync({ appPreviews: orderedIds });
+    }
+  }
 }
 
 /**

--- a/packages/eas-cli/src/metadata/apple/types.ts
+++ b/packages/eas-cli/src/metadata/apple/types.ts
@@ -36,11 +36,16 @@ export type ApplePreviewConfig =
 
 /**
  * Video previews organized by display type.
- * Key is the display type (e.g., 'IPHONE_67'), value is the preview config.
+ * Key is the display type (e.g., 'IPHONE_67'), value is the preview config or an array of preview configs.
+ * Apple supports up to 3 previews per device type. A single object/string is still
+ * accepted for backwards compatibility with existing store configs.
  * @example { "IPHONE_67": "./previews/demo.mp4" }
  * @example { "IPHONE_67": { path: "./previews/demo.mp4", previewFrameTimeCode: "00:05:00" } }
+ * @example { "IPHONE_67": ["./previews/intro.mp4", "./previews/features.mp4"] }
  */
-export type ApplePreviews = Partial<Record<ApplePreviewType, ApplePreviewConfig>>;
+export type ApplePreviews = Partial<
+  Record<ApplePreviewType, ApplePreviewConfig | ApplePreviewConfig[]>
+>;
 
 export interface AppleMetadata {
   version?: string;


### PR DESCRIPTION
## Summary

- Lift the hard-coded single-preview-per-`PreviewType` limit in `metadata:push`/`metadata:pull`. Apple supports up to 3 video previews per device type; we now sync all of them.
- `ApplePreviews` accepts either a single `ApplePreviewConfig` (legacy form, still works) or an array of configs. Existing `store.config.json` files using the single-object form continue to parse and push without changes.
- `metadata:pull` mirrors how screenshots are emitted: 0 -> omitted, 1 -> single object (back-compat), 2+ -> array. Order is preserved.
- `metadata:push` now mirrors the screenshots sync pipeline for previews: match existing previews by `fileName` + `fileSize` + completion state, upload only changed entries, delete removed ones, and reorder via `AppPreviewSet.reorderPreviewsAsync` to match config order. Existing previews with only a `previewFrameTimeCode` change are patched in place.
- JSON schema (`schema/metadata-0.json`) updated to allow either form for each preview type.

## Test plan

- [x] `yarn jest src/metadata/apple/tasks/__tests__/previews.test.ts` — 16 passing, including new cases:
  - single string preview (legacy)
  - single object preview with `previewFrameTimeCode` (legacy)
  - multi-preview array with mixed string + object entries
  - reorder when ASC ordering differs from config
  - empty array short-circuits without uploading
  - downloadAsync emits an array when a set has multiple previews
- [x] `yarn jest src/metadata/apple/config` — reader/writer tests still pass (63)
- [x] `yarn lint` on changed files — no errors (only the same pre-existing `no-unnecessary-type-assertion` warning that already exists in `screenshots.ts`)
- [x] `yarn fmt` applied
- [ ] Manual `metadata:pull` against an app that has multiple previews per device type
- [ ] Manual `metadata:push` with both single-object and array forms in `store.config.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)