### PR TITLE
[worker] - wrap error log fetch in try-catch to prevent unhandled rejections

### DIFF
--- a/packages/worker/jest/integration-setup.ts
+++ b/packages/worker/jest/integration-setup.ts
@@ -14,3 +14,4 @@ if (!process.env.LISTENING_TO_UNHANDLED_REJECTION) {
 
 // Always mock:
 jest.mock('../src/CacheManager');
+jest.mock('../src/utils/turtleFetch');

--- a/packages/worker/src/__integration__/abortBuild.test.ts
+++ b/packages/worker/src/__integration__/abortBuild.test.ts
@@ -70,6 +70,7 @@ jest.mock('../config', () => {
     default: {
       ...config.default,
       buildId: 'e9b99e52-fb74-4927-be63-33d7447ddfd4',
+      wwwApiV2BaseUrl: 'http://api.expo.test/v2/',
     },
   };
 });

--- a/packages/worker/src/__integration__/jobExecution.test.ts
+++ b/packages/worker/src/__integration__/jobExecution.test.ts
@@ -40,6 +40,7 @@ jest.mock('../config', () => {
   return {
     ...config,
     buildId: 'e9b99e52-fb74-4927-be63-33d7447ddfd4',
+    wwwApiV2BaseUrl: 'http://api.expo.test/v2/',
   };
 });
 

--- a/packages/worker/src/__integration__/possiblyHangingWorker.test.ts
+++ b/packages/worker/src/__integration__/possiblyHangingWorker.test.ts
@@ -40,6 +40,7 @@ jest.mock('../config', () => {
   return {
     ...config,
     buildId: 'f38532aa-81a8-4db7-915f-6e7afe46e22f',
+    wwwApiV2BaseUrl: 'http://api.expo.test/v2/',
   };
 });
 

--- a/packages/worker/src/__integration__/stateSync.test.ts
+++ b/packages/worker/src/__integration__/stateSync.test.ts
@@ -77,6 +77,7 @@ jest.mock('../config', () => {
   return {
     ...config,
     buildId: 'e9b99e52-fb74-4927-be63-33d7447ddfd4',
+    wwwApiV2BaseUrl: 'http://api.expo.test/v2/',
   };
 });
 jest.mock('../upload', () => {

--- a/packages/worker/src/service.ts
+++ b/packages/worker/src/service.ts
@@ -344,34 +344,38 @@ export default class BuildService {
           rawErrorMessage = maybeRawError?.message ?? err.message;
         }
 
-        await turtleFetch(
-          new URL('turtle-builds/error-logs', config.wwwApiV2BaseUrl).toString(),
-          'POST',
-          {
-            json: {
-              buildId: this.buildId,
-              message: rawErrorMessage,
-              buildPhase: err.buildPhase ?? null,
-              errorCode: err.errorCode,
-              tags: {
-                platform: job.platform,
-                workflow: job.type,
-                sdk_version: metadata?.sdkVersion ?? null,
-                react_native_version: metadata?.reactNativeVersion ?? null,
-                app_id: job.appId ?? null,
-                build_profile: metadata?.buildProfile ?? null,
-                app_name: metadata?.appName ?? null,
-                app_identifier: metadata?.appIdentifier ?? null,
-                distribution: metadata?.distribution ?? null,
-                cli_version: metadata?.cliVersion ?? null,
+        try {
+          await turtleFetch(
+            new URL('turtle-builds/error-logs', config.wwwApiV2BaseUrl).toString(),
+            'POST',
+            {
+              json: {
+                buildId: this.buildId,
+                message: rawErrorMessage,
+                buildPhase: err.buildPhase ?? null,
+                errorCode: err.errorCode,
+                tags: {
+                  platform: job.platform,
+                  workflow: job.type,
+                  sdk_version: metadata?.sdkVersion ?? null,
+                  react_native_version: metadata?.reactNativeVersion ?? null,
+                  app_id: job.appId ?? null,
+                  build_profile: metadata?.buildProfile ?? null,
+                  app_name: metadata?.appName ?? null,
+                  app_identifier: metadata?.appIdentifier ?? null,
+                  distribution: metadata?.distribution ?? null,
+                  cli_version: metadata?.cliVersion ?? null,
+                },
               },
-            },
-            headers: {
-              Authorization: `Bearer ${robotAccessToken}`,
-            },
-            shouldThrowOnNotOk: false,
-          }
-        );
+              headers: {
+                Authorization: `Bearer ${robotAccessToken}`,
+              },
+              shouldThrowOnNotOk: false,
+            }
+          );
+        } catch (fetchError: any) {
+          logger.warn({ err: fetchError }, 'Failed to send build error log');
+        }
       }
 
       await this.finishError(err, maybeArtifacts);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The `turtleFetch` call to `turtle-builds/error-logs` can throw a network-level `FetchError` (e.g. DNS failure). Since `startBuildInternal` is called without `await`, this becomes an unhandled promise rejection. 

This was surfaced after removing the `UNKNOWN_ERROR` gate — now that all errors are logged, the fetch runs in more cases (including integration tests where the CI can't reach `api.expo.dev`).

# How

Wrapped the `turtleFetch` call in a try-catch. The error log to Datadog is best-effort — a failed fetch should never block `finishError` or crash the worker.

# Test Plan

  - CI integration tests should pass (no more unhandled `FetchError`)
