### PR TITLE
[eas-cli] Add Convex team delete command

### DIFF
--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/team-delete.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/team-delete.test.ts
@@ -1,0 +1,187 @@
+import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../../credentials/__tests__/fixtures-constants';
+import { ConvexMutation } from '../../../../graphql/mutations/ConvexMutation';
+import { ConvexQuery } from '../../../../graphql/queries/ConvexQuery';
+import { ConvexTeamConnectionData } from '../../../../graphql/types/ConvexTeamConnection';
+import Log from '../../../../log';
+import { getOwnerAccountForProjectIdAsync } from '../../../../project/projectUtils';
+import { confirmAsync, selectAsync } from '../../../../prompts';
+import IntegrationsConvexTeamDelete from '../team/delete';
+
+jest.mock('../../../../graphql/queries/ConvexQuery');
+jest.mock('../../../../graphql/mutations/ConvexMutation');
+jest.mock('../../../../project/projectUtils');
+jest.mock('../../../../prompts');
+jest.mock('../../../../log');
+jest.mock('../../../../ora', () => ({
+  ora: () => ({
+    start: jest.fn().mockReturnThis(),
+    succeed: jest.fn().mockReturnThis(),
+    fail: jest.fn().mockReturnThis(),
+  }),
+}));
+
+describe(IntegrationsConvexTeamDelete, () => {
+  const graphqlClient = {} as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+  const testAccountId = 'test-account-id';
+  const testAccountName = 'testuser';
+
+  const mockAccount = {
+    id: testAccountId,
+    name: testAccountName,
+    ownerUserActor: { id: 'test-user-id', username: testAccountName },
+    users: [{ role: 'OWNER' as any, actor: { id: 'test-user-id' } }],
+  };
+
+  const mockConnection: ConvexTeamConnectionData = {
+    id: 'connection-1',
+    convexTeamIdentifier: 'team-123',
+    convexTeamName: 'Test Team',
+    convexTeamSlug: 'test-team',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    invitedAt: '2024-01-02T00:00:00.000Z',
+    invitedEmail: 'user@example.com',
+  };
+
+  function createCommand(argv: string[]): IntegrationsConvexTeamDelete {
+    const command = new IntegrationsConvexTeamDelete(argv, mockConfig);
+    jest.spyOn(command as any, 'getContextAsync').mockReturnValue({
+      privateProjectConfig: {
+        projectId: testProjectId,
+      },
+      loggedIn: { graphqlClient },
+    } as never);
+    return command;
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    jest.spyOn(Log, 'error').mockImplementation(() => {});
+    jest.spyOn(Log, 'addNewLineIfNone').mockImplementation(() => {});
+    jest.spyOn(Log, 'newLine').mockImplementation(() => {});
+
+    jest.mocked(getOwnerAccountForProjectIdAsync).mockResolvedValue(mockAccount as any);
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection]);
+    jest.mocked(ConvexMutation.deleteConvexTeamConnectionAsync).mockResolvedValue(mockConnection);
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+  });
+
+  it('deletes the selected Convex team link after confirmation', async () => {
+    await createCommand(['test-team']).runAsync();
+
+    expect(confirmAsync).toHaveBeenCalledWith({
+      message: expect.stringContaining('This does not destroy resources on Convex'),
+    });
+    expect(ConvexMutation.deleteConvexTeamConnectionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      'connection-1'
+    );
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('Test Team / test-team'));
+    expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('team-123'));
+  });
+
+  it('skips deletion when the user cancels', async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+
+    await createCommand(['test-team']).runAsync();
+
+    expect(ConvexMutation.deleteConvexTeamConnectionAsync).not.toHaveBeenCalled();
+    expect(Log.error).toHaveBeenCalledWith('Canceled deletion of the Convex team link');
+  });
+
+  it('uses --yes to skip the confirmation prompt', async () => {
+    await createCommand(['test-team', '--yes']).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('This does not destroy resources on Convex')
+    );
+    expect(ConvexMutation.deleteConvexTeamConnectionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      'connection-1'
+    );
+  });
+
+  it('logs an empty state when no team links exist', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([]);
+
+    await createCommand([]).runAsync();
+
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('No Convex team is linked'));
+    expect(ConvexMutation.deleteConvexTeamConnectionAsync).not.toHaveBeenCalled();
+  });
+
+  it('throws when the provided team is not linked to the account', async () => {
+    await expect(createCommand(['missing-team']).runAsync()).rejects.toThrow(
+      'Convex team missing-team is not linked to this account.'
+    );
+    expect(ConvexMutation.deleteConvexTeamConnectionAsync).not.toHaveBeenCalled();
+  });
+
+  it('resolves a team by slug when multiple links exist', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([
+      mockConnection,
+      {
+        ...mockConnection,
+        id: 'connection-2',
+        convexTeamIdentifier: 'team-456',
+        convexTeamName: 'Other Team',
+        convexTeamSlug: 'other-team',
+      },
+    ]);
+
+    await createCommand(['other-team', '--non-interactive', '--yes']).runAsync();
+
+    expect(ConvexMutation.deleteConvexTeamConnectionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      'connection-2'
+    );
+  });
+
+  it('requires a team slug in non-interactive mode when multiple links exist', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([
+      mockConnection,
+      {
+        ...mockConnection,
+        id: 'connection-2',
+        convexTeamName: 'Other Team',
+        convexTeamSlug: 'other-team',
+      },
+    ]);
+
+    await expect(createCommand(['--non-interactive']).runAsync()).rejects.toThrow(
+      'Convex team slug must be provided'
+    );
+  });
+
+  it('prompts to select a team link when multiple links exist in interactive mode', async () => {
+    const otherConnection = {
+      ...mockConnection,
+      id: 'connection-2',
+      convexTeamName: 'Other Team',
+      convexTeamSlug: 'other-team',
+    };
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection, otherConnection]);
+    jest.mocked(selectAsync).mockResolvedValue(otherConnection);
+
+    await createCommand(['--yes']).runAsync();
+
+    expect(selectAsync).toHaveBeenCalledWith(
+      'Select a Convex team link to remove',
+      expect.any(Array)
+    );
+    expect(ConvexMutation.deleteConvexTeamConnectionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      'connection-2'
+    );
+  });
+});

--- a/packages/eas-cli/src/commands/integrations/convex/team/delete.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/team/delete.ts
@@ -1,0 +1,138 @@
+import { Args, Flags } from '@oclif/core';
+import chalk from 'chalk';
+
+import EasCommand from '../../../../commandUtils/EasCommand';
+import {
+  formatConvexTeam,
+  formatConvexTeamConnection,
+  getConvexTeamDashboardUrl,
+  logNoConvexTeams,
+} from '../../../../commandUtils/convex';
+import { EASNonInteractiveFlag } from '../../../../commandUtils/flags';
+import { ConvexMutation } from '../../../../graphql/mutations/ConvexMutation';
+import { ConvexQuery } from '../../../../graphql/queries/ConvexQuery';
+import { ConvexTeamConnectionData } from '../../../../graphql/types/ConvexTeamConnection';
+import Log, { link } from '../../../../log';
+import { ora } from '../../../../ora';
+import { getOwnerAccountForProjectIdAsync } from '../../../../project/projectUtils';
+import { confirmAsync, selectAsync } from '../../../../prompts';
+
+export default class IntegrationsConvexTeamDelete extends EasCommand {
+  static override description =
+    "remove a Convex team link from the current Expo app owner account's EAS servers";
+
+  static override args = {
+    CONVEX_TEAM: Args.string({
+      required: false,
+      description: 'Slug of the Convex team to remove',
+    }),
+  };
+
+  static override flags = {
+    ...EASNonInteractiveFlag,
+    yes: Flags.boolean({
+      char: 'y',
+      description: 'Skip confirmation prompt',
+      default: false,
+    }),
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      args: { CONVEX_TEAM: team },
+      flags: { 'non-interactive': nonInteractive, yes },
+    } = await this.parse(IntegrationsConvexTeamDelete);
+
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(IntegrationsConvexTeamDelete, {
+      nonInteractive,
+      withServerSideEnvironment: null,
+    });
+
+    const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
+    const connections = await ConvexQuery.getConvexTeamConnectionsByAccountIdAsync(
+      graphqlClient,
+      account.id
+    );
+
+    if (connections.length === 0) {
+      logNoConvexTeams(account.name);
+      return;
+    }
+
+    const connection = await this.resolveConnectionAsync(connections, team, nonInteractive);
+
+    Log.addNewLineIfNone();
+    Log.log(formatConvexTeamConnection(connection));
+    Log.newLine();
+
+    const dashboardUrl = getConvexTeamDashboardUrl(connection);
+    if (!nonInteractive && !yes) {
+      const confirmed = await confirmAsync({
+        message: `Remove this Convex team link from EAS servers? This does not destroy resources on Convex. Convex dashboard: ${link(
+          dashboardUrl,
+          { dim: false }
+        )}`,
+      });
+      if (!confirmed) {
+        Log.error('Canceled deletion of the Convex team link');
+        return;
+      }
+    } else {
+      Log.warn(
+        `Removing the Convex team link from EAS servers. This does not destroy resources on Convex: ${dashboardUrl}`
+      );
+    }
+
+    const spinner = ora('Removing Convex team link').start();
+    try {
+      await ConvexMutation.deleteConvexTeamConnectionAsync(graphqlClient, connection.id);
+      spinner.succeed(
+        `Removed Convex team ${chalk.bold(formatConvexTeam(connection))} from EAS servers`
+      );
+    } catch (error) {
+      spinner.fail('Failed to remove Convex team link');
+      throw error;
+    }
+  }
+
+  private async resolveConnectionAsync(
+    connections: ConvexTeamConnectionData[],
+    team: string | undefined,
+    nonInteractive: boolean
+  ): Promise<ConvexTeamConnectionData> {
+    if (team) {
+      const connection = connections.find(
+        item => item.convexTeamSlug === team || item.convexTeamName === team || item.id === team
+      );
+      if (!connection) {
+        throw new Error(`Convex team ${team} is not linked to this account.`);
+      }
+      return connection;
+    }
+
+    if (connections.length === 1) {
+      return connections[0];
+    }
+
+    if (nonInteractive) {
+      throw new Error(
+        'Convex team slug must be provided in non-interactive mode when multiple Convex team links exist.'
+      );
+    }
+
+    return await selectAsync(
+      'Select a Convex team link to remove',
+      connections.map(connection => ({
+        title: formatConvexTeam(connection),
+        value: connection,
+      }))
+    );
+  }
+}


### PR DESCRIPTION
# Why
Users need a way to remove stale EAS-side Convex team links.

# How
Adds `eas integrations:convex:team:delete`, with selection by ID/prompt, `--yes`, non-interactive handling, and prompts that state Convex-side resources are not destroyed.

# Test Plan
Local E2E rerun against the team link created in a fresh Expo app before project setup was API-throttled.

Commands run (with `REPO=/Users/fiberjw/Developer/expo/eas-cli`):
```sh
cd packages/eas-cli && yarn build
cd /tmp/eas-convex-e2e-teamfmt
$REPO/packages/eas-cli/bin/run integrations:convex:team:delete 019dda27-c450-7647-8ce4-97124c421f91 --non-interactive --yes
$REPO/packages/eas-cli/bin/run integrations:convex:team
```

Output/verification:
```text
Team: fiberjw's team (Expo) / fiberjw-ef4a2 (Convex ID: 478548)
EAS connection ID: 019dda27-c450-7647-8ce4-97124c421f91
Dashboard: https://dashboard.convex.dev/t/fiberjw-ef4a2
Invited email: datwheat@gmail.com
Removing the Convex team link from EAS servers. This does not destroy resources on Convex: https://dashboard.convex.dev/t/fiberjw-ef4a2
✔ Removed Convex team fiberjw's team (Expo) / fiberjw-ef4a2 (Convex ID: 478548) from EAS servers
No Convex team is linked to account fiberjw on EAS.
```
