### PR TITLE
[build-tools] Reuse target_names to avoid duplicate iOS credentials preparation

### DIFF
--- a/packages/build-tools/src/steps/functionGroups/__tests__/build.test.ts
+++ b/packages/build-tools/src/steps/functionGroups/__tests__/build.test.ts
@@ -107,6 +107,27 @@ describe(createEasBuildBuildFunctionGroup, () => {
       }
     });
 
+    it('wires configure_ios_credentials target_names into configure_ios_version', () => {
+      const buildToolsContext = createMockBuildToolsContext({
+        platform: Platform.IOS,
+        buildCredentials: { test: {} },
+      });
+      const functionGroup = createEasBuildBuildFunctionGroup(buildToolsContext);
+      const globalCtx = createGlobalContextMock({ logger: createMockLogger() });
+
+      const steps = functionGroup.createBuildStepsFromFunctionGroupCall(globalCtx, {
+        callInputs: { working_directory: './my-app' },
+      });
+
+      const configureIosVersionStep = steps.find(s => s.displayName === 'Configure iOS version');
+      const targetNamesInput = configureIosVersionStep?.inputs?.find(
+        input => input.id === 'target_names'
+      );
+
+      expect(configureIosVersionStep).toBeDefined();
+      expect(targetNamesInput?.rawValue).toBe('${ steps.configure_ios_credentials.target_names }');
+    });
+
     it('composes working directory with installPods step-level ./ios dir (iOS)', () => {
       const buildToolsContext = createMockBuildToolsContext({
         platform: Platform.IOS,

--- a/packages/build-tools/src/steps/functionGroups/__tests__/build.test.ts
+++ b/packages/build-tools/src/steps/functionGroups/__tests__/build.test.ts
@@ -125,7 +125,9 @@ describe(createEasBuildBuildFunctionGroup, () => {
       );
 
       expect(configureIosVersionStep).toBeDefined();
-      expect(targetNamesInput?.rawValue).toBe('${ steps.configure_ios_credentials.target_names }');
+      expect(targetNamesInput?.rawValue).toBe(
+        '${{ steps.configure_ios_credentials.outputs.target_names }}'
+      );
     });
 
     it('composes working directory with installPods step-level ./ios dir (iOS)', () => {

--- a/packages/build-tools/src/steps/functionGroups/build.ts
+++ b/packages/build-tools/src/steps/functionGroups/build.ts
@@ -255,7 +255,6 @@ function createStepsForIosBuildWithCredentials({
       workingDirectory,
     }),
     configureIosVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
-      id: 'configure_ios_version',
       workingDirectory,
       callInputs: {
         target_names: '${ steps.configure_ios_credentials.target_names }',

--- a/packages/build-tools/src/steps/functionGroups/build.ts
+++ b/packages/build-tools/src/steps/functionGroups/build.ts
@@ -251,10 +251,15 @@ function createStepsForIosBuildWithCredentials({
     installPods,
     configureEASUpdate,
     configureIosCredentialsFunction().createBuildStepFromFunctionCall(globalCtx, {
+      id: 'configure_ios_credentials',
       workingDirectory,
     }),
     configureIosVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
+      id: 'configure_ios_version',
       workingDirectory,
+      callInputs: {
+        target_names: '${ steps.configure_ios_credentials.target_names }',
+      },
     }),
     ...(shouldUseEagerBundle(globalCtx.staticContext.metadata)
       ? [

--- a/packages/build-tools/src/steps/functionGroups/build.ts
+++ b/packages/build-tools/src/steps/functionGroups/build.ts
@@ -257,7 +257,7 @@ function createStepsForIosBuildWithCredentials({
     configureIosVersionFunction().createBuildStepFromFunctionCall(globalCtx, {
       workingDirectory,
       callInputs: {
-        target_names: '${ steps.configure_ios_credentials.target_names }',
+        target_names: '${{ steps.configure_ios_credentials.outputs.target_names }}',
       },
     }),
     ...(shouldUseEagerBundle(globalCtx.staticContext.metadata)

--- a/packages/build-tools/src/steps/functions/__tests__/configureIosCredentials.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/configureIosCredentials.test.ts
@@ -1,0 +1,81 @@
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createTestIosJob } from '../../../__tests__/utils/job';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { configureCredentialsAsync } from '../../utils/ios/configure';
+import IosCredentialsManager, { type Credentials } from '../../utils/ios/credentials/manager';
+import { DistributionType } from '../../utils/ios/credentials/provisioningProfile';
+import { configureIosCredentialsFunction } from '../configureIosCredentials';
+
+jest.mock('../../utils/ios/configure');
+jest.mock('../../utils/ios/credentials/manager');
+
+function createCredentials({
+  targetNames = ['app', 'share-extension'],
+}: {
+  targetNames?: string[];
+} = {}): Credentials {
+  return {
+    applicationTargetProvisioningProfile: {} as Credentials['applicationTargetProvisioningProfile'],
+    keychainPath: '/tmp/keychain',
+    targetProvisioningProfiles: Object.fromEntries(
+      targetNames.map(targetName => [
+        targetName,
+        {
+          path: `/tmp/${targetName}.mobileprovision`,
+          target: targetName,
+          bundleIdentifier: `com.example.${targetName}`,
+          teamId: 'TEAMID123',
+          uuid: `${targetName}-uuid`,
+          name: `${targetName} profile`,
+          distributionType: DistributionType.AD_HOC,
+          developerCertificate: Buffer.from('certificate'),
+          certificateCommonName: `${targetName} cert`,
+        },
+      ])
+    ),
+    distributionType: DistributionType.AD_HOC,
+    teamId: 'TEAMID123',
+  };
+}
+
+function createRawCredentials() {
+  return {
+    app: {
+      provisioningProfileBase64: 'cHJvZmlsZQ==',
+      distributionCertificate: {
+        dataBase64: 'Y2VydA==',
+        password: '',
+      },
+    },
+  };
+}
+
+describe(configureIosCredentialsFunction, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mocked(configureCredentialsAsync).mockResolvedValue(undefined);
+  });
+
+  it('exports target_names from prepared credentials', async () => {
+    jest
+      .spyOn(IosCredentialsManager.prototype, 'prepare')
+      .mockResolvedValue(createCredentials({ targetNames: ['app', 'widget'] }));
+
+    const buildStep = configureIosCredentialsFunction().createBuildStepFromFunctionCall(
+      createGlobalContextMock({
+        logger: createMockLogger(),
+        staticContextContent: { job: createTestIosJob() },
+      }),
+      {
+        callInputs: {
+          credentials: createRawCredentials(),
+        },
+      }
+    );
+
+    await buildStep.executeAsync();
+
+    expect(configureCredentialsAsync).toHaveBeenCalled();
+    expect(buildStep.outputById.target_names.value).toBe(JSON.stringify(['app', 'widget']));
+  });
+});

--- a/packages/build-tools/src/steps/functions/__tests__/configureIosVersion.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/configureIosVersion.test.ts
@@ -1,3 +1,4 @@
+import { UserError } from '@expo/eas-build-job';
 import { BuildWorkflow } from '@expo/steps';
 
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
@@ -202,7 +203,7 @@ describe(configureIosVersionFunction, () => {
       globalCtx,
       {
         callInputs: {
-          target_names: '${ steps.configure_ios_credentials.target_names }',
+          target_names: '${{ steps.configure_ios_credentials.outputs.target_names }}',
           app_version: '1.2.3',
         },
       }
@@ -265,9 +266,9 @@ describe(configureIosVersionFunction, () => {
       },
     });
 
-    await expect(buildStep.executeAsync()).rejects.toThrow(
-      '"target_names" input must be an array of strings.'
-    );
+    const promise = buildStep.executeAsync();
+    await expect(promise).rejects.toBeInstanceOf(UserError);
+    await expect(promise).rejects.toThrow('"target_names" input must be an array of strings.');
   });
 
   it('uses the corrected App version error text', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/configureIosVersion.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/configureIosVersion.test.ts
@@ -1,9 +1,11 @@
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createTestIosJob } from '../../../__tests__/utils/job';
 import { createMockLogger } from '../../../__tests__/utils/logger';
+import { BuildWorkflow } from '@expo/steps';
 import { updateVersionsAsync } from '../../utils/ios/configure';
 import IosCredentialsManager, { type Credentials } from '../../utils/ios/credentials/manager';
 import { DistributionType } from '../../utils/ios/credentials/provisioningProfile';
+import { configureIosCredentialsFunction } from '../configureIosCredentials';
 import { configureIosVersionFunction } from '../configureIosVersion';
 
 jest.mock('../../utils/ios/configure');
@@ -176,6 +178,53 @@ describe(configureIosVersionFunction, () => {
       },
       {
         targetNames: ['input-target'],
+        buildConfiguration: 'Release',
+      }
+    );
+  });
+
+  it('parses target_names exported by configure_ios_credentials through workflow interpolation', async () => {
+    const prepareSpy = jest
+      .spyOn(IosCredentialsManager.prototype, 'prepare')
+      .mockResolvedValue(createCredentials({ targetNames: ['app', 'widget'] }));
+    const globalCtx = createGlobalContextMock({
+      logger: createMockLogger(),
+      staticContextContent: {
+        job: createTestIosJob({ buildCredentials: createRawCredentials() }),
+      },
+    });
+    const configureIosCredentialsStep =
+      configureIosCredentialsFunction().createBuildStepFromFunctionCall(globalCtx, {
+        id: 'configure_ios_credentials',
+      });
+    const configureIosVersionStep = configureIosVersionFunction().createBuildStepFromFunctionCall(
+      globalCtx,
+      {
+        callInputs: {
+          target_names: '${ steps.configure_ios_credentials.target_names }',
+          app_version: '1.2.3',
+        },
+      }
+    );
+
+    await new BuildWorkflow(globalCtx, {
+      buildSteps: [configureIosCredentialsStep, configureIosVersionStep],
+      buildFunctions: {},
+    }).executeAsync();
+
+    expect(prepareSpy).toHaveBeenCalledTimes(1);
+    expect(configureIosCredentialsStep.outputById.target_names.value).toBe(
+      JSON.stringify(['app', 'widget'])
+    );
+    expect(updateVersionsAsync).toHaveBeenCalledWith(
+      expect.anything(),
+      configureIosVersionStep.ctx.workingDirectory,
+      {
+        buildNumber: undefined,
+        appVersion: '1.2.3',
+      },
+      {
+        targetNames: ['app', 'widget'],
         buildConfiguration: 'Release',
       }
     );

--- a/packages/build-tools/src/steps/functions/__tests__/configureIosVersion.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/configureIosVersion.test.ts
@@ -1,0 +1,235 @@
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createTestIosJob } from '../../../__tests__/utils/job';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { updateVersionsAsync } from '../../utils/ios/configure';
+import IosCredentialsManager, { type Credentials } from '../../utils/ios/credentials/manager';
+import { DistributionType } from '../../utils/ios/credentials/provisioningProfile';
+import { configureIosVersionFunction } from '../configureIosVersion';
+
+jest.mock('../../utils/ios/configure');
+jest.mock('../../utils/ios/credentials/manager');
+
+function createCredentials({
+  targetNames = ['app', 'share-extension'],
+}: {
+  targetNames?: string[];
+} = {}): Credentials {
+  return {
+    applicationTargetProvisioningProfile: {} as Credentials['applicationTargetProvisioningProfile'],
+    keychainPath: '/tmp/keychain',
+    targetProvisioningProfiles: Object.fromEntries(
+      targetNames.map(targetName => [
+        targetName,
+        {
+          path: `/tmp/${targetName}.mobileprovision`,
+          target: targetName,
+          bundleIdentifier: `com.example.${targetName}`,
+          teamId: 'TEAMID123',
+          uuid: `${targetName}-uuid`,
+          name: `${targetName} profile`,
+          distributionType: DistributionType.AD_HOC,
+          developerCertificate: Buffer.from('certificate'),
+          certificateCommonName: `${targetName} cert`,
+        },
+      ])
+    ),
+    distributionType: DistributionType.AD_HOC,
+    teamId: 'TEAMID123',
+  };
+}
+
+function createRawCredentials() {
+  return {
+    app: {
+      provisioningProfileBase64: 'cHJvZmlsZQ==',
+      distributionCertificate: {
+        dataBase64: 'Y2VydA==',
+        password: '',
+      },
+    },
+  };
+}
+
+function createBuildStep({
+  callInputs = {},
+  job = createTestIosJob(),
+}: {
+  callInputs?: Record<string, unknown>;
+  job?: ReturnType<typeof createTestIosJob>;
+} = {}) {
+  return configureIosVersionFunction().createBuildStepFromFunctionCall(
+    createGlobalContextMock({
+      logger: createMockLogger(),
+      staticContextContent: { job },
+    }),
+    { callInputs }
+  );
+}
+
+describe(configureIosVersionFunction, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mocked(updateVersionsAsync).mockResolvedValue(undefined);
+  });
+
+  it('uses target_names without an explicit credentials input', async () => {
+    const buildStep = createBuildStep({
+      callInputs: {
+        target_names: ['app', 'widget'],
+        build_number: '42',
+      },
+    });
+
+    await buildStep.executeAsync();
+
+    expect(updateVersionsAsync).toHaveBeenCalledWith(
+      expect.anything(),
+      buildStep.ctx.workingDirectory,
+      {
+        buildNumber: '42',
+        appVersion: undefined,
+      },
+      {
+        targetNames: ['app', 'widget'],
+        buildConfiguration: 'Release',
+      }
+    );
+  });
+
+  it('uses credentials only to preserve the existing fallback path', async () => {
+    jest
+      .spyOn(IosCredentialsManager.prototype, 'prepare')
+      .mockResolvedValue(createCredentials({ targetNames: ['app', 'widget'] }));
+    const buildStep = createBuildStep({
+      callInputs: {
+        credentials: createRawCredentials(),
+        app_version: '1.2.3',
+      },
+    });
+
+    await buildStep.executeAsync();
+
+    expect(IosCredentialsManager.prototype.prepare).toHaveBeenCalledTimes(1);
+    expect(updateVersionsAsync).toHaveBeenCalledWith(
+      expect.anything(),
+      buildStep.ctx.workingDirectory,
+      {
+        buildNumber: undefined,
+        appVersion: '1.2.3',
+      },
+      {
+        targetNames: ['app', 'widget'],
+        buildConfiguration: 'Release',
+      }
+    );
+  });
+
+  it('uses the implicit credentials default fallback from the job secrets', async () => {
+    const prepareSpy = jest
+      .spyOn(IosCredentialsManager.prototype, 'prepare')
+      .mockResolvedValue(createCredentials({ targetNames: ['app', 'widget'] }));
+    const buildStep = createBuildStep({
+      job: createTestIosJob({ buildCredentials: createRawCredentials() }),
+      callInputs: {
+        app_version: '1.2.3',
+      },
+    });
+
+    await buildStep.executeAsync();
+
+    expect(prepareSpy).toHaveBeenCalledTimes(1);
+    expect(updateVersionsAsync).toHaveBeenCalledWith(
+      expect.anything(),
+      buildStep.ctx.workingDirectory,
+      {
+        buildNumber: undefined,
+        appVersion: '1.2.3',
+      },
+      {
+        targetNames: ['app', 'widget'],
+        buildConfiguration: 'Release',
+      }
+    );
+  });
+
+  it('prefers target_names when both target_names and credentials are provided', async () => {
+    const prepareSpy = jest
+      .spyOn(IosCredentialsManager.prototype, 'prepare')
+      .mockResolvedValue(createCredentials({ targetNames: ['credentials-target'] }));
+    const buildStep = createBuildStep({
+      callInputs: {
+        target_names: ['input-target'],
+        credentials: createRawCredentials(),
+        app_version: '1.2.3',
+      },
+    });
+
+    await buildStep.executeAsync();
+
+    expect(prepareSpy).not.toHaveBeenCalled();
+    expect(updateVersionsAsync).toHaveBeenCalledWith(
+      expect.anything(),
+      buildStep.ctx.workingDirectory,
+      {
+        buildNumber: undefined,
+        appVersion: '1.2.3',
+      },
+      {
+        targetNames: ['input-target'],
+        buildConfiguration: 'Release',
+      }
+    );
+  });
+
+  it('accepts an empty target_names array without crashing', async () => {
+    const prepareSpy = jest.spyOn(IosCredentialsManager.prototype, 'prepare');
+    const buildStep = createBuildStep({
+      callInputs: {
+        target_names: [],
+        app_version: '1.2.3',
+      },
+    });
+
+    await expect(buildStep.executeAsync()).resolves.toBeUndefined();
+
+    expect(prepareSpy).not.toHaveBeenCalled();
+    expect(updateVersionsAsync).toHaveBeenCalledWith(
+      expect.anything(),
+      buildStep.ctx.workingDirectory,
+      {
+        buildNumber: undefined,
+        appVersion: '1.2.3',
+      },
+      {
+        targetNames: [],
+        buildConfiguration: 'Release',
+      }
+    );
+  });
+
+  it('rejects invalid target_names', async () => {
+    const buildStep = createBuildStep({
+      callInputs: {
+        target_names: ['app', 123],
+        app_version: '1.2.3',
+      },
+    });
+
+    await expect(buildStep.executeAsync()).rejects.toThrow(
+      '"target_names" input must be an array of strings.'
+    );
+  });
+
+  it('uses the corrected App version error text', async () => {
+    const buildStep = createBuildStep({
+      callInputs: {
+        target_names: ['app'],
+        app_version: 'invalid-semver',
+      },
+    });
+
+    await expect(buildStep.executeAsync()).rejects.toThrow(
+      'App version provided by the "app_version" input is not a valid semver version: invalid-semver'
+    );
+  });
+});

--- a/packages/build-tools/src/steps/functions/__tests__/configureIosVersion.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/configureIosVersion.test.ts
@@ -1,7 +1,8 @@
+import { BuildWorkflow } from '@expo/steps';
+
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createTestIosJob } from '../../../__tests__/utils/job';
 import { createMockLogger } from '../../../__tests__/utils/logger';
-import { BuildWorkflow } from '@expo/steps';
 import { updateVersionsAsync } from '../../utils/ios/configure';
 import IosCredentialsManager, { type Credentials } from '../../utils/ios/credentials/manager';
 import { DistributionType } from '../../utils/ios/credentials/provisioningProfile';

--- a/packages/build-tools/src/steps/functions/configureIosCredentials.ts
+++ b/packages/build-tools/src/steps/functions/configureIosCredentials.ts
@@ -38,8 +38,7 @@ export function configureIosCredentialsFunction(): BuildFunction {
       }),
     ],
     fn: async (stepCtx, { inputs, outputs }) => {
-      const rawCredentialsInput = inputs.credentials.value as Record<string, any>;
-      const { value, error } = IosBuildCredentialsSchema.validate(rawCredentialsInput, {
+      const { value, error } = IosBuildCredentialsSchema.validate(inputs.credentials.value, {
         stripUnknown: true,
         convert: true,
         abortEarly: false,

--- a/packages/build-tools/src/steps/functions/configureIosCredentials.ts
+++ b/packages/build-tools/src/steps/functions/configureIosCredentials.ts
@@ -1,5 +1,10 @@
 import { Ios } from '@expo/eas-build-job';
-import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
+import {
+  BuildFunction,
+  BuildStepInput,
+  BuildStepInputValueTypeName,
+  BuildStepOutput,
+} from '@expo/steps';
 import assert from 'assert';
 
 import { configureCredentialsAsync } from '../utils/ios/configure';
@@ -26,7 +31,13 @@ export function configureIosCredentialsFunction(): BuildFunction {
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
     ],
-    fn: async (stepCtx, { inputs }) => {
+    outputProviders: [
+      BuildStepOutput.createProvider({
+        id: 'target_names',
+        required: true,
+      }),
+    ],
+    fn: async (stepCtx, { inputs, outputs }) => {
       const rawCredentialsInput = inputs.credentials.value as Record<string, any>;
       const { value, error } = IosBuildCredentialsSchema.validate(rawCredentialsInput, {
         stripUnknown: true,
@@ -50,6 +61,7 @@ export function configureIosCredentialsFunction(): BuildFunction {
           inputs.build_configuration.value as string | undefined
         ),
       });
+      outputs.target_names.set(JSON.stringify(Object.keys(credentials.targetProvisioningProfiles)));
 
       stepCtx.logger.info('Successfully configured iOS credentials');
     },

--- a/packages/build-tools/src/steps/functions/configureIosVersion.ts
+++ b/packages/build-tools/src/steps/functions/configureIosVersion.ts
@@ -1,7 +1,8 @@
-import { Ios } from '@expo/eas-build-job';
+import { Ios, UserError } from '@expo/eas-build-job';
 import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
 import assert from 'assert';
 import semver from 'semver';
+import { z } from 'zod';
 
 import { updateVersionsAsync } from '../utils/ios/configure';
 import { IosBuildCredentialsSchema } from '../utils/ios/credentials/credentials';
@@ -51,7 +52,8 @@ export function configureIosVersionFunction(): BuildFunction {
       const appVersion =
         (inputs.app_version.value as string | undefined) ?? job.version?.appVersion;
       if (appVersion && !semver.valid(appVersion)) {
-        throw new Error(
+        throw new UserError(
+          'EAS_CONFIGURE_IOS_VERSION_INVALID_APP_VERSION',
           `App version provided by the "app_version" input is not a valid semver version: ${appVersion}`
         );
       }
@@ -66,13 +68,15 @@ export function configureIosVersionFunction(): BuildFunction {
       const targetNamesInput = inputs.target_names.value;
       let targetNames: string[];
       if (targetNamesInput !== undefined) {
-        if (
-          !Array.isArray(targetNamesInput) ||
-          targetNamesInput.some(targetName => typeof targetName !== 'string')
-        ) {
-          throw new Error('"target_names" input must be an array of strings.');
+        const parsed = z.array(z.string()).safeParse(targetNamesInput);
+        if (!parsed.success) {
+          throw new UserError(
+            'EAS_CONFIGURE_IOS_VERSION_INVALID_TARGET_NAMES',
+            '"target_names" input must be an array of strings.',
+            { cause: parsed.error }
+          );
         }
-        targetNames = targetNamesInput;
+        targetNames = parsed.data;
       } else {
         const { value, error } = IosBuildCredentialsSchema.validate(inputs.credentials.value, {
           stripUnknown: true,

--- a/packages/build-tools/src/steps/functions/configureIosVersion.ts
+++ b/packages/build-tools/src/steps/functions/configureIosVersion.ts
@@ -17,9 +17,14 @@ export function configureIosVersionFunction(): BuildFunction {
     inputProviders: [
       BuildStepInput.createProvider({
         id: 'credentials',
-        required: true,
+        required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.JSON,
         defaultValue: '${ eas.job.secrets.buildCredentials }',
+      }),
+      BuildStepInput.createProvider({
+        id: 'target_names',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.JSON,
       }),
       BuildStepInput.createProvider({
         id: 'build_configuration',
@@ -38,19 +43,6 @@ export function configureIosVersionFunction(): BuildFunction {
       }),
     ],
     fn: async (stepCtx, { inputs }) => {
-      const rawCredentialsInput = inputs.credentials.value as Record<string, any>;
-      const { value, error } = IosBuildCredentialsSchema.validate(rawCredentialsInput, {
-        stripUnknown: true,
-        convert: true,
-        abortEarly: false,
-      });
-      if (error) {
-        throw error;
-      }
-
-      const credentialsManager = new IosCredentialsManager(value);
-      const credentials = await credentialsManager.prepare(stepCtx.logger);
-
       assert(stepCtx.global.staticContext.job, 'Job is not defined');
       const job = stepCtx.global.staticContext.job as Ios.Job;
 
@@ -60,7 +52,7 @@ export function configureIosVersionFunction(): BuildFunction {
         (inputs.app_version.value as string | undefined) ?? job.version?.appVersion;
       if (appVersion && !semver.valid(appVersion)) {
         throw new Error(
-          `App verrsion provided by the "app_version" input is not a valid semver version: ${appVersion}`
+          `App version provided by the "app_version" input is not a valid semver version: ${appVersion}`
         );
       }
 
@@ -69,6 +61,36 @@ export function configureIosVersionFunction(): BuildFunction {
           'No build number or app version provided. Skipping the step to configure iOS version.'
         );
         return;
+      }
+
+      const targetNamesInput = inputs.target_names.value as unknown;
+      let targetNames: string[];
+      if (targetNamesInput !== undefined) {
+        if (
+          !Array.isArray(targetNamesInput) ||
+          targetNamesInput.some(targetName => typeof targetName !== 'string')
+        ) {
+          throw new Error('"target_names" input must be an array of strings.');
+        }
+        targetNames = targetNamesInput;
+      } else {
+        const rawCredentialsInput = inputs.credentials.value as Record<string, any> | undefined;
+        if (!rawCredentialsInput) {
+          throw new Error('Either "target_names" or "credentials" input must be provided.');
+        }
+
+        const { value, error } = IosBuildCredentialsSchema.validate(rawCredentialsInput, {
+          stripUnknown: true,
+          convert: true,
+          abortEarly: false,
+        });
+        if (error) {
+          throw error;
+        }
+
+        const credentialsManager = new IosCredentialsManager(value);
+        const credentials = await credentialsManager.prepare(stepCtx.logger);
+        targetNames = Object.keys(credentials.targetProvisioningProfiles);
       }
 
       stepCtx.logger.info('Setting iOS version...');
@@ -87,7 +109,7 @@ export function configureIosVersionFunction(): BuildFunction {
           appVersion,
         },
         {
-          targetNames: Object.keys(credentials.targetProvisioningProfiles),
+          targetNames,
           buildConfiguration: resolveBuildConfiguration(
             job,
             inputs.build_configuration.value as string | undefined

--- a/packages/build-tools/src/steps/functions/configureIosVersion.ts
+++ b/packages/build-tools/src/steps/functions/configureIosVersion.ts
@@ -63,7 +63,7 @@ export function configureIosVersionFunction(): BuildFunction {
         return;
       }
 
-      const targetNamesInput = inputs.target_names.value as unknown;
+      const targetNamesInput = inputs.target_names.value;
       let targetNames: string[];
       if (targetNamesInput !== undefined) {
         if (
@@ -74,12 +74,7 @@ export function configureIosVersionFunction(): BuildFunction {
         }
         targetNames = targetNamesInput;
       } else {
-        const rawCredentialsInput = inputs.credentials.value as Record<string, any> | undefined;
-        if (!rawCredentialsInput) {
-          throw new Error('Either "target_names" or "credentials" input must be provided.');
-        }
-
-        const { value, error } = IosBuildCredentialsSchema.validate(rawCredentialsInput, {
+        const { value, error } = IosBuildCredentialsSchema.validate(inputs.credentials.value, {
           stripUnknown: true,
           convert: true,
           abortEarly: false,


### PR DESCRIPTION
# Why

`eas/configure_ios_version` was preparing iOS credentials again just to recover target names, even when `eas/configure_ios_credentials` had already done that work.

This PR removes that duplicate work so credentials-backed iOS builds can move through the version step faster.

Related: `ENG-20324`

# How

- add an optional `target_names` input to `eas/configure_ios_version`
- make `target_names` take priority so the step can skip the second credentials preparation pass
- add a `target_names` output to `eas/configure_ios_credentials`
- wire the built-in iOS credentials workflow to pass `configure_ios_credentials.target_names` into `configure_ios_version`
- preserve the existing credentials fallback behavior when `target_names` is not provided

# Test Plan

- `cd packages/build-tools && yarn test src/steps/functions/__tests__/configureIosVersion.test.ts`
- `cd packages/build-tools && yarn test src/steps/functions/__tests__/configureIosCredentials.test.ts`
- `cd packages/build-tools && yarn test src/steps/functionGroups/__tests__/build.test.ts`