### PR TITLE
[eas-cli] Add Convex project delete command

### DIFF
--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/project-delete.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/project-delete.test.ts
@@ -1,0 +1,120 @@
+import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../../credentials/__tests__/fixtures-constants';
+import { ConvexMutation } from '../../../../graphql/mutations/ConvexMutation';
+import { ConvexQuery } from '../../../../graphql/queries/ConvexQuery';
+import {
+  ConvexProjectData,
+  ConvexTeamConnectionData,
+} from '../../../../graphql/types/ConvexTeamConnection';
+import Log from '../../../../log';
+import { confirmAsync } from '../../../../prompts';
+import IntegrationsConvexProjectDelete from '../project/delete';
+
+jest.mock('../../../../graphql/queries/ConvexQuery');
+jest.mock('../../../../graphql/mutations/ConvexMutation');
+jest.mock('../../../../prompts');
+jest.mock('../../../../log');
+jest.mock('../../../../ora', () => ({
+  ora: () => ({
+    start: jest.fn().mockReturnThis(),
+    succeed: jest.fn().mockReturnThis(),
+    fail: jest.fn().mockReturnThis(),
+  }),
+}));
+
+describe(IntegrationsConvexProjectDelete, () => {
+  const graphqlClient = {} as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+
+  const mockConnection: ConvexTeamConnectionData = {
+    id: 'connection-1',
+    convexTeamIdentifier: 'team-123',
+    convexTeamName: 'Test Team',
+    convexTeamSlug: 'test-team',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    invitedAt: null,
+    invitedEmail: null,
+  };
+
+  const mockProject: ConvexProjectData = {
+    id: 'convex-project-1',
+    convexProjectIdentifier: 'project-123',
+    convexProjectName: 'Test Project',
+    convexProjectSlug: 'test-project',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    convexTeamConnection: mockConnection,
+  };
+
+  function createCommand(argv: string[]): IntegrationsConvexProjectDelete {
+    const command = new IntegrationsConvexProjectDelete(argv, mockConfig);
+    jest.spyOn(command as any, 'getContextAsync').mockReturnValue({
+      privateProjectConfig: {
+        projectId: testProjectId,
+        exp: { slug: 'testapp' },
+      },
+      loggedIn: { graphqlClient },
+    } as never);
+    return command;
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    jest.spyOn(Log, 'error').mockImplementation(() => {});
+    jest.spyOn(Log, 'addNewLineIfNone').mockImplementation(() => {});
+    jest.spyOn(Log, 'newLine').mockImplementation(() => {});
+
+    jest.mocked(ConvexQuery.getConvexProjectByAppIdAsync).mockResolvedValue(mockProject);
+    jest.mocked(ConvexMutation.deleteConvexProjectAsync).mockResolvedValue('convex-project-1');
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+  });
+
+  it('deletes the linked Convex project after confirmation', async () => {
+    await createCommand([]).runAsync();
+
+    expect(confirmAsync).toHaveBeenCalledWith({
+      message: expect.stringContaining('This does not destroy resources on Convex'),
+    });
+    expect(ConvexMutation.deleteConvexProjectAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      'convex-project-1'
+    );
+  });
+
+  it('skips deletion when the user cancels', async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+
+    await createCommand([]).runAsync();
+
+    expect(ConvexMutation.deleteConvexProjectAsync).not.toHaveBeenCalled();
+    expect(Log.error).toHaveBeenCalledWith('Canceled deletion of the Convex project link');
+  });
+
+  it('uses --yes to skip the confirmation prompt', async () => {
+    await createCommand(['--yes']).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('This does not destroy resources on Convex')
+    );
+    expect(ConvexMutation.deleteConvexProjectAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      'convex-project-1'
+    );
+  });
+
+  it('logs an empty state when no project link exists', async () => {
+    jest.mocked(ConvexQuery.getConvexProjectByAppIdAsync).mockResolvedValue(null);
+
+    await createCommand([]).runAsync();
+
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('No Convex project is linked to Expo app')
+    );
+    expect(ConvexMutation.deleteConvexProjectAsync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/commands/integrations/convex/project/delete.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/project/delete.ts
@@ -1,0 +1,87 @@
+import { Flags } from '@oclif/core';
+import chalk from 'chalk';
+
+import EasCommand from '../../../../commandUtils/EasCommand';
+import {
+  formatConvexProject,
+  getConvexProjectDashboardUrl,
+  logNoConvexProject,
+} from '../../../../commandUtils/convex';
+import { EASNonInteractiveFlag } from '../../../../commandUtils/flags';
+import { ConvexMutation } from '../../../../graphql/mutations/ConvexMutation';
+import { ConvexQuery } from '../../../../graphql/queries/ConvexQuery';
+import Log, { link } from '../../../../log';
+import { ora } from '../../../../ora';
+import { confirmAsync } from '../../../../prompts';
+
+export default class IntegrationsConvexProjectDelete extends EasCommand {
+  static override description =
+    'remove the Convex project link for the current Expo app from EAS servers';
+
+  static override flags = {
+    ...EASNonInteractiveFlag,
+    yes: Flags.boolean({
+      char: 'y',
+      description: 'Skip confirmation prompt',
+      default: false,
+    }),
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      flags: { 'non-interactive': nonInteractive, yes },
+    } = await this.parse(IntegrationsConvexProjectDelete);
+
+    const {
+      privateProjectConfig: { projectId, exp },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(IntegrationsConvexProjectDelete, {
+      nonInteractive,
+      withServerSideEnvironment: null,
+    });
+
+    const convexProject = await ConvexQuery.getConvexProjectByAppIdAsync(graphqlClient, projectId);
+
+    if (!convexProject) {
+      logNoConvexProject(exp.slug);
+      return;
+    }
+
+    Log.addNewLineIfNone();
+    Log.log(formatConvexProject(convexProject));
+    Log.newLine();
+
+    const dashboardUrl = getConvexProjectDashboardUrl(convexProject);
+    if (!nonInteractive && !yes) {
+      const confirmed = await confirmAsync({
+        message: `Remove this Convex project link from EAS servers? This does not destroy resources on Convex. Convex dashboard: ${link(
+          dashboardUrl,
+          { dim: false }
+        )}`,
+      });
+      if (!confirmed) {
+        Log.error('Canceled deletion of the Convex project link');
+        return;
+      }
+    } else {
+      Log.warn(
+        `Removing the Convex project link from EAS servers. This does not destroy resources on Convex: ${dashboardUrl}`
+      );
+    }
+
+    const spinner = ora('Removing Convex project link').start();
+    try {
+      await ConvexMutation.deleteConvexProjectAsync(graphqlClient, convexProject.id);
+      spinner.succeed(
+        `Removed Convex project ${chalk.bold(convexProject.convexProjectName)} from EAS servers`
+      );
+    } catch (error) {
+      spinner.fail('Failed to remove Convex project link');
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
# Why
Users need a way to remove the EAS-side Convex project link for an Expo app.

# How
Adds `eas integrations:convex:project:delete`, with `--yes`, non-interactive handling, and prompts that include the Convex dashboard URL and state Convex-side resources are not destroyed.

# Test Plan
Local E2E rerun after the formatting change. Linked project setup is currently blocked by the API project setup throttle, so this rerun covers the no-project delete path from a fresh Expo app.

Commands run (with `REPO=/Users/fiberjw/Developer/expo/eas-cli`):
```sh
cd packages/eas-cli && yarn build
cd /tmp/eas-convex-e2e-teamfmt
$REPO/packages/eas-cli/bin/run integrations:convex:project:delete --non-interactive --yes
```

Output/verification:
```text
No Convex project is linked to Expo app eas-convex-e2e-teamfmt on EAS.
```
