### PR TITLE
[eas-cli] Add Convex team invite command

### DIFF
--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/team-invite.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/team-invite.test.ts
@@ -1,0 +1,220 @@
+import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../../credentials/__tests__/fixtures-constants';
+import { ConvexMutation } from '../../../../graphql/mutations/ConvexMutation';
+import { ConvexQuery } from '../../../../graphql/queries/ConvexQuery';
+import { ConvexTeamConnectionData } from '../../../../graphql/types/ConvexTeamConnection';
+import Log from '../../../../log';
+import { getOwnerAccountForProjectIdAsync } from '../../../../project/projectUtils';
+import { confirmAsync, selectAsync } from '../../../../prompts';
+import IntegrationsConvexTeamInvite from '../team/invite';
+
+jest.mock('../../../../graphql/queries/ConvexQuery');
+jest.mock('../../../../graphql/mutations/ConvexMutation');
+jest.mock('../../../../project/projectUtils');
+jest.mock('../../../../prompts');
+jest.mock('../../../../log');
+jest.mock('../../../../ora', () => ({
+  ora: () => ({
+    start: jest.fn().mockReturnThis(),
+    succeed: jest.fn().mockReturnThis(),
+    fail: jest.fn().mockReturnThis(),
+  }),
+}));
+
+describe(IntegrationsConvexTeamInvite, () => {
+  const graphqlClient = {} as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+  const testAccountId = 'test-account-id';
+  const testAccountName = 'testuser';
+
+  const mockActor = {
+    __typename: 'User',
+    id: 'test-user-id',
+    email: 'user@example.com',
+    accounts: [],
+  };
+
+  const mockAccount = {
+    id: testAccountId,
+    name: testAccountName,
+    ownerUserActor: { id: 'test-user-id', username: testAccountName },
+    users: [{ role: 'OWNER' as any, actor: { id: 'test-user-id' } }],
+  };
+
+  const mockConnection: ConvexTeamConnectionData = {
+    id: 'connection-1',
+    convexTeamIdentifier: 'team-123',
+    convexTeamName: 'Test Team',
+    convexTeamSlug: 'test-team',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    invitedAt: '2024-01-02T00:00:00.000Z',
+    invitedEmail: 'previous@example.com',
+  };
+
+  function createCommand(
+    argv: string[],
+    actor: { __typename: string; [key: string]: any } = mockActor
+  ): IntegrationsConvexTeamInvite {
+    const command = new IntegrationsConvexTeamInvite(argv, mockConfig);
+    jest.spyOn(command as any, 'getContextAsync').mockReturnValue({
+      privateProjectConfig: {
+        projectId: testProjectId,
+      },
+      loggedIn: { graphqlClient, actor },
+    } as never);
+    return command;
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    jest.spyOn(Log, 'addNewLineIfNone').mockImplementation(() => {});
+    jest.spyOn(Log, 'newLine').mockImplementation(() => {});
+
+    jest.mocked(getOwnerAccountForProjectIdAsync).mockResolvedValue(mockAccount as any);
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection]);
+    jest.mocked(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).mockResolvedValue(true);
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+  });
+
+  it('sends an invite for the linked Convex team', async () => {
+    await createCommand([]).runAsync();
+
+    expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      { convexTeamConnectionId: 'connection-1' }
+    );
+  });
+
+  it('prints previous invite metadata when it exists', async () => {
+    await createCommand([]).runAsync();
+
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('Test Team / test-team'));
+    expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('team-123'));
+    expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('connection-1'));
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('Previous invite'));
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('previous@example.com'));
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('2024-01-02T00:00:00.000Z'));
+  });
+
+  it('prompts before resending a recent invite', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([
+      {
+        ...mockConnection,
+        invitedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      },
+    ]);
+
+    await createCommand([]).runAsync();
+
+    expect(confirmAsync).toHaveBeenCalledWith({
+      message: expect.stringContaining('Are you sure you want to send another invite?'),
+    });
+    expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).toHaveBeenCalled();
+  });
+
+  it('skips resending a recent invite when the user does not confirm', async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([
+      {
+        ...mockConnection,
+        invitedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      },
+    ]);
+
+    await createCommand([]).runAsync();
+
+    expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith('Skipped sending Convex team invitation.');
+  });
+
+  it('resends recent invites in non-interactive mode with a warning', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([
+      {
+        ...mockConnection,
+        invitedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      },
+    ]);
+
+    await createCommand(['--non-interactive']).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('non-interactive mode'));
+    expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).toHaveBeenCalled();
+  });
+
+  it('skips the invite when the actor has no email', async () => {
+    await createCommand([], { __typename: 'Robot', id: 'robot-1' }).runAsync();
+
+    expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Could not determine your verified email address')
+    );
+    expect(Log.warn).not.toHaveBeenCalledWith(expect.stringContaining('Convex dashboard'));
+  });
+
+  it('selects a team link when multiple are available', async () => {
+    const otherConnection = {
+      ...mockConnection,
+      id: 'connection-2',
+      convexTeamName: 'Other Team',
+      convexTeamSlug: 'other-team',
+    };
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection, otherConnection]);
+    jest.mocked(selectAsync).mockResolvedValue(otherConnection);
+
+    await createCommand([]).runAsync();
+
+    expect(selectAsync).toHaveBeenCalledWith(
+      'Select a Convex team link to invite yourself to',
+      expect.any(Array)
+    );
+    expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      { convexTeamConnectionId: 'connection-2' }
+    );
+  });
+
+  it('resolves a team by slug when multiple links exist', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([
+      mockConnection,
+      {
+        ...mockConnection,
+        id: 'connection-2',
+        convexTeamIdentifier: 'team-456',
+        convexTeamName: 'Other Team',
+        convexTeamSlug: 'other-team',
+      },
+    ]);
+
+    await createCommand(['other-team', '--non-interactive']).runAsync();
+
+    expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      { convexTeamConnectionId: 'connection-2' }
+    );
+  });
+
+  it('requires a team slug in non-interactive mode when multiple links exist', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([
+      mockConnection,
+      {
+        ...mockConnection,
+        id: 'connection-2',
+        convexTeamName: 'Other Team',
+        convexTeamSlug: 'other-team',
+      },
+    ]);
+
+    await expect(createCommand(['--non-interactive']).runAsync()).rejects.toThrow(
+      'Convex team slug must be provided'
+    );
+  });
+});

--- a/packages/eas-cli/src/commands/integrations/convex/team/invite.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/team/invite.ts
@@ -1,0 +1,159 @@
+import { Args } from '@oclif/core';
+import chalk from 'chalk';
+
+import EasCommand from '../../../../commandUtils/EasCommand';
+import {
+  confirmRecentConvexInviteAsync,
+  formatConvexTeam,
+  getConvexTeamDashboardUrl,
+  logNoConvexTeams,
+} from '../../../../commandUtils/convex';
+import { EASNonInteractiveFlag } from '../../../../commandUtils/flags';
+import { ConvexMutation } from '../../../../graphql/mutations/ConvexMutation';
+import { ConvexQuery } from '../../../../graphql/queries/ConvexQuery';
+import { ConvexTeamConnectionData } from '../../../../graphql/types/ConvexTeamConnection';
+import Log, { link } from '../../../../log';
+import { ora } from '../../../../ora';
+import { getOwnerAccountForProjectIdAsync } from '../../../../project/projectUtils';
+import { selectAsync } from '../../../../prompts';
+
+export default class IntegrationsConvexTeamInvite extends EasCommand {
+  static override description = 'send a Convex team invitation to your verified email address';
+
+  static override args = {
+    CONVEX_TEAM: Args.string({
+      required: false,
+      description: 'Slug of the Convex team to invite yourself to',
+    }),
+  };
+
+  static override flags = {
+    ...EASNonInteractiveFlag,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      args: { CONVEX_TEAM: team },
+      flags: { 'non-interactive': nonInteractive },
+    } = await this.parse(IntegrationsConvexTeamInvite);
+
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient, actor },
+    } = await this.getContextAsync(IntegrationsConvexTeamInvite, {
+      nonInteractive,
+      withServerSideEnvironment: null,
+    });
+
+    const email = this.getActorEmail(actor);
+    if (!email) {
+      Log.warn(
+        `Could not determine your verified email address, so no Convex team invitation was sent. Run ${chalk.cyan(
+          'eas integrations:convex:team:invite'
+        )} after signing in with a user account.`
+      );
+      return;
+    }
+
+    const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
+    const connections = await ConvexQuery.getConvexTeamConnectionsByAccountIdAsync(
+      graphqlClient,
+      account.id
+    );
+
+    if (connections.length === 0) {
+      logNoConvexTeams(account.name);
+      return;
+    }
+
+    const connection = await this.resolveConnectionAsync(connections, team, nonInteractive);
+
+    Log.addNewLineIfNone();
+    this.logTeam(connection);
+    this.logPreviousInvite(connection);
+    Log.newLine();
+
+    if (!(await confirmRecentConvexInviteAsync(connection, { nonInteractive }))) {
+      Log.warn('Skipped sending Convex team invitation.');
+      return;
+    }
+
+    const spinner = ora(`Sending Convex team invitation to ${email}`).start();
+    try {
+      await ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync(graphqlClient, {
+        convexTeamConnectionId: connection.id,
+      });
+      spinner.succeed(
+        `Sent Convex team invitation to ${chalk.bold(email)} for ${chalk.bold(formatConvexTeam(connection))}`
+      );
+      Log.log(`Convex dashboard: ${link(getConvexTeamDashboardUrl(connection), { dim: false })}`);
+    } catch (error) {
+      spinner.fail('Failed to send Convex team invitation');
+      throw error;
+    }
+  }
+
+  private getActorEmail(actor: { __typename: string; [key: string]: any }): string | null {
+    return 'email' in actor && typeof actor.email === 'string' ? actor.email : null;
+  }
+
+  private logTeam(connection: ConvexTeamConnectionData): void {
+    Log.log(chalk.bold(`Convex team ${formatConvexTeam(connection)}`));
+    Log.log(
+      `${chalk.bold('Dashboard')}: ${link(getConvexTeamDashboardUrl(connection), { dim: false })}`
+    );
+  }
+
+  private logPreviousInvite(connection: ConvexTeamConnectionData): void {
+    if (!connection.invitedEmail && !connection.invitedAt) {
+      return;
+    }
+
+    Log.newLine();
+    Log.log(chalk.bold('Previous invite'));
+    if (connection.invitedEmail) {
+      Log.log(`${chalk.bold('Email')}: ${connection.invitedEmail}`);
+    }
+    if (connection.invitedAt) {
+      Log.log(`${chalk.bold('Sent at')}: ${connection.invitedAt}`);
+    }
+  }
+
+  private async resolveConnectionAsync(
+    connections: ConvexTeamConnectionData[],
+    team: string | undefined,
+    nonInteractive: boolean
+  ): Promise<ConvexTeamConnectionData> {
+    if (team) {
+      const connection = connections.find(
+        item => item.convexTeamSlug === team || item.convexTeamName === team || item.id === team
+      );
+      if (!connection) {
+        throw new Error(`Convex team ${team} is not linked to this account.`);
+      }
+      return connection;
+    }
+
+    if (connections.length === 1) {
+      return connections[0];
+    }
+
+    if (nonInteractive) {
+      throw new Error(
+        'Convex team slug must be provided in non-interactive mode when multiple Convex team links exist.'
+      );
+    }
+
+    return await selectAsync(
+      'Select a Convex team link to invite yourself to',
+      connections.map(connection => ({
+        title: formatConvexTeam(connection),
+        value: connection,
+      }))
+    );
+  }
+}


### PR DESCRIPTION
# Why
Users may need to resend a Convex team invite if they missed the original email.

# How
Adds `eas integrations:convex:team:invite`, including previous invite metadata, recent-resend confirmation in interactive mode, and non-interactive warning behavior.

# Test Plan
Local E2E rerun against the team link created in a fresh Expo app before project setup was API-throttled.

Commands run (with `REPO=/Users/fiberjw/Developer/expo/eas-cli`):
```sh
cd packages/eas-cli && yarn build
cd /tmp/eas-convex-e2e-teamfmt
$REPO/packages/eas-cli/bin/run integrations:convex:team:invite --non-interactive
```

Output/verification:
```text
Convex team fiberjw's team (Expo) / fiberjw-ef4a2 (Convex ID: 478548)
EAS connection ID: 019dda27-c450-7647-8ce4-97124c421f91
Dashboard: https://dashboard.convex.dev/t/fiberjw-ef4a2
- Sending Convex team invitation to datwheat@gmail.com
✔ Sent Convex team invitation to datwheat@gmail.com for fiberjw's team (Expo) / fiberjw-ef4a2 (Convex ID: 478548)
Convex dashboard: https://dashboard.convex.dev/t/fiberjw-ef4a2
```
