### PR TITLE
[eas-cli] Improve observe:metrics handling of app version update IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Fixes for `observe` commands, including an issue for apps with many update IDs. ([#3609](https://github.com/expo/eas-cli/pull/3609) by [@douglowder](https://github.com/douglowder))
+
 ### 🧹 Chores
 
 ## [18.7.0](https://github.com/expo/eas-cli/releases/tag/v18.7.0) - 2026-04-14

--- a/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
@@ -199,6 +199,8 @@ describe(ObserveMetrics, () => {
       expect.any(Map),
       expect.any(Array),
       ['min', 'average'],
+      expect.any(Map),
+      expect.any(Map),
       expect.any(Map)
     );
     expect(mockPrintJsonOnlyOutput).toHaveBeenCalled();

--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -81,16 +81,29 @@ export default class ObserveEvents extends EasCommand {
     ...this.ContextOptions.LoggedIn,
   };
 
+  private static loggedInOnlyContextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+  };
+
   async runAsync(): Promise<void> {
     const { flags, args } = await this.parse(ObserveEvents);
-    const {
-      projectId: contextProjectId,
-      loggedIn: { graphqlClient },
-    } = await this.getContextAsync(ObserveEvents, {
-      nonInteractive: flags['non-interactive'],
-    });
 
-    const projectId = flags['project-id'] ?? contextProjectId;
+    let projectId: string;
+    let graphqlClient;
+    if (flags['project-id']) {
+      projectId = flags['project-id'];
+      const ctx = await this.getContextAsync(
+        { contextDefinition: ObserveEvents.loggedInOnlyContextDefinition },
+        { nonInteractive: flags['non-interactive'] }
+      );
+      graphqlClient = ctx.loggedIn.graphqlClient;
+    } else {
+      const ctx = await this.getContextAsync(ObserveEvents, {
+        nonInteractive: flags['non-interactive'],
+      });
+      projectId = ctx.projectId;
+      graphqlClient = ctx.loggedIn.graphqlClient;
+    }
 
     if (flags.json) {
       enableJsonOutput();

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -78,16 +78,29 @@ export default class ObserveMetrics extends EasCommand {
     ...this.ContextOptions.LoggedIn,
   };
 
+  private static loggedInOnlyContextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+  };
+
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(ObserveMetrics);
-    const {
-      projectId: contextProjectId,
-      loggedIn: { graphqlClient },
-    } = await this.getContextAsync(ObserveMetrics, {
-      nonInteractive: flags['non-interactive'],
-    });
 
-    const projectId = flags['project-id'] ?? contextProjectId;
+    let projectId: string;
+    let graphqlClient;
+    if (flags['project-id']) {
+      projectId = flags['project-id'];
+      const ctx = await this.getContextAsync(
+        { contextDefinition: ObserveMetrics.loggedInOnlyContextDefinition },
+        { nonInteractive: flags['non-interactive'] }
+      );
+      graphqlClient = ctx.loggedIn.graphqlClient;
+    } else {
+      const ctx = await this.getContextAsync(ObserveMetrics, {
+        nonInteractive: flags['non-interactive'],
+      });
+      projectId = ctx.projectId;
+      graphqlClient = ctx.loggedIn.graphqlClient;
+    }
 
     if (flags.json) {
       enableJsonOutput();

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -122,7 +122,14 @@ export default class ObserveMetrics extends EasCommand {
     if (flags.json) {
       const stats: StatisticKey[] = argumentsStat ?? DEFAULT_STATS_JSON;
       printJsonOnlyOutput(
-        buildObserveMetricsJson(metricsMap, metricNames, stats, totalEventCounts)
+        buildObserveMetricsJson(
+          metricsMap,
+          metricNames,
+          stats,
+          totalEventCounts,
+          buildNumbersMap,
+          updateIdsMap
+        )
       );
     } else {
       const stats: StatisticKey[] = argumentsStat ?? DEFAULT_STATS_TABLE;
@@ -131,7 +138,6 @@ export default class ObserveMetrics extends EasCommand {
         buildObserveMetricsTable(metricsMap, metricNames, stats, {
           daysBack,
           buildNumbersMap,
-          updateIdsMap,
           totalEventCounts,
         })
       );

--- a/packages/eas-cli/src/commands/observe/versions.ts
+++ b/packages/eas-cli/src/commands/observe/versions.ts
@@ -42,16 +42,29 @@ export default class ObserveVersions extends EasCommand {
     ...this.ContextOptions.LoggedIn,
   };
 
+  private static loggedInOnlyContextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+  };
+
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(ObserveVersions);
-    const {
-      projectId: contextProjectId,
-      loggedIn: { graphqlClient },
-    } = await this.getContextAsync(ObserveVersions, {
-      nonInteractive: flags['non-interactive'],
-    });
 
-    const projectId = flags['project-id'] ?? contextProjectId;
+    let projectId: string;
+    let graphqlClient;
+    if (flags['project-id']) {
+      projectId = flags['project-id'];
+      const ctx = await this.getContextAsync(
+        { contextDefinition: ObserveVersions.loggedInOnlyContextDefinition },
+        { nonInteractive: flags['non-interactive'] }
+      );
+      graphqlClient = ctx.loggedIn.graphqlClient;
+    } else {
+      const ctx = await this.getContextAsync(ObserveVersions, {
+        nonInteractive: flags['non-interactive'],
+      });
+      projectId = ctx.projectId;
+      graphqlClient = ctx.loggedIn.graphqlClient;
+    }
 
     if (flags.json) {
       enableJsonOutput();

--- a/packages/eas-cli/src/observe/__tests__/formatMetrics.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatMetrics.test.ts
@@ -126,6 +126,8 @@ describe(buildObserveMetricsJson, () => {
     expect(result.versions[0]).toEqual({
       appVersion: '1.0.0',
       platform: AppPlatform.Ios,
+      buildNumbers: [],
+      updateIds: [],
       metrics: {
         'expo.app_startup.tti': {
           min: 0.1,

--- a/packages/eas-cli/src/observe/formatMetrics.ts
+++ b/packages/eas-cli/src/observe/formatMetrics.ts
@@ -105,6 +105,8 @@ export type MetricValuesJson = Partial<Record<StatisticKey, number | null>>;
 export interface ObserveMetricsVersionResult {
   appVersion: string;
   platform: AppPlatform;
+  buildNumbers: string[];
+  updateIds: string[];
   metrics: Record<string, MetricValuesJson>;
 }
 
@@ -117,7 +119,9 @@ export function buildObserveMetricsJson(
   metricsMap: ObserveMetricsMap,
   metricNames: string[],
   stats: StatisticKey[],
-  totalEventCounts?: Map<string, number>
+  totalEventCounts?: Map<string, number>,
+  buildNumbersMap?: BuildNumbersMap,
+  updateIdsMap?: UpdateIdsMap
 ): ObserveMetricsJsonOutput {
   const versions: ObserveMetricsVersionResult[] = [];
 
@@ -134,7 +138,13 @@ export function buildObserveMetricsJson(
       metrics[metricName] = statValues;
     }
 
-    versions.push({ appVersion, platform, metrics });
+    versions.push({
+      appVersion,
+      platform,
+      buildNumbers: buildNumbersMap?.get(key) ?? [],
+      updateIds: updateIdsMap?.get(key) ?? [],
+      metrics,
+    });
   }
 
   // Group total event counts by metric → platform
@@ -188,7 +198,6 @@ export function buildObserveMetricsTable(
   options?: {
     daysBack?: number;
     buildNumbersMap?: BuildNumbersMap;
-    updateIdsMap?: UpdateIdsMap;
     totalEventCounts?: Map<string, number>;
   }
 ): string {
@@ -232,12 +241,7 @@ export function buildObserveMetricsTable(
       }
     }
   }
-  // Check if any version has updates
-  const hasUpdates = options?.updateIdsMap
-    ? Array.from(options.updateIdsMap.values()).some(ids => ids.length > 0)
-    : false;
-
-  const headers = ['App Version', ...(hasUpdates ? ['Updates'] : []), ...metricHeaders];
+  const headers = ['App Version', ...metricHeaders];
 
   const sections: string[] = [chalk.bold(summaryLine)];
 
@@ -245,15 +249,13 @@ export function buildObserveMetricsTable(
     sections.push('');
     sections.push(chalk.bold(appPlatformDisplayNames[platform]));
 
-    const rows: string[][] = platformResults.map(result => {
+    const rows: string[][] = [];
+    for (const result of platformResults) {
       const key = makeMetricsKey(result.appVersion, result.platform);
       const buildNumbers = options?.buildNumbersMap?.get(key);
       const versionLabel = buildNumbers?.length
         ? `${result.appVersion} (${buildNumbers.join(', ')})`
         : result.appVersion;
-
-      const updateIds = options?.updateIdsMap?.get(key);
-      const updatesLabel = updateIds?.length ? updateIds.join(', ') : '';
 
       const metricCells: string[] = [];
       for (const m of metricNames) {
@@ -272,8 +274,9 @@ export function buildObserveMetricsTable(
           }
         }
       }
-      return [versionLabel, ...(hasUpdates ? [updatesLabel] : []), ...metricCells];
-    });
+
+      rows.push([versionLabel, ...metricCells]);
+    }
 
     let footerRow: string[] | undefined;
     if (options?.totalEventCounts) {
@@ -283,7 +286,7 @@ export function buildObserveMetricsTable(
         countCells.push(count != null ? count.toLocaleString() : '-');
       }
       if (countCells.some(c => c !== '-')) {
-        footerRow = ['Total events', ...(hasUpdates ? [''] : []), ...countCells];
+        footerRow = ['Total events', ...countCells];
       }
     }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Currently the output of observe:metrics is unusable if an app version has many updates. Since the metrics are not broken out by update, it makes sense to make two changes:

- Remove update IDs from the display table
- Add the update IDs to the JSON output as an array, in case they are needed as input to other commands, or to AI

Additionally, made a change so that if a project ID is manually passed in, the observe commands do not unnecessarily try to create a new EAS project where none is needed.

# Test Plan

- Unit tests pass
- Tested manually against existing projects with metrics