### PR TITLE
[build-tools] Add eas/deploy function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [build-tools] Add `eas/read_package_json` and `eas/read_app_config` functions ([#3585](https://github.com/expo/eas-cli/pull/3585) by [@gwdp](https://github.com/gwdp))
+- [build-tools] Add eas/deploy function group. ([#3598](https://github.com/expo/eas-cli/pull/3598) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [build-tools] Add `eas/read_package_json` and `eas/read_app_config` functions ([#3585](https://github.com/expo/eas-cli/pull/3585) by [@gwdp](https://github.com/gwdp))
-- [build-tools] Add `eas/deploy` function group. ([#3598](https://github.com/expo/eas-cli/pull/3598) by [@gwdp](https://github.com/gwdp))
+- [build-tools] Add `eas/deploy` function for EAS Hosting web deployments. ([#3598](https://github.com/expo/eas-cli/pull/3598) by [@gwdp](https://github.com/gwdp))
+- [build-tools] Add `eas/export` function for Expo web exports. ([#3598](https://github.com/expo/eas-cli/pull/3598) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [build-tools] Add `eas/read_package_json` and `eas/read_app_config` functions ([#3585](https://github.com/expo/eas-cli/pull/3585) by [@gwdp](https://github.com/gwdp))
-- [build-tools] Add eas/deploy function group. ([#3598](https://github.com/expo/eas-cli/pull/3598) by [@gwdp](https://github.com/gwdp))
+- [build-tools] Add `eas/deploy` function group. ([#3598](https://github.com/expo/eas-cli/pull/3598) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/packages/build-tools/src/common/__tests__/easBuildInternal.test.ts
+++ b/packages/build-tools/src/common/__tests__/easBuildInternal.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../utils/easCli', () => ({
   resolveEasCommandPrefixAndEnvAsync: jest.fn(),
 }));
 
-describe('easBuildInternal logger plumbing', () => {
+describe('easBuildInternal', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.mocked(resolveEasCommandPrefixAndEnvAsync).mockResolvedValue({
@@ -23,7 +23,7 @@ describe('easBuildInternal logger plumbing', () => {
     });
   });
 
-  it('passes logger to resolveEasCommandPrefixAndEnvAsync in runEasBuildInternalAsync', async () => {
+  it('calls resolveEasCommandPrefixAndEnvAsync in runEasBuildInternalAsync', async () => {
     const logger = {
       info: jest.fn(),
       warn: jest.fn(),
@@ -45,11 +45,11 @@ describe('easBuildInternal logger plumbing', () => {
       })
     ).rejects.toThrow('build profile is missing in a build from git-based integration.');
 
-    expect(resolveEasCommandPrefixAndEnvAsync).toHaveBeenCalledWith({ logger });
+    expect(resolveEasCommandPrefixAndEnvAsync).toHaveBeenCalledWith();
     expect(spawn).not.toHaveBeenCalled();
   });
 
-  it('passes ctx.logger to resolveEasCommandPrefixAndEnvAsync in resolveEnvFromBuildProfileAsync', async () => {
+  it('calls resolveEasCommandPrefixAndEnvAsync in resolveEnvFromBuildProfileAsync', async () => {
     const logger = {
       info: jest.fn(),
       warn: jest.fn(),
@@ -66,7 +66,7 @@ describe('easBuildInternal logger plumbing', () => {
       'build profile is missing in a build from git-based integration.'
     );
 
-    expect(resolveEasCommandPrefixAndEnvAsync).toHaveBeenCalledWith({ logger: ctx.logger });
+    expect(resolveEasCommandPrefixAndEnvAsync).toHaveBeenCalledWith();
     expect(spawn).not.toHaveBeenCalled();
   });
 });

--- a/packages/build-tools/src/common/__tests__/easBuildInternal.test.ts
+++ b/packages/build-tools/src/common/__tests__/easBuildInternal.test.ts
@@ -1,0 +1,72 @@
+import { BuildJob } from '@expo/eas-build-job';
+import spawn from '@expo/turtle-spawn';
+
+import { resolveEnvFromBuildProfileAsync, runEasBuildInternalAsync } from '../easBuildInternal';
+import { resolveEasCommandPrefixAndEnvAsync } from '../../utils/easCli';
+
+jest.mock('@expo/turtle-spawn', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock('../../utils/easCli', () => ({
+  ...jest.requireActual('../../utils/easCli'),
+  resolveEasCommandPrefixAndEnvAsync: jest.fn(),
+}));
+
+describe('easBuildInternal logger plumbing', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mocked(resolveEasCommandPrefixAndEnvAsync).mockResolvedValue({
+      cmd: 'npx',
+      args: ['-y', 'eas-cli@latest'],
+      extraEnv: {},
+    });
+  });
+
+  it('passes logger to resolveEasCommandPrefixAndEnvAsync in runEasBuildInternalAsync', async () => {
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      child: jest.fn(),
+    } as any;
+
+    const job = {
+      platform: 'android',
+      secrets: { robotAccessToken: 'token' },
+    } as unknown as BuildJob;
+
+    await expect(
+      runEasBuildInternalAsync({
+        job,
+        logger,
+        env: {},
+        cwd: '/tmp/project',
+      })
+    ).rejects.toThrow('build profile is missing in a build from git-based integration.');
+
+    expect(resolveEasCommandPrefixAndEnvAsync).toHaveBeenCalledWith({ logger });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('passes ctx.logger to resolveEasCommandPrefixAndEnvAsync in resolveEnvFromBuildProfileAsync', async () => {
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      child: jest.fn(),
+    } as any;
+    const ctx = {
+      logger,
+      env: {},
+      job: { platform: 'ios' },
+    } as any;
+
+    await expect(resolveEnvFromBuildProfileAsync(ctx, { cwd: '/tmp/project' })).rejects.toThrow(
+      'build profile is missing in a build from git-based integration.'
+    );
+
+    expect(resolveEasCommandPrefixAndEnvAsync).toHaveBeenCalledWith({ logger: ctx.logger });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -1,11 +1,4 @@
-import {
-  BuildJob,
-  EasCliNpmTags,
-  Env,
-  Metadata,
-  sanitizeBuildJob,
-  sanitizeMetadata,
-} from '@expo/eas-build-job';
+import { BuildJob, Env, Metadata, sanitizeBuildJob, sanitizeMetadata } from '@expo/eas-build-job';
 import { PipeMode, bunyan } from '@expo/logger';
 import { BuildStepEnv } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
@@ -14,7 +7,7 @@ import Joi from 'joi';
 import nullthrows from 'nullthrows';
 
 import { BuildContext } from '../context';
-import { isAtLeastNpm7Async } from '../utils/packageManager';
+import { resolveEasCommandPrefixAndEnvAsync } from '../utils/easCli';
 
 const EasBuildInternalResultSchema = Joi.object<{ job: object; metadata: object }>({
   job: Joi.object().unknown(),
@@ -119,33 +112,6 @@ export async function resolveEnvFromBuildProfileAsync<TJob extends BuildJob>(
   const parsed = JSON.parse(stdout);
   const env = validateEnvs(parsed.buildProfile);
   return env;
-}
-
-async function resolveEasCommandPrefixAndEnvAsync(): Promise<{
-  cmd: string;
-  args: string[];
-  extraEnv: Env;
-}> {
-  const npxArgsPrefix = (await isAtLeastNpm7Async()) ? ['-y'] : [];
-  if (process.env.ENVIRONMENT === 'development') {
-    return {
-      cmd: 'npx',
-      args: [...npxArgsPrefix, `eas-cli@${EasCliNpmTags.STAGING}`],
-      extraEnv: {},
-    };
-  } else if (process.env.ENVIRONMENT === 'staging') {
-    return {
-      cmd: 'npx',
-      args: [...npxArgsPrefix, `eas-cli@${EasCliNpmTags.STAGING}`],
-      extraEnv: { EXPO_STAGING: '1' },
-    };
-  } else {
-    return {
-      cmd: 'npx',
-      args: [...npxArgsPrefix, `eas-cli@${EasCliNpmTags.PRODUCTION}`],
-      extraEnv: {},
-    };
-  }
 }
 
 function validateEasBuildInternalResult<TJob extends BuildJob>({

--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -30,7 +30,7 @@ export async function runEasBuildInternalAsync<TJob extends BuildJob>({
   newJob: TJob;
   newMetadata: Metadata;
 }> {
-  const { cmd, args, extraEnv } = await resolveEasCommandPrefixAndEnvAsync({ logger });
+  const { cmd, args, extraEnv } = await resolveEasCommandPrefixAndEnvAsync();
   const { buildProfile, githubTriggerOptions } = job;
   assert(buildProfile, 'build profile is missing in a build from git-based integration.');
 
@@ -80,9 +80,7 @@ export async function resolveEnvFromBuildProfileAsync<TJob extends BuildJob>(
   ctx: BuildContext<TJob>,
   { cwd }: { cwd: string }
 ): Promise<Env> {
-  const { cmd, args, extraEnv } = await resolveEasCommandPrefixAndEnvAsync({
-    logger: ctx.logger,
-  });
+  const { cmd, args, extraEnv } = await resolveEasCommandPrefixAndEnvAsync();
   const { buildProfile } = ctx.job;
   assert(buildProfile, 'build profile is missing in a build from git-based integration.');
   let spawnResult;

--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -30,7 +30,7 @@ export async function runEasBuildInternalAsync<TJob extends BuildJob>({
   newJob: TJob;
   newMetadata: Metadata;
 }> {
-  const { cmd, args, extraEnv } = await resolveEasCommandPrefixAndEnvAsync();
+  const { cmd, args, extraEnv } = await resolveEasCommandPrefixAndEnvAsync({ logger });
   const { buildProfile, githubTriggerOptions } = job;
   assert(buildProfile, 'build profile is missing in a build from git-based integration.');
 
@@ -80,7 +80,9 @@ export async function resolveEnvFromBuildProfileAsync<TJob extends BuildJob>(
   ctx: BuildContext<TJob>,
   { cwd }: { cwd: string }
 ): Promise<Env> {
-  const { cmd, args, extraEnv } = await resolveEasCommandPrefixAndEnvAsync();
+  const { cmd, args, extraEnv } = await resolveEasCommandPrefixAndEnvAsync({
+    logger: ctx.logger,
+  });
   const { buildProfile } = ctx.job;
   assert(buildProfile, 'build profile is missing in a build from git-based integration.');
   let spawnResult;

--- a/packages/build-tools/src/steps/__tests__/easFunctionGroups.test.ts
+++ b/packages/build-tools/src/steps/__tests__/easFunctionGroups.test.ts
@@ -1,0 +1,27 @@
+import { getEasFunctionGroups } from '../easFunctionGroups';
+
+describe(getEasFunctionGroups, () => {
+  it('includes eas/maestro_test for non-build jobs', () => {
+    const ctx = {
+      hasBuildJob: () => false,
+      job: {},
+    } as unknown as Parameters<typeof getEasFunctionGroups>[0];
+
+    const functionGroupIds = getEasFunctionGroups(ctx).map(functionGroup =>
+      functionGroup.getFullId()
+    );
+    expect(functionGroupIds).toEqual(['eas/maestro_test']);
+  });
+
+  it('includes eas/build for build jobs', () => {
+    const ctx = {
+      hasBuildJob: () => true,
+      job: {},
+    } as unknown as Parameters<typeof getEasFunctionGroups>[0];
+
+    const functionGroupIds = getEasFunctionGroups(ctx).map(functionGroup =>
+      functionGroup.getFullId()
+    );
+    expect(functionGroupIds).toEqual(expect.arrayContaining(['eas/build', 'eas/maestro_test']));
+  });
+});

--- a/packages/build-tools/src/steps/easFunctionGroups.ts
+++ b/packages/build-tools/src/steps/easFunctionGroups.ts
@@ -8,7 +8,7 @@ export function getEasFunctionGroups(ctx: CustomBuildContext): BuildFunctionGrou
   const functionGroups = [createEasMaestroTestFunctionGroup(ctx)];
 
   if (ctx.hasBuildJob()) {
-    functionGroups.push(...[createEasBuildBuildFunctionGroup(ctx)]);
+    functionGroups.push(createEasBuildBuildFunctionGroup(ctx));
   }
 
   return functionGroups;

--- a/packages/build-tools/src/steps/easFunctionGroups.ts
+++ b/packages/build-tools/src/steps/easFunctionGroups.ts
@@ -8,7 +8,7 @@ export function getEasFunctionGroups(ctx: CustomBuildContext): BuildFunctionGrou
   const functionGroups = [createEasMaestroTestFunctionGroup(ctx)];
 
   if (ctx.hasBuildJob()) {
-    functionGroups.push(createEasBuildBuildFunctionGroup(ctx));
+    functionGroups.push(...[createEasBuildBuildFunctionGroup(ctx)]);
   }
 
   return functionGroups;

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -10,6 +10,7 @@ import { createSubmissionEntityFunction } from './functions/createSubmissionEnti
 import { createDownloadArtifactFunction } from './functions/downloadArtifact';
 import { createDownloadBuildFunction } from './functions/downloadBuild';
 import { createEasDeployBuildFunction } from './functions/deploy';
+import { createEasExportBuildFunction } from './functions/export';
 import { eagerBundleBuildFunction } from './functions/eagerBundle';
 import { createFindAndUploadBuildArtifactsBuildFunction } from './functions/findAndUploadBuildArtifacts';
 import { generateGymfileFromTemplateFunction } from './functions/generateGymfileFromTemplate';
@@ -56,6 +57,7 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createPrebuildBuildFunction(),
     createReadIpaInfoBuildFunction(),
     createDownloadBuildFunction(),
+    createEasExportBuildFunction(),
     createEasDeployBuildFunction(),
     createRepackBuildFunction(),
     createRestoreCacheFunction(),

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -9,6 +9,7 @@ import { configureIosVersionFunction } from './functions/configureIosVersion';
 import { createSubmissionEntityFunction } from './functions/createSubmissionEntity';
 import { createDownloadArtifactFunction } from './functions/downloadArtifact';
 import { createDownloadBuildFunction } from './functions/downloadBuild';
+import { createEasDeployBuildFunction } from './functions/deploy';
 import { eagerBundleBuildFunction } from './functions/eagerBundle';
 import { createFindAndUploadBuildArtifactsBuildFunction } from './functions/findAndUploadBuildArtifacts';
 import { generateGymfileFromTemplateFunction } from './functions/generateGymfileFromTemplate';
@@ -55,6 +56,7 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createPrebuildBuildFunction(),
     createReadIpaInfoBuildFunction(),
     createDownloadBuildFunction(),
+    createEasDeployBuildFunction(),
     createRepackBuildFunction(),
     createRestoreCacheFunction(),
     createRestoreBuildCacheFunction(),

--- a/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
@@ -1,0 +1,166 @@
+jest.mock('@expo/steps', () => {
+  const actual = jest.requireActual('@expo/steps');
+  return {
+    ...actual,
+    spawnAsync: jest.fn(),
+  };
+});
+
+import { BuildRuntimePlatform, spawnAsync } from '@expo/steps';
+
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { runEasCliCommand } from '../../../utils/easCli';
+import { createEasDeployBuildFunction } from '../deploy';
+
+jest.mock('../../../utils/easCli', () => ({
+  runEasCliCommand: jest.fn(),
+}));
+
+describe(createEasDeployBuildFunction, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mocked(spawnAsync).mockResolvedValue({} as any);
+  });
+
+  it('passes deploy flags from function inputs and sets deploy_json output', async () => {
+    jest.mocked(runEasCliCommand).mockResolvedValue({
+      stdout: Buffer.from('{"url":"https://example.dev"}'),
+      stderr: Buffer.from(''),
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+      error: null,
+    } as any);
+
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+      staticContextContent: {
+        metadata: {
+          environment: 'production',
+        },
+      },
+    });
+
+    const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      callInputs: {
+        alias: 'preview-link',
+        prod: true,
+        source_maps: false,
+        export_command: 'echo exported',
+      },
+      env: { HOME: '/tmp/home' },
+    });
+    await buildStep.executeAsync();
+
+    expect(buildStep.ctx.logger.info).toHaveBeenCalledWith('Running export command: echo exported');
+    expect(buildStep.ctx.logger.info).toHaveBeenCalledWith(
+      'Running deploy command: eas deploy --non-interactive --json --environment production --alias preview-link --prod --no-source-maps'
+    );
+    expect(spawnAsync).toHaveBeenCalledWith('sh', ['-c', 'echo exported'], {
+      cwd: buildStep.ctx.workingDirectory,
+      env: expect.objectContaining({ HOME: '/tmp/home' }),
+      logger: buildStep.ctx.logger,
+      stdio: 'pipe',
+    });
+    expect(runEasCliCommand).toHaveBeenCalledWith({
+      args: [
+        'deploy',
+        '--non-interactive',
+        '--json',
+        '--environment',
+        'production',
+        '--alias',
+        'preview-link',
+        '--prod',
+        '--no-source-maps',
+      ],
+      options: expect.objectContaining({
+        cwd: buildStep.ctx.workingDirectory,
+        env: expect.objectContaining({ HOME: '/tmp/home' }),
+        logger: buildStep.ctx.logger,
+      }),
+    });
+    expect(buildStep.outputById.deploy_json.value).toBe('{"url":"https://example.dev"}');
+  });
+
+  it('uses metadata environment when available', async () => {
+    jest.mocked(runEasCliCommand).mockResolvedValue({
+      stdout: Buffer.from('{"url":"https://example.dev"}'),
+      stderr: Buffer.from(''),
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+      error: null,
+    } as any);
+
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+      staticContextContent: {
+        metadata: {
+          environment: 'preview',
+        },
+      },
+    });
+
+    const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      callInputs: {
+        source_maps: true,
+        export_command: 'echo exported',
+      },
+    });
+    await buildStep.executeAsync();
+
+    expect(runEasCliCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: expect.arrayContaining(['--environment', 'preview', '--source-maps']),
+      })
+    );
+  });
+
+  it('throws with deploy phase in error message when deploy command fails', async () => {
+    jest.mocked(runEasCliCommand).mockRejectedValue(new Error('deploy failed'));
+
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+    });
+    const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      callInputs: {
+        export_command: 'echo exported',
+      },
+    });
+
+    await expect(buildStep.executeAsync()).rejects.toThrow(
+      'Deploy command failed: deploy failed'
+    );
+  });
+
+  it('throws with export phase in error message when export command fails', async () => {
+    jest.mocked(spawnAsync).mockRejectedValue(new Error('export failed'));
+
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+    });
+
+    const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      callInputs: {
+        export_command: 'echo exported',
+      },
+    });
+
+    await expect(buildStep.executeAsync()).rejects.toThrow(
+      'Export command failed: export failed'
+    );
+    expect(runEasCliCommand).not.toHaveBeenCalled();
+  });
+});

--- a/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
@@ -138,9 +138,7 @@ describe(createEasDeployBuildFunction, () => {
       },
     });
 
-    await expect(buildStep.executeAsync()).rejects.toThrow(
-      'Deploy command failed: deploy failed'
-    );
+    await expect(buildStep.executeAsync()).rejects.toThrow('Deploy command failed: deploy failed');
   });
 
   it('throws with export phase in error message when export command fails', async () => {
@@ -158,9 +156,7 @@ describe(createEasDeployBuildFunction, () => {
       },
     });
 
-    await expect(buildStep.executeAsync()).rejects.toThrow(
-      'Export command failed: export failed'
-    );
+    await expect(buildStep.executeAsync()).rejects.toThrow('Export command failed: export failed');
     expect(runEasCliCommand).not.toHaveBeenCalled();
   });
 });

--- a/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
@@ -222,9 +222,41 @@ describe(createEasDeployBuildFunction, () => {
 
     expect(buildStep.outputById.deploy_json.value).toBe('not-json');
     expect(buildStep.ctx.logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to parse deploy JSON'),
-      expect.any(Object)
+      expect.objectContaining({ err: expect.anything() }),
+      expect.stringContaining('Failed to parse deploy JSON')
     );
     expect(buildStep.outputById.deploy_url.value).toBeUndefined();
+  });
+
+  it('sets outputs from partial deploy JSON and leaves missing fields undefined', async () => {
+    const partialDeployStdout = JSON.stringify({
+      url: 'https://example.dev-only',
+      dashboardUrl: 'https://expo.dev/dashboard-only',
+    });
+    jest.mocked(runEasCliCommand).mockResolvedValue({
+      stdout: Buffer.from(partialDeployStdout),
+      stderr: Buffer.from(''),
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+      error: null,
+    } as any);
+
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+    });
+
+    const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {});
+    await buildStep.executeAsync();
+
+    expect(buildStep.outputById.deploy_json.value).toBe(partialDeployStdout);
+    expect(buildStep.outputById.deploy_url.value).toBe('https://example.dev-only');
+    expect(buildStep.outputById.deploy_deployment_url.value).toBe('https://example.dev-only');
+    expect(buildStep.outputById.deploy_dashboard_url.value).toBe('https://expo.dev/dashboard-only');
+    expect(buildStep.outputById.deploy_identifier.value).toBeUndefined();
+    expect(buildStep.outputById.deploy_alias_url.value).toBeUndefined();
   });
 });

--- a/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
@@ -37,11 +37,6 @@ describe(createEasDeployBuildFunction, () => {
     const globalCtx = createGlobalContextMock({
       logger,
       runtimePlatform: BuildRuntimePlatform.LINUX,
-      staticContextContent: {
-        metadata: {
-          environment: 'production',
-        },
-      },
     });
 
     const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
@@ -55,7 +50,7 @@ describe(createEasDeployBuildFunction, () => {
     await buildStep.executeAsync();
 
     expect(buildStep.ctx.logger.info).toHaveBeenCalledWith(
-      'Running deploy command: eas deploy --non-interactive --json --export-dir dist --environment production --alias preview-link --prod'
+      'Running deploy command: eas deploy --non-interactive --json --export-dir dist --alias preview-link --prod'
     );
     expect(runEasCliCommand).toHaveBeenCalledWith({
       args: [
@@ -64,8 +59,6 @@ describe(createEasDeployBuildFunction, () => {
         '--json',
         '--export-dir',
         'dist',
-        '--environment',
-        'production',
         '--alias',
         'preview-link',
         '--prod',
@@ -84,7 +77,7 @@ describe(createEasDeployBuildFunction, () => {
     expect(buildStep.outputById.deploy_alias_url.value).toBe('https://example.alias');
   });
 
-  it('uses metadata environment when available', async () => {
+  it('forwards workflow step env to the eas deploy process', async () => {
     jest.mocked(runEasCliCommand).mockResolvedValue({
       stdout: Buffer.from(mockDeployStdout),
       stderr: Buffer.from(''),
@@ -99,23 +92,27 @@ describe(createEasDeployBuildFunction, () => {
     const globalCtx = createGlobalContextMock({
       logger,
       runtimePlatform: BuildRuntimePlatform.LINUX,
-      staticContextContent: {
-        metadata: {
-          environment: 'preview',
-        },
-      },
     });
 
     const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
-      callInputs: {
-        source_maps: true,
-      },
+      callInputs: { source_maps: true },
+      env: { HOME: '/tmp/home', EXAMPLE_WORKFLOW_ENV: 'from-workflow' },
     });
     await buildStep.executeAsync();
 
     expect(runEasCliCommand).toHaveBeenCalledWith(
       expect.objectContaining({
-        args: expect.arrayContaining(['--environment', 'preview', '--source-maps']),
+        args: expect.arrayContaining(['--source-maps']),
+      })
+    );
+    expect(runEasCliCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          env: expect.objectContaining({
+            HOME: '/tmp/home',
+            EXAMPLE_WORKFLOW_ENV: 'from-workflow',
+          }),
+        }),
       })
     );
   });
@@ -223,7 +220,7 @@ describe(createEasDeployBuildFunction, () => {
     expect(buildStep.outputById.deploy_json.value).toBe('not-json');
     expect(buildStep.ctx.logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ err: expect.anything() }),
-      expect.stringContaining('Failed to parse deploy JSON')
+      expect.stringContaining('Failed to parse')
     );
     expect(buildStep.outputById.deploy_url.value).toBeUndefined();
   });

--- a/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
@@ -1,12 +1,4 @@
-jest.mock('@expo/steps', () => {
-  const actual = jest.requireActual('@expo/steps');
-  return {
-    ...actual,
-    spawnAsync: jest.fn(),
-  };
-});
-
-import { BuildRuntimePlatform, spawnAsync } from '@expo/steps';
+import { BuildRuntimePlatform } from '@expo/steps';
 
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createMockLogger } from '../../../__tests__/utils/logger';
@@ -17,15 +9,22 @@ jest.mock('../../../utils/easCli', () => ({
   runEasCliCommand: jest.fn(),
 }));
 
+const mockDeployStdout = JSON.stringify({
+  url: 'https://example.dev',
+  production: { url: 'https://example.prod' },
+  aliases: [{ url: 'https://example.alias' }],
+  identifier: 'abc',
+  dashboardUrl: 'https://expo.dev/dashboard',
+});
+
 describe(createEasDeployBuildFunction, () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    jest.mocked(spawnAsync).mockResolvedValue({} as any);
   });
 
   it('passes deploy flags from function inputs and sets deploy_json output', async () => {
     jest.mocked(runEasCliCommand).mockResolvedValue({
-      stdout: Buffer.from('{"url":"https://example.dev"}'),
+      stdout: Buffer.from(mockDeployStdout),
       stderr: Buffer.from(''),
       pid: 1,
       output: [],
@@ -50,33 +49,26 @@ describe(createEasDeployBuildFunction, () => {
         alias: 'preview-link',
         prod: true,
         source_maps: false,
-        export_command: 'echo exported',
       },
       env: { HOME: '/tmp/home' },
     });
     await buildStep.executeAsync();
 
-    expect(buildStep.ctx.logger.info).toHaveBeenCalledWith('Running export command: echo exported');
     expect(buildStep.ctx.logger.info).toHaveBeenCalledWith(
-      'Running deploy command: eas deploy --non-interactive --json --environment production --alias preview-link --prod --no-source-maps'
+      'Running deploy command: eas deploy --non-interactive --json --export-dir dist --environment production --alias preview-link --prod'
     );
-    expect(spawnAsync).toHaveBeenCalledWith('sh', ['-c', 'echo exported'], {
-      cwd: buildStep.ctx.workingDirectory,
-      env: expect.objectContaining({ HOME: '/tmp/home' }),
-      logger: buildStep.ctx.logger,
-      stdio: 'pipe',
-    });
     expect(runEasCliCommand).toHaveBeenCalledWith({
       args: [
         'deploy',
         '--non-interactive',
         '--json',
+        '--export-dir',
+        'dist',
         '--environment',
         'production',
         '--alias',
         'preview-link',
         '--prod',
-        '--no-source-maps',
       ],
       options: expect.objectContaining({
         cwd: buildStep.ctx.workingDirectory,
@@ -84,12 +76,17 @@ describe(createEasDeployBuildFunction, () => {
         logger: buildStep.ctx.logger,
       }),
     });
-    expect(buildStep.outputById.deploy_json.value).toBe('{"url":"https://example.dev"}');
+    expect(buildStep.outputById.deploy_json.value).toBe(mockDeployStdout);
+    expect(buildStep.outputById.deploy_url.value).toBe('https://example.prod');
+    expect(buildStep.outputById.deploy_deployment_url.value).toBe('https://example.dev');
+    expect(buildStep.outputById.deploy_identifier.value).toBe('abc');
+    expect(buildStep.outputById.deploy_dashboard_url.value).toBe('https://expo.dev/dashboard');
+    expect(buildStep.outputById.deploy_alias_url.value).toBe('https://example.alias');
   });
 
   it('uses metadata environment when available', async () => {
     jest.mocked(runEasCliCommand).mockResolvedValue({
-      stdout: Buffer.from('{"url":"https://example.dev"}'),
+      stdout: Buffer.from(mockDeployStdout),
       stderr: Buffer.from(''),
       pid: 1,
       output: [],
@@ -112,7 +109,6 @@ describe(createEasDeployBuildFunction, () => {
     const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
       callInputs: {
         source_maps: true,
-        export_command: 'echo exported',
       },
     });
     await buildStep.executeAsync();
@@ -132,17 +128,21 @@ describe(createEasDeployBuildFunction, () => {
       logger,
       runtimePlatform: BuildRuntimePlatform.LINUX,
     });
-    const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
-      callInputs: {
-        export_command: 'echo exported',
-      },
-    });
+    const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {});
 
     await expect(buildStep.executeAsync()).rejects.toThrow('Deploy command failed: deploy failed');
   });
 
-  it('throws with export phase in error message when export command fails', async () => {
-    jest.mocked(spawnAsync).mockRejectedValue(new Error('export failed'));
+  it('passes custom export_dir to eas deploy', async () => {
+    jest.mocked(runEasCliCommand).mockResolvedValue({
+      stdout: Buffer.from(mockDeployStdout),
+      stderr: Buffer.from(''),
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+      error: null,
+    } as any);
 
     const logger = createMockLogger();
     const globalCtx = createGlobalContextMock({
@@ -151,12 +151,68 @@ describe(createEasDeployBuildFunction, () => {
     });
 
     const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
-      callInputs: {
-        export_command: 'echo exported',
-      },
+      callInputs: { export_dir: 'web-build' },
+    });
+    await buildStep.executeAsync();
+
+    expect(runEasCliCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: expect.arrayContaining(['--export-dir', 'web-build']),
+      })
+    );
+  });
+
+  it('does not pass --source-maps when source_maps is false', async () => {
+    jest.mocked(runEasCliCommand).mockResolvedValue({
+      stdout: Buffer.from(mockDeployStdout),
+      stderr: Buffer.from(''),
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+      error: null,
+    } as any);
+
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
     });
 
-    await expect(buildStep.executeAsync()).rejects.toThrow('Export command failed: export failed');
-    expect(runEasCliCommand).not.toHaveBeenCalled();
+    const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      callInputs: { source_maps: false },
+    });
+    await buildStep.executeAsync();
+
+    const { args } = jest.mocked(runEasCliCommand).mock.calls[0][0];
+    expect(args).not.toContain('--source-maps');
+  });
+
+  it('sets deploy_json and skips optional outputs when stdout is not valid JSON', async () => {
+    jest.mocked(runEasCliCommand).mockResolvedValue({
+      stdout: Buffer.from('not-json'),
+      stderr: Buffer.from(''),
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+      error: null,
+    } as any);
+
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+    });
+
+    const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {});
+    await buildStep.executeAsync();
+
+    expect(buildStep.outputById.deploy_json.value).toBe('not-json');
+    expect(buildStep.ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse deploy JSON'),
+      expect.any(Object)
+    );
+    expect(buildStep.outputById.deploy_url.value).toBeUndefined();
   });
 });

--- a/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
@@ -256,4 +256,35 @@ describe(createEasDeployBuildFunction, () => {
     expect(buildStep.outputById.deploy_identifier.value).toBeUndefined();
     expect(buildStep.outputById.deploy_alias_url.value).toBeUndefined();
   });
+
+  it('sets deploy_url from aliases[0].url when production is absent but aliases exist', async () => {
+    const stdout = JSON.stringify({
+      url: 'https://example.deployment',
+      aliases: [{ url: 'https://example.alias-first' }],
+      identifier: 'partial-alias',
+    });
+    jest.mocked(runEasCliCommand).mockResolvedValue({
+      stdout: Buffer.from(stdout),
+      stderr: Buffer.from(''),
+      pid: 1,
+      output: [],
+      status: 0,
+      signal: null,
+      error: null,
+    } as any);
+
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+    });
+
+    const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {});
+    await buildStep.executeAsync();
+
+    expect(buildStep.outputById.deploy_url.value).toBe('https://example.alias-first');
+    expect(buildStep.outputById.deploy_deployment_url.value).toBe('https://example.deployment');
+    expect(buildStep.outputById.deploy_alias_url.value).toBe('https://example.alias-first');
+    expect(buildStep.outputById.deploy_identifier.value).toBe('partial-alias');
+  });
 });

--- a/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/deploy.test.ts
@@ -120,7 +120,7 @@ describe(createEasDeployBuildFunction, () => {
     );
   });
 
-  it('throws with deploy phase in error message when deploy command fails', async () => {
+  it('throws an actionable error message when deploy command fails', async () => {
     jest.mocked(runEasCliCommand).mockRejectedValue(new Error('deploy failed'));
 
     const logger = createMockLogger();
@@ -130,7 +130,19 @@ describe(createEasDeployBuildFunction, () => {
     });
     const buildStep = createEasDeployBuildFunction().createBuildStepFromFunctionCall(globalCtx, {});
 
-    await expect(buildStep.executeAsync()).rejects.toThrow('Deploy command failed: deploy failed');
+    let errorMessage = '';
+    try {
+      await buildStep.executeAsync();
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(errorMessage).toContain('Deploy command failed.');
+    expect(errorMessage).toContain('This can happen when deploy inputs are invalid');
+    expect(errorMessage).toContain(
+      'Check the deploy step logs, verify your deploy configuration and exported files, then retry.'
+    );
+    expect(errorMessage).toContain('Original error: deploy failed');
   });
 
   it('passes custom export_dir to eas deploy', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/export.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/export.test.ts
@@ -61,9 +61,9 @@ describe(createEasExportBuildFunction, () => {
       callInputs: {
         output_dir: 'web-out',
         dev: true,
-        no_minify: true,
-        assetmap: true,
-        no_ssg: true,
+        minify: false,
+        dump_assetmap: true,
+        ssg: false,
         api_only: true,
         platform: 'web',
       },
@@ -118,20 +118,5 @@ describe(createEasExportBuildFunction, () => {
     const buildStep = createEasExportBuildFunction().createBuildStepFromFunctionCall(globalCtx, {});
 
     await expect(buildStep.executeAsync()).rejects.toThrow('Export command failed: export failed');
-  });
-
-  it('throws when platform is invalid', async () => {
-    const logger = createMockLogger();
-    const globalCtx = createGlobalContextMock({
-      logger,
-      runtimePlatform: BuildRuntimePlatform.LINUX,
-    });
-
-    const buildStep = createEasExportBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
-      callInputs: { platform: 'watchos' },
-    });
-
-    await expect(buildStep.executeAsync()).rejects.toThrow('Invalid export platform');
-    expect(runExpoCliCommand).not.toHaveBeenCalled();
   });
 });

--- a/packages/build-tools/src/steps/functions/__tests__/export.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/export.test.ts
@@ -1,0 +1,137 @@
+jest.mock('../../../utils/project', () => ({
+  runExpoCliCommand: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../../../utils/packageManager', () => ({
+  ...jest.requireActual('../../../utils/packageManager'),
+  resolvePackageManager: jest.fn(),
+}));
+
+import { BuildRuntimePlatform } from '@expo/steps';
+
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { PackageManager, resolvePackageManager } from '../../../utils/packageManager';
+import { runExpoCliCommand } from '../../../utils/project';
+import { createEasExportBuildFunction } from '../export';
+
+describe(createEasExportBuildFunction, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mocked(resolvePackageManager).mockReturnValue(PackageManager.NPM);
+    jest.mocked(runExpoCliCommand).mockResolvedValue({} as any);
+  });
+
+  it('runs expo export via runExpoCliCommand with default output_dir and platform web', async () => {
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+    });
+
+    const buildStep = createEasExportBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      env: { HOME: '/tmp/home' },
+    });
+    await buildStep.executeAsync();
+
+    expect(buildStep.ctx.logger.info).toHaveBeenCalledWith(
+      'Running export command: expo export --output-dir dist --platform web'
+    );
+    expect(runExpoCliCommand).toHaveBeenCalledWith({
+      packageManager: PackageManager.NPM,
+      args: ['export', '--output-dir', 'dist', '--platform', 'web'],
+      options: {
+        cwd: buildStep.ctx.workingDirectory,
+        env: expect.objectContaining({ HOME: '/tmp/home' }),
+        logger: buildStep.ctx.logger,
+        stdio: 'pipe',
+      },
+    });
+    expect(buildStep.outputById.export_dir.value).toBe('dist');
+  });
+
+  it('passes optional flags matching expo export CLI', async () => {
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+    });
+
+    const buildStep = createEasExportBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      callInputs: {
+        output_dir: 'web-out',
+        dev: true,
+        no_minify: true,
+        assetmap: true,
+        no_ssg: true,
+        api_only: true,
+        platform: 'web',
+      },
+    });
+    await buildStep.executeAsync();
+
+    expect(runExpoCliCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: [
+          'export',
+          '--output-dir',
+          'web-out',
+          '--platform',
+          'web',
+          '--dev',
+          '--no-minify',
+          '--dump-assetmap',
+          '--no-ssg',
+          '--api-only',
+        ],
+      })
+    );
+    expect(buildStep.outputById.export_dir.value).toBe('web-out');
+  });
+
+  it('uses resolved package manager (e.g. yarn)', async () => {
+    jest.mocked(resolvePackageManager).mockReturnValue(PackageManager.YARN);
+
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+    });
+
+    const buildStep = createEasExportBuildFunction().createBuildStepFromFunctionCall(globalCtx, {});
+    await buildStep.executeAsync();
+
+    expect(runExpoCliCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ packageManager: PackageManager.YARN })
+    );
+  });
+
+  it('throws when export command fails', async () => {
+    jest.mocked(runExpoCliCommand).mockRejectedValue(new Error('export failed'));
+
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+    });
+
+    const buildStep = createEasExportBuildFunction().createBuildStepFromFunctionCall(globalCtx, {});
+
+    await expect(buildStep.executeAsync()).rejects.toThrow('Export command failed: export failed');
+  });
+
+  it('throws when platform is invalid', async () => {
+    const logger = createMockLogger();
+    const globalCtx = createGlobalContextMock({
+      logger,
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+    });
+
+    const buildStep = createEasExportBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+      callInputs: { platform: 'watchos' },
+    });
+
+    await expect(buildStep.executeAsync()).rejects.toThrow('Invalid export platform');
+    expect(runExpoCliCommand).not.toHaveBeenCalled();
+  });
+});

--- a/packages/build-tools/src/steps/functions/deploy.ts
+++ b/packages/build-tools/src/steps/functions/deploy.ts
@@ -111,7 +111,8 @@ export function createEasDeployBuildFunction(): BuildFunction {
           'Deploy command failed.\n\n' +
             `This can happen when deploy inputs are invalid, the export directory "${exportDir}" is missing, or EAS CLI authentication/network checks fail.\n` +
             'Check the deploy step logs, verify your deploy configuration and exported files, then retry.\n' +
-            `Original error: ${errorMessage}`
+            `Original error: ${errorMessage}`,
+          { cause: error }
         );
       }
     },

--- a/packages/build-tools/src/steps/functions/deploy.ts
+++ b/packages/build-tools/src/steps/functions/deploy.ts
@@ -118,10 +118,8 @@ function getDeployCommand({
     deployCommand.push('--prod');
   }
 
-  if (sourceMaps === true) {
+  if (sourceMaps) {
     deployCommand.push('--source-maps');
-  } else if (sourceMaps === false) {
-    deployCommand.push('--no-source-maps');
   }
 
   return deployCommand;

--- a/packages/build-tools/src/steps/functions/deploy.ts
+++ b/packages/build-tools/src/steps/functions/deploy.ts
@@ -168,7 +168,7 @@ function parseDeploymentOutput({ deployJson, logger }: { deployJson: string; log
   } catch (error: unknown) {
     logger.warn(
       { err: error },
-      'Failed to parse deploy JSON. DEPLOY_URL, DEPLOY_DEPLOYMENT_URL, DEPLOY_IDENTIFIER, DEPLOY_DASHBOARD_URL, DEPLOY_ALIAS_URL will be unavailable on this build.'
+      'Failed to parse "eas deploy" JSON output. Some outputs expected from this step will be undefined.'
     );
     return null;
   }

--- a/packages/build-tools/src/steps/functions/deploy.ts
+++ b/packages/build-tools/src/steps/functions/deploy.ts
@@ -75,7 +75,6 @@ export function createEasDeployBuildFunction(): BuildFunction {
         exportDir,
         alias,
         prod,
-        environment: stepsCtx.global.staticContext.metadata?.environment,
         sourceMaps,
       });
       stepsCtx.logger.info(`Running deploy command: eas ${deployCommand.join(' ')}`);
@@ -97,13 +96,11 @@ export function createEasDeployBuildFunction(): BuildFunction {
           deployJson,
           logger: stepsCtx.logger,
         });
-        if (parsedDeploymentOutput) {
-          outputs.deploy_url.set(parsedDeploymentOutput.deploy_url);
-          outputs.deploy_deployment_url.set(parsedDeploymentOutput.deploy_deployment_url);
-          outputs.deploy_identifier.set(parsedDeploymentOutput.deploy_identifier);
-          outputs.deploy_dashboard_url.set(parsedDeploymentOutput.deploy_dashboard_url);
-          outputs.deploy_alias_url.set(parsedDeploymentOutput.deploy_alias_url);
-        }
+        outputs.deploy_url.set(parsedDeploymentOutput.deploy_url);
+        outputs.deploy_deployment_url.set(parsedDeploymentOutput.deploy_deployment_url);
+        outputs.deploy_identifier.set(parsedDeploymentOutput.deploy_identifier);
+        outputs.deploy_dashboard_url.set(parsedDeploymentOutput.deploy_dashboard_url);
+        outputs.deploy_alias_url.set(parsedDeploymentOutput.deploy_alias_url);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'unknown error';
         throw new UserError(
@@ -123,19 +120,14 @@ function getDeployCommand({
   exportDir,
   alias,
   prod,
-  environment,
   sourceMaps,
 }: {
   exportDir: string;
   alias?: string;
   prod?: boolean;
-  environment?: string;
   sourceMaps?: boolean;
 }): string[] {
   const deployCommand = ['deploy', '--non-interactive', '--json', '--export-dir', exportDir];
-  if (environment) {
-    deployCommand.push('--environment', environment);
-  }
   if (alias) {
     deployCommand.push('--alias', alias);
   }
@@ -154,7 +146,7 @@ function parseDeploymentOutput({ deployJson, logger }: { deployJson: string; log
   deploy_identifier?: string;
   deploy_dashboard_url?: string;
   deploy_alias_url?: string;
-} | null {
+} {
   try {
     const deployObject = JSON.parse(deployJson);
     return {
@@ -170,6 +162,6 @@ function parseDeploymentOutput({ deployJson, logger }: { deployJson: string; log
       { err: error },
       'Failed to parse "eas deploy" JSON output. Some outputs expected from this step will be undefined.'
     );
-    return null;
+    return {};
   }
 }

--- a/packages/build-tools/src/steps/functions/deploy.ts
+++ b/packages/build-tools/src/steps/functions/deploy.ts
@@ -152,11 +152,12 @@ function parseDeploymentOutput({ deployJson, logger }: { deployJson: string; log
     // TODO: improve typing here; Look into WorkerDeploymentData
     const deployObject = JSON.parse(deployJson);
     return {
-      deploy_url: deployObject.production.url || deployObject.aliases[0].url || deployObject.url,
+      deploy_url:
+        deployObject.production?.url || deployObject.aliases?.[0]?.url || deployObject.url,
       deploy_deployment_url: deployObject.url,
       deploy_identifier: deployObject.identifier,
       deploy_dashboard_url: deployObject.dashboardUrl,
-      deploy_alias_url: deployObject.aliases[0].url,
+      deploy_alias_url: deployObject.aliases?.[0]?.url,
     };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
@@ -164,7 +165,7 @@ function parseDeploymentOutput({ deployJson, logger }: { deployJson: string; log
       'Failed to parse deploy JSON: ' +
         `${message}\n` +
         'DEPLOY_URL, DEPLOY_DEPLOYMENT_URL, DEPLOY_IDENTIFIER, DEPLOY_DASHBOARD_URL, DEPLOY_ALIAS_URL will be unavailable on this build.',
-      { error }
+      { error, deployJson }
     );
     return null;
   }

--- a/packages/build-tools/src/steps/functions/deploy.ts
+++ b/packages/build-tools/src/steps/functions/deploy.ts
@@ -98,9 +98,11 @@ export function createEasDeployBuildFunction(): BuildFunction {
           logger: stepsCtx.logger,
         });
         if (parsedDeploymentOutput) {
-          for (const [key, value] of Object.entries(parsedDeploymentOutput)) {
-            outputs[key].set(value);
-          }
+          outputs.deploy_url.set(parsedDeploymentOutput.deploy_url);
+          outputs.deploy_deployment_url.set(parsedDeploymentOutput.deploy_deployment_url);
+          outputs.deploy_identifier.set(parsedDeploymentOutput.deploy_identifier);
+          outputs.deploy_dashboard_url.set(parsedDeploymentOutput.deploy_dashboard_url);
+          outputs.deploy_alias_url.set(parsedDeploymentOutput.deploy_alias_url);
         }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'unknown error';
@@ -146,14 +148,13 @@ function getDeployCommand({
 }
 
 function parseDeploymentOutput({ deployJson, logger }: { deployJson: string; logger: bunyan }): {
-  deploy_url: string;
-  deploy_deployment_url: string;
-  deploy_identifier: string;
-  deploy_dashboard_url: string;
-  deploy_alias_url: string;
+  deploy_url?: string;
+  deploy_deployment_url?: string;
+  deploy_identifier?: string;
+  deploy_dashboard_url?: string;
+  deploy_alias_url?: string;
 } | null {
   try {
-    // TODO: improve typing here; Look into WorkerDeploymentData
     const deployObject = JSON.parse(deployJson);
     return {
       deploy_url:
@@ -164,12 +165,9 @@ function parseDeploymentOutput({ deployJson, logger }: { deployJson: string; log
       deploy_alias_url: deployObject.aliases?.[0]?.url,
     };
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
     logger.warn(
-      'Failed to parse deploy JSON: ' +
-        `${message}\n` +
-        'DEPLOY_URL, DEPLOY_DEPLOYMENT_URL, DEPLOY_IDENTIFIER, DEPLOY_DASHBOARD_URL, DEPLOY_ALIAS_URL will be unavailable on this build.',
-      { error, deployJson }
+      { err: error },
+      'Failed to parse deploy JSON. DEPLOY_URL, DEPLOY_DEPLOYMENT_URL, DEPLOY_IDENTIFIER, DEPLOY_DASHBOARD_URL, DEPLOY_ALIAS_URL will be unavailable on this build.'
     );
     return null;
   }

--- a/packages/build-tools/src/steps/functions/deploy.ts
+++ b/packages/build-tools/src/steps/functions/deploy.ts
@@ -1,10 +1,10 @@
 import { UserError } from '@expo/eas-build-job';
+import { PipeMode, bunyan } from '@expo/logger';
 import {
   BuildFunction,
   BuildStepInput,
   BuildStepInputValueTypeName,
   BuildStepOutput,
-  spawnAsync,
 } from '@expo/steps';
 
 import { runEasCliCommand } from '../../utils/easCli';
@@ -31,11 +31,12 @@ export function createEasDeployBuildFunction(): BuildFunction {
         allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
         required: false,
       }),
+      // Match eas/export default `output_dir`
       BuildStepInput.createProvider({
-        id: 'export_command',
+        id: 'export_dir',
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
         required: false,
-        defaultValue: 'npx expo export --platform web',
+        defaultValue: 'dist',
       }),
     ],
     outputProviders: [
@@ -43,29 +44,35 @@ export function createEasDeployBuildFunction(): BuildFunction {
         id: 'deploy_json',
         required: true,
       }),
+      BuildStepOutput.createProvider({
+        id: 'deploy_url',
+        required: false,
+      }),
+      BuildStepOutput.createProvider({
+        id: 'deploy_deployment_url',
+        required: false,
+      }),
+      BuildStepOutput.createProvider({
+        id: 'deploy_identifier',
+        required: false,
+      }),
+      BuildStepOutput.createProvider({
+        id: 'deploy_dashboard_url',
+        required: false,
+      }),
+      BuildStepOutput.createProvider({
+        id: 'deploy_alias_url',
+        required: false,
+      }),
     ],
     fn: async (stepsCtx, { inputs, outputs, env }) => {
       const alias = inputs.alias.value as string | undefined;
       const prod = inputs.prod.value as boolean | undefined;
       const sourceMaps = inputs.source_maps.value as boolean | undefined;
-      const exportCommand = inputs.export_command.value as string;
-
-      stepsCtx.logger.info(`Running export command: ${exportCommand}`);
-      try {
-        await spawnAsync('sh', ['-c', exportCommand], {
-          cwd: stepsCtx.workingDirectory,
-          env,
-          logger: stepsCtx.logger,
-          stdio: 'pipe',
-        });
-      } catch (error) {
-        throw new UserError(
-          'EAS_DEPLOY_EXPORT_FAILED',
-          `Export command failed: ${error instanceof Error ? error.message : 'unknown error'}`
-        );
-      }
+      const exportDir = inputs.export_dir.value as string;
 
       const deployCommand = getDeployCommand({
+        exportDir,
         alias,
         prod,
         environment: stepsCtx.global.staticContext.metadata?.environment,
@@ -80,9 +87,21 @@ export function createEasDeployBuildFunction(): BuildFunction {
             cwd: stepsCtx.workingDirectory,
             env,
             logger: stepsCtx.logger,
+            mode: PipeMode.STDERR_ONLY_AS_STDOUT,
           },
         });
-        outputs.deploy_json.set(result.stdout.toString());
+
+        const deployJson = result.stdout.toString();
+        outputs.deploy_json.set(deployJson);
+        const parsedDeploymentOutput = parseDeploymentOutput({
+          deployJson,
+          logger: stepsCtx.logger,
+        });
+        if (parsedDeploymentOutput) {
+          for (const [key, value] of Object.entries(parsedDeploymentOutput)) {
+            outputs[key].set(value);
+          }
+        }
       } catch (error) {
         throw new UserError(
           'EAS_DEPLOY_FAILED',
@@ -94,33 +113,59 @@ export function createEasDeployBuildFunction(): BuildFunction {
 }
 
 function getDeployCommand({
+  exportDir,
   alias,
   prod,
   environment,
   sourceMaps,
 }: {
+  exportDir: string;
   alias?: string;
   prod?: boolean;
   environment?: string;
   sourceMaps?: boolean;
 }): string[] {
-  const deployCommand = ['deploy', '--non-interactive', '--json'];
-
+  const deployCommand = ['deploy', '--non-interactive', '--json', '--export-dir', exportDir];
   if (environment) {
     deployCommand.push('--environment', environment);
   }
-
   if (alias) {
     deployCommand.push('--alias', alias);
   }
-
   if (prod) {
     deployCommand.push('--prod');
   }
-
   if (sourceMaps) {
     deployCommand.push('--source-maps');
   }
-
   return deployCommand;
+}
+
+function parseDeploymentOutput({ deployJson, logger }: { deployJson: string; logger: bunyan }): {
+  deploy_url: string;
+  deploy_deployment_url: string;
+  deploy_identifier: string;
+  deploy_dashboard_url: string;
+  deploy_alias_url: string;
+} | null {
+  try {
+    // TODO: improve typing here; Look into WorkerDeploymentData
+    const deployObject = JSON.parse(deployJson);
+    return {
+      deploy_url: deployObject.production.url || deployObject.aliases[0].url || deployObject.url,
+      deploy_deployment_url: deployObject.url,
+      deploy_identifier: deployObject.identifier,
+      deploy_dashboard_url: deployObject.dashboardUrl,
+      deploy_alias_url: deployObject.aliases[0].url,
+    };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(
+      'Failed to parse deploy JSON: ' +
+        `${message}\n` +
+        'DEPLOY_URL, DEPLOY_DEPLOYMENT_URL, DEPLOY_IDENTIFIER, DEPLOY_DASHBOARD_URL, DEPLOY_ALIAS_URL will be unavailable on this build.',
+      { error }
+    );
+    return null;
+  }
 }

--- a/packages/build-tools/src/steps/functions/deploy.ts
+++ b/packages/build-tools/src/steps/functions/deploy.ts
@@ -103,9 +103,13 @@ export function createEasDeployBuildFunction(): BuildFunction {
           }
         }
       } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'unknown error';
         throw new UserError(
           'EAS_DEPLOY_FAILED',
-          `Deploy command failed: ${error instanceof Error ? error.message : 'unknown error'}`
+          'Deploy command failed.\n\n' +
+            `This can happen when deploy inputs are invalid, the export directory "${exportDir}" is missing, or EAS CLI authentication/network checks fail.\n` +
+            'Check the deploy step logs, verify your deploy configuration and exported files, then retry.\n' +
+            `Original error: ${errorMessage}`
         );
       }
     },

--- a/packages/build-tools/src/steps/functions/deploy.ts
+++ b/packages/build-tools/src/steps/functions/deploy.ts
@@ -1,0 +1,128 @@
+import { UserError } from '@expo/eas-build-job';
+import {
+  BuildFunction,
+  BuildStepInput,
+  BuildStepInputValueTypeName,
+  BuildStepOutput,
+  spawnAsync,
+} from '@expo/steps';
+
+import { runEasCliCommand } from '../../utils/easCli';
+
+export function createEasDeployBuildFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'deploy',
+    name: 'Deploy',
+    __metricsId: 'eas/deploy',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'alias',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'prod',
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'source_maps',
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'export_command',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        required: false,
+        defaultValue: 'npx expo export --platform web',
+      }),
+    ],
+    outputProviders: [
+      BuildStepOutput.createProvider({
+        id: 'deploy_json',
+        required: true,
+      }),
+    ],
+    fn: async (stepsCtx, { inputs, outputs, env }) => {
+      const alias = inputs.alias.value as string | undefined;
+      const prod = inputs.prod.value as boolean | undefined;
+      const sourceMaps = inputs.source_maps.value as boolean | undefined;
+      const exportCommand = inputs.export_command.value as string;
+
+      stepsCtx.logger.info(`Running export command: ${exportCommand}`);
+      try {
+        await spawnAsync('sh', ['-c', exportCommand], {
+          cwd: stepsCtx.workingDirectory,
+          env,
+          logger: stepsCtx.logger,
+          stdio: 'pipe',
+        });
+      } catch (error) {
+        throw new UserError(
+          'EAS_DEPLOY_EXPORT_FAILED',
+          `Export command failed: ${error instanceof Error ? error.message : 'unknown error'}`
+        );
+      }
+
+      const deployCommand = getDeployCommand({
+        alias,
+        prod,
+        environment: stepsCtx.global.staticContext.metadata?.environment,
+        sourceMaps,
+      });
+      stepsCtx.logger.info(`Running deploy command: eas ${deployCommand.join(' ')}`);
+
+      try {
+        const result = await runEasCliCommand({
+          args: deployCommand,
+          options: {
+            cwd: stepsCtx.workingDirectory,
+            env,
+            logger: stepsCtx.logger,
+          },
+        });
+        outputs.deploy_json.set(result.stdout.toString());
+      } catch (error) {
+        throw new UserError(
+          'EAS_DEPLOY_FAILED',
+          `Deploy command failed: ${error instanceof Error ? error.message : 'unknown error'}`
+        );
+      }
+    },
+  });
+}
+
+function getDeployCommand({
+  alias,
+  prod,
+  environment,
+  sourceMaps,
+}: {
+  alias?: string;
+  prod?: boolean;
+  environment?: string;
+  sourceMaps?: boolean;
+}): string[] {
+  const deployCommand = ['deploy', '--non-interactive', '--json'];
+
+  if (environment) {
+    deployCommand.push('--environment', environment);
+  }
+
+  if (alias) {
+    deployCommand.push('--alias', alias);
+  }
+
+  if (prod) {
+    deployCommand.push('--prod');
+  }
+
+  if (sourceMaps === true) {
+    deployCommand.push('--source-maps');
+  } else if (sourceMaps === false) {
+    deployCommand.push('--no-source-maps');
+  }
+
+  return deployCommand;
+}

--- a/packages/build-tools/src/steps/functions/export.ts
+++ b/packages/build-tools/src/steps/functions/export.ts
@@ -66,7 +66,7 @@ export function createEasExportBuildFunction(): BuildFunction {
       const outputDir = inputs.output_dir.value as string;
       const dev = inputs.dev.value as boolean | undefined;
       const minify = inputs.minify.value as boolean | undefined;
-      const dump_assetmap = inputs.dump_assetmap.value as boolean | undefined;
+      const dumpAssetmap = inputs.dump_assetmap.value as boolean | undefined;
       const ssg = inputs.ssg.value as boolean | undefined;
       const apiOnly = inputs.api_only.value as boolean | undefined;
       const platform = inputs.platform.value as string;
@@ -76,7 +76,7 @@ export function createEasExportBuildFunction(): BuildFunction {
         outputDir,
         dev,
         minify,
-        dump_assetmap,
+        dumpAssetmap,
         ssg,
         apiOnly,
         platform,
@@ -109,7 +109,7 @@ function getExportCommand({
   outputDir,
   dev,
   minify,
-  dump_assetmap,
+  dumpAssetmap,
   ssg,
   apiOnly,
   platform,
@@ -117,7 +117,7 @@ function getExportCommand({
   outputDir: string;
   dev?: boolean;
   minify?: boolean;
-  dump_assetmap?: boolean;
+  dumpAssetmap?: boolean;
   ssg?: boolean;
   apiOnly?: boolean;
   platform: string;
@@ -129,7 +129,7 @@ function getExportCommand({
   if (!minify) {
     exportCommand.push('--no-minify');
   }
-  if (dump_assetmap) {
+  if (dumpAssetmap) {
     exportCommand.push('--dump-assetmap');
   }
   if (!ssg) {

--- a/packages/build-tools/src/steps/functions/export.ts
+++ b/packages/build-tools/src/steps/functions/export.ts
@@ -9,9 +9,6 @@ import {
 import { resolvePackageManager } from '../../utils/packageManager';
 import { runExpoCliCommand } from '../../utils/project';
 
-/** Matches `npx expo export -p` / `--platform` (see `npx expo export --help`). */
-const EXPO_EXPORT_PLATFORMS = new Set(['android', 'ios', 'web', 'all']);
-
 export function createEasExportBuildFunction(): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
@@ -31,19 +28,21 @@ export function createEasExportBuildFunction(): BuildFunction {
         required: false,
       }),
       BuildStepInput.createProvider({
-        id: 'no_minify',
+        id: 'minify',
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        required: false,
+        defaultValue: true,
+      }),
+      BuildStepInput.createProvider({
+        id: 'dump_assetmap',
         allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
         required: false,
       }),
       BuildStepInput.createProvider({
-        id: 'assetmap',
+        id: 'ssg',
         allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
         required: false,
-      }),
-      BuildStepInput.createProvider({
-        id: 'no_ssg',
-        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
-        required: false,
+        defaultValue: true,
       }),
       BuildStepInput.createProvider({
         id: 'api_only',
@@ -66,20 +65,19 @@ export function createEasExportBuildFunction(): BuildFunction {
     fn: async (stepsCtx, { inputs, outputs, env }) => {
       const outputDir = inputs.output_dir.value as string;
       const dev = inputs.dev.value as boolean | undefined;
-      const noMinify = inputs.no_minify.value as boolean | undefined;
-      const assetmap = inputs.assetmap.value as boolean | undefined;
-      const noSsg = inputs.no_ssg.value as boolean | undefined;
+      const minify = inputs.minify.value as boolean | undefined;
+      const dump_assetmap = inputs.dump_assetmap.value as boolean | undefined;
+      const ssg = inputs.ssg.value as boolean | undefined;
       const apiOnly = inputs.api_only.value as boolean | undefined;
       const platform = inputs.platform.value as string;
-
 
       const packageManager = resolvePackageManager(stepsCtx.workingDirectory);
       const exportCommand = getExportCommand({
         outputDir,
         dev,
-        noMinify,
-        assetmap,
-        noSsg,
+        minify,
+        dump_assetmap,
+        ssg,
         apiOnly,
         platform,
       });
@@ -110,17 +108,17 @@ export function createEasExportBuildFunction(): BuildFunction {
 function getExportCommand({
   outputDir,
   dev,
-  noMinify,
-  assetmap,
-  noSsg,
+  minify,
+  dump_assetmap,
+  ssg,
   apiOnly,
   platform,
 }: {
   outputDir: string;
   dev?: boolean;
-  noMinify?: boolean;
-  assetmap?: boolean;
-  noSsg?: boolean;
+  minify?: boolean;
+  dump_assetmap?: boolean;
+  ssg?: boolean;
   apiOnly?: boolean;
   platform: string;
 }): string[] {
@@ -128,13 +126,13 @@ function getExportCommand({
   if (dev) {
     exportCommand.push('--dev');
   }
-  if (noMinify) {
+  if (!minify) {
     exportCommand.push('--no-minify');
   }
-  if (assetmap) {
+  if (dump_assetmap) {
     exportCommand.push('--dump-assetmap');
   }
-  if (noSsg) {
+  if (!ssg) {
     exportCommand.push('--no-ssg');
   }
   if (apiOnly) {

--- a/packages/build-tools/src/steps/functions/export.ts
+++ b/packages/build-tools/src/steps/functions/export.ts
@@ -72,12 +72,6 @@ export function createEasExportBuildFunction(): BuildFunction {
       const apiOnly = inputs.api_only.value as boolean | undefined;
       const platform = inputs.platform.value as string;
 
-      if (!EXPO_EXPORT_PLATFORMS.has(platform)) {
-        throw new UserError(
-          'EXPO_EXPORT_INVALID_PLATFORM',
-          `Invalid export platform "${platform}". Expected one of: android, ios, web, all.`
-        );
-      }
 
       const packageManager = resolvePackageManager(stepsCtx.workingDirectory);
       const exportCommand = getExportCommand({

--- a/packages/build-tools/src/steps/functions/export.ts
+++ b/packages/build-tools/src/steps/functions/export.ts
@@ -31,7 +31,6 @@ export function createEasExportBuildFunction(): BuildFunction {
         id: 'minify',
         allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
         required: false,
-        defaultValue: true,
       }),
       BuildStepInput.createProvider({
         id: 'dump_assetmap',
@@ -42,7 +41,6 @@ export function createEasExportBuildFunction(): BuildFunction {
         id: 'ssg',
         allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
         required: false,
-        defaultValue: true,
       }),
       BuildStepInput.createProvider({
         id: 'api_only',
@@ -126,13 +124,13 @@ function getExportCommand({
   if (dev) {
     exportCommand.push('--dev');
   }
-  if (!minify) {
+  if (minify === false) {
     exportCommand.push('--no-minify');
   }
   if (dumpAssetmap) {
     exportCommand.push('--dump-assetmap');
   }
-  if (!ssg) {
+  if (ssg === false) {
     exportCommand.push('--no-ssg');
   }
   if (apiOnly) {

--- a/packages/build-tools/src/steps/functions/export.ts
+++ b/packages/build-tools/src/steps/functions/export.ts
@@ -1,0 +1,150 @@
+import { UserError } from '@expo/eas-build-job';
+import {
+  BuildFunction,
+  BuildStepInput,
+  BuildStepInputValueTypeName,
+  BuildStepOutput,
+} from '@expo/steps';
+
+import { resolvePackageManager } from '../../utils/packageManager';
+import { runExpoCliCommand } from '../../utils/project';
+
+/** Matches `npx expo export -p` / `--platform` (see `npx expo export --help`). */
+const EXPO_EXPORT_PLATFORMS = new Set(['android', 'ios', 'web', 'all']);
+
+export function createEasExportBuildFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'export',
+    name: 'Export',
+    __metricsId: 'eas/export',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'output_dir',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        required: false,
+        defaultValue: 'dist',
+      }),
+      BuildStepInput.createProvider({
+        id: 'dev',
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'no_minify',
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'assetmap',
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'no_ssg',
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'api_only',
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'platform',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        required: false,
+        defaultValue: 'web',
+      }),
+    ],
+    outputProviders: [
+      BuildStepOutput.createProvider({
+        id: 'export_dir',
+        required: true,
+      }),
+    ],
+    fn: async (stepsCtx, { inputs, outputs, env }) => {
+      const outputDir = inputs.output_dir.value as string;
+      const dev = inputs.dev.value as boolean | undefined;
+      const noMinify = inputs.no_minify.value as boolean | undefined;
+      const assetmap = inputs.assetmap.value as boolean | undefined;
+      const noSsg = inputs.no_ssg.value as boolean | undefined;
+      const apiOnly = inputs.api_only.value as boolean | undefined;
+      const platform = inputs.platform.value as string;
+
+      if (!EXPO_EXPORT_PLATFORMS.has(platform)) {
+        throw new UserError(
+          'EXPO_EXPORT_INVALID_PLATFORM',
+          `Invalid export platform "${platform}". Expected one of: android, ios, web, all.`
+        );
+      }
+
+      const packageManager = resolvePackageManager(stepsCtx.workingDirectory);
+      const exportCommand = getExportCommand({
+        outputDir,
+        dev,
+        noMinify,
+        assetmap,
+        noSsg,
+        apiOnly,
+        platform,
+      });
+      stepsCtx.logger.info(`Running export command: expo ${exportCommand.join(' ')}`);
+
+      try {
+        await runExpoCliCommand({
+          packageManager,
+          args: exportCommand,
+          options: {
+            cwd: stepsCtx.workingDirectory,
+            env,
+            logger: stepsCtx.logger,
+            stdio: 'pipe',
+          },
+        });
+        outputs.export_dir.set(outputDir);
+      } catch (error) {
+        throw new UserError(
+          'EXPO_EXPORT_FAILED',
+          `Export command failed: ${error instanceof Error ? error.message : 'unknown error'}`
+        );
+      }
+    },
+  });
+}
+
+function getExportCommand({
+  outputDir,
+  dev,
+  noMinify,
+  assetmap,
+  noSsg,
+  apiOnly,
+  platform,
+}: {
+  outputDir: string;
+  dev?: boolean;
+  noMinify?: boolean;
+  assetmap?: boolean;
+  noSsg?: boolean;
+  apiOnly?: boolean;
+  platform: string;
+}): string[] {
+  const exportCommand = ['export', '--output-dir', outputDir, '--platform', platform];
+  if (dev) {
+    exportCommand.push('--dev');
+  }
+  if (noMinify) {
+    exportCommand.push('--no-minify');
+  }
+  if (assetmap) {
+    exportCommand.push('--dump-assetmap');
+  }
+  if (noSsg) {
+    exportCommand.push('--no-ssg');
+  }
+  if (apiOnly) {
+    exportCommand.push('--api-only');
+  }
+  return exportCommand;
+}

--- a/packages/build-tools/src/utils/__tests__/easCli.test.ts
+++ b/packages/build-tools/src/utils/__tests__/easCli.test.ts
@@ -42,15 +42,17 @@ describe(resolveEasCommandPrefixAndEnvAsync, () => {
     );
   });
 
-  it('logs when using easd in development', async () => {
+  it('warns when using easd in development', async () => {
     process.env.ENVIRONMENT = 'development';
-    const info = jest.fn();
-    const logger = { info } as any;
+    const warn = jest.fn();
+    const logger = { warn } as any;
     jest.mocked(spawn).mockResolvedValueOnce({ status: 0 } as any);
 
     await resolveEasCommandPrefixAndEnvAsync({ logger });
 
-    expect(info).toHaveBeenCalledWith('Using easd (local EAS CLI) for development.');
+    expect(warn).toHaveBeenCalledWith(
+      `easd found, using it instead of npx eas-cli@${EasCliNpmTags.STAGING} for development.`
+    );
   });
 
   it('resolves staging tag in development when easd --help fails', async () => {
@@ -64,21 +66,6 @@ describe(resolveEasCommandPrefixAndEnvAsync, () => {
       args: ['-y', `eas-cli@${EasCliNpmTags.STAGING}`],
       extraEnv: {},
     });
-  });
-
-  it('logs info when falling back to npx in development', async () => {
-    process.env.ENVIRONMENT = 'development';
-    const info = jest.fn();
-    const logger = { info } as any;
-    jest.mocked(spawn).mockResolvedValueOnce({ status: 1 } as any);
-
-    await resolveEasCommandPrefixAndEnvAsync({ logger });
-
-    expect(info).toHaveBeenCalledWith(
-      expect.stringMatching(
-        /easd not found or "easd --help" did not succeed; falling back to npx eas-cli@/
-      )
-    );
   });
 
   it('resolves staging tag and EXPO_STAGING env in staging environment', async () => {

--- a/packages/build-tools/src/utils/__tests__/easCli.test.ts
+++ b/packages/build-tools/src/utils/__tests__/easCli.test.ts
@@ -1,0 +1,89 @@
+import { EasCliNpmTags } from '@expo/eas-build-job';
+import spawn from '@expo/turtle-spawn';
+
+import { resolveEasCommandPrefixAndEnvAsync, runEasCliCommand } from '../easCli';
+import { isAtLeastNpm7Async } from '../packageManager';
+
+jest.mock('@expo/turtle-spawn', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock('../packageManager', () => ({
+  ...jest.requireActual('../packageManager'),
+  isAtLeastNpm7Async: jest.fn(async () => true),
+}));
+
+describe(resolveEasCommandPrefixAndEnvAsync, () => {
+  const originalEnvironment = process.env.ENVIRONMENT;
+
+  afterEach(() => {
+    process.env.ENVIRONMENT = originalEnvironment;
+  });
+
+  it('resolves staging tag in development environment', async () => {
+    process.env.ENVIRONMENT = 'development';
+    const result = await resolveEasCommandPrefixAndEnvAsync();
+    expect(result).toEqual({
+      cmd: 'npx',
+      args: ['-y', `eas-cli@${EasCliNpmTags.STAGING}`],
+      extraEnv: {},
+    });
+  });
+
+  it('resolves staging tag and EXPO_STAGING env in staging environment', async () => {
+    process.env.ENVIRONMENT = 'staging';
+    const result = await resolveEasCommandPrefixAndEnvAsync();
+    expect(result).toEqual({
+      cmd: 'npx',
+      args: ['-y', `eas-cli@${EasCliNpmTags.STAGING}`],
+      extraEnv: { EXPO_STAGING: '1' },
+    });
+  });
+
+  it('resolves production tag by default', async () => {
+    process.env.ENVIRONMENT = 'production';
+    const result = await resolveEasCommandPrefixAndEnvAsync();
+    expect(result).toEqual({
+      cmd: 'npx',
+      args: ['-y', `eas-cli@${EasCliNpmTags.PRODUCTION}`],
+      extraEnv: {},
+    });
+  });
+
+  it('omits -y when npm is older than v7', async () => {
+    jest.mocked(isAtLeastNpm7Async).mockResolvedValueOnce(false);
+    process.env.ENVIRONMENT = 'production';
+    const result = await resolveEasCommandPrefixAndEnvAsync();
+    expect(result).toEqual({
+      cmd: 'npx',
+      args: [`eas-cli@${EasCliNpmTags.PRODUCTION}`],
+      extraEnv: {},
+    });
+  });
+});
+
+describe(runEasCliCommand, () => {
+  it('merges caller env with resolved extra env', async () => {
+    process.env.ENVIRONMENT = 'staging';
+
+    await runEasCliCommand({
+      args: ['deploy', '--json'],
+      options: {
+        cwd: '/tmp/project',
+        env: { FOO: 'bar' },
+      },
+    });
+
+    expect(spawn).toHaveBeenCalledWith(
+      'npx',
+      expect.arrayContaining([`eas-cli@${EasCliNpmTags.STAGING}`, 'deploy', '--json']),
+      expect.objectContaining({
+        cwd: '/tmp/project',
+        env: expect.objectContaining({
+          FOO: 'bar',
+          EXPO_STAGING: '1',
+        }),
+      })
+    );
+  });
+});

--- a/packages/build-tools/src/utils/__tests__/easCli.test.ts
+++ b/packages/build-tools/src/utils/__tests__/easCli.test.ts
@@ -103,8 +103,14 @@ describe(resolveEasCommandPrefixAndEnvAsync, () => {
 });
 
 describe(runEasCliCommand, () => {
+  const originalEnvironment = process.env.ENVIRONMENT;
+
   beforeEach(() => {
     jest.mocked(spawn).mockReset();
+  });
+
+  afterEach(() => {
+    process.env.ENVIRONMENT = originalEnvironment;
   });
 
   it('merges caller env with resolved extra env', async () => {

--- a/packages/build-tools/src/utils/__tests__/easCli.test.ts
+++ b/packages/build-tools/src/utils/__tests__/easCli.test.ts
@@ -42,19 +42,6 @@ describe(resolveEasCommandPrefixAndEnvAsync, () => {
     );
   });
 
-  it('warns when using easd in development', async () => {
-    process.env.ENVIRONMENT = 'development';
-    const warn = jest.fn();
-    const logger = { warn } as any;
-    jest.mocked(spawn).mockResolvedValueOnce({ status: 0 } as any);
-
-    await resolveEasCommandPrefixAndEnvAsync({ logger });
-
-    expect(warn).toHaveBeenCalledWith(
-      `easd found, using it instead of npx eas-cli@${EasCliNpmTags.STAGING} for development.`
-    );
-  });
-
   it('resolves staging tag in development when easd --help fails', async () => {
     process.env.ENVIRONMENT = 'development';
     jest.mocked(spawn).mockResolvedValueOnce({ status: 1 } as any);

--- a/packages/build-tools/src/utils/__tests__/easCli.test.ts
+++ b/packages/build-tools/src/utils/__tests__/easCli.test.ts
@@ -16,18 +16,69 @@ jest.mock('../packageManager', () => ({
 describe(resolveEasCommandPrefixAndEnvAsync, () => {
   const originalEnvironment = process.env.ENVIRONMENT;
 
+  beforeEach(() => {
+    jest.mocked(spawn).mockReset();
+  });
+
   afterEach(() => {
     process.env.ENVIRONMENT = originalEnvironment;
   });
 
-  it('resolves staging tag in development environment', async () => {
+  it('resolves easd in development when easd --help succeeds', async () => {
     process.env.ENVIRONMENT = 'development';
+    jest.mocked(spawn).mockResolvedValueOnce({ status: 0 } as any);
+
     const result = await resolveEasCommandPrefixAndEnvAsync();
+
+    expect(result).toEqual({
+      cmd: 'easd',
+      args: [],
+      extraEnv: {},
+    });
+    expect(spawn).toHaveBeenCalledWith(
+      'easd',
+      ['--help'],
+      expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
+    );
+  });
+
+  it('logs when using easd in development', async () => {
+    process.env.ENVIRONMENT = 'development';
+    const info = jest.fn();
+    const logger = { info } as any;
+    jest.mocked(spawn).mockResolvedValueOnce({ status: 0 } as any);
+
+    await resolveEasCommandPrefixAndEnvAsync({ logger });
+
+    expect(info).toHaveBeenCalledWith('Using easd (local EAS CLI) for development.');
+  });
+
+  it('resolves staging tag in development when easd --help fails', async () => {
+    process.env.ENVIRONMENT = 'development';
+    jest.mocked(spawn).mockResolvedValueOnce({ status: 1 } as any);
+
+    const result = await resolveEasCommandPrefixAndEnvAsync();
+
     expect(result).toEqual({
       cmd: 'npx',
       args: ['-y', `eas-cli@${EasCliNpmTags.STAGING}`],
       extraEnv: {},
     });
+  });
+
+  it('logs info when falling back to npx in development', async () => {
+    process.env.ENVIRONMENT = 'development';
+    const info = jest.fn();
+    const logger = { info } as any;
+    jest.mocked(spawn).mockResolvedValueOnce({ status: 1 } as any);
+
+    await resolveEasCommandPrefixAndEnvAsync({ logger });
+
+    expect(info).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /easd not found or "easd --help" did not succeed; falling back to npx eas-cli@/
+      )
+    );
   });
 
   it('resolves staging tag and EXPO_STAGING env in staging environment', async () => {
@@ -38,6 +89,7 @@ describe(resolveEasCommandPrefixAndEnvAsync, () => {
       args: ['-y', `eas-cli@${EasCliNpmTags.STAGING}`],
       extraEnv: { EXPO_STAGING: '1' },
     });
+    expect(spawn).not.toHaveBeenCalled();
   });
 
   it('resolves production tag by default', async () => {
@@ -48,6 +100,7 @@ describe(resolveEasCommandPrefixAndEnvAsync, () => {
       args: ['-y', `eas-cli@${EasCliNpmTags.PRODUCTION}`],
       extraEnv: {},
     });
+    expect(spawn).not.toHaveBeenCalled();
   });
 
   it('omits -y when npm is older than v7', async () => {
@@ -63,6 +116,10 @@ describe(resolveEasCommandPrefixAndEnvAsync, () => {
 });
 
 describe(runEasCliCommand, () => {
+  beforeEach(() => {
+    jest.mocked(spawn).mockReset();
+  });
+
   it('merges caller env with resolved extra env', async () => {
     process.env.ENVIRONMENT = 'staging';
 

--- a/packages/build-tools/src/utils/__tests__/easCli.test.ts
+++ b/packages/build-tools/src/utils/__tests__/easCli.test.ts
@@ -68,6 +68,19 @@ describe(resolveEasCommandPrefixAndEnvAsync, () => {
     });
   });
 
+  it('resolves staging tag in development when easd probe throws', async () => {
+    process.env.ENVIRONMENT = 'development';
+    jest.mocked(spawn).mockRejectedValueOnce(new Error('easd not installed') as any);
+
+    const result = await resolveEasCommandPrefixAndEnvAsync();
+
+    expect(result).toEqual({
+      cmd: 'npx',
+      args: ['-y', `eas-cli@${EasCliNpmTags.STAGING}`],
+      extraEnv: {},
+    });
+  });
+
   it('resolves staging tag and EXPO_STAGING env in staging environment', async () => {
     process.env.ENVIRONMENT = 'staging';
     const result = await resolveEasCommandPrefixAndEnvAsync();

--- a/packages/build-tools/src/utils/easCli.ts
+++ b/packages/build-tools/src/utils/easCli.ts
@@ -1,0 +1,45 @@
+import spawn, { SpawnOptions, SpawnResult } from '@expo/turtle-spawn';
+import { EasCliNpmTags, Env } from '@expo/eas-build-job';
+
+import { isAtLeastNpm7Async } from './packageManager';
+
+export async function resolveEasCommandPrefixAndEnvAsync(): Promise<{
+  cmd: string;
+  args: string[];
+  extraEnv: Env;
+}> {
+  const npxArgsPrefix = (await isAtLeastNpm7Async()) ? ['-y'] : [];
+  if (process.env.ENVIRONMENT === 'development') {
+    return {
+      cmd: 'npx',
+      args: [...npxArgsPrefix, `eas-cli@${EasCliNpmTags.STAGING}`],
+      extraEnv: {},
+    };
+  } else if (process.env.ENVIRONMENT === 'staging') {
+    return {
+      cmd: 'npx',
+      args: [...npxArgsPrefix, `eas-cli@${EasCliNpmTags.STAGING}`],
+      extraEnv: { EXPO_STAGING: '1' },
+    };
+  } else {
+    return {
+      cmd: 'npx',
+      args: [...npxArgsPrefix, `eas-cli@${EasCliNpmTags.PRODUCTION}`],
+      extraEnv: {},
+    };
+  }
+}
+
+export async function runEasCliCommand({
+  args,
+  options,
+}: {
+  args: string[];
+  options: SpawnOptions;
+}): Promise<SpawnResult> {
+  const { cmd, args: commandPrefixArgs, extraEnv } = await resolveEasCommandPrefixAndEnvAsync();
+  return await spawn(cmd, [...commandPrefixArgs, ...args], {
+    ...options,
+    env: { ...options.env, ...extraEnv },
+  });
+}

--- a/packages/build-tools/src/utils/easCli.ts
+++ b/packages/build-tools/src/utils/easCli.ts
@@ -1,6 +1,5 @@
 import spawn, { SpawnOptions, SpawnResult } from '@expo/turtle-spawn';
 import { EasCliNpmTags, Env } from '@expo/eas-build-job';
-import { bunyan } from '@expo/logger';
 
 import { isAtLeastNpm7Async } from './packageManager';
 

--- a/packages/build-tools/src/utils/easCli.ts
+++ b/packages/build-tools/src/utils/easCli.ts
@@ -15,18 +15,14 @@ async function probeEasdAsync(): Promise<boolean> {
   }
 }
 
-export async function resolveEasCommandPrefixAndEnvAsync(options?: { logger?: bunyan }): Promise<{
+export async function resolveEasCommandPrefixAndEnvAsync(): Promise<{
   cmd: string;
   args: string[];
   extraEnv: Env;
 }> {
-  const { logger } = options ?? {};
   const npxArgsPrefix = (await isAtLeastNpm7Async()) ? ['-y'] : [];
   if (process.env.ENVIRONMENT === 'development') {
     if (await probeEasdAsync()) {
-      logger?.warn(
-        `easd found, using it instead of npx eas-cli@${EasCliNpmTags.STAGING} for development.`
-      );
       return { cmd: 'easd', args: [], extraEnv: {} };
     }
     return {
@@ -57,13 +53,7 @@ export async function runEasCliCommand({
   options: SpawnOptions;
 }): Promise<SpawnResult> {
   const { logger, ...spawnOptions } = options;
-  const {
-    cmd,
-    args: commandPrefixArgs,
-    extraEnv,
-  } = await resolveEasCommandPrefixAndEnvAsync({
-    logger,
-  });
+  const { cmd, args: commandPrefixArgs, extraEnv } = await resolveEasCommandPrefixAndEnvAsync();
   return await spawn(cmd, [...commandPrefixArgs, ...args], {
     ...spawnOptions,
     logger,

--- a/packages/build-tools/src/utils/easCli.ts
+++ b/packages/build-tools/src/utils/easCli.ts
@@ -1,15 +1,34 @@
 import spawn, { SpawnOptions, SpawnResult } from '@expo/turtle-spawn';
 import { EasCliNpmTags, Env } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
 
 import { isAtLeastNpm7Async } from './packageManager';
 
-export async function resolveEasCommandPrefixAndEnvAsync(): Promise<{
+async function probeEasdAsync(): Promise<boolean> {
+  try {
+    const result = await spawn('easd', ['--help'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveEasCommandPrefixAndEnvAsync(options?: { logger?: bunyan }): Promise<{
   cmd: string;
   args: string[];
   extraEnv: Env;
 }> {
+  const { logger } = options ?? {};
   const npxArgsPrefix = (await isAtLeastNpm7Async()) ? ['-y'] : [];
   if (process.env.ENVIRONMENT === 'development') {
+    if (await probeEasdAsync()) {
+      logger?.warn(
+        `easd found, using it instead of npx eas-cli@${EasCliNpmTags.STAGING} for development.`
+      );
+      return { cmd: 'easd', args: [], extraEnv: {} };
+    }
     return {
       cmd: 'npx',
       args: [...npxArgsPrefix, `eas-cli@${EasCliNpmTags.STAGING}`],
@@ -37,9 +56,17 @@ export async function runEasCliCommand({
   args: string[];
   options: SpawnOptions;
 }): Promise<SpawnResult> {
-  const { cmd, args: commandPrefixArgs, extraEnv } = await resolveEasCommandPrefixAndEnvAsync();
+  const { logger, ...spawnOptions } = options;
+  const {
+    cmd,
+    args: commandPrefixArgs,
+    extraEnv,
+  } = await resolveEasCommandPrefixAndEnvAsync({
+    logger,
+  });
   return await spawn(cmd, [...commandPrefixArgs, ...args], {
-    ...options,
-    env: { ...options.env, ...extraEnv },
+    ...spawnOptions,
+    logger,
+    env: { ...spawnOptions.env, ...extraEnv },
   });
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Introduce `eas/deploy` function to streamline export+deploy usual combination within single unit. Includes `deploy_json` output from `eas deploy --json` for anything that comes after.

Ref ENG-14737

# How

New function with configurable export command, deploy alias, prod and source_maps

# Test Plan

Local run with the following workflows

✅ Success path (alias did not play nicely locally, so skipped this validation)
```
name: deploy-web-custom

on:
  workflow_dispatch: {}

jobs:
  deploy_custom:
    name: Deploy web with custom steps
    type: custom
    runs_on: linux-medium
    environment: production
    outputs:
      deploy_json: ${{ steps.deploy.outputs.deploy_json }}
      deploy_url: ${{ steps.deploy.outputs.deploy_url }}
      deploy_deployment_url: ${{ steps.deploy.outputs.deploy_deployment_url }}
      deploy_identifier: ${{ steps.deploy.outputs.deploy_identifier }}
      deploy_dashboard_url: ${{ steps.deploy.outputs.deploy_dashboard_url }}
      deploy_alias_url: ${{ steps.deploy.outputs.deploy_alias_url }}
    env:
      APP_VARIANT: production
    steps:
      - uses: eas/checkout
      - uses: eas/use_npm_token
      - uses: eas/install_node_modules
      - uses: eas/export
      - uses: eas/deploy
        id: deploy
      - run: echo "Deploy output - ${{ steps.deploy.outputs.deploy_json }}"
      - run: echo "Deploy URL - ${{ steps.deploy.outputs.deploy_url }}"
      - run: echo "Deployment URL - ${{ steps.deploy.outputs.deploy_deployment_url }}"
      - run: echo "Deployment identifier - ${{ steps.deploy.outputs.deploy_identifier }}"
      - run: echo "Dashboard URL - ${{ steps.deploy.outputs.deploy_dashboard_url }}"
      - run: echo "Alias URL - ${{ steps.deploy.outputs.deploy_alias_url }}"

  read_output:
    name: Read deploy output from another job
    type: custom
    runs_on: linux-medium
    needs: [deploy_custom]
    steps:
      - run: echo "Deploy JSON from previous job - ${{ needs.deploy_custom.outputs.deploy_json }}"
      - run: echo "Deploy URL from previous job - ${{ needs.deploy_custom.outputs.deploy_url }}"
      - run: echo "Deployment URL from previous job - ${{ needs.deploy_custom.outputs.deploy_deployment_url }}"
      - run: echo "Deployment identifier from previous job - ${{ needs.deploy_custom.outputs.deploy_identifier }}"
      - run: echo "Dashboard URL from previous job - ${{ needs.deploy_custom.outputs.deploy_dashboard_url }}"
      - run: echo "Alias URL from previous job - ${{ needs.deploy_custom.outputs.deploy_alias_url }}"
```

<img width="1054" height="787" alt="Screenshot 2026-04-17 at 1 06 25 PM" src="https://github.com/user-attachments/assets/7e247422-d12a-405a-b317-83cfbce7fe23" />
<img width="1043" height="458" alt="Screenshot 2026-04-17 at 1 06 34 PM" src="https://github.com/user-attachments/assets/da0a5fd4-0cd5-42e1-ba7e-0c8dc004db40" />




❌  Failure pattern
```
name: deploy-web-custom-simple-no-setup

on:
  workflow_dispatch: {}

jobs:
  deploy_custom:
    name: Deploy web without setup steps (expected to fail)
    type: custom
    runs_on: linux-medium
    environment: production
    env:
      APP_VARIANT: production
    steps:
      - run: echo "Before eas/deploy - no npm token, or node_modules"
      - uses: eas/checkout
      # MISSING: use_npm_token, install_node_modules here to simulate failure
      - uses: eas/export
      - uses: eas/deploy
      - run: echo "After eas/deploy stub"
```
<img width="1069" height="678" alt="Screenshot 2026-04-17 at 1 07 22 PM" src="https://github.com/user-attachments/assets/2862b030-ba3d-47b3-9010-94daa088459a" />
