### PR TITLE
[build-tools] Scope precompiled modules env to pod install

### DIFF
--- a/packages/build-tools/src/ios/__tests__/pod.test.ts
+++ b/packages/build-tools/src/ios/__tests__/pod.test.ts
@@ -1,0 +1,149 @@
+import { Ios } from '@expo/eas-build-job';
+import spawn from '@expo/turtle-spawn';
+import { vol } from 'memfs';
+import path from 'path';
+
+import { createTestIosJob } from '../../__tests__/utils/job';
+import { createMockLogger } from '../../__tests__/utils/logger';
+import { BuildContext } from '../../context';
+import { installPods } from '../pod';
+
+jest.mock('@expo/turtle-spawn', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const WORKING_DIR = '/workingdir';
+const PROJECT_DIR = path.join(WORKING_DIR, 'build');
+const IOS_DIR = path.join(PROJECT_DIR, 'ios');
+
+function makeIosBuildContext({
+  expoVersion,
+  usePrecompiledModules = true,
+}: {
+  expoVersion?: string;
+  usePrecompiledModules?: boolean;
+}): BuildContext<Ios.Job> {
+  vol.fromJSON({
+    [path.join(IOS_DIR, '.keep')]: '',
+    ...(expoVersion
+      ? {
+          [path.join(PROJECT_DIR, 'node_modules/expo/package.json')]: JSON.stringify({
+            version: expoVersion,
+          }),
+        }
+      : {}),
+  });
+
+  const job: Ios.Job = {
+    ...createTestIosJob(),
+    builderEnvironment: {
+      env: {
+        ...(usePrecompiledModules ? { EAS_USE_PRECOMPILED_MODULES: '1' } : {}),
+      },
+    },
+  };
+
+  return new BuildContext(job, {
+    workingdir: WORKING_DIR,
+    logger: createMockLogger(),
+    logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+    env: { __API_SERVER_URL: 'http://api.expo.test' },
+    uploadArtifact: jest.fn(),
+  });
+}
+
+describe(installPods, () => {
+  beforeEach(() => {
+    vol.reset();
+    (spawn as jest.Mock).mockImplementation(command => {
+      if (command === 'node') {
+        return Promise.resolve({
+          stdout: Buffer.from(path.join(PROJECT_DIR, 'node_modules/expo/package.json')),
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+  });
+
+  it('adds precompiled modules env var for Expo versions that support them', async () => {
+    const ctx = makeIosBuildContext({ expoVersion: '55.0.18' });
+
+    await installPods(ctx, {});
+
+    expect(spawn).toHaveBeenCalledWith(
+      'node',
+      ['--print', "require.resolve('expo/package.json')"],
+      expect.objectContaining({
+        cwd: PROJECT_DIR,
+        env: expect.objectContaining({
+          __API_SERVER_URL: 'http://api.expo.test',
+        }),
+        stdio: 'pipe',
+      })
+    );
+    expect(spawn).toHaveBeenCalledWith(
+      'pod',
+      ['install'],
+      expect.objectContaining({
+        cwd: IOS_DIR,
+        env: expect.objectContaining({
+          EXPO_USE_PRECOMPILED_MODULES: '1',
+        }),
+      })
+    );
+    expect(
+      (spawn as jest.Mock).mock.calls[1][2].env.EXPO_PRECOMPILED_MODULES_BASE_URL
+    ).toBeUndefined();
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      'Detected expo=55.0.18; enabling precompiled modules use. Installing pods with additional environment variables.\nEXPO_USE_PRECOMPILED_MODULES=1\nPrecompiled modules pod install environment is configured.'
+    );
+  });
+
+  it('does not add precompiled modules env vars below the minimum Expo version', async () => {
+    const ctx = makeIosBuildContext({ expoVersion: '55.0.17' });
+
+    await installPods(ctx, {});
+
+    expect((spawn as jest.Mock).mock.calls[1][2].env.EXPO_USE_PRECOMPILED_MODULES).toBeUndefined();
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      'Detected expo=55.0.17; not enabling precompiled modules use because precompiled modules require expo>=55.0.18.'
+    );
+  });
+
+  it('does not add precompiled modules env vars when Expo version is invalid', async () => {
+    const ctx = makeIosBuildContext({ expoVersion: 'invalid-version' });
+
+    await installPods(ctx, {});
+
+    expect((spawn as jest.Mock).mock.calls[1][2].env.EXPO_USE_PRECOMPILED_MODULES).toBeUndefined();
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      'Detected expo=invalid-version; not enabling precompiled modules use because the installed Expo package version is not a valid semver version.'
+    );
+  });
+
+  it('does not add precompiled modules env vars when Expo version detection fails', async () => {
+    const ctx = makeIosBuildContext({});
+
+    await installPods(ctx, {});
+
+    expect((spawn as jest.Mock).mock.calls[1][2].env.EXPO_USE_PRECOMPILED_MODULES).toBeUndefined();
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.objectContaining({ code: 'ENOENT' }) }),
+      'Failed to detect installed Expo package version; not enabling precompiled modules use.'
+    );
+  });
+
+  it('does not add precompiled modules env vars without the builder flag', async () => {
+    const ctx = makeIosBuildContext({
+      expoVersion: '55.0.18',
+      usePrecompiledModules: false,
+    });
+
+    await installPods(ctx, {});
+
+    expect((spawn as jest.Mock).mock.calls[0][2].env.EAS_USE_PRECOMPILED_MODULES).toBeUndefined();
+    expect((spawn as jest.Mock).mock.calls[0][2].env.EXPO_USE_PRECOMPILED_MODULES).toBeUndefined();
+    expect(ctx.logger.info).not.toHaveBeenCalled();
+  });
+});

--- a/packages/build-tools/src/ios/pod.ts
+++ b/packages/build-tools/src/ios/pod.ts
@@ -1,8 +1,13 @@
-import { Ios } from '@expo/eas-build-job';
+import { Env, Ios } from '@expo/eas-build-job';
 import spawn, { SpawnOptions, SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
+import fs from 'fs-extra';
 import path from 'path';
+import semver from 'semver';
 
 import { BuildContext } from '../context';
+
+const MIN_PRECOMPILED_MODULES_EXPO_VERSION = '55.0.18';
+// const PRECOMPILED_MODULES_BASE_URL = 'https://storage.googleapis.com/eas-build-precompiled-modules/';
 
 export async function installPods<TJob extends Ios.Job>(
   ctx: BuildContext<TJob>,
@@ -12,6 +17,7 @@ export async function installPods<TJob extends Ios.Job>(
 
   const verboseFlag = ctx.env['EAS_VERBOSE'] === '1' ? ['--verbose'] : [];
   const cocoapodsDeploymentFlag = ctx.env['POD_INSTALL_DEPLOYMENT'] === '1' ? ['--deployment'] : [];
+  const precompiledModulesEnv = await resolvePrecompiledModulesPodInstallEnvAsync(ctx);
 
   return {
     spawnPromise: spawn('pod', ['install', ...verboseFlag, ...cocoapodsDeploymentFlag], {
@@ -20,6 +26,7 @@ export async function installPods<TJob extends Ios.Job>(
       env: {
         ...ctx.env,
         LANG: 'en_US.UTF-8',
+        ...precompiledModulesEnv,
       },
       lineTransformer: (line?: string) => {
         if (
@@ -35,3 +42,77 @@ export async function installPods<TJob extends Ios.Job>(
     }),
   };
 }
+
+async function resolvePrecompiledModulesPodInstallEnvAsync<TJob extends Ios.Job>(
+  ctx: BuildContext<TJob>
+): Promise<Env> {
+  if (ctx.job.builderEnvironment?.env?.EAS_USE_PRECOMPILED_MODULES !== '1') {
+    return {};
+  }
+
+  let expoPackageVersion: string;
+  try {
+    expoPackageVersion = await getInstalledExpoPackageVersionAsync(ctx);
+  } catch (err) {
+    ctx.logger.info(
+      { err },
+      'Failed to detect installed Expo package version; not enabling precompiled modules use.'
+    );
+    return {};
+  }
+
+  const validExpoPackageVersion = semver.valid(expoPackageVersion);
+  if (!validExpoPackageVersion) {
+    ctx.logger.info(
+      `Detected expo=${expoPackageVersion}; not enabling precompiled modules use because the installed Expo package version is not a valid semver version.`
+    );
+    return {};
+  }
+
+  if (semver.lt(validExpoPackageVersion, MIN_PRECOMPILED_MODULES_EXPO_VERSION)) {
+    ctx.logger.info(
+      `Detected expo=${validExpoPackageVersion}; not enabling precompiled modules use because precompiled modules require expo>=${MIN_PRECOMPILED_MODULES_EXPO_VERSION}.`
+    );
+    return {};
+  }
+
+  // Start rollout with Expo precompiled modules only. Add third-party modules after this is stable.
+  const env: Env = {
+    EXPO_USE_PRECOMPILED_MODULES: '1',
+    // EXPO_PRECOMPILED_MODULES_BASE_URL: getPrecompiledModulesBaseUrl(),
+  };
+
+  ctx.logger.info(
+    `Detected expo=${validExpoPackageVersion}; enabling precompiled modules use. Installing pods with additional environment variables.\n${Object.entries(
+      env
+    )
+      .map(([key, value]) => `${key}=${value}`)
+      .join('\n')}\nPrecompiled modules pod install environment is configured.`
+  );
+
+  return env;
+}
+
+async function getInstalledExpoPackageVersionAsync<TJob extends Ios.Job>(
+  ctx: BuildContext<TJob>
+): Promise<string> {
+  const { stdout } = await spawn('node', ['--print', "require.resolve('expo/package.json')"], {
+    cwd: ctx.getReactNativeProjectDirectory(),
+    env: ctx.env,
+    stdio: 'pipe',
+  });
+  const expoPackageJsonPath = stdout.toString().trim();
+  return (await fs.readJson(expoPackageJsonPath)).version;
+}
+
+// function getPrecompiledModulesBaseUrl<TJob extends Ios.Job>(ctx: BuildContext<TJob>): string {
+//   if (!ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL) {
+//     return PRECOMPILED_MODULES_BASE_URL;
+//   }
+//
+//   const parsedUrl = new URL(PRECOMPILED_MODULES_BASE_URL);
+//   return PRECOMPILED_MODULES_BASE_URL.replace(
+//     `${parsedUrl.protocol}//${parsedUrl.host}`,
+//     `${ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL.replace(/\/$/, '')}/${parsedUrl.host}`
+//   );
+// }

--- a/packages/worker/src/__unit__/env.test.ts
+++ b/packages/worker/src/__unit__/env.test.ts
@@ -5,11 +5,9 @@ import { getBuildEnv } from '../env';
 
 describe(getBuildEnv.name, () => {
   const originalSentryDsn = config.sentry.dsn;
-  const originalCocoapodsCacheUrl = config.cocoapodsCacheUrl;
 
   afterEach(() => {
     config.sentry.dsn = originalSentryDsn;
-    config.cocoapodsCacheUrl = originalCocoapodsCacheUrl;
   });
 
   it('passes the CLI sentry DSN to worker child processes', () => {
@@ -36,7 +34,7 @@ describe(getBuildEnv.name, () => {
     expect(env.EAS_CLI_SENTRY_DSN).toBe(config.sentry.dsn);
   });
 
-  it('passes through EXPO_USE_PRECOMPILED_MODULES for flagged iOS jobs', () => {
+  it('does not add precompiled modules env vars to flagged iOS jobs', () => {
     const env = getBuildEnv({
       job: {
         platform: Platform.IOS,
@@ -56,37 +54,9 @@ describe(getBuildEnv.name, () => {
       buildId: 'build-id',
     });
 
-    expect(env.EXPO_USE_PRECOMPILED_MODULES).toBe('1');
-    expect(env.EXPO_PRECOMPILED_MODULES_BASE_URL).toBe(
-      'https://storage.googleapis.com/eas-build-precompiled-modules/'
-    );
+    expect(env.EAS_USE_PRECOMPILED_MODULES).toBeUndefined();
+    expect(env.EXPO_USE_PRECOMPILED_MODULES).toBeUndefined();
+    expect(env.EXPO_PRECOMPILED_MODULES_BASE_URL).toBeUndefined();
     expect(env.EXPO_PRECOMPILED_MODULES_PATH).toBeUndefined();
-  });
-
-  it('passes precompiled modules through the CocoaPods cache URL when available', () => {
-    config.cocoapodsCacheUrl = 'https://cache.example.com';
-
-    const env = getBuildEnv({
-      job: {
-        platform: Platform.IOS,
-        type: Workflow.GENERIC,
-        builderEnvironment: {
-          env: {
-            EAS_USE_PRECOMPILED_MODULES: '1',
-          },
-        },
-      } as any,
-      projectId: 'project-id',
-      metadata: {
-        buildProfile: 'production',
-        gitCommitHash: 'abc123',
-        username: 'expo-user',
-      } as any,
-      buildId: 'build-id',
-    });
-
-    expect(env.EXPO_PRECOMPILED_MODULES_BASE_URL).toBe(
-      'https://cache.example.com/storage.googleapis.com/eas-build-precompiled-modules/'
-    );
   });
 });

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -12,9 +12,6 @@ import {
 } from './external/turtle';
 import { getAccessedEnvs } from './utils/env';
 
-const PRECOMPILED_MODULES_BASE_URL =
-  'https://storage.googleapis.com/eas-build-precompiled-modules/';
-
 // keep in sync with local-build-plugin env vars
 // see packages/local-build-plugin/src/build.ts
 export function getBuildEnv({
@@ -56,10 +53,6 @@ export function getBuildEnv({
   if (runnerPlatform === Platform.IOS) {
     setEnv(env, 'EAS_BUILD_COCOAPODS_CACHE_URL', config.cocoapodsCacheUrl);
     setEnv(env, 'COMPILER_INDEX_STORE_ENABLE', 'NO');
-    if (job.builderEnvironment?.env?.EAS_USE_PRECOMPILED_MODULES === '1') {
-      setEnv(env, 'EXPO_USE_PRECOMPILED_MODULES', '1');
-      setEnv(env, 'EXPO_PRECOMPILED_MODULES_BASE_URL', getPrecompiledModulesBaseUrl());
-    }
 
     if (job.builderEnvironment?.env?.EAS_USE_CACHE === '1') {
       setEnv(env, 'USE_CCACHE', '1');
@@ -168,18 +161,6 @@ function setEnv(env: Env, key: string, value: string | null | undefined): void {
   if (value) {
     env[key] = value;
   }
-}
-
-function getPrecompiledModulesBaseUrl(): string {
-  if (!config.cocoapodsCacheUrl) {
-    return PRECOMPILED_MODULES_BASE_URL;
-  }
-
-  const parsedUrl = new URL(PRECOMPILED_MODULES_BASE_URL);
-  return PRECOMPILED_MODULES_BASE_URL.replace(
-    `${parsedUrl.protocol}//${parsedUrl.host}`,
-    `${config.cocoapodsCacheUrl.replace(/\/$/, '')}/${parsedUrl.host}`
-  );
 }
 
 const ResourceClassToMaxHeapSize: Record<ResourceClass, string | null> = {


### PR DESCRIPTION
## Summary

- Stops adding precompiled modules environment variables to the whole worker build environment.
- Adds `EXPO_USE_PRECOMPILED_MODULES=1` only to the iOS `pod install` environment when requested and when the installed Expo package is at least `55.0.18`.
- Logs the detected Expo package version, the reason precompiled modules are not enabled, or the exact pod-install environment values that are added.
- Leaves the precompiled modules base URL helper commented out for the later third-party module rollout.

## Validation

- `yarn oxfmt packages/build-tools/src/ios/pod.ts packages/build-tools/src/ios/__tests__/pod.test.ts packages/worker/src/env.ts packages/worker/src/__unit__/env.test.ts`
- `yarn workspace @expo/build-tools jest-unit pod.test.ts`
- `yarn workspace @expo/worker test:unit -- env.test.ts`
- `yarn workspace @expo/build-tools typecheck`
- `yarn workspace @expo/worker typecheck`