### PR TITLE
[codex] Add simulator-id support to build run and dev

### DIFF
--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -65,6 +65,7 @@ import {
 } from '../project/remoteVersionSource';
 import { confirmAsync } from '../prompts';
 import { getEasBuildRunCachedAppPath, runAsync } from '../run/run';
+import type { RunOptions } from '../run/run';
 import { isRunnableOnSimulatorOrEmulator } from '../run/utils';
 import { createSubmissionContextAsync } from '../submit/context';
 import {
@@ -113,6 +114,7 @@ export async function runBuildAndSubmitAsync({
   actor,
   getDynamicPrivateProjectConfigAsync,
   downloadSimBuildAutoConfirm,
+  runOptions,
   envOverride,
 }: {
   graphqlClient: ExpoGraphqlClient;
@@ -123,6 +125,7 @@ export async function runBuildAndSubmitAsync({
   actor: Actor;
   getDynamicPrivateProjectConfigAsync: DynamicConfigContextFn;
   downloadSimBuildAutoConfirm?: boolean;
+  runOptions?: RunOptions;
   envOverride?: Env;
 }): Promise<{
   buildIds: string[];
@@ -331,7 +334,12 @@ export async function runBuildAndSubmitAsync({
       [BuildStatus.Errored, BuildStatus.Canceled, BuildStatus.PendingCancel].includes(build?.status)
   );
 
-  await maybeDownloadAndRunSimulatorBuildsAsync(builds, flags, downloadSimBuildAutoConfirm);
+  await maybeDownloadAndRunSimulatorBuildsAsync(
+    builds,
+    flags,
+    downloadSimBuildAutoConfirm,
+    runOptions
+  );
 
   if (haveAllBuildsFailedOrCanceled || !flags.autoSubmit) {
     if (flags.json) {
@@ -579,14 +587,17 @@ function exitWithNonZeroCodeIfSomeBuildsFailed(maybeBuilds: (BuildFragment | nul
   }
 }
 
-export async function downloadAndRunAsync(build: BuildFragment): Promise<void> {
+export async function downloadAndRunAsync(
+  build: BuildFragment,
+  runOptions?: RunOptions
+): Promise<void> {
   assert(build.artifacts?.applicationArchiveUrl);
   const cachedAppPath = getEasBuildRunCachedAppPath(build.project.id, build.id, build.platform);
 
   if (await pathExists(cachedAppPath)) {
     Log.newLine();
     Log.log(`Using cached app...`);
-    await runAsync(cachedAppPath, build.platform);
+    await runAsync(cachedAppPath, build.platform, runOptions);
     return;
   }
 
@@ -595,13 +606,14 @@ export async function downloadAndRunAsync(build: BuildFragment): Promise<void> {
     build.platform,
     cachedAppPath
   );
-  await runAsync(buildPath, build.platform);
+  await runAsync(buildPath, build.platform, runOptions);
 }
 
 async function maybeDownloadAndRunSimulatorBuildsAsync(
   builds: MaybeBuildFragment[],
   flags: BuildFlags,
-  autoConfirm?: boolean
+  autoConfirm?: boolean,
+  runOptions?: RunOptions
 ): Promise<void> {
   const simBuilds = builds.filter(truthy).filter(isRunnableOnSimulatorOrEmulator);
 
@@ -617,9 +629,9 @@ async function maybeDownloadAndRunSimulatorBuildsAsync(
             } build on ${
               simBuild.platform === AppPlatform.Android ? 'an emulator' : 'a simulator'
             }?`,
-          }));
+        }));
         if (confirm) {
-          await downloadAndRunAsync(simBuild);
+          await downloadAndRunAsync(simBuild, runOptions);
         }
       }
     }

--- a/packages/eas-cli/src/commands/build/dev.ts
+++ b/packages/eas-cli/src/commands/build/dev.ts
@@ -43,6 +43,9 @@ export default class BuildDev extends EasCommand {
       description: `Name of the build profile from eas.json. It must be a profile allowing to create emulator/simulator internal distribution dev client builds. The "${DEFAULT_EAS_BUILD_RUN_PROFILE_NAME}" build profile will be selected by default.`,
       helpValue: 'PROFILE_NAME',
     }),
+    'simulator-id': Flags.string({
+      description: 'ID of the iOS simulator to install the dev client on.',
+    }),
     'skip-build-if-not-found': Flags.boolean({
       description: 'Skip build if no successful build with matching fingerprint is found.',
       default: false,
@@ -76,6 +79,11 @@ export default class BuildDev extends EasCommand {
     const platform = await this.selectPlatformAsync(flags.platform);
     if (process.platform !== 'darwin' && platform === Platform.IOS) {
       Errors.error('Running iOS builds in simulator is only supported on macOS.', { exit: 1 });
+    }
+    if (flags['simulator-id'] && platform === Platform.ANDROID) {
+      Errors.error('The --simulator-id flag is only supported for iOS simulator builds.', {
+        exit: 1,
+      });
     }
 
     await vcsClient.ensureRepoExistsAsync();
@@ -128,7 +136,7 @@ export default class BuildDev extends EasCommand {
       );
 
       if (build.artifacts?.applicationArchiveUrl) {
-        await downloadAndRunAsync(build);
+        await downloadAndRunAsync(build, { simulatorId: flags['simulator-id'] });
         await this.startDevServerAsync({ projectDir, platform });
         return;
       } else {
@@ -180,6 +188,7 @@ export default class BuildDev extends EasCommand {
       actor,
       getDynamicPrivateProjectConfigAsync,
       downloadSimBuildAutoConfirm: true,
+      runOptions: { simulatorId: flags['simulator-id'] },
       envOverride: env,
     });
     await this.startDevServerAsync({ projectDir, platform });

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -17,6 +17,7 @@ import { appPlatformDisplayNames } from '../../platform';
 import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { RunArchiveFlags, getEasBuildRunCachedAppPath, runAsync } from '../../run/run';
+import type { RunOptions } from '../../run/run';
 import { isRunnableOnSimulatorOrEmulator } from '../../run/utils';
 import {
   downloadAndMaybeExtractAppAsync,
@@ -32,11 +33,13 @@ interface RawRunFlags {
   limit?: number;
   offset?: number;
   profile?: string;
+  'simulator-id'?: string;
 }
 
 interface RunCommandFlags {
   selectedPlatform: AppPlatform;
   runArchiveFlags: RunArchiveFlags;
+  runOptions: RunOptions;
   limit?: number;
   offset?: number;
   profile?: string;
@@ -61,6 +64,9 @@ export default class Run extends EasCommand {
     id: Flags.string({
       description: 'ID of the simulator/emulator build to run',
       exclusive: ['latest, path, url'],
+    }),
+    'simulator-id': Flags.string({
+      description: 'ID of the iOS simulator to install the build on.',
     }),
     platform: Flags.option({
       char: 'p',
@@ -99,16 +105,28 @@ export default class Run extends EasCommand {
       queryOptions
     );
 
-    await runAsync(simulatorBuildPath, flags.selectedPlatform);
+    await runAsync(simulatorBuildPath, flags.selectedPlatform, flags.runOptions);
   }
 
   private async sanitizeFlagsAsync(flags: RawRunFlags): Promise<RunCommandFlags> {
-    const { platform, limit, offset, profile, ...runArchiveFlags } = flags;
+    const {
+      platform,
+      limit,
+      offset,
+      profile,
+      'simulator-id': simulatorId,
+      ...runArchiveFlags
+    } = flags;
 
     const selectedPlatform = await resolvePlatformAsync(platform);
 
     if (platform === 'ios' && process.platform !== 'darwin') {
       Errors.error('You can only use an iOS simulator to run apps on macOS devices', {
+        exit: 1,
+      });
+    }
+    if (simulatorId && selectedPlatform === AppPlatform.Android) {
+      Errors.error('The --simulator-id flag is only supported for iOS simulator builds.', {
         exit: 1,
       });
     }
@@ -134,6 +152,7 @@ export default class Run extends EasCommand {
     return {
       selectedPlatform,
       runArchiveFlags,
+      runOptions: { simulatorId },
       limit,
       offset,
       profile,

--- a/packages/eas-cli/src/run/ios/run.ts
+++ b/packages/eas-cli/src/run/ios/run.ts
@@ -4,10 +4,13 @@ import path from 'path';
 import * as simulator from './simulator';
 import { validateSystemRequirementsAsync } from './systemRequirements';
 
-export async function runAppOnIosSimulatorAsync(appPath: string): Promise<void> {
+export async function runAppOnIosSimulatorAsync(
+  appPath: string,
+  simulatorId?: string
+): Promise<void> {
   await validateSystemRequirementsAsync();
 
-  const selectedSimulator = await simulator.selectSimulatorAsync();
+  const selectedSimulator = await simulator.selectSimulatorAsync(simulatorId);
   await simulator.ensureSimulatorBootedAsync(selectedSimulator);
 
   await simulator.ensureSimulatorAppOpenedAsync(selectedSimulator.udid);

--- a/packages/eas-cli/src/run/ios/simulator.ts
+++ b/packages/eas-cli/src/run/ios/simulator.ts
@@ -18,7 +18,11 @@ interface IosSimulator {
   lastBootedAt?: Date;
 }
 
-export async function selectSimulatorAsync(): Promise<IosSimulator> {
+export async function selectSimulatorAsync(simulatorId?: string): Promise<IosSimulator> {
+  if (simulatorId) {
+    return await getIosSimulatorByIdAsync(simulatorId);
+  }
+
   const bootedSimulator = await getFirstBootedIosSimulatorAsync();
 
   if (bootedSimulator) {
@@ -37,6 +41,19 @@ export async function selectSimulatorAsync(): Promise<IosSimulator> {
       value: simulator,
     })),
   });
+
+  return selectedSimulator;
+}
+
+async function getIosSimulatorByIdAsync(simulatorId: string): Promise<IosSimulator> {
+  const simulators = await getAvaliableIosSimulatorsListAsync();
+  const selectedSimulator = simulators.find(
+    simulator => simulator.udid.toLowerCase() === simulatorId.toLowerCase()
+  );
+
+  if (!selectedSimulator) {
+    throw new Error(`iOS simulator with id "${simulatorId}" was not found.`);
+  }
 
   return selectedSimulator;
 }

--- a/packages/eas-cli/src/run/run.ts
+++ b/packages/eas-cli/src/run/run.ts
@@ -12,12 +12,17 @@ export interface RunArchiveFlags {
   url?: string;
 }
 
+export interface RunOptions {
+  simulatorId?: string;
+}
+
 export async function runAsync(
   simulatorBuildPath: string,
-  selectedPlatform: AppPlatform
+  selectedPlatform: AppPlatform,
+  options: RunOptions = {}
 ): Promise<void> {
   if (selectedPlatform === AppPlatform.Ios) {
-    await runAppOnIosSimulatorAsync(simulatorBuildPath);
+    await runAppOnIosSimulatorAsync(simulatorBuildPath, options.simulatorId);
   } else {
     await runAppOnAndroidEmulatorAsync(simulatorBuildPath);
   }


### PR DESCRIPTION
## Summary

Adds a `--simulator-id` flag for iOS simulator runs without overloading the existing `--id` build selector.

The new option is shared by:

- `eas build:run`, where `--id` continues to mean build ID and `--simulator-id` selects the target iOS simulator UDID
- `eas build:dev`, where `--simulator-id` selects the target iOS simulator UDID for both fingerprint-cache hits and newly-created builds

The shared run helpers now accept optional run options, and the iOS simulator selector resolves the provided simulator id before booting/installing. Android rejects `--simulator-id` because the target-id behavior is iOS-simulator specific.

## Validation

- `yarn exec oxfmt packages/eas-cli/src/commands/build/run.ts packages/eas-cli/src/commands/build/dev.ts packages/eas-cli/src/build/runBuildAndSubmit.ts packages/eas-cli/src/run/ios/run.ts packages/eas-cli/src/run/ios/simulator.ts packages/eas-cli/src/run/run.ts`
- `git diff --check`
- Built local workspace dependencies: `@expo/logger`, `@expo/eas-build-job`, `@expo/steps`, `@expo/eas-json`
- `yarn workspace eas-cli typecheck` and `yarn workspace eas-cli typecheck-for-build` were attempted, but both are blocked by existing `@expo/apple-utils` metadata/App Clip type mismatches unrelated to this change.
