### PR TITLE
Refactor submit config resolution by platform

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -39,6 +39,7 @@
     "@expo/config-plugins": "55.0.7",
     "@expo/downloader": "18.5.0",
     "@expo/eas-build-job": "18.8.0",
+    "@expo/eas-json": "18.8.0",
     "@expo/env": "^0.4.0",
     "@expo/logger": "18.5.0",
     "@expo/package-manager": "1.9.10",

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -27,6 +27,7 @@ import { createRepackBuildFunction } from './functions/repack';
 import { createReportMaestroTestResultsFunction } from './functions/reportMaestroTestResults';
 import { resolveAppleTeamIdFromCredentialsFunction } from './functions/resolveAppleTeamIdFromCredentials';
 import { createResolveBuildConfigBuildFunction } from './functions/resolveBuildConfig';
+import { createResolveSubmitConfigBuildFunction } from './functions/resolveSubmitConfig';
 import {
   createCacheStatsBuildFunction,
   createRestoreBuildCacheFunction,
@@ -88,6 +89,7 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     calculateEASUpdateRuntimeVersionFunction(),
 
     createSubmissionEntityFunction(),
+    createResolveSubmitConfigBuildFunction(ctx),
     createUploadToAscBuildFunction(),
 
     createReportMaestroTestResultsFunction(ctx),

--- a/packages/build-tools/src/steps/functions/resolveSubmitConfig/android.ts
+++ b/packages/build-tools/src/steps/functions/resolveSubmitConfig/android.ts
@@ -1,0 +1,195 @@
+import { Platform, SubmissionConfig } from '@expo/eas-build-job';
+import { SubmitProfile } from '@expo/eas-json';
+import { bunyan } from '@expo/logger';
+import { asyncResult } from '@expo/results';
+import spawn from '@expo/turtle-spawn';
+import { BuildStepEnv } from '@expo/steps';
+import fs from 'fs-extra';
+import { graphql } from 'gql.tada';
+import path from 'node:path';
+import { z } from 'zod';
+
+import { BuildInfo, ResolvedSubmitConfig } from './common';
+import { CustomBuildContext } from '../../../customBuildContext';
+
+const ANDROID_APP_CREDENTIALS_QUERY = graphql(`
+  query ResolveSubmitConfigAndroidAppCredentials(
+    $projectFullName: String!
+    $applicationIdentifier: String
+  ) {
+    app {
+      byFullName(fullName: $projectFullName) {
+        id
+        androidAppCredentials(filter: { applicationIdentifier: $applicationIdentifier }) {
+          id
+          googleServiceAccountKeyForSubmissions {
+            id
+          }
+        }
+      }
+    }
+  }
+`);
+
+const GOOGLE_SERVICE_ACCOUNT_KEY_QUERY = graphql(`
+  query ResolveSubmitConfigGoogleServiceAccountKey($id: ID!) {
+    googleServiceAccountKey {
+      byId(id: $id) {
+        id
+        keyJson
+      }
+    }
+  }
+`);
+
+export async function resolveAndroidSubmitConfigAsync({
+  artifactPath,
+  build,
+  ctx,
+  env,
+  logger,
+  profile,
+  workingDirectory,
+}: {
+  artifactPath?: string;
+  build: BuildInfo;
+  ctx: CustomBuildContext;
+  env: BuildStepEnv;
+  logger: bunyan;
+  profile: SubmitProfile<Platform.ANDROID>;
+  workingDirectory: string;
+}): Promise<ResolvedSubmitConfig> {
+  const applicationId =
+    build.appIdentifier ??
+    profile.applicationId ??
+    (artifactPath ? await readAndroidApplicationIdAsync(artifactPath, env, logger) : undefined);
+
+  const googleServiceAccountKeyJson = profile.serviceAccountKeyPath
+    ? await fs.readFile(path.resolve(workingDirectory, profile.serviceAccountKeyPath), 'utf8')
+    : await getGoogleServiceAccountKeyJsonAsync({
+        applicationId,
+        build,
+        ctx,
+      });
+
+  const releaseStatus = profile.releaseStatus as unknown as SubmissionConfig.Android.ReleaseStatus;
+  const baseConfigInput = {
+    changesNotSentForReview: profile.changesNotSentForReview,
+    googleServiceAccountKeyJson,
+    track: profile.track,
+  };
+  const configInput: z.input<typeof SubmissionConfig.Android.SchemaZ> =
+    releaseStatus === SubmissionConfig.Android.ReleaseStatus.IN_PROGRESS
+      ? {
+          ...baseConfigInput,
+          releaseStatus,
+          rollout: profile.rollout,
+        }
+      : {
+          ...baseConfigInput,
+          releaseStatus,
+        };
+
+  return {
+    appIdentifier: applicationId,
+    config: SubmissionConfig.Android.SchemaZ.parse(configInput),
+    platform: Platform.ANDROID,
+  };
+}
+
+async function getGoogleServiceAccountKeyJsonAsync({
+  applicationId,
+  build,
+  ctx,
+}: {
+  applicationId?: string;
+  build: BuildInfo;
+  ctx: CustomBuildContext;
+}): Promise<string> {
+  if (!applicationId) {
+    throw new Error('Could not resolve Android applicationId from build metadata or artifact.');
+  }
+
+  const credentialsResult = await ctx.graphqlClient
+    .query(ANDROID_APP_CREDENTIALS_QUERY, {
+      applicationIdentifier: applicationId,
+      projectFullName: build.projectFullName,
+    })
+    .toPromise();
+  if (credentialsResult.error) {
+    throw credentialsResult.error;
+  }
+
+  const keyId =
+    credentialsResult.data?.app.byFullName.androidAppCredentials[0]
+      ?.googleServiceAccountKeyForSubmissions?.id;
+  if (!keyId) {
+    throw new Error(
+      `Google Service Account Key for submissions is not configured for ${applicationId}.`
+    );
+  }
+
+  const keyResult = await ctx.graphqlClient
+    .query(GOOGLE_SERVICE_ACCOUNT_KEY_QUERY, { id: keyId })
+    .toPromise();
+  if (keyResult.error) {
+    throw keyResult.error;
+  }
+  const keyJson = keyResult.data?.googleServiceAccountKey.byId.keyJson;
+  if (!keyJson) {
+    throw new Error(`Google Service Account Key ${keyId} could not be resolved.`);
+  }
+  return keyJson;
+}
+
+async function readAndroidApplicationIdAsync(
+  artifactPath: string,
+  env: BuildStepEnv,
+  logger: bunyan
+): Promise<string | undefined> {
+  if (artifactPath.endsWith('.apk')) {
+    return await readAndroidApplicationIdFromApkAsync(artifactPath, env, logger);
+  } else if (artifactPath.endsWith('.aab')) {
+    return await readAndroidApplicationIdFromAabAsync(artifactPath, env, logger);
+  }
+  return undefined;
+}
+
+async function readAndroidApplicationIdFromApkAsync(
+  apkPath: string,
+  env: BuildStepEnv,
+  logger: bunyan
+): Promise<string | undefined> {
+  const aapt2Result = await asyncResult(spawn('aapt2', ['dump', 'packagename', apkPath], { env }));
+  if (aapt2Result.ok) {
+    return aapt2Result.value.stdout.trim();
+  }
+  logger.warn('Failed to read APK package name with aapt2, trying aapt.');
+
+  const aaptResult = await asyncResult(spawn('aapt', ['dump', 'badging', apkPath], { env }));
+  if (!aaptResult.ok) {
+    logger.warn('Failed to read APK package name with aapt.');
+    return undefined;
+  }
+  return aaptResult.value.stdout.match(/package: name='([^']+)'/)?.[1];
+}
+
+async function readAndroidApplicationIdFromAabAsync(
+  aabPath: string,
+  env: BuildStepEnv,
+  logger: bunyan
+): Promise<string | undefined> {
+  const result = await asyncResult(
+    spawn('bundletool', ['dump', 'manifest', `--bundle=${aabPath}`, '--xpath=/manifest/@package'], {
+      env,
+    })
+  );
+  if (!result.ok) {
+    logger.warn('Failed to read AAB package name with bundletool.');
+    return undefined;
+  }
+  return result.value.stdout
+    .trim()
+    .replace(/^package="/, '')
+    .replace(/"$/, '');
+}

--- a/packages/build-tools/src/steps/functions/resolveSubmitConfig/android.ts
+++ b/packages/build-tools/src/steps/functions/resolveSubmitConfig/android.ts
@@ -1,4 +1,4 @@
-import { Platform, SubmissionConfig } from '@expo/eas-build-job';
+import { Platform, SubmissionConfig, SystemError, UserError } from '@expo/eas-build-job';
 import { SubmitProfile } from '@expo/eas-json';
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
@@ -24,19 +24,9 @@ const ANDROID_APP_CREDENTIALS_QUERY = graphql(`
           id
           googleServiceAccountKeyForSubmissions {
             id
+            keyJson
           }
         }
-      }
-    }
-  }
-`);
-
-const GOOGLE_SERVICE_ACCOUNT_KEY_QUERY = graphql(`
-  query ResolveSubmitConfigGoogleServiceAccountKey($id: ID!) {
-    googleServiceAccountKey {
-      byId(id: $id) {
-        id
-        keyJson
       }
     }
   }
@@ -51,7 +41,7 @@ export async function resolveAndroidSubmitConfigAsync({
   profile,
   workingDirectory,
 }: {
-  artifactPath?: string;
+  artifactPath: string;
   build: BuildInfo;
   ctx: CustomBuildContext;
   env: BuildStepEnv;
@@ -62,7 +52,7 @@ export async function resolveAndroidSubmitConfigAsync({
   const applicationId =
     build.appIdentifier ??
     profile.applicationId ??
-    (artifactPath ? await readAndroidApplicationIdAsync(artifactPath, env, logger) : undefined);
+    (await readAndroidApplicationIdAsync(artifactPath, env, logger));
 
   const googleServiceAccountKeyJson = profile.serviceAccountKeyPath
     ? await fs.readFile(path.resolve(workingDirectory, profile.serviceAccountKeyPath), 'utf8')
@@ -107,7 +97,10 @@ async function getGoogleServiceAccountKeyJsonAsync({
   ctx: CustomBuildContext;
 }): Promise<string> {
   if (!applicationId) {
-    throw new Error('Could not resolve Android applicationId from build metadata or artifact.');
+    throw new UserError(
+      'EAS_RESOLVE_SUBMIT_CONFIG_ANDROID_APPLICATION_ID_NOT_FOUND',
+      'Could not resolve Android applicationId from build metadata or artifact.'
+    );
   }
 
   const credentialsResult = await ctx.graphqlClient
@@ -120,26 +113,20 @@ async function getGoogleServiceAccountKeyJsonAsync({
     throw credentialsResult.error;
   }
 
-  const keyId =
+  const key =
     credentialsResult.data?.app.byFullName.androidAppCredentials[0]
-      ?.googleServiceAccountKeyForSubmissions?.id;
-  if (!keyId) {
-    throw new Error(
+      ?.googleServiceAccountKeyForSubmissions;
+  if (!key) {
+    throw new UserError(
+      'EAS_RESOLVE_SUBMIT_CONFIG_ANDROID_SERVICE_ACCOUNT_KEY_NOT_CONFIGURED',
       `Google Service Account Key for submissions is not configured for ${applicationId}.`
     );
   }
 
-  const keyResult = await ctx.graphqlClient
-    .query(GOOGLE_SERVICE_ACCOUNT_KEY_QUERY, { id: keyId })
-    .toPromise();
-  if (keyResult.error) {
-    throw keyResult.error;
+  if (!key.keyJson) {
+    throw new SystemError(`Google Service Account Key ${key.id} could not be resolved.`);
   }
-  const keyJson = keyResult.data?.googleServiceAccountKey.byId.keyJson;
-  if (!keyJson) {
-    throw new Error(`Google Service Account Key ${keyId} could not be resolved.`);
-  }
-  return keyJson;
+  return key.keyJson;
 }
 
 async function readAndroidApplicationIdAsync(

--- a/packages/build-tools/src/steps/functions/resolveSubmitConfig/android.ts
+++ b/packages/build-tools/src/steps/functions/resolveSubmitConfig/android.ts
@@ -1,5 +1,5 @@
 import { Platform, SubmissionConfig, SystemError, UserError } from '@expo/eas-build-job';
-import { SubmitProfile } from '@expo/eas-json';
+import { AndroidReleaseStatus, SubmitProfile } from '@expo/eas-json';
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
 import spawn from '@expo/turtle-spawn';
@@ -14,11 +14,11 @@ import { CustomBuildContext } from '../../../customBuildContext';
 
 const ANDROID_APP_CREDENTIALS_QUERY = graphql(`
   query ResolveSubmitConfigAndroidAppCredentials(
-    $projectFullName: String!
+    $appId: String!
     $applicationIdentifier: String
   ) {
     app {
-      byFullName(fullName: $projectFullName) {
+      byId(appId: $appId) {
         id
         androidAppCredentials(filter: { applicationIdentifier: $applicationIdentifier }) {
           id
@@ -31,6 +31,16 @@ const ANDROID_APP_CREDENTIALS_QUERY = graphql(`
     }
   }
 `);
+
+const AndroidReleaseStatusToSubmissionReleaseStatus: Record<
+  AndroidReleaseStatus,
+  SubmissionConfig.Android.ReleaseStatus
+> = {
+  [AndroidReleaseStatus.completed]: SubmissionConfig.Android.ReleaseStatus.COMPLETED,
+  [AndroidReleaseStatus.draft]: SubmissionConfig.Android.ReleaseStatus.DRAFT,
+  [AndroidReleaseStatus.halted]: SubmissionConfig.Android.ReleaseStatus.HALTED,
+  [AndroidReleaseStatus.inProgress]: SubmissionConfig.Android.ReleaseStatus.IN_PROGRESS,
+};
 
 export async function resolveAndroidSubmitConfigAsync({
   artifactPath,
@@ -53,16 +63,22 @@ export async function resolveAndroidSubmitConfigAsync({
     build.appIdentifier ??
     profile.applicationId ??
     (await readAndroidApplicationIdAsync(artifactPath, env, logger));
+  if (!applicationId) {
+    throw new UserError(
+      'EAS_RESOLVE_SUBMIT_CONFIG_ANDROID_APPLICATION_ID_NOT_FOUND',
+      'Could not resolve Android applicationId from build metadata or artifact. Set applicationId in the Android submit profile, or pass an APK/AAB artifact with a readable package name.'
+    );
+  }
 
   const googleServiceAccountKeyJson = profile.serviceAccountKeyPath
     ? await fs.readFile(path.resolve(workingDirectory, profile.serviceAccountKeyPath), 'utf8')
     : await getGoogleServiceAccountKeyJsonAsync({
         applicationId,
-        build,
+        appId: build.appId,
         ctx,
       });
 
-  const releaseStatus = profile.releaseStatus as unknown as SubmissionConfig.Android.ReleaseStatus;
+  const releaseStatus = AndroidReleaseStatusToSubmissionReleaseStatus[profile.releaseStatus];
   const baseConfigInput = {
     changesNotSentForReview: profile.changesNotSentForReview,
     googleServiceAccountKeyJson,
@@ -89,24 +105,17 @@ export async function resolveAndroidSubmitConfigAsync({
 
 async function getGoogleServiceAccountKeyJsonAsync({
   applicationId,
-  build,
+  appId,
   ctx,
 }: {
-  applicationId?: string;
-  build: BuildInfo;
+  applicationId: string;
+  appId: string;
   ctx: CustomBuildContext;
 }): Promise<string> {
-  if (!applicationId) {
-    throw new UserError(
-      'EAS_RESOLVE_SUBMIT_CONFIG_ANDROID_APPLICATION_ID_NOT_FOUND',
-      'Could not resolve Android applicationId from build metadata or artifact.'
-    );
-  }
-
   const credentialsResult = await ctx.graphqlClient
     .query(ANDROID_APP_CREDENTIALS_QUERY, {
+      appId,
       applicationIdentifier: applicationId,
-      projectFullName: build.projectFullName,
     })
     .toPromise();
   if (credentialsResult.error) {
@@ -114,12 +123,12 @@ async function getGoogleServiceAccountKeyJsonAsync({
   }
 
   const key =
-    credentialsResult.data?.app.byFullName.androidAppCredentials[0]
+    credentialsResult.data?.app.byId.androidAppCredentials[0]
       ?.googleServiceAccountKeyForSubmissions;
   if (!key) {
     throw new UserError(
       'EAS_RESOLVE_SUBMIT_CONFIG_ANDROID_SERVICE_ACCOUNT_KEY_NOT_CONFIGURED',
-      `Google Service Account Key for submissions is not configured for ${applicationId}.`
+      `Google Service Account Key for submissions is not configured for ${applicationId}. Configure a Google Service Account Key for submissions in EAS credentials, or set serviceAccountKeyPath in the Android submit profile.`
     );
   }
 
@@ -151,14 +160,8 @@ async function readAndroidApplicationIdFromApkAsync(
   if (aapt2Result.ok) {
     return aapt2Result.value.stdout.trim();
   }
-  logger.warn('Failed to read APK package name with aapt2, trying aapt.');
-
-  const aaptResult = await asyncResult(spawn('aapt', ['dump', 'badging', apkPath], { env }));
-  if (!aaptResult.ok) {
-    logger.warn('Failed to read APK package name with aapt.');
-    return undefined;
-  }
-  return aaptResult.value.stdout.match(/package: name='([^']+)'/)?.[1];
+  logger.warn('Failed to read APK package name with aapt2.');
+  return undefined;
 }
 
 async function readAndroidApplicationIdFromAabAsync(
@@ -175,8 +178,5 @@ async function readAndroidApplicationIdFromAabAsync(
     logger.warn('Failed to read AAB package name with bundletool.');
     return undefined;
   }
-  return result.value.stdout
-    .trim()
-    .replace(/^package="/, '')
-    .replace(/"$/, '');
+  return result.value.stdout.trim();
 }

--- a/packages/build-tools/src/steps/functions/resolveSubmitConfig/common.ts
+++ b/packages/build-tools/src/steps/functions/resolveSubmitConfig/common.ts
@@ -13,10 +13,10 @@ export const AppPlatformToPlatform: Record<AppPlatform, Platform> = {
 
 export type BuildInfo = {
   appIdentifier?: string | null;
+  appId: string;
   buildId: string;
+  projectOwnerAccountId: string;
   platform: Platform;
-  projectFullName: string;
-  projectOwnerAccountName: string;
 };
 
 export type ResolvedSubmitConfig = {
@@ -34,10 +34,8 @@ const BUILD_BY_ID_QUERY = graphql(`
         appIdentifier
         app {
           id
-          slug
           ownerAccount {
             id
-            name
           }
         }
       }
@@ -62,10 +60,10 @@ export async function getBuildInfoAsync(
   }
   return {
     appIdentifier: build.appIdentifier,
+    appId: build.app.id,
     buildId: build.id,
+    projectOwnerAccountId: build.app.ownerAccount.id,
     platform: AppPlatformToPlatform[build.platform],
-    projectFullName: `@${build.app.ownerAccount.name}/${build.app.slug}`,
-    projectOwnerAccountName: build.app.ownerAccount.name,
   };
 }
 

--- a/packages/build-tools/src/steps/functions/resolveSubmitConfig/common.ts
+++ b/packages/build-tools/src/steps/functions/resolveSubmitConfig/common.ts
@@ -1,0 +1,129 @@
+import { Platform, SubmissionConfig } from '@expo/eas-build-job';
+import { EasJsonAccessor, EasJsonUtils, SubmitProfile } from '@expo/eas-json';
+import { bunyan } from '@expo/logger';
+import { BuildStepEnv } from '@expo/steps';
+import { graphql } from 'gql.tada';
+
+import { downloadBuildAsync } from '../downloadBuild';
+import { CustomBuildContext } from '../../../customBuildContext';
+
+export type AppPlatform = 'ANDROID' | 'IOS';
+
+export type BuildInfo = {
+  appIdentifier?: string | null;
+  appPlatform: AppPlatform;
+  buildId: string;
+  buildProfile?: string | null;
+  projectFullName: string;
+  projectOwnerAccountName: string;
+};
+
+export type ResolvedSubmitConfig = {
+  appIdentifier?: string;
+  config: SubmissionConfig.Android | SubmissionConfig.Ios;
+  platform: Platform;
+};
+
+const BUILD_BY_ID_QUERY = graphql(`
+  query ResolveSubmitConfigBuildById($buildId: ID!) {
+    builds {
+      byId(buildId: $buildId) {
+        id
+        platform
+        appIdentifier
+        buildProfile
+        app {
+          id
+          slug
+          ownerAccount {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+`);
+
+export async function getBuildInfoAsync(
+  ctx: CustomBuildContext,
+  buildId: string
+): Promise<BuildInfo> {
+  const result = await ctx.graphqlClient.query(BUILD_BY_ID_QUERY, { buildId }).toPromise();
+  if (result.error) {
+    throw result.error;
+  }
+  const build = result.data?.builds.byId;
+  if (!build) {
+    throw new Error(`Could not find build ${buildId}.`);
+  }
+  return {
+    appIdentifier: build.appIdentifier,
+    appPlatform: build.platform,
+    buildId: build.id,
+    buildProfile: build.buildProfile,
+    projectFullName: `@${build.app.ownerAccount.name}/${build.app.slug}`,
+    projectOwnerAccountName: build.app.ownerAccount.name,
+  };
+}
+
+export async function getSubmitProfileAsync<T extends Platform>({
+  env,
+  platform,
+  profileName,
+  workingDirectory,
+}: {
+  env: BuildStepEnv;
+  platform: T;
+  profileName?: string;
+  workingDirectory: string;
+}): Promise<SubmitProfile<T>> {
+  return await withEnvAsync(env, async () =>
+    EasJsonUtils.getSubmitProfileAsync(
+      EasJsonAccessor.fromProjectPath(workingDirectory),
+      platform,
+      profileName
+    )
+  );
+}
+
+export async function resolveArtifactPathAsync({
+  artifactPath,
+  build,
+  ctx,
+  logger,
+  platform,
+}: {
+  artifactPath?: string;
+  build: BuildInfo;
+  ctx: CustomBuildContext;
+  logger: bunyan;
+  platform: Platform;
+}): Promise<string | undefined> {
+  if (artifactPath || build.appIdentifier) {
+    return artifactPath;
+  }
+
+  const { artifactPath: downloadedArtifactPath } = await downloadBuildAsync({
+    buildId: build.buildId,
+    extensions: platform === Platform.ANDROID ? ['apk', 'aab'] : ['ipa'],
+    expoApiServerURL: ctx.env.__API_SERVER_URL,
+    logger,
+    robotAccessToken: ctx.job.secrets?.robotAccessToken ?? null,
+  });
+  return downloadedArtifactPath;
+}
+
+export function appPlatformToPlatform(platform: AppPlatform): Platform {
+  return platform === 'ANDROID' ? Platform.ANDROID : Platform.IOS;
+}
+
+async function withEnvAsync<T>(env: BuildStepEnv, fn: () => Promise<T>): Promise<T> {
+  const originalEnv = process.env;
+  try {
+    process.env = { ...process.env, ...env };
+    return await fn();
+  } finally {
+    process.env = originalEnv;
+  }
+}

--- a/packages/build-tools/src/steps/functions/resolveSubmitConfig/common.ts
+++ b/packages/build-tools/src/steps/functions/resolveSubmitConfig/common.ts
@@ -1,19 +1,20 @@
-import { Platform, SubmissionConfig } from '@expo/eas-build-job';
+import { Platform, SubmissionConfig, UserError } from '@expo/eas-build-job';
 import { EasJsonAccessor, EasJsonUtils, SubmitProfile } from '@expo/eas-json';
-import { bunyan } from '@expo/logger';
-import { BuildStepEnv } from '@expo/steps';
 import { graphql } from 'gql.tada';
 
-import { downloadBuildAsync } from '../downloadBuild';
 import { CustomBuildContext } from '../../../customBuildContext';
 
 export type AppPlatform = 'ANDROID' | 'IOS';
 
+export const AppPlatformToPlatform: Record<AppPlatform, Platform> = {
+  ANDROID: Platform.ANDROID,
+  IOS: Platform.IOS,
+};
+
 export type BuildInfo = {
   appIdentifier?: string | null;
-  appPlatform: AppPlatform;
   buildId: string;
-  buildProfile?: string | null;
+  platform: Platform;
   projectFullName: string;
   projectOwnerAccountName: string;
 };
@@ -31,7 +32,6 @@ const BUILD_BY_ID_QUERY = graphql(`
         id
         platform
         appIdentifier
-        buildProfile
         app {
           id
           slug
@@ -55,75 +55,32 @@ export async function getBuildInfoAsync(
   }
   const build = result.data?.builds.byId;
   if (!build) {
-    throw new Error(`Could not find build ${buildId}.`);
+    throw new UserError(
+      'EAS_RESOLVE_SUBMIT_CONFIG_BUILD_NOT_FOUND',
+      `Could not find build ${buildId}.`
+    );
   }
   return {
     appIdentifier: build.appIdentifier,
-    appPlatform: build.platform,
     buildId: build.id,
-    buildProfile: build.buildProfile,
+    platform: AppPlatformToPlatform[build.platform],
     projectFullName: `@${build.app.ownerAccount.name}/${build.app.slug}`,
     projectOwnerAccountName: build.app.ownerAccount.name,
   };
 }
 
 export async function getSubmitProfileAsync<T extends Platform>({
-  env,
   platform,
   profileName,
   workingDirectory,
 }: {
-  env: BuildStepEnv;
   platform: T;
-  profileName?: string;
+  profileName: string;
   workingDirectory: string;
 }): Promise<SubmitProfile<T>> {
-  return await withEnvAsync(env, async () =>
-    EasJsonUtils.getSubmitProfileAsync(
-      EasJsonAccessor.fromProjectPath(workingDirectory),
-      platform,
-      profileName
-    )
+  return await EasJsonUtils.getSubmitProfileAsync(
+    EasJsonAccessor.fromProjectPath(workingDirectory),
+    platform,
+    profileName
   );
-}
-
-export async function resolveArtifactPathAsync({
-  artifactPath,
-  build,
-  ctx,
-  logger,
-  platform,
-}: {
-  artifactPath?: string;
-  build: BuildInfo;
-  ctx: CustomBuildContext;
-  logger: bunyan;
-  platform: Platform;
-}): Promise<string | undefined> {
-  if (artifactPath || build.appIdentifier) {
-    return artifactPath;
-  }
-
-  const { artifactPath: downloadedArtifactPath } = await downloadBuildAsync({
-    buildId: build.buildId,
-    extensions: platform === Platform.ANDROID ? ['apk', 'aab'] : ['ipa'],
-    expoApiServerURL: ctx.env.__API_SERVER_URL,
-    logger,
-    robotAccessToken: ctx.job.secrets?.robotAccessToken ?? null,
-  });
-  return downloadedArtifactPath;
-}
-
-export function appPlatformToPlatform(platform: AppPlatform): Platform {
-  return platform === 'ANDROID' ? Platform.ANDROID : Platform.IOS;
-}
-
-async function withEnvAsync<T>(env: BuildStepEnv, fn: () => Promise<T>): Promise<T> {
-  const originalEnv = process.env;
-  try {
-    process.env = { ...process.env, ...env };
-    return await fn();
-  } finally {
-    process.env = originalEnv;
-  }
 }

--- a/packages/build-tools/src/steps/functions/resolveSubmitConfig/index.ts
+++ b/packages/build-tools/src/steps/functions/resolveSubmitConfig/index.ts
@@ -1,4 +1,4 @@
-import { Platform } from '@expo/eas-build-job';
+import { Platform, SystemError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import {
   BuildFunction,
@@ -11,13 +11,7 @@ import path from 'node:path';
 import { z } from 'zod';
 
 import { resolveAndroidSubmitConfigAsync } from './android';
-import {
-  ResolvedSubmitConfig,
-  appPlatformToPlatform,
-  getBuildInfoAsync,
-  getSubmitProfileAsync,
-  resolveArtifactPathAsync,
-} from './common';
+import { ResolvedSubmitConfig, getBuildInfoAsync, getSubmitProfileAsync } from './common';
 import { resolveIosSubmitConfigAsync } from './ios';
 import { CustomBuildContext } from '../../../customBuildContext';
 
@@ -35,18 +29,18 @@ export function createResolveSubmitConfigBuildFunction(ctx: CustomBuildContext):
       }),
       BuildStepInput.createProvider({
         id: 'profile',
-        required: false,
+        required: true,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
       BuildStepInput.createProvider({
         id: 'artifact_path',
-        required: false,
+        required: true,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
     ],
     outputProviders: [
       BuildStepOutput.createProvider({
-        id: 'config',
+        id: 'config_json',
         required: true,
       }),
       BuildStepOutput.createProvider({
@@ -60,10 +54,11 @@ export function createResolveSubmitConfigBuildFunction(ctx: CustomBuildContext):
     ],
     fn: async (stepsCtx, { env, inputs, outputs }) => {
       const buildId = z.string().uuid().parse(inputs.build_id.value);
-      const profileName = inputs.profile.value ? z.string().parse(inputs.profile.value) : undefined;
-      const artifactPath = inputs.artifact_path.value
-        ? path.resolve(stepsCtx.workingDirectory, z.string().parse(inputs.artifact_path.value))
-        : undefined;
+      const profileName = z.string().parse(inputs.profile.value);
+      const artifactPath = path.resolve(
+        stepsCtx.workingDirectory,
+        z.string().parse(inputs.artifact_path.value)
+      );
 
       const { config, platform, appIdentifier } = await resolveSubmitConfigAsync({
         artifactPath,
@@ -75,7 +70,7 @@ export function createResolveSubmitConfigBuildFunction(ctx: CustomBuildContext):
         workingDirectory: stepsCtx.workingDirectory,
       });
 
-      outputs.config.set(JSON.stringify(config));
+      outputs.config_json.set(JSON.stringify(config));
       outputs.platform.set(platform);
       if (appIdentifier) {
         outputs.app_identifier.set(appIdentifier);
@@ -93,56 +88,50 @@ export async function resolveSubmitConfigAsync({
   profileName,
   workingDirectory,
 }: {
-  artifactPath?: string;
+  artifactPath: string;
   buildId: string;
   ctx: CustomBuildContext;
   env: BuildStepEnv;
   logger: bunyan;
-  profileName?: string;
+  profileName: string;
   workingDirectory: string;
 }): Promise<ResolvedSubmitConfig> {
   logger.info('Resolving submit config...');
   const build = await getBuildInfoAsync(ctx, buildId);
-  const platform = appPlatformToPlatform(build.appPlatform);
-  const submitProfileName = profileName ?? build.buildProfile ?? undefined;
-  const resolvedArtifactPath = await resolveArtifactPathAsync({
-    artifactPath,
-    build,
-    ctx,
-    logger,
-    platform,
-  });
 
-  if (platform === Platform.ANDROID) {
-    const profile = await getSubmitProfileAsync({
-      env,
-      platform,
-      profileName: submitProfileName,
-      workingDirectory,
-    });
-    return await resolveAndroidSubmitConfigAsync({
-      artifactPath: resolvedArtifactPath,
-      build,
-      ctx,
-      env,
-      logger,
-      profile,
-      workingDirectory,
-    });
+  switch (build.platform) {
+    case Platform.ANDROID: {
+      const profile = await getSubmitProfileAsync({
+        platform: build.platform,
+        profileName,
+        workingDirectory,
+      });
+      return await resolveAndroidSubmitConfigAsync({
+        artifactPath,
+        build,
+        ctx,
+        env,
+        logger,
+        profile,
+        workingDirectory,
+      });
+    }
+    case Platform.IOS: {
+      const profile = await getSubmitProfileAsync({
+        platform: build.platform,
+        profileName,
+        workingDirectory,
+      });
+      return await resolveIosSubmitConfigAsync({
+        artifactPath,
+        build,
+        ctx,
+        env,
+        profile,
+        workingDirectory,
+      });
+    }
+    default:
+      throw new SystemError(`Unsupported platform: ${build.platform}`);
   }
-
-  const profile = await getSubmitProfileAsync({
-    env,
-    platform,
-    profileName: submitProfileName,
-    workingDirectory,
-  });
-  return await resolveIosSubmitConfigAsync({
-    artifactPath: resolvedArtifactPath,
-    build,
-    ctx,
-    env,
-    profile,
-    workingDirectory,
-  });
 }

--- a/packages/build-tools/src/steps/functions/resolveSubmitConfig/index.ts
+++ b/packages/build-tools/src/steps/functions/resolveSubmitConfig/index.ts
@@ -124,10 +124,12 @@ export async function resolveSubmitConfigAsync({
       });
       return await resolveIosSubmitConfigAsync({
         artifactPath,
-        build,
+        appId: build.appId,
+        buildAppIdentifier: build.appIdentifier,
         ctx,
         env,
         profile,
+        projectOwnerAccountId: build.projectOwnerAccountId,
         workingDirectory,
       });
     }

--- a/packages/build-tools/src/steps/functions/resolveSubmitConfig/index.ts
+++ b/packages/build-tools/src/steps/functions/resolveSubmitConfig/index.ts
@@ -1,0 +1,148 @@
+import { Platform } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
+import {
+  BuildFunction,
+  BuildStepEnv,
+  BuildStepInput,
+  BuildStepInputValueTypeName,
+  BuildStepOutput,
+} from '@expo/steps';
+import path from 'node:path';
+import { z } from 'zod';
+
+import { resolveAndroidSubmitConfigAsync } from './android';
+import {
+  ResolvedSubmitConfig,
+  appPlatformToPlatform,
+  getBuildInfoAsync,
+  getSubmitProfileAsync,
+  resolveArtifactPathAsync,
+} from './common';
+import { resolveIosSubmitConfigAsync } from './ios';
+import { CustomBuildContext } from '../../../customBuildContext';
+
+export function createResolveSubmitConfigBuildFunction(ctx: CustomBuildContext): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'resolve_submit_config',
+    name: 'Resolve submit config',
+    __metricsId: 'eas/resolve_submit_config',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'build_id',
+        required: true,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+      BuildStepInput.createProvider({
+        id: 'profile',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+      BuildStepInput.createProvider({
+        id: 'artifact_path',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+    ],
+    outputProviders: [
+      BuildStepOutput.createProvider({
+        id: 'config',
+        required: true,
+      }),
+      BuildStepOutput.createProvider({
+        id: 'platform',
+        required: true,
+      }),
+      BuildStepOutput.createProvider({
+        id: 'app_identifier',
+        required: false,
+      }),
+    ],
+    fn: async (stepsCtx, { env, inputs, outputs }) => {
+      const buildId = z.string().uuid().parse(inputs.build_id.value);
+      const profileName = inputs.profile.value ? z.string().parse(inputs.profile.value) : undefined;
+      const artifactPath = inputs.artifact_path.value
+        ? path.resolve(stepsCtx.workingDirectory, z.string().parse(inputs.artifact_path.value))
+        : undefined;
+
+      const { config, platform, appIdentifier } = await resolveSubmitConfigAsync({
+        artifactPath,
+        buildId,
+        ctx,
+        env,
+        logger: stepsCtx.logger,
+        profileName,
+        workingDirectory: stepsCtx.workingDirectory,
+      });
+
+      outputs.config.set(JSON.stringify(config));
+      outputs.platform.set(platform);
+      if (appIdentifier) {
+        outputs.app_identifier.set(appIdentifier);
+      }
+    },
+  });
+}
+
+export async function resolveSubmitConfigAsync({
+  artifactPath,
+  buildId,
+  ctx,
+  env,
+  logger,
+  profileName,
+  workingDirectory,
+}: {
+  artifactPath?: string;
+  buildId: string;
+  ctx: CustomBuildContext;
+  env: BuildStepEnv;
+  logger: bunyan;
+  profileName?: string;
+  workingDirectory: string;
+}): Promise<ResolvedSubmitConfig> {
+  logger.info('Resolving submit config...');
+  const build = await getBuildInfoAsync(ctx, buildId);
+  const platform = appPlatformToPlatform(build.appPlatform);
+  const submitProfileName = profileName ?? build.buildProfile ?? undefined;
+  const resolvedArtifactPath = await resolveArtifactPathAsync({
+    artifactPath,
+    build,
+    ctx,
+    logger,
+    platform,
+  });
+
+  if (platform === Platform.ANDROID) {
+    const profile = await getSubmitProfileAsync({
+      env,
+      platform,
+      profileName: submitProfileName,
+      workingDirectory,
+    });
+    return await resolveAndroidSubmitConfigAsync({
+      artifactPath: resolvedArtifactPath,
+      build,
+      ctx,
+      env,
+      logger,
+      profile,
+      workingDirectory,
+    });
+  }
+
+  const profile = await getSubmitProfileAsync({
+    env,
+    platform,
+    profileName: submitProfileName,
+    workingDirectory,
+  });
+  return await resolveIosSubmitConfigAsync({
+    artifactPath: resolvedArtifactPath,
+    build,
+    ctx,
+    env,
+    profile,
+    workingDirectory,
+  });
+}

--- a/packages/build-tools/src/steps/functions/resolveSubmitConfig/ios.ts
+++ b/packages/build-tools/src/steps/functions/resolveSubmitConfig/ios.ts
@@ -1,4 +1,4 @@
-import { Platform, SubmissionConfig } from '@expo/eas-build-job';
+import { Platform, SubmissionConfig, SystemError, UserError } from '@expo/eas-build-job';
 import { SubmitProfile } from '@expo/eas-json';
 import { BuildStepEnv } from '@expo/steps';
 import fs from 'fs-extra';
@@ -67,7 +67,7 @@ export async function resolveIosSubmitConfigAsync({
   profile,
   workingDirectory,
 }: {
-  artifactPath?: string;
+  artifactPath: string;
   build: BuildInfo;
   ctx: CustomBuildContext;
   env: BuildStepEnv;
@@ -77,10 +77,13 @@ export async function resolveIosSubmitConfigAsync({
   const bundleIdentifier =
     build.appIdentifier ??
     profile.bundleIdentifier ??
-    (artifactPath ? (await readIpaInfoAsync(artifactPath)).bundleIdentifier : undefined);
+    (await readIpaInfoAsync(artifactPath)).bundleIdentifier;
 
   if (!profile.ascAppId) {
-    throw new Error('Set ascAppId in the submit profile in eas.json.');
+    throw new UserError(
+      'EAS_RESOLVE_SUBMIT_CONFIG_IOS_ASC_APP_ID_NOT_CONFIGURED',
+      'Set ascAppId in the submit profile in eas.json.'
+    );
   }
 
   const appSpecificPassword = env.EXPO_APPLE_APP_SPECIFIC_PASSWORD;
@@ -132,13 +135,17 @@ async function getAscApiJsonKeyAsync({
   }
 
   if (profile.ascApiKeyPath || profile.ascApiKeyIssuerId || profile.ascApiKeyId) {
-    throw new Error(
+    throw new UserError(
+      'EAS_RESOLVE_SUBMIT_CONFIG_IOS_ASC_API_KEY_INCOMPLETE',
       'ascApiKeyPath, ascApiKeyIssuerId and ascApiKeyId must all be defined in eas.json.'
     );
   }
 
   if (!bundleIdentifier) {
-    throw new Error('Could not resolve iOS bundleIdentifier from build metadata or artifact.');
+    throw new UserError(
+      'EAS_RESOLVE_SUBMIT_CONFIG_IOS_BUNDLE_IDENTIFIER_NOT_FOUND',
+      'Could not resolve iOS bundleIdentifier from build metadata or artifact.'
+    );
   }
 
   const appleAppIdentifierResult = await ctx.graphqlClient
@@ -154,7 +161,10 @@ async function getAscApiJsonKeyAsync({
   const appleAppIdentifierId =
     appleAppIdentifierResult.data?.account.byName.appleAppIdentifiers[0]?.id;
   if (!appleAppIdentifierId) {
-    throw new Error(`Apple App Identifier is not configured for ${bundleIdentifier}.`);
+    throw new UserError(
+      'EAS_RESOLVE_SUBMIT_CONFIG_IOS_APP_IDENTIFIER_NOT_CONFIGURED',
+      `Apple App Identifier is not configured for ${bundleIdentifier}.`
+    );
   }
 
   const credentialsResult = await ctx.graphqlClient
@@ -171,7 +181,8 @@ async function getAscApiJsonKeyAsync({
     credentialsResult.data?.app.byFullName.iosAppCredentials[0]?.appStoreConnectApiKeyForSubmissions
       ?.id;
   if (!ascApiKeyId) {
-    throw new Error(
+    throw new UserError(
+      'EAS_RESOLVE_SUBMIT_CONFIG_IOS_ASC_API_KEY_NOT_CONFIGURED',
       `App Store Connect API Key for submissions is not configured for ${bundleIdentifier}.`
     );
   }
@@ -185,7 +196,7 @@ async function getAscApiJsonKeyAsync({
 
   const apiKey = apiKeyResult.data?.appStoreConnectApiKey.byId;
   if (!apiKey) {
-    throw new Error(`App Store Connect API Key ${ascApiKeyId} could not be resolved.`);
+    throw new SystemError(`App Store Connect API Key ${ascApiKeyId} could not be resolved.`);
   }
   return JSON.stringify({
     issuer_id: apiKey.issuerIdentifier,
@@ -196,7 +207,8 @@ async function getAscApiJsonKeyAsync({
 
 function validateAppSpecificPassword(password: string): string {
   if (!/^[a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4}$/.test(password)) {
-    throw new Error(
+    throw new UserError(
+      'EAS_RESOLVE_SUBMIT_CONFIG_IOS_APP_SPECIFIC_PASSWORD_INVALID',
       'EXPO_APPLE_APP_SPECIFIC_PASSWORD must be in the format xxxx-xxxx-xxxx-xxxx, where x is a lowercase letter.'
     );
   }
@@ -205,7 +217,8 @@ function validateAppSpecificPassword(password: string): string {
 
 function requireAppleIdUsername(appleIdUsername?: string): string {
   if (!appleIdUsername) {
-    throw new Error(
+    throw new UserError(
+      'EAS_RESOLVE_SUBMIT_CONFIG_IOS_APPLE_ID_NOT_CONFIGURED',
       'Set appleId in the submit profile or EXPO_APPLE_ID when using EXPO_APPLE_APP_SPECIFIC_PASSWORD.'
     );
   }

--- a/packages/build-tools/src/steps/functions/resolveSubmitConfig/ios.ts
+++ b/packages/build-tools/src/steps/functions/resolveSubmitConfig/ios.ts
@@ -1,4 +1,4 @@
-import { Platform, SubmissionConfig, SystemError, UserError } from '@expo/eas-build-job';
+import { Platform, SubmissionConfig, UserError } from '@expo/eas-build-job';
 import { SubmitProfile } from '@expo/eas-json';
 import { BuildStepEnv } from '@expo/steps';
 import fs from 'fs-extra';
@@ -7,16 +7,16 @@ import path from 'node:path';
 import { z } from 'zod';
 
 import { readIpaInfoAsync } from '../readIpaInfo';
-import { BuildInfo, ResolvedSubmitConfig } from './common';
+import { ResolvedSubmitConfig } from './common';
 import { CustomBuildContext } from '../../../customBuildContext';
 
 const APPLE_APP_IDENTIFIER_QUERY = graphql(`
   query ResolveSubmitConfigAppleAppIdentifier(
-    $accountName: String!
+    $accountId: String!
     $bundleIdentifier: String!
   ) {
     account {
-      byName(accountName: $accountName) {
+      byId(accountId: $accountId) {
         id
         appleAppIdentifiers(bundleIdentifier: $bundleIdentifier) {
           id
@@ -29,16 +29,19 @@ const APPLE_APP_IDENTIFIER_QUERY = graphql(`
 
 const IOS_APP_CREDENTIALS_QUERY = graphql(`
   query ResolveSubmitConfigIosAppCredentials(
-    $projectFullName: String!
+    $appId: String!
     $appleAppIdentifierId: String!
   ) {
     app {
-      byFullName(fullName: $projectFullName) {
+      byId(appId: $appId) {
         id
         iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
           id
           appStoreConnectApiKeyForSubmissions {
             id
+            issuerIdentifier
+            keyIdentifier
+            keyP8
           }
         }
       }
@@ -46,36 +49,27 @@ const IOS_APP_CREDENTIALS_QUERY = graphql(`
   }
 `);
 
-const APP_STORE_CONNECT_API_KEY_QUERY = graphql(`
-  query ResolveSubmitConfigAppStoreConnectApiKey($id: ID!) {
-    appStoreConnectApiKey {
-      byId(id: $id) {
-        id
-        issuerIdentifier
-        keyIdentifier
-        keyP8
-      }
-    }
-  }
-`);
-
 export async function resolveIosSubmitConfigAsync({
+  appId,
   artifactPath,
-  build,
+  buildAppIdentifier,
   ctx,
   env,
   profile,
+  projectOwnerAccountId,
   workingDirectory,
 }: {
+  appId: string;
   artifactPath: string;
-  build: BuildInfo;
+  buildAppIdentifier?: string | null;
   ctx: CustomBuildContext;
   env: BuildStepEnv;
   profile: SubmitProfile<Platform.IOS>;
+  projectOwnerAccountId: string;
   workingDirectory: string;
 }): Promise<ResolvedSubmitConfig> {
   const bundleIdentifier =
-    build.appIdentifier ??
+    buildAppIdentifier ??
     profile.bundleIdentifier ??
     (await readIpaInfoAsync(artifactPath)).bundleIdentifier;
 
@@ -97,7 +91,8 @@ export async function resolveIosSubmitConfigAsync({
         }
       : {
           ascApiJsonKey: await getAscApiJsonKeyAsync({
-            build,
+            accountId: projectOwnerAccountId,
+            appId,
             bundleIdentifier,
             ctx,
             profile,
@@ -114,18 +109,21 @@ export async function resolveIosSubmitConfigAsync({
 }
 
 async function getAscApiJsonKeyAsync({
-  build,
+  accountId,
+  appId,
   bundleIdentifier,
   ctx,
   profile,
   workingDirectory,
 }: {
-  build: BuildInfo;
+  accountId: string;
+  appId: string;
   bundleIdentifier?: string;
   ctx: CustomBuildContext;
   profile: SubmitProfile<Platform.IOS>;
   workingDirectory: string;
 }): Promise<string> {
+  // Prefer explicit local ASC API key fields from eas.json when all are present.
   if (profile.ascApiKeyPath && profile.ascApiKeyIssuerId && profile.ascApiKeyId) {
     return JSON.stringify({
       issuer_id: profile.ascApiKeyIssuerId,
@@ -144,13 +142,14 @@ async function getAscApiJsonKeyAsync({
   if (!bundleIdentifier) {
     throw new UserError(
       'EAS_RESOLVE_SUBMIT_CONFIG_IOS_BUNDLE_IDENTIFIER_NOT_FOUND',
-      'Could not resolve iOS bundleIdentifier from build metadata or artifact.'
+      'Could not resolve iOS bundleIdentifier from build metadata or artifact. Set bundleIdentifier in the iOS submit profile, or pass an IPA artifact with a readable bundle identifier.'
     );
   }
 
+  // Server credentials are keyed by the Apple App Identifier, so first map the bundle id to it.
   const appleAppIdentifierResult = await ctx.graphqlClient
     .query(APPLE_APP_IDENTIFIER_QUERY, {
-      accountName: build.projectOwnerAccountName,
+      accountId,
       bundleIdentifier,
     })
     .toPromise();
@@ -159,49 +158,38 @@ async function getAscApiJsonKeyAsync({
   }
 
   const appleAppIdentifierId =
-    appleAppIdentifierResult.data?.account.byName.appleAppIdentifiers[0]?.id;
+    appleAppIdentifierResult.data?.account.byId.appleAppIdentifiers[0]?.id;
   if (!appleAppIdentifierId) {
     throw new UserError(
       'EAS_RESOLVE_SUBMIT_CONFIG_IOS_APP_IDENTIFIER_NOT_CONFIGURED',
-      `Apple App Identifier is not configured for ${bundleIdentifier}.`
+      `Apple App Identifier is not configured for ${bundleIdentifier}. Configure the bundle identifier in EAS credentials for this account.`
     );
   }
 
+  // The app credentials record points at the ASC API key selected for submissions.
   const credentialsResult = await ctx.graphqlClient
     .query(IOS_APP_CREDENTIALS_QUERY, {
+      appId,
       appleAppIdentifierId,
-      projectFullName: build.projectFullName,
     })
     .toPromise();
   if (credentialsResult.error) {
     throw credentialsResult.error;
   }
 
-  const ascApiKeyId =
-    credentialsResult.data?.app.byFullName.iosAppCredentials[0]?.appStoreConnectApiKeyForSubmissions
-      ?.id;
-  if (!ascApiKeyId) {
+  const ascApiKey =
+    credentialsResult.data?.app.byId.iosAppCredentials[0]?.appStoreConnectApiKeyForSubmissions;
+  if (!ascApiKey) {
     throw new UserError(
       'EAS_RESOLVE_SUBMIT_CONFIG_IOS_ASC_API_KEY_NOT_CONFIGURED',
-      `App Store Connect API Key for submissions is not configured for ${bundleIdentifier}.`
+      `App Store Connect API Key for submissions is not configured for ${bundleIdentifier}. Configure an App Store Connect API Key for submissions in EAS credentials, or set ascApiKeyPath, ascApiKeyIssuerId, and ascApiKeyId in the iOS submit profile.`
     );
   }
 
-  const apiKeyResult = await ctx.graphqlClient
-    .query(APP_STORE_CONNECT_API_KEY_QUERY, { id: ascApiKeyId })
-    .toPromise();
-  if (apiKeyResult.error) {
-    throw apiKeyResult.error;
-  }
-
-  const apiKey = apiKeyResult.data?.appStoreConnectApiKey.byId;
-  if (!apiKey) {
-    throw new SystemError(`App Store Connect API Key ${ascApiKeyId} could not be resolved.`);
-  }
   return JSON.stringify({
-    issuer_id: apiKey.issuerIdentifier,
-    key: apiKey.keyP8,
-    key_id: apiKey.keyIdentifier,
+    issuer_id: ascApiKey.issuerIdentifier,
+    key: ascApiKey.keyP8,
+    key_id: ascApiKey.keyIdentifier,
   });
 }
 

--- a/packages/build-tools/src/steps/functions/resolveSubmitConfig/ios.ts
+++ b/packages/build-tools/src/steps/functions/resolveSubmitConfig/ios.ts
@@ -1,0 +1,213 @@
+import { Platform, SubmissionConfig } from '@expo/eas-build-job';
+import { SubmitProfile } from '@expo/eas-json';
+import { BuildStepEnv } from '@expo/steps';
+import fs from 'fs-extra';
+import { graphql } from 'gql.tada';
+import path from 'node:path';
+import { z } from 'zod';
+
+import { readIpaInfoAsync } from '../readIpaInfo';
+import { BuildInfo, ResolvedSubmitConfig } from './common';
+import { CustomBuildContext } from '../../../customBuildContext';
+
+const APPLE_APP_IDENTIFIER_QUERY = graphql(`
+  query ResolveSubmitConfigAppleAppIdentifier(
+    $accountName: String!
+    $bundleIdentifier: String!
+  ) {
+    account {
+      byName(accountName: $accountName) {
+        id
+        appleAppIdentifiers(bundleIdentifier: $bundleIdentifier) {
+          id
+          bundleIdentifier
+        }
+      }
+    }
+  }
+`);
+
+const IOS_APP_CREDENTIALS_QUERY = graphql(`
+  query ResolveSubmitConfigIosAppCredentials(
+    $projectFullName: String!
+    $appleAppIdentifierId: String!
+  ) {
+    app {
+      byFullName(fullName: $projectFullName) {
+        id
+        iosAppCredentials(filter: { appleAppIdentifierId: $appleAppIdentifierId }) {
+          id
+          appStoreConnectApiKeyForSubmissions {
+            id
+          }
+        }
+      }
+    }
+  }
+`);
+
+const APP_STORE_CONNECT_API_KEY_QUERY = graphql(`
+  query ResolveSubmitConfigAppStoreConnectApiKey($id: ID!) {
+    appStoreConnectApiKey {
+      byId(id: $id) {
+        id
+        issuerIdentifier
+        keyIdentifier
+        keyP8
+      }
+    }
+  }
+`);
+
+export async function resolveIosSubmitConfigAsync({
+  artifactPath,
+  build,
+  ctx,
+  env,
+  profile,
+  workingDirectory,
+}: {
+  artifactPath?: string;
+  build: BuildInfo;
+  ctx: CustomBuildContext;
+  env: BuildStepEnv;
+  profile: SubmitProfile<Platform.IOS>;
+  workingDirectory: string;
+}): Promise<ResolvedSubmitConfig> {
+  const bundleIdentifier =
+    build.appIdentifier ??
+    profile.bundleIdentifier ??
+    (artifactPath ? (await readIpaInfoAsync(artifactPath)).bundleIdentifier : undefined);
+
+  if (!profile.ascAppId) {
+    throw new Error('Set ascAppId in the submit profile in eas.json.');
+  }
+
+  const appSpecificPassword = env.EXPO_APPLE_APP_SPECIFIC_PASSWORD;
+  const configInput: z.input<typeof SubmissionConfig.Ios.SchemaZ> = {
+    ascAppIdentifier: profile.ascAppId,
+    groups: profile.groups,
+    ...(appSpecificPassword
+      ? {
+          appleAppSpecificPassword: validateAppSpecificPassword(appSpecificPassword),
+          appleIdUsername: requireAppleIdUsername(profile.appleId ?? env.EXPO_APPLE_ID),
+        }
+      : {
+          ascApiJsonKey: await getAscApiJsonKeyAsync({
+            build,
+            bundleIdentifier,
+            ctx,
+            profile,
+            workingDirectory,
+          }),
+        }),
+  };
+
+  return {
+    appIdentifier: bundleIdentifier,
+    config: SubmissionConfig.Ios.SchemaZ.parse(configInput),
+    platform: Platform.IOS,
+  };
+}
+
+async function getAscApiJsonKeyAsync({
+  build,
+  bundleIdentifier,
+  ctx,
+  profile,
+  workingDirectory,
+}: {
+  build: BuildInfo;
+  bundleIdentifier?: string;
+  ctx: CustomBuildContext;
+  profile: SubmitProfile<Platform.IOS>;
+  workingDirectory: string;
+}): Promise<string> {
+  if (profile.ascApiKeyPath && profile.ascApiKeyIssuerId && profile.ascApiKeyId) {
+    return JSON.stringify({
+      issuer_id: profile.ascApiKeyIssuerId,
+      key: await fs.readFile(path.resolve(workingDirectory, profile.ascApiKeyPath), 'utf8'),
+      key_id: profile.ascApiKeyId,
+    });
+  }
+
+  if (profile.ascApiKeyPath || profile.ascApiKeyIssuerId || profile.ascApiKeyId) {
+    throw new Error(
+      'ascApiKeyPath, ascApiKeyIssuerId and ascApiKeyId must all be defined in eas.json.'
+    );
+  }
+
+  if (!bundleIdentifier) {
+    throw new Error('Could not resolve iOS bundleIdentifier from build metadata or artifact.');
+  }
+
+  const appleAppIdentifierResult = await ctx.graphqlClient
+    .query(APPLE_APP_IDENTIFIER_QUERY, {
+      accountName: build.projectOwnerAccountName,
+      bundleIdentifier,
+    })
+    .toPromise();
+  if (appleAppIdentifierResult.error) {
+    throw appleAppIdentifierResult.error;
+  }
+
+  const appleAppIdentifierId =
+    appleAppIdentifierResult.data?.account.byName.appleAppIdentifiers[0]?.id;
+  if (!appleAppIdentifierId) {
+    throw new Error(`Apple App Identifier is not configured for ${bundleIdentifier}.`);
+  }
+
+  const credentialsResult = await ctx.graphqlClient
+    .query(IOS_APP_CREDENTIALS_QUERY, {
+      appleAppIdentifierId,
+      projectFullName: build.projectFullName,
+    })
+    .toPromise();
+  if (credentialsResult.error) {
+    throw credentialsResult.error;
+  }
+
+  const ascApiKeyId =
+    credentialsResult.data?.app.byFullName.iosAppCredentials[0]?.appStoreConnectApiKeyForSubmissions
+      ?.id;
+  if (!ascApiKeyId) {
+    throw new Error(
+      `App Store Connect API Key for submissions is not configured for ${bundleIdentifier}.`
+    );
+  }
+
+  const apiKeyResult = await ctx.graphqlClient
+    .query(APP_STORE_CONNECT_API_KEY_QUERY, { id: ascApiKeyId })
+    .toPromise();
+  if (apiKeyResult.error) {
+    throw apiKeyResult.error;
+  }
+
+  const apiKey = apiKeyResult.data?.appStoreConnectApiKey.byId;
+  if (!apiKey) {
+    throw new Error(`App Store Connect API Key ${ascApiKeyId} could not be resolved.`);
+  }
+  return JSON.stringify({
+    issuer_id: apiKey.issuerIdentifier,
+    key: apiKey.keyP8,
+    key_id: apiKey.keyIdentifier,
+  });
+}
+
+function validateAppSpecificPassword(password: string): string {
+  if (!/^[a-z]{4}-[a-z]{4}-[a-z]{4}-[a-z]{4}$/.test(password)) {
+    throw new Error(
+      'EXPO_APPLE_APP_SPECIFIC_PASSWORD must be in the format xxxx-xxxx-xxxx-xxxx, where x is a lowercase letter.'
+    );
+  }
+  return password;
+}
+
+function requireAppleIdUsername(appleIdUsername?: string): string {
+  if (!appleIdUsername) {
+    throw new Error(
+      'Set appleId in the submit profile or EXPO_APPLE_ID when using EXPO_APPLE_APP_SPECIFIC_PASSWORD.'
+    );
+  }
+  return appleIdUsername;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2864,6 +2864,7 @@ __metadata:
     "@expo/config-plugins": "npm:55.0.7"
     "@expo/downloader": "npm:18.5.0"
     "@expo/eas-build-job": "npm:18.8.0"
+    "@expo/eas-json": "npm:18.8.0"
     "@expo/env": "npm:^0.4.0"
     "@expo/logger": "npm:18.5.0"
     "@expo/package-manager": "npm:1.9.10"


### PR DESCRIPTION
## Summary
- Remove the `platform` input from `eas/resolve_submit_config` and infer it from the build ID
- Split submit config resolution into Android and iOS modules for easier review
- Resolve Android service account JSON directly from GraphQL and use `UserError`/`SystemError` for failures
- Rename the config output to `config_json`

## Testing
- `yarn workspace @expo/build-tools typecheck`
- `yarn exec oxfmt --check packages/build-tools/src/steps/functions/resolveSubmitConfig/index.ts packages/build-tools/src/steps/functions/resolveSubmitConfig/common.ts packages/build-tools/src/steps/functions/resolveSubmitConfig/android.ts packages/build-tools/src/steps/functions/resolveSubmitConfig/ios.ts packages/build-tools/src/steps/easFunctions.ts packages/build-tools/package.json`