### PR TITLE
[eas-cli] Fix adding existing capability identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [eas-cli] Fixes for `observe` commands, including an issue for apps with many update IDs. ([#3609](https://github.com/expo/eas-cli/pull/3609) by [@douglowder](https://github.com/douglowder))
+- [eas-cli] Add existing capability identifiers. ([#3615](https://github.com/expo/eas-cli/pull/3615) by [@jakex7](https://github.com/jakex7))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/capabilityIdentifiers-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/capabilityIdentifiers-test.ts
@@ -12,6 +12,29 @@ const mockItems = {
   },
 };
 
+const buildBundleInfo = (linked: {
+  appGroups: Array<{ id: string }>;
+  merchantIds: Array<{ id: string }>;
+  cloudContainers: Array<{ id: string }>;
+}): any => ({
+  attributes: {
+    bundleIdCapabilities: [
+      {
+        isType: (t: string) => t === 'APPLE_PAY',
+        attributes: { merchantIds: linked.merchantIds },
+      },
+      {
+        isType: (t: string) => t === 'APP_GROUPS',
+        attributes: { appGroups: linked.appGroups },
+      },
+      {
+        isType: (t: string) => t === 'ICLOUD',
+        attributes: { cloudContainers: linked.cloudContainers },
+      },
+    ],
+  },
+});
+
 function mockCapabilities(Apple: any): void {
   const mockGetAsync = (existingItems: any[]): jest.Mock =>
     jest.fn(() => Promise.resolve(existingItems));
@@ -35,6 +58,16 @@ function mockCapabilities(Apple: any): void {
   Apple.CloudContainer.getAsync = mockGetAsync([mockItems.cloudContainer.expo]);
 
   Apple.CloudContainer.createAsync = mockCreateAsync('XXX-icloud-2');
+
+  Apple.BundleId.infoAsync = jest.fn(() =>
+    Promise.resolve(
+      buildBundleInfo({
+        merchantIds: [mockItems.merchant.expo],
+        appGroups: [mockItems.appGroup.expo],
+        cloudContainers: [mockItems.cloudContainer.expo],
+      })
+    )
+  );
 }
 
 function mockCapabilitiesAlreadyCreated(Apple: any): void {
@@ -52,6 +85,23 @@ function mockCapabilitiesAlreadyCreated(Apple: any): void {
     mockItems.cloudContainer.expo,
     { id: 'XXX-icloud-2', attributes: { identifier: 'iCloud.bacon' } },
   ]);
+
+  Apple.BundleId.infoAsync.mockResolvedValue(
+    buildBundleInfo({
+      merchantIds: [
+        mockItems.merchant.expo,
+        { id: 'XXX-merch-2', attributes: { identifier: 'merchant.bacon' } },
+      ],
+      appGroups: [
+        mockItems.appGroup.expo,
+        { id: 'XXX-group-2', attributes: { identifier: 'group.bacon' } },
+      ],
+      cloudContainers: [
+        mockItems.cloudContainer.expo,
+        { id: 'XXX-icloud-2', attributes: { identifier: 'iCloud.bacon' } },
+      ],
+    })
+  );
 }
 
 describe(syncCapabilityIdentifiersForEntitlementsAsync, () => {

--- a/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
@@ -103,13 +103,11 @@ export async function syncCapabilityIdentifiersForEntitlementsAsync(
 
       // Identifier already exists.
       if (remoteIdModel) {
-        // Identifier already linked to this bundle.
-        if (alreadyLinkedOpaqueIds.has(remoteIdModel.id)) {
-          continue;
+        if (!alreadyLinkedOpaqueIds.has(remoteIdModel.id)) {
+          // Link the existing identifier to this bundle.
+          linkedIds.push(remoteIdModel.attributes.identifier);
+          capabilityIdOpaqueIds.push(remoteIdModel.id);
         }
-        // Link the existing identifier to this bundle.
-        linkedIds.push(remoteIdModel.attributes.identifier);
-        capabilityIdOpaqueIds.push(remoteIdModel.id);
         continue;
       }
 

--- a/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/capabilityIdentifiers.ts
@@ -44,6 +44,20 @@ export async function syncCapabilityIdentifiersForEntitlementsAsync(
 
   const updateRequest: UpdateCapabilityRequest = [];
 
+  // Fetch the bundle with its linked capability identifiers to check for already linked identifiers.
+  const bundleWithRelationships = await BundleId.infoAsync(bundleId.context, {
+    id: bundleId.id,
+    query: {
+      includes: [
+        'bundleIdCapabilities',
+        'bundleIdCapabilities.appGroups',
+        'bundleIdCapabilities.merchantIds',
+        'bundleIdCapabilities.cloudContainers',
+      ],
+    },
+  });
+  const linkedBundleCapabilities = bundleWithRelationships.attributes.bundleIdCapabilities ?? [];
+
   // Iterate through the supported capabilities to build the request.
   for (const classifier of CapabilityIdMapping) {
     const CapabilityModel = classifier.capabilityIdModel;
@@ -73,15 +87,31 @@ export async function syncCapabilityIdentifiersForEntitlementsAsync(
     // Get a list of all of the capability IDs that are already created on the server.
     const existingIds = await CapabilityModel.getAsync(bundleId.context);
 
-    // A list of server IDs for linking.
-    const capabilityIdOpaqueIds = [];
-
-    const capabilitiesWithoutRemoteModels = capabilityIds.filter(
-      localId => existingIds.find(model => model.attributes.identifier === localId) === undefined
+    // Opaque ids of identifiers already linked to this capability.
+    const remoteLinkedIds = linkedBundleCapabilities.find(c => c.isType(classifier.capability))
+      ?.attributes as Record<string, { id: string }[] | undefined> | undefined;
+    const alreadyLinkedOpaqueIds = new Set<string>(
+      (remoteLinkedIds?.[CapabilityModel.type] ?? []).map(model => model.id)
     );
+
+    // A list of server IDs for linking.
+    const capabilityIdOpaqueIds: string[] = [];
+
     // Iterate through all the local IDs and see if they exist on the server.
-    for (const localId of capabilitiesWithoutRemoteModels) {
-      let remoteIdModel = undefined;
+    for (const localId of capabilityIds) {
+      let remoteIdModel = existingIds.find(model => model.attributes.identifier === localId);
+
+      // Identifier already exists.
+      if (remoteIdModel) {
+        // Identifier already linked to this bundle.
+        if (alreadyLinkedOpaqueIds.has(remoteIdModel.id)) {
+          continue;
+        }
+        // Link the existing identifier to this bundle.
+        linkedIds.push(remoteIdModel.attributes.identifier);
+        capabilityIdOpaqueIds.push(remoteIdModel.id);
+        continue;
+      }
 
       if (Log.isDebug) {
         Log.log(`Creating capability ID: ${localId} (${CapabilityModel.type})`);


### PR DESCRIPTION
# Why

When an iOS app extension target declares App Group entitlements (e.g. `'com.apple.security.application-groups': ['group.com.easwidgets']`) and the app group already exists in the Apple Developer team but is not linked to the target's bundle identifier, credential setup enabled the App Groups capability on the bundle but never attached the group resulting with capability on but 0 groups linked.
```
Current local entitlements:
{
  "com.apple.security.application-groups": [
    "group.com.easwidgets"
  ]
}
Will enable remote capability: com.apple.security.application-groups (App Groups).
Existing to disable:  [ 'FJXGJ28CQS_IN_APP_PURCHASE' ]
Patch Request: [ { capabilityType: 'APP_GROUPS', option: 'ON' } ]
✔ Synced capabilities: Enabled: App Groups
- Syncing capabilities identifiers
No capability identifiers need to be updated
✔ Synced capability identifiers: No updates
```
This is a regression introduced in https://github.com/expo/eas-cli/pull/3088/
Fixes https://github.com/expo/expo/issues/43677

# How

Fetch the bundle via `BundleId.infoAsync` to determine which IDs are already linked to this bundle.
- If it exists and ID is already linked -> skip.
- If it exists but is not linked -> just link.
- If it doesn't exist -> create it, then link (unchanged behavior).

# Test Plan

After this changes:
```
Current local entitlements:
{
  "com.apple.security.application-groups": [
    "group.com.easwidgets"
  ]
}
Will enable remote capability: com.apple.security.application-groups (App Groups).
Existing to disable:  [ '6C659CPDFA_IN_APP_PURCHASE' ]
Patch Request: [ { capabilityType: 'APP_GROUPS', option: 'ON' } ]
✔ Synced capabilities: Enabled: App Groups
- Syncing capabilities identifiers
Updating bundle identifier with capability identifiers: [
  {
    "capabilityType": "APP_GROUPS",
    "option": "ON",
    "relationships": {
      "appGroups": [
        "NW5UULASH8"
      ]
    }
  }
]
✔ Synced capability identifiers: Linked: group.com.easwidgets
```