### PR TITLE
[eas-build-job] Extend the `app_store_connect.build_upload` workflows interpolation context

### DIFF
--- a/packages/eas-build-job/src/__tests__/common.test.ts
+++ b/packages/eas-build-job/src/__tests__/common.test.ts
@@ -56,6 +56,110 @@ describe('StaticWorkflowInterpolationContextZ', () => {
     expect(StaticWorkflowInterpolationContextZ.parse(context)).toEqual(context);
   });
 
+  it('accepts app_store_connect build_upload with cf_bundle_version', () => {
+    const context = {
+      after: {},
+      needs: {},
+      workflow: {
+        id: 'workflow-id',
+        name: 'workflow-name',
+        filename: 'workflow.yml',
+        url: 'https://expo.dev/accounts/example/workflows/workflow-id',
+      },
+      app: {
+        id: 'app-id',
+        slug: 'app-slug',
+      },
+      account: {
+        id: 'account-id',
+        name: 'account-name',
+      },
+      app_store_connect: {
+        app: {
+          id: '1234567890',
+        },
+        build_upload: {
+          id: '123e4567-e89b-42d3-a456-426614174000',
+          state: 'processing',
+          cf_bundle_version: '42',
+        },
+      },
+    };
+
+    expect(StaticWorkflowInterpolationContextZ.parse(context)).toEqual(context);
+  });
+
+  it('accepts app_store_connect build_upload with build.id', () => {
+    const context = {
+      after: {},
+      needs: {},
+      workflow: {
+        id: 'workflow-id',
+        name: 'workflow-name',
+        filename: 'workflow.yml',
+        url: 'https://expo.dev/accounts/example/workflows/workflow-id',
+      },
+      app: {
+        id: 'app-id',
+        slug: 'app-slug',
+      },
+      account: {
+        id: 'account-id',
+        name: 'account-name',
+      },
+      app_store_connect: {
+        app: {
+          id: '1234567890',
+        },
+        build_upload: {
+          id: '123e4567-e89b-42d3-a456-426614174000',
+          state: 'complete',
+          build: {
+            id: 'build-abc123',
+          },
+        },
+      },
+    };
+
+    expect(StaticWorkflowInterpolationContextZ.parse(context)).toEqual(context);
+  });
+
+  it('accepts app_store_connect build_upload with both cf_bundle_version and build.id', () => {
+    const context = {
+      after: {},
+      needs: {},
+      workflow: {
+        id: 'workflow-id',
+        name: 'workflow-name',
+        filename: 'workflow.yml',
+        url: 'https://expo.dev/accounts/example/workflows/workflow-id',
+      },
+      app: {
+        id: 'app-id',
+        slug: 'app-slug',
+      },
+      account: {
+        id: 'account-id',
+        name: 'account-name',
+      },
+      app_store_connect: {
+        app: {
+          id: '1234567890',
+        },
+        build_upload: {
+          id: '123e4567-e89b-42d3-a456-426614174000',
+          state: 'complete',
+          cf_bundle_version: '42',
+          build: {
+            id: 'build-abc123',
+          },
+        },
+      },
+    };
+
+    expect(StaticWorkflowInterpolationContextZ.parse(context)).toEqual(context);
+  });
+
   it('accepts app_store_connect context without build_upload', () => {
     const context = {
       after: {},

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -256,6 +256,12 @@ const AppStoreConnectContextZ = z.looseObject({
     .looseObject({
       id: z.string(),
       state: z.enum(['awaiting_upload', 'processing', 'failed', 'complete']),
+      cf_bundle_version: z.string().optional(),
+      build: z
+        .looseObject({
+          id: z.string(),
+        })
+        .optional(),
     })
     .optional(),
   external_beta: z


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We want to add some convenience values to the `app_store_connect.build_upload` workflows interpolation context, like `cf_bundle_version` or related build ID.

# How

Extended the Zod schema. Made the new fields optional to maintain backwards compatibility.

# Test Plan

Added unit tests.