### PR TITLE
Collect staged Android emulator logs

### DIFF
--- a/packages/build-tools/src/__tests__/utils/context.ts
+++ b/packages/build-tools/src/__tests__/utils/context.ts
@@ -45,6 +45,7 @@ interface BuildContextParams {
   runtimePlatform?: BuildRuntimePlatform;
   projectSourceDirectory?: string;
   projectTargetDirectory?: string;
+  buildLogsDirectory?: string;
   relativeWorkingDirectory?: string;
   staticContextContent?: Record<string, any>;
 }
@@ -56,6 +57,7 @@ export function createStepContextMock({
   runtimePlatform,
   projectSourceDirectory,
   projectTargetDirectory,
+  buildLogsDirectory,
   relativeWorkingDirectory,
   staticContextContent,
 }: BuildContextParams = {}): BuildStepContext {
@@ -66,6 +68,7 @@ export function createStepContextMock({
     runtimePlatform,
     projectSourceDirectory,
     projectTargetDirectory,
+    buildLogsDirectory,
     relativeWorkingDirectory,
     staticContextContent,
   });
@@ -94,6 +97,7 @@ export function createGlobalContextMock({
   runtimePlatform,
   projectSourceDirectory,
   projectTargetDirectory,
+  buildLogsDirectory,
   relativeWorkingDirectory,
   staticContextContent,
 }: BuildContextParams = {}): BuildStepGlobalContext {
@@ -108,7 +112,7 @@ export function createGlobalContextMock({
       relativeWorkingDirectory
         ? path.resolve(resolvedProjectTargetDirectory, relativeWorkingDirectory)
         : resolvedProjectTargetDirectory,
-      '/non/existent/dir',
+      buildLogsDirectory ?? '/non/existent/dir',
       staticContextContent ?? {}
     ),
     skipCleanup ?? false

--- a/packages/build-tools/src/steps/__tests__/easFunctionGroups.test.ts
+++ b/packages/build-tools/src/steps/__tests__/easFunctionGroups.test.ts
@@ -1,4 +1,8 @@
+import { Platform } from '@expo/eas-build-job';
+
+import { createGlobalContextMock } from '../../__tests__/utils/context';
 import { getEasFunctionGroups } from '../easFunctionGroups';
+import { createEasMaestroTestFunctionGroup } from '../functionGroups/maestroTest';
 
 describe(getEasFunctionGroups, () => {
   it('includes eas/maestro_test for non-build jobs', () => {
@@ -23,5 +27,36 @@ describe(getEasFunctionGroups, () => {
       functionGroup.getFullId()
     );
     expect(functionGroupIds).toEqual(expect.arrayContaining(['eas/build', 'eas/maestro_test']));
+  });
+
+  it('collects Android emulator logs before uploading Maestro results', () => {
+    const ctx = {
+      job: {
+        platform: Platform.ANDROID,
+      },
+    } as unknown as Parameters<typeof createEasMaestroTestFunctionGroup>[0];
+    const globalCtx = createGlobalContextMock();
+
+    const steps = createEasMaestroTestFunctionGroup(ctx).createBuildStepsFromFunctionGroupCall(
+      globalCtx,
+      {
+        callInputs: {
+          flow_path: 'maestro/home.yml\nmaestro/login.yml',
+        },
+      }
+    );
+
+    const stepDisplayNames = steps.map(step => step.displayName);
+    expect(stepDisplayNames).toEqual([
+      'Install Maestro',
+      'Start Android Emulator',
+      'Install app to Emulator',
+      'maestro test maestro/home.yml',
+      'maestro test maestro/login.yml',
+      'Collect Android emulator logs',
+      'Upload Maestro test results',
+    ]);
+    expect(steps[5].ifCondition).toBe('${ always() }');
+    expect(steps[6].ifCondition).toBe('${ always() }');
   });
 });

--- a/packages/build-tools/src/steps/__tests__/easFunctionGroups.test.ts
+++ b/packages/build-tools/src/steps/__tests__/easFunctionGroups.test.ts
@@ -59,4 +59,24 @@ describe(getEasFunctionGroups, () => {
     expect(steps[5].ifCondition).toBe('${ always() }');
     expect(steps[6].ifCondition).toBe('${ always() }');
   });
+
+  it('does not collect Android emulator logs for iOS Maestro tests', () => {
+    const ctx = {
+      job: {
+        platform: Platform.IOS,
+      },
+    } as unknown as Parameters<typeof createEasMaestroTestFunctionGroup>[0];
+    const globalCtx = createGlobalContextMock();
+
+    const steps = createEasMaestroTestFunctionGroup(ctx).createBuildStepsFromFunctionGroupCall(
+      globalCtx,
+      {
+        callInputs: {
+          flow_path: 'maestro/home.yml',
+        },
+      }
+    );
+
+    expect(steps.map(step => step.displayName)).not.toContain('Collect Android emulator logs');
+  });
 });

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -3,6 +3,7 @@ import { BuildFunction } from '@expo/steps';
 import { calculateEASUpdateRuntimeVersionFunction } from './functions/calculateEASUpdateRuntimeVersion';
 import { createCapturePosthogEventFunction } from './functions/capturePosthogEvent';
 import { createCheckoutBuildFunction } from './functions/checkout';
+import { createCollectEmulatorLogsBuildFunction } from './functions/collectEmulatorLogs';
 import { configureAndroidVersionFunction } from './functions/configureAndroidVersion';
 import { configureEASUpdateIfInstalledFunction } from './functions/configureEASUpdateIfInstalled';
 import { configureIosCredentialsFunction } from './functions/configureIosCredentials';
@@ -64,6 +65,7 @@ import { CustomBuildContext } from '../customBuildContext';
 export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
   const functions = [
     createCheckoutBuildFunction(),
+    createCollectEmulatorLogsBuildFunction(),
     createDownloadArtifactFunction(),
     createUploadArtifactBuildFunction(ctx),
     createSetUpNpmrcBuildFunction(),

--- a/packages/build-tools/src/steps/functionGroups/maestroTest.ts
+++ b/packages/build-tools/src/steps/functionGroups/maestroTest.ts
@@ -7,6 +7,7 @@ import {
 } from '@expo/steps';
 
 import { CustomBuildContext } from '../../customBuildContext';
+import { createCollectEmulatorLogsBuildFunction } from '../functions/collectEmulatorLogs';
 import { createInstallMaestroBuildFunction } from '../functions/installMaestro';
 import { createStartAndroidEmulatorBuildFunction } from '../functions/startAndroidEmulator';
 import { createStartIosSimulatorBuildFunction } from '../functions/startIosSimulator';
@@ -138,6 +139,12 @@ export function createEasMaestroTestFunctionGroup(
           })
         );
       }
+
+      steps.push(
+        createCollectEmulatorLogsBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+          ifCondition: '${ always() }',
+        })
+      );
 
       steps.push(
         createUploadArtifactBuildFunction(buildToolsContext).createBuildStepFromFunctionCall(

--- a/packages/build-tools/src/steps/functionGroups/maestroTest.ts
+++ b/packages/build-tools/src/steps/functionGroups/maestroTest.ts
@@ -140,11 +140,13 @@ export function createEasMaestroTestFunctionGroup(
         );
       }
 
-      steps.push(
-        createCollectEmulatorLogsBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
-          ifCondition: '${ always() }',
-        })
-      );
+      if (buildToolsContext.job.platform === Platform.ANDROID) {
+        steps.push(
+          createCollectEmulatorLogsBuildFunction().createBuildStepFromFunctionCall(globalCtx, {
+            ifCondition: '${ always() }',
+          })
+        );
+      }
 
       steps.push(
         createUploadArtifactBuildFunction(buildToolsContext).createBuildStepFromFunctionCall(

--- a/packages/build-tools/src/steps/functions/__integration-tests__/collectEmulatorLogs.test.ts
+++ b/packages/build-tools/src/steps/functions/__integration-tests__/collectEmulatorLogs.test.ts
@@ -1,10 +1,18 @@
+import { asyncResult } from '@expo/results';
+import spawn from '@expo/turtle-spawn';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { randomUUID } from 'node:crypto';
 
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createMockLogger } from '../../../__tests__/utils/logger';
-import { AndroidEmulatorUtils } from '../../../utils/AndroidEmulatorUtils';
+import {
+  AndroidEmulatorUtils,
+  AndroidDeviceSerialId,
+  AndroidVirtualDeviceName,
+} from '../../../utils/AndroidEmulatorUtils';
+import { retryAsync } from '../../../utils/retry';
 import { createCollectEmulatorLogsBuildFunction } from '../collectEmulatorLogs';
 
 jest.unmock('fs');
@@ -51,4 +59,121 @@ describe('createCollectEmulatorLogsBuildFunction', () => {
       await fs.promises.rm(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('collects streamed logcat output from a running emulator', async () => {
+    const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'collect-emulator-logs-'));
+    const deviceName =
+      `android-emulator-logcat-e2e-${randomUUID().slice(0, 8)}` as AndroidVirtualDeviceName;
+    let emulatorPromise: Promise<unknown> | null = null;
+    let serialId: AndroidDeviceSerialId | null = null;
+
+    try {
+      const logger = createMockLogger({ logToConsole: true });
+      const buildLogsDirectory = path.join(tempDir, 'build-logs');
+      const destinationPath = path.join(tempDir, 'maestro-tests', 'emulator-logs');
+      const sourcePath = AndroidEmulatorUtils.getLogcatStagingDirectoryPath({ buildLogsDirectory });
+      const marker = `ENG-20762-${randomUUID()}`;
+
+      await AndroidEmulatorUtils.createAsync({
+        deviceName,
+        systemImagePackage: AndroidEmulatorUtils.defaultSystemImagePackage,
+        deviceIdentifier: null,
+        env: process.env,
+        logger,
+      });
+
+      const startResult = await AndroidEmulatorUtils.startAsync({
+        deviceName,
+        env: { ...process.env, ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: '1' },
+      });
+      serialId = startResult.serialId;
+      emulatorPromise = asyncResult(startResult.emulatorPromise);
+
+      const streamResult = await AndroidEmulatorUtils.startLogcatStreamingAsync({
+        serialId: startResult.serialId,
+        outputDir: sourcePath,
+        env: process.env,
+        logger,
+      });
+      expect(streamResult).not.toBeNull();
+
+      await AndroidEmulatorUtils.waitForReadyAsync({
+        serialId: startResult.serialId,
+        env: process.env,
+      });
+
+      await spawn(
+        'adb',
+        ['-s', startResult.serialId, 'shell', 'log', '-t', 'EAS_CLI_TEST', marker],
+        { env: process.env }
+      );
+
+      await retryAsync(
+        async () => {
+          const stagedLogFiles = (await fs.promises.readdir(sourcePath)).filter(entry =>
+            entry.endsWith('.log')
+          );
+          expect(stagedLogFiles.length).toBeGreaterThan(0);
+          const stagedLogPath = path.join(sourcePath, stagedLogFiles[0]);
+          const contents = await fs.promises.readFile(stagedLogPath, 'utf-8');
+          if (!contents.includes(marker)) {
+            throw new Error(`Did not find marker ${marker} in staged log yet.`);
+          }
+        },
+        {
+          logger,
+          retryOptions: {
+            retries: 10,
+            retryIntervalMs: 1_000,
+          },
+        }
+      );
+
+      const collectEmulatorLogs = createCollectEmulatorLogsBuildFunction();
+      const step = collectEmulatorLogs.createBuildStepFromFunctionCall(
+        createGlobalContextMock({
+          logger,
+          buildLogsDirectory,
+        }),
+        {
+          callInputs: {
+            destination_path: destinationPath,
+          },
+        }
+      );
+
+      await expect(step.executeAsync()).resolves.not.toThrow();
+
+      const collectedLogFiles = (await fs.promises.readdir(destinationPath)).filter(entry =>
+        entry.endsWith('.log')
+      );
+      expect(collectedLogFiles.length).toBeGreaterThan(0);
+      const collectedLogPath = path.join(destinationPath, collectedLogFiles[0]);
+      await expect(fs.promises.readFile(collectedLogPath, 'utf-8')).resolves.toContain(marker);
+    } finally {
+      try {
+        if (serialId) {
+          await AndroidEmulatorUtils.deleteAsync({
+            serialId,
+            deviceName,
+            env: process.env,
+          });
+        } else {
+          await AndroidEmulatorUtils.deleteAsync({
+            deviceName,
+            env: process.env,
+          });
+        }
+      } catch (error) {
+        console.warn(
+          'Failed to clean up emulator during collectEmulatorLogs integration test',
+          error
+        );
+      }
+      if (emulatorPromise) {
+        await emulatorPromise;
+      }
+      await fs.promises.rm(tempDir, { recursive: true, force: true });
+    }
+  }, 180_000);
 });

--- a/packages/build-tools/src/steps/functions/__integration-tests__/collectEmulatorLogs.test.ts
+++ b/packages/build-tools/src/steps/functions/__integration-tests__/collectEmulatorLogs.test.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { AndroidEmulatorUtils } from '../../../utils/AndroidEmulatorUtils';
+import { createCollectEmulatorLogsBuildFunction } from '../collectEmulatorLogs';
+
+jest.unmock('fs');
+jest.unmock('node:fs');
+
+describe('createCollectEmulatorLogsBuildFunction', () => {
+  it('copies staged emulator logcat files from the build logs directory', async () => {
+    const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'collect-emulator-logs-'));
+    try {
+      const buildLogsDirectory = path.join(tempDir, 'build-logs');
+      const destinationPath = path.join(tempDir, 'maestro-tests', 'emulator-logs');
+      const sourcePath = AndroidEmulatorUtils.getLogcatStagingDirectoryPath({ buildLogsDirectory });
+
+      await fs.promises.mkdir(sourcePath, { recursive: true });
+      await fs.promises.writeFile(path.join(sourcePath, '1111-emulator-5554.log'), 'first log\n');
+      await fs.promises.writeFile(path.join(sourcePath, '2222-emulator-5556.log'), 'second log\n');
+      await fs.promises.writeFile(path.join(sourcePath, '2222-emulator-5556.log.json'), '{}\n');
+
+      const collectEmulatorLogs = createCollectEmulatorLogsBuildFunction();
+      const step = collectEmulatorLogs.createBuildStepFromFunctionCall(
+        createGlobalContextMock({
+          logger: createMockLogger({ logToConsole: true }),
+          buildLogsDirectory,
+        }),
+        {
+          callInputs: {
+            destination_path: destinationPath,
+          },
+        }
+      );
+
+      await expect(step.executeAsync()).resolves.not.toThrow();
+
+      await expect(
+        fs.promises.readFile(path.join(destinationPath, '1111-emulator-5554.log'), 'utf-8')
+      ).resolves.toBe('first log\n');
+      await expect(
+        fs.promises.readFile(path.join(destinationPath, '2222-emulator-5556.log'), 'utf-8')
+      ).resolves.toBe('second log\n');
+      await expect(
+        fs.promises.access(path.join(destinationPath, '2222-emulator-5556.log.json'))
+      ).rejects.toThrow();
+    } finally {
+      await fs.promises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/build-tools/src/steps/functions/__integration-tests__/collectEmulatorLogs.test.ts
+++ b/packages/build-tools/src/steps/functions/__integration-tests__/collectEmulatorLogs.test.ts
@@ -8,8 +8,8 @@ import { randomUUID } from 'node:crypto';
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createMockLogger } from '../../../__tests__/utils/logger';
 import {
-  AndroidEmulatorUtils,
   AndroidDeviceSerialId,
+  AndroidEmulatorUtils,
   AndroidVirtualDeviceName,
 } from '../../../utils/AndroidEmulatorUtils';
 import { retryAsync } from '../../../utils/retry';

--- a/packages/build-tools/src/steps/functions/__integration-tests__/collectEmulatorLogs.test.ts
+++ b/packages/build-tools/src/steps/functions/__integration-tests__/collectEmulatorLogs.test.ts
@@ -60,7 +60,7 @@ describe('createCollectEmulatorLogsBuildFunction', () => {
     }
   });
 
-  it('collects streamed logcat output from a running emulator', async () => {
+  it('collects native logcat output across an ADB server restart', async () => {
     const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'collect-emulator-logs-'));
     const deviceName =
       `android-emulator-logcat-e2e-${randomUUID().slice(0, 8)}` as AndroidVirtualDeviceName;
@@ -85,23 +85,19 @@ describe('createCollectEmulatorLogsBuildFunction', () => {
       const startResult = await AndroidEmulatorUtils.startAsync({
         deviceName,
         env: { ...process.env, ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: '1' },
+        logcat: { outputDir: sourcePath, logger },
       });
       serialId = startResult.serialId;
       emulatorPromise = asyncResult(startResult.emulatorPromise);
-
-      const streamResult = await AndroidEmulatorUtils.startLogcatStreamingAsync({
-        serialId: startResult.serialId,
-        outputDir: sourcePath,
-        env: process.env,
-        logger,
-      });
-      expect(streamResult).not.toBeNull();
+      expect(startResult.logcatOutputPath).not.toBeNull();
 
       await AndroidEmulatorUtils.waitForReadyAsync({
         serialId: startResult.serialId,
         env: process.env,
       });
 
+      await spawn('adb', ['kill-server'], { env: process.env });
+      await spawn('adb', ['start-server'], { env: process.env });
       await spawn(
         'adb',
         ['-s', startResult.serialId, 'shell', 'log', '-t', 'EAS_CLI_TEST', marker],

--- a/packages/build-tools/src/steps/functions/__integration-tests__/collectEmulatorLogs.test.ts
+++ b/packages/build-tools/src/steps/functions/__integration-tests__/collectEmulatorLogs.test.ts
@@ -26,10 +26,15 @@ describe('createCollectEmulatorLogsBuildFunction', () => {
       const destinationPath = path.join(tempDir, 'maestro-tests', 'emulator-logs');
       const sourcePath = AndroidEmulatorUtils.getLogcatStagingDirectoryPath({ buildLogsDirectory });
 
-      await fs.promises.mkdir(sourcePath, { recursive: true });
-      await fs.promises.writeFile(path.join(sourcePath, '1111-emulator-5554.log'), 'first log\n');
-      await fs.promises.writeFile(path.join(sourcePath, '2222-emulator-5556.log'), 'second log\n');
-      await fs.promises.writeFile(path.join(sourcePath, '2222-emulator-5556.log.json'), '{}\n');
+      const firstLogDirectory = path.join(sourcePath, 'EasAndroidDevice01-abc123');
+      const secondLogDirectory = path.join(sourcePath, 'eas-simulator-1-def456');
+      await Promise.all([
+        fs.promises.mkdir(firstLogDirectory, { recursive: true }),
+        fs.promises.mkdir(secondLogDirectory, { recursive: true }),
+      ]);
+      await fs.promises.writeFile(path.join(firstLogDirectory, 'logcat.log'), 'first log\n');
+      await fs.promises.writeFile(path.join(secondLogDirectory, 'logcat.log'), 'second log\n');
+      await fs.promises.writeFile(path.join(secondLogDirectory, 'metadata.json'), '{}\n');
 
       const collectEmulatorLogs = createCollectEmulatorLogsBuildFunction();
       const step = collectEmulatorLogs.createBuildStepFromFunctionCall(
@@ -47,13 +52,13 @@ describe('createCollectEmulatorLogsBuildFunction', () => {
       await expect(step.executeAsync()).resolves.not.toThrow();
 
       await expect(
-        fs.promises.readFile(path.join(destinationPath, '1111-emulator-5554.log'), 'utf-8')
+        fs.promises.readFile(path.join(destinationPath, 'EasAndroidDevice01-abc123.log'), 'utf-8')
       ).resolves.toBe('first log\n');
       await expect(
-        fs.promises.readFile(path.join(destinationPath, '2222-emulator-5556.log'), 'utf-8')
+        fs.promises.readFile(path.join(destinationPath, 'eas-simulator-1-def456.log'), 'utf-8')
       ).resolves.toBe('second log\n');
       await expect(
-        fs.promises.access(path.join(destinationPath, '2222-emulator-5556.log.json'))
+        fs.promises.access(path.join(destinationPath, 'metadata.json'))
       ).rejects.toThrow();
     } finally {
       await fs.promises.rm(tempDir, { recursive: true, force: true });
@@ -71,7 +76,6 @@ describe('createCollectEmulatorLogsBuildFunction', () => {
       const logger = createMockLogger({ logToConsole: true });
       const buildLogsDirectory = path.join(tempDir, 'build-logs');
       const destinationPath = path.join(tempDir, 'maestro-tests', 'emulator-logs');
-      const sourcePath = AndroidEmulatorUtils.getLogcatStagingDirectoryPath({ buildLogsDirectory });
       const marker = `ENG-20762-${randomUUID()}`;
 
       await AndroidEmulatorUtils.createAsync({
@@ -83,13 +87,12 @@ describe('createCollectEmulatorLogsBuildFunction', () => {
       });
 
       const startResult = await AndroidEmulatorUtils.startAsync({
+        buildLogsDirectory,
         deviceName,
         env: { ...process.env, ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: '1' },
-        logcat: { outputDir: sourcePath, logger },
       });
       serialId = startResult.serialId;
       emulatorPromise = asyncResult(startResult.emulatorPromise);
-      expect(startResult.logcatOutputPath).not.toBeNull();
 
       await AndroidEmulatorUtils.waitForReadyAsync({
         serialId: startResult.serialId,
@@ -106,12 +109,7 @@ describe('createCollectEmulatorLogsBuildFunction', () => {
 
       await retryAsync(
         async () => {
-          const stagedLogFiles = (await fs.promises.readdir(sourcePath)).filter(entry =>
-            entry.endsWith('.log')
-          );
-          expect(stagedLogFiles.length).toBeGreaterThan(0);
-          const stagedLogPath = path.join(sourcePath, stagedLogFiles[0]);
-          const contents = await fs.promises.readFile(stagedLogPath, 'utf-8');
+          const contents = await fs.promises.readFile(startResult.logcatOutputPath, 'utf-8');
           if (!contents.includes(marker)) {
             throw new Error(`Did not find marker ${marker} in staged log yet.`);
           }

--- a/packages/build-tools/src/steps/functions/__tests__/collectEmulatorLogs.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/collectEmulatorLogs.test.ts
@@ -1,0 +1,97 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { createCollectEmulatorLogsBuildFunction } from '../collectEmulatorLogs';
+
+function createStep(callInputs?: Record<string, unknown>, envOverrides?: NodeJS.ProcessEnv) {
+  const logger = createMockLogger();
+  const fn = createCollectEmulatorLogsBuildFunction();
+  const buildLogsDirectory =
+    typeof envOverrides?.BUILD_LOGS_DIRECTORY === 'string'
+      ? envOverrides.BUILD_LOGS_DIRECTORY
+      : undefined;
+  const globalCtx = createGlobalContextMock({ logger, buildLogsDirectory });
+  globalCtx.updateEnv({ HOME: '/home/expo', ...envOverrides });
+  const step = fn.createBuildStepFromFunctionCall(globalCtx, {
+    callInputs,
+  });
+  return Object.assign(step, { logger });
+}
+
+describe(createCollectEmulatorLogsBuildFunction, () => {
+  it('copies staged logs to the destination path', async () => {
+    const buildLogsDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'build-logs-'));
+    const sourcePath = path.join(buildLogsDirectory, 'android-emulator-logcat');
+    const destinationPath = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'logcat-destination-')
+    );
+    await fs.promises.mkdir(sourcePath, { recursive: true });
+    const logPath = path.join(sourcePath, 'emulator-5554.log');
+    await fs.promises.writeFile(logPath, 'log line\n');
+
+    await createStep(
+      {
+        destination_path: destinationPath,
+      },
+      {
+        BUILD_LOGS_DIRECTORY: buildLogsDirectory,
+      }
+    ).executeAsync();
+
+    await expect(
+      fs.promises.readFile(path.join(destinationPath, 'emulator-5554.log'), 'utf-8')
+    ).resolves.toBe('log line\n');
+  });
+
+  it('copies staged logs in parallel and skips metadata files', async () => {
+    const buildLogsDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'build-logs-'));
+    const sourcePath = path.join(buildLogsDirectory, 'android-emulator-logcat');
+    const destinationPath = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'logcat-destination-')
+    );
+    await fs.promises.mkdir(sourcePath, { recursive: true });
+    await fs.promises.writeFile(path.join(sourcePath, '1234-emulator-5554.log'), 'first\n');
+    await fs.promises.writeFile(path.join(sourcePath, '5678-emulator-5556.log'), 'second\n');
+    await fs.promises.writeFile(path.join(sourcePath, '5678-emulator-5556.log.json'), '{}\n');
+
+    const step = createStep(
+      {
+        destination_path: destinationPath,
+      },
+      {
+        BUILD_LOGS_DIRECTORY: buildLogsDirectory,
+      }
+    );
+    await expect(step.executeAsync()).resolves.toBeUndefined();
+    await expect(
+      fs.promises.readFile(path.join(destinationPath, '1234-emulator-5554.log'), 'utf-8')
+    ).resolves.toBe('first\n');
+    await expect(
+      fs.promises.readFile(path.join(destinationPath, '5678-emulator-5556.log'), 'utf-8')
+    ).resolves.toBe('second\n');
+    await expect(
+      fs.promises.access(path.join(destinationPath, '5678-emulator-5556.log.json'))
+    ).rejects.toThrow();
+  });
+
+  it('warns but does not fail when the staging directory is missing', async () => {
+    const buildLogsDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'build-logs-'));
+    const sourcePath = path.join(buildLogsDirectory, 'android-emulator-logcat');
+    const step = createStep(
+      {
+        destination_path: await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-destination-')),
+      },
+      {
+        BUILD_LOGS_DIRECTORY: buildLogsDirectory,
+      }
+    );
+
+    await expect(step.executeAsync()).resolves.toBeUndefined();
+    expect(step.ctx.logger.warn).toHaveBeenCalledWith(
+      `No Android emulator logcat staging directory found at ${sourcePath}.`
+    );
+  });
+});

--- a/packages/build-tools/src/steps/functions/__tests__/collectEmulatorLogs.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/collectEmulatorLogs.test.ts
@@ -22,12 +22,24 @@ function createStep(callInputs?: Record<string, unknown>, envOverrides?: NodeJS.
 }
 
 describe(createCollectEmulatorLogsBuildFunction, () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      temporaryDirectories.splice(0).map(async temporaryDirectory => {
+        await fs.promises.rm(temporaryDirectory, { force: true, recursive: true });
+      })
+    );
+  });
+
   it('copies staged logs to the destination path', async () => {
     const buildLogsDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'build-logs-'));
+    temporaryDirectories.push(buildLogsDirectory);
     const sourcePath = path.join(buildLogsDirectory, 'android-emulator-logcat');
     const destinationPath = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), 'logcat-destination-')
     );
+    temporaryDirectories.push(destinationPath);
     await fs.promises.mkdir(sourcePath, { recursive: true });
     const logPath = path.join(sourcePath, 'emulator-5554.log');
     await fs.promises.writeFile(logPath, 'log line\n');
@@ -48,10 +60,12 @@ describe(createCollectEmulatorLogsBuildFunction, () => {
 
   it('copies staged logs in parallel and skips metadata files', async () => {
     const buildLogsDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'build-logs-'));
+    temporaryDirectories.push(buildLogsDirectory);
     const sourcePath = path.join(buildLogsDirectory, 'android-emulator-logcat');
     const destinationPath = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), 'logcat-destination-')
     );
+    temporaryDirectories.push(destinationPath);
     await fs.promises.mkdir(sourcePath, { recursive: true });
     await fs.promises.writeFile(path.join(sourcePath, '1234-emulator-5554.log'), 'first\n');
     await fs.promises.writeFile(path.join(sourcePath, '5678-emulator-5556.log'), 'second\n');
@@ -79,10 +93,15 @@ describe(createCollectEmulatorLogsBuildFunction, () => {
 
   it('warns but does not fail when the staging directory is missing', async () => {
     const buildLogsDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'build-logs-'));
+    temporaryDirectories.push(buildLogsDirectory);
     const sourcePath = path.join(buildLogsDirectory, 'android-emulator-logcat');
+    const destinationPath = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'logcat-destination-')
+    );
+    temporaryDirectories.push(destinationPath);
     const step = createStep(
       {
-        destination_path: await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-destination-')),
+        destination_path: destinationPath,
       },
       {
         BUILD_LOGS_DIRECTORY: buildLogsDirectory,

--- a/packages/build-tools/src/steps/functions/__tests__/collectEmulatorLogs.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/collectEmulatorLogs.test.ts
@@ -40,8 +40,9 @@ describe(createCollectEmulatorLogsBuildFunction, () => {
       path.join(os.tmpdir(), 'logcat-destination-')
     );
     temporaryDirectories.push(destinationPath);
-    await fs.promises.mkdir(sourcePath, { recursive: true });
-    const logPath = path.join(sourcePath, 'emulator-5554.log');
+    const logDirectory = path.join(sourcePath, 'EasAndroidDevice01-abc123');
+    await fs.promises.mkdir(logDirectory, { recursive: true });
+    const logPath = path.join(logDirectory, 'logcat.log');
     await fs.promises.writeFile(logPath, 'log line\n');
 
     await createStep(
@@ -54,7 +55,7 @@ describe(createCollectEmulatorLogsBuildFunction, () => {
     ).executeAsync();
 
     await expect(
-      fs.promises.readFile(path.join(destinationPath, 'emulator-5554.log'), 'utf-8')
+      fs.promises.readFile(path.join(destinationPath, 'EasAndroidDevice01-abc123.log'), 'utf-8')
     ).resolves.toBe('log line\n');
   });
 
@@ -66,10 +67,15 @@ describe(createCollectEmulatorLogsBuildFunction, () => {
       path.join(os.tmpdir(), 'logcat-destination-')
     );
     temporaryDirectories.push(destinationPath);
-    await fs.promises.mkdir(sourcePath, { recursive: true });
-    await fs.promises.writeFile(path.join(sourcePath, '1234-emulator-5554.log'), 'first\n');
-    await fs.promises.writeFile(path.join(sourcePath, '5678-emulator-5556.log'), 'second\n');
-    await fs.promises.writeFile(path.join(sourcePath, '5678-emulator-5556.log.json'), '{}\n');
+    const firstLogDirectory = path.join(sourcePath, 'EasAndroidDevice01-abc123');
+    const secondLogDirectory = path.join(sourcePath, 'eas-simulator-1-def456');
+    await Promise.all([
+      fs.promises.mkdir(firstLogDirectory, { recursive: true }),
+      fs.promises.mkdir(secondLogDirectory, { recursive: true }),
+    ]);
+    await fs.promises.writeFile(path.join(firstLogDirectory, 'logcat.log'), 'first\n');
+    await fs.promises.writeFile(path.join(secondLogDirectory, 'logcat.log'), 'second\n');
+    await fs.promises.writeFile(path.join(secondLogDirectory, 'metadata.json'), '{}\n');
 
     const step = createStep(
       {
@@ -81,14 +87,12 @@ describe(createCollectEmulatorLogsBuildFunction, () => {
     );
     await expect(step.executeAsync()).resolves.toBeUndefined();
     await expect(
-      fs.promises.readFile(path.join(destinationPath, '1234-emulator-5554.log'), 'utf-8')
+      fs.promises.readFile(path.join(destinationPath, 'EasAndroidDevice01-abc123.log'), 'utf-8')
     ).resolves.toBe('first\n');
     await expect(
-      fs.promises.readFile(path.join(destinationPath, '5678-emulator-5556.log'), 'utf-8')
+      fs.promises.readFile(path.join(destinationPath, 'eas-simulator-1-def456.log'), 'utf-8')
     ).resolves.toBe('second\n');
-    await expect(
-      fs.promises.access(path.join(destinationPath, '5678-emulator-5556.log.json'))
-    ).rejects.toThrow();
+    await expect(fs.promises.access(path.join(destinationPath, 'metadata.json'))).rejects.toThrow();
   });
 
   it('warns but does not fail when the staging directory is missing', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts
@@ -25,6 +25,8 @@ jest.mock('../../../utils/AndroidEmulatorUtils', () => ({
     createAsync: jest.fn(),
     cloneAsync: jest.fn(),
     startAsync: jest.fn(),
+    startLogcatStreamingAsync: jest.fn(),
+    getLogcatStagingDirectoryPath: jest.fn(),
     waitForReadyAsync: jest.fn(),
     disableWindowAndTransitionAnimationsAsync: jest.fn(),
     deleteAsync: jest.fn(),
@@ -59,6 +61,12 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
     mockedAndroidUtils.createAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.cloneAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.startAsync.mockResolvedValue(createStartResult('emulator-default'));
+    mockedAndroidUtils.startLogcatStreamingAsync.mockResolvedValue({
+      outputPath: '/non/existent/dir/android-emulator-logcat/emulator-default.log',
+    });
+    mockedAndroidUtils.getLogcatStagingDirectoryPath.mockReturnValue(
+      '/non/existent/dir/android-emulator-logcat'
+    );
     mockedAndroidUtils.waitForReadyAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.disableWindowAndTransitionAnimationsAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.deleteAsync.mockResolvedValue(undefined);
@@ -105,6 +113,23 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
       expect.objectContaining({
         serialId: 'emulator-2222',
       })
+    );
+    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        serialId: 'emulator-1111',
+        outputDir: '/non/existent/dir/android-emulator-logcat',
+      })
+    );
+    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        serialId: 'emulator-2222',
+        outputDir: '/non/existent/dir/android-emulator-logcat',
+      })
+    );
+    expect(mockedAndroidUtils.startLogcatStreamingAsync.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedAndroidUtils.waitForReadyAsync.mock.invocationCallOrder[0]
     );
     expect(mockedAndroidUtils.deleteAsync).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -174,6 +199,26 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
         serialId: 'emulator-clone-2-attempt-1',
       })
     );
+    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serialId: 'emulator-base',
+      })
+    );
+    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serialId: 'emulator-clone-1-attempt-1',
+      })
+    );
+    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serialId: 'emulator-clone-1-attempt-2',
+      })
+    );
+    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serialId: 'emulator-clone-2-attempt-1',
+      })
+    );
 
     expect(mockedAndroidUtils.deleteAsync).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -200,6 +245,24 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
       })
     );
     expect(mockedAndroidUtils.deleteAsync).toHaveBeenCalledTimes(3);
+    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenCalledTimes(3);
+  });
+
+  it('continues emulator startup when logcat streaming fails', async () => {
+    mockedAndroidUtils.startLogcatStreamingAsync.mockResolvedValue(null);
+
+    await createStep().executeAsync();
+
+    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serialId: 'emulator-default',
+      })
+    );
+    expect(mockedAndroidUtils.waitForReadyAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serialId: 'emulator-default',
+      })
+    );
   });
 
   it('skips animation scale adjustments when opt out env var is disabled', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts
@@ -25,7 +25,6 @@ jest.mock('../../../utils/AndroidEmulatorUtils', () => ({
     createAsync: jest.fn(),
     cloneAsync: jest.fn(),
     startAsync: jest.fn(),
-    startLogcatStreamingAsync: jest.fn(),
     getLogcatStagingDirectoryPath: jest.fn(),
     waitForReadyAsync: jest.fn(),
     disableWindowAndTransitionAnimationsAsync: jest.fn(),
@@ -61,9 +60,6 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
     mockedAndroidUtils.createAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.cloneAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.startAsync.mockResolvedValue(createStartResult('emulator-default'));
-    mockedAndroidUtils.startLogcatStreamingAsync.mockResolvedValue({
-      outputPath: '/non/existent/dir/android-emulator-logcat/emulator-default.log',
-    });
     mockedAndroidUtils.getLogcatStagingDirectoryPath.mockReturnValue(
       '/non/existent/dir/android-emulator-logcat'
     );
@@ -114,22 +110,23 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
         serialId: 'emulator-2222',
       })
     );
-    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenNthCalledWith(
+    expect(mockedAndroidUtils.startAsync).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        serialId: 'emulator-1111',
-        outputDir: '/non/existent/dir/android-emulator-logcat',
+        deviceName: 'EasAndroidDevice01',
+        logcat: expect.objectContaining({
+          outputDir: '/non/existent/dir/android-emulator-logcat',
+        }),
       })
     );
-    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenNthCalledWith(
+    expect(mockedAndroidUtils.startAsync).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        serialId: 'emulator-2222',
-        outputDir: '/non/existent/dir/android-emulator-logcat',
+        deviceName: 'EasAndroidDevice01',
+        logcat: expect.objectContaining({
+          outputDir: '/non/existent/dir/android-emulator-logcat',
+        }),
       })
-    );
-    expect(mockedAndroidUtils.startLogcatStreamingAsync.mock.invocationCallOrder[0]).toBeLessThan(
-      mockedAndroidUtils.waitForReadyAsync.mock.invocationCallOrder[0]
     );
     expect(mockedAndroidUtils.deleteAsync).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -199,24 +196,22 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
         serialId: 'emulator-clone-2-attempt-1',
       })
     );
-    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenCalledWith(
+    expect(mockedAndroidUtils.startAsync).toHaveBeenCalledWith(
       expect.objectContaining({
-        serialId: 'emulator-base',
+        deviceName: 'EasAndroidDevice01',
+        logcat: expect.any(Object),
       })
     );
-    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenCalledWith(
+    expect(mockedAndroidUtils.startAsync).toHaveBeenCalledWith(
       expect.objectContaining({
-        serialId: 'emulator-clone-1-attempt-1',
+        deviceName: 'eas-simulator-1',
+        logcat: expect.any(Object),
       })
     );
-    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenCalledWith(
+    expect(mockedAndroidUtils.startAsync).toHaveBeenCalledWith(
       expect.objectContaining({
-        serialId: 'emulator-clone-1-attempt-2',
-      })
-    );
-    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenCalledWith(
-      expect.objectContaining({
-        serialId: 'emulator-clone-2-attempt-1',
+        deviceName: 'eas-simulator-2',
+        logcat: expect.any(Object),
       })
     );
 
@@ -245,17 +240,17 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
       })
     );
     expect(mockedAndroidUtils.deleteAsync).toHaveBeenCalledTimes(3);
-    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenCalledTimes(3);
+    expect(mockedAndroidUtils.startAsync).toHaveBeenCalledTimes(3);
   });
 
-  it('continues emulator startup when logcat streaming fails', async () => {
-    mockedAndroidUtils.startLogcatStreamingAsync.mockResolvedValue(null);
-
+  it('passes the logcat staging directory when starting an emulator', async () => {
     await createStep().executeAsync();
 
-    expect(mockedAndroidUtils.startLogcatStreamingAsync).toHaveBeenCalledWith(
+    expect(mockedAndroidUtils.startAsync).toHaveBeenCalledWith(
       expect.objectContaining({
-        serialId: 'emulator-default',
+        logcat: expect.objectContaining({
+          outputDir: '/non/existent/dir/android-emulator-logcat',
+        }),
       })
     );
     expect(mockedAndroidUtils.waitForReadyAsync).toHaveBeenCalledWith(

--- a/packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts
@@ -25,7 +25,6 @@ jest.mock('../../../utils/AndroidEmulatorUtils', () => ({
     createAsync: jest.fn(),
     cloneAsync: jest.fn(),
     startAsync: jest.fn(),
-    getLogcatStagingDirectoryPath: jest.fn(),
     waitForReadyAsync: jest.fn(),
     disableWindowAndTransitionAnimationsAsync: jest.fn(),
     deleteAsync: jest.fn(),
@@ -60,9 +59,6 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
     mockedAndroidUtils.createAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.cloneAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.startAsync.mockResolvedValue(createStartResult('emulator-default'));
-    mockedAndroidUtils.getLogcatStagingDirectoryPath.mockReturnValue(
-      '/non/existent/dir/android-emulator-logcat'
-    );
     mockedAndroidUtils.waitForReadyAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.disableWindowAndTransitionAnimationsAsync.mockResolvedValue(undefined);
     mockedAndroidUtils.deleteAsync.mockResolvedValue(undefined);
@@ -113,19 +109,15 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
     expect(mockedAndroidUtils.startAsync).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
+        buildLogsDirectory: '/non/existent/dir',
         deviceName: 'EasAndroidDevice01',
-        logcat: expect.objectContaining({
-          outputDir: '/non/existent/dir/android-emulator-logcat',
-        }),
       })
     );
     expect(mockedAndroidUtils.startAsync).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
+        buildLogsDirectory: '/non/existent/dir',
         deviceName: 'EasAndroidDevice01',
-        logcat: expect.objectContaining({
-          outputDir: '/non/existent/dir/android-emulator-logcat',
-        }),
       })
     );
     expect(mockedAndroidUtils.deleteAsync).toHaveBeenCalledWith(
@@ -198,20 +190,20 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
     );
     expect(mockedAndroidUtils.startAsync).toHaveBeenCalledWith(
       expect.objectContaining({
+        buildLogsDirectory: '/non/existent/dir',
         deviceName: 'EasAndroidDevice01',
-        logcat: expect.any(Object),
       })
     );
     expect(mockedAndroidUtils.startAsync).toHaveBeenCalledWith(
       expect.objectContaining({
+        buildLogsDirectory: '/non/existent/dir',
         deviceName: 'eas-simulator-1',
-        logcat: expect.any(Object),
       })
     );
     expect(mockedAndroidUtils.startAsync).toHaveBeenCalledWith(
       expect.objectContaining({
+        buildLogsDirectory: '/non/existent/dir',
         deviceName: 'eas-simulator-2',
-        logcat: expect.any(Object),
       })
     );
 
@@ -243,14 +235,12 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
     expect(mockedAndroidUtils.startAsync).toHaveBeenCalledTimes(3);
   });
 
-  it('passes the logcat staging directory when starting an emulator', async () => {
+  it('passes the build logs directory when starting an emulator', async () => {
     await createStep().executeAsync();
 
     expect(mockedAndroidUtils.startAsync).toHaveBeenCalledWith(
       expect.objectContaining({
-        logcat: expect.objectContaining({
-          outputDir: '/non/existent/dir/android-emulator-logcat',
-        }),
+        buildLogsDirectory: '/non/existent/dir',
       })
     );
     expect(mockedAndroidUtils.waitForReadyAsync).toHaveBeenCalledWith(

--- a/packages/build-tools/src/steps/functions/collectEmulatorLogs.ts
+++ b/packages/build-tools/src/steps/functions/collectEmulatorLogs.ts
@@ -1,0 +1,83 @@
+import { bunyan } from '@expo/logger';
+import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { AndroidEmulatorUtils } from '../../utils/AndroidEmulatorUtils';
+
+export function createCollectEmulatorLogsBuildFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'collect_emulator_logs',
+    name: 'Collect Android emulator logs',
+    __metricsId: 'eas/collect_emulator_logs',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'destination_path',
+        required: false,
+        defaultValue: '${{ env.HOME }}/.maestro/tests/emulator-logs',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+    ],
+    fn: async ({ logger, global }, { inputs }) => {
+      const sourcePath = AndroidEmulatorUtils.getLogcatStagingDirectoryPath({
+        buildLogsDirectory: global.buildLogsDirectory,
+      });
+      const destinationPath = `${inputs.destination_path.value}`;
+
+      await collectEmulatorLogsAsync({ sourcePath, destinationPath, logger });
+    },
+  });
+}
+
+async function collectEmulatorLogsAsync({
+  sourcePath,
+  destinationPath,
+  logger,
+}: {
+  sourcePath: string;
+  destinationPath: string;
+  logger: bunyan;
+}): Promise<void> {
+  let directoryEntries: string[];
+  try {
+    directoryEntries = await fs.promises.readdir(sourcePath);
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') {
+      logger.warn(`No Android emulator logcat staging directory found at ${sourcePath}.`);
+      return;
+    }
+    logger.warn({ err }, `Failed to read Android emulator logcat staging directory ${sourcePath}.`);
+    return;
+  }
+
+  const logFiles = directoryEntries.filter(entry => entry.endsWith('.log'));
+  if (logFiles.length === 0) {
+    logger.warn(`No Android emulator logcat files found at ${sourcePath}.`);
+    return;
+  }
+
+  try {
+    await fs.promises.mkdir(destinationPath, { recursive: true });
+  } catch (err) {
+    logger.warn({ err }, `Failed to create Android emulator log destination ${destinationPath}.`);
+    return;
+  }
+
+  const copyResults = await Promise.all(
+    logFiles.map(async logFile => {
+      const sourceFilePath = path.join(sourcePath, logFile);
+      const destinationFilePath = path.join(destinationPath, logFile);
+      try {
+        await fs.promises.copyFile(sourceFilePath, destinationFilePath);
+        return true;
+      } catch (err) {
+        logger.warn({ err }, `Failed to copy Android emulator log ${sourceFilePath}.`);
+        return false;
+      }
+    })
+  );
+  const copiedCount = copyResults.filter(Boolean).length;
+
+  logger.info(`Collected ${copiedCount} Android emulator logcat file(s) to ${destinationPath}.`);
+}

--- a/packages/build-tools/src/steps/functions/collectEmulatorLogs.ts
+++ b/packages/build-tools/src/steps/functions/collectEmulatorLogs.ts
@@ -1,5 +1,6 @@
 import { bunyan } from '@expo/logger';
 import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
+import FastGlob from 'fast-glob';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -39,9 +40,8 @@ async function collectEmulatorLogsAsync({
   destinationPath: string;
   logger: bunyan;
 }): Promise<void> {
-  let directoryEntries: string[];
   try {
-    directoryEntries = await fs.promises.readdir(sourcePath);
+    await fs.promises.access(sourcePath);
   } catch (err: any) {
     if (err?.code === 'ENOENT') {
       logger.warn(`No Android emulator logcat staging directory found at ${sourcePath}.`);
@@ -51,7 +51,18 @@ async function collectEmulatorLogsAsync({
     return;
   }
 
-  const logFiles = directoryEntries.filter(entry => entry.endsWith('.log'));
+  let logFiles: string[];
+  try {
+    logFiles = await FastGlob('**/*.log', {
+      absolute: true,
+      cwd: sourcePath,
+      followSymbolicLinks: false,
+      onlyFiles: true,
+    });
+  } catch (err) {
+    logger.warn({ err }, `Failed to find Android emulator logcat files at ${sourcePath}.`);
+    return;
+  }
   if (logFiles.length === 0) {
     logger.warn(`No Android emulator logcat files found at ${sourcePath}.`);
     return;
@@ -65,9 +76,9 @@ async function collectEmulatorLogsAsync({
   }
 
   const copyResults = await Promise.all(
-    logFiles.map(async logFile => {
-      const sourceFilePath = path.join(sourcePath, logFile);
-      const destinationFilePath = path.join(destinationPath, logFile);
+    logFiles.map(async sourceFilePath => {
+      const stagingDirectoryName = path.basename(path.dirname(sourceFilePath));
+      const destinationFilePath = path.join(destinationPath, `${stagingDirectoryName}.log`);
       try {
         await fs.promises.copyFile(sourceFilePath, destinationFilePath);
         return true;

--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -49,7 +49,7 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
         allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
       }),
     ],
-    fn: async ({ logger }, { inputs, env }) => {
+    fn: async ({ logger, global }, { inputs, env }) => {
       if (env.EAS_NO_EMULATOR_HOST_SUPPORT_CHECK !== '1') {
         await assertAndroidEmulatorHostSupportAsync({ env });
       } else {
@@ -100,6 +100,9 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
 
       let emulatorPromise = null;
       let serialId = null;
+      const logcatOutputDir = AndroidEmulatorUtils.getLogcatStagingDirectoryPath({
+        buildLogsDirectory: global.buildLogsDirectory,
+      });
       await retryAsync(
         async attemptCount => {
           const timeoutMs = ANDROID_STARTUP_ATTEMPT_TIMEOUT_MS[attemptCount];
@@ -124,6 +127,12 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
               env,
             });
             attemptSerialId = startResult.serialId;
+            await AndroidEmulatorUtils.startLogcatStreamingAsync({
+              serialId: attemptSerialId,
+              outputDir: logcatOutputDir,
+              env,
+              logger,
+            });
             await AndroidEmulatorUtils.waitForReadyAsync({
               env,
               serialId: attemptSerialId,
@@ -213,6 +222,12 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
                   env,
                 });
                 cloneSerialId = startResult.serialId;
+                await AndroidEmulatorUtils.startLogcatStreamingAsync({
+                  serialId: cloneSerialId,
+                  outputDir: logcatOutputDir,
+                  env,
+                  logger,
+                });
 
                 logger.info('Waiting for emulator to become ready');
                 await AndroidEmulatorUtils.waitForReadyAsync({

--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -100,9 +100,6 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
 
       let emulatorPromise = null;
       let serialId = null;
-      const logcatOutputDir = AndroidEmulatorUtils.getLogcatStagingDirectoryPath({
-        buildLogsDirectory: global.buildLogsDirectory,
-      });
       await retryAsync(
         async attemptCount => {
           const timeoutMs = ANDROID_STARTUP_ATTEMPT_TIMEOUT_MS[attemptCount];
@@ -123,9 +120,9 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
 
             logger.info(`Starting emulator device${attemptSuffix}.`);
             const startResult = await AndroidEmulatorUtils.startAsync({
+              buildLogsDirectory: global.buildLogsDirectory,
               deviceName,
               env,
-              logcat: { outputDir: logcatOutputDir, logger },
             });
             attemptSerialId = startResult.serialId;
             await AndroidEmulatorUtils.waitForReadyAsync({
@@ -213,9 +210,9 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
 
                 logger.info(`Starting emulator device${attemptSuffix}.`);
                 const startResult = await AndroidEmulatorUtils.startAsync({
+                  buildLogsDirectory: global.buildLogsDirectory,
                   deviceName: cloneIdentifier,
                   env,
-                  logcat: { outputDir: logcatOutputDir, logger },
                 });
                 cloneSerialId = startResult.serialId;
 

--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -125,14 +125,9 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
             const startResult = await AndroidEmulatorUtils.startAsync({
               deviceName,
               env,
+              logcat: { outputDir: logcatOutputDir, logger },
             });
             attemptSerialId = startResult.serialId;
-            await AndroidEmulatorUtils.startLogcatStreamingAsync({
-              serialId: attemptSerialId,
-              outputDir: logcatOutputDir,
-              env,
-              logger,
-            });
             await AndroidEmulatorUtils.waitForReadyAsync({
               env,
               serialId: attemptSerialId,
@@ -220,14 +215,9 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
                 const startResult = await AndroidEmulatorUtils.startAsync({
                   deviceName: cloneIdentifier,
                   env,
+                  logcat: { outputDir: logcatOutputDir, logger },
                 });
                 cloneSerialId = startResult.serialId;
-                await AndroidEmulatorUtils.startLogcatStreamingAsync({
-                  serialId: cloneSerialId,
-                  outputDir: logcatOutputDir,
-                  env,
-                  logger,
-                });
 
                 logger.info('Waiting for emulator to become ready');
                 await AndroidEmulatorUtils.waitForReadyAsync({

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -517,7 +517,7 @@ export namespace AndroidEmulatorUtils {
 
       const logcatPromise = spawn('adb', ['-s', serialId, 'logcat', '-v', 'threadtime'], {
         env,
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: ['ignore', 'pipe', 'ignore'],
       });
       const { child } = logcatPromise;
 
@@ -534,6 +534,9 @@ export namespace AndroidEmulatorUtils {
       });
       writeStream.on('error', err => {
         logger.warn({ err }, `Failed to write Android emulator logcat for ${serialId}.`);
+      });
+      child.on('error', err => {
+        logger.warn({ err }, `Android emulator logcat process for ${serialId} failed.`);
       });
       child.on('close', () => {
         writeStream.end();

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -529,21 +529,36 @@ export namespace AndroidEmulatorUtils {
         throw new Error('"adb logcat" did not start correctly.');
       }
 
+      const childStdout = child.stdout;
       const safeSerialId = serialId.replace(/[^a-zA-Z0-9_.-]/g, '_');
       const outputPath = path.join(outputDir, `${child.pid}-${safeSerialId}.log`);
       const writeStream = fs.createWriteStream(outputPath);
-      child.stdout.pipe(writeStream);
-      child.stdout.on('error', err => {
+      const cleanupStreams = () => {
+        childStdout.unpipe(writeStream);
+        if (!childStdout.destroyed) {
+          childStdout.destroy();
+        }
+        if (!writeStream.destroyed) {
+          writeStream.destroy();
+        }
+      };
+
+      childStdout.pipe(writeStream);
+      childStdout.on('error', err => {
         logger.warn({ err }, `Failed to read Android emulator logcat for ${serialId}.`);
+        cleanupStreams();
       });
       writeStream.on('error', err => {
         logger.warn({ err }, `Failed to write Android emulator logcat for ${serialId}.`);
+        cleanupStreams();
       });
       child.on('error', err => {
         logger.warn({ err }, `Android emulator logcat process for ${serialId} failed.`);
       });
       child.on('close', () => {
-        writeStream.end();
+        if (!writeStream.destroyed && !writeStream.writableEnded) {
+          writeStream.end();
+        }
       });
       child.unref();
 

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -3,6 +3,7 @@ import { asyncResult } from '@expo/results';
 import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
 import assert from 'assert';
 import FastGlob from 'fast-glob';
+import { once } from 'node:events';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -534,6 +535,12 @@ export namespace AndroidEmulatorUtils {
       const safeSerialId = serialId.replace(/[^a-zA-Z0-9_.-]/g, '_');
       const outputPath = path.join(outputDir, `${child.pid}-${safeSerialId}.log`);
       const writeStream = fs.createWriteStream(outputPath);
+      try {
+        await once(writeStream, 'open');
+      } catch (err) {
+        child.kill();
+        throw err;
+      }
       void pipeline(childStdout, writeStream).catch(err => {
         logger.warn({ err }, `Android emulator logcat stream for ${serialId} failed.`);
       });

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -3,11 +3,10 @@ import { asyncResult } from '@expo/results';
 import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
 import assert from 'assert';
 import FastGlob from 'fast-glob';
-import { once } from 'node:events';
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { pipeline } from 'node:stream/promises';
 import { setTimeout } from 'node:timers/promises';
 import { z } from 'zod';
 
@@ -304,10 +303,31 @@ export namespace AndroidEmulatorUtils {
   export async function startAsync({
     deviceName,
     env,
+    logcat,
   }: {
     deviceName: AndroidVirtualDeviceName;
     env: NodeJS.ProcessEnv;
-  }): Promise<{ emulatorPromise: SpawnPromise<SpawnResult>; serialId: AndroidDeviceSerialId }> {
+    logcat?: { outputDir: string; logger: bunyan };
+  }): Promise<{
+    emulatorPromise: SpawnPromise<SpawnResult>;
+    serialId: AndroidDeviceSerialId;
+    logcatOutputPath: string | null;
+  }> {
+    let logcatOutputPath: string | null = null;
+    if (logcat) {
+      try {
+        await fs.promises.mkdir(logcat.outputDir, { recursive: true });
+        const safeDeviceName = deviceName.replace(/[^a-zA-Z0-9_.-]/g, '_');
+        logcatOutputPath = path.join(logcat.outputDir, `${safeDeviceName}-${randomUUID()}.log`);
+        await fs.promises.writeFile(logcatOutputPath, '', { flag: 'wx' });
+      } catch (err) {
+        logcat.logger.warn(
+          { err },
+          `Failed to prepare Android emulator logcat output for ${deviceName}.`
+        );
+      }
+    }
+
     const emulatorPromise = spawn(
       `${process.env.ANDROID_HOME}/emulator/emulator`,
       [
@@ -316,6 +336,7 @@ export namespace AndroidEmulatorUtils {
         '-writable-system',
         '-noaudio',
         '-no-snapshot-save',
+        ...(logcatOutputPath ? ['-logcat', '*:v', '-logcat-output', logcatOutputPath] : []),
         '-avd',
         deviceName,
         '-accel',
@@ -362,7 +383,7 @@ export namespace AndroidEmulatorUtils {
 
     // We don't want to await the SpawnPromise here.
     // eslint-disable-next-line @typescript-eslint/return-await
-    return { emulatorPromise, serialId };
+    return { emulatorPromise, serialId, logcatOutputPath };
   }
 
   export async function waitForReadyAsync({
@@ -501,65 +522,6 @@ export namespace AndroidEmulatorUtils {
     });
 
     return { outputPath };
-  }
-
-  export async function startLogcatStreamingAsync({
-    serialId,
-    outputDir,
-    env,
-    logger,
-  }: {
-    serialId: AndroidDeviceSerialId;
-    outputDir: string;
-    env: NodeJS.ProcessEnv;
-    logger: bunyan;
-  }): Promise<{ outputPath: string } | null> {
-    try {
-      await fs.promises.mkdir(outputDir, { recursive: true });
-
-      const logcatPromise = spawn('adb', ['-s', serialId, 'logcat', '-v', 'threadtime'], {
-        env,
-        stdio: ['ignore', 'pipe', 'ignore'],
-      });
-      const { child } = logcatPromise;
-
-      if (!child.stdout) {
-        throw new Error('"adb logcat" did not start correctly.');
-      }
-      if (!child.pid) {
-        await logcatPromise;
-        throw new Error('"adb logcat" did not start correctly.');
-      }
-
-      const childStdout = child.stdout;
-      const safeSerialId = serialId.replace(/[^a-zA-Z0-9_.-]/g, '_');
-      const outputPath = path.join(outputDir, `${child.pid}-${safeSerialId}.log`);
-      const writeStream = fs.createWriteStream(outputPath);
-      try {
-        await once(writeStream, 'open');
-      } catch (err) {
-        child.kill();
-        throw err;
-      }
-      void pipeline(childStdout, writeStream).catch(err => {
-        logger.warn({ err }, `Android emulator logcat stream for ${serialId} failed.`);
-      });
-      child.on('error', err => {
-        logger.warn({ err }, `Android emulator logcat process for ${serialId} failed.`);
-      });
-      child.unref();
-
-      void logcatPromise.catch(err => {
-        logger.warn({ err }, `Android emulator logcat stream for ${serialId} stopped.`);
-      });
-
-      logger.info(`Streaming Android emulator logcat for ${serialId} to ${outputPath}.`);
-
-      return { outputPath };
-    } catch (err) {
-      logger.warn({ err }, `Failed to start Android emulator logcat stream for ${serialId}.`);
-      return null;
-    }
   }
 
   export async function stopAsync({

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -24,6 +24,14 @@ export namespace AndroidEmulatorUtils {
     process.arch === 'arm64' ? 'arm64-v8a' : 'x86_64'
   }`;
 
+  export function getLogcatStagingDirectoryPath({
+    buildLogsDirectory,
+  }: {
+    buildLogsDirectory: string;
+  }): string {
+    return path.join(buildLogsDirectory, 'android-emulator-logcat');
+  }
+
   export async function getAvailableDevicesAsync({
     env,
   }: {
@@ -491,6 +499,58 @@ export namespace AndroidEmulatorUtils {
     });
 
     return { outputPath };
+  }
+
+  export async function startLogcatStreamingAsync({
+    serialId,
+    outputDir,
+    env,
+    logger,
+  }: {
+    serialId: AndroidDeviceSerialId;
+    outputDir: string;
+    env: NodeJS.ProcessEnv;
+    logger: bunyan;
+  }): Promise<{ outputPath: string } | null> {
+    try {
+      await fs.promises.mkdir(outputDir, { recursive: true });
+
+      const logcatPromise = spawn('adb', ['-s', serialId, 'logcat', '-v', 'threadtime'], {
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      const { child } = logcatPromise;
+
+      if (!child.stdout) {
+        throw new Error('"adb logcat" did not start correctly.');
+      }
+
+      const safeSerialId = serialId.replace(/[^a-zA-Z0-9_.-]/g, '_');
+      const outputPath = path.join(outputDir, `${child.pid}-${safeSerialId}.log`);
+      const writeStream = fs.createWriteStream(outputPath);
+      child.stdout.pipe(writeStream);
+      child.stdout.on('error', err => {
+        logger.warn({ err }, `Failed to read Android emulator logcat for ${serialId}.`);
+      });
+      writeStream.on('error', err => {
+        logger.warn({ err }, `Failed to write Android emulator logcat for ${serialId}.`);
+      });
+      child.on('close', () => {
+        writeStream.end();
+      });
+      child.unref();
+
+      void logcatPromise.catch(err => {
+        logger.warn({ err }, `Android emulator logcat stream for ${serialId} stopped.`);
+      });
+
+      logger.info(`Streaming Android emulator logcat for ${serialId} to ${outputPath}.`);
+
+      return { outputPath };
+    } catch (err) {
+      logger.warn({ err }, `Failed to start Android emulator logcat stream for ${serialId}.`);
+      return null;
+    }
   }
 
   export async function stopAsync({

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -6,6 +6,7 @@ import FastGlob from 'fast-glob';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
 import { setTimeout } from 'node:timers/promises';
 import { z } from 'zod';
 
@@ -533,32 +534,11 @@ export namespace AndroidEmulatorUtils {
       const safeSerialId = serialId.replace(/[^a-zA-Z0-9_.-]/g, '_');
       const outputPath = path.join(outputDir, `${child.pid}-${safeSerialId}.log`);
       const writeStream = fs.createWriteStream(outputPath);
-      const cleanupStreams = () => {
-        childStdout.unpipe(writeStream);
-        if (!childStdout.destroyed) {
-          childStdout.destroy();
-        }
-        if (!writeStream.destroyed) {
-          writeStream.destroy();
-        }
-      };
-
-      childStdout.pipe(writeStream);
-      childStdout.on('error', err => {
-        logger.warn({ err }, `Failed to read Android emulator logcat for ${serialId}.`);
-        cleanupStreams();
-      });
-      writeStream.on('error', err => {
-        logger.warn({ err }, `Failed to write Android emulator logcat for ${serialId}.`);
-        cleanupStreams();
+      void pipeline(childStdout, writeStream).catch(err => {
+        logger.warn({ err }, `Android emulator logcat stream for ${serialId} failed.`);
       });
       child.on('error', err => {
         logger.warn({ err }, `Android emulator logcat process for ${serialId} failed.`);
-      });
-      child.on('close', () => {
-        if (!writeStream.destroyed && !writeStream.writableEnded) {
-          writeStream.end();
-        }
       });
       child.unref();
 

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -1,9 +1,9 @@
+import { SystemError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
 import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
 import assert from 'assert';
 import FastGlob from 'fast-glob';
-import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -301,31 +301,32 @@ export namespace AndroidEmulatorUtils {
   }
 
   export async function startAsync({
+    buildLogsDirectory,
     deviceName,
     env,
-    logcat,
   }: {
+    buildLogsDirectory: string;
     deviceName: AndroidVirtualDeviceName;
     env: NodeJS.ProcessEnv;
-    logcat?: { outputDir: string; logger: bunyan };
   }): Promise<{
     emulatorPromise: SpawnPromise<SpawnResult>;
     serialId: AndroidDeviceSerialId;
-    logcatOutputPath: string | null;
+    logcatOutputPath: string;
   }> {
-    let logcatOutputPath: string | null = null;
-    if (logcat) {
-      try {
-        await fs.promises.mkdir(logcat.outputDir, { recursive: true });
-        const safeDeviceName = deviceName.replace(/[^a-zA-Z0-9_.-]/g, '_');
-        logcatOutputPath = path.join(logcat.outputDir, `${safeDeviceName}-${randomUUID()}.log`);
-        await fs.promises.writeFile(logcatOutputPath, '', { flag: 'wx' });
-      } catch (err) {
-        logcat.logger.warn(
-          { err },
-          `Failed to prepare Android emulator logcat output for ${deviceName}.`
-        );
-      }
+    const logcatStagingDirectory = getLogcatStagingDirectoryPath({ buildLogsDirectory });
+    let logcatOutputPath: string;
+    try {
+      await fs.promises.mkdir(logcatStagingDirectory, { recursive: true });
+      const safeDeviceName = deviceName.replace(/[^a-zA-Z0-9_.-]/g, '_');
+      const logcatOutputDirectory = await fs.promises.mkdtemp(
+        path.join(logcatStagingDirectory, `${safeDeviceName}-`)
+      );
+      logcatOutputPath = path.join(logcatOutputDirectory, 'logcat.log');
+      await fs.promises.writeFile(logcatOutputPath, '', { flag: 'wx' });
+    } catch (err) {
+      throw new SystemError(`Failed to prepare Android emulator logcat output for ${deviceName}.`, {
+        cause: err,
+      });
     }
 
     const emulatorPromise = spawn(
@@ -336,7 +337,10 @@ export namespace AndroidEmulatorUtils {
         '-writable-system',
         '-noaudio',
         '-no-snapshot-save',
-        ...(logcatOutputPath ? ['-logcat', '*:v', '-logcat-output', logcatOutputPath] : []),
+        '-logcat',
+        '*:v',
+        '-logcat-output',
+        logcatOutputPath,
         '-avd',
         deviceName,
         '-accel',

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -524,6 +524,10 @@ export namespace AndroidEmulatorUtils {
       if (!child.stdout) {
         throw new Error('"adb logcat" did not start correctly.');
       }
+      if (!child.pid) {
+        await logcatPromise;
+        throw new Error('"adb logcat" did not start correctly.');
+      }
 
       const safeSerialId = serialId.replace(/[^a-zA-Z0-9_.-]/g, '_');
       const outputPath = path.join(outputDir, `${child.pid}-${safeSerialId}.log`);

--- a/packages/build-tools/src/utils/__integration-tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__integration-tests__/AndroidEmulatorUtils.test.ts
@@ -1,6 +1,8 @@
 import { asyncResult } from '@expo/results';
 import spawn from '@expo/turtle-spawn';
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { setTimeout } from 'timers/promises';
 
 import { createMockLogger } from '../../__tests__/utils/logger';
@@ -16,6 +18,8 @@ jest.unmock('fs');
 jest.unmock('node:fs');
 
 describe('AndroidEmulatorUtils', () => {
+  const buildLogsDirectory = path.join(os.tmpdir(), 'android-emulator-utils-integration-logs');
+
   beforeEach(async () => {
     const devices = await AndroidEmulatorUtils.getAttachedDevicesAsync({ env: process.env });
     for (const { serialId } of devices) {
@@ -42,6 +46,7 @@ describe('AndroidEmulatorUtils', () => {
         console.error('Failed to delete emulator', error);
       }
     }
+    await fs.promises.rm(buildLogsDirectory, { force: true, recursive: true });
   });
 
   describe('getAvailableDevicesAsync', () => {
@@ -69,6 +74,7 @@ describe('AndroidEmulatorUtils', () => {
         logger: createMockLogger({ logToConsole: true }),
       });
       ({ serialId } = await AndroidEmulatorUtils.startAsync({
+        buildLogsDirectory,
         deviceName,
         env: { ...process.env, ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: '1' },
       }));
@@ -92,6 +98,7 @@ describe('AndroidEmulatorUtils', () => {
       logger: createMockLogger({ logToConsole: true }),
     });
     const { serialId, emulatorPromise } = await AndroidEmulatorUtils.startAsync({
+      buildLogsDirectory,
       deviceName,
       env: { ...process.env, ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: '1' },
     });
@@ -121,6 +128,7 @@ describe('AndroidEmulatorUtils', () => {
 
     const { serialId: serialIdClone, emulatorPromise: emulatorPromiseClone } =
       await AndroidEmulatorUtils.startAsync({
+        buildLogsDirectory,
         deviceName: cloneDeviceName,
         env: { ...process.env, ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: '1' },
       });
@@ -154,6 +162,7 @@ describe('AndroidEmulatorUtils', () => {
     });
 
     const { serialId, emulatorPromise } = await AndroidEmulatorUtils.startAsync({
+      buildLogsDirectory,
       deviceName,
       env: { ...process.env, ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: '1' },
     });
@@ -204,6 +213,7 @@ describe('AndroidEmulatorUtils', () => {
           });
 
           const startResult = await AndroidEmulatorUtils.startAsync({
+            buildLogsDirectory,
             deviceName,
             env: envForAttempt,
           });
@@ -273,6 +283,7 @@ describe('AndroidEmulatorUtils', () => {
     });
 
     const { serialId, emulatorPromise } = await AndroidEmulatorUtils.startAsync({
+      buildLogsDirectory,
       deviceName,
       env: { ...process.env, ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: '1' },
     });

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -1,5 +1,5 @@
 import spawn from '@expo/turtle-spawn';
-import { EventEmitter } from 'node:events';
+import { EventEmitter, once } from 'node:events';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -22,17 +22,27 @@ const mockedSpawn = jest.mocked(spawn);
 const mockedRetryAsync = jest.mocked(retryAsync);
 
 describe('AndroidEmulatorUtils', () => {
+  let temporaryDirectories: string[] = [];
+
   beforeEach(() => {
+    temporaryDirectories = [];
     mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
     mockedRetryAsync.mockImplementation(async fn => await fn(0));
   });
 
-  describe(AndroidEmulatorUtils.startLogcatStreamingAsync, () => {
+  afterEach(async () => {
+    await Promise.all(
+      temporaryDirectories.map(async temporaryDirectory => {
+        await fs.promises.rm(temporaryDirectory, { force: true, recursive: true });
+      })
+    );
+  });
+
+  describe('AndroidEmulatorUtils.startLogcatStreamingAsync', () => {
     function createSpawnPromise() {
       const child = Object.assign(new EventEmitter(), {
         pid: 1234,
         stdout: new PassThrough(),
-        stderr: new PassThrough(),
         unref: jest.fn(),
       });
       const spawnPromise = Promise.resolve({ stdout: '', stderr: '' }) as any;
@@ -42,41 +52,56 @@ describe('AndroidEmulatorUtils', () => {
 
     it('streams logcat to a staged file', async () => {
       const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-staging-'));
+      temporaryDirectories.push(outputDir);
       const logger = createMockLogger();
       const { child, spawnPromise } = createSpawnPromise();
       mockedSpawn.mockReturnValueOnce(spawnPromise);
-
-      const result = await AndroidEmulatorUtils.startLogcatStreamingAsync({
-        serialId: 'emulator-5554' as any,
-        outputDir,
-        env: process.env,
-        logger,
-      });
-
-      expect(result).not.toBeNull();
-      expect(mockedSpawn).toHaveBeenCalledWith(
-        'adb',
-        ['-s', 'emulator-5554', 'logcat', '-v', 'threadtime'],
-        {
+      const originalCreateWriteStream = fs.createWriteStream.bind(fs);
+      let writeStream: fs.WriteStream | undefined;
+      const createWriteStreamSpy = jest.spyOn(fs, 'createWriteStream').mockImplementation(((
+        ...args
+      ) => {
+        writeStream = originalCreateWriteStream(...args);
+        return writeStream;
+      }) as typeof fs.createWriteStream);
+      try {
+        const result = await AndroidEmulatorUtils.startLogcatStreamingAsync({
+          serialId: 'emulator-5554' as any,
+          outputDir,
           env: process.env,
-          stdio: ['ignore', 'pipe', 'pipe'],
-        }
-      );
-      expect(child.unref).toHaveBeenCalled();
+          logger,
+        });
 
-      child.stdout.write('log line\n');
-      child.emit('close', 0);
-      await new Promise(resolve => setTimeout(resolve, 10));
+        expect(result).not.toBeNull();
+        expect(mockedSpawn).toHaveBeenCalledWith(
+          'adb',
+          ['-s', 'emulator-5554', 'logcat', '-v', 'threadtime'],
+          {
+            env: process.env,
+            stdio: ['ignore', 'pipe', 'ignore'],
+          }
+        );
+        expect(child.unref).toHaveBeenCalled();
 
-      expect(result!.outputPath.startsWith(outputDir)).toBe(true);
-      await expect(fs.promises.readFile(result!.outputPath, 'utf-8')).resolves.toContain(
-        'log line'
-      );
-      expect(path.basename(result!.outputPath)).toBe('1234-emulator-5554.log');
+        child.stdout.write('log line\n');
+        child.stdout.end();
+        child.emit('close', 0);
+        expect(writeStream).toBeDefined();
+        await once(writeStream!, 'finish');
+
+        expect(result!.outputPath.startsWith(outputDir)).toBe(true);
+        await expect(fs.promises.readFile(result!.outputPath, 'utf-8')).resolves.toContain(
+          'log line'
+        );
+        expect(path.basename(result!.outputPath)).toBe('1234-emulator-5554.log');
+      } finally {
+        createWriteStreamSpy.mockRestore();
+      }
     });
 
     it('returns null and warns when logcat cannot start', async () => {
       const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-staging-'));
+      temporaryDirectories.push(outputDir);
       const logger = createMockLogger();
       mockedSpawn.mockImplementationOnce(() => {
         throw new Error('spawn failed');

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -1,9 +1,10 @@
 import spawn from '@expo/turtle-spawn';
-import { EventEmitter, once } from 'node:events';
+import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
+import { finished } from 'node:stream/promises';
 
 import { createMockLogger } from '../../__tests__/utils/logger';
 import { AndroidEmulatorUtils } from '../AndroidEmulatorUtils';
@@ -84,10 +85,9 @@ describe('AndroidEmulatorUtils', () => {
         expect(child.unref).toHaveBeenCalled();
 
         expect(writeStream).toBeDefined();
-        const finishPromise = once(writeStream!, 'finish');
+        const finishPromise = finished(writeStream!);
         child.stdout.write('log line\n');
         child.stdout.end();
-        child.emit('close', 0);
         await finishPromise;
 
         expect(result!.outputPath.startsWith(outputDir)).toBe(true);

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -83,11 +83,12 @@ describe('AndroidEmulatorUtils', () => {
         );
         expect(child.unref).toHaveBeenCalled();
 
+        expect(writeStream).toBeDefined();
+        const finishPromise = once(writeStream!, 'finish');
         child.stdout.write('log line\n');
         child.stdout.end();
         child.emit('close', 0);
-        expect(writeStream).toBeDefined();
-        await once(writeStream!, 'finish');
+        await finishPromise;
 
         expect(result!.outputPath.startsWith(outputDir)).toBe(true);
         await expect(fs.promises.readFile(result!.outputPath, 'utf-8')).resolves.toContain(

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -123,6 +123,37 @@ describe('AndroidEmulatorUtils', () => {
         'Failed to start Android emulator logcat stream for emulator-5554.'
       );
     });
+
+    it('returns null when logcat child pid is missing', async () => {
+      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-staging-'));
+      temporaryDirectories.push(outputDir);
+      const logger = createMockLogger();
+      const child = Object.assign(new EventEmitter(), {
+        pid: undefined,
+        stdout: new PassThrough(),
+        unref: jest.fn(),
+      });
+      const spawnError = new Error('spawn failed');
+      const spawnPromise = Promise.reject(spawnError) as any;
+      spawnPromise.child = child;
+      mockedSpawn.mockReturnValueOnce(spawnPromise);
+
+      await expect(
+        AndroidEmulatorUtils.startLogcatStreamingAsync({
+          serialId: 'emulator-5554' as any,
+          outputDir,
+          env: process.env,
+          logger,
+        })
+      ).resolves.toBeNull();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          err: expect.objectContaining({ message: 'spawn failed' }),
+        }),
+        'Failed to start Android emulator logcat stream for emulator-5554.'
+      );
+    });
   });
 
   describe(AndroidEmulatorUtils.waitForReadyAsync, () => {

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -1,4 +1,9 @@
 import spawn from '@expo/turtle-spawn';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
 
 import { createMockLogger } from '../../__tests__/utils/logger';
 import { AndroidEmulatorUtils } from '../AndroidEmulatorUtils';
@@ -20,6 +25,79 @@ describe('AndroidEmulatorUtils', () => {
   beforeEach(() => {
     mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
     mockedRetryAsync.mockImplementation(async fn => await fn(0));
+  });
+
+  describe(AndroidEmulatorUtils.startLogcatStreamingAsync, () => {
+    function createSpawnPromise() {
+      const child = Object.assign(new EventEmitter(), {
+        pid: 1234,
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        unref: jest.fn(),
+      });
+      const spawnPromise = Promise.resolve({ stdout: '', stderr: '' }) as any;
+      spawnPromise.child = child;
+      return { child, spawnPromise };
+    }
+
+    it('streams logcat to a staged file', async () => {
+      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-staging-'));
+      const logger = createMockLogger();
+      const { child, spawnPromise } = createSpawnPromise();
+      mockedSpawn.mockReturnValueOnce(spawnPromise);
+
+      const result = await AndroidEmulatorUtils.startLogcatStreamingAsync({
+        serialId: 'emulator-5554' as any,
+        outputDir,
+        env: process.env,
+        logger,
+      });
+
+      expect(result).not.toBeNull();
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        'adb',
+        ['-s', 'emulator-5554', 'logcat', '-v', 'threadtime'],
+        {
+          env: process.env,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }
+      );
+      expect(child.unref).toHaveBeenCalled();
+
+      child.stdout.write('log line\n');
+      child.emit('close', 0);
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(result!.outputPath.startsWith(outputDir)).toBe(true);
+      await expect(fs.promises.readFile(result!.outputPath, 'utf-8')).resolves.toContain(
+        'log line'
+      );
+      expect(path.basename(result!.outputPath)).toBe('1234-emulator-5554.log');
+    });
+
+    it('returns null and warns when logcat cannot start', async () => {
+      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-staging-'));
+      const logger = createMockLogger();
+      mockedSpawn.mockImplementationOnce(() => {
+        throw new Error('spawn failed');
+      });
+
+      await expect(
+        AndroidEmulatorUtils.startLogcatStreamingAsync({
+          serialId: 'emulator-5554' as any,
+          outputDir,
+          env: process.env,
+          logger,
+        })
+      ).resolves.toBeNull();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          err: expect.objectContaining({ message: 'spawn failed' }),
+        }),
+        'Failed to start Android emulator logcat stream for emulator-5554.'
+      );
+    });
   });
 
   describe(AndroidEmulatorUtils.waitForReadyAsync, () => {

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -1,3 +1,4 @@
+import { SystemError } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -59,19 +60,19 @@ describe('AndroidEmulatorUtils', () => {
     it('captures logcat through the emulator process', async () => {
       const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-staging-'));
       temporaryDirectories.push(outputDir);
-      const logger = createMockLogger();
       const deviceName = 'eas-simulator' as AndroidVirtualDeviceName;
       const { child } = mockSuccessfulStart(deviceName);
 
       const result = await AndroidEmulatorUtils.startAsync({
+        buildLogsDirectory: outputDir,
         deviceName,
         env: process.env,
-        logcat: { outputDir, logger },
       });
 
       expect(result.logcatOutputPath).toMatch(
-        new RegExp(`^${outputDir}/eas-simulator-[0-9a-f-]+\\.log$`)
+        new RegExp(`^${outputDir}/android-emulator-logcat/eas-simulator-[^/]+/logcat\\.log$`)
       );
+      await expect(fs.promises.access(result.logcatOutputPath)).resolves.toBeUndefined();
       expect(mockedSpawn).toHaveBeenCalledWith(
         expect.stringMatching(/\/emulator\/emulator$/),
         expect.arrayContaining(['-logcat', '*:v', '-logcat-output', result.logcatOutputPath]),
@@ -85,30 +86,25 @@ describe('AndroidEmulatorUtils', () => {
       expect(child.unref).toHaveBeenCalled();
     });
 
-    it('starts without logcat capture when the staging directory cannot be prepared', async () => {
+    it('throws a SystemError when the staging directory cannot be prepared', async () => {
       const outputDir = '/unwritable/logcat-staging';
-      const logger = createMockLogger();
       const deviceName = 'eas-simulator' as AndroidVirtualDeviceName;
-      mockSuccessfulStart(deviceName);
       const mkdirError = new Error('mkdir failed');
       const mkdirSpy = jest.spyOn(fs.promises, 'mkdir').mockRejectedValueOnce(mkdirError);
 
       try {
-        const result = await AndroidEmulatorUtils.startAsync({
-          deviceName,
-          env: process.env,
-          logcat: { outputDir, logger },
-        });
-
-        expect(result.logcatOutputPath).toBeNull();
-        expect(logger.warn).toHaveBeenCalledWith(
-          expect.objectContaining({ err: mkdirError }),
-          'Failed to prepare Android emulator logcat output for eas-simulator.'
+        await expect(
+          AndroidEmulatorUtils.startAsync({
+            buildLogsDirectory: outputDir,
+            deviceName,
+            env: process.env,
+          })
+        ).rejects.toEqual(
+          new SystemError('Failed to prepare Android emulator logcat output for eas-simulator.', {
+            cause: mkdirError,
+          })
         );
-        const emulatorArgs = mockedSpawn.mock.calls.find(([command]) =>
-          command.endsWith('/emulator/emulator')
-        )?.[1];
-        expect(emulatorArgs).not.toContain('-logcat');
+        expect(mockedSpawn).not.toHaveBeenCalled();
       } finally {
         mkdirSpy.mockRestore();
       }

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -1,13 +1,10 @@
 import spawn from '@expo/turtle-spawn';
-import { EventEmitter } from 'node:events';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { PassThrough } from 'node:stream';
-import { finished } from 'node:stream/promises';
 
 import { createMockLogger } from '../../__tests__/utils/logger';
-import { AndroidEmulatorUtils } from '../AndroidEmulatorUtils';
+import { AndroidEmulatorUtils, AndroidVirtualDeviceName } from '../AndroidEmulatorUtils';
 import { retryAsync } from '../retry';
 
 jest.mock('@expo/turtle-spawn', () => ({
@@ -39,154 +36,82 @@ describe('AndroidEmulatorUtils', () => {
     );
   });
 
-  describe('AndroidEmulatorUtils.startLogcatStreamingAsync', () => {
-    function createSpawnPromise() {
-      const child = Object.assign(new EventEmitter(), {
-        kill: jest.fn(),
-        pid: 1234,
-        stdout: new PassThrough(),
-        unref: jest.fn(),
-      });
+  describe(AndroidEmulatorUtils.startAsync, () => {
+    function mockSuccessfulStart(deviceName: AndroidVirtualDeviceName) {
+      const child = { pid: 1234, unref: jest.fn() };
       const spawnPromise = Promise.resolve({ stdout: '', stderr: '' }) as any;
       spawnPromise.child = child;
-      return { child, spawnPromise };
+      mockedSpawn.mockImplementation(((command: string, args: string[]) => {
+        if (command.endsWith('/emulator/emulator')) {
+          return spawnPromise;
+        }
+        if (command === 'adb' && args[0] === 'devices') {
+          return Promise.resolve({ stdout: 'emulator-5554\tdevice\n', stderr: '' });
+        }
+        if (command === 'adb' && args[0] === '-s' && args[2] === 'emu') {
+          return Promise.resolve({ stdout: `${deviceName}\nOK\n`, stderr: '' });
+        }
+        throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
+      }) as any);
+      return { child };
     }
 
-    it('streams logcat to a staged file', async () => {
+    it('captures logcat through the emulator process', async () => {
       const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-staging-'));
       temporaryDirectories.push(outputDir);
       const logger = createMockLogger();
-      const { child, spawnPromise } = createSpawnPromise();
-      mockedSpawn.mockReturnValueOnce(spawnPromise);
-      const originalCreateWriteStream = fs.createWriteStream.bind(fs);
-      let writeStream: fs.WriteStream | undefined;
-      const createWriteStreamSpy = jest.spyOn(fs, 'createWriteStream').mockImplementation(((
-        ...args
-      ) => {
-        writeStream = originalCreateWriteStream(...args);
-        return writeStream;
-      }) as typeof fs.createWriteStream);
-      try {
-        const result = await AndroidEmulatorUtils.startLogcatStreamingAsync({
-          serialId: 'emulator-5554' as any,
-          outputDir,
-          env: process.env,
-          logger,
-        });
+      const deviceName = 'eas-simulator' as AndroidVirtualDeviceName;
+      const { child } = mockSuccessfulStart(deviceName);
 
-        expect(result).not.toBeNull();
-        expect(mockedSpawn).toHaveBeenCalledWith(
-          'adb',
-          ['-s', 'emulator-5554', 'logcat', '-v', 'threadtime'],
-          {
-            env: process.env,
-            stdio: ['ignore', 'pipe', 'ignore'],
-          }
-        );
-        expect(child.unref).toHaveBeenCalled();
-
-        expect(writeStream).toBeDefined();
-        const finishPromise = finished(writeStream!);
-        child.stdout.write('log line\n');
-        child.stdout.end();
-        await finishPromise;
-
-        expect(result!.outputPath.startsWith(outputDir)).toBe(true);
-        await expect(fs.promises.readFile(result!.outputPath, 'utf-8')).resolves.toContain(
-          'log line'
-        );
-        expect(path.basename(result!.outputPath)).toBe('1234-emulator-5554.log');
-      } finally {
-        createWriteStreamSpy.mockRestore();
-      }
-    });
-
-    it('returns null and warns when logcat cannot start', async () => {
-      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-staging-'));
-      temporaryDirectories.push(outputDir);
-      const logger = createMockLogger();
-      mockedSpawn.mockImplementationOnce(() => {
-        throw new Error('spawn failed');
+      const result = await AndroidEmulatorUtils.startAsync({
+        deviceName,
+        env: process.env,
+        logcat: { outputDir, logger },
       });
 
-      await expect(
-        AndroidEmulatorUtils.startLogcatStreamingAsync({
-          serialId: 'emulator-5554' as any,
-          outputDir,
-          env: process.env,
-          logger,
-        })
-      ).resolves.toBeNull();
-
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          err: expect.objectContaining({ message: 'spawn failed' }),
-        }),
-        'Failed to start Android emulator logcat stream for emulator-5554.'
+      expect(result.logcatOutputPath).toMatch(
+        new RegExp(`^${outputDir}/eas-simulator-[0-9a-f-]+\\.log$`)
       );
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        expect.stringMatching(/\/emulator\/emulator$/),
+        expect.arrayContaining(['-logcat', '*:v', '-logcat-output', result.logcatOutputPath]),
+        expect.objectContaining({ detached: true, stdio: 'inherit' })
+      );
+      expect(mockedSpawn).not.toHaveBeenCalledWith(
+        'adb',
+        expect.arrayContaining(['logcat']),
+        expect.anything()
+      );
+      expect(child.unref).toHaveBeenCalled();
     });
 
-    it('returns null and stops logcat when the output file cannot open', async () => {
-      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-staging-'));
-      temporaryDirectories.push(outputDir);
+    it('starts without logcat capture when the staging directory cannot be prepared', async () => {
+      const outputDir = '/unwritable/logcat-staging';
       const logger = createMockLogger();
-      const { child, spawnPromise } = createSpawnPromise();
-      mockedSpawn.mockReturnValueOnce(spawnPromise);
-      const writeStream = new PassThrough();
-      const openError = new Error('open failed');
-      const createWriteStreamSpy = jest.spyOn(fs, 'createWriteStream').mockImplementation(() => {
-        process.nextTick(() => writeStream.emit('error', openError));
-        return writeStream as unknown as fs.WriteStream;
-      });
+      const deviceName = 'eas-simulator' as AndroidVirtualDeviceName;
+      mockSuccessfulStart(deviceName);
+      const mkdirError = new Error('mkdir failed');
+      const mkdirSpy = jest.spyOn(fs.promises, 'mkdir').mockRejectedValueOnce(mkdirError);
 
       try {
-        const resultPromise = AndroidEmulatorUtils.startLogcatStreamingAsync({
-          serialId: 'emulator-5554' as any,
-          outputDir,
+        const result = await AndroidEmulatorUtils.startAsync({
+          deviceName,
           env: process.env,
-          logger,
+          logcat: { outputDir, logger },
         });
 
-        await expect(resultPromise).resolves.toBeNull();
-        expect(child.kill).toHaveBeenCalled();
+        expect(result.logcatOutputPath).toBeNull();
         expect(logger.warn).toHaveBeenCalledWith(
-          expect.objectContaining({ err: openError }),
-          'Failed to start Android emulator logcat stream for emulator-5554.'
+          expect.objectContaining({ err: mkdirError }),
+          'Failed to prepare Android emulator logcat output for eas-simulator.'
         );
+        const emulatorArgs = mockedSpawn.mock.calls.find(([command]) =>
+          command.endsWith('/emulator/emulator')
+        )?.[1];
+        expect(emulatorArgs).not.toContain('-logcat');
       } finally {
-        createWriteStreamSpy.mockRestore();
+        mkdirSpy.mockRestore();
       }
-    });
-
-    it('returns null when logcat child pid is missing', async () => {
-      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-staging-'));
-      temporaryDirectories.push(outputDir);
-      const logger = createMockLogger();
-      const child = Object.assign(new EventEmitter(), {
-        pid: undefined,
-        stdout: new PassThrough(),
-        unref: jest.fn(),
-      });
-      const spawnError = new Error('spawn failed');
-      const spawnPromise = Promise.reject(spawnError) as any;
-      spawnPromise.child = child;
-      mockedSpawn.mockReturnValueOnce(spawnPromise);
-
-      await expect(
-        AndroidEmulatorUtils.startLogcatStreamingAsync({
-          serialId: 'emulator-5554' as any,
-          outputDir,
-          env: process.env,
-          logger,
-        })
-      ).resolves.toBeNull();
-
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          err: expect.objectContaining({ message: 'spawn failed' }),
-        }),
-        'Failed to start Android emulator logcat stream for emulator-5554.'
-      );
     });
   });
 

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -42,6 +42,7 @@ describe('AndroidEmulatorUtils', () => {
   describe('AndroidEmulatorUtils.startLogcatStreamingAsync', () => {
     function createSpawnPromise() {
       const child = Object.assign(new EventEmitter(), {
+        kill: jest.fn(),
         pid: 1234,
         stdout: new PassThrough(),
         unref: jest.fn(),
@@ -123,6 +124,38 @@ describe('AndroidEmulatorUtils', () => {
         }),
         'Failed to start Android emulator logcat stream for emulator-5554.'
       );
+    });
+
+    it('returns null and stops logcat when the output file cannot open', async () => {
+      const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-staging-'));
+      temporaryDirectories.push(outputDir);
+      const logger = createMockLogger();
+      const { child, spawnPromise } = createSpawnPromise();
+      mockedSpawn.mockReturnValueOnce(spawnPromise);
+      const writeStream = new PassThrough();
+      const openError = new Error('open failed');
+      const createWriteStreamSpy = jest.spyOn(fs, 'createWriteStream').mockImplementation(() => {
+        process.nextTick(() => writeStream.emit('error', openError));
+        return writeStream as unknown as fs.WriteStream;
+      });
+
+      try {
+        const resultPromise = AndroidEmulatorUtils.startLogcatStreamingAsync({
+          serialId: 'emulator-5554' as any,
+          outputDir,
+          env: process.env,
+          logger,
+        });
+
+        await expect(resultPromise).resolves.toBeNull();
+        expect(child.kill).toHaveBeenCalled();
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ err: openError }),
+          'Failed to start Android emulator logcat stream for emulator-5554.'
+        );
+      } finally {
+        createWriteStreamSpy.mockRestore();
+      }
     });
 
     it('returns null when logcat child pid is missing', async () => {


### PR DESCRIPTION
## Summary
- add `eas/collect_emulator_logs` to find staged emulator-native Logcat files under the fixed staging parent
- copy each file with its unique `mkdtemp` directory name into the destination directory
- run the collection step for Android Maestro function groups before uploading `~/.maestro/tests`
- keep missing or unreadable staged logs non-fatal
- verify capture and collection with a real emulator across an ADB server restart

## Why
Live logs stay under `<buildLogsDirectory>/android-emulator-logcat` while tests run. Each emulator start writes to `<deviceName>-XXXXXX/logcat.log`. The collection step scans that stable parent recursively and copies a snapshot into the Maestro artifact directory only when the workflow is ready to upload it. This avoids an artifact tar operation racing with the emulator-owned output file.

## Test plan
- `yarn workspace @expo/build-tools test --runInBand`
- `yarn workspace @expo/build-tools jest-integration src/steps/functions/__integration-tests__/collectEmulatorLogs.test.ts --runInBand`
- `yarn typecheck`
- `yarn lint`
- `yarn fmt:check`
