### PR TITLE
feat(metadata): Warn on unknown previews; clear old previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Fix `metadata:push` not deleting video previews from App Store Connect when removed from config. ([#3603](https://github.com/expo/eas-cli/pull/3603) by [@EvanBacon](https://github.com/EvanBacon))
+- [eas-cli] Warn and skip unknown preview types in `metadata:push` with a helpful suggestion when the `APP_` screenshot prefix is mistakenly used. ([#3603](https://github.com/expo/eas-cli/pull/3603) by [@EvanBacon](https://github.com/EvanBacon))
+- [eas-cli] Delete all existing previews in a preview set before uploading to avoid Apple's "Too many app previews" error. ([#3603](https://github.com/expo/eas-cli/pull/3603) by [@EvanBacon](https://github.com/EvanBacon))
 - [eas-cli] Fixes for `observe` commands, including an issue for apps with many update IDs. ([#3609](https://github.com/expo/eas-cli/pull/3609) by [@douglowder](https://github.com/douglowder))
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/metadata/apple/tasks/__mocks__/nock.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__mocks__/nock.ts
@@ -5,4 +5,4 @@ import { getAdapter } from 'axios';
 // see: https://github.com/nock/nock#axios
 
 export { default } from 'nock';
-getRequestClient().defaults.adapter = getAdapter('http');
+getRequestClient().defaults.adapter = getAdapter('http') as any;

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/previews.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/previews.test.ts
@@ -11,9 +11,18 @@ import { AppleConfigReader } from '../../config/reader';
 import { AppleConfigWriter } from '../../config/writer';
 import { PartialAppleData } from '../../data';
 import { PreviewsTask } from '../previews';
+import Log from '../../../../log';
 
 jest.mock('../../../../ora');
 jest.mock('../../config/writer');
+jest.mock('../../../../log', () => ({
+  __esModule: true,
+  default: {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
 
 const mockFetch = jest.fn();
 jest.mock('../../../../fetch', () => ({
@@ -377,6 +386,71 @@ describe(PreviewsTask, () => {
       );
     });
 
+    it('warns and skips when preview type uses screenshot display type (APP_ prefix)', async () => {
+      const config = new AppleConfigReader({
+        info: {
+          'en-US': {
+            title: 'My App',
+            previews: {
+              APP_IPHONE_67: './previews/demo.mp4',
+            } as any,
+          },
+        },
+      });
+
+      const locale = new AppStoreVersionLocalization(requestContext, 'LOC_1', {
+        locale: 'en-US',
+      } as any);
+
+      const previewSets = new Map();
+      previewSets.set('en-US', new Map());
+
+      await new PreviewsTask().uploadAsync({
+        config,
+        context: {
+          previewSets,
+          versionLocales: [locale],
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('APP_IPHONE_67'));
+      expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('IPHONE_67'));
+    });
+
+    it('warns and skips completely unknown preview types', async () => {
+      const config = new AppleConfigReader({
+        info: {
+          'en-US': {
+            title: 'My App',
+            previews: {
+              FAKE_DEVICE: './previews/demo.mp4',
+            } as any,
+          },
+        },
+      });
+
+      const locale = new AppStoreVersionLocalization(requestContext, 'LOC_1', {
+        locale: 'en-US',
+      } as any);
+
+      const previewSets = new Map();
+      previewSets.set('en-US', new Map());
+
+      await new PreviewsTask().uploadAsync({
+        config,
+        context: {
+          previewSets,
+          versionLocales: [locale],
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('FAKE_DEVICE'));
+      // Should not suggest stripping APP_ prefix for non-APP_ types
+      expect(Log.warn).not.toHaveBeenCalledWith(expect.stringContaining('Did you mean'));
+    });
+
     it('uploads new preview with object config including previewFrameTimeCode', async () => {
       const config = new AppleConfigReader({
         info: {
@@ -442,6 +516,55 @@ describe(PreviewsTask, () => {
           previewFrameTimeCode: '00:05:00',
         })
       );
+    });
+
+    it('deletes remote previews when preview type is removed from config', async () => {
+      const config = new AppleConfigReader({
+        info: {
+          'en-US': {
+            title: 'My App',
+            // No previews configured — the IPHONE_67 preview should be deleted
+          },
+        },
+      });
+
+      const locale = new AppStoreVersionLocalization(requestContext, 'LOC_1', {
+        locale: 'en-US',
+      } as any);
+
+      const existingPreview = new AppPreview(requestContext, 'PV_1', {
+        fileName: 'demo.mp4',
+        fileSize: 10240,
+        previewFrameTimeCode: null,
+        assetDeliveryState: { state: 'COMPLETE', errors: [], warnings: [] },
+      } as any);
+
+      const deleteScope = nock('https://api.appstoreconnect.apple.com')
+        .delete(`/v1/${AppPreview.type}/PV_1`)
+        .reply(204);
+
+      const previewTypeMap = new Map<PreviewType, AppPreviewSet>();
+      previewTypeMap.set(
+        PreviewType.IPHONE_67,
+        new AppPreviewSet(requestContext, 'PSET_1', {
+          previewType: PreviewType.IPHONE_67,
+          appPreviews: [existingPreview],
+        } as any)
+      );
+
+      const previewSets = new Map();
+      previewSets.set('en-US', previewTypeMap);
+
+      await new PreviewsTask().uploadAsync({
+        config,
+        context: {
+          previewSets,
+          versionLocales: [locale],
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      expect(deleteScope.isDone()).toBeTruthy();
     });
   });
 });

--- a/packages/eas-cli/src/metadata/apple/tasks/previews.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/previews.ts
@@ -1,4 +1,5 @@
 import {
+  ALL_PREVIEW_TYPES,
   AppPreview,
   AppPreviewSet,
   AppStoreVersionLocalization,
@@ -136,9 +137,7 @@ export class PreviewsTask extends AppleTask {
 
     for (const localeCode of locales) {
       const previews = config.getPreviews(localeCode);
-      if (!previews || Object.keys(previews).length === 0) {
-        continue;
-      }
+      const existingSets = context.previewSets.get(localeCode);
 
       const localization = context.versionLocales.find(l => l.attributes.locale === localeCode);
       if (!localization) {
@@ -146,18 +145,51 @@ export class PreviewsTask extends AppleTask {
         continue;
       }
 
-      for (const [previewType, previewConfig] of Object.entries(previews)) {
-        if (!previewConfig) {
-          continue;
-        }
+      // Upload/sync configured previews
+      if (previews) {
+        for (const [previewType, previewConfig] of Object.entries(previews)) {
+          if (!previewConfig) {
+            continue;
+          }
 
-        await syncPreviewSetAsync(
-          context.projectDir,
-          localization,
-          previewType as PreviewType,
-          normalizePreviewConfig(previewConfig),
-          context.previewSets.get(localeCode)
-        );
+          if (!ALL_PREVIEW_TYPES.includes(previewType as PreviewType)) {
+            const strippedType = previewType.replace(/^APP_/, '');
+            const suggestion = ALL_PREVIEW_TYPES.includes(strippedType as PreviewType)
+              ? chalk` Did you mean {bold ${strippedType}}? Preview types don't use the "APP_" prefix (that's only for screenshots).`
+              : '';
+            Log.warn(
+              chalk`{yellow Unknown preview type {bold ${previewType}} for ${localeCode}, skipping.${suggestion}}`
+            );
+            Log.warn(chalk`{yellow Valid preview types: ${ALL_PREVIEW_TYPES.join(', ')}}`);
+            continue;
+          }
+
+          await syncPreviewSetAsync(
+            context.projectDir,
+            localization,
+            previewType as PreviewType,
+            normalizePreviewConfig(previewConfig),
+            existingSets
+          );
+        }
+      }
+
+      // Delete remote previews for types no longer in config
+      if (existingSets) {
+        for (const [previewType, previewSet] of existingSets) {
+          if (previews?.[previewType]) {
+            continue;
+          }
+
+          const existingPreviews = previewSet.attributes.appPreviews || [];
+          for (const preview of existingPreviews) {
+            await logAsync(() => preview.deleteAsync(), {
+              pending: `Deleting video preview ${chalk.bold(preview.attributes.fileName)} (${localeCode})...`,
+              success: `Deleted video preview ${chalk.bold(preview.attributes.fileName)} (${localeCode})`,
+              failure: `Failed deleting video preview ${chalk.bold(preview.attributes.fileName)} (${localeCode})`,
+            });
+          }
+        }
       }
     }
   }
@@ -231,15 +263,15 @@ async function syncPreviewSetAsync(
     return;
   }
 
-  // Delete existing previews that don't match
+  // Delete all existing previews before uploading the new one.
+  // Apple limits each set to 3 previews, and we manage one preview per set,
+  // so we need to clean up stale entries to avoid "Too many app previews" errors.
   for (const preview of existingPreviews) {
-    if (preview.attributes.fileName !== fileName) {
-      await logAsync(() => preview.deleteAsync(), {
-        pending: `Deleting old preview ${chalk.bold(preview.attributes.fileName)} (${locale})...`,
-        success: `Deleted old preview ${chalk.bold(preview.attributes.fileName)} (${locale})`,
-        failure: `Failed deleting old preview ${chalk.bold(preview.attributes.fileName)} (${locale})`,
-      });
-    }
+    await logAsync(() => preview.deleteAsync(), {
+      pending: `Deleting old preview ${chalk.bold(preview.attributes.fileName)} (${locale})...`,
+      success: `Deleted old preview ${chalk.bold(preview.attributes.fileName)} (${locale})`,
+      failure: `Failed deleting old preview ${chalk.bold(preview.attributes.fileName)} (${locale})`,
+    });
   }
 
   // Upload new preview


### PR DESCRIPTION
Validate preview types and improve cleanup to avoid Apple limits.

- In PreviewsTask.uploadAsync, skip unknown preview types and emit warnings. If the type uses an APP_ prefix and the stripped type is valid, suggest the corrected type. Also log the list of valid preview types.
- In syncPreviewSetAsync, delete all existing previews before uploading the new one to avoid "Too many app previews" errors (Apple limits each set to 3 previews).
- Add tests covering APP_ prefix suggestion and fully unknown preview types, and mock the Log module in tests.

<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->
