### PR TITLE
[eas-cli] prompt users to stop device run session when they are done by running eas simulator:stop command

### DIFF
--- a/packages/eas-cli/src/commands/simulator/start.ts
+++ b/packages/eas-cli/src/commands/simulator/start.ts
@@ -149,6 +149,10 @@ export default class SimulatorStart extends EasCommand {
     Log.log(`🔑 Run the following in your shell to attach to ${flags.type}:`);
     Log.newLine();
     Log.log(result.message);
+    Log.newLine();
+    Log.log(
+      `When you are done, stop the session with: eas simulator:stop --id ${deviceRunSessionId}`
+    );
   }
 }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Prompt users to stop device run session when they are done by running eas simulator:stop command.

# How

Prompt users to stop device run session when they are done by running eas simulator:stop command.