### PR TITLE
Proxy Bun downloads through CocoaPods cache on iOS

### DIFF
--- a/packages/worker/src/__unit__/runtimeEnvironment.test.ts
+++ b/packages/worker/src/__unit__/runtimeEnvironment.test.ts
@@ -2,6 +2,7 @@
 import { Android, Ios, Job } from '@expo/eas-build-job';
 import spawn, { SpawnResult } from '@expo/turtle-spawn';
 import { pathExists } from 'fs-extra';
+import config from '../config';
 import { prepareRuntimeEnvironment } from '../runtimeEnvironment';
 
 jest.mock('fs-extra');
@@ -33,6 +34,17 @@ const builderConfig: Ios.BuilderEnvironment | Android.BuilderEnvironment = {};
 describe('prepareRuntimeEnvironment', () => {
   beforeEach(() => {
     jest.mocked(spawn).mockReset();
+    jest.mocked(spawn).mockResolvedValue(spawnResult);
+    jest.clearAllMocks();
+    ctx.job = {} as Job;
+    ctx.env = {
+      ...process.env,
+      EAS_BUILD_ID: 'build-id',
+    };
+    delete ctx.env.GITHUB;
+    builderConfig.node = undefined;
+    builderConfig.bun = undefined;
+    config.cocoapodsCacheUrl = null;
   });
 
   describe('installNode', () => {
@@ -122,6 +134,117 @@ describe('prepareRuntimeEnvironment', () => {
         expect(spawn).toHaveBeenCalledWith('rm', [expect.anything()], expect.anything());
 
         expect(spawn).toHaveBeenCalledWith('bun', ['--version'], expect.anything());
+      });
+
+      it('proxies Bun install script and GitHub release ZIP downloads through CocoaPods cache on iOS', async () => {
+        let isFirstTimeCheckingBunVersion = true;
+        config.cocoapodsCacheUrl = 'https://cocoapods-cache.example.com';
+
+        jest.mocked(spawn).mockImplementation((cmd, _args, _opts) => {
+          if (cmd === 'bun') {
+            const stdout = isFirstTimeCheckingBunVersion ? '1.0.0' : '2.0.0';
+            isFirstTimeCheckingBunVersion = false;
+            return Promise.resolve({
+              ...spawnResult,
+              stdout,
+            });
+          }
+          return Promise.resolve(spawnResult);
+        });
+
+        await prepareRuntimeEnvironment(ctx, { bun: '2.0.0' }, false);
+
+        expect(spawn).toHaveBeenCalledWith(
+          'curl',
+          ['-fsSL', 'https://cocoapods-cache.example.com/bun.sh/install', '-o', expect.anything()],
+          expect.anything()
+        );
+        expect(spawn).toHaveBeenCalledWith(
+          'bash',
+          [expect.anything(), 'bun-v2.0.0'],
+          expect.objectContaining({
+            env: expect.objectContaining({
+              GITHUB: 'https://cocoapods-cache.example.com/github.com',
+            }),
+          })
+        );
+      });
+
+      it('retries Bun install script download without proxy when CocoaPods cache request fails', async () => {
+        let isFirstTimeCheckingBunVersion = true;
+        let bunInstallScriptCurlAttempts = 0;
+        config.cocoapodsCacheUrl = 'https://cocoapods-cache.example.com';
+
+        jest.mocked(spawn).mockImplementation((cmd, args, _opts) => {
+          if (cmd === 'bun') {
+            const stdout = isFirstTimeCheckingBunVersion ? '1.0.0' : '2.0.0';
+            isFirstTimeCheckingBunVersion = false;
+            return Promise.resolve({
+              ...spawnResult,
+              stdout,
+            });
+          }
+          if (cmd === 'curl' && args[1] === 'https://cocoapods-cache.example.com/bun.sh/install') {
+            bunInstallScriptCurlAttempts += 1;
+            return Promise.reject(new Error('proxy download failed'));
+          }
+          return Promise.resolve(spawnResult);
+        });
+
+        await prepareRuntimeEnvironment(ctx, { bun: '2.0.0' }, false);
+
+        expect(bunInstallScriptCurlAttempts).toBe(1);
+        expect(spawn).toHaveBeenCalledWith(
+          'curl',
+          ['-fsSL', 'https://bun.sh/install', '-o', expect.anything()],
+          expect.anything()
+        );
+        expect(ctx.logger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ err: expect.any(Error) }),
+          'Failed to download Bun install script through proxy, retrying directly.'
+        );
+      });
+
+      it('retries Bun installation without proxy when proxied release ZIP download fails', async () => {
+        let isFirstTimeCheckingBunVersion = true;
+        let proxiedInstallAttempted = false;
+        config.cocoapodsCacheUrl = 'https://cocoapods-cache.example.com';
+
+        jest.mocked(spawn).mockImplementation((cmd, _args, opts) => {
+          if (cmd === 'bun') {
+            const stdout = isFirstTimeCheckingBunVersion ? '1.0.0' : '2.0.0';
+            isFirstTimeCheckingBunVersion = false;
+            return Promise.resolve({
+              ...spawnResult,
+              stdout,
+            });
+          }
+          if (
+            cmd === 'bash' &&
+            opts?.env?.GITHUB === 'https://cocoapods-cache.example.com/github.com'
+          ) {
+            proxiedInstallAttempted = true;
+            return Promise.reject(new Error('proxied bun install failed'));
+          }
+          return Promise.resolve(spawnResult);
+        });
+
+        await prepareRuntimeEnvironment(ctx, { bun: '2.0.0' }, false);
+
+        expect(proxiedInstallAttempted).toBe(true);
+        expect(spawn).toHaveBeenCalledWith(
+          'bash',
+          [expect.anything(), 'bun-v2.0.0'],
+          expect.objectContaining({
+            env: expect.not.objectContaining({
+              GITHUB: expect.anything(),
+            }),
+          })
+        );
+        expect(ctx.logger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ err: expect.any(Error) }),
+          'Failed to install Bun through proxy, retrying directly.'
+        );
       });
 
       it('does not install Bun when a specified version is the same as the installed version', async () => {

--- a/packages/worker/src/runtimeEnvironment.ts
+++ b/packages/worker/src/runtimeEnvironment.ts
@@ -194,51 +194,55 @@ async function installBun({
     ctx.logger.info(`Installing bun@${versionToInstall}`);
 
     const bunInstallScriptPath = path.join(os.tmpdir(), `install-bun-${uuidv4()}.sh`);
-    await runWithProxyFallbackAsync({
-      primaryOperation: proxyUrl
-        ? () =>
-            spawn(
-              'curl',
-              [
-                '-fsSL',
-                rewriteUrlThroughProxy('https://bun.sh/install', proxyUrl),
-                '-o',
-                bunInstallScriptPath,
-              ],
-              {
-                logger: ctx.logger,
-                env: ctx.env,
-              }
-            )
-        : null,
-      fallbackOperation: () =>
-        spawn('curl', ['-fsSL', 'https://bun.sh/install', '-o', bunInstallScriptPath], {
-          logger: ctx.logger,
-          env: ctx.env,
-        }),
-      logger: ctx.logger,
-      warningMessage: 'Failed to download Bun install script through proxy, retrying directly.',
-    });
+    const proxiedBunInstallScriptUrl = proxyUrl
+      ? rewriteUrlThroughProxy('https://bun.sh/install', proxyUrl)
+      : null;
 
-    await runWithProxyFallbackAsync({
-      primaryOperation: proxyUrl
-        ? () =>
-            spawn('bash', [bunInstallScriptPath, `bun-v${versionToInstall}`], {
-              logger: ctx.logger,
-              env: {
-                ...ctx.env,
-                GITHUB: rewriteUrlThroughProxy('https://github.com', proxyUrl),
-              },
-            })
-        : null,
-      fallbackOperation: () =>
-        spawn('bash', [bunInstallScriptPath, `bun-v${versionToInstall}`], {
+    if (proxiedBunInstallScriptUrl) {
+      try {
+        await spawn('curl', ['-fsSL', proxiedBunInstallScriptUrl, '-o', bunInstallScriptPath], {
           logger: ctx.logger,
           env: ctx.env,
-        }),
-      logger: ctx.logger,
-      warningMessage: 'Failed to install Bun through proxy, retrying directly.',
-    });
+        });
+      } catch (err: any) {
+        ctx.logger.warn(
+          { err },
+          'Failed to download Bun install script through proxy, retrying directly.'
+        );
+        await spawn('curl', ['-fsSL', 'https://bun.sh/install', '-o', bunInstallScriptPath], {
+          logger: ctx.logger,
+          env: ctx.env,
+        });
+      }
+    } else {
+      await spawn('curl', ['-fsSL', 'https://bun.sh/install', '-o', bunInstallScriptPath], {
+        logger: ctx.logger,
+        env: ctx.env,
+      });
+    }
+
+    if (proxyUrl) {
+      try {
+        await spawn('bash', [bunInstallScriptPath, `bun-v${versionToInstall}`], {
+          logger: ctx.logger,
+          env: {
+            ...ctx.env,
+            GITHUB: rewriteUrlThroughProxy('https://github.com', proxyUrl),
+          },
+        });
+      } catch (err: any) {
+        ctx.logger.warn({ err }, 'Failed to install Bun through proxy, retrying directly.');
+        await spawn('bash', [bunInstallScriptPath, `bun-v${versionToInstall}`], {
+          logger: ctx.logger,
+          env: ctx.env,
+        });
+      }
+    } else {
+      await spawn('bash', [bunInstallScriptPath, `bun-v${versionToInstall}`], {
+        logger: ctx.logger,
+        env: ctx.env,
+      });
+    }
 
     await spawn('rm', [bunInstallScriptPath], {
       logger: ctx.logger,
@@ -269,30 +273,6 @@ async function installBun({
 function rewriteUrlThroughProxy(url: string, proxy: string): string {
   const parsedUrl = new URL(url);
   return url.replace(`${parsedUrl.protocol}//${parsedUrl.host}`, `${proxy}/${parsedUrl.host}`);
-}
-
-async function runWithProxyFallbackAsync({
-  primaryOperation,
-  fallbackOperation,
-  logger,
-  warningMessage,
-}: {
-  primaryOperation: (() => Promise<unknown>) | null;
-  fallbackOperation: () => Promise<unknown>;
-  logger: PreDownloadBuildContext['logger'];
-  warningMessage: string;
-}): Promise<void> {
-  if (!primaryOperation) {
-    await fallbackOperation();
-    return;
-  }
-
-  try {
-    await primaryOperation();
-  } catch (err: any) {
-    logger.warn({ err }, warningMessage);
-    await fallbackOperation();
-  }
 }
 
 async function installPnpm({

--- a/packages/worker/src/runtimeEnvironment.ts
+++ b/packages/worker/src/runtimeEnvironment.ts
@@ -189,19 +189,55 @@ async function installBun({
   currentVersion: string;
 }): Promise<void> {
   const versionToInstall = userSpecifiedVersion ?? currentVersion;
+  const proxyUrl = config.cocoapodsCacheUrl;
   try {
     ctx.logger.info(`Installing bun@${versionToInstall}`);
 
     const bunInstallScriptPath = path.join(os.tmpdir(), `install-bun-${uuidv4()}.sh`);
-
-    await spawn('curl', ['-fsSL', 'https://bun.sh/install', '-o', bunInstallScriptPath], {
+    await runWithProxyFallbackAsync({
+      primaryOperation: proxyUrl
+        ? () =>
+            spawn(
+              'curl',
+              [
+                '-fsSL',
+                rewriteUrlThroughProxy('https://bun.sh/install', proxyUrl),
+                '-o',
+                bunInstallScriptPath,
+              ],
+              {
+                logger: ctx.logger,
+                env: ctx.env,
+              }
+            )
+        : null,
+      fallbackOperation: () =>
+        spawn('curl', ['-fsSL', 'https://bun.sh/install', '-o', bunInstallScriptPath], {
+          logger: ctx.logger,
+          env: ctx.env,
+        }),
       logger: ctx.logger,
-      env: ctx.env,
+      warningMessage: 'Failed to download Bun install script through proxy, retrying directly.',
     });
 
-    await spawn('bash', [bunInstallScriptPath, `bun-v${versionToInstall}`], {
+    await runWithProxyFallbackAsync({
+      primaryOperation: proxyUrl
+        ? () =>
+            spawn('bash', [bunInstallScriptPath, `bun-v${versionToInstall}`], {
+              logger: ctx.logger,
+              env: {
+                ...ctx.env,
+                GITHUB: rewriteUrlThroughProxy('https://github.com', proxyUrl),
+              },
+            })
+        : null,
+      fallbackOperation: () =>
+        spawn('bash', [bunInstallScriptPath, `bun-v${versionToInstall}`], {
+          logger: ctx.logger,
+          env: ctx.env,
+        }),
       logger: ctx.logger,
-      env: ctx.env,
+      warningMessage: 'Failed to install Bun through proxy, retrying directly.',
     });
 
     await spawn('rm', [bunInstallScriptPath], {
@@ -227,6 +263,35 @@ async function installBun({
         `Failed to install bun@${versionToInstall}. Continuing because Bun is not the primary package manager for this project.`
       );
     }
+  }
+}
+
+function rewriteUrlThroughProxy(url: string, proxy: string): string {
+  const parsedUrl = new URL(url);
+  return url.replace(`${parsedUrl.protocol}//${parsedUrl.host}`, `${proxy}/${parsedUrl.host}`);
+}
+
+async function runWithProxyFallbackAsync({
+  primaryOperation,
+  fallbackOperation,
+  logger,
+  warningMessage,
+}: {
+  primaryOperation: (() => Promise<unknown>) | null;
+  fallbackOperation: () => Promise<unknown>;
+  logger: PreDownloadBuildContext['logger'];
+  warningMessage: string;
+}): Promise<void> {
+  if (!primaryOperation) {
+    await fallbackOperation();
+    return;
+  }
+
+  try {
+    await primaryOperation();
+  } catch (err: any) {
+    logger.warn({ err }, warningMessage);
+    await fallbackOperation();
   }
 }
 


### PR DESCRIPTION
## Summary
- Route the Bun install script and release ZIP downloads through the CocoaPods cache when available on iOS
- Retry both steps directly if the proxied request fails
- Add unit coverage for proxied and fallback paths

## Testing
- `yarn test:unit runtimeEnvironment.test.ts --runInBand` in `packages/worker`