### PR TITLE
[eas-cli] Add customParams support to observe:events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Support custom params in `observe:events` results. ([#3620](https://github.com/expo/eas-cli/pull/3620) by [@douglowder](https://github.com/douglowder))
 - [build-tools] Add `eas/deploy` function for EAS Hosting web deployments. ([#3598](https://github.com/expo/eas-cli/pull/3598) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Add `eas/export` function for Expo web exports. ([#3598](https://github.com/expo/eas-cli/pull/3598) by [@gwdp](https://github.com/gwdp))
 - [eas-cli] Add `eas update:insights <groupId>` command to display launch, crash, unique-user, and payload-size metrics for an update group. ([#3614](https://github.com/expo/eas-cli/pull/3614) by [@kadikraman](https://github.com/kadikraman))

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -783,8 +783,11 @@ export type AccountNotificationPreferenceInput = {
 export type AccountOnboardingStats = {
   __typename?: 'AccountOnboardingStats';
   firstBuildCompletedAt?: Maybe<Scalars['DateTime']['output']>;
+  firstProjectCreatedAt?: Maybe<Scalars['DateTime']['output']>;
   firstSubmissionCompletedAt?: Maybe<Scalars['DateTime']['output']>;
+  firstUpdateCreatedAt?: Maybe<Scalars['DateTime']['output']>;
   hasConfiguredUpdate: Scalars['Boolean']['output'];
+  hasConfiguredWorkflow: Scalars['Boolean']['output'];
   hasTeamMembers: Scalars['Boolean']['output'];
 };
 
@@ -4082,6 +4085,7 @@ export type ConvexTeamConnectionMutation = {
   __typename?: 'ConvexTeamConnectionMutation';
   createConvexTeamConnection: ConvexTeamConnection;
   deleteConvexTeamConnection: ConvexTeamConnection;
+  sendConvexTeamInviteToVerifiedEmail: Scalars['Boolean']['output'];
 };
 
 
@@ -4092,6 +4096,11 @@ export type ConvexTeamConnectionMutationCreateConvexTeamConnectionArgs = {
 
 export type ConvexTeamConnectionMutationDeleteConvexTeamConnectionArgs = {
   convexTeamConnectionId: Scalars['ID']['input'];
+};
+
+
+export type ConvexTeamConnectionMutationSendConvexTeamInviteToVerifiedEmailArgs = {
+  input: SendConvexTeamInviteToVerifiedEmailInput;
 };
 
 export enum CrashSampleFor {
@@ -8113,6 +8122,10 @@ export enum SecondFactorMethod {
 export type SecondFactorRegenerateBackupCodesResult = {
   __typename?: 'SecondFactorRegenerateBackupCodesResult';
   plaintextBackupCodes: Array<Scalars['String']['output']>;
+};
+
+export type SendConvexTeamInviteToVerifiedEmailInput = {
+  convexTeamConnectionId: Scalars['ID']['input'];
 };
 
 export type SentryInstallation = {
@@ -12191,7 +12204,7 @@ export type AppObserveEventsQueryVariables = Exact<{
 }>;
 
 
-export type AppObserveEventsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', events: { __typename?: 'AppObserveEventsConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveEventEdge', cursor: string, node: { __typename?: 'AppObserveEvent', id: string, metricName: string, metricValue: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string } }> } } } } };
+export type AppObserveEventsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', events: { __typename?: 'AppObserveEventsConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveEventEdge', cursor: string, node: { __typename?: 'AppObserveEvent', id: string, metricName: string, metricValue: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null } }> } } } } };
 
 export type GetAssetMetadataQueryVariables = Exact<{
   storageKeys: Array<Scalars['String']['input']> | Scalars['String']['input'];
@@ -12383,7 +12396,7 @@ export type FingerprintFragment = { __typename?: 'Fingerprint', id: string, hash
 
 export type AppObserveTimeSeriesFragment = { __typename?: 'AppObserveTimeSeries', eventCount: number, appVersionMarkers: Array<{ __typename?: 'AppObserveAppVersion', appVersion: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, buildNumbers: Array<{ __typename?: 'AppObserveAppBuildNumber', appBuildNumber: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, updates: Array<{ __typename?: 'AppObserveAppUpdate', appUpdateId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, metrics: Array<{ __typename?: 'AppObserveAppVersionMetric', metricName: string, eventCount: number, statistics: { __typename?: 'AppObserveVersionMarkerStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } }> }>, statistics: { __typename?: 'AppObserveTimeSeriesStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } };
 
-export type AppObserveEventFragment = { __typename?: 'AppObserveEvent', id: string, metricName: string, metricValue: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string };
+export type AppObserveEventFragment = { __typename?: 'AppObserveEvent', id: string, metricName: string, metricValue: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null };
 
 export type AppObserveAppVersionFragment = { __typename?: 'AppObserveAppVersion', appVersion: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, buildNumbers: Array<{ __typename?: 'AppObserveAppBuildNumber', appBuildNumber: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, updates: Array<{ __typename?: 'AppObserveAppUpdate', appUpdateId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, metrics: Array<{ __typename?: 'AppObserveAppVersionMetric', metricName: string, eventCount: number, statistics: { __typename?: 'AppObserveVersionMarkerStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } }> };
 

--- a/packages/eas-cli/src/graphql/types/Observe.ts
+++ b/packages/eas-cli/src/graphql/types/Observe.ts
@@ -33,6 +33,7 @@ export const AppObserveEventFragmentNode = gql`
     countryCode
     sessionId
     easClientId
+    customParams
   }
 `;
 

--- a/packages/eas-cli/src/observe/__tests__/formatEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatEvents.test.ts
@@ -158,6 +158,7 @@ describe(buildObserveEventsJson, () => {
           sessionId: 'session-1',
           easClientId: 'client-1',
           timestamp: '2025-01-15T10:30:00.000Z',
+          customParams: null,
         },
       ],
       pageInfo: {

--- a/packages/eas-cli/src/observe/formatEvents.ts
+++ b/packages/eas-cli/src/observe/formatEvents.ts
@@ -44,10 +44,6 @@ function resolveCustomParams(event: AppObserveEvent): { [key: string]: any } | n
   return event.customParams ?? null;
 }
 
-function formatCustomParamEntry(key: string, value: any): string {
-  return `${key}=${typeof value === 'object' ? JSON.stringify(value) : String(value)}`;
-}
-
 export interface BuildEventsTableOptions {
   metricName: string;
   daysBack?: number;
@@ -66,8 +62,6 @@ export function buildObserveEventsTable(
   }
 
   const hasUpdates = events.some(e => e.appUpdateId);
-  const resolvedCustomParams = events.map(event => resolveCustomParams(event));
-  const hasCustomParams = resolvedCustomParams.some(p => p !== null);
 
   const headers = [
     'Value',
@@ -77,43 +71,17 @@ export function buildObserveEventsTable(
     'Device',
     'Country',
     'Timestamp',
-    ...(hasCustomParams ? ['Custom Params'] : []),
   ];
 
-  const rows: string[][] = [];
-  events.forEach((event, index) => {
-    const eventCells = [
-      `${event.metricValue.toFixed(2)}s`,
-      `${event.appVersion} (${event.appBuildNumber})`,
-      ...(hasUpdates ? [event.appUpdateId ?? '-'] : []),
-      `${event.deviceOs} ${event.deviceOsVersion}`,
-      event.deviceModel,
-      event.countryCode ?? '-',
-      formatTimestamp(event.timestamp),
-    ];
-
-    if (!hasCustomParams) {
-      rows.push(eventCells);
-      return;
-    }
-
-    const paramEntries = Object.entries(resolvedCustomParams[index] ?? {});
-    if (paramEntries.length === 0) {
-      rows.push([...eventCells, '']);
-      return;
-    }
-
-    // First row: event data + first param
-    rows.push([...eventCells, formatCustomParamEntry(paramEntries[0][0], paramEntries[0][1])]);
-    // Continuation rows: blank event cells + next param
-    const blankEventCells = eventCells.map(() => '');
-    for (let i = 1; i < paramEntries.length; i++) {
-      rows.push([
-        ...blankEventCells,
-        formatCustomParamEntry(paramEntries[i][0], paramEntries[i][1]),
-      ]);
-    }
-  });
+  const rows: string[][] = events.map(event => [
+    `${event.metricValue.toFixed(2)}s`,
+    `${event.appVersion} (${event.appBuildNumber})`,
+    ...(hasUpdates ? [event.appUpdateId ?? '-'] : []),
+    `${event.deviceOs} ${event.deviceOsVersion}`,
+    event.deviceModel,
+    event.countryCode ?? '-',
+    formatTimestamp(event.timestamp),
+  ]);
 
   const colWidths = headers.map((h, i) => Math.max(h.length, ...rows.map(r => r[i].length)));
 

--- a/packages/eas-cli/src/observe/formatEvents.ts
+++ b/packages/eas-cli/src/observe/formatEvents.ts
@@ -44,13 +44,8 @@ function resolveCustomParams(event: AppObserveEvent): { [key: string]: any } | n
   return event.customParams ?? null;
 }
 
-function formatCustomParams(params: { [key: string]: any } | null): string {
-  if (!params) {
-    return '';
-  }
-  return Object.entries(params)
-    .map(([k, v]) => `${k}=${typeof v === 'object' ? JSON.stringify(v) : String(v)}`)
-    .join(', ');
+function formatCustomParamEntry(key: string, value: any): string {
+  return `${key}=${typeof value === 'object' ? JSON.stringify(value) : String(value)}`;
 }
 
 export interface BuildEventsTableOptions {
@@ -85,16 +80,40 @@ export function buildObserveEventsTable(
     ...(hasCustomParams ? ['Custom Params'] : []),
   ];
 
-  const rows: string[][] = events.map((event, index) => [
-    `${event.metricValue.toFixed(2)}s`,
-    `${event.appVersion} (${event.appBuildNumber})`,
-    ...(hasUpdates ? [event.appUpdateId ?? '-'] : []),
-    `${event.deviceOs} ${event.deviceOsVersion}`,
-    event.deviceModel,
-    event.countryCode ?? '-',
-    formatTimestamp(event.timestamp),
-    ...(hasCustomParams ? [formatCustomParams(resolvedCustomParams[index])] : []),
-  ]);
+  const rows: string[][] = [];
+  events.forEach((event, index) => {
+    const eventCells = [
+      `${event.metricValue.toFixed(2)}s`,
+      `${event.appVersion} (${event.appBuildNumber})`,
+      ...(hasUpdates ? [event.appUpdateId ?? '-'] : []),
+      `${event.deviceOs} ${event.deviceOsVersion}`,
+      event.deviceModel,
+      event.countryCode ?? '-',
+      formatTimestamp(event.timestamp),
+    ];
+
+    if (!hasCustomParams) {
+      rows.push(eventCells);
+      return;
+    }
+
+    const paramEntries = Object.entries(resolvedCustomParams[index] ?? {});
+    if (paramEntries.length === 0) {
+      rows.push([...eventCells, '']);
+      return;
+    }
+
+    // First row: event data + first param
+    rows.push([...eventCells, formatCustomParamEntry(paramEntries[0][0], paramEntries[0][1])]);
+    // Continuation rows: blank event cells + next param
+    const blankEventCells = eventCells.map(() => '');
+    for (let i = 1; i < paramEntries.length; i++) {
+      rows.push([
+        ...blankEventCells,
+        formatCustomParamEntry(paramEntries[i][0], paramEntries[i][1]),
+      ]);
+    }
+  });
 
   const colWidths = headers.map((h, i) => Math.max(h.length, ...rows.map(r => r[i].length)));
 

--- a/packages/eas-cli/src/observe/formatEvents.ts
+++ b/packages/eas-cli/src/observe/formatEvents.ts
@@ -28,6 +28,7 @@ export interface ObserveEventJson {
   sessionId: string | null;
   easClientId: string;
   timestamp: string;
+  customParams: { [key: string]: any } | null;
 }
 
 function formatDate(isoString: string): string {
@@ -37,6 +38,19 @@ function formatDate(isoString: string): string {
     month: 'short',
     day: 'numeric',
   });
+}
+
+function resolveCustomParams(event: AppObserveEvent): { [key: string]: any } | null {
+  return event.customParams ?? null;
+}
+
+function formatCustomParams(params: { [key: string]: any } | null): string {
+  if (!params) {
+    return '';
+  }
+  return Object.entries(params)
+    .map(([k, v]) => `${k}=${typeof v === 'object' ? JSON.stringify(v) : String(v)}`)
+    .join(', ');
 }
 
 export interface BuildEventsTableOptions {
@@ -57,6 +71,8 @@ export function buildObserveEventsTable(
   }
 
   const hasUpdates = events.some(e => e.appUpdateId);
+  const resolvedCustomParams = events.map(event => resolveCustomParams(event));
+  const hasCustomParams = resolvedCustomParams.some(p => p !== null);
 
   const headers = [
     'Value',
@@ -66,9 +82,10 @@ export function buildObserveEventsTable(
     'Device',
     'Country',
     'Timestamp',
+    ...(hasCustomParams ? ['Custom Params'] : []),
   ];
 
-  const rows: string[][] = events.map(event => [
+  const rows: string[][] = events.map((event, index) => [
     `${event.metricValue.toFixed(2)}s`,
     `${event.appVersion} (${event.appBuildNumber})`,
     ...(hasUpdates ? [event.appUpdateId ?? '-'] : []),
@@ -76,6 +93,7 @@ export function buildObserveEventsTable(
     event.deviceModel,
     event.countryCode ?? '-',
     formatTimestamp(event.timestamp),
+    ...(hasCustomParams ? [formatCustomParams(resolvedCustomParams[index])] : []),
   ]);
 
   const colWidths = headers.map((h, i) => Math.max(h.length, ...rows.map(r => r[i].length)));
@@ -131,6 +149,7 @@ export function buildObserveEventsJson(
       sessionId: event.sessionId ?? null,
       easClientId: event.easClientId,
       timestamp: event.timestamp,
+      customParams: resolveCustomParams(event),
     })),
     pageInfo: {
       hasNextPage: pageInfo.hasNextPage,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Allow any custom params in Observe events to be retrieved as part of `observe:events` queries, and included in display and JSON output.

# How

Updated the event query and formatter.

# Test Plan

- Tested against projects in production
- Unit tests pass