### PR TITLE
[build-tools] Add eas/run_maestro_tests step with smart retry

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
@@ -1075,18 +1075,17 @@ describe('mergeJUnitReports', () => {
     ).rejects.toThrow(/no \*\.xml files/);
   });
 
-  it('throws when no parseable testcases are found across inputs', async () => {
-    // Malformed XML with no parseable <testsuite> / <testcase>. Without a
-    // throw here, mergeJUnitReports would silently emit an empty merged
-    // document and Phase 3's copyLatestAttemptXml fallback (which only
-    // triggers on throw) would never run.
+  it('throws on invalid XML so caller can fall back to copyLatestAttemptXml', async () => {
+    // Without a throw, mergeJUnitReports would silently emit an empty merged
+    // document and the copy-latest fallback (which only triggers on throw)
+    // would never run.
     vol.fromJSON({
       '/tmp/r/android-maestro-junit-attempt-0.xml': 'not xml at all',
     });
 
     await expect(
       mergeJUnitReports({ sourceDir: '/tmp/r', outputPath: '/tmp/final.xml' })
-    ).rejects.toThrow(/no parseable testcases/);
+    ).rejects.toThrow(/invalid XML/);
   });
 
   it('throws when every input has <testsuites> but no <testcase> elements', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
@@ -1,8 +1,11 @@
+import { XMLParser } from 'fast-xml-parser';
 import fs from 'fs/promises';
 import { vol } from 'memfs';
 
 import {
   copyLatestAttemptXml,
+  mergeJUnitReports,
+  parseFailedFlowsFromJUnit,
   parseFlowMetadata,
   parseJUnitTestCases,
   parseMaestroResults,
@@ -803,6 +806,364 @@ describe(parseJUnitTestCases, () => {
 
     const results = await parseJUnitTestCases('/junit');
     expect(results[0].properties).toEqual({});
+  });
+});
+
+describe('parseFailedFlowsFromJUnit', () => {
+  it('returns the subset of input flow paths whose testcases failed', async () => {
+    // memfs setup: 3 input flows, 1 junit file with 1 failure, 1 timestamp dir with 3 ai-*.json
+    vol.fromJSON({
+      '/project/flows/login.yaml': '',
+      '/project/flows/search.yaml': '',
+      '/project/flows/checkout.yaml': '',
+      '/tmp/junit-reports/android-maestro-junit-attempt-0.xml': `<?xml version="1.0"?>
+<testsuites>
+  <testsuite>
+    <testcase name="Login" status="SUCCESS" time="1.0" />
+    <testcase name="Search" status="SUCCESS" time="1.0" />
+    <testcase name="Checkout" time="1.0"><failure>something</failure></testcase>
+  </testsuite>
+</testsuites>`,
+      '/tmp/tests/2026-04-23_120000/ai-Login.json': JSON.stringify({
+        flow_name: 'Login',
+        flow_file_path: '/project/flows/login.yaml',
+      }),
+      '/tmp/tests/2026-04-23_120000/ai-Search.json': JSON.stringify({
+        flow_name: 'Search',
+        flow_file_path: '/project/flows/search.yaml',
+      }),
+      '/tmp/tests/2026-04-23_120000/ai-Checkout.json': JSON.stringify({
+        flow_name: 'Checkout',
+        flow_file_path: '/project/flows/checkout.yaml',
+      }),
+    });
+
+    const result = await parseFailedFlowsFromJUnit({
+      junitFile: '/tmp/junit-reports/android-maestro-junit-attempt-0.xml',
+      testsDirectory: '/tmp/tests',
+      inputFlowPaths: ['flows/login.yaml', 'flows/search.yaml', 'flows/checkout.yaml'],
+      projectRoot: '/project',
+    });
+
+    expect(result).toEqual(['flows/checkout.yaml']);
+  });
+
+  it('accepts flow files discovered under a directory input (documented usage)', async () => {
+    // Users may set `flow_path: ./maestro/flows` (a directory). Maestro then
+    // discovers the YAMLs inside; smart retry must still subset to the failing
+    // child file, not fall back to dumb retry.
+    vol.fromJSON({
+      '/project/flows/login.yaml': '',
+      '/project/flows/checkout.yaml': '',
+      '/tmp/junit-reports/attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="Login" status="SUCCESS" time="1.0" />
+  <testcase name="Checkout" time="1.0"><failure>x</failure></testcase>
+</testsuite></testsuites>`,
+      '/tmp/tests/2026-04-23_120000/ai-Login.json': JSON.stringify({
+        flow_name: 'Login',
+        flow_file_path: '/project/flows/login.yaml',
+      }),
+      '/tmp/tests/2026-04-23_120000/ai-Checkout.json': JSON.stringify({
+        flow_name: 'Checkout',
+        flow_file_path: '/project/flows/checkout.yaml',
+      }),
+    });
+
+    const result = await parseFailedFlowsFromJUnit({
+      junitFile: '/tmp/junit-reports/attempt-0.xml',
+      testsDirectory: '/tmp/tests',
+      inputFlowPaths: ['flows'],
+      projectRoot: '/project',
+    });
+
+    expect(result).toEqual(['flows/checkout.yaml']);
+  });
+
+  it('returns null when two failing testcases share the same name (collision)', async () => {
+    vol.fromJSON({
+      '/project/flows/a.yaml': '',
+      '/project/flows/b.yaml': '',
+      '/tmp/junit-reports/android-maestro-junit-attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="Duplicate" time="1.0"><failure>x</failure></testcase>
+  <testcase name="Duplicate" time="1.0"><failure>y</failure></testcase>
+</testsuite></testsuites>`,
+      '/tmp/tests/2026-04-23_120000/ai-Duplicate.json': JSON.stringify({
+        flow_name: 'Duplicate',
+        flow_file_path: '/project/flows/a.yaml',
+      }),
+    });
+
+    const result = await parseFailedFlowsFromJUnit({
+      junitFile: '/tmp/junit-reports/android-maestro-junit-attempt-0.xml',
+      testsDirectory: '/tmp/tests',
+      inputFlowPaths: ['flows/a.yaml', 'flows/b.yaml'],
+      projectRoot: '/project',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when a failing testcase shares a name with any other testcase (pass or fail)', async () => {
+    vol.fromJSON({
+      '/project/flows/a.yaml': '',
+      '/project/flows/b.yaml': '',
+      '/tmp/junit-reports/android-maestro-junit-attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="Shared" status="SUCCESS" time="1.0" />
+  <testcase name="Shared" time="2.0"><failure>x</failure></testcase>
+</testsuite></testsuites>`,
+      '/tmp/tests/2026-04-23_120000/ai-Shared.json': JSON.stringify({
+        flow_name: 'Shared',
+        flow_file_path: '/project/flows/a.yaml',
+      }),
+    });
+
+    const result = await parseFailedFlowsFromJUnit({
+      junitFile: '/tmp/junit-reports/android-maestro-junit-attempt-0.xml',
+      testsDirectory: '/tmp/tests',
+      inputFlowPaths: ['flows/a.yaml', 'flows/b.yaml'],
+      projectRoot: '/project',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when junit file does not exist', async () => {
+    vol.fromJSON({
+      '/project/flows/a.yaml': '',
+    });
+    const result = await parseFailedFlowsFromJUnit({
+      junitFile: '/tmp/missing.xml',
+      testsDirectory: '/tmp/tests',
+      inputFlowPaths: ['flows/a.yaml'],
+      projectRoot: '/project',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when junit file is malformed', async () => {
+    vol.fromJSON({
+      '/tmp/junit-reports/bad.xml': 'this is not xml',
+    });
+    const result = await parseFailedFlowsFromJUnit({
+      junitFile: '/tmp/junit-reports/bad.xml',
+      testsDirectory: '/tmp/tests',
+      inputFlowPaths: ['flows/a.yaml'],
+      projectRoot: '/project',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when junit XML is truncated mid-tag (partial parse risk)', async () => {
+    // fast-xml-parser can produce a partial parse from truncated XML — without
+    // strict validation, smart retry would only retry the visible failures and
+    // silently skip flows that were cut off, masking real failures when the
+    // subset retry passes. Validation must reject the file → dumb retry.
+    vol.fromJSON({
+      '/project/flows/a.yaml': '',
+      '/project/flows/b.yaml': '',
+      '/tmp/junit-reports/attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="A" time="1.0"><failure>x</failure></testcase>
+  <testcase name="B"`, // intentionally truncated mid-tag
+      '/tmp/tests/2026-04-23_120000/ai-A.json': JSON.stringify({
+        flow_name: 'A',
+        flow_file_path: '/project/flows/a.yaml',
+      }),
+      '/tmp/tests/2026-04-23_120000/ai-B.json': JSON.stringify({
+        flow_name: 'B',
+        flow_file_path: '/project/flows/b.yaml',
+      }),
+    });
+    const result = await parseFailedFlowsFromJUnit({
+      junitFile: '/tmp/junit-reports/attempt-0.xml',
+      testsDirectory: '/tmp/tests',
+      inputFlowPaths: ['flows/a.yaml', 'flows/b.yaml'],
+      projectRoot: '/project',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when junit XML has unclosed tags (partial parse risk)', async () => {
+    vol.fromJSON({
+      '/project/flows/a.yaml': '',
+      '/tmp/junit-reports/attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="A" time="1.0"><failure>x</failure></testcase>
+</testsuite>`, // missing </testsuites>
+      '/tmp/tests/2026-04-23_120000/ai-A.json': JSON.stringify({
+        flow_name: 'A',
+        flow_file_path: '/project/flows/a.yaml',
+      }),
+    });
+    const result = await parseFailedFlowsFromJUnit({
+      junitFile: '/tmp/junit-reports/attempt-0.xml',
+      testsDirectory: '/tmp/tests',
+      inputFlowPaths: ['flows/a.yaml'],
+      projectRoot: '/project',
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('mergeJUnitReports', () => {
+  it('identity-copies a single attempt (preserves suite-level metadata)', async () => {
+    // Single-attempt runs should land in final_report_path with the same
+    // suite-level attributes (tests/failures/time) and non-testcase children
+    // (e.g. <system-out>) that the legacy bash `cp` upload preserved. The
+    // rebuild path used for multi-attempt merges drops these, so the single
+    // case must short-circuit to a byte-equivalent copy.
+    const input = `<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="Maestro Flows" tests="2" failures="0" time="3.0" device="Pixel 7">
+    <testcase name="A" status="SUCCESS" time="1.0" />
+    <testcase name="B" status="SUCCESS" time="2.0" />
+    <system-out>boot complete</system-out>
+  </testsuite>
+</testsuites>`;
+    vol.fromJSON({
+      '/tmp/junit-reports/android-maestro-junit-attempt-0.xml': input,
+    });
+
+    await mergeJUnitReports({
+      sourceDir: '/tmp/junit-reports',
+      outputPath: '/tmp/final.xml',
+    });
+
+    const out = await fs.readFile('/tmp/final.xml', 'utf-8');
+    expect(out).toBe(input);
+  });
+
+  it('keeps the latest attempt per flow name across multiple files', async () => {
+    vol.fromJSON({
+      '/tmp/r/android-maestro-junit-attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="A" status="SUCCESS" time="1.0" />
+  <testcase name="B" time="2.0"><failure>bad</failure></testcase>
+</testsuite></testsuites>`,
+      '/tmp/r/android-maestro-junit-attempt-1.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="B" status="SUCCESS" time="3.0" />
+</testsuite></testsuites>`,
+    });
+
+    await mergeJUnitReports({ sourceDir: '/tmp/r', outputPath: '/tmp/final.xml' });
+
+    const out = await fs.readFile('/tmp/final.xml', 'utf-8');
+    const parsed = new XMLParser({ ignoreAttributes: false }).parse(out);
+    const testcases = parsed.testsuites.testsuite.testcase;
+    const a = testcases.find((t: any) => t['@_name'] === 'A');
+    const b = testcases.find((t: any) => t['@_name'] === 'B');
+    expect(a['@_status']).toBe('SUCCESS'); // from attempt 0
+    expect(b['@_status']).toBe('SUCCESS'); // from attempt 1 (latest)
+    expect(b.failure).toBeUndefined();
+  });
+
+  it('throws when source directory contains no *.xml files', async () => {
+    // No per-attempt JUnit files were ever written (maestro crashed before
+    // producing output). Phase 3 in runMaestroTests treats this as a SystemError
+    // — without a throw here, mergeJUnitReports would silently write an empty
+    // <testsuite> and the caller would upload a misleading empty report.
+    vol.fromJSON({
+      '/tmp/r/.gitkeep': '',
+    });
+
+    await expect(
+      mergeJUnitReports({ sourceDir: '/tmp/r', outputPath: '/tmp/final.xml' })
+    ).rejects.toThrow(/no \*\.xml files/);
+  });
+
+  it('throws when no parseable testcases are found across inputs', async () => {
+    // Malformed XML with no parseable <testsuite> / <testcase>. Without a
+    // throw here, mergeJUnitReports would silently emit an empty merged
+    // document and Phase 3's copyLatestAttemptXml fallback (which only
+    // triggers on throw) would never run.
+    vol.fromJSON({
+      '/tmp/r/android-maestro-junit-attempt-0.xml': 'not xml at all',
+    });
+
+    await expect(
+      mergeJUnitReports({ sourceDir: '/tmp/r', outputPath: '/tmp/final.xml' })
+    ).rejects.toThrow(/no parseable testcases/);
+  });
+
+  it('throws when every input has <testsuites> but no <testcase> elements', async () => {
+    vol.fromJSON({
+      '/tmp/r/android-maestro-junit-attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite></testsuite></testsuites>`,
+    });
+
+    await expect(
+      mergeJUnitReports({ sourceDir: '/tmp/r', outputPath: '/tmp/final.xml' })
+    ).rejects.toThrow(/no parseable testcases/);
+  });
+
+  it('throws when any input XML is malformed (even if others parse)', async () => {
+    vol.fromJSON({
+      '/tmp/r/attempt-0.xml': `<?xml version="1.0"?><testsuites><testsuite><testcase name="A" status="SUCCESS" time="1.0"/></testsuite></testsuites>`,
+      '/tmp/r/attempt-1.xml': 'garbage not xml',
+    });
+    await expect(
+      mergeJUnitReports({ sourceDir: '/tmp/r', outputPath: '/tmp/final.xml' })
+    ).rejects.toThrow();
+  });
+
+  it('throws when an input XML is truncated mid-tag (would otherwise partial-parse)', async () => {
+    // fast-xml-parser is lenient and can return partial results from truncated
+    // XML. Without strict validation, mergeJUnitReports would emit a merged
+    // report missing the cut-off flows and Phase 3's copy-latest fallback
+    // would never run. Validation must reject the file.
+    vol.fromJSON({
+      '/tmp/r/attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="A" status="SUCCESS" time="1.0"/>
+  <testcase name="B"`, // truncated mid-tag
+    });
+    await expect(
+      mergeJUnitReports({ sourceDir: '/tmp/r', outputPath: '/tmp/final.xml' })
+    ).rejects.toThrow();
+  });
+
+  it('throws when an input XML has unclosed tags (would otherwise partial-parse)', async () => {
+    vol.fromJSON({
+      '/tmp/r/attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="A" status="SUCCESS" time="1.0"/>
+</testsuite>`, // missing </testsuites>
+    });
+    await expect(
+      mergeJUnitReports({ sourceDir: '/tmp/r', outputPath: '/tmp/final.xml' })
+    ).rejects.toThrow();
+  });
+
+  it('throws when any input XML parses but has no testcases (even if others have testcases)', async () => {
+    vol.fromJSON({
+      '/tmp/r/attempt-0.xml': `<?xml version="1.0"?><testsuites><testsuite><testcase name="A" status="SUCCESS" time="1.0"/></testsuite></testsuites>`,
+      '/tmp/r/attempt-1.xml': `<?xml version="1.0"?><testsuites></testsuites>`,
+    });
+    await expect(
+      mergeJUnitReports({ sourceDir: '/tmp/r', outputPath: '/tmp/final.xml' })
+    ).rejects.toThrow();
+  });
+
+  it('preserves duplicate names within the same attempt', async () => {
+    vol.fromJSON({
+      '/tmp/r/attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="Dup" status="SUCCESS" time="1.0" />
+  <testcase name="Dup" status="SUCCESS" time="2.0" />
+</testsuite></testsuites>`,
+    });
+
+    await mergeJUnitReports({ sourceDir: '/tmp/r', outputPath: '/tmp/final.xml' });
+
+    const out = await fs.readFile('/tmp/final.xml', 'utf-8');
+    const parsed = new XMLParser({ ignoreAttributes: false, isArray: n => n === 'testcase' }).parse(
+      out
+    );
+    expect(parsed.testsuites.testsuite.testcase).toHaveLength(2);
   });
 });
 

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -49,10 +49,10 @@ function createStep(
 describe('createMaestroTestsBuildFunction', () => {
   beforeEach(() => {
     mockedSpawn.mockReset();
-    // Default-stub copyLatestAttemptXml so tests that don't care about it
-    // don't hit the real disk. Individual tests override this.
+    // Default-stub the merge helper so tests that don't care about it don't
+    // hit the real disk. Individual tests override this.
     jest.restoreAllMocks();
-    jest.spyOn(parser, 'copyLatestAttemptXml').mockResolvedValue();
+    jest.spyOn(parser, 'mergeJUnitReports').mockResolvedValue();
   });
 
   it('exports a factory that returns a BuildFunction instance', () => {
@@ -141,10 +141,9 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(mockedSpawn).toHaveBeenCalledTimes(1);
   });
 
-  it('retries all flows on failure', async () => {
-    const spawnMock = mockedSpawn
-      .mockRejectedValueOnce(rejectExit1())
-      .mockResolvedValueOnce(SPAWN_SUCCESS);
+  it('retries only the failed flows on the next attempt (junit mode)', async () => {
+    mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
+    jest.spyOn(parser, 'parseFailedFlowsFromJUnit').mockResolvedValue(['flows/b.yaml']);
 
     const step = createStep({
       flow_path: ['flows/a.yaml', 'flows/b.yaml', 'flows/c.yaml'],
@@ -154,6 +153,32 @@ describe('createMaestroTestsBuildFunction', () => {
     });
     await step.executeAsync();
 
+    // Attempt 0 saw all 3
+    expect(mockedSpawn.mock.calls[0][1]).toEqual(
+      expect.arrayContaining(['flows/a.yaml', 'flows/b.yaml', 'flows/c.yaml'])
+    );
+    // Attempt 1 saw only the failed one
+    const a1Args = mockedSpawn.mock.calls[1][1]!;
+    expect(a1Args).toContain('flows/b.yaml');
+    expect(a1Args).not.toContain('flows/a.yaml');
+    expect(a1Args).not.toContain('flows/c.yaml');
+  });
+
+  it('retries all flows when parseFailedFlowsFromJUnit returns null', async () => {
+    const spawnMock = mockedSpawn
+      .mockRejectedValueOnce(rejectExit1())
+      .mockResolvedValueOnce(SPAWN_SUCCESS);
+    jest.spyOn(parser, 'parseFailedFlowsFromJUnit').mockResolvedValue(null);
+
+    const step = createStep({
+      flow_path: ['flows/a.yaml', 'flows/b.yaml', 'flows/c.yaml'],
+      retries: 1,
+      output_format: 'junit',
+      platform: 'android',
+    });
+    await step.executeAsync();
+
+    // Both attempts saw all 3 flows
     expect(spawnMock.mock.calls[0][1]).toEqual(
       expect.arrayContaining(['flows/a.yaml', 'flows/b.yaml', 'flows/c.yaml'])
     );
@@ -162,8 +187,48 @@ describe('createMaestroTestsBuildFunction', () => {
     );
   });
 
-  it('writes final report via copyLatestAttemptXml on success', async () => {
+  it('always retries all flows when output_format is not junit', async () => {
+    const spawnMock = mockedSpawn
+      .mockRejectedValueOnce(rejectExit1())
+      .mockResolvedValueOnce(SPAWN_SUCCESS);
+    const parseSpy = jest.spyOn(parser, 'parseFailedFlowsFromJUnit');
+
+    const step = createStep({
+      flow_path: ['flows/a.yaml', 'flows/b.yaml'],
+      retries: 1,
+      output_format: 'html',
+      platform: 'android',
+    });
+    await step.executeAsync();
+
+    expect(parseSpy).not.toHaveBeenCalled();
+    expect(spawnMock.mock.calls[1][1]).toEqual(
+      expect.arrayContaining(['flows/a.yaml', 'flows/b.yaml'])
+    );
+  });
+
+  it('writes merged junit on success', async () => {
     mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const mergeSpy = jest.spyOn(parser, 'mergeJUnitReports').mockResolvedValue();
+
+    const step = createStep({
+      flow_path: ['a.yaml'],
+      output_format: 'junit',
+      platform: 'android',
+    });
+    await step.executeAsync();
+
+    expect(mergeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceDir: expect.stringContaining('junit-reports'),
+        outputPath: expect.stringContaining('android-maestro-junit.xml'),
+      })
+    );
+  });
+
+  it('falls back to copyLatestAttemptXml when mergeJUnitReports throws a data error', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    jest.spyOn(parser, 'mergeJUnitReports').mockRejectedValue(new Error('bad xml'));
     const copySpy = jest.spyOn(parser, 'copyLatestAttemptXml').mockResolvedValue();
 
     const step = createStep({
@@ -173,19 +238,15 @@ describe('createMaestroTestsBuildFunction', () => {
     });
     await step.executeAsync();
 
-    expect(copySpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourceDir: expect.stringContaining('junit-reports'),
-        outputPath: expect.stringContaining('android-maestro-junit.xml'),
-      })
-    );
+    expect(copySpy).toHaveBeenCalled();
   });
 
-  it('swallows copyLatestAttemptXml failure when maestro succeeded', async () => {
+  it('swallows merge and copy-latest failures when maestro succeeded', async () => {
     // Throwing on copy failure would mask the real reason for early-failing
     // maestro runs (bad YAML writes no *.xml) and would also wrap a user-side
     // failure as SystemError, which cancels the build's billing.
     mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    jest.spyOn(parser, 'mergeJUnitReports').mockRejectedValue(new Error('bad xml'));
     jest
       .spyOn(parser, 'copyLatestAttemptXml')
       .mockRejectedValue(Object.assign(new Error('no space'), { code: 'ENOSPC' }));
@@ -230,6 +291,8 @@ describe('createMaestroTestsBuildFunction', () => {
         pid: 1,
       })
     );
+    jest.spyOn(parser, 'parseFailedFlowsFromJUnit').mockResolvedValue(['flows/a.yaml']);
+    jest.spyOn(parser, 'mergeJUnitReports').mockResolvedValue();
 
     const step = createStep({
       flow_path: ['flows/a.yaml'],
@@ -298,9 +361,9 @@ describe('createMaestroTestsBuildFunction', () => {
 
   it('accepts output_format casing variations (e.g. JUNIT) case-insensitively', async () => {
     // output_format.toLowerCase() must propagate end-to-end: final_report_path
-    // populated, per-attempt XMLs written into junit-reports/, copy invoked.
+    // populated, per-attempt XMLs written into junit-reports/, merge invoked.
     mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
-    const copySpy = jest.spyOn(parser, 'copyLatestAttemptXml').mockResolvedValue();
+    const mergeSpy = jest.spyOn(parser, 'mergeJUnitReports').mockResolvedValue();
 
     const step = createStep({
       flow_path: ['flows/a.yaml'],
@@ -309,13 +372,16 @@ describe('createMaestroTestsBuildFunction', () => {
     });
     await step.executeAsync();
 
+    // Phase 1: final_report_path populated
     expect(step.getOutputValueByName('final_report_path')).toMatch(
       /\.maestro\/tests\/android-maestro-junit\.xml$/
     );
+    // Retry loop: --output written into junit-reports/ (not legacy path)
     const args = mockedSpawn.mock.calls[0][1] as string[];
     const outputArg = args.find(a => a.startsWith('--output='));
     expect(outputArg).toMatch(/junit-reports\/android-maestro-junit-attempt-0\.xml$/);
-    expect(copySpy).toHaveBeenCalledWith(
+    // Phase 3: merge invoked
+    expect(mergeSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         sourceDir: expect.stringContaining('junit-reports'),
         outputPath: expect.stringContaining('android-maestro-junit.xml'),

--- a/packages/build-tools/src/steps/functions/maestroResultParser.ts
+++ b/packages/build-tools/src/steps/functions/maestroResultParser.ts
@@ -1,4 +1,4 @@
-import { XMLParser } from 'fast-xml-parser';
+import { XMLBuilder, XMLParser, XMLValidator } from 'fast-xml-parser';
 import fs from 'fs/promises';
 import path from 'path';
 import { z } from 'zod';
@@ -41,11 +41,9 @@ const xmlParser = new XMLParser({
   isArray: name => ['testsuite', 'testcase', 'property'].includes(name),
 });
 
-// Internal helper — not exported. Parses a single JUnit XML file.
-async function parseJUnitFile(filePath: string): Promise<JUnitTestCaseResult[]> {
+function parseJUnitContent(content: string): JUnitTestCaseResult[] {
   const results: JUnitTestCaseResult[] = [];
   try {
-    const content = await fs.readFile(filePath, 'utf-8');
     const parsed = xmlParser.parse(content);
 
     const testsuites = parsed?.testsuites?.testsuite;
@@ -109,9 +107,18 @@ async function parseJUnitFile(filePath: string): Promise<JUnitTestCaseResult[]> 
       }
     }
   } catch {
-    // Skip malformed XML files
+    // Malformed XML — return whatever we collected before the parser bailed.
   }
   return results;
+}
+
+async function parseJUnitFile(filePath: string): Promise<JUnitTestCaseResult[]> {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return parseJUnitContent(content);
+  } catch {
+    return [];
+  }
 }
 
 export async function parseJUnitTestCases(junitDirectory: string): Promise<JUnitTestCaseResult[]> {
@@ -127,11 +134,10 @@ export async function parseJUnitTestCases(junitDirectory: string): Promise<JUnit
     return [];
   }
 
-  const results: JUnitTestCaseResult[] = [];
-  for (const xmlFile of xmlFiles) {
-    results.push(...(await parseJUnitFile(path.join(junitDirectory, xmlFile))));
-  }
-  return results;
+  const perFile = await Promise.all(
+    xmlFiles.map(f => parseJUnitFile(path.join(junitDirectory, f)))
+  );
+  return perFile.flat();
 }
 
 const FlowMetadataFileSchema = z.object({
@@ -301,6 +307,292 @@ export async function parseMaestroResults(
   return results;
 }
 
+/**
+ * Returns the subset of `inputFlowPaths` whose testcases failed in the given
+ * attempt's JUnit file, or `null` when the result cannot be trusted (caller
+ * then falls back to dumb retry — re-run everything).
+ *
+ * Mapping: <testcase> only carries `name`, so we recover `flow_file_path`
+ * from `ai-${flow_name}.json` under testsDirectory and match it back to
+ * inputFlowPaths.
+ */
+export async function parseFailedFlowsFromJUnit(args: {
+  junitFile: string;
+  testsDirectory: string;
+  inputFlowPaths: string[];
+  projectRoot: string;
+}): Promise<string[] | null> {
+  // fast-xml-parser is lenient — truncated XML can produce a partial parse
+  // with some testcases dropped. Trusting that subset for smart retry would
+  // skip retries for cut-off flows; reject any malformed XML and fall back
+  // to dumb retry.
+  let content: string;
+  try {
+    content = await fs.readFile(args.junitFile, 'utf-8');
+  } catch {
+    return null;
+  }
+  if (XMLValidator.validate(content) !== true) {
+    return null;
+  }
+
+  const testcases = parseJUnitContent(content);
+  if (testcases.length === 0) {
+    return null;
+  }
+
+  const failing = testcases.filter(tc => tc.status === 'failed');
+  if (failing.length === 0) {
+    return [];
+  }
+
+  // Two testcases with the same name (pass+fail or fail+fail) make it
+  // impossible to map back to a single input flow_path, since the
+  // ai-*.json keyed map collapses duplicates. Signal "unknown" → dumb retry.
+  const allNameCounts = new Map<string, number>();
+  for (const tc of testcases) {
+    allNameCounts.set(tc.name, (allNameCounts.get(tc.name) ?? 0) + 1);
+  }
+  for (const count of allNameCounts.values()) {
+    if (count > 1) {
+      return null;
+    }
+  }
+
+  // Build flow_name → flow_file_path map from ai-*.json across timestamped
+  // subdirectories (same traversal as parseMaestroResults).
+  const nameToPath = new Map<string, string>();
+  let entries: string[];
+  try {
+    entries = await fs.readdir(args.testsDirectory);
+  } catch {
+    entries = [];
+  }
+  const timestampDirs = entries.filter(name => TIMESTAMP_DIR_PATTERN.test(name)).sort();
+  for (const dir of timestampDirs) {
+    const dirPath = path.join(args.testsDirectory, dir);
+    let files: string[];
+    try {
+      files = await fs.readdir(dirPath);
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      const flowKey = extractFlowKey(file, 'ai');
+      if (!flowKey) {
+        continue;
+      }
+      const metadata = await parseFlowMetadata(path.join(dirPath, file));
+      if (!metadata) {
+        continue;
+      }
+      // Latest timestamp dir wins if the same flow appears in multiple attempts.
+      nameToPath.set(metadata.flow_name, metadata.flow_file_path);
+    }
+  }
+
+  const matched: string[] = [];
+  for (const tc of failing) {
+    const abs = nameToPath.get(tc.name);
+    if (!abs) {
+      return null; // unknown mapping; safer to fall back
+    }
+    const relative = await relativizePathAsync(abs, args.projectRoot);
+    // Accept exact matches and flow files discovered under an input directory
+    // (documented usage: `flow_path: ./maestro/flows` discovers nested .yml).
+    // Anything outside every input is treated as out-of-scope → dumb retry.
+    if (!args.inputFlowPaths.some(input => isPathWithinOrEqual(relative, input))) {
+      return null;
+    }
+    matched.push(relative);
+  }
+
+  return matched;
+}
+
+function isPathWithinOrEqual(child: string, parent: string): boolean {
+  const rel = path.relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+/**
+ * Reads every *.xml in sourceDir (per-attempt JUnit files), picks the latest
+ * attempt's <testcase> per unique flow name (latest determined from the
+ * filename's `attempt-(\d+)` marker; files without the marker = attempt 0),
+ * and writes a merged document to outputPath.
+ *
+ * Throws on empty/malformed/no-testcase input so the caller can fall back to
+ * copyLatestAttemptXml — silently dropping bad attempts could keep stale
+ * failure rows around and produce a misleading merged report.
+ */
+export async function mergeJUnitReports(args: {
+  sourceDir: string;
+  outputPath: string;
+}): Promise<void> {
+  const entries = await fs.readdir(args.sourceDir);
+  const xmlFiles = entries.filter(f => f.endsWith('.xml')).sort();
+
+  if (xmlFiles.length === 0) {
+    throw new Error(`mergeJUnitReports: no *.xml files found in ${args.sourceDir}`);
+  }
+
+  interface FileGroup {
+    attemptIndex: number;
+    filename: string;
+    content: string;
+    testcasesByName: Map<string, unknown[]>;
+  }
+  const contents = await Promise.all(
+    xmlFiles.map(async f => ({
+      filename: f,
+      content: await fs.readFile(path.join(args.sourceDir, f), 'utf-8'),
+    }))
+  );
+  const fileGroups: FileGroup[] = [];
+  const skippedFiles: string[] = [];
+  for (const { filename, content } of contents) {
+    if (XMLValidator.validate(content) !== true) {
+      skippedFiles.push(filename);
+      continue;
+    }
+    let parsed: any;
+    try {
+      parsed = xmlParser.parse(content);
+    } catch {
+      skippedFiles.push(filename);
+      continue;
+    }
+    const testsuites = parsed?.testsuites?.testsuite;
+    if (!Array.isArray(testsuites)) {
+      skippedFiles.push(filename);
+      continue;
+    }
+    const match = filename.match(ATTEMPT_PATTERN);
+    const attemptIndex = match ? parseInt(match[1], 10) : 0;
+    const testcasesByName = new Map<string, unknown[]>();
+    for (const suite of testsuites) {
+      const cases = suite?.testcase;
+      if (!Array.isArray(cases)) {
+        continue;
+      }
+      for (const tc of cases) {
+        const name = tc?.['@_name'];
+        if (typeof name !== 'string') {
+          continue;
+        }
+        const group = testcasesByName.get(name) ?? [];
+        group.push(tc);
+        testcasesByName.set(name, group);
+      }
+    }
+    if (testcasesByName.size === 0) {
+      skippedFiles.push(filename);
+      continue;
+    }
+    fileGroups.push({ attemptIndex, filename, content, testcasesByName });
+  }
+
+  if (skippedFiles.length > 0) {
+    throw new Error(
+      `mergeJUnitReports: no parseable testcases found in ${skippedFiles.join(', ')}`
+    );
+  }
+
+  // Single attempt: copy the original XML so suite-level metadata (testsuite
+  // attributes, <system-out>, etc.) survives. The rebuild path below would
+  // collapse those to a single attribute-less <testsuite>.
+  if (fileGroups.length === 1) {
+    await fs.writeFile(args.outputPath, fileGroups[0].content);
+    return;
+  }
+
+  // For each unique name, pick the file with the highest attempt index that
+  // contains it (ties broken by sorted filename — later wins). Preserve every
+  // <testcase> element from the winning file for that name, so same-attempt
+  // duplicates survive.
+  const nameToWinningFile = new Map<string, FileGroup>();
+  for (const group of fileGroups) {
+    for (const name of group.testcasesByName.keys()) {
+      const current = nameToWinningFile.get(name);
+      if (!current || group.attemptIndex >= current.attemptIndex) {
+        nameToWinningFile.set(name, group);
+      }
+    }
+  }
+
+  // Emit in first-seen order (iteration over `fileGroups` yields stable order
+  // matching the sorted filename list).
+  const testcases: unknown[] = [];
+  const emitted = new Set<string>();
+  for (const group of fileGroups) {
+    for (const [name, cases] of group.testcasesByName) {
+      if (emitted.has(name)) {
+        continue;
+      }
+      const winner = nameToWinningFile.get(name);
+      if (winner === group) {
+        for (const tc of cases) {
+          testcases.push(tc);
+        }
+        emitted.add(name);
+      }
+    }
+  }
+
+  const builder = new XMLBuilder({
+    ignoreAttributes: false,
+    attributeNamePrefix: '@_',
+    format: true,
+    suppressEmptyNode: true,
+  });
+  const xml = builder.build({
+    testsuites: {
+      testsuite: {
+        testcase: testcases,
+      },
+    },
+  });
+  await fs.writeFile(args.outputPath, xml);
+}
+
+/**
+ * Copies the highest-attempt-index *.xml file from sourceDir to outputPath.
+ * Used as a fallback when mergeJUnitReports fails due to data issues but the
+ * step still needs to produce final_report_path.
+ *
+ * Throws if sourceDir contains no *.xml files or if the copy fails.
+ */
+export async function copyLatestAttemptXml(args: {
+  sourceDir: string;
+  outputPath: string;
+}): Promise<void> {
+  const entries = await fs.readdir(args.sourceDir);
+  const xmlFiles = entries.filter(f => f.endsWith('.xml')).sort();
+  if (xmlFiles.length === 0) {
+    throw new Error(`No *.xml files found in ${args.sourceDir}`);
+  }
+
+  // Pick the file with the highest attempt index. Files without the marker are
+  // treated as attempt 0. Ties are broken by sorted filename — later wins
+  // (same rule as mergeJUnitReports).
+  let winner = xmlFiles[0];
+  let winnerAttempt = (() => {
+    const m = winner.match(ATTEMPT_PATTERN);
+    return m ? parseInt(m[1], 10) : 0;
+  })();
+  for (let i = 1; i < xmlFiles.length; i++) {
+    const candidate = xmlFiles[i];
+    const match = candidate.match(ATTEMPT_PATTERN);
+    const attempt = match ? parseInt(match[1], 10) : 0;
+    if (attempt >= winnerAttempt) {
+      winner = candidate;
+      winnerAttempt = attempt;
+    }
+  }
+
+  await fs.copyFile(path.join(args.sourceDir, winner), args.outputPath);
+}
+
 async function relativizePathAsync(flowFilePath: string, projectRoot: string): Promise<string> {
   if (!path.isAbsolute(flowFilePath)) {
     return flowFilePath;
@@ -321,42 +613,4 @@ async function relativizePathAsync(flowFilePath: string, projectRoot: string): P
     return flowFilePath;
   }
   return relative;
-}
-
-/**
- * Copies the highest-attempt-index *.xml file from sourceDir to outputPath.
- * After the maestro retry loop completes, this produces a single canonical
- * JUnit report at final_report_path matching the bash step's "cp latest
- * attempt" semantics.
- *
- * Throws if sourceDir contains no *.xml files or if the copy fails.
- */
-export async function copyLatestAttemptXml(args: {
-  sourceDir: string;
-  outputPath: string;
-}): Promise<void> {
-  const entries = await fs.readdir(args.sourceDir);
-  const xmlFiles = entries.filter(f => f.endsWith('.xml')).sort();
-  if (xmlFiles.length === 0) {
-    throw new Error(`No *.xml files found in ${args.sourceDir}`);
-  }
-
-  // Pick the file with the highest attempt index. Files without the marker are
-  // treated as attempt 0. Ties are broken by sorted filename — later wins.
-  let winner = xmlFiles[0];
-  let winnerAttempt = (() => {
-    const m = winner.match(ATTEMPT_PATTERN);
-    return m ? parseInt(m[1], 10) : 0;
-  })();
-  for (let i = 1; i < xmlFiles.length; i++) {
-    const candidate = xmlFiles[i];
-    const match = candidate.match(ATTEMPT_PATTERN);
-    const attempt = match ? parseInt(match[1], 10) : 0;
-    if (attempt >= winnerAttempt) {
-      winner = candidate;
-      winnerAttempt = attempt;
-    }
-  }
-
-  await fs.copyFile(path.join(args.sourceDir, winner), args.outputPath);
 }

--- a/packages/build-tools/src/steps/functions/maestroResultParser.ts
+++ b/packages/build-tools/src/steps/functions/maestroResultParser.ts
@@ -449,23 +449,19 @@ export async function mergeJUnitReports(args: {
     }))
   );
   const fileGroups: FileGroup[] = [];
-  const skippedFiles: string[] = [];
   for (const { filename, content } of contents) {
     if (XMLValidator.validate(content) !== true) {
-      skippedFiles.push(filename);
-      continue;
+      throw new Error(`mergeJUnitReports: invalid XML in ${filename}`);
     }
     let parsed: any;
     try {
       parsed = xmlParser.parse(content);
-    } catch {
-      skippedFiles.push(filename);
-      continue;
+    } catch (err) {
+      throw new Error(`mergeJUnitReports: failed to parse ${filename}`, { cause: err });
     }
     const testsuites = parsed?.testsuites?.testsuite;
     if (!Array.isArray(testsuites)) {
-      skippedFiles.push(filename);
-      continue;
+      throw new Error(`mergeJUnitReports: no <testsuite> array in ${filename}`);
     }
     const match = filename.match(ATTEMPT_PATTERN);
     const attemptIndex = match ? parseInt(match[1], 10) : 0;
@@ -486,16 +482,9 @@ export async function mergeJUnitReports(args: {
       }
     }
     if (testcasesByName.size === 0) {
-      skippedFiles.push(filename);
-      continue;
+      throw new Error(`mergeJUnitReports: no parseable testcases in ${filename}`);
     }
     fileGroups.push({ attemptIndex, filename, content, testcasesByName });
-  }
-
-  if (skippedFiles.length > 0) {
-    throw new Error(
-      `mergeJUnitReports: no parseable testcases found in ${skippedFiles.join(', ')}`
-    );
   }
 
   // Single attempt: copy the original XML so suite-level metadata (testsuite

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -11,7 +11,11 @@ import fs from 'fs/promises';
 import path from 'path';
 import { z } from 'zod';
 
-import { copyLatestAttemptXml } from './maestroResultParser';
+import {
+  copyLatestAttemptXml,
+  mergeJUnitReports,
+  parseFailedFlowsFromJUnit,
+} from './maestroResultParser';
 import { sleepAsync } from '../../utils/retry';
 
 const FlowPathSchema = z.array(z.string().min(1)).min(1);
@@ -28,6 +32,19 @@ function parseInput<S extends z.ZodTypeAny>(
     throw new UserError('ERR_MAESTRO_INVALID_INPUT', message, { cause: result.error });
   }
   return result.data;
+}
+
+// ENOENT is excluded — "input XML missing" is a data issue, not a storage
+// fault, so the post-loop merge should fall through to copy-latest instead
+// of throwing.
+function isFilesystemError(err: any): boolean {
+  if (!err || typeof err !== 'object') {
+    return false;
+  }
+  const code = err.code;
+  return (
+    code === 'ENOSPC' || code === 'EACCES' || code === 'EROFS' || code === 'EIO' || code === 'EPERM'
+  );
 }
 
 // `outputPath: null` means "let maestro pick" (no --output flag). Junit and
@@ -180,6 +197,10 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
       //   numeric err.status → maestro exited non-zero → retry.
       //   else (signal-only, OOM kill, unknown) → infra → SystemError, never
       //     downgraded to "tests failed".
+      // Smart retry (junit mode): after a failed attempt, subset to the failing
+      // flows. parseFailedFlowsFromJUnit returns null when the JUnit cannot be
+      // trusted; we then fall through to dumb retry (re-run everything).
+      let flowsToRun: string[] = flowPaths;
       let lastAttemptExitCode: number | null = null;
 
       for (let attempt = 0; attempt <= retries; attempt++) {
@@ -194,7 +215,7 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
           await spawn(
             'maestro',
             buildMaestroArgs({
-              flow_path: flowPaths,
+              flow_path: flowsToRun,
               outputPath,
               output_format: outputFormat,
               shards,
@@ -219,26 +240,50 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
           break;
         }
 
+        if (outputFormat === 'junit' && outputPath) {
+          const failed = await parseFailedFlowsFromJUnit({
+            junitFile: outputPath,
+            testsDirectory,
+            inputFlowPaths: flowsToRun,
+            projectRoot: stepCtx.workingDirectory,
+          });
+          if (failed !== null && failed.length > 0) {
+            flowsToRun = failed;
+          }
+        }
+
         logger.info('Test failed, retrying...');
         await sleepAsync(2000);
       }
 
-      // Copy the latest attempt's JUnit to the final report path so downstream
-      // upload/report steps have a single canonical file.
+      // Smart merge first; on data errors (bad XML, missing input) fall back
+      // to copy-latest so the caller still gets a single JUnit file.
+      // Filesystem errors short-circuit straight to SystemError.
       if (finalReportPath !== undefined) {
         try {
-          await copyLatestAttemptXml({
+          await mergeJUnitReports({
             sourceDir: junitReportDirectory,
             outputPath: finalReportPath,
           });
-        } catch (copyErr: any) {
-          // Swallow: a copy failure usually means maestro itself failed early
-          // (bad YAML wrote no *.xml). Throwing SystemError here would mask
-          // the real reason and cancel billing for a user-side failure — let
-          // the lastAttemptExitCode check below surface ERR_MAESTRO_TESTS_FAILED.
-          logger.warn(
-            `Failed to produce final_report_path at ${finalReportPath}: ${copyErr?.message ?? copyErr}`
-          );
+        } catch (mergeErr: any) {
+          if (isFilesystemError(mergeErr)) {
+            throw new SystemError('Failed to write final_report_path', { cause: mergeErr });
+          }
+          logger.warn({ err: mergeErr }, 'Smart merge failed; falling back to copy-latest.');
+          try {
+            await copyLatestAttemptXml({
+              sourceDir: junitReportDirectory,
+              outputPath: finalReportPath,
+            });
+          } catch (copyErr: any) {
+            // Swallow: a copy failure here usually means maestro itself failed
+            // early (bad YAML wrote no *.xml). Throwing SystemError would mask
+            // the real reason and cancel billing for a user-side failure — let
+            // the lastAttemptExitCode check below surface ERR_MAESTRO_TESTS_FAILED.
+            logger.warn(
+              `Failed to produce final_report_path at ${finalReportPath}: ${copyErr?.message ?? copyErr}`
+            );
+          }
         }
       }
 


### PR DESCRIPTION
# Why

After porting the Maestro step to TS (#3641), we want to stop re-running the entire flow set on every retry. With dozens of flows a single flaky one masks other failures and inflates the whole run. Smart retry re-runs only the flows that actually failed.

Linear: [ENG-19927](https://linear.app/expo/issue/ENG-19927). Stacked on #3641.

# How

After each failed attempt, parse the per-attempt JUnit XML, find the failing testcase names, map them back to flow file paths, and pass only those paths to the next `maestro test` invocation.

- `parseFailedFlowsFromJUnit` returns the failed-flow subset, or `null` when the result can't be trusted (malformed XML, duplicate testcase names, unknown flow). On `null` the loop falls back to dumb retry, preserving the previous behavior.
- Replaces "copy latest attempt's JUnit" with `mergeJUnitReports`, which keeps the latest result *per flow* across attempts. The merged final report reflects each flow's best outcome (a flow that flaked once and passed on retry shows as passed).

The `flow_name → flow_file_path` map is built from Maestro's `ai-*.json` debug output. PR #3639 (next in stack) replaces this with a self-built map after Maestro 2.5.0 broke this assumption.

# Test Plan

- Unit tests in `maestroResultParser.test.ts` for `parseFailedFlowsFromJUnit` (happy path, all-passing, collisions, malformed XML, partial parse) and `mergeJUnitReports` (per-flow latest, fallback on data errors).
- New cases in `runMaestroTests.test.ts` exercising the smart-retry loop.
- Local end-to-end smoke test against the playground.
