### PR TITLE
Fix interpolation dispatcher misclassifying multi-expression values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- Fix EAS Workflows interpolation throwing `Unexpected "}" at character N` when a single value contains multiple `${{ ... }}` expressions (for example, `changelog: ${{ a }}: ${{ b }}`). ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@brentvatne](https://github.com/brentvatne))
+- Fix EAS Workflows interpolation throwing `Unexpected "}" at character N` when a single value contains multiple `${{ ... }}` expressions (for example, `changelog: ${{ a }}: ${{ b }}`). ([#3643](https://github.com/expo/eas-cli/pull/3643) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- Fix EAS Workflows interpolation throwing `Unexpected "}" at character N` when a single value contains multiple `${{ ... }}` expressions (for example, `changelog: ${{ a }}: ${{ b }}`). ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🧹 Chores
 
 ## [18.8.1](https://github.com/expo/eas-cli/releases/tag/v18.8.1) - 2026-04-23

--- a/packages/steps/src/__tests__/interpolation-test.ts
+++ b/packages/steps/src/__tests__/interpolation-test.ts
@@ -1,0 +1,83 @@
+import { JobInterpolationContext } from '@expo/eas-build-job';
+
+import { interpolateJobContext } from '../interpolation';
+
+const context = {
+  inputs: {
+    profile: 'production',
+    flags: { quiet: true, retries: 3 },
+  },
+  github: {
+    event: {
+      pull_request: {
+        html_url: 'https://github.com/foo/bar/pull/42',
+        title: 'Add cool feature',
+      },
+    },
+  },
+} as unknown as JobInterpolationContext;
+
+describe(interpolateJobContext, () => {
+  test('single expression value preserves the underlying type', () => {
+    const result = interpolateJobContext({
+      target: '${{ inputs.flags }}',
+      context,
+    });
+    expect(result).toEqual({ quiet: true, retries: 3 });
+  });
+
+  test('single expression value resolves to a string', () => {
+    const result = interpolateJobContext({
+      target: '${{ inputs.profile }}',
+      context,
+    });
+    expect(result).toBe('production');
+  });
+
+  test('multiple expressions in one value are each replaced with their string result', () => {
+    const result = interpolateJobContext({
+      target:
+        '${{ github.event.pull_request.html_url }}: ${{ github.event.pull_request.title }}',
+      context,
+    });
+    expect(result).toBe('https://github.com/foo/bar/pull/42: Add cool feature');
+  });
+
+  test('plain text is returned unchanged', () => {
+    const result = interpolateJobContext({ target: 'just text', context });
+    expect(result).toBe('just text');
+  });
+
+  test('expression with text around it is interpolated as a string', () => {
+    const result = interpolateJobContext({
+      target: 'profile=${{ inputs.profile }}',
+      context,
+    });
+    expect(result).toBe('profile=production');
+  });
+
+  test('object values recurse', () => {
+    const result = interpolateJobContext({
+      target: { profile: '${{ inputs.profile }}', literal: 'x' },
+      context,
+    });
+    expect(result).toEqual({ profile: 'production', literal: 'x' });
+  });
+
+  test('array values recurse', () => {
+    const result = interpolateJobContext({
+      target: ['${{ inputs.profile }}', 'literal'],
+      context,
+    });
+    expect(result).toEqual(['production', 'literal']);
+  });
+
+  test('string concatenation inside a single expression', () => {
+    const result = interpolateJobContext({
+      target:
+        "${{ github.event.pull_request.html_url + ': ' + github.event.pull_request.title }}",
+      context,
+    });
+    expect(result).toBe('https://github.com/foo/bar/pull/42: Add cool feature');
+  });
+});

--- a/packages/steps/src/interpolation.ts
+++ b/packages/steps/src/interpolation.ts
@@ -10,9 +10,19 @@ export function interpolateJobContext({
   context: JobInterpolationContext;
 }): unknown {
   if (typeof target === 'string') {
-    // If the value is e.g. `build: ${{ inputs.build }}`, we will interpolate the value
-    // without changing `inputs.build` type, i.e. if it is an object it'll be like `build: {...inputs.build}`.
-    if (target.startsWith('${{') && target.endsWith('}}')) {
+    // If the value is exactly one `${{ ... }}` expression, we interpolate it without
+    // changing the result's type, i.e. if `inputs.build` is an object then
+    // `build: ${{ inputs.build }}` becomes `build: {...inputs.build}`.
+    //
+    // `startsWith('${{') && endsWith('}}')` alone is not enough: a value like
+    // `${{ a }}: ${{ b }}` also starts with `${{` and ends with `}}`, but those
+    // delimiters are not a matched pair. We must also confirm there's no second
+    // `${{` after the opening one.
+    if (
+      target.startsWith('${{') &&
+      target.endsWith('}}') &&
+      target.indexOf('${{', 3) === -1
+    ) {
       return jsepEval(target.slice(3, -2), context);
     }
 


### PR DESCRIPTION
Note: this is generated by Claude, I'll promote from draft after I've had a chance to review it.

<hr />

## Summary

EAS Workflows interpolation throws `Unexpected "}" at character N` for any value that contains multiple `${{ ... }}` expressions, e.g.:

```yaml
changelog: ${{ github.event.pull_request.html_url }}: ${{ github.event.pull_request.title }}
```

Customer hit this in the wild — the error message points at the value but doesn't make it obvious that multi-expression values aren't being routed correctly.

## Why

`interpolateJobContext` in `packages/steps/src/interpolation.ts` dispatches between two paths based on whether the value `startsWith('${{')` and `endsWith('}}')`. If both are true it treats the value as a single expression, slices off the outer delimiters, and hands the rest to jsep — preserving the result's underlying type so that, e.g., `${{ inputs.flags }}` resolves to the actual object instead of `[object Object]`.

The problem: the check doesn't verify those two delimiters are a *matched pair*. A value like `${{ a }}: ${{ b }}` also starts with `${{` and ends with `}}`, but those are the open of expression #1 and the close of expression #2, not a matched pair. The dispatcher takes the single-expression branch, slices off 3 leading and 2 trailing characters, and hands jsep:

```
 github.event.pull_request.html_url }}: ${{ github.event.pull_request.title 
```

jsep parses `github.event.pull_request.html_url` fine, then hits the literal `}` and throws `Unexpected "}" at character 36` — the exact error customers see.

## Fix

Add a third condition: the opening `${{` must be the *only* `${{` in the string. Multi-expression values then fall through to the existing `replace(/\$\{\{(.+?)\}\}/g, ...)` branch, which already handles N expressions correctly.

```ts
if (
  target.startsWith('${{') &&
  target.endsWith('}}') &&
  target.indexOf('${{', 3) === -1
) {
  return jsepEval(target.slice(3, -2), context);
}
```

## Test plan

- [x] New `packages/steps/src/__tests__/interpolation-test.ts` covering single-expression type preservation, multi-expression interpolation, plain text passthrough, recursion into objects/arrays, and the `+` string-concat workaround we'd recommended to customers.
- [x] All 300 existing `packages/steps` tests still pass.
- [x] `yarn typecheck` clean.
- [x] `yarn lint` clean on the changed files.
- [x] Manually reproduced the original error and confirmed the fix produces the expected interpolated string.