### PR TITLE
fix(eas-cli): Abort early on asset upload errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] Bump `@expo/apple-utils` to `2.1.18` to fix `metadata:push` failing on `ageRatingDeclarations` due to the removed `gamblingAndContests` attribute. ([#3588](https://github.com/expo/eas-cli/pull/3588) by [@EvanBacon](https://github.com/EvanBacon))
 - [eas-cli] Bump `@expo/apple-utils` to `2.1.19` to fix image and video uploads via `metadata:push` getting stuck in `AWAITING_UPLOAD` state. The asset client was inheriting Bearer token injection from the App Store Connect API client, which caused S3 presigned URL uploads to be silently mishandled by Apple's CDN. Fixes screenshots, previews, and App Clip header image uploads. ([#3590](https://github.com/expo/eas-cli/pull/3590) by [@EvanBacon](https://github.com/EvanBacon))
 - [eas-cli] `metadata:pull` now preserves screenshot, video preview, and App Clip header image entries with placeholder paths when the asset is in an unrendered state, so users can recover broken records by replacing the file or removing the entry instead of having entries silently dropped from `store.config.json`. ([#3590](https://github.com/expo/eas-cli/pull/3590) by [@EvanBacon](https://github.com/EvanBacon))
+- [eas-cli] Surface hosting deployment's asset upload errors sooner ([#3600](https://github.com/expo/eas-cli/pull/3600) by [@kitten](https://github.com/kitten))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/deploy/index.ts
+++ b/packages/eas-cli/src/commands/deploy/index.ts
@@ -362,8 +362,22 @@ export default class WorkerDeploy extends EasCommand {
       throw error;
     }
 
-    await uploadAssetsAsync(assetFiles, deployResult);
-    await finalizeDeployAsync(deployResult);
+    let uploadError: unknown;
+    try {
+      await uploadAssetsAsync(assetFiles, deployResult);
+    } catch (error) {
+      uploadError = error;
+    }
+    try {
+      await finalizeDeployAsync(deployResult);
+    } catch (finalizeError) {
+      if (!uploadError) {
+        throw finalizeError;
+      }
+    }
+    if (uploadError) {
+      throw uploadError;
+    }
 
     let deploymentAlias: null | Awaited<ReturnType<typeof assignWorkerDeploymentAliasAsync>> = null;
     if (flags.aliasName) {

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -203,6 +203,7 @@ export async function* batchUploadAsync(
     (() => {
       onProgressUpdate(getProgressValue());
     });
+  let firstError: unknown = null;
   try {
     let index = 0;
     while (index < payloads.length || queue.size > 0) {
@@ -215,28 +216,37 @@ export async function* batchUploadAsync(
             progressTracker[currentIndex] = progress;
             sendProgressUpdate();
           });
-        const uploadPromise = uploadAsync(initWithSignal, payload, onChildProgressUpdate).finally(
-          () => {
+        const uploadPromise = uploadAsync(initWithSignal, payload, onChildProgressUpdate).then(
+          result => {
             queue.delete(uploadPromise);
             progressTracker[currentIndex] = 1;
+            return result;
+          },
+          error => {
+            queue.delete(uploadPromise);
+            firstError ??= error;
+            controller.abort();
+            throw error;
           }
         );
         queue.add(uploadPromise);
         yield { payload, progress: getProgressValue() };
+      }
+      if (firstError) {
+        break;
       }
       yield {
         ...(await Promise.race(queue)),
         progress: getProgressValue(),
       };
     }
-
-    if (queue.size > 0) {
-      controller.abort();
-    }
   } catch (error: any) {
     if (error.name !== 'AbortError') {
-      throw error;
+      firstError ??= error;
     }
+  }
+  if (firstError) {
+    throw firstError;
   }
 }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We previously preferred to not abort during upload errors and let the finalize call at the end of the deployment procedure take care of evaluating whether a deployment was successful. However, if asset uploads persistently fail, there's no point in proceeding with all of them.

# How

- Abort when there's an upload error for assets and surface the error
- Call the finalize endpoint, then surface the original error

# Test Plan

- Tested manually
