### PR TITLE
[eas-cli] Add Convex project command

### DIFF
--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/project.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/project.test.ts
@@ -1,0 +1,78 @@
+import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../../credentials/__tests__/fixtures-constants';
+import { ConvexQuery } from '../../../../graphql/queries/ConvexQuery';
+import {
+  ConvexProjectData,
+  ConvexTeamConnectionData,
+} from '../../../../graphql/types/ConvexTeamConnection';
+import Log from '../../../../log';
+import IntegrationsConvexProject from '../project';
+
+jest.mock('../../../../graphql/queries/ConvexQuery');
+jest.mock('../../../../log');
+
+describe(IntegrationsConvexProject, () => {
+  const graphqlClient = {} as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+
+  const mockConnection: ConvexTeamConnectionData = {
+    id: 'connection-1',
+    convexTeamIdentifier: 'team-123',
+    convexTeamName: 'Test Team',
+    convexTeamSlug: 'test-team',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    invitedAt: null,
+    invitedEmail: null,
+  };
+
+  const mockProject: ConvexProjectData = {
+    id: 'convex-project-1',
+    convexProjectIdentifier: 'project-123',
+    convexProjectName: 'Test Project',
+    convexProjectSlug: 'test-project',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    convexTeamConnection: mockConnection,
+  };
+
+  function createCommand(): IntegrationsConvexProject {
+    const command = new IntegrationsConvexProject([], mockConfig);
+    jest.spyOn(command as any, 'getContextAsync').mockReturnValue({
+      privateProjectConfig: {
+        projectId: testProjectId,
+        exp: { slug: 'testapp' },
+      },
+      loggedIn: { graphqlClient },
+    } as never);
+    return command;
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
+  });
+
+  it('prints linked Convex project metadata', async () => {
+    jest.mocked(ConvexQuery.getConvexProjectByAppIdAsync).mockResolvedValue(mockProject);
+
+    await createCommand().runAsync();
+
+    expect(Log.log).toHaveBeenCalledWith(
+      expect.stringContaining('Convex project linked to testapp')
+    );
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('project-123'));
+  });
+
+  it('prints an empty state when no Convex project is linked', async () => {
+    jest.mocked(ConvexQuery.getConvexProjectByAppIdAsync).mockResolvedValue(null);
+
+    await createCommand().runAsync();
+
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('No Convex project is linked to Expo app')
+    );
+  });
+});

--- a/packages/eas-cli/src/commands/integrations/convex/project.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/project.ts
@@ -1,0 +1,34 @@
+import chalk from 'chalk';
+
+import EasCommand from '../../../commandUtils/EasCommand';
+import { formatConvexProject, logNoConvexProject } from '../../../commandUtils/convex';
+import { ConvexQuery } from '../../../graphql/queries/ConvexQuery';
+import Log from '../../../log';
+
+export default class IntegrationsConvexProject extends EasCommand {
+  static override description = 'display the Convex project linked to the current Expo app';
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      privateProjectConfig: { projectId, exp },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(IntegrationsConvexProject, {
+      nonInteractive: false,
+      withServerSideEnvironment: null,
+    });
+
+    const convexProject = await ConvexQuery.getConvexProjectByAppIdAsync(graphqlClient, projectId);
+
+    if (!convexProject) {
+      logNoConvexProject(exp.slug);
+      return;
+    }
+
+    Log.log(chalk.bold(`Convex project linked to ${exp.slug}`));
+    Log.log(formatConvexProject(convexProject));
+  }
+}


### PR DESCRIPTION
# Why
Users need to inspect the Convex project linked to the current Expo app.

# How
Adds `eas integrations:convex:project` to display the app-linked Convex project with IDs, slugs, identifiers, team, and dashboard URL. The team line now uses the human-readable team name/slug first, then the Convex ID.

# Test Plan
Local E2E rerun after the formatting change. Linked project setup is currently blocked by the API project setup throttle, so this rerun covers the command's no-project state from a fresh Expo app.

Commands run (with `REPO=/Users/fiberjw/Developer/expo/eas-cli`):
```sh
cd packages/eas-cli && yarn build
cd /tmp/eas-convex-e2e-teamfmt
$REPO/packages/eas-cli/bin/run integrations:convex:project
```

Output/verification:
```text
No Convex project is linked to Expo app eas-convex-e2e-teamfmt on EAS.
```
