### PR TITLE
[eas-cli] stop device run session when time out happens

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -13961,6 +13961,39 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "updates",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveUpdatesInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveUpdatesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -16792,6 +16825,447 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUpdate",
+        "description": null,
+        "fields": [
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "downloadCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstSeenAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "medianDownloadTime",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "p90DownloadTime",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUpdateEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveUpdate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUpdatesConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveUpdateEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalDownloads",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveUpdatesInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "after",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "first",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "orderBy",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AppObserveUpdatesOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObservePlatform",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveUpdatesOrderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveUpdatesOrderByDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveUpdatesOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppObserveUpdatesOrderByDirection",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppObserveUpdatesOrderByField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DOWNLOAD_COUNT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FIRST_SEEN_AT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MEDIAN_DOWNLOAD_TIME",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "P90_DOWNLOAD_TIME",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -29936,6 +30410,30 @@
             "deprecationReason": null
           },
           {
+            "name": "convexProjects",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ConvexProject",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "convexTeamIdentifier",
             "description": null,
             "args": [],
@@ -29993,6 +30491,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasBeenClaimed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               }
             },
@@ -35503,8 +36017,8 @@
             "deprecationReason": null
           },
           {
-            "name": "stopDeviceRunSession",
-            "description": "Stop a device run session",
+            "name": "ensureDeviceRunSessionStopped",
+            "description": "Ensure a device run session is stopped. Idempotent: if the session has already\nfinished, the existing session is returned unchanged (an ERRORED session stays\nERRORED).",
             "args": [
               {
                 "name": "deviceRunSessionId",
@@ -79174,6 +79688,12 @@
         "enumValues": [
           {
             "name": "APPLE_DEVICE_REGISTRATION_REQUEST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BRANCH_DELETE",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/commands/simulator/start.ts
+++ b/packages/eas-cli/src/commands/simulator/start.ts
@@ -2,6 +2,7 @@ import { Flags } from '@oclif/core';
 
 import { getBareJobRunUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import {
   AppPlatform,
@@ -76,6 +77,7 @@ export default class SimulatorStart extends EasCommand {
 
     const createSpinner = ora('🚀 Creating device run session').start();
     let deviceRunSessionId: string;
+    let jobRunUrl: string;
     try {
       const session = await DeviceRunSessionMutation.createDeviceRunSessionAsync(graphqlClient, {
         appId: projectId,
@@ -85,7 +87,7 @@ export default class SimulatorStart extends EasCommand {
       });
       deviceRunSessionId = session.id;
       const jobRunId = nullthrows(session.turtleJobRun?.id, 'Expected device run session to start');
-      const jobRunUrl = getBareJobRunUrl(session.app.ownerAccount.name, session.app.slug, jobRunId);
+      jobRunUrl = getBareJobRunUrl(session.app.ownerAccount.name, session.app.slug, jobRunId);
       createSpinner.succeed(
         `Device run session created (id: ${deviceRunSessionId}) ${link(jobRunUrl)}`
       );
@@ -109,7 +111,7 @@ export default class SimulatorStart extends EasCommand {
           session.status === DeviceRunSessionStatus.Stopped
         ) {
           throw new Error(
-            `Device run session ${deviceRunSessionId} ${session.status.toLowerCase()} before the ${flags.type} daemon was ready.`
+            `Device run session ${deviceRunSessionId} ${session.status.toLowerCase()} before the ${flags.type} daemon was ready. ${link(jobRunUrl)}`
           );
         }
 
@@ -120,7 +122,7 @@ export default class SimulatorStart extends EasCommand {
           jobRunStatus === JobRunStatus.Finished
         ) {
           throw new Error(
-            `Turtle job run for device run session ${deviceRunSessionId} ${jobRunStatus.toLowerCase()} before the ${flags.type} daemon was ready.`
+            `Turtle job run for device run session ${deviceRunSessionId} ${jobRunStatus.toLowerCase()} before the ${flags.type} daemon was ready. ${link(jobRunUrl)}`
           );
         }
 
@@ -135,13 +137,15 @@ export default class SimulatorStart extends EasCommand {
       }
     } catch (err) {
       pollSpinner.fail(`Failed while polling for ${flags.type} daemon logs`);
+      await ensureDeviceRunSessionStoppedSafelyAsync(graphqlClient, deviceRunSessionId);
       throw err;
     }
 
     if (!result.ready) {
       pollSpinner.fail(`Timed out waiting for ${flags.type} daemon to start`);
+      await ensureDeviceRunSessionStoppedSafelyAsync(graphqlClient, deviceRunSessionId);
       throw new Error(
-        `Timed out after ${Math.round(POLL_TIMEOUT_MS / 1000)}s waiting for ${flags.type} daemon to start.`
+        `Timed out after ${Math.round(POLL_TIMEOUT_MS / 1000)}s waiting for ${flags.type} daemon to start. ${link(jobRunUrl)}`
       );
     }
 
@@ -152,6 +156,25 @@ export default class SimulatorStart extends EasCommand {
     Log.newLine();
     Log.log(
       `When you are done, stop the session with: eas simulator:stop --id ${deviceRunSessionId}`
+    );
+  }
+}
+
+async function ensureDeviceRunSessionStoppedSafelyAsync(
+  graphqlClient: ExpoGraphqlClient,
+  deviceRunSessionId: string
+): Promise<void> {
+  try {
+    await DeviceRunSessionMutation.ensureDeviceRunSessionStoppedAsync(
+      graphqlClient,
+      deviceRunSessionId
+    );
+  } catch (err) {
+    // Cleanup is best-effort; surface the failure but don't mask the original error.
+    Log.warn(
+      `Failed to stop device run session ${deviceRunSessionId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
     );
   }
 }

--- a/packages/eas-cli/src/commands/simulator/stop.ts
+++ b/packages/eas-cli/src/commands/simulator/stop.ts
@@ -33,7 +33,7 @@ export default class SimulatorStop extends EasCommand {
 
     const stopSpinner = ora(`🛑 Stopping device run session ${flags.id}`).start();
     try {
-      const session = await DeviceRunSessionMutation.stopDeviceRunSessionAsync(
+      const session = await DeviceRunSessionMutation.ensureDeviceRunSessionStoppedAsync(
         graphqlClient,
         flags.id
       );

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2094,6 +2094,7 @@ export type AppObserve = {
   events: AppObserveEventsConnection;
   timeSeries: AppObserveTimeSeries;
   totalEventCount: Scalars['Int']['output'];
+  updates: AppObserveUpdatesConnection;
 };
 
 
@@ -2143,6 +2144,11 @@ export type AppObserveEventsArgs = {
 
 export type AppObserveTimeSeriesArgs = {
   input: AppObserveTimeSeriesInput;
+};
+
+
+export type AppObserveUpdatesArgs = {
+  input: AppObserveUpdatesInput;
 };
 
 export type AppObserveAppBuildNumber = {
@@ -2427,6 +2433,57 @@ export type AppObserveTimeSeriesStatistics = {
   p90?: Maybe<Scalars['Float']['output']>;
   p99?: Maybe<Scalars['Float']['output']>;
 };
+
+export type AppObserveUpdate = {
+  __typename?: 'AppObserveUpdate';
+  appUpdateId: Scalars['String']['output'];
+  appVersion: Scalars['String']['output'];
+  downloadCount: Scalars['Int']['output'];
+  firstSeenAt: Scalars['DateTime']['output'];
+  medianDownloadTime: Scalars['Float']['output'];
+  p90DownloadTime: Scalars['Float']['output'];
+};
+
+export type AppObserveUpdateEdge = {
+  __typename?: 'AppObserveUpdateEdge';
+  cursor: Scalars['String']['output'];
+  node: AppObserveUpdate;
+};
+
+export type AppObserveUpdatesConnection = {
+  __typename?: 'AppObserveUpdatesConnection';
+  edges: Array<AppObserveUpdateEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+  totalDownloads: Scalars['Int']['output'];
+};
+
+export type AppObserveUpdatesInput = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AppObserveUpdatesOrderBy>;
+  platform: AppObservePlatform;
+  startTime: Scalars['DateTime']['input'];
+};
+
+export type AppObserveUpdatesOrderBy = {
+  direction: AppObserveUpdatesOrderByDirection;
+  field: AppObserveUpdatesOrderByField;
+};
+
+export enum AppObserveUpdatesOrderByDirection {
+  Asc = 'ASC',
+  Desc = 'DESC'
+}
+
+export enum AppObserveUpdatesOrderByField {
+  DownloadCount = 'DOWNLOAD_COUNT',
+  FirstSeenAt = 'FIRST_SEEN_AT',
+  MedianDownloadTime = 'MEDIAN_DOWNLOAD_TIME',
+  P90DownloadTime = 'P90_DOWNLOAD_TIME'
+}
 
 export type AppObserveVersionMarkerStatistics = {
   __typename?: 'AppObserveVersionMarkerStatistics';
@@ -4251,10 +4308,12 @@ export type ConvexProjectMutationSetupConvexProjectArgs = {
 export type ConvexTeamConnection = {
   __typename?: 'ConvexTeamConnection';
   account: Account;
+  convexProjects: Array<ConvexProject>;
   convexTeamIdentifier: Scalars['String']['output'];
   convexTeamName: Scalars['String']['output'];
   convexTeamSlug: Scalars['String']['output'];
   createdAt: Scalars['DateTime']['output'];
+  hasBeenClaimed: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
   invitedAt?: Maybe<Scalars['DateTime']['output']>;
   invitedEmail?: Maybe<Scalars['String']['output']>;
@@ -4985,8 +5044,12 @@ export type DeviceRunSessionMutation = {
   __typename?: 'DeviceRunSessionMutation';
   /** Create a device run session */
   createDeviceRunSession: DeviceRunSession;
-  /** Stop a device run session */
-  stopDeviceRunSession: DeviceRunSession;
+  /**
+   * Ensure a device run session is stopped. Idempotent: if the session has already
+   * finished, the existing session is returned unchanged (an ERRORED session stays
+   * ERRORED).
+   */
+  ensureDeviceRunSessionStopped: DeviceRunSession;
 };
 
 
@@ -4995,7 +5058,7 @@ export type DeviceRunSessionMutationCreateDeviceRunSessionArgs = {
 };
 
 
-export type DeviceRunSessionMutationStopDeviceRunSessionArgs = {
+export type DeviceRunSessionMutationEnsureDeviceRunSessionStoppedArgs = {
   deviceRunSessionId: Scalars['ID']['input'];
 };
 
@@ -11003,6 +11066,7 @@ export enum WorkflowJobStatus {
 
 export enum WorkflowJobType {
   AppleDeviceRegistrationRequest = 'APPLE_DEVICE_REGISTRATION_REQUEST',
+  BranchDelete = 'BRANCH_DELETE',
   Build = 'BUILD',
   Custom = 'CUSTOM',
   Deploy = 'DEPLOY',
@@ -11984,12 +12048,12 @@ export type CreateDeviceRunSessionMutationVariables = Exact<{
 
 export type CreateDeviceRunSessionMutation = { __typename?: 'RootMutation', deviceRunSession: { __typename?: 'DeviceRunSessionMutation', createDeviceRunSession: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, turtleJobRun?: { __typename?: 'JobRun', id: string } | null } } };
 
-export type StopDeviceRunSessionMutationVariables = Exact<{
+export type EnsureDeviceRunSessionStoppedMutationVariables = Exact<{
   deviceRunSessionId: Scalars['ID']['input'];
 }>;
 
 
-export type StopDeviceRunSessionMutation = { __typename?: 'RootMutation', deviceRunSession: { __typename?: 'DeviceRunSessionMutation', stopDeviceRunSession: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus } } };
+export type EnsureDeviceRunSessionStoppedMutation = { __typename?: 'RootMutation', deviceRunSession: { __typename?: 'DeviceRunSessionMutation', ensureDeviceRunSessionStopped: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus } } };
 
 export type CreateEnvironmentSecretForAccountMutationVariables = Exact<{
   input: CreateEnvironmentSecretInput;

--- a/packages/eas-cli/src/graphql/mutations/DeviceRunSessionMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/DeviceRunSessionMutation.ts
@@ -6,8 +6,8 @@ import {
   CreateDeviceRunSessionInput,
   CreateDeviceRunSessionMutation,
   CreateDeviceRunSessionMutationVariables,
-  StopDeviceRunSessionMutation,
-  StopDeviceRunSessionMutationVariables,
+  EnsureDeviceRunSessionStoppedMutation,
+  EnsureDeviceRunSessionStoppedMutationVariables,
 } from '../generated';
 
 export const DeviceRunSessionMutation = {
@@ -46,17 +46,22 @@ export const DeviceRunSessionMutation = {
     );
     return data.deviceRunSession.createDeviceRunSession;
   },
-  async stopDeviceRunSessionAsync(
+  async ensureDeviceRunSessionStoppedAsync(
     graphqlClient: ExpoGraphqlClient,
     deviceRunSessionId: string
-  ): Promise<StopDeviceRunSessionMutation['deviceRunSession']['stopDeviceRunSession']> {
+  ): Promise<
+    EnsureDeviceRunSessionStoppedMutation['deviceRunSession']['ensureDeviceRunSessionStopped']
+  > {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .mutation<StopDeviceRunSessionMutation, StopDeviceRunSessionMutationVariables>(
+        .mutation<
+          EnsureDeviceRunSessionStoppedMutation,
+          EnsureDeviceRunSessionStoppedMutationVariables
+        >(
           gql`
-            mutation StopDeviceRunSessionMutation($deviceRunSessionId: ID!) {
+            mutation EnsureDeviceRunSessionStoppedMutation($deviceRunSessionId: ID!) {
               deviceRunSession {
-                stopDeviceRunSession(deviceRunSessionId: $deviceRunSessionId) {
+                ensureDeviceRunSessionStopped(deviceRunSessionId: $deviceRunSessionId) {
                   id
                   status
                 }
@@ -68,6 +73,6 @@ export const DeviceRunSessionMutation = {
         )
         .toPromise()
     );
-    return data.deviceRunSession.stopDeviceRunSession;
+    return data.deviceRunSession.ensureDeviceRunSessionStopped;
   },
 };


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When the readiness polling loop in `eas simulator:start` timed out (15 min) or threw, the device run session was left running on the server. Users had to remember to clean it up manually with `eas simulator:stop --id <id>`.

# How

On timeout or any failure during the readiness polling loop, call the server-side `ensureDeviceRunSessionStopped` mutation. The mutation is idempotent (no-op if the session is already stopped), so we don't need a client-side liveness flag — addresses [@sjchmiela's review feedback](https://github.com/expo/eas-cli/pull/3634#discussion_r3155123755).

The call is wrapped in a best-effort helper that catches transport-level errors and logs them as warnings, so cleanup failures don't mask the original error being thrown to the user.

`eas simulator:stop` is migrated to the same mutation for consistency.

# Test Plan

- [ ] `eas simulator:start --platform ios --type agent-device` succeeds, then `eas simulator:stop --id <id>` returns a stopped session
- [ ] Force the polling loop to time out (e.g. point readiness check at logs that never produce the daemon URL) and confirm the session ends up stopped on the server
- [ ] Trigger a failure mid-poll (e.g. session errored) and confirm the original error is surfaced while cleanup still runs
- [ ] `yarn typecheck`, `yarn lint`, `yarn fmt:check` pass