### PR TITLE
[worker] Set precompiled modules base URL

### DIFF
--- a/packages/worker/src/__unit__/env.test.ts
+++ b/packages/worker/src/__unit__/env.test.ts
@@ -5,9 +5,11 @@ import { getBuildEnv } from '../env';
 
 describe(getBuildEnv.name, () => {
   const originalSentryDsn = config.sentry.dsn;
+  const originalCocoapodsCacheUrl = config.cocoapodsCacheUrl;
 
   afterEach(() => {
     config.sentry.dsn = originalSentryDsn;
+    config.cocoapodsCacheUrl = originalCocoapodsCacheUrl;
   });
 
   it('passes the CLI sentry DSN to worker child processes', () => {
@@ -55,6 +57,36 @@ describe(getBuildEnv.name, () => {
     });
 
     expect(env.EXPO_USE_PRECOMPILED_MODULES).toBe('1');
+    expect(env.EXPO_PRECOMPILED_MODULES_BASE_URL).toBe(
+      'https://storage.googleapis.com/eas-build-precompiled-modules/'
+    );
     expect(env.EXPO_PRECOMPILED_MODULES_PATH).toBeUndefined();
+  });
+
+  it('passes precompiled modules through the CocoaPods cache URL when available', () => {
+    config.cocoapodsCacheUrl = 'https://cache.example.com';
+
+    const env = getBuildEnv({
+      job: {
+        platform: Platform.IOS,
+        type: Workflow.GENERIC,
+        builderEnvironment: {
+          env: {
+            EAS_USE_PRECOMPILED_MODULES: '1',
+          },
+        },
+      } as any,
+      projectId: 'project-id',
+      metadata: {
+        buildProfile: 'production',
+        gitCommitHash: 'abc123',
+        username: 'expo-user',
+      } as any,
+      buildId: 'build-id',
+    });
+
+    expect(env.EXPO_PRECOMPILED_MODULES_BASE_URL).toBe(
+      'https://cache.example.com/storage.googleapis.com/eas-build-precompiled-modules/'
+    );
   });
 });

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -12,6 +12,9 @@ import {
 } from './external/turtle';
 import { getAccessedEnvs } from './utils/env';
 
+const PRECOMPILED_MODULES_BASE_URL =
+  'https://storage.googleapis.com/eas-build-precompiled-modules/';
+
 // keep in sync with local-build-plugin env vars
 // see packages/local-build-plugin/src/build.ts
 export function getBuildEnv({
@@ -55,6 +58,7 @@ export function getBuildEnv({
     setEnv(env, 'COMPILER_INDEX_STORE_ENABLE', 'NO');
     if (job.builderEnvironment?.env?.EAS_USE_PRECOMPILED_MODULES === '1') {
       setEnv(env, 'EXPO_USE_PRECOMPILED_MODULES', '1');
+      setEnv(env, 'EXPO_PRECOMPILED_MODULES_BASE_URL', getPrecompiledModulesBaseUrl());
     }
 
     if (job.builderEnvironment?.env?.EAS_USE_CACHE === '1') {
@@ -164,6 +168,18 @@ function setEnv(env: Env, key: string, value: string | null | undefined): void {
   if (value) {
     env[key] = value;
   }
+}
+
+function getPrecompiledModulesBaseUrl(): string {
+  if (!config.cocoapodsCacheUrl) {
+    return PRECOMPILED_MODULES_BASE_URL;
+  }
+
+  const parsedUrl = new URL(PRECOMPILED_MODULES_BASE_URL);
+  return PRECOMPILED_MODULES_BASE_URL.replace(
+    `${parsedUrl.protocol}//${parsedUrl.host}`,
+    `${config.cocoapodsCacheUrl.replace(/\/$/, '')}/${parsedUrl.host}`
+  );
 }
 
 const ResourceClassToMaxHeapSize: Record<ResourceClass, string | null> = {


### PR DESCRIPTION
## Summary

Sets `EXPO_PRECOMPILED_MODULES_BASE_URL` for iOS worker builds that opt into precompiled modules with `EAS_USE_PRECOMPILED_MODULES=1`.

When the CocoaPods cache is configured, the URL is routed through that cache using the same host-prefix style as other cached downloads. When the cache is not configured, it points directly to `https://storage.googleapis.com/eas-build-precompiled-modules/`.

Local builds are unchanged and do not receive this env var.

## Test Plan

- `yarn oxfmt packages/worker/src/env.ts packages/worker/src/__unit__/env.test.ts`
- `yarn workspace @expo/worker test:unit -- env.test.ts`
- `yarn workspace @expo/worker typecheck`