### PR TITLE
[eas-cli] Add Convex team command

### DIFF
--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/team.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/team.test.ts
@@ -1,0 +1,78 @@
+import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../../credentials/__tests__/fixtures-constants';
+import { ConvexQuery } from '../../../../graphql/queries/ConvexQuery';
+import { ConvexTeamConnectionData } from '../../../../graphql/types/ConvexTeamConnection';
+import Log from '../../../../log';
+import { getOwnerAccountForProjectIdAsync } from '../../../../project/projectUtils';
+import IntegrationsConvexTeam from '../team';
+
+jest.mock('../../../../graphql/queries/ConvexQuery');
+jest.mock('../../../../project/projectUtils');
+jest.mock('../../../../log');
+
+describe(IntegrationsConvexTeam, () => {
+  const graphqlClient = {} as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+  const testAccountId = 'test-account-id';
+  const testAccountName = 'testuser';
+
+  const mockAccount = {
+    id: testAccountId,
+    name: testAccountName,
+    ownerUserActor: { id: 'test-user-id', username: testAccountName },
+    users: [{ role: 'OWNER' as any, actor: { id: 'test-user-id' } }],
+  };
+
+  const mockConnection: ConvexTeamConnectionData = {
+    id: 'connection-1',
+    convexTeamIdentifier: 'team-123',
+    convexTeamName: 'Test Team',
+    convexTeamSlug: 'test-team',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    invitedAt: null,
+    invitedEmail: null,
+  };
+
+  function createCommand(): IntegrationsConvexTeam {
+    const command = new IntegrationsConvexTeam([], mockConfig);
+    jest.spyOn(command as any, 'getContextAsync').mockReturnValue({
+      privateProjectConfig: {
+        projectId: testProjectId,
+      },
+      loggedIn: { graphqlClient },
+    } as never);
+    return command;
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    jest.spyOn(Log, 'newLine').mockImplementation(() => {});
+    jest.mocked(getOwnerAccountForProjectIdAsync).mockResolvedValue(mockAccount as any);
+  });
+
+  it('prints linked Convex team metadata', async () => {
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection]);
+
+    await createCommand().runAsync();
+
+    expect(Log.log).toHaveBeenCalledWith(
+      expect.stringContaining('Convex teams linked to @testuser')
+    );
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('Test Team / test-team'));
+    expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('team-123'));
+  });
+
+  it('prints an empty state when no Convex teams are linked', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([]);
+
+    await createCommand().runAsync();
+
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('No Convex team is linked'));
+  });
+});

--- a/packages/eas-cli/src/commands/integrations/convex/team.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/team.ts
@@ -1,0 +1,45 @@
+import chalk from 'chalk';
+
+import EasCommand from '../../../commandUtils/EasCommand';
+import { formatConvexTeamConnection, logNoConvexTeams } from '../../../commandUtils/convex';
+import { ConvexQuery } from '../../../graphql/queries/ConvexQuery';
+import Log from '../../../log';
+import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
+
+export default class IntegrationsConvexTeam extends EasCommand {
+  static override description =
+    "display Convex teams linked to the current Expo app's owner account";
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(IntegrationsConvexTeam, {
+      nonInteractive: false,
+      withServerSideEnvironment: null,
+    });
+
+    const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
+    const connections = await ConvexQuery.getConvexTeamConnectionsByAccountIdAsync(
+      graphqlClient,
+      account.id
+    );
+
+    if (connections.length === 0) {
+      logNoConvexTeams(account.name);
+      return;
+    }
+
+    Log.log(chalk.bold(`Convex teams linked to @${account.name}`));
+    for (const [index, connection] of connections.entries()) {
+      if (index > 0) {
+        Log.newLine();
+      }
+      Log.log(formatConvexTeamConnection(connection));
+    }
+  }
+}


### PR DESCRIPTION
# Why
Users need to inspect Convex team links stored for the current Expo app owner account.

# How
Adds `eas integrations:convex:team` to list linked Convex teams with the human-readable team name/slug first, then the Convex ID, plus the EAS connection ID, dashboard URL, and invite metadata.

# Test Plan
Local E2E rerun against a fresh Expo app. Project setup is currently API-throttled, but team creation succeeded before setup was rejected, allowing the display command to be verified.

Commands run (with `REPO=/Users/fiberjw/Developer/expo/eas-cli`):
```sh
cd packages/eas-cli && yarn build
npx create-expo-app@latest /tmp/eas-convex-e2e-teamfmt --yes
cd /tmp/eas-convex-e2e-teamfmt
$REPO/packages/eas-cli/bin/run init --non-interactive --force
$REPO/packages/eas-cli/bin/run integrations:convex:connect --non-interactive --project-name e2eteamfmt || true
$REPO/packages/eas-cli/bin/run integrations:convex:team
```

Output/verification:
```text
✔ Created @fiberjw/eas-convex-e2e-teamfmt
✔ Project successfully linked (ID: 194b1351-323e-4b8d-a0ce-af93fee1ac74)
✔ Created Convex team fiberjw's team (Expo) / fiberjw-ef4a2 (Convex ID: 478548)
Convex teams linked to @fiberjw
Team: fiberjw's team (Expo) / fiberjw-ef4a2 (Convex ID: 478548)
EAS connection ID: 019dda27-c450-7647-8ce4-97124c421f91
Dashboard: https://dashboard.convex.dev/t/fiberjw-ef4a2
```
