### PR TITLE
add simulator flag to build dev and run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add `--simulator` to `eas build:dev` and `eas build:run` to select which iOS simulator to install and run builds on. ([#3637](https://github.com/expo/eas-cli/pull/3637) by [@mmichels-brex](https://github.com/mmichels-brex))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -65,6 +65,7 @@ import {
 } from '../project/remoteVersionSource';
 import { confirmAsync } from '../prompts';
 import { getEasBuildRunCachedAppPath, runAsync } from '../run/run';
+import { SimulatorRunTarget } from '../run/ios/run';
 import { isRunnableOnSimulatorOrEmulator } from '../run/utils';
 import { createSubmissionContextAsync } from '../submit/context';
 import {
@@ -102,6 +103,7 @@ export interface BuildFlags {
   freezeCredentials: boolean;
   isVerboseLoggingEnabled?: boolean;
   whatToTest?: string;
+  simulator?: SimulatorRunTarget;
 }
 
 export async function runBuildAndSubmitAsync({
@@ -579,14 +581,17 @@ function exitWithNonZeroCodeIfSomeBuildsFailed(maybeBuilds: (BuildFragment | nul
   }
 }
 
-export async function downloadAndRunAsync(build: BuildFragment): Promise<void> {
+export async function downloadAndRunAsync(
+  build: BuildFragment,
+  simulator?: SimulatorRunTarget
+): Promise<void> {
   assert(build.artifacts?.applicationArchiveUrl);
   const cachedAppPath = getEasBuildRunCachedAppPath(build.project.id, build.id, build.platform);
 
   if (await pathExists(cachedAppPath)) {
     Log.newLine();
     Log.log(`Using cached app...`);
-    await runAsync(cachedAppPath, build.platform);
+    await runAsync(cachedAppPath, build.platform, simulator);
     return;
   }
 
@@ -595,7 +600,7 @@ export async function downloadAndRunAsync(build: BuildFragment): Promise<void> {
     build.platform,
     cachedAppPath
   );
-  await runAsync(buildPath, build.platform);
+  await runAsync(buildPath, build.platform, simulator);
 }
 
 async function maybeDownloadAndRunSimulatorBuildsAsync(
@@ -617,9 +622,9 @@ async function maybeDownloadAndRunSimulatorBuildsAsync(
             } build on ${
               simBuild.platform === AppPlatform.Android ? 'an emulator' : 'a simulator'
             }?`,
-          }));
+        }));
         if (confirm) {
-          await downloadAndRunAsync(simBuild);
+          await downloadAndRunAsync(simBuild, flags.simulator);
         }
       }
     }

--- a/packages/eas-cli/src/commandUtils/buildFlags.ts
+++ b/packages/eas-cli/src/commandUtils/buildFlags.ts
@@ -1,0 +1,20 @@
+export function preprocessBuildCommandArgs(argv: string[]): string[] {
+  return withOptionalSimulatorValue(argv);
+}
+
+// oclif does not support string flags with optional values. We want "--simulator"
+// to prompt for a simulator, while still supporting "--simulator <name-or-udid>".
+// Insert an empty string value for the bare flag before oclif parses argv.
+function withOptionalSimulatorValue(argv: string[]): string[] {
+  const simulatorFlagIndex = argv.indexOf('--simulator');
+  const simulatorValue = argv[simulatorFlagIndex + 1];
+
+  if (
+    simulatorFlagIndex === -1 ||
+    (simulatorValue !== undefined && !simulatorValue.startsWith('-'))
+  ) {
+    return argv;
+  }
+
+  return [...argv.slice(0, simulatorFlagIndex + 1), '', ...argv.slice(simulatorFlagIndex + 1)];
+}

--- a/packages/eas-cli/src/commands/build/dev.ts
+++ b/packages/eas-cli/src/commands/build/dev.ts
@@ -12,6 +12,7 @@ import { evaluateConfigWithEnvVarsAsync } from '../../build/evaluateConfigWithEn
 import { downloadAndRunAsync, runBuildAndSubmitAsync } from '../../build/runBuildAndSubmit';
 import { ensureRepoIsCleanAsync } from '../../build/utils/repository';
 import EasCommand from '../../commandUtils/EasCommand';
+import { preprocessBuildCommandArgs } from '../../commandUtils/buildFlags';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { createFingerprintAsync } from '../../fingerprint/cli';
 import { BuildFragment, BuildStatus, DistributionType } from '../../graphql/generated';
@@ -51,6 +52,11 @@ export default class BuildDev extends EasCommand {
       description: 'Install and run the development build without starting the bundler server.',
       default: false,
     }),
+    simulator: Flags.string({
+      description:
+        'iOS simulator name or UDID to install and run the development build on. If no value is provided, you will be prompted to select a simulator.',
+      multiple: false,
+    }),
   };
 
   static override contextDefinition = {
@@ -63,7 +69,7 @@ export default class BuildDev extends EasCommand {
   };
 
   protected override async runAsync(): Promise<any> {
-    const { flags } = await this.parse(BuildDev);
+    const { flags } = await this.parse(BuildDev, preprocessBuildCommandArgs(this.argv));
 
     const {
       loggedIn: { actor, graphqlClient },
@@ -81,6 +87,10 @@ export default class BuildDev extends EasCommand {
     if (process.platform !== 'darwin' && platform === Platform.IOS) {
       Errors.error('Running iOS builds in simulator is only supported on macOS.', { exit: 1 });
     }
+    if (flags.simulator && platform !== Platform.IOS) {
+      Errors.error('The --simulator flag can only be used with --platform ios.', { exit: 1 });
+    }
+    const simulator = flags.simulator === '' ? true : flags.simulator;
 
     await vcsClient.ensureRepoExistsAsync();
     await ensureRepoIsCleanAsync(vcsClient, flags.nonInteractive);
@@ -132,7 +142,7 @@ export default class BuildDev extends EasCommand {
       );
 
       if (build.artifacts?.applicationArchiveUrl) {
-        await downloadAndRunAsync(build);
+        await downloadAndRunAsync(build, simulator);
         if (!flags['skip-bundler']) {
           await this.startDevServerAsync({ projectDir, platform });
         }
@@ -182,6 +192,7 @@ export default class BuildDev extends EasCommand {
         autoSubmit: false,
         localBuildOptions: {},
         profile: flags.profile ?? DEFAULT_EAS_BUILD_RUN_PROFILE_NAME,
+        simulator,
       },
       actor,
       getDynamicPrivateProjectConfigAsync,

--- a/packages/eas-cli/src/commands/build/run.ts
+++ b/packages/eas-cli/src/commands/build/run.ts
@@ -4,6 +4,7 @@ import { pathExists } from 'fs-extra';
 
 import { getLatestBuildAsync, listAndSelectBuildOnAppAsync } from '../../build/queries';
 import EasCommand from '../../commandUtils/EasCommand';
+import { preprocessBuildCommandArgs } from '../../commandUtils/buildFlags';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import {
   EasPaginatedQueryFlags,
@@ -17,6 +18,7 @@ import { appPlatformDisplayNames } from '../../platform';
 import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { promptAsync } from '../../prompts';
 import { RunArchiveFlags, getEasBuildRunCachedAppPath, runAsync } from '../../run/run';
+import { SimulatorRunTarget } from '../../run/ios/run';
 import { isRunnableOnSimulatorOrEmulator } from '../../run/utils';
 import {
   downloadAndMaybeExtractAppAsync,
@@ -32,6 +34,7 @@ interface RawRunFlags {
   limit?: number;
   offset?: number;
   profile?: string;
+  simulator?: string;
 }
 
 interface RunCommandFlags {
@@ -40,6 +43,7 @@ interface RunCommandFlags {
   limit?: number;
   offset?: number;
   profile?: string;
+  simulator?: SimulatorRunTarget;
 }
 
 export default class Run extends EasCommand {
@@ -72,6 +76,11 @@ export default class Run extends EasCommand {
         'Name of the build profile used to create the build to run. When specified, only builds created with the specified build profile will be queried.',
       helpValue: 'PROFILE_NAME',
     }),
+    simulator: Flags.string({
+      description:
+        'iOS simulator name or UDID to install and run the build on. If no value is provided, you will be prompted to select a simulator.',
+      multiple: false,
+    }),
     ...EasPaginatedQueryFlags,
   };
 
@@ -82,7 +91,7 @@ export default class Run extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
-    const { flags: rawFlags } = await this.parse(Run);
+    const { flags: rawFlags } = await this.parse(Run, preprocessBuildCommandArgs(this.argv));
     const flags = await this.sanitizeFlagsAsync(rawFlags);
     const queryOptions = getPaginatedQueryOptions(flags);
     const {
@@ -99,11 +108,11 @@ export default class Run extends EasCommand {
       queryOptions
     );
 
-    await runAsync(simulatorBuildPath, flags.selectedPlatform);
+    await runAsync(simulatorBuildPath, flags.selectedPlatform, flags.simulator);
   }
 
   private async sanitizeFlagsAsync(flags: RawRunFlags): Promise<RunCommandFlags> {
-    const { platform, limit, offset, profile, ...runArchiveFlags } = flags;
+    const { platform, limit, offset, profile, simulator, ...runArchiveFlags } = flags;
 
     const selectedPlatform = await resolvePlatformAsync(platform);
 
@@ -111,6 +120,9 @@ export default class Run extends EasCommand {
       Errors.error('You can only use an iOS simulator to run apps on macOS devices', {
         exit: 1,
       });
+    }
+    if (simulator && selectedPlatform !== AppPlatform.Ios) {
+      Errors.error('The --simulator flag can only be used with --platform ios.', { exit: 1 });
     }
 
     if (
@@ -137,6 +149,7 @@ export default class Run extends EasCommand {
       limit,
       offset,
       profile,
+      simulator: simulator === '' ? true : simulator,
     };
   }
 }

--- a/packages/eas-cli/src/run/ios/run.ts
+++ b/packages/eas-cli/src/run/ios/run.ts
@@ -4,10 +4,20 @@ import path from 'path';
 import * as simulator from './simulator';
 import { validateSystemRequirementsAsync } from './systemRequirements';
 
-export async function runAppOnIosSimulatorAsync(appPath: string): Promise<void> {
+export type SimulatorRunTarget = true | string | undefined;
+
+export async function runAppOnIosSimulatorAsync(
+  appPath: string,
+  simulatorRunTarget?: SimulatorRunTarget
+): Promise<void> {
   await validateSystemRequirementsAsync();
 
-  const selectedSimulator = await simulator.selectSimulatorAsync();
+  const selectedSimulator =
+    simulatorRunTarget === true
+      ? await simulator.selectSimulatorAsync({ forcePrompt: true })
+      : simulatorRunTarget
+        ? await simulator.getIosSimulatorByIdOrNameAsync(simulatorRunTarget)
+        : await simulator.selectSimulatorAsync();
   await simulator.ensureSimulatorBootedAsync(selectedSimulator);
 
   await simulator.ensureSimulatorAppOpenedAsync(selectedSimulator.udid);

--- a/packages/eas-cli/src/run/ios/simulator.ts
+++ b/packages/eas-cli/src/run/ios/simulator.ts
@@ -18,8 +18,10 @@ interface IosSimulator {
   lastBootedAt?: Date;
 }
 
-export async function selectSimulatorAsync(): Promise<IosSimulator> {
-  const bootedSimulator = await getFirstBootedIosSimulatorAsync();
+export async function selectSimulatorAsync({
+  forcePrompt = false,
+}: { forcePrompt?: boolean } = {}): Promise<IosSimulator> {
+  const bootedSimulator = forcePrompt ? undefined : await getFirstBootedIosSimulatorAsync();
 
   if (bootedSimulator) {
     return bootedSimulator;
@@ -37,7 +39,22 @@ export async function selectSimulatorAsync(): Promise<IosSimulator> {
       value: simulator,
     })),
   });
+  if (!selectedSimulator) {
+    throw new Error('No simulator selected.');
+  }
 
+  return selectedSimulator;
+}
+
+export async function getIosSimulatorByIdOrNameAsync(simulator: string): Promise<IosSimulator> {
+  const simulators = await getAvaliableIosSimulatorsListAsync();
+  const selectedSimulator = simulators.find(
+    availableSimulator =>
+      availableSimulator.udid === simulator || availableSimulator.name === simulator
+  );
+  if (!selectedSimulator) {
+    throw new Error(`Could not find an available iOS simulator with name or UDID "${simulator}".`);
+  }
   return selectedSimulator;
 }
 

--- a/packages/eas-cli/src/run/run.ts
+++ b/packages/eas-cli/src/run/run.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { runAppOnAndroidEmulatorAsync } from './android/run';
-import { runAppOnIosSimulatorAsync } from './ios/run';
+import { SimulatorRunTarget, runAppOnIosSimulatorAsync } from './ios/run';
 import { AppPlatform } from '../graphql/generated';
 import { getEasBuildRunCacheDirectoryPath } from '../utils/paths';
 
@@ -14,10 +14,11 @@ export interface RunArchiveFlags {
 
 export async function runAsync(
   simulatorBuildPath: string,
-  selectedPlatform: AppPlatform
+  selectedPlatform: AppPlatform,
+  simulator?: SimulatorRunTarget
 ): Promise<void> {
   if (selectedPlatform === AppPlatform.Ios) {
-    await runAppOnIosSimulatorAsync(simulatorBuildPath);
+    await runAppOnIosSimulatorAsync(simulatorBuildPath, simulator);
   } else {
     await runAppOnAndroidEmulatorAsync(simulatorBuildPath);
   }


### PR DESCRIPTION
## Summary
- add a --simulator flag to eas build:dev and eas build:run for iOS dev-client/simulator installs
- support both --simulator <name-or-udid> and bare --simulator, which prompts for an available simulator
- reuse the same optional-value flag preprocessing and shared simulator run target path for both commands

## Validation

https://github.com/user-attachments/assets/da061a03-59b0-45c1-ab80-dc528f8c4a62