### PR TITLE
[steps] Fix job context interpolation when one string has multiple `${{ }}` blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [steps] Fix workflow job context interpolation when a string contains multiple `${{ }}` expressions on the same line (for example a changelog built from two context values). ([#3644](https://github.com/expo/eas-cli/pull/3644) by [@gwdp](https://github.com/gwdp))
+
 ### 🧹 Chores
 
 ## [18.8.1](https://github.com/expo/eas-cli/releases/tag/v18.8.1) - 2026-04-23

--- a/packages/steps/src/__tests__/interpolation-test.ts
+++ b/packages/steps/src/__tests__/interpolation-test.ts
@@ -1,0 +1,39 @@
+import type { JobInterpolationContext } from '@expo/eas-build-job';
+
+import { interpolateJobContext } from '../interpolation';
+
+describe(interpolateJobContext, () => {
+  it('interpolates multiple ${{ }} segments when the string starts with ${{ and ends with }}', () => {
+    const context = {
+      github: {
+        event: {
+          pull_request: {
+            html_url: 'https://github.com/acme/app/pull/42',
+            title: 'Fix crash',
+          },
+        },
+      },
+    } as unknown as JobInterpolationContext;
+
+    expect(
+      interpolateJobContext({
+        target:
+          '${{ github.event.pull_request.html_url }}: ${{ github.event.pull_request.title }}',
+        context,
+      })
+    ).toBe('https://github.com/acme/app/pull/42: Fix crash');
+  });
+
+  it('still preserves non-string types for a single whole-string interpolation', () => {
+    const context = {
+      build: { profile: 'production', id: '123' },
+    } as unknown as JobInterpolationContext;
+
+    expect(
+      interpolateJobContext({
+        target: '${{ build }}',
+        context,
+      })
+    ).toEqual({ profile: 'production', id: '123' });
+  });
+});

--- a/packages/steps/src/__tests__/interpolation-test.ts
+++ b/packages/steps/src/__tests__/interpolation-test.ts
@@ -35,4 +35,17 @@ describe(interpolateJobContext, () => {
       })
     ).toEqual({ profile: 'production', id: '123' });
   });
+
+  it("handles a single interpolation when the expression contains '}}' in a string literal", () => {
+    const context = {
+      build: { profile: 'production}}' },
+    } as unknown as JobInterpolationContext;
+
+    expect(
+      interpolateJobContext({
+        target: "${{ build.profile == 'production}}' }}",
+        context,
+      })
+    ).toBe(true);
+  });
 });

--- a/packages/steps/src/__tests__/interpolation-test.ts
+++ b/packages/steps/src/__tests__/interpolation-test.ts
@@ -17,8 +17,7 @@ describe(interpolateJobContext, () => {
 
     expect(
       interpolateJobContext({
-        target:
-          '${{ github.event.pull_request.html_url }}: ${{ github.event.pull_request.title }}',
+        target: '${{ github.event.pull_request.html_url }}: ${{ github.event.pull_request.title }}',
         context,
       })
     ).toBe('https://github.com/acme/app/pull/42: Fix crash');

--- a/packages/steps/src/interpolation.ts
+++ b/packages/steps/src/interpolation.ts
@@ -3,7 +3,7 @@ import { JobInterpolationContext } from '@expo/eas-build-job';
 import { jsepEval } from './utils/jsepEval';
 
 function isSingleWholeStringInterpolation(value: string): boolean {
-  return value.startsWith('${{') && value.endsWith('}}') && value.indexOf('${{', 3) === -1;
+  return value.startsWith('${{') && value.endsWith('}}') && !value.includes('${{', 3);
 }
 
 export function interpolateJobContext({

--- a/packages/steps/src/interpolation.ts
+++ b/packages/steps/src/interpolation.ts
@@ -4,7 +4,9 @@ import { jsepEval } from './utils/jsepEval';
 
 function isSingleWholeStringInterpolation(value: string): boolean {
   return (
-    value.startsWith('${{') && value.endsWith('}}') && value.indexOf('}}', 3) === value.length - 2
+    value.startsWith('${{') &&
+    value.endsWith('}}') &&
+    value.indexOf('${{', 3) === -1
   );
 }
 

--- a/packages/steps/src/interpolation.ts
+++ b/packages/steps/src/interpolation.ts
@@ -4,9 +4,7 @@ import { jsepEval } from './utils/jsepEval';
 
 function isSingleWholeStringInterpolation(value: string): boolean {
   return (
-    value.startsWith('${{') &&
-    value.endsWith('}}') &&
-    value.indexOf('}}', 3) === value.length - 2
+    value.startsWith('${{') && value.endsWith('}}') && value.indexOf('}}', 3) === value.length - 2
   );
 }
 

--- a/packages/steps/src/interpolation.ts
+++ b/packages/steps/src/interpolation.ts
@@ -3,11 +3,7 @@ import { JobInterpolationContext } from '@expo/eas-build-job';
 import { jsepEval } from './utils/jsepEval';
 
 function isSingleWholeStringInterpolation(value: string): boolean {
-  return (
-    value.startsWith('${{') &&
-    value.endsWith('}}') &&
-    value.indexOf('${{', 3) === -1
-  );
+  return value.startsWith('${{') && value.endsWith('}}') && value.indexOf('${{', 3) === -1;
 }
 
 export function interpolateJobContext({

--- a/packages/steps/src/interpolation.ts
+++ b/packages/steps/src/interpolation.ts
@@ -2,6 +2,14 @@ import { JobInterpolationContext } from '@expo/eas-build-job';
 
 import { jsepEval } from './utils/jsepEval';
 
+function isSingleWholeStringInterpolation(value: string): boolean {
+  return (
+    value.startsWith('${{') &&
+    value.endsWith('}}') &&
+    value.indexOf('}}', 3) === value.length - 2
+  );
+}
+
 export function interpolateJobContext({
   target,
   context,
@@ -12,7 +20,7 @@ export function interpolateJobContext({
   if (typeof target === 'string') {
     // If the value is e.g. `build: ${{ inputs.build }}`, we will interpolate the value
     // without changing `inputs.build` type, i.e. if it is an object it'll be like `build: {...inputs.build}`.
-    if (target.startsWith('${{') && target.endsWith('}}')) {
+    if (isSingleWholeStringInterpolation(target)) {
       return jsepEval(target.slice(3, -2), context);
     }
 


### PR DESCRIPTION
## Why

Workflow strings that contain more than one ${{ … }} block but still start with ${{ and end with }} were treated as a single expression. The whole string was passed to jsepEval incorrectly and interpolation failed on 

```
submit_ios:
    needs: [build_ios]
    type: testflight
    params:
      build_id: ${{ needs.build_ios.outputs.build_id }}
      profile: internal
      changelog: >-
        ${{ github.event.pull_request.html_url }}: ${{ github.event.pull_request.title }}
```
Although the example above might not be interpolated here, also addressing interpolation case here as a possible use case we didn't handled well.

## How
Use the “whole-string / type-preserving” path only when the string is a single interpolation block: it starts with ${{, ends with }}, and does not contain another ${{ after the first one (isSingleWholeStringInterpolation). Otherwise, use the existing replace-each-segment behavior.

## Test Plan

New test covering this case + CI passing
