### PR TITLE
[eas-cli] Add observe:logs command for viewing custom events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [eas-cli] Add `eas integrations:convex` commands to manage Convex integrations for EAS projects. ([#3575](https://github.com/expo/eas-cli/pull/3575) by [@fiberjw](https://github.com/fiberjw))
+- [eas-cli] New command `observe:logs` for custom events. ([#3638](https://github.com/expo/eas-cli/pull/3638) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/observe/__tests__/logs.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/logs.test.ts
@@ -83,6 +83,15 @@ describe(ObserveLogs, () => {
     expect(options.eventName).toBeUndefined();
   });
 
+  it('throws when both an event name argument and --all-events are provided', async () => {
+    const command = createCommand(['my_event', '--all-events']);
+    await expect(command.runAsync()).rejects.toThrow(
+      '--all-events cannot be combined with an event name argument'
+    );
+    expect(mockFetchObserveCustomEventsAsync).not.toHaveBeenCalled();
+    expect(mockCustomEventNamesAsync).not.toHaveBeenCalled();
+  });
+
   it('passes the resolved time range and platform to customEventNamesAsync', async () => {
     const now = new Date('2025-06-15T12:00:00.000Z');
     jest.useFakeTimers({ now });

--- a/packages/eas-cli/src/commands/observe/__tests__/logs.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/logs.test.ts
@@ -5,6 +5,8 @@ import { ObserveQuery } from '../../../graphql/queries/ObserveQuery';
 import { fetchObserveCustomEventsAsync } from '../../../observe/fetchCustomEvents';
 import {
   buildObserveCustomEventNamesJson,
+  buildObserveCustomEventsEmptyWithSuggestionsJson,
+  buildObserveCustomEventsEmptyWithSuggestionsTable,
   buildObserveCustomEventsJson,
 } from '../../../observe/formatCustomEvents';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
@@ -16,6 +18,15 @@ jest.mock('../../../observe/formatCustomEvents', () => ({
   buildObserveCustomEventsJson: jest.fn().mockReturnValue({}),
   buildObserveCustomEventNamesTable: jest.fn().mockReturnValue('names-table'),
   buildObserveCustomEventNamesJson: jest.fn().mockReturnValue({ names: [], isTruncated: false }),
+  buildObserveCustomEventsEmptyWithSuggestionsTable: jest
+    .fn()
+    .mockReturnValue('empty-with-suggestions-table'),
+  buildObserveCustomEventsEmptyWithSuggestionsJson: jest.fn().mockReturnValue({
+    filteredEventName: 'my_event',
+    events: [],
+    availableEventNames: [],
+    availableEventNamesIsTruncated: false,
+  }),
 }));
 jest.mock('../../../graphql/queries/ObserveQuery', () => ({
   ObserveQuery: {
@@ -28,6 +39,12 @@ jest.mock('../../../utils/json');
 const mockFetchObserveCustomEventsAsync = jest.mocked(fetchObserveCustomEventsAsync);
 const mockBuildObserveCustomEventsJson = jest.mocked(buildObserveCustomEventsJson);
 const mockBuildObserveCustomEventNamesJson = jest.mocked(buildObserveCustomEventNamesJson);
+const mockBuildObserveCustomEventsEmptyWithSuggestionsTable = jest.mocked(
+  buildObserveCustomEventsEmptyWithSuggestionsTable
+);
+const mockBuildObserveCustomEventsEmptyWithSuggestionsJson = jest.mocked(
+  buildObserveCustomEventsEmptyWithSuggestionsJson
+);
 const mockCustomEventNamesAsync = jest.mocked(ObserveQuery.customEventNamesAsync);
 const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
 const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
@@ -57,6 +74,10 @@ describe(ObserveLogs, () => {
   }
 
   it('passes eventName arg to fetchObserveCustomEventsAsync', async () => {
+    mockFetchObserveCustomEventsAsync.mockResolvedValue({
+      events: [{ id: 'evt-1' } as any],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    });
     const command = createCommand(['my_event']);
     await command.runAsync();
 
@@ -239,6 +260,105 @@ describe(ObserveLogs, () => {
       expect.objectContaining({ hasNextPage: false })
     );
     expect(mockPrintJsonOnlyOutput).toHaveBeenCalled();
+  });
+
+  it('falls back to fetching event names and renders the empty-with-suggestions table when filtered fetch returns 0 events', async () => {
+    mockFetchObserveCustomEventsAsync.mockResolvedValue({
+      events: [],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    });
+    const mockNames = [
+      { eventName: 'foo', count: 10 },
+      { eventName: 'bar', count: 5 },
+    ];
+    mockCustomEventNamesAsync.mockResolvedValue({
+      names: mockNames as any,
+      isTruncated: false,
+    });
+
+    const command = createCommand(['my_event']);
+    await command.runAsync();
+
+    expect(mockFetchObserveCustomEventsAsync).toHaveBeenCalledTimes(1);
+    expect(mockCustomEventNamesAsync).toHaveBeenCalledTimes(1);
+    expect(mockBuildObserveCustomEventsEmptyWithSuggestionsTable).toHaveBeenCalledWith(
+      'my_event',
+      mockNames,
+      expect.objectContaining({ isTruncated: false })
+    );
+  });
+
+  it('does not call customEventNamesAsync when filtered fetch returns at least one event', async () => {
+    mockFetchObserveCustomEventsAsync.mockResolvedValue({
+      events: [
+        {
+          id: 'evt-1',
+          eventName: 'my_event',
+          timestamp: '2025-01-15T10:30:00.000Z',
+          appVersion: '1.0.0',
+          appBuildNumber: '42',
+          deviceModel: 'iPhone 15',
+          deviceOs: 'iOS',
+          deviceOsVersion: '17.0',
+          easClientId: 'client-1',
+          properties: [],
+        } as any,
+      ],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    });
+
+    const command = createCommand(['my_event']);
+    await command.runAsync();
+
+    expect(mockCustomEventNamesAsync).not.toHaveBeenCalled();
+    expect(mockBuildObserveCustomEventsEmptyWithSuggestionsTable).not.toHaveBeenCalled();
+  });
+
+  it('emits empty-with-suggestions JSON when filtered fetch returns 0 events and --json is set', async () => {
+    mockFetchObserveCustomEventsAsync.mockResolvedValue({
+      events: [],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    });
+    const mockNames = [{ eventName: 'foo', count: 10 }];
+    mockCustomEventNamesAsync.mockResolvedValue({
+      names: mockNames as any,
+      isTruncated: false,
+    });
+
+    const command = createCommand(['my_event', '--json', '--non-interactive']);
+    await command.runAsync();
+
+    expect(mockEnableJsonOutput).toHaveBeenCalled();
+    expect(mockBuildObserveCustomEventsEmptyWithSuggestionsJson).toHaveBeenCalledWith(
+      'my_event',
+      mockNames,
+      false
+    );
+    expect(mockBuildObserveCustomEventsJson).not.toHaveBeenCalled();
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalled();
+  });
+
+  it('does not run the empty-with-suggestions fallback when no event name is provided (event names mode)', async () => {
+    mockCustomEventNamesAsync.mockResolvedValue({ names: [], isTruncated: false });
+
+    const command = createCommand([]);
+    await command.runAsync();
+
+    expect(mockBuildObserveCustomEventsEmptyWithSuggestionsTable).not.toHaveBeenCalled();
+    expect(mockBuildObserveCustomEventsEmptyWithSuggestionsJson).not.toHaveBeenCalled();
+  });
+
+  it('does not run the empty-with-suggestions fallback for --all-events with 0 results', async () => {
+    mockFetchObserveCustomEventsAsync.mockResolvedValue({
+      events: [],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    });
+
+    const command = createCommand(['--all-events']);
+    await command.runAsync();
+
+    expect(mockCustomEventNamesAsync).not.toHaveBeenCalled();
+    expect(mockBuildObserveCustomEventsEmptyWithSuggestionsTable).not.toHaveBeenCalled();
   });
 
   it('emits JSON of event names + counts when --json is provided without an event name', async () => {

--- a/packages/eas-cli/src/commands/observe/__tests__/logs.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/logs.test.ts
@@ -73,6 +73,16 @@ describe(ObserveLogs, () => {
     expect(mockFetchObserveCustomEventsAsync).not.toHaveBeenCalled();
   });
 
+  it('routes to fetchObserveCustomEventsAsync when --all-events is set with no positional arg', async () => {
+    const command = createCommand(['--all-events']);
+    await command.runAsync();
+
+    expect(mockFetchObserveCustomEventsAsync).toHaveBeenCalledTimes(1);
+    expect(mockCustomEventNamesAsync).not.toHaveBeenCalled();
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.eventName).toBeUndefined();
+  });
+
   it('passes the resolved time range and platform to customEventNamesAsync', async () => {
     const now = new Date('2025-06-15T12:00:00.000Z');
     jest.useFakeTimers({ now });

--- a/packages/eas-cli/src/commands/observe/__tests__/logs.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/logs.test.ts
@@ -1,8 +1,12 @@
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { getMockOclifConfig } from '../../../__tests__/commands/utils';
 import { AppObservePlatform } from '../../../graphql/generated';
+import { ObserveQuery } from '../../../graphql/queries/ObserveQuery';
 import { fetchObserveCustomEventsAsync } from '../../../observe/fetchCustomEvents';
-import { buildObserveCustomEventsJson } from '../../../observe/formatCustomEvents';
+import {
+  buildObserveCustomEventNamesJson,
+  buildObserveCustomEventsJson,
+} from '../../../observe/formatCustomEvents';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
 import ObserveLogs from '../logs';
 
@@ -10,12 +14,21 @@ jest.mock('../../../observe/fetchCustomEvents');
 jest.mock('../../../observe/formatCustomEvents', () => ({
   buildObserveCustomEventsTable: jest.fn().mockReturnValue('table'),
   buildObserveCustomEventsJson: jest.fn().mockReturnValue({}),
+  buildObserveCustomEventNamesTable: jest.fn().mockReturnValue('names-table'),
+  buildObserveCustomEventNamesJson: jest.fn().mockReturnValue({ names: [], isTruncated: false }),
+}));
+jest.mock('../../../graphql/queries/ObserveQuery', () => ({
+  ObserveQuery: {
+    customEventNamesAsync: jest.fn(),
+  },
 }));
 jest.mock('../../../log');
 jest.mock('../../../utils/json');
 
 const mockFetchObserveCustomEventsAsync = jest.mocked(fetchObserveCustomEventsAsync);
 const mockBuildObserveCustomEventsJson = jest.mocked(buildObserveCustomEventsJson);
+const mockBuildObserveCustomEventNamesJson = jest.mocked(buildObserveCustomEventNamesJson);
+const mockCustomEventNamesAsync = jest.mocked(ObserveQuery.customEventNamesAsync);
 const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
 const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
 
@@ -30,6 +43,7 @@ describe(ObserveLogs, () => {
       events: [],
       pageInfo: { hasNextPage: false, hasPreviousPage: false },
     });
+    mockCustomEventNamesAsync.mockResolvedValue({ names: [], isTruncated: false });
   });
 
   function createCommand(argv: string[]): ObserveLogs {
@@ -48,21 +62,39 @@ describe(ObserveLogs, () => {
 
     const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
     expect(options.eventName).toBe('my_event');
+    expect(mockCustomEventNamesAsync).not.toHaveBeenCalled();
   });
 
-  it('does not pass eventName when no positional arg is provided', async () => {
+  it('routes to customEventNamesAsync when no positional arg is provided', async () => {
     const command = createCommand([]);
     await command.runAsync();
 
-    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
-    expect(options.eventName).toBeUndefined();
+    expect(mockCustomEventNamesAsync).toHaveBeenCalledTimes(1);
+    expect(mockFetchObserveCustomEventsAsync).not.toHaveBeenCalled();
   });
 
-  it('uses --days to compute start/end time range', async () => {
+  it('passes the resolved time range and platform to customEventNamesAsync', async () => {
     const now = new Date('2025-06-15T12:00:00.000Z');
     jest.useFakeTimers({ now });
 
-    const command = createCommand(['--days', '7']);
+    const command = createCommand(['--days', '7', '--platform', 'ios']);
+    await command.runAsync();
+
+    expect(mockCustomEventNamesAsync).toHaveBeenCalledWith(graphqlClient, {
+      appId: projectId,
+      startTime: '2025-06-08T12:00:00.000Z',
+      endTime: '2025-06-15T12:00:00.000Z',
+      platform: AppObservePlatform.Ios,
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('uses --days to compute start/end time range when an event name is provided', async () => {
+    const now = new Date('2025-06-15T12:00:00.000Z');
+    jest.useFakeTimers({ now });
+
+    const command = createCommand(['my_event', '--days', '7']);
     await command.runAsync();
 
     const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
@@ -72,22 +104,9 @@ describe(ObserveLogs, () => {
     jest.useRealTimers();
   });
 
-  it('uses DEFAULT_DAYS_BACK (60 days) when neither --days nor --start/--end are provided', async () => {
-    const now = new Date('2025-06-15T12:00:00.000Z');
-    jest.useFakeTimers({ now });
-
-    const command = createCommand([]);
-    await command.runAsync();
-
-    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
-    expect(options.startTime).toBe('2025-04-16T12:00:00.000Z');
-    expect(options.endTime).toBe('2025-06-15T12:00:00.000Z');
-
-    jest.useRealTimers();
-  });
-
   it('uses explicit --start and --end when provided', async () => {
     const command = createCommand([
+      'my_event',
       '--start',
       '2025-01-01T00:00:00.000Z',
       '--end',
@@ -101,12 +120,18 @@ describe(ObserveLogs, () => {
   });
 
   it('rejects --days combined with --start', async () => {
-    const command = createCommand(['--days', '7', '--start', '2025-01-01T00:00:00.000Z']);
+    const command = createCommand([
+      'my_event',
+      '--days',
+      '7',
+      '--start',
+      '2025-01-01T00:00:00.000Z',
+    ]);
     await expect(command.runAsync()).rejects.toThrow();
   });
 
   it('passes --limit to fetchObserveCustomEventsAsync', async () => {
-    const command = createCommand(['--limit', '42']);
+    const command = createCommand(['my_event', '--limit', '42']);
     await command.runAsync();
 
     const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
@@ -114,7 +139,7 @@ describe(ObserveLogs, () => {
   });
 
   it('passes --after cursor', async () => {
-    const command = createCommand(['--after', 'cursor-xyz']);
+    const command = createCommand(['my_event', '--after', 'cursor-xyz']);
     await command.runAsync();
 
     const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
@@ -122,7 +147,7 @@ describe(ObserveLogs, () => {
   });
 
   it('passes --platform ios as AppObservePlatform.Ios', async () => {
-    const command = createCommand(['--platform', 'ios']);
+    const command = createCommand(['my_event', '--platform', 'ios']);
     await command.runAsync();
 
     const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
@@ -130,7 +155,7 @@ describe(ObserveLogs, () => {
   });
 
   it('passes --app-version', async () => {
-    const command = createCommand(['--app-version', '2.1.0']);
+    const command = createCommand(['my_event', '--app-version', '2.1.0']);
     await command.runAsync();
 
     const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
@@ -138,7 +163,7 @@ describe(ObserveLogs, () => {
   });
 
   it('passes --update-id', async () => {
-    const command = createCommand(['--update-id', 'update-xyz']);
+    const command = createCommand(['my_event', '--update-id', 'update-xyz']);
     await command.runAsync();
 
     const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
@@ -146,7 +171,7 @@ describe(ObserveLogs, () => {
   });
 
   it('passes --session-id', async () => {
-    const command = createCommand(['--session-id', 'session-xyz']);
+    const command = createCommand(['my_event', '--session-id', 'session-xyz']);
     await command.runAsync();
 
     const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
@@ -154,7 +179,7 @@ describe(ObserveLogs, () => {
   });
 
   it('does not pass platform, appVersion, updateId, or sessionId when flags are not provided', async () => {
-    const command = createCommand([]);
+    const command = createCommand(['my_event']);
     await command.runAsync();
 
     const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
@@ -164,7 +189,7 @@ describe(ObserveLogs, () => {
     expect(options.sessionId).toBeUndefined();
   });
 
-  it('calls enableJsonOutput and printJsonOnlyOutput when --json is provided', async () => {
+  it('calls enableJsonOutput and printJsonOnlyOutput when --json is provided with an event name', async () => {
     const mockEvents = [
       {
         id: 'evt-1',
@@ -186,7 +211,7 @@ describe(ObserveLogs, () => {
       pageInfo: { hasNextPage: false, hasPreviousPage: false },
     });
 
-    const command = createCommand(['--json', '--non-interactive']);
+    const command = createCommand(['my_event', '--json', '--non-interactive']);
     await command.runAsync();
 
     expect(mockEnableJsonOutput).toHaveBeenCalled();
@@ -194,6 +219,24 @@ describe(ObserveLogs, () => {
       mockEvents,
       expect.objectContaining({ hasNextPage: false })
     );
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalled();
+  });
+
+  it('emits JSON of event names + counts when --json is provided without an event name', async () => {
+    const mockNames = [
+      { eventName: 'foo', count: 10 },
+      { eventName: 'bar', count: 5 },
+    ];
+    mockCustomEventNamesAsync.mockResolvedValue({
+      names: mockNames as any,
+      isTruncated: false,
+    });
+
+    const command = createCommand(['--json', '--non-interactive']);
+    await command.runAsync();
+
+    expect(mockEnableJsonOutput).toHaveBeenCalled();
+    expect(mockBuildObserveCustomEventNamesJson).toHaveBeenCalledWith(mockNames, false);
     expect(mockPrintJsonOnlyOutput).toHaveBeenCalled();
   });
 });

--- a/packages/eas-cli/src/commands/observe/__tests__/logs.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/logs.test.ts
@@ -1,0 +1,199 @@
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { getMockOclifConfig } from '../../../__tests__/commands/utils';
+import { AppObservePlatform } from '../../../graphql/generated';
+import { fetchObserveCustomEventsAsync } from '../../../observe/fetchCustomEvents';
+import { buildObserveCustomEventsJson } from '../../../observe/formatCustomEvents';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+import ObserveLogs from '../logs';
+
+jest.mock('../../../observe/fetchCustomEvents');
+jest.mock('../../../observe/formatCustomEvents', () => ({
+  buildObserveCustomEventsTable: jest.fn().mockReturnValue('table'),
+  buildObserveCustomEventsJson: jest.fn().mockReturnValue({}),
+}));
+jest.mock('../../../log');
+jest.mock('../../../utils/json');
+
+const mockFetchObserveCustomEventsAsync = jest.mocked(fetchObserveCustomEventsAsync);
+const mockBuildObserveCustomEventsJson = jest.mocked(buildObserveCustomEventsJson);
+const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
+const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
+
+describe(ObserveLogs, () => {
+  const graphqlClient = {} as any as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+  const projectId = 'test-project-id';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchObserveCustomEventsAsync.mockResolvedValue({
+      events: [],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    });
+  });
+
+  function createCommand(argv: string[]): ObserveLogs {
+    const command = new ObserveLogs(argv, mockConfig);
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      projectId,
+      loggedIn: { graphqlClient },
+    });
+    return command;
+  }
+
+  it('passes eventName arg to fetchObserveCustomEventsAsync', async () => {
+    const command = createCommand(['my_event']);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.eventName).toBe('my_event');
+  });
+
+  it('does not pass eventName when no positional arg is provided', async () => {
+    const command = createCommand([]);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.eventName).toBeUndefined();
+  });
+
+  it('uses --days to compute start/end time range', async () => {
+    const now = new Date('2025-06-15T12:00:00.000Z');
+    jest.useFakeTimers({ now });
+
+    const command = createCommand(['--days', '7']);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.endTime).toBe('2025-06-15T12:00:00.000Z');
+    expect(options.startTime).toBe('2025-06-08T12:00:00.000Z');
+
+    jest.useRealTimers();
+  });
+
+  it('uses DEFAULT_DAYS_BACK (60 days) when neither --days nor --start/--end are provided', async () => {
+    const now = new Date('2025-06-15T12:00:00.000Z');
+    jest.useFakeTimers({ now });
+
+    const command = createCommand([]);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.startTime).toBe('2025-04-16T12:00:00.000Z');
+    expect(options.endTime).toBe('2025-06-15T12:00:00.000Z');
+
+    jest.useRealTimers();
+  });
+
+  it('uses explicit --start and --end when provided', async () => {
+    const command = createCommand([
+      '--start',
+      '2025-01-01T00:00:00.000Z',
+      '--end',
+      '2025-02-01T00:00:00.000Z',
+    ]);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.startTime).toBe('2025-01-01T00:00:00.000Z');
+    expect(options.endTime).toBe('2025-02-01T00:00:00.000Z');
+  });
+
+  it('rejects --days combined with --start', async () => {
+    const command = createCommand(['--days', '7', '--start', '2025-01-01T00:00:00.000Z']);
+    await expect(command.runAsync()).rejects.toThrow();
+  });
+
+  it('passes --limit to fetchObserveCustomEventsAsync', async () => {
+    const command = createCommand(['--limit', '42']);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.limit).toBe(42);
+  });
+
+  it('passes --after cursor', async () => {
+    const command = createCommand(['--after', 'cursor-xyz']);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.after).toBe('cursor-xyz');
+  });
+
+  it('passes --platform ios as AppObservePlatform.Ios', async () => {
+    const command = createCommand(['--platform', 'ios']);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.platform).toBe(AppObservePlatform.Ios);
+  });
+
+  it('passes --app-version', async () => {
+    const command = createCommand(['--app-version', '2.1.0']);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.appVersion).toBe('2.1.0');
+  });
+
+  it('passes --update-id', async () => {
+    const command = createCommand(['--update-id', 'update-xyz']);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.updateId).toBe('update-xyz');
+  });
+
+  it('passes --session-id', async () => {
+    const command = createCommand(['--session-id', 'session-xyz']);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.sessionId).toBe('session-xyz');
+  });
+
+  it('does not pass platform, appVersion, updateId, or sessionId when flags are not provided', async () => {
+    const command = createCommand([]);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.platform).toBeUndefined();
+    expect(options.appVersion).toBeUndefined();
+    expect(options.updateId).toBeUndefined();
+    expect(options.sessionId).toBeUndefined();
+  });
+
+  it('calls enableJsonOutput and printJsonOnlyOutput when --json is provided', async () => {
+    const mockEvents = [
+      {
+        id: 'evt-1',
+        eventName: 'my_event',
+        timestamp: '2025-01-15T10:30:00.000Z',
+        appVersion: '1.0.0',
+        appBuildNumber: '42',
+        deviceModel: 'iPhone 15',
+        deviceOs: 'iOS',
+        deviceOsVersion: '17.0',
+        countryCode: 'US',
+        sessionId: 'session-1',
+        easClientId: 'client-1',
+        properties: [],
+      },
+    ];
+    mockFetchObserveCustomEventsAsync.mockResolvedValue({
+      events: mockEvents as any,
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    });
+
+    const command = createCommand(['--json', '--non-interactive']);
+    await command.runAsync();
+
+    expect(mockEnableJsonOutput).toHaveBeenCalled();
+    expect(mockBuildObserveCustomEventsJson).toHaveBeenCalledWith(
+      mockEvents,
+      expect.objectContaining({ hasNextPage: false })
+    );
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -4,7 +4,6 @@ import EasCommand from '../../commandUtils/EasCommand';
 import { EasCommandError } from '../../commandUtils/errors';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { getLimitFlagWithCustomValues } from '../../commandUtils/pagination';
-import { AppObservePlatform, AppPlatform } from '../../graphql/generated';
 import Log from '../../log';
 import {
   EventsOrderPreset,
@@ -14,6 +13,11 @@ import {
 } from '../../observe/fetchEvents';
 import { METRIC_ALIASES, METRIC_SHORT_NAMES, resolveMetricName } from '../../observe/metricNames';
 import { buildObserveEventsJson, buildObserveEventsTable } from '../../observe/formatEvents';
+import {
+  allowedPlatformFlagValues,
+  appObservePlatformFromFlag,
+  appPlatformsFromFlag,
+} from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { selectAsync } from '../../prompts';
@@ -42,7 +46,7 @@ export default class ObserveEvents extends EasCommand {
     })(),
     platform: Flags.option({
       description: 'Filter by platform',
-      options: Object.values(AppObservePlatform).map(s => s.toLowerCase()),
+      options: allowedPlatformFlagValues,
     })(),
     after: Flags.string({
       description:
@@ -122,15 +126,8 @@ export default class ObserveEvents extends EasCommand {
 
     const { daysBack, startTime, endTime } = resolveTimeRange(flags);
 
-    const platform = flags.platform
-      ? flags.platform === 'android'
-        ? AppObservePlatform.Android
-        : AppObservePlatform.Ios
-      : undefined;
-
-    const platforms: AppPlatform[] = platform
-      ? [platform === AppObservePlatform.Android ? AppPlatform.Android : AppPlatform.Ios]
-      : [AppPlatform.Android, AppPlatform.Ios];
+    const platform = appObservePlatformFromFlag(flags.platform);
+    const platforms = appPlatformsFromFlag(flags.platform);
 
     const [{ events, pageInfo }, totalEventCount] = await Promise.all([
       fetchObserveEventsAsync(graphqlClient, projectId, {

--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -14,6 +14,7 @@ import {
 } from '../../observe/fetchEvents';
 import { METRIC_ALIASES, METRIC_SHORT_NAMES, resolveMetricName } from '../../observe/metricNames';
 import { buildObserveEventsJson, buildObserveEventsTable } from '../../observe/formatEvents';
+import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { selectAsync } from '../../prompts';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
@@ -88,22 +89,13 @@ export default class ObserveEvents extends EasCommand {
   async runAsync(): Promise<void> {
     const { flags, args } = await this.parse(ObserveEvents);
 
-    let projectId: string;
-    let graphqlClient;
-    if (flags['project-id']) {
-      projectId = flags['project-id'];
-      const ctx = await this.getContextAsync(
-        { contextDefinition: ObserveEvents.loggedInOnlyContextDefinition },
-        { nonInteractive: flags['non-interactive'] }
-      );
-      graphqlClient = ctx.loggedIn.graphqlClient;
-    } else {
-      const ctx = await this.getContextAsync(ObserveEvents, {
-        nonInteractive: flags['non-interactive'],
-      });
-      projectId = ctx.projectId;
-      graphqlClient = ctx.loggedIn.graphqlClient;
-    }
+    const { projectId, graphqlClient } = await resolveObserveCommandContextAsync({
+      command: this,
+      commandClass: ObserveEvents,
+      loggedInOnlyContextDefinition: ObserveEvents.loggedInOnlyContextDefinition,
+      projectIdOverride: flags['project-id'],
+      nonInteractive: flags['non-interactive'],
+    });
 
     if (flags.json) {
       enableJsonOutput();

--- a/packages/eas-cli/src/commands/observe/logs.ts
+++ b/packages/eas-cli/src/commands/observe/logs.ts
@@ -13,6 +13,7 @@ import {
   buildObserveCustomEventsJson,
   buildObserveCustomEventsTable,
 } from '../../observe/formatCustomEvents';
+import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
@@ -88,22 +89,13 @@ export default class ObserveLogs extends EasCommand {
   async runAsync(): Promise<void> {
     const { flags, args } = await this.parse(ObserveLogs);
 
-    let projectId: string;
-    let graphqlClient;
-    if (flags['project-id']) {
-      projectId = flags['project-id'];
-      const ctx = await this.getContextAsync(
-        { contextDefinition: ObserveLogs.loggedInOnlyContextDefinition },
-        { nonInteractive: flags['non-interactive'] }
-      );
-      graphqlClient = ctx.loggedIn.graphqlClient;
-    } else {
-      const ctx = await this.getContextAsync(ObserveLogs, {
-        nonInteractive: flags['non-interactive'],
-      });
-      projectId = ctx.projectId;
-      graphqlClient = ctx.loggedIn.graphqlClient;
-    }
+    const { projectId, graphqlClient } = await resolveObserveCommandContextAsync({
+      command: this,
+      commandClass: ObserveLogs,
+      loggedInOnlyContextDefinition: ObserveLogs.loggedInOnlyContextDefinition,
+      projectIdOverride: flags['project-id'],
+      nonInteractive: flags['non-interactive'],
+    });
 
     if (flags.json) {
       enableJsonOutput();

--- a/packages/eas-cli/src/commands/observe/logs.ts
+++ b/packages/eas-cli/src/commands/observe/logs.ts
@@ -64,6 +64,11 @@ export default class ObserveLogs extends EasCommand {
     'session-id': Flags.string({
       description: 'Filter by session ID',
     }),
+    'all-events': Flags.boolean({
+      description:
+        'When no event name argument is provided, list all events across all event names instead of a summary of event names + counts.',
+      default: false,
+    }),
     'project-id': Flags.string({
       description: 'EAS project ID (defaults to the project ID of the current directory)',
     }),
@@ -113,7 +118,7 @@ export default class ObserveLogs extends EasCommand {
         : AppObservePlatform.Ios
       : undefined;
 
-    if (!args.eventName) {
+    if (!args.eventName && !flags['all-events']) {
       const { names, isTruncated } = await ObserveQuery.customEventNamesAsync(graphqlClient, {
         appId: projectId,
         startTime,

--- a/packages/eas-cli/src/commands/observe/logs.ts
+++ b/packages/eas-cli/src/commands/observe/logs.ts
@@ -89,6 +89,12 @@ export default class ObserveLogs extends EasCommand {
   async runAsync(): Promise<void> {
     const { flags, args } = await this.parse(ObserveLogs);
 
+    if (args.eventName && flags['all-events']) {
+      throw new Error(
+        '--all-events cannot be combined with an event name argument. Pass an event name to filter by it, or pass --all-events to list all events across all event names.'
+      );
+    }
+
     const { projectId, graphqlClient } = await resolveObserveCommandContextAsync({
       command: this,
       commandClass: ObserveLogs,

--- a/packages/eas-cli/src/commands/observe/logs.ts
+++ b/packages/eas-cli/src/commands/observe/logs.ts
@@ -20,7 +20,8 @@ const DEFAULT_EVENTS_LIMIT = 10;
 
 export default class ObserveLogs extends EasCommand {
   static override hidden = true;
-  static override description = 'display individual custom events (logs) emitted by the app';
+  static override description =
+    'display individual custom events (logs) emitted by the app, filtered by the event name in the argument. With no arguments, a list of the available event names and associated event counts is returned.';
 
   static override args = {
     eventName: Args.string({

--- a/packages/eas-cli/src/commands/observe/logs.ts
+++ b/packages/eas-cli/src/commands/observe/logs.ts
@@ -9,6 +9,8 @@ import { fetchObserveCustomEventsAsync } from '../../observe/fetchCustomEvents';
 import {
   buildObserveCustomEventNamesJson,
   buildObserveCustomEventNamesTable,
+  buildObserveCustomEventsEmptyWithSuggestionsJson,
+  buildObserveCustomEventsEmptyWithSuggestionsTable,
   buildObserveCustomEventsJson,
   buildObserveCustomEventsTable,
 } from '../../observe/formatCustomEvents';
@@ -148,6 +150,32 @@ export default class ObserveLogs extends EasCommand {
       updateId: flags['update-id'],
       sessionId: flags['session-id'],
     });
+
+    if (args.eventName && events.length === 0) {
+      const { names, isTruncated } = await ObserveQuery.customEventNamesAsync(graphqlClient, {
+        appId: projectId,
+        startTime,
+        endTime,
+        platform,
+      });
+
+      if (flags.json) {
+        printJsonOnlyOutput(
+          buildObserveCustomEventsEmptyWithSuggestionsJson(args.eventName, names, isTruncated)
+        );
+      } else {
+        Log.addNewLineIfNone();
+        Log.log(
+          buildObserveCustomEventsEmptyWithSuggestionsTable(args.eventName, names, {
+            daysBack,
+            startTime,
+            endTime,
+            isTruncated,
+          })
+        );
+      }
+      return;
+    }
 
     if (flags.json) {
       printJsonOnlyOutput(buildObserveCustomEventsJson(events, pageInfo));

--- a/packages/eas-cli/src/commands/observe/logs.ts
+++ b/packages/eas-cli/src/commands/observe/logs.ts
@@ -5,8 +5,11 @@ import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { getLimitFlagWithCustomValues } from '../../commandUtils/pagination';
 import { AppObservePlatform } from '../../graphql/generated';
 import Log from '../../log';
+import { ObserveQuery } from '../../graphql/queries/ObserveQuery';
 import { fetchObserveCustomEventsAsync } from '../../observe/fetchCustomEvents';
 import {
+  buildObserveCustomEventNamesJson,
+  buildObserveCustomEventNamesTable,
   buildObserveCustomEventsJson,
   buildObserveCustomEventsTable,
 } from '../../observe/formatCustomEvents';
@@ -109,6 +112,30 @@ export default class ObserveLogs extends EasCommand {
         ? AppObservePlatform.Android
         : AppObservePlatform.Ios
       : undefined;
+
+    if (!args.eventName) {
+      const { names, isTruncated } = await ObserveQuery.customEventNamesAsync(graphqlClient, {
+        appId: projectId,
+        startTime,
+        endTime,
+        platform,
+      });
+
+      if (flags.json) {
+        printJsonOnlyOutput(buildObserveCustomEventNamesJson(names, isTruncated));
+      } else {
+        Log.addNewLineIfNone();
+        Log.log(
+          buildObserveCustomEventNamesTable(names, {
+            daysBack,
+            startTime,
+            endTime,
+            isTruncated,
+          })
+        );
+      }
+      return;
+    }
 
     const { events, pageInfo } = await fetchObserveCustomEventsAsync(graphqlClient, projectId, {
       eventName: args.eventName,

--- a/packages/eas-cli/src/commands/observe/logs.ts
+++ b/packages/eas-cli/src/commands/observe/logs.ts
@@ -3,7 +3,6 @@ import { Args, Flags } from '@oclif/core';
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import { getLimitFlagWithCustomValues } from '../../commandUtils/pagination';
-import { AppObservePlatform } from '../../graphql/generated';
 import Log from '../../log';
 import { ObserveQuery } from '../../graphql/queries/ObserveQuery';
 import { fetchObserveCustomEventsAsync } from '../../observe/fetchCustomEvents';
@@ -13,6 +12,7 @@ import {
   buildObserveCustomEventsJson,
   buildObserveCustomEventsTable,
 } from '../../observe/formatCustomEvents';
+import { allowedPlatformFlagValues, appObservePlatformFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
@@ -34,7 +34,7 @@ export default class ObserveLogs extends EasCommand {
   static override flags = {
     platform: Flags.option({
       description: 'Filter by platform',
-      options: Object.values(AppObservePlatform).map(s => s.toLowerCase()),
+      options: allowedPlatformFlagValues,
     })(),
     after: Flags.string({
       description:
@@ -105,11 +105,7 @@ export default class ObserveLogs extends EasCommand {
 
     const { daysBack, startTime, endTime } = resolveTimeRange(flags);
 
-    const platform = flags.platform
-      ? flags.platform === 'android'
-        ? AppObservePlatform.Android
-        : AppObservePlatform.Ios
-      : undefined;
+    const platform = appObservePlatformFromFlag(flags.platform);
 
     if (!args.eventName && !flags['all-events']) {
       const { names, isTruncated } = await ObserveQuery.customEventNamesAsync(graphqlClient, {

--- a/packages/eas-cli/src/commands/observe/logs.ts
+++ b/packages/eas-cli/src/commands/observe/logs.ts
@@ -1,0 +1,139 @@
+import { Args, Flags } from '@oclif/core';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { getLimitFlagWithCustomValues } from '../../commandUtils/pagination';
+import { AppObservePlatform } from '../../graphql/generated';
+import Log from '../../log';
+import { fetchObserveCustomEventsAsync } from '../../observe/fetchCustomEvents';
+import {
+  buildObserveCustomEventsJson,
+  buildObserveCustomEventsTable,
+} from '../../observe/formatCustomEvents';
+import { resolveTimeRange } from '../../observe/startAndEndTime';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+
+const DEFAULT_EVENTS_LIMIT = 10;
+
+export default class ObserveLogs extends EasCommand {
+  static override hidden = true;
+  static override description = 'display individual custom events (logs) emitted by the app';
+
+  static override args = {
+    eventName: Args.string({
+      description: 'Custom event name to filter by',
+      required: false,
+    }),
+  };
+
+  static override flags = {
+    platform: Flags.option({
+      description: 'Filter by platform',
+      options: Object.values(AppObservePlatform).map(s => s.toLowerCase()),
+    })(),
+    after: Flags.string({
+      description:
+        'Cursor for pagination. Use the endCursor from a previous query to fetch the next page.',
+    }),
+    limit: getLimitFlagWithCustomValues({
+      defaultTo: DEFAULT_EVENTS_LIMIT,
+      limit: 100,
+    }),
+    start: Flags.string({
+      description: 'Start of time range (ISO date)',
+      exclusive: ['days'],
+    }),
+    end: Flags.string({
+      description: 'End of time range (ISO date)',
+      exclusive: ['days'],
+    }),
+    days: Flags.integer({
+      description: 'Show events from the last N days (mutually exclusive with --start/--end)',
+      min: 1,
+      exclusive: ['start', 'end'],
+    }),
+    'app-version': Flags.string({
+      description: 'Filter by app version',
+    }),
+    'update-id': Flags.string({
+      description: 'Filter by EAS update ID',
+    }),
+    'session-id': Flags.string({
+      description: 'Filter by session ID',
+    }),
+    'project-id': Flags.string({
+      description: 'EAS project ID (defaults to the project ID of the current directory)',
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectId,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  private static loggedInOnlyContextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags, args } = await this.parse(ObserveLogs);
+
+    let projectId: string;
+    let graphqlClient;
+    if (flags['project-id']) {
+      projectId = flags['project-id'];
+      const ctx = await this.getContextAsync(
+        { contextDefinition: ObserveLogs.loggedInOnlyContextDefinition },
+        { nonInteractive: flags['non-interactive'] }
+      );
+      graphqlClient = ctx.loggedIn.graphqlClient;
+    } else {
+      const ctx = await this.getContextAsync(ObserveLogs, {
+        nonInteractive: flags['non-interactive'],
+      });
+      projectId = ctx.projectId;
+      graphqlClient = ctx.loggedIn.graphqlClient;
+    }
+
+    if (flags.json) {
+      enableJsonOutput();
+    } else {
+      Log.warn('EAS Observe is in preview and subject to breaking changes.');
+    }
+
+    const { daysBack, startTime, endTime } = resolveTimeRange(flags);
+
+    const platform = flags.platform
+      ? flags.platform === 'android'
+        ? AppObservePlatform.Android
+        : AppObservePlatform.Ios
+      : undefined;
+
+    const { events, pageInfo } = await fetchObserveCustomEventsAsync(graphqlClient, projectId, {
+      eventName: args.eventName,
+      limit: flags.limit ?? DEFAULT_EVENTS_LIMIT,
+      ...(flags.after && { after: flags.after }),
+      startTime,
+      endTime,
+      platform,
+      appVersion: flags['app-version'],
+      updateId: flags['update-id'],
+      sessionId: flags['session-id'],
+    });
+
+    if (flags.json) {
+      printJsonOnlyOutput(buildObserveCustomEventsJson(events, pageInfo));
+    } else {
+      Log.addNewLineIfNone();
+      Log.log(
+        buildObserveCustomEventsTable(events, pageInfo, {
+          eventName: args.eventName,
+          daysBack,
+          startTime,
+          endTime,
+        })
+      );
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -2,7 +2,6 @@ import { Flags } from '@oclif/core';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import { AppObservePlatform, AppPlatform } from '../../graphql/generated';
 import Log from '../../log';
 import { fetchObserveMetricsAsync } from '../../observe/fetchMetrics';
 import {
@@ -12,6 +11,7 @@ import {
   resolveStatKey,
 } from '../../observe/formatMetrics';
 import { METRIC_ALIASES, resolveMetricName } from '../../observe/metricNames';
+import { allowedPlatformFlagValues, appPlatformsFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
@@ -43,7 +43,7 @@ export default class ObserveMetrics extends EasCommand {
   static override flags = {
     platform: Flags.option({
       description: 'Filter by platform',
-      options: Object.values(AppObservePlatform).map(s => s.toLowerCase()),
+      options: allowedPlatformFlagValues,
     })(),
     metric: Flags.option({
       description: 'Metric name to display (can be specified multiple times).',
@@ -106,9 +106,7 @@ export default class ObserveMetrics extends EasCommand {
 
     const { daysBack, startTime, endTime } = resolveTimeRange(flags);
 
-    const platforms: AppPlatform[] = flags.platform
-      ? [flags.platform === 'android' ? AppPlatform.Android : AppPlatform.Ios]
-      : [AppPlatform.Android, AppPlatform.Ios];
+    const platforms = appPlatformsFromFlag(flags.platform);
 
     const { metricsMap, buildNumbersMap, updateIdsMap, totalEventCounts } =
       await fetchObserveMetricsAsync(

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -12,6 +12,7 @@ import {
   resolveStatKey,
 } from '../../observe/formatMetrics';
 import { METRIC_ALIASES, resolveMetricName } from '../../observe/metricNames';
+import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
@@ -85,22 +86,13 @@ export default class ObserveMetrics extends EasCommand {
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(ObserveMetrics);
 
-    let projectId: string;
-    let graphqlClient;
-    if (flags['project-id']) {
-      projectId = flags['project-id'];
-      const ctx = await this.getContextAsync(
-        { contextDefinition: ObserveMetrics.loggedInOnlyContextDefinition },
-        { nonInteractive: flags['non-interactive'] }
-      );
-      graphqlClient = ctx.loggedIn.graphqlClient;
-    } else {
-      const ctx = await this.getContextAsync(ObserveMetrics, {
-        nonInteractive: flags['non-interactive'],
-      });
-      projectId = ctx.projectId;
-      graphqlClient = ctx.loggedIn.graphqlClient;
-    }
+    const { projectId, graphqlClient } = await resolveObserveCommandContextAsync({
+      command: this,
+      commandClass: ObserveMetrics,
+      loggedInOnlyContextDefinition: ObserveMetrics.loggedInOnlyContextDefinition,
+      projectIdOverride: flags['project-id'],
+      nonInteractive: flags['non-interactive'],
+    });
 
     if (flags.json) {
       enableJsonOutput();

--- a/packages/eas-cli/src/commands/observe/versions.ts
+++ b/packages/eas-cli/src/commands/observe/versions.ts
@@ -6,6 +6,7 @@ import { AppObservePlatform, AppPlatform } from '../../graphql/generated';
 import Log from '../../log';
 import { fetchObserveVersionsAsync } from '../../observe/fetchVersions';
 import { buildObserveVersionsJson, buildObserveVersionsTable } from '../../observe/formatVersions';
+import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
@@ -49,22 +50,13 @@ export default class ObserveVersions extends EasCommand {
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(ObserveVersions);
 
-    let projectId: string;
-    let graphqlClient;
-    if (flags['project-id']) {
-      projectId = flags['project-id'];
-      const ctx = await this.getContextAsync(
-        { contextDefinition: ObserveVersions.loggedInOnlyContextDefinition },
-        { nonInteractive: flags['non-interactive'] }
-      );
-      graphqlClient = ctx.loggedIn.graphqlClient;
-    } else {
-      const ctx = await this.getContextAsync(ObserveVersions, {
-        nonInteractive: flags['non-interactive'],
-      });
-      projectId = ctx.projectId;
-      graphqlClient = ctx.loggedIn.graphqlClient;
-    }
+    const { projectId, graphqlClient } = await resolveObserveCommandContextAsync({
+      command: this,
+      commandClass: ObserveVersions,
+      loggedInOnlyContextDefinition: ObserveVersions.loggedInOnlyContextDefinition,
+      projectIdOverride: flags['project-id'],
+      nonInteractive: flags['non-interactive'],
+    });
 
     if (flags.json) {
       enableJsonOutput();

--- a/packages/eas-cli/src/commands/observe/versions.ts
+++ b/packages/eas-cli/src/commands/observe/versions.ts
@@ -2,10 +2,10 @@ import { Flags } from '@oclif/core';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
-import { AppObservePlatform, AppPlatform } from '../../graphql/generated';
 import Log from '../../log';
 import { fetchObserveVersionsAsync } from '../../observe/fetchVersions';
 import { buildObserveVersionsJson, buildObserveVersionsTable } from '../../observe/formatVersions';
+import { allowedPlatformFlagValues, appPlatformsFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
@@ -17,7 +17,7 @@ export default class ObserveVersions extends EasCommand {
   static override flags = {
     platform: Flags.option({
       description: 'Filter by platform',
-      options: Object.values(AppObservePlatform).map(s => s.toLowerCase()),
+      options: allowedPlatformFlagValues,
     })(),
     start: Flags.string({
       description: 'Start of time range (ISO date)',
@@ -66,9 +66,7 @@ export default class ObserveVersions extends EasCommand {
 
     const { startTime, endTime } = resolveTimeRange(flags);
 
-    const platforms: AppPlatform[] = flags.platform
-      ? [flags.platform === 'android' ? AppPlatform.Android : AppPlatform.Ios]
-      : [AppPlatform.Android, AppPlatform.Ios];
+    const platforms = appPlatformsFromFlag(flags.platform);
 
     const results = await fetchObserveVersionsAsync(
       graphqlClient,

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -12643,6 +12643,16 @@ export type AppObserveEventsQueryVariables = Exact<{
 
 export type AppObserveEventsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', events: { __typename?: 'AppObserveEventsConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveEventEdge', cursor: string, node: { __typename?: 'AppObserveEvent', id: string, metricName: string, metricValue: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null } }> } } } } };
 
+export type AppObserveCustomEventListQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+  filter?: InputMaybe<AppObserveCustomEventListFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type AppObserveCustomEventListQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', customEventList: { __typename?: 'AppObserveCustomEventListConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveCustomEventEdge', cursor: string, node: { __typename?: 'AppObserveCustomEvent', id: string, eventName: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> } }> } } } } };
+
 export type GetAssetMetadataQueryVariables = Exact<{
   storageKeys: Array<Scalars['String']['input']> | Scalars['String']['input'];
 }>;
@@ -12838,6 +12848,8 @@ export type EnvironmentVariableWithSecretFragment = { __typename?: 'EnvironmentV
 export type FingerprintFragment = { __typename?: 'Fingerprint', id: string, hash: string, debugInfoUrl?: string | null, builds: { __typename?: 'AppBuildsConnection', edges: Array<{ __typename?: 'AppBuildEdge', node: { __typename?: 'Build', platform: AppPlatform, id: string } }> }, updates: { __typename?: 'AppUpdatesConnection', edges: Array<{ __typename?: 'AppUpdateEdge', node: { __typename?: 'Update', id: string, platform: string } }> } };
 
 export type AppObserveTimeSeriesFragment = { __typename?: 'AppObserveTimeSeries', eventCount: number, appVersionMarkers: Array<{ __typename?: 'AppObserveAppVersion', appVersion: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, buildNumbers: Array<{ __typename?: 'AppObserveAppBuildNumber', appBuildNumber: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, updates: Array<{ __typename?: 'AppObserveAppUpdate', appUpdateId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, metrics: Array<{ __typename?: 'AppObserveAppVersionMetric', metricName: string, eventCount: number, statistics: { __typename?: 'AppObserveVersionMarkerStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } }> }>, statistics: { __typename?: 'AppObserveTimeSeriesStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } };
+
+export type AppObserveCustomEventFragment = { __typename?: 'AppObserveCustomEvent', id: string, eventName: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> };
 
 export type AppObserveEventFragment = { __typename?: 'AppObserveEvent', id: string, metricName: string, metricValue: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null };
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -12653,6 +12653,17 @@ export type AppObserveCustomEventListQueryVariables = Exact<{
 
 export type AppObserveCustomEventListQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', customEventList: { __typename?: 'AppObserveCustomEventListConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveCustomEventEdge', cursor: string, node: { __typename?: 'AppObserveCustomEvent', id: string, eventName: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> } }> } } } } };
 
+export type AppObserveCustomEventNamesQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+  startTime: Scalars['DateTime']['input'];
+  endTime: Scalars['DateTime']['input'];
+  platform?: InputMaybe<AppObservePlatform>;
+  environment?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type AppObserveCustomEventNamesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', customEventNames: { __typename?: 'AppObserveCustomEventNames', isTruncated: boolean, names: Array<{ __typename?: 'AppObserveCustomEventName', eventName: string, count: number }> } } } } };
+
 export type GetAssetMetadataQueryVariables = Exact<{
   storageKeys: Array<Scalars['String']['input']> | Scalars['String']['input'];
 }>;

--- a/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
@@ -19,8 +19,8 @@ import { print } from 'graphql';
 import {
   AppObserveAppVersionFragmentNode,
   AppObserveCustomEventFragmentNode,
-  AppObserveTimeSeriesFragmentNode,
   AppObserveEventFragmentNode,
+  AppObserveTimeSeriesFragmentNode,
 } from '../types/Observe';
 
 export type AppObserveTimeSeriesResult = {
@@ -291,6 +291,7 @@ export const ObserveQuery = {
                       edges {
                         cursor
                         node {
+                          id
                           ...AppObserveCustomEventFragment
                         }
                       }

--- a/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
@@ -4,6 +4,8 @@ import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/creat
 import { withErrorHandlingAsync } from '../client';
 import {
   AppObserveAppVersion,
+  AppObserveCustomEvent,
+  AppObserveCustomEventListFilter,
   AppObserveEvent,
   AppObserveEventsFilter,
   AppObserveEventsOrderBy,
@@ -16,6 +18,7 @@ import {
 import { print } from 'graphql';
 import {
   AppObserveAppVersionFragmentNode,
+  AppObserveCustomEventFragmentNode,
   AppObserveTimeSeriesFragmentNode,
   AppObserveEventFragmentNode,
 } from '../types/Observe';
@@ -81,6 +84,30 @@ type AppObserveEventsQueryVariables = {
   first?: number;
   after?: string;
   orderBy?: AppObserveEventsOrderBy;
+};
+
+type AppObserveCustomEventListQuery = {
+  app: {
+    byId: {
+      id: string;
+      observe: {
+        customEventList: {
+          pageInfo: PageInfo;
+          edges: Array<{
+            cursor: string;
+            node: AppObserveCustomEvent;
+          }>;
+        };
+      };
+    };
+  };
+};
+
+type AppObserveCustomEventListQueryVariables = {
+  appId: string;
+  filter?: AppObserveCustomEventListFilter;
+  first?: number;
+  after?: string;
 };
 
 export const ObserveQuery = {
@@ -231,6 +258,55 @@ export const ObserveQuery = {
     );
 
     const { edges, pageInfo } = data.app.byId.observe.events;
+    return {
+      events: edges.map(edge => edge.node),
+      pageInfo,
+    };
+  },
+
+  async customEventListAsync(
+    graphqlClient: ExpoGraphqlClient,
+    variables: AppObserveCustomEventListQueryVariables
+  ): Promise<{ events: AppObserveCustomEvent[]; pageInfo: PageInfo }> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<AppObserveCustomEventListQuery, AppObserveCustomEventListQueryVariables>(
+          gql`
+            query AppObserveCustomEventList(
+              $appId: String!
+              $filter: AppObserveCustomEventListFilter
+              $first: Int
+              $after: String
+            ) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  observe {
+                    customEventList(filter: $filter, first: $first, after: $after) {
+                      pageInfo {
+                        hasNextPage
+                        hasPreviousPage
+                        endCursor
+                      }
+                      edges {
+                        cursor
+                        node {
+                          ...AppObserveCustomEventFragment
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            ${print(AppObserveCustomEventFragmentNode)}
+          `,
+          variables
+        )
+        .toPromise()
+    );
+
+    const { edges, pageInfo } = data.app.byId.observe.customEventList;
     return {
       events: edges.map(edge => edge.node),
       pageInfo,

--- a/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
@@ -6,6 +6,7 @@ import {
   AppObserveAppVersion,
   AppObserveCustomEvent,
   AppObserveCustomEventListFilter,
+  AppObserveCustomEventName,
   AppObserveEvent,
   AppObserveEventsFilter,
   AppObserveEventsOrderBy,
@@ -108,6 +109,28 @@ type AppObserveCustomEventListQueryVariables = {
   filter?: AppObserveCustomEventListFilter;
   first?: number;
   after?: string;
+};
+
+type AppObserveCustomEventNamesQuery = {
+  app: {
+    byId: {
+      id: string;
+      observe: {
+        customEventNames: {
+          isTruncated: boolean;
+          names: AppObserveCustomEventName[];
+        };
+      };
+    };
+  };
+};
+
+type AppObserveCustomEventNamesQueryVariables = {
+  appId: string;
+  startTime: string;
+  endTime: string;
+  platform?: AppObservePlatform;
+  environment?: string;
 };
 
 export const ObserveQuery = {
@@ -312,5 +335,67 @@ export const ObserveQuery = {
       events: edges.map(edge => edge.node),
       pageInfo,
     };
+  },
+
+  async customEventNamesAsync(
+    graphqlClient: ExpoGraphqlClient,
+    {
+      appId,
+      startTime,
+      endTime,
+      platform,
+      environment,
+    }: {
+      appId: string;
+      startTime: string;
+      endTime: string;
+      platform?: AppObservePlatform;
+      environment?: string;
+    }
+  ): Promise<{ names: AppObserveCustomEventName[]; isTruncated: boolean }> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<AppObserveCustomEventNamesQuery, AppObserveCustomEventNamesQueryVariables>(
+          gql`
+            query AppObserveCustomEventNames(
+              $appId: String!
+              $startTime: DateTime!
+              $endTime: DateTime!
+              $platform: AppObservePlatform
+              $environment: String
+            ) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  observe {
+                    customEventNames(
+                      startTime: $startTime
+                      endTime: $endTime
+                      platform: $platform
+                      environment: $environment
+                    ) {
+                      isTruncated
+                      names {
+                        eventName
+                        count
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          `,
+          {
+            appId,
+            startTime,
+            endTime,
+            ...(platform && { platform }),
+            ...(environment && { environment }),
+          }
+        )
+        .toPromise()
+    );
+
+    return data.app.byId.observe.customEventNames;
   },
 };

--- a/packages/eas-cli/src/graphql/types/Observe.ts
+++ b/packages/eas-cli/src/graphql/types/Observe.ts
@@ -18,6 +18,32 @@ export const AppObserveTimeSeriesFragmentNode = gql`
   }
 `;
 
+export const AppObserveCustomEventFragmentNode = gql`
+  fragment AppObserveCustomEventFragment on AppObserveCustomEvent {
+    id
+    eventName
+    timestamp
+    sessionId
+    severityNumber
+    severityText
+    properties {
+      key
+      value
+      type
+    }
+    appVersion
+    appBuildNumber
+    appUpdateId
+    appEasBuildId
+    deviceOs
+    deviceOsVersion
+    deviceModel
+    environment
+    easClientId
+    countryCode
+  }
+`;
+
 export const AppObserveEventFragmentNode = gql`
   fragment AppObserveEventFragment on AppObserveEvent {
     id

--- a/packages/eas-cli/src/observe/__tests__/fetchCustomEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchCustomEvents.test.ts
@@ -1,0 +1,152 @@
+import { AppObserveCustomEvent, AppObservePlatform } from '../../graphql/generated';
+import { ObserveQuery } from '../../graphql/queries/ObserveQuery';
+import { fetchObserveCustomEventsAsync } from '../fetchCustomEvents';
+
+jest.mock('../../graphql/queries/ObserveQuery');
+
+function makeCustomEvent(overrides: Partial<AppObserveCustomEvent> = {}): AppObserveCustomEvent {
+  return {
+    __typename: 'AppObserveCustomEvent' as const,
+    id: 'evt-1',
+    eventName: 'my_event',
+    timestamp: '2025-01-01T00:00:00.000Z',
+    appVersion: '1.0.0',
+    appBuildNumber: '1',
+    deviceModel: 'iPhone 15',
+    deviceOs: 'iOS',
+    deviceOsVersion: '17.0',
+    easClientId: 'client-1',
+    properties: [],
+    ...overrides,
+  } as AppObserveCustomEvent;
+}
+
+describe('fetchObserveCustomEventsAsync', () => {
+  const mockCustomEventListAsync = jest.mocked(ObserveQuery.customEventListAsync);
+  const mockGraphqlClient = {} as any;
+
+  beforeEach(() => {
+    mockCustomEventListAsync.mockClear();
+    mockCustomEventListAsync.mockResolvedValue({
+      events: [],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    });
+  });
+
+  it('passes appId, time range, and limit to customEventListAsync', async () => {
+    await fetchObserveCustomEventsAsync(mockGraphqlClient, 'project-123', {
+      limit: 25,
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+    });
+
+    expect(mockCustomEventListAsync).toHaveBeenCalledTimes(1);
+    const callArgs = mockCustomEventListAsync.mock.calls[0][1];
+    expect(callArgs.appId).toBe('project-123');
+    expect(callArgs.first).toBe(25);
+    expect(callArgs.filter?.startTime).toBe('2025-01-01T00:00:00.000Z');
+    expect(callArgs.filter?.endTime).toBe('2025-03-01T00:00:00.000Z');
+  });
+
+  it('forwards eventName filter when provided', async () => {
+    await fetchObserveCustomEventsAsync(mockGraphqlClient, 'project-123', {
+      limit: 10,
+      eventName: 'my_event',
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+    });
+
+    const filter = mockCustomEventListAsync.mock.calls[0][1].filter;
+    expect(filter?.eventName).toBe('my_event');
+  });
+
+  it('forwards platform, appVersion, and sessionId filters when provided', async () => {
+    await fetchObserveCustomEventsAsync(mockGraphqlClient, 'project-123', {
+      limit: 10,
+      platform: AppObservePlatform.Ios,
+      appVersion: '2.1.0',
+      sessionId: 'session-xyz',
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+    });
+
+    const filter = mockCustomEventListAsync.mock.calls[0][1].filter;
+    expect(filter?.platform).toBe(AppObservePlatform.Ios);
+    expect(filter?.appVersion).toBe('2.1.0');
+    expect(filter?.sessionId).toBe('session-xyz');
+  });
+
+  it('maps updateId to appUpdateId when provided', async () => {
+    await fetchObserveCustomEventsAsync(mockGraphqlClient, 'project-123', {
+      limit: 10,
+      updateId: 'update-xyz',
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+    });
+
+    const filter = mockCustomEventListAsync.mock.calls[0][1].filter;
+    expect(filter?.appUpdateId).toBe('update-xyz');
+  });
+
+  it('does not send appUpdateId when updateId is undefined', async () => {
+    await fetchObserveCustomEventsAsync(mockGraphqlClient, 'project-123', {
+      limit: 10,
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+    });
+
+    const filter = mockCustomEventListAsync.mock.calls[0][1].filter;
+    expect(filter).not.toHaveProperty('appUpdateId');
+  });
+
+  it('does not send optional filters when their inputs are undefined', async () => {
+    await fetchObserveCustomEventsAsync(mockGraphqlClient, 'project-123', {
+      limit: 10,
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+    });
+
+    const filter = mockCustomEventListAsync.mock.calls[0][1].filter;
+    expect(filter).not.toHaveProperty('eventName');
+    expect(filter).not.toHaveProperty('platform');
+    expect(filter).not.toHaveProperty('appVersion');
+    expect(filter).not.toHaveProperty('appUpdateId');
+    expect(filter).not.toHaveProperty('sessionId');
+  });
+
+  it('forwards after cursor when provided', async () => {
+    await fetchObserveCustomEventsAsync(mockGraphqlClient, 'project-123', {
+      limit: 10,
+      after: 'cursor-abc',
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+    });
+
+    expect(mockCustomEventListAsync.mock.calls[0][1].after).toBe('cursor-abc');
+  });
+
+  it('does not send after when not provided', async () => {
+    await fetchObserveCustomEventsAsync(mockGraphqlClient, 'project-123', {
+      limit: 10,
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+    });
+
+    expect(mockCustomEventListAsync.mock.calls[0][1]).not.toHaveProperty('after');
+  });
+
+  it('returns the events and pageInfo from the underlying query', async () => {
+    const events = [makeCustomEvent()];
+    const pageInfo = { hasNextPage: true, hasPreviousPage: false, endCursor: 'cursor-end' };
+    mockCustomEventListAsync.mockResolvedValue({ events, pageInfo });
+
+    const result = await fetchObserveCustomEventsAsync(mockGraphqlClient, 'project-123', {
+      limit: 10,
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+    });
+
+    expect(result.events).toBe(events);
+    expect(result.pageInfo).toBe(pageInfo);
+  });
+});

--- a/packages/eas-cli/src/observe/__tests__/fetchMetrics.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchMetrics.test.ts
@@ -1,4 +1,4 @@
-import { AppObservePlatform, AppPlatform } from '../../graphql/generated';
+import { AppObserveAppVersion, AppObservePlatform, AppPlatform } from '../../graphql/generated';
 import { ObserveQuery } from '../../graphql/queries/ObserveQuery';
 import { makeMetricsKey } from '../formatMetrics';
 import { fetchObserveMetricsAsync } from '../fetchMetrics';
@@ -21,7 +21,7 @@ function makeAppVersion(
       p99: number;
     };
   }>
-) {
+): AppObserveAppVersion {
   return {
     __typename: 'AppObserveAppVersion' as const,
     appVersion,

--- a/packages/eas-cli/src/observe/__tests__/formatCustomEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatCustomEvents.test.ts
@@ -23,11 +23,127 @@ function makeCustomEvent(overrides: Partial<AppObserveCustomEvent> = {}): AppObs
 }
 
 const noNextPage: PageInfo = { hasNextPage: false, hasPreviousPage: false };
+const withNextPage: PageInfo = {
+  hasNextPage: true,
+  hasPreviousPage: false,
+  endCursor: 'cursor-abc',
+};
 
 describe(buildObserveCustomEventsTable, () => {
+  it('formats events into aligned columns', () => {
+    const events = [
+      makeCustomEvent({
+        eventName: 'login',
+        appVersion: '1.2.0',
+        appBuildNumber: '42',
+        deviceOs: 'iOS',
+        deviceOsVersion: '17.0',
+        deviceModel: 'iPhone 15',
+        countryCode: 'US',
+        timestamp: '2025-01-15T10:30:00.000Z',
+      }),
+      makeCustomEvent({
+        id: 'evt-2',
+        eventName: 'checkout',
+        appVersion: '1.1.0',
+        appBuildNumber: '38',
+        deviceOs: 'Android',
+        deviceOsVersion: '14',
+        deviceModel: 'Pixel 8',
+        countryCode: 'PL',
+        timestamp: '2025-01-14T08:15:00.000Z',
+      }),
+    ];
+
+    const output = buildObserveCustomEventsTable(events, noNextPage);
+
+    expect(output).toMatchInlineSnapshot(`
+"[1mTimestamp                      Event     App Version  Platform    Device     Country[22m
+-----------------------------  --------  -----------  ----------  ---------  -------
+Jan 15, 2025, 10:30:00.000 AM  login     1.2.0 (42)   iOS 17.0    iPhone 15  US     
+Jan 14, 2025, 08:15:00.000 AM  checkout  1.1.0 (38)   Android 14  Pixel 8    PL     "
+`);
+  });
+
   it('returns yellow warning for empty events', () => {
     const output = buildObserveCustomEventsTable([], noNextPage);
     expect(output).toContain('No custom events found.');
+  });
+
+  it('shows event name in summary header when an event name option is provided', () => {
+    const events = [makeCustomEvent({ eventName: 'login' })];
+    const output = buildObserveCustomEventsTable(events, noNextPage, {
+      eventName: 'login',
+      daysBack: 30,
+    });
+
+    expect(output).toContain('login events for the last 30 days');
+  });
+
+  it('shows the generic "Custom events" subject when no event name option is provided', () => {
+    const events = [makeCustomEvent()];
+    const output = buildObserveCustomEventsTable(events, noNextPage, {
+      daysBack: 30,
+    });
+
+    expect(output).toContain('Custom events for the last 30 days');
+  });
+
+  it('shows date range in summary header when start/end provided', () => {
+    const events = [makeCustomEvent()];
+    const output = buildObserveCustomEventsTable(events, noNextPage, {
+      eventName: 'login',
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-02-01T00:00:00.000Z',
+    });
+
+    expect(output).toContain('login events from Jan 1, 2025 to Feb 1, 2025');
+  });
+
+  it('appends total event count to summary header when provided', () => {
+    const events = [makeCustomEvent()];
+    const output = buildObserveCustomEventsTable(events, noNextPage, {
+      eventName: 'login',
+      daysBack: 7,
+      totalEventCount: 1234,
+    });
+
+    expect(output).toContain('login events for the last 7 days — 1,234 total events');
+  });
+
+  it('shows - for null countryCode', () => {
+    const events = [makeCustomEvent({ countryCode: null })];
+    const output = buildObserveCustomEventsTable(events, noNextPage);
+
+    const lines = output.split('\n');
+    const dataLine = lines[2]; // header, separator, first data row
+    expect(dataLine).toContain('-');
+  });
+
+  it('appends next page hint when hasNextPage is true', () => {
+    const events = [makeCustomEvent()];
+    const output = buildObserveCustomEventsTable(events, withNextPage);
+
+    expect(output).toContain('Next page: --after cursor-abc');
+  });
+
+  it('does not append next page hint when hasNextPage is false', () => {
+    const events = [makeCustomEvent()];
+    const output = buildObserveCustomEventsTable(events, noNextPage);
+
+    expect(output).not.toContain('Next page');
+  });
+
+  it('omits the Event column when an event name option is provided (single-event view)', () => {
+    const events = [makeCustomEvent({ eventName: 'login' })];
+    const output = buildObserveCustomEventsTable(events, noNextPage, {
+      eventName: 'login',
+    });
+
+    // The summary header still mentions "login events" but the table should
+    // not have an "Event" column header.
+    const headerLine = output.split('\n').find(line => line.includes('Timestamp'));
+    expect(headerLine).not.toContain('Event ');
   });
 
   it('shows the Severity column when at least one event has severityText', () => {
@@ -88,6 +204,88 @@ describe(buildObserveCustomEventsJson, () => {
 
     expect(result.events[0].severityText).toBeNull();
     expect(result.events[0].severityNumber).toBeNull();
+  });
+
+  it('maps event to JSON shape with all relevant fields and pageInfo', () => {
+    const events = [
+      makeCustomEvent({
+        id: 'evt-1',
+        eventName: 'login',
+        timestamp: '2025-01-15T10:30:00.000Z',
+        sessionId: 'session-1',
+        severityText: 'INFO',
+        severityNumber: 9,
+        appVersion: '1.0.0',
+        appBuildNumber: '42',
+        appUpdateId: 'update-xyz',
+        appEasBuildId: 'build-abc',
+        deviceModel: 'iPhone 15',
+        deviceOs: 'iOS',
+        deviceOsVersion: '17.0',
+        countryCode: 'US',
+        environment: 'production',
+        easClientId: 'client-1',
+        properties: [
+          { __typename: 'AppObserveEventProperty', key: 'foo', value: 'bar', type: 'STRING' },
+        ] as any,
+      }),
+    ];
+
+    const result = buildObserveCustomEventsJson(events, withNextPage);
+
+    expect(result).toEqual({
+      events: [
+        {
+          id: 'evt-1',
+          eventName: 'login',
+          timestamp: '2025-01-15T10:30:00.000Z',
+          sessionId: 'session-1',
+          severityText: 'INFO',
+          severityNumber: 9,
+          properties: [{ key: 'foo', value: 'bar', type: 'STRING' }],
+          appVersion: '1.0.0',
+          appBuildNumber: '42',
+          appUpdateId: 'update-xyz',
+          appEasBuildId: 'build-abc',
+          deviceModel: 'iPhone 15',
+          deviceOs: 'iOS',
+          deviceOsVersion: '17.0',
+          countryCode: 'US',
+          environment: 'production',
+          easClientId: 'client-1',
+        },
+      ],
+      pageInfo: {
+        hasNextPage: true,
+        endCursor: 'cursor-abc',
+      },
+    });
+  });
+
+  it('handles null optional fields', () => {
+    const events = [
+      makeCustomEvent({
+        countryCode: null,
+        sessionId: null,
+        appUpdateId: null,
+        appEasBuildId: null,
+        environment: null,
+      }),
+    ];
+
+    const result = buildObserveCustomEventsJson(events, noNextPage);
+
+    expect(result.events[0].countryCode).toBeNull();
+    expect(result.events[0].sessionId).toBeNull();
+    expect(result.events[0].appUpdateId).toBeNull();
+    expect(result.events[0].appEasBuildId).toBeNull();
+    expect(result.events[0].environment).toBeNull();
+  });
+
+  it('returns empty events array for empty input', () => {
+    const result = buildObserveCustomEventsJson([], noNextPage);
+    expect(result.events).toEqual([]);
+    expect(result.pageInfo).toEqual({ hasNextPage: false, endCursor: null });
   });
 });
 

--- a/packages/eas-cli/src/observe/__tests__/formatCustomEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatCustomEvents.test.ts
@@ -1,0 +1,118 @@
+import { AppObserveCustomEvent, PageInfo } from '../../graphql/generated';
+import {
+  buildObserveCustomEventNamesTable,
+  buildObserveCustomEventsJson,
+  buildObserveCustomEventsTable,
+} from '../formatCustomEvents';
+
+function makeCustomEvent(overrides: Partial<AppObserveCustomEvent> = {}): AppObserveCustomEvent {
+  return {
+    __typename: 'AppObserveCustomEvent' as const,
+    id: 'evt-1',
+    eventName: 'my_event',
+    timestamp: '2025-01-15T10:30:00.000Z',
+    appVersion: '1.0.0',
+    appBuildNumber: '42',
+    deviceModel: 'iPhone 15',
+    deviceOs: 'iOS',
+    deviceOsVersion: '17.0',
+    easClientId: 'client-1',
+    properties: [],
+    ...overrides,
+  } as AppObserveCustomEvent;
+}
+
+const noNextPage: PageInfo = { hasNextPage: false, hasPreviousPage: false };
+
+describe(buildObserveCustomEventsTable, () => {
+  it('returns yellow warning for empty events', () => {
+    const output = buildObserveCustomEventsTable([], noNextPage);
+    expect(output).toContain('No custom events found.');
+  });
+
+  it('shows the Severity column when at least one event has severityText', () => {
+    const events = [makeCustomEvent({ severityText: 'INFO' }), makeCustomEvent({ id: 'evt-2' })];
+    const output = buildObserveCustomEventsTable(events, noNextPage);
+
+    expect(output).toContain('Severity');
+    expect(output).toContain('INFO');
+  });
+
+  it('shows the Severity column with the number as fallback when only severityNumber is set', () => {
+    const events = [makeCustomEvent({ severityNumber: 9 })];
+    const output = buildObserveCustomEventsTable(events, noNextPage);
+
+    expect(output).toContain('Severity');
+    expect(output).toContain('9');
+  });
+
+  it('hides the Severity column when no event has any severity data', () => {
+    const events = [makeCustomEvent()];
+    const output = buildObserveCustomEventsTable(events, noNextPage);
+
+    expect(output).not.toContain('Severity');
+  });
+
+  it('prefers severityText when both severityText and severityNumber are set', () => {
+    const events = [makeCustomEvent({ severityText: 'WARN', severityNumber: 13 })];
+    const output = buildObserveCustomEventsTable(events, noNextPage);
+
+    expect(output).toContain('WARN');
+    // The number alone should not appear when text is present.
+    expect(output).not.toMatch(/\b13\b/);
+  });
+
+  it('falls back to "-" for events that have no severity but the column is visible', () => {
+    const events = [makeCustomEvent({ severityText: 'INFO' }), makeCustomEvent({ id: 'evt-2' })];
+    const output = buildObserveCustomEventsTable(events, noNextPage);
+
+    // The second row's severity cell is "-".
+    const lines = output.split('\n');
+    // header + separator + 2 data rows
+    expect(lines[3]).toMatch(/-/);
+  });
+});
+
+describe(buildObserveCustomEventsJson, () => {
+  it('preserves both severityText and severityNumber in the JSON output', () => {
+    const events = [makeCustomEvent({ severityText: 'INFO', severityNumber: 9 })];
+    const result = buildObserveCustomEventsJson(events, noNextPage);
+
+    expect(result.events[0].severityText).toBe('INFO');
+    expect(result.events[0].severityNumber).toBe(9);
+  });
+
+  it('returns null severity fields when not set', () => {
+    const events = [makeCustomEvent()];
+    const result = buildObserveCustomEventsJson(events, noNextPage);
+
+    expect(result.events[0].severityText).toBeNull();
+    expect(result.events[0].severityNumber).toBeNull();
+  });
+});
+
+describe(buildObserveCustomEventNamesTable, () => {
+  it('returns yellow warning when names list is empty', () => {
+    const output = buildObserveCustomEventNamesTable([]);
+    expect(output).toContain('No custom event names found.');
+  });
+
+  it('shows event names with counts', () => {
+    const output = buildObserveCustomEventNamesTable([
+      { __typename: 'AppObserveCustomEventName', eventName: 'foo', count: 10 },
+      { __typename: 'AppObserveCustomEventName', eventName: 'bar', count: 5 },
+    ]);
+    expect(output).toContain('foo');
+    expect(output).toContain('10');
+    expect(output).toContain('bar');
+    expect(output).toContain('5');
+  });
+
+  it('appends a truncation notice when isTruncated is true', () => {
+    const output = buildObserveCustomEventNamesTable(
+      [{ __typename: 'AppObserveCustomEventName', eventName: 'foo', count: 10 }],
+      { isTruncated: true }
+    );
+    expect(output).toContain('Result is truncated');
+  });
+});

--- a/packages/eas-cli/src/observe/__tests__/formatCustomEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatCustomEvents.test.ts
@@ -1,6 +1,8 @@
 import { AppObserveCustomEvent, PageInfo } from '../../graphql/generated';
 import {
   buildObserveCustomEventNamesTable,
+  buildObserveCustomEventsEmptyWithSuggestionsJson,
+  buildObserveCustomEventsEmptyWithSuggestionsTable,
   buildObserveCustomEventsJson,
   buildObserveCustomEventsTable,
 } from '../formatCustomEvents';
@@ -312,5 +314,76 @@ describe(buildObserveCustomEventNamesTable, () => {
       { isTruncated: true }
     );
     expect(output).toContain('Result is truncated');
+  });
+});
+
+describe(buildObserveCustomEventsEmptyWithSuggestionsTable, () => {
+  it('shows the filtered event name and the available event names', () => {
+    const output = buildObserveCustomEventsEmptyWithSuggestionsTable('login', [
+      { __typename: 'AppObserveCustomEventName', eventName: 'foo', count: 10 },
+      { __typename: 'AppObserveCustomEventName', eventName: 'bar', count: 5 },
+    ]);
+
+    expect(output).toContain('No events found matching "login"');
+    expect(output).toContain('Available event names in this time range:');
+    expect(output).toContain('foo');
+    expect(output).toContain('10');
+    expect(output).toContain('bar');
+    expect(output).toContain('5');
+  });
+
+  it('falls back to "no event names found" message when names list is also empty', () => {
+    const output = buildObserveCustomEventsEmptyWithSuggestionsTable('login', []);
+
+    expect(output).toContain('No events found matching "login"');
+    expect(output).toContain('No custom event names found in this time range.');
+  });
+
+  it('appends a truncation notice when isTruncated is set', () => {
+    const output = buildObserveCustomEventsEmptyWithSuggestionsTable(
+      'login',
+      [{ __typename: 'AppObserveCustomEventName', eventName: 'foo', count: 10 }],
+      { isTruncated: true }
+    );
+
+    expect(output).toContain('Result is truncated');
+  });
+
+  it('includes the time range description in the message when provided', () => {
+    const output = buildObserveCustomEventsEmptyWithSuggestionsTable(
+      'login',
+      [{ __typename: 'AppObserveCustomEventName', eventName: 'foo', count: 10 }],
+      { daysBack: 7 }
+    );
+
+    expect(output).toContain('No events found matching "login" for the last 7 days.');
+  });
+});
+
+describe(buildObserveCustomEventsEmptyWithSuggestionsJson, () => {
+  it('returns the filtered event name, empty events array, and available names', () => {
+    const result = buildObserveCustomEventsEmptyWithSuggestionsJson(
+      'login',
+      [
+        { __typename: 'AppObserveCustomEventName', eventName: 'foo', count: 10 },
+        { __typename: 'AppObserveCustomEventName', eventName: 'bar', count: 5 },
+      ],
+      false
+    );
+
+    expect(result).toEqual({
+      filteredEventName: 'login',
+      events: [],
+      availableEventNames: [
+        { eventName: 'foo', count: 10 },
+        { eventName: 'bar', count: 5 },
+      ],
+      availableEventNamesIsTruncated: false,
+    });
+  });
+
+  it('preserves the isTruncated flag', () => {
+    const result = buildObserveCustomEventsEmptyWithSuggestionsJson('login', [], true);
+    expect(result.availableEventNamesIsTruncated).toBe(true);
   });
 });

--- a/packages/eas-cli/src/observe/__tests__/formatEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatEvents.test.ts
@@ -63,10 +63,10 @@ describe(buildObserveEventsTable, () => {
 
     // Escape codes are included, because the header is bolded.
     expect(output).toMatchInlineSnapshot(`
-"[1mValue  App Version  Platform    Device     Country  Timestamp             [22m
------  -----------  ----------  ---------  -------  ----------------------
-1.23s  1.2.0 (42)   iOS 17.0    iPhone 15  US       Jan 15, 2025, 10:30 AM
-0.85s  1.1.0 (38)   Android 14  Pixel 8    PL       Jan 14, 2025, 08:15 AM"
+"[1mValue  App Version  Platform    Device     Country  Timestamp                    [22m
+-----  -----------  ----------  ---------  -------  -----------------------------
+1.23s  1.2.0 (42)   iOS 17.0    iPhone 15  US       Jan 15, 2025, 10:30:00.000 AM
+0.85s  1.1.0 (38)   Android 14  Pixel 8    PL       Jan 14, 2025, 08:15:00.000 AM"
 `);
   });
 

--- a/packages/eas-cli/src/observe/__tests__/formatEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatEvents.test.ts
@@ -63,10 +63,10 @@ describe(buildObserveEventsTable, () => {
 
     // Escape codes are included, because the header is bolded.
     expect(output).toMatchInlineSnapshot(`
-"[1mValue  App Version  Platform    Device     Country  Timestamp                    [22m
------  -----------  ----------  ---------  -------  -----------------------------
-1.23s  1.2.0 (42)   iOS 17.0    iPhone 15  US       Jan 15, 2025, 10:30:00.000 AM
-0.85s  1.1.0 (38)   Android 14  Pixel 8    PL       Jan 14, 2025, 08:15:00.000 AM"
+"[1mValue  App Version  Platform    Device     Country  Timestamp             [22m
+-----  -----------  ----------  ---------  -------  ----------------------
+1.23s  1.2.0 (42)   iOS 17.0    iPhone 15  US       Jan 15, 2025, 10:30 AM
+0.85s  1.1.0 (38)   Android 14  Pixel 8    PL       Jan 14, 2025, 08:15 AM"
 `);
   });
 

--- a/packages/eas-cli/src/observe/__tests__/formatMetrics.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatMetrics.test.ts
@@ -1,12 +1,12 @@
 import { AppPlatform } from '../../graphql/generated';
 import {
+  type MetricValues,
   ObserveMetricsMap,
   StatisticKey,
   buildObserveMetricsJson,
   buildObserveMetricsTable,
   makeMetricsKey,
   resolveStatKey,
-  type MetricValues,
 } from '../formatMetrics';
 
 const DEFAULT_STATS_TABLE: StatisticKey[] = ['median', 'eventCount'];

--- a/packages/eas-cli/src/observe/fetchCustomEvents.ts
+++ b/packages/eas-cli/src/observe/fetchCustomEvents.ts
@@ -1,0 +1,48 @@
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import {
+  AppObserveCustomEvent,
+  AppObserveCustomEventListFilter,
+  AppObservePlatform,
+  PageInfo,
+} from '../graphql/generated';
+import { ObserveQuery } from '../graphql/queries/ObserveQuery';
+
+interface FetchCustomEventsOptions {
+  eventName?: string;
+  limit: number;
+  after?: string;
+  startTime: string;
+  endTime: string;
+  platform?: AppObservePlatform;
+  appVersion?: string;
+  updateId?: string;
+  sessionId?: string;
+}
+
+interface FetchCustomEventsResult {
+  events: AppObserveCustomEvent[];
+  pageInfo: PageInfo;
+}
+
+export async function fetchObserveCustomEventsAsync(
+  graphqlClient: ExpoGraphqlClient,
+  appId: string,
+  options: FetchCustomEventsOptions
+): Promise<FetchCustomEventsResult> {
+  const filter: AppObserveCustomEventListFilter = {
+    startTime: options.startTime,
+    endTime: options.endTime,
+    ...(options.eventName && { eventName: options.eventName }),
+    ...(options.platform && { platform: options.platform }),
+    ...(options.appVersion && { appVersion: options.appVersion }),
+    ...(options.updateId && { appUpdateId: options.updateId }),
+    ...(options.sessionId && { sessionId: options.sessionId }),
+  };
+
+  return await ObserveQuery.customEventListAsync(graphqlClient, {
+    appId,
+    filter,
+    first: options.limit,
+    ...(options.after && { after: options.after }),
+  });
+}

--- a/packages/eas-cli/src/observe/formatCustomEvents.ts
+++ b/packages/eas-cli/src/observe/formatCustomEvents.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import { AppObserveCustomEvent, PageInfo } from '../graphql/generated';
+import { AppObserveCustomEvent, AppObserveCustomEventName, PageInfo } from '../graphql/generated';
 import renderTextTable from '../utils/renderTextTable';
 import { buildTimeRangeDescription, formatTimestamp } from './formatUtils';
 
@@ -126,5 +126,50 @@ export function buildObserveCustomEventsJson(
       hasNextPage: pageInfo.hasNextPage,
       endCursor: pageInfo.endCursor ?? null,
     },
+  };
+}
+
+export interface BuildCustomEventNamesTableOptions {
+  daysBack?: number;
+  startTime?: string;
+  endTime?: string;
+  isTruncated?: boolean;
+}
+
+export function buildObserveCustomEventNamesTable(
+  names: AppObserveCustomEventName[],
+  options?: BuildCustomEventNamesTableOptions
+): string {
+  if (names.length === 0) {
+    return chalk.yellow('No custom event names found.');
+  }
+
+  const headers = ['Event Name', 'Count'];
+  const rows: string[][] = names.map(n => [n.eventName, n.count.toLocaleString()]);
+
+  const lines: string[] = [];
+
+  if (options) {
+    const timeDesc = buildTimeRangeDescription(options);
+    const subject = 'Custom event names';
+    lines.push(chalk.bold(`${subject} ${timeDesc}`.trim()), '');
+  }
+
+  lines.push(renderTextTable(headers, rows));
+
+  if (options?.isTruncated) {
+    lines.push('', chalk.yellow('Result is truncated; not all event names are shown.'));
+  }
+
+  return lines.join('\n');
+}
+
+export function buildObserveCustomEventNamesJson(
+  names: AppObserveCustomEventName[],
+  isTruncated: boolean
+): { names: Array<{ eventName: string; count: number }>; isTruncated: boolean } {
+  return {
+    names: names.map(n => ({ eventName: n.eventName, count: n.count })),
+    isTruncated,
   };
 }

--- a/packages/eas-cli/src/observe/formatCustomEvents.ts
+++ b/packages/eas-cli/src/observe/formatCustomEvents.ts
@@ -1,28 +1,8 @@
 import chalk from 'chalk';
 
 import { AppObserveCustomEvent, PageInfo } from '../graphql/generated';
-
-function formatTimestamp(isoString: string): string {
-  const date = new Date(isoString);
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    fractionalSecondDigits: 3,
-  });
-}
-
-function formatDate(isoString: string): string {
-  const date = new Date(isoString);
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
-}
+import renderTextTable from '../utils/renderTextTable';
+import { buildTimeRangeDescription, formatTimestamp } from './formatUtils';
 
 export interface ObserveCustomEventPropertyJson {
   key: string;
@@ -90,22 +70,10 @@ export function buildObserveCustomEventsTable(
     event.countryCode ?? '-',
   ]);
 
-  const colWidths = headers.map((h, i) => Math.max(h.length, ...rows.map(r => r[i].length)));
-  const headerLine = headers.map((h, i) => h.padEnd(colWidths[i])).join('  ');
-  const separatorLine = colWidths.map(w => '-'.repeat(w)).join('  ');
-  const dataLines = rows.map(row => row.map((cell, i) => cell.padEnd(colWidths[i])).join('  '));
-
   const lines: string[] = [];
 
   if (options) {
-    let timeDesc: string;
-    if (options.daysBack) {
-      timeDesc = `for the last ${options.daysBack} days`;
-    } else if (options.startTime && options.endTime) {
-      timeDesc = `from ${formatDate(options.startTime)} to ${formatDate(options.endTime)}`;
-    } else {
-      timeDesc = '';
-    }
+    const timeDesc = buildTimeRangeDescription(options);
     const totalDesc =
       options.totalEventCount != null
         ? ` — ${options.totalEventCount.toLocaleString()} total events`
@@ -114,7 +82,7 @@ export function buildObserveCustomEventsTable(
     lines.push(chalk.bold(`${subject} ${timeDesc}${totalDesc}`.trim()), '');
   }
 
-  lines.push(chalk.bold(headerLine), separatorLine, ...dataLines);
+  lines.push(renderTextTable(headers, rows));
 
   if (pageInfo.hasNextPage && pageInfo.endCursor) {
     lines.push('', `Next page: --after ${pageInfo.endCursor}`);

--- a/packages/eas-cli/src/observe/formatCustomEvents.ts
+++ b/packages/eas-cli/src/observe/formatCustomEvents.ts
@@ -1,0 +1,162 @@
+import chalk from 'chalk';
+
+import { AppObserveCustomEvent, PageInfo } from '../graphql/generated';
+
+function formatTimestamp(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    fractionalSecondDigits: 3,
+  });
+}
+
+function formatDate(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export interface ObserveCustomEventPropertyJson {
+  key: string;
+  value: string;
+  type: string;
+}
+
+export interface ObserveCustomEventJson {
+  id: string;
+  eventName: string;
+  timestamp: string;
+  sessionId: string | null;
+  severityNumber: number | null;
+  severityText: string | null;
+  properties: ObserveCustomEventPropertyJson[];
+  appVersion: string;
+  appBuildNumber: string;
+  appUpdateId: string | null;
+  appEasBuildId: string | null;
+  deviceModel: string;
+  deviceOs: string;
+  deviceOsVersion: string;
+  countryCode: string | null;
+  environment: string | null;
+  easClientId: string;
+}
+
+export interface BuildCustomEventsTableOptions {
+  eventName?: string;
+  daysBack?: number;
+  startTime?: string;
+  endTime?: string;
+  totalEventCount?: number;
+}
+
+export function buildObserveCustomEventsTable(
+  events: AppObserveCustomEvent[],
+  pageInfo: PageInfo,
+  options?: BuildCustomEventsTableOptions
+): string {
+  if (events.length === 0) {
+    return chalk.yellow('No custom events found.');
+  }
+
+  const showEventName = !options?.eventName;
+  const hasSeverity = events.some(e => e.severityText);
+
+  const headers = [
+    'Timestamp',
+    ...(showEventName ? ['Event'] : []),
+    ...(hasSeverity ? ['Severity'] : []),
+    'App Version',
+    'Platform',
+    'Device',
+    'Country',
+  ];
+
+  const rows: string[][] = events.map(event => [
+    formatTimestamp(event.timestamp),
+    ...(showEventName ? [event.eventName] : []),
+    ...(hasSeverity ? [event.severityText ?? '-'] : []),
+    `${event.appVersion} (${event.appBuildNumber})`,
+    `${event.deviceOs} ${event.deviceOsVersion}`,
+    event.deviceModel,
+    event.countryCode ?? '-',
+  ]);
+
+  const colWidths = headers.map((h, i) => Math.max(h.length, ...rows.map(r => r[i].length)));
+  const headerLine = headers.map((h, i) => h.padEnd(colWidths[i])).join('  ');
+  const separatorLine = colWidths.map(w => '-'.repeat(w)).join('  ');
+  const dataLines = rows.map(row => row.map((cell, i) => cell.padEnd(colWidths[i])).join('  '));
+
+  const lines: string[] = [];
+
+  if (options) {
+    let timeDesc: string;
+    if (options.daysBack) {
+      timeDesc = `for the last ${options.daysBack} days`;
+    } else if (options.startTime && options.endTime) {
+      timeDesc = `from ${formatDate(options.startTime)} to ${formatDate(options.endTime)}`;
+    } else {
+      timeDesc = '';
+    }
+    const totalDesc =
+      options.totalEventCount != null
+        ? ` — ${options.totalEventCount.toLocaleString()} total events`
+        : '';
+    const subject = options.eventName ? `${options.eventName} events` : 'Custom events';
+    lines.push(chalk.bold(`${subject} ${timeDesc}${totalDesc}`.trim()), '');
+  }
+
+  lines.push(chalk.bold(headerLine), separatorLine, ...dataLines);
+
+  if (pageInfo.hasNextPage && pageInfo.endCursor) {
+    lines.push('', `Next page: --after ${pageInfo.endCursor}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function buildObserveCustomEventsJson(
+  events: AppObserveCustomEvent[],
+  pageInfo: PageInfo
+): {
+  events: ObserveCustomEventJson[];
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+} {
+  return {
+    events: events.map(event => ({
+      id: event.id,
+      eventName: event.eventName,
+      timestamp: event.timestamp,
+      sessionId: event.sessionId ?? null,
+      severityNumber: event.severityNumber ?? null,
+      severityText: event.severityText ?? null,
+      properties: event.properties.map(p => ({
+        key: p.key,
+        value: p.value,
+        type: p.type,
+      })),
+      appVersion: event.appVersion,
+      appBuildNumber: event.appBuildNumber,
+      appUpdateId: event.appUpdateId ?? null,
+      appEasBuildId: event.appEasBuildId ?? null,
+      deviceModel: event.deviceModel,
+      deviceOs: event.deviceOs,
+      deviceOsVersion: event.deviceOsVersion,
+      countryCode: event.countryCode ?? null,
+      environment: event.environment ?? null,
+      easClientId: event.easClientId,
+    })),
+    pageInfo: {
+      hasNextPage: pageInfo.hasNextPage,
+      endCursor: pageInfo.endCursor ?? null,
+    },
+  };
+}

--- a/packages/eas-cli/src/observe/formatCustomEvents.ts
+++ b/packages/eas-cli/src/observe/formatCustomEvents.ts
@@ -4,6 +4,16 @@ import { AppObserveCustomEvent, AppObserveCustomEventName, PageInfo } from '../g
 import renderTextTable from '../utils/renderTextTable';
 import { buildTimeRangeDescription, formatTimestamp } from './formatUtils';
 
+function formatSeverity(event: AppObserveCustomEvent): string {
+  if (event.severityText) {
+    return event.severityText;
+  }
+  if (event.severityNumber != null) {
+    return String(event.severityNumber);
+  }
+  return '-';
+}
+
 export interface ObserveCustomEventPropertyJson {
   key: string;
   value: string;
@@ -48,7 +58,7 @@ export function buildObserveCustomEventsTable(
   }
 
   const showEventName = !options?.eventName;
-  const hasSeverity = events.some(e => e.severityText);
+  const hasSeverity = events.some(e => e.severityText != null || e.severityNumber != null);
 
   const headers = [
     'Timestamp',
@@ -63,7 +73,7 @@ export function buildObserveCustomEventsTable(
   const rows: string[][] = events.map(event => [
     formatTimestamp(event.timestamp),
     ...(showEventName ? [event.eventName] : []),
-    ...(hasSeverity ? [event.severityText ?? '-'] : []),
+    ...(hasSeverity ? [formatSeverity(event)] : []),
     `${event.appVersion} (${event.appBuildNumber})`,
     `${event.deviceOs} ${event.deviceOsVersion}`,
     event.deviceModel,

--- a/packages/eas-cli/src/observe/formatCustomEvents.ts
+++ b/packages/eas-cli/src/observe/formatCustomEvents.ts
@@ -139,6 +139,58 @@ export function buildObserveCustomEventsJson(
   };
 }
 
+export interface BuildEmptyCustomEventsWithSuggestionsOptions {
+  daysBack?: number;
+  startTime?: string;
+  endTime?: string;
+  isTruncated?: boolean;
+}
+
+export function buildObserveCustomEventsEmptyWithSuggestionsTable(
+  eventName: string,
+  names: AppObserveCustomEventName[],
+  options?: BuildEmptyCustomEventsWithSuggestionsOptions
+): string {
+  const lines: string[] = [];
+  const timeDesc = options ? buildTimeRangeDescription(options) : '';
+  lines.push(chalk.yellow(`No events found matching "${eventName}" ${timeDesc}.`.trim()));
+
+  if (names.length === 0) {
+    lines.push('', chalk.yellow('No custom event names found in this time range.'));
+    return lines.join('\n');
+  }
+
+  lines.push('', 'Available event names in this time range:', '');
+
+  const headers = ['Event Name', 'Count'];
+  const rows: string[][] = names.map(n => [n.eventName, n.count.toLocaleString()]);
+  lines.push(renderTextTable(headers, rows));
+
+  if (options?.isTruncated) {
+    lines.push('', chalk.yellow('Result is truncated; not all event names are shown.'));
+  }
+
+  return lines.join('\n');
+}
+
+export function buildObserveCustomEventsEmptyWithSuggestionsJson(
+  eventName: string,
+  names: AppObserveCustomEventName[],
+  isTruncated: boolean
+): {
+  filteredEventName: string;
+  events: [];
+  availableEventNames: Array<{ eventName: string; count: number }>;
+  availableEventNamesIsTruncated: boolean;
+} {
+  return {
+    filteredEventName: eventName,
+    events: [],
+    availableEventNames: names.map(n => ({ eventName: n.eventName, count: n.count })),
+    availableEventNamesIsTruncated: isTruncated,
+  };
+}
+
 export interface BuildCustomEventNamesTableOptions {
   daysBack?: number;
   startTime?: string;

--- a/packages/eas-cli/src/observe/formatCustomEvents.ts
+++ b/packages/eas-cli/src/observe/formatCustomEvents.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 
 import { AppObserveCustomEvent, AppObserveCustomEventName, PageInfo } from '../graphql/generated';
 import renderTextTable from '../utils/renderTextTable';
-import { buildTimeRangeDescription, formatTimestamp } from './formatUtils';
+import { buildTimeRangeDescription, formatLogTimestamp } from './formatUtils';
 
 function formatSeverity(event: AppObserveCustomEvent): string {
   if (event.severityText) {
@@ -71,7 +71,7 @@ export function buildObserveCustomEventsTable(
   ];
 
   const rows: string[][] = events.map(event => [
-    formatTimestamp(event.timestamp),
+    formatLogTimestamp(event.timestamp),
     ...(showEventName ? [event.eventName] : []),
     ...(hasSeverity ? [formatSeverity(event)] : []),
     `${event.appVersion} (${event.appBuildNumber})`,

--- a/packages/eas-cli/src/observe/formatEvents.ts
+++ b/packages/eas-cli/src/observe/formatEvents.ts
@@ -1,18 +1,9 @@
 import chalk from 'chalk';
 
 import { AppObserveEvent, PageInfo } from '../graphql/generated';
+import renderTextTable from '../utils/renderTextTable';
+import { buildTimeRangeDescription, formatTimestamp } from './formatUtils';
 import { getMetricDisplayName } from './metricNames';
-
-function formatTimestamp(isoString: string): string {
-  const date = new Date(isoString);
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
 
 export interface ObserveEventJson {
   id: string;
@@ -29,15 +20,6 @@ export interface ObserveEventJson {
   easClientId: string;
   timestamp: string;
   customParams: { [key: string]: any } | null;
-}
-
-function formatDate(isoString: string): string {
-  const date = new Date(isoString);
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
 }
 
 function resolveCustomParams(event: AppObserveEvent): { [key: string]: any } | null {
@@ -83,24 +65,11 @@ export function buildObserveEventsTable(
     formatTimestamp(event.timestamp),
   ]);
 
-  const colWidths = headers.map((h, i) => Math.max(h.length, ...rows.map(r => r[i].length)));
-
-  const headerLine = headers.map((h, i) => h.padEnd(colWidths[i])).join('  ');
-  const separatorLine = colWidths.map(w => '-'.repeat(w)).join('  ');
-  const dataLines = rows.map(row => row.map((cell, i) => cell.padEnd(colWidths[i])).join('  '));
-
   const lines: string[] = [];
 
   if (options) {
     const metricDisplay = getMetricDisplayName(options.metricName);
-    let timeDesc: string;
-    if (options.daysBack) {
-      timeDesc = `for the last ${options.daysBack} days`;
-    } else if (options.startTime && options.endTime) {
-      timeDesc = `from ${formatDate(options.startTime)} to ${formatDate(options.endTime)}`;
-    } else {
-      timeDesc = '';
-    }
+    const timeDesc = buildTimeRangeDescription(options);
     const totalDesc =
       options.totalEventCount != null
         ? ` — ${options.totalEventCount.toLocaleString()} total events`
@@ -108,7 +77,7 @@ export function buildObserveEventsTable(
     lines.push(chalk.bold(`${metricDisplay} events ${timeDesc}${totalDesc}`.trim()), '');
   }
 
-  lines.push(chalk.bold(headerLine), separatorLine, ...dataLines);
+  lines.push(renderTextTable(headers, rows));
 
   if (pageInfo.hasNextPage && pageInfo.endCursor) {
     lines.push('', `Next page: --after ${pageInfo.endCursor}`);

--- a/packages/eas-cli/src/observe/formatMetrics.ts
+++ b/packages/eas-cli/src/observe/formatMetrics.ts
@@ -4,6 +4,7 @@ import { EasCommandError } from '../commandUtils/errors';
 import { AppPlatform } from '../graphql/generated';
 import { appPlatformDisplayNames } from '../platform';
 import renderTextTable from '../utils/renderTextTable';
+import { buildTimeRangeDescription } from './formatUtils';
 import { getMetricDisplayName } from './metricNames';
 
 export type StatisticKey =
@@ -169,13 +170,6 @@ function buildStatsDescription(displayStats: StatisticKey[]): string {
   return displayStats.map(s => STAT_DISPLAY_NAMES[s]).join(', ');
 }
 
-function buildTimeRangeDescription(daysBack?: number): string {
-  if (daysBack) {
-    return `for the last ${daysBack} days`;
-  }
-  return '';
-}
-
 export function buildObserveMetricsTable(
   metricsMap: ObserveMetricsMap,
   metricNames: string[],
@@ -197,7 +191,7 @@ export function buildObserveMetricsTable(
 
   // Build summary header
   const statsDesc = displayStats.length > 0 ? buildStatsDescription(displayStats) : 'Event count';
-  const timeDesc = buildTimeRangeDescription(options?.daysBack);
+  const timeDesc = buildTimeRangeDescription({ daysBack: options?.daysBack });
   const countSuffix = hasEventCount && displayStats.length > 0 ? ' (event count)' : '';
   const summaryLine = `${statsDesc} values${countSuffix}${timeDesc ? ` ${timeDesc}` : ''}`;
 

--- a/packages/eas-cli/src/observe/formatUtils.ts
+++ b/packages/eas-cli/src/observe/formatUtils.ts
@@ -1,0 +1,47 @@
+/**
+ * Format an ISO timestamp for display in event tables, including
+ * seconds and milliseconds.
+ */
+export function formatTimestamp(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    fractionalSecondDigits: 3,
+  });
+}
+
+/**
+ * Format an ISO timestamp for display as a date only (no time).
+ */
+export function formatDate(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Build the time-range fragment used in summary headers, e.g.
+ * "for the last 7 days" or "from Jan 1, 2025 to Feb 1, 2025".
+ * Returns an empty string when no range information is provided.
+ */
+export function buildTimeRangeDescription(options: {
+  daysBack?: number;
+  startTime?: string;
+  endTime?: string;
+}): string {
+  if (options.daysBack) {
+    return `for the last ${options.daysBack} days`;
+  }
+  if (options.startTime && options.endTime) {
+    return `from ${formatDate(options.startTime)} to ${formatDate(options.endTime)}`;
+  }
+  return '';
+}

--- a/packages/eas-cli/src/observe/formatUtils.ts
+++ b/packages/eas-cli/src/observe/formatUtils.ts
@@ -1,10 +1,10 @@
 /**
  * Format an ISO timestamp for display in event tables, including
- * seconds and milliseconds.
+ * seconds and milliseconds. Uses the runtime's default locale.
  */
 export function formatTimestamp(isoString: string): string {
   const date = new Date(isoString);
-  return date.toLocaleDateString('en-US', {
+  return date.toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
@@ -16,11 +16,12 @@ export function formatTimestamp(isoString: string): string {
 }
 
 /**
- * Format an ISO timestamp for display as a date only (no time).
+ * Format an ISO timestamp for display as a date only (no time). Uses the
+ * runtime's default locale.
  */
 export function formatDate(isoString: string): string {
   const date = new Date(isoString);
-  return date.toLocaleDateString('en-US', {
+  return date.toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',

--- a/packages/eas-cli/src/observe/formatUtils.ts
+++ b/packages/eas-cli/src/observe/formatUtils.ts
@@ -1,8 +1,25 @@
 /**
- * Format an ISO timestamp for display in event tables, including
- * seconds and milliseconds. Uses the runtime's default locale.
+ * Format an ISO timestamp for display in event tables (minute precision).
+ * Uses the runtime's default locale.
  */
 export function formatTimestamp(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Format an ISO timestamp for display in log tables (millisecond precision).
+ * Use this instead of formatTimestamp when the table represents individual
+ * log entries where sub-minute resolution matters. Uses the runtime's
+ * default locale.
+ */
+export function formatLogTimestamp(isoString: string): string {
   const date = new Date(isoString);
   return date.toLocaleDateString(undefined, {
     year: 'numeric',

--- a/packages/eas-cli/src/observe/formatVersions.ts
+++ b/packages/eas-cli/src/observe/formatVersions.ts
@@ -8,15 +8,7 @@ import {
 import { appPlatformDisplayNames } from '../platform';
 import renderTextTable from '../utils/renderTextTable';
 import { AppVersionsResult } from './fetchVersions';
-
-function formatDate(isoString: string): string {
-  const date = new Date(isoString);
-  return date.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
-}
+import { formatDate } from './formatUtils';
 
 export interface AppVersionJson {
   platform: string;

--- a/packages/eas-cli/src/observe/platforms.ts
+++ b/packages/eas-cli/src/observe/platforms.ts
@@ -1,0 +1,53 @@
+import { AppObservePlatform, AppPlatform } from '../graphql/generated';
+
+/**
+ * Allowed values for the --platform flag in observe commands.
+ * Derived from the AppObservePlatform enum so new platforms added on
+ * the server are automatically picked up.
+ */
+export const allowedPlatformFlagValues = Object.values(AppObservePlatform).map(s =>
+  s.toLowerCase()
+);
+
+const defaultAppObservePlatform = AppObservePlatform.Ios;
+const defaultAppPlatform = AppPlatform.Ios;
+
+type PlatformFlagValue = (typeof allowedPlatformFlagValues)[number];
+
+/**
+ * Resolve a single AppObservePlatform from a --platform flag value.
+ * Returns undefined when no flag was provided.
+ */
+export function appObservePlatformFromFlag(
+  flag: PlatformFlagValue | undefined
+): AppObservePlatform | undefined {
+  if (!flag) {
+    return undefined;
+  }
+  switch (flag) {
+    case 'android':
+      return AppObservePlatform.Android;
+    case 'ios':
+      return AppObservePlatform.Ios;
+  }
+  return defaultAppObservePlatform;
+}
+
+/**
+ * Resolve a list of AppPlatform values from a --platform flag value.
+ * Returns the single matching platform when a flag is provided, or all
+ * known platforms when no flag is provided (so the caller queries every
+ * platform).
+ */
+export function appPlatformsFromFlag(flag: PlatformFlagValue | undefined): AppPlatform[] {
+  if (!flag) {
+    return [AppPlatform.Android, AppPlatform.Ios];
+  }
+  switch (flag) {
+    case 'android':
+      return [AppPlatform.Android];
+    case 'ios':
+      return [AppPlatform.Ios];
+  }
+  return [defaultAppPlatform];
+}

--- a/packages/eas-cli/src/observe/resolveProjectContext.ts
+++ b/packages/eas-cli/src/observe/resolveProjectContext.ts
@@ -1,0 +1,43 @@
+import EasCommand, { ContextInput } from '../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+
+/**
+ * Shared context resolution for observe commands.
+ *
+ * If `projectIdOverride` is provided (typically via `--project-id`), the
+ * helper only requires the LoggedIn context (so the command can run outside
+ * of a project directory). Otherwise it uses the full context definition,
+ * which derives the project ID from the local app config.
+ */
+export async function resolveObserveCommandContextAsync({
+  command,
+  commandClass,
+  loggedInOnlyContextDefinition,
+  projectIdOverride,
+  nonInteractive,
+}: {
+  command: EasCommand;
+  commandClass: { contextDefinition: ContextInput<any> };
+  loggedInOnlyContextDefinition: ContextInput<any>;
+  projectIdOverride?: string;
+  nonInteractive: boolean;
+}): Promise<{ projectId: string; graphqlClient: ExpoGraphqlClient }> {
+  // `getContextAsync` is `protected` on EasCommand; cast to access from this helper.
+  const commandWithContextAccess = command as unknown as {
+    getContextAsync: (
+      cls: { contextDefinition: ContextInput<any> },
+      options: { nonInteractive: boolean }
+    ) => Promise<any>;
+  };
+
+  if (projectIdOverride) {
+    const ctx = await commandWithContextAccess.getContextAsync(
+      { contextDefinition: loggedInOnlyContextDefinition },
+      { nonInteractive }
+    );
+    return { projectId: projectIdOverride, graphqlClient: ctx.loggedIn.graphqlClient };
+  }
+
+  const ctx = await commandWithContextAccess.getContextAsync(commandClass, { nonInteractive });
+  return { projectId: ctx.projectId, graphqlClient: ctx.loggedIn.graphqlClient };
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Add new command to retrieve custom events for Expo Observe.

```
USAGE
  $ eas observe:logs [EVENTNAME] [--platform android|ios] [--after <value>] [--limit <value>] [--start <value> |
    --days <value>] [--end <value> | ] [--app-version <value>] [--update-id <value>] [--session-id <value>]
    [--all-events] [--project-id <value>] [--json] [--non-interactive]

ARGUMENTS
  [EVENTNAME]  Custom event name to filter by

FLAGS
  --after=<value>        Cursor for pagination. Use the endCursor from a previous query to fetch the next page.
  --all-events           When no event name argument is provided, list all events across all event names instead of a
                         summary of event names + counts.
  --app-version=<value>  Filter by app version
  --days=<value>         Show events from the last N days (mutually exclusive with --start/--end)
  --end=<value>          End of time range (ISO date)
  --json                 Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.
  --limit=<value>        The number of items to fetch each query. Defaults to 10 and is capped at 100.
  --non-interactive      Run the command in non-interactive mode.
  --platform=<option>    Filter by platform
                         <options: android|ios>
  --project-id=<value>   EAS project ID (defaults to the project ID of the current directory)
  --session-id=<value>   Filter by session ID
  --start=<value>        Start of time range (ISO date)
  --update-id=<value>    Filter by EAS update ID

DESCRIPTION
  display individual custom events (logs) emitted by the app, filtered by the event name in the argument. With no
  arguments, a list of the available event names and associated event counts is returned.


```

# How

- Add new GraphQL query and fragment, and new formatter for the retrieved custom events
- New command `observe:logs`, designed to be similar to `observe:events`
- Did some refactoring so that observe commands reuse methods for formatting results

The command can return a list of the different event names found and their counts, a list of events for a specific name, or a list of all events found:

```
  ┌───────────────────────────┬───────────────────────────────────────────┐                                             
  │        invocation         │                  result                   │                                             
  ├───────────────────────────┼───────────────────────────────────────────┤                                             
  │ observe:logs              │ event-name summary table (names + counts) │                                             
  ├───────────────────────────┼───────────────────────────────────────────┤                                             
  │ observe:logs --all-events │ full list of events across all names      │                                             
  ├───────────────────────────┼───────────────────────────────────────────┤                                             
  │ observe:logs <event>      │ full list of events filtered by name      │                                             
  └───────────────────────────┴───────────────────────────────────────────┘  
```

# Test Plan

- New unit tests added
- Will test against Kadi's ingestion endpoint data