### PR TITLE
[build-tools] Add EAS_FALLBACK_PACKAGE_MANAGER env var support to package manager resolver

### DIFF
--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -173,7 +173,10 @@ export class BuildContext<TJob extends Job = Job> {
     return path.join(this.workingdir, 'env');
   }
   public get packageManager(): PackageManager {
-    return resolvePackageManager(this.getReactNativeProjectDirectory());
+    return resolvePackageManager(this.getReactNativeProjectDirectory(), {
+      env: this.env,
+      logger: this.logger,
+    });
   }
   public get appConfig(): Promise<ExpoConfig> {
     if (!this._appConfig) {

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -175,7 +175,6 @@ export class BuildContext<TJob extends Job = Job> {
   public get packageManager(): PackageManager {
     return resolvePackageManager(this.getReactNativeProjectDirectory(), {
       env: this.env,
-      logger: this.logger,
     });
   }
   public get appConfig(): Promise<ExpoConfig> {

--- a/packages/build-tools/src/steps/functions/eagerBundle.ts
+++ b/packages/build-tools/src/steps/functions/eagerBundle.ts
@@ -29,10 +29,7 @@ export function eagerBundleBuildFunction(): BuildFunction {
         throw new Error('Eager bundle is not supported for SDK version < 52');
       }
 
-      const packageManager = resolvePackageManager(stepsCtx.workingDirectory, {
-        env,
-        logger: stepsCtx.logger,
-      });
+      const packageManager = resolvePackageManager(stepsCtx.workingDirectory, { env });
       const resolvedEASUpdateRuntimeVersion = inputs.resolved_eas_update_runtime_version.value as
         | string
         | undefined;

--- a/packages/build-tools/src/steps/functions/eagerBundle.ts
+++ b/packages/build-tools/src/steps/functions/eagerBundle.ts
@@ -29,7 +29,10 @@ export function eagerBundleBuildFunction(): BuildFunction {
         throw new Error('Eager bundle is not supported for SDK version < 52');
       }
 
-      const packageManager = resolvePackageManager(stepsCtx.workingDirectory);
+      const packageManager = resolvePackageManager(stepsCtx.workingDirectory, {
+        env,
+        logger: stepsCtx.logger,
+      });
       const resolvedEASUpdateRuntimeVersion = inputs.resolved_eas_update_runtime_version.value as
         | string
         | undefined;

--- a/packages/build-tools/src/steps/functions/export.ts
+++ b/packages/build-tools/src/steps/functions/export.ts
@@ -69,7 +69,10 @@ export function createEasExportBuildFunction(): BuildFunction {
       const apiOnly = inputs.api_only.value as boolean | undefined;
       const platform = inputs.platform.value as string;
 
-      const packageManager = resolvePackageManager(stepsCtx.workingDirectory);
+      const packageManager = resolvePackageManager(stepsCtx.workingDirectory, {
+        env,
+        logger: stepsCtx.logger,
+      });
       const exportCommand = getExportCommand({
         outputDir,
         dev,

--- a/packages/build-tools/src/steps/functions/export.ts
+++ b/packages/build-tools/src/steps/functions/export.ts
@@ -69,10 +69,7 @@ export function createEasExportBuildFunction(): BuildFunction {
       const apiOnly = inputs.api_only.value as boolean | undefined;
       const platform = inputs.platform.value as string;
 
-      const packageManager = resolvePackageManager(stepsCtx.workingDirectory, {
-        env,
-        logger: stepsCtx.logger,
-      });
+      const packageManager = resolvePackageManager(stepsCtx.workingDirectory, { env });
       const exportCommand = getExportCommand({
         outputDir,
         dev,

--- a/packages/build-tools/src/steps/functions/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/installNodeModules.ts
@@ -27,7 +27,7 @@ export async function installNodeModules(
   env: BuildStepEnv
 ): Promise<void> {
   const { logger } = stepCtx;
-  const packageManager = resolvePackageManager(stepCtx.workingDirectory, { env, logger });
+  const packageManager = resolvePackageManager(stepCtx.workingDirectory, { env });
   const packagerRunDir = findPackagerRootDir(stepCtx.workingDirectory);
 
   if (packagerRunDir !== stepCtx.workingDirectory) {

--- a/packages/build-tools/src/steps/functions/installNodeModules.ts
+++ b/packages/build-tools/src/steps/functions/installNodeModules.ts
@@ -27,7 +27,7 @@ export async function installNodeModules(
   env: BuildStepEnv
 ): Promise<void> {
   const { logger } = stepCtx;
-  const packageManager = resolvePackageManager(stepCtx.workingDirectory);
+  const packageManager = resolvePackageManager(stepCtx.workingDirectory, { env, logger });
   const packagerRunDir = findPackagerRootDir(stepCtx.workingDirectory);
 
   if (packagerRunDir !== stepCtx.workingDirectory) {

--- a/packages/build-tools/src/steps/functions/prebuild.ts
+++ b/packages/build-tools/src/steps/functions/prebuild.ts
@@ -32,7 +32,7 @@ export function createPrebuildBuildFunction(): BuildFunction {
     fn: async (stepCtx, { inputs, env }) => {
       const { logger } = stepCtx;
       const appleTeamId = inputs.apple_team_id.value as string | undefined;
-      const packageManager = resolvePackageManager(stepCtx.workingDirectory);
+      const packageManager = resolvePackageManager(stepCtx.workingDirectory, { env, logger });
       const defaultPlatform = process.platform === 'darwin' ? 'ios' : 'android';
 
       const job = stepCtx.global.staticContext.job;

--- a/packages/build-tools/src/steps/functions/prebuild.ts
+++ b/packages/build-tools/src/steps/functions/prebuild.ts
@@ -32,7 +32,7 @@ export function createPrebuildBuildFunction(): BuildFunction {
     fn: async (stepCtx, { inputs, env }) => {
       const { logger } = stepCtx;
       const appleTeamId = inputs.apple_team_id.value as string | undefined;
-      const packageManager = resolvePackageManager(stepCtx.workingDirectory, { env, logger });
+      const packageManager = resolvePackageManager(stepCtx.workingDirectory, { env });
       const defaultPlatform = process.platform === 'darwin' ? 'ios' : 'android';
 
       const job = stepCtx.global.staticContext.job;

--- a/packages/build-tools/src/utils/__tests__/packageManager.test.ts
+++ b/packages/build-tools/src/utils/__tests__/packageManager.test.ts
@@ -4,7 +4,9 @@ import { vol } from 'memfs';
 import path from 'path';
 import semver from 'semver';
 
+import { createMockLogger } from '../../__tests__/utils/logger';
 import {
+  PackageManager,
   findPackagerRootDir,
   getPackageVersionFromPackageJson,
   resolvePackageManager,
@@ -68,6 +70,70 @@ describe(resolvePackageManager, () => {
     await fs.writeFile(path.join(nestedDir, 'package.json'), 'content');
 
     expect(resolvePackageManager(nestedDir)).toBe('yarn');
+  });
+
+  it('returns yarn when no lockfile and no env var is provided', () => {
+    expect(resolvePackageManager(rootDir, { env: {} })).toBe(PackageManager.YARN);
+  });
+
+  it('returns yarn when no lockfile and env var is an empty string', () => {
+    const logger = createMockLogger();
+    expect(
+      resolvePackageManager(rootDir, {
+        env: { EAS_FALLBACK_PACKAGE_MANAGER: '' },
+        logger,
+      })
+    ).toBe(PackageManager.YARN);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('returns bun from EAS_FALLBACK_PACKAGE_MANAGER when no lockfile', () => {
+    expect(resolvePackageManager(rootDir, { env: { EAS_FALLBACK_PACKAGE_MANAGER: 'bun' } })).toBe(
+      PackageManager.BUN
+    );
+  });
+
+  it('returns pnpm from EAS_FALLBACK_PACKAGE_MANAGER when no lockfile', () => {
+    expect(resolvePackageManager(rootDir, { env: { EAS_FALLBACK_PACKAGE_MANAGER: 'pnpm' } })).toBe(
+      PackageManager.PNPM
+    );
+  });
+
+  it('ignores EAS_FALLBACK_PACKAGE_MANAGER when a lockfile exists', async () => {
+    await fs.writeFile(path.join(rootDir, 'package-lock.json'), 'content');
+    const logger = createMockLogger();
+    expect(
+      resolvePackageManager(rootDir, {
+        env: { EAS_FALLBACK_PACKAGE_MANAGER: 'bunn' }, // invalid, but should not even be read
+        logger,
+      })
+    ).toBe(PackageManager.NPM);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs a warning and falls back to yarn on unsupported EAS_FALLBACK_PACKAGE_MANAGER value', () => {
+    const logger = createMockLogger();
+    expect(
+      resolvePackageManager(rootDir, {
+        env: { EAS_FALLBACK_PACKAGE_MANAGER: 'bunn' },
+        logger,
+      })
+    ).toBe(PackageManager.YARN);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('bunn'));
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('EAS_FALLBACK_PACKAGE_MANAGER')
+    );
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('yarn'));
+  });
+
+  it('falls back to yarn on unsupported EAS_FALLBACK_PACKAGE_MANAGER value when no logger is provided', () => {
+    expect(() =>
+      resolvePackageManager(rootDir, { env: { EAS_FALLBACK_PACKAGE_MANAGER: 'bunn' } })
+    ).not.toThrow();
+    expect(resolvePackageManager(rootDir, { env: { EAS_FALLBACK_PACKAGE_MANAGER: 'bunn' } })).toBe(
+      PackageManager.YARN
+    );
   });
 });
 

--- a/packages/build-tools/src/utils/__tests__/packageManager.test.ts
+++ b/packages/build-tools/src/utils/__tests__/packageManager.test.ts
@@ -1,10 +1,10 @@
+import { errors } from '@expo/eas-build-job';
 import { type bunyan } from '@expo/logger';
 import fs from 'fs-extra';
 import { vol } from 'memfs';
 import path from 'path';
 import semver from 'semver';
 
-import { createMockLogger } from '../../__tests__/utils/logger';
 import {
   PackageManager,
   findPackagerRootDir,
@@ -25,23 +25,23 @@ describe(resolvePackageManager, () => {
   });
 
   it('returns yarn when no lockfiles exist', async () => {
-    expect(resolvePackageManager(rootDir)).toBe('yarn');
+    expect(resolvePackageManager(rootDir, { env: {} })).toBe('yarn');
   });
 
   it('returns npm when only package-json.lock exist', async () => {
     await fs.writeFile(path.join(rootDir, 'package-lock.json'), 'content');
-    expect(resolvePackageManager(rootDir)).toBe('npm');
+    expect(resolvePackageManager(rootDir, { env: {} })).toBe('npm');
   });
 
   it('returns yarn when only yarn.lock exists', async () => {
     await fs.writeFile(path.join(rootDir, 'yarn.lock'), 'content');
-    expect(resolvePackageManager(rootDir)).toBe('yarn');
+    expect(resolvePackageManager(rootDir, { env: {} })).toBe('yarn');
   });
 
   it('returns yarn when both lockfiles exists', async () => {
     await fs.writeFile(path.join(rootDir, 'yarn.lock'), 'content');
     await fs.writeFile(path.join(rootDir, 'package-lock.json'), 'content');
-    expect(resolvePackageManager(rootDir)).toBe('yarn');
+    expect(resolvePackageManager(rootDir, { env: {} })).toBe('yarn');
   });
 
   it('returns npm within a monorepo', async () => {
@@ -57,7 +57,7 @@ describe(resolvePackageManager, () => {
       name: '@monorepo/expo-app',
     });
 
-    expect(resolvePackageManager(nestedDir)).toBe('npm');
+    expect(resolvePackageManager(nestedDir, { env: {} })).toBe('npm');
   });
 
   it('returns yarn with an invalid monorepo', async () => {
@@ -69,22 +69,15 @@ describe(resolvePackageManager, () => {
     await fs.mkdirp(nestedDir);
     await fs.writeFile(path.join(nestedDir, 'package.json'), 'content');
 
-    expect(resolvePackageManager(nestedDir)).toBe('yarn');
-  });
-
-  it('returns yarn when no lockfile and no env var is provided', () => {
-    expect(resolvePackageManager(rootDir, { env: {} })).toBe(PackageManager.YARN);
+    expect(resolvePackageManager(nestedDir, { env: {} })).toBe('yarn');
   });
 
   it('returns yarn when no lockfile and env var is an empty string', () => {
-    const logger = createMockLogger();
     expect(
       resolvePackageManager(rootDir, {
         env: { EAS_FALLBACK_PACKAGE_MANAGER: '' },
-        logger,
       })
     ).toBe(PackageManager.YARN);
-    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('returns bun from EAS_FALLBACK_PACKAGE_MANAGER when no lockfile', () => {
@@ -101,39 +94,26 @@ describe(resolvePackageManager, () => {
 
   it('ignores EAS_FALLBACK_PACKAGE_MANAGER when a lockfile exists', async () => {
     await fs.writeFile(path.join(rootDir, 'package-lock.json'), 'content');
-    const logger = createMockLogger();
     expect(
       resolvePackageManager(rootDir, {
         env: { EAS_FALLBACK_PACKAGE_MANAGER: 'bunn' }, // invalid, but should not even be read
-        logger,
       })
     ).toBe(PackageManager.NPM);
-    expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it('logs a warning and falls back to yarn on unsupported EAS_FALLBACK_PACKAGE_MANAGER value', () => {
-    const logger = createMockLogger();
-    expect(
-      resolvePackageManager(rootDir, {
-        env: { EAS_FALLBACK_PACKAGE_MANAGER: 'bunn' },
-        logger,
-      })
-    ).toBe(PackageManager.YARN);
-    expect(logger.warn).toHaveBeenCalledTimes(1);
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('bunn'));
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('EAS_FALLBACK_PACKAGE_MANAGER')
-    );
-    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('yarn'));
-  });
-
-  it('falls back to yarn on unsupported EAS_FALLBACK_PACKAGE_MANAGER value when no logger is provided', () => {
+  it('throws a UserError on unsupported EAS_FALLBACK_PACKAGE_MANAGER value', () => {
     expect(() =>
       resolvePackageManager(rootDir, { env: { EAS_FALLBACK_PACKAGE_MANAGER: 'bunn' } })
-    ).not.toThrow();
-    expect(resolvePackageManager(rootDir, { env: { EAS_FALLBACK_PACKAGE_MANAGER: 'bunn' } })).toBe(
-      PackageManager.YARN
-    );
+    ).toThrow(errors.UserError);
+    try {
+      resolvePackageManager(rootDir, { env: { EAS_FALLBACK_PACKAGE_MANAGER: 'bunn' } });
+    } catch (e) {
+      expect(e).toBeInstanceOf(errors.UserError);
+      const error = e as errors.UserError;
+      expect(error.errorCode).toBe('EAS_INVALID_FALLBACK_PACKAGE_MANAGER');
+      expect(error.message).toContain('bunn');
+      expect(error.message).toContain('yarn, npm, pnpm, bun');
+    }
   });
 });
 

--- a/packages/build-tools/src/utils/packageManager.ts
+++ b/packages/build-tools/src/utils/packageManager.ts
@@ -1,5 +1,6 @@
 import { type bunyan } from '@expo/logger';
 import * as PackageManagerUtils from '@expo/package-manager';
+import { type BuildStepEnv } from '@expo/steps';
 import spawnAsync from '@expo/turtle-spawn';
 import semver from 'semver';
 import { z } from 'zod';
@@ -11,7 +12,16 @@ export enum PackageManager {
   BUN = 'bun',
 }
 
-export function resolvePackageManager(directory: string): PackageManager {
+export function resolvePackageManager(
+  directory: string,
+  {
+    env,
+    logger,
+  }: {
+    env?: BuildStepEnv;
+    logger?: bunyan;
+  } = {}
+): PackageManager {
   try {
     const manager = PackageManagerUtils.resolvePackageManager(directory);
     if (manager === 'npm') {
@@ -20,12 +30,23 @@ export function resolvePackageManager(directory: string): PackageManager {
       return PackageManager.PNPM;
     } else if (manager === 'bun') {
       return PackageManager.BUN;
-    } else {
+    } else if (manager === 'yarn') {
       return PackageManager.YARN;
     }
-  } catch {
-    return PackageManager.YARN;
+  } catch {}
+
+  const fallback = env?.EAS_FALLBACK_PACKAGE_MANAGER;
+  if (fallback) {
+    const parsed = z.enum(PackageManager).safeParse(fallback);
+    if (parsed.success) {
+      return parsed.data;
+    }
+    const allowed = Object.values(PackageManager).join(', ');
+    logger?.warn(
+      `Ignoring invalid EAS_FALLBACK_PACKAGE_MANAGER value "${fallback}" (expected one of: ${allowed}). Falling back to ${PackageManager.YARN}.`
+    );
   }
+  return PackageManager.YARN;
 }
 
 /**

--- a/packages/build-tools/src/utils/packageManager.ts
+++ b/packages/build-tools/src/utils/packageManager.ts
@@ -1,3 +1,4 @@
+import { errors } from '@expo/eas-build-job';
 import { type bunyan } from '@expo/logger';
 import * as PackageManagerUtils from '@expo/package-manager';
 import { type BuildStepEnv } from '@expo/steps';
@@ -14,13 +15,7 @@ export enum PackageManager {
 
 export function resolvePackageManager(
   directory: string,
-  {
-    env,
-    logger,
-  }: {
-    env?: BuildStepEnv;
-    logger?: bunyan;
-  } = {}
+  { env }: { env: BuildStepEnv }
 ): PackageManager {
   try {
     const manager = PackageManagerUtils.resolvePackageManager(directory);
@@ -35,15 +30,16 @@ export function resolvePackageManager(
     }
   } catch {}
 
-  const fallback = env?.EAS_FALLBACK_PACKAGE_MANAGER;
+  const fallback = env.EAS_FALLBACK_PACKAGE_MANAGER;
   if (fallback) {
     const parsed = z.enum(PackageManager).safeParse(fallback);
     if (parsed.success) {
       return parsed.data;
     }
     const allowed = Object.values(PackageManager).join(', ');
-    logger?.warn(
-      `Ignoring invalid EAS_FALLBACK_PACKAGE_MANAGER value "${fallback}" (expected one of: ${allowed}). Falling back to ${PackageManager.YARN}.`
+    throw new errors.UserError(
+      'EAS_INVALID_FALLBACK_PACKAGE_MANAGER',
+      `Invalid EAS_FALLBACK_PACKAGE_MANAGER value "${fallback}" (expected one of: ${allowed}).`
     );
   }
   return PackageManager.YARN;

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -403,6 +403,7 @@ describe('Ios.JobSchema', () => {
     );
     expect(value).not.toMatchObject(managedJob);
   });
+
   test('validates channel', () => {
     const managedJob = {
       secrets: {


### PR DESCRIPTION
# Why

This PR implements the `eas-cli` / build-tools side of [ENG-20326](https://linear.app/expo/issue/ENG-20326).

Today, when package manager detection cannot determine a package manager from the project, build-tools falls back to `yarn`. That fallback is hardcoded. For example, if Launch wants to use `bun` as the fallback package manager, it currently has to fork steps such as `install_node_modules` to get that behavior.

We want to support a way for Launch (and any job) to customize this fallback. After review discussion (thanks @sjchmiela), we landed on an env-var-based approach: setting `EAS_FALLBACK_PACKAGE_MANAGER` at the job env level is enough to override the `yarn` default. This keeps the surface area minimal — no changes to `@expo/eas-build-job` schemas or the `www` workflow compilation are needed.

The env var propagates through the existing env chain (`jobs.<job>.env` → `job.builderEnvironment.env` → `BuildContext.env` → step `env` parameter), so Launch sets it once per job and all steps that resolve package managers pick it up automatically.

# How

- `resolvePackageManager()` gets two new optional parameters, `env` and `logger`.
- When lockfile detection returns no known package manager, the resolver reads `env?.EAS_FALLBACK_PACKAGE_MANAGER`, validates it against the `PackageManager` enum, and returns the chosen manager. Invalid values log a warning and fall back to `yarn` — user typos don't fail the build.
- Five call sites updated to forward the `env` / `logger` they already hold:
  - `BuildContext.packageManager` getter
  - `eas/install_node_modules`, `eas/prebuild`, `eas/eager_bundle`, `eas/export` step functions

# Test Plan

Automation tests in `packages/build-tools/src/utils/__tests__/packageManager.test.ts` cover:
- detection still wins when a lockfile exists (env var is ignored even if invalid)
- empty / unset env var falls back to `yarn` silently
- valid env var values (`bun`, `pnpm`, …) are honored
- invalid env var values fall back to `yarn` and log a warning with the offending value and env var name
- no logger passed → falls back silently without throwing