### PR TITLE
[eas-cli] Allow eas build:download to accept a build ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [eas-cli] Add `eas integrations:asc` commands to manage App Store Connect integrations for EAS projects. ([#3558](https://github.com/expo/eas-cli/pull/3558) by [@sswrk](https://github.com/sswrk))
+- [eas-cli] Allow `eas build:download` to accept a build ID. ([#3655](https://github.com/expo/eas-cli/pull/3655) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/build/__tests__/download.test.ts
+++ b/packages/eas-cli/src/commands/build/__tests__/download.test.ts
@@ -1,0 +1,197 @@
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { getMockOclifConfig } from '../../../__tests__/commands/utils';
+import { AppPlatform, BuildFragment } from '../../../graphql/generated';
+import { BuildQuery } from '../../../graphql/queries/BuildQuery';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+import Download from '../download';
+
+jest.mock('../../../graphql/queries/BuildQuery');
+jest.mock('../../../log');
+jest.mock('../../../utils/json');
+
+const mockByIdAsync = jest.mocked(BuildQuery.byIdAsync);
+const mockViewBuildsOnAppAsync = jest.mocked(BuildQuery.viewBuildsOnAppAsync);
+const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
+const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
+
+function makeBuild(overrides: Partial<BuildFragment> = {}): BuildFragment {
+  return {
+    id: 'build-123',
+    platform: AppPlatform.Ios,
+    project: { id: 'project-1' },
+    artifacts: {
+      applicationArchiveUrl: 'https://example.com/app.tar.gz',
+      buildArtifactsUrl: null,
+      xcodeBuildLogsUrl: null,
+      buildUrl: null,
+    },
+    ...overrides,
+  } as unknown as BuildFragment;
+}
+
+describe(Download, () => {
+  const graphqlClient = {} as any as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+  const projectId = 'test-project-id';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createCommand(argv: string[]): Download {
+    const command = new Download(argv, mockConfig);
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockResolvedValue({
+      projectId,
+      loggedIn: { graphqlClient },
+    });
+    // Stub the file-system-touching helpers so we don't hit disk.
+    jest
+      .spyOn(command as any, 'getPathToBuildArtifactAsync')
+      .mockResolvedValue('/cache/path/to/build.app');
+    jest.spyOn(command as any, 'downloadExtraArtifactsAsync').mockResolvedValue({});
+    return command;
+  }
+
+  it('errors when neither --build-id nor --fingerprint is provided', async () => {
+    const command = createCommand([]);
+    await expect(command.runAsync()).rejects.toThrow(
+      'Either --build-id or --fingerprint is required.'
+    );
+  });
+
+  it('fetches build by ID when --build-id is provided', async () => {
+    mockByIdAsync.mockResolvedValue(makeBuild());
+
+    const command = createCommand(['--build-id', 'build-123']);
+    await command.runAsync();
+
+    expect(mockByIdAsync).toHaveBeenCalledWith(graphqlClient, 'build-123');
+    expect(mockViewBuildsOnAppAsync).not.toHaveBeenCalled();
+  });
+
+  it('fetches builds by fingerprint when --fingerprint is provided', async () => {
+    mockViewBuildsOnAppAsync.mockResolvedValue([makeBuild()]);
+
+    const command = createCommand(['--fingerprint', 'fp-abc', '--platform', 'ios']);
+    await command.runAsync();
+
+    expect(mockViewBuildsOnAppAsync).toHaveBeenCalledTimes(1);
+    expect(mockViewBuildsOnAppAsync.mock.calls[0][1].filter?.fingerprintHash).toBe('fp-abc');
+    expect(mockByIdAsync).not.toHaveBeenCalled();
+  });
+
+  it('uses platform from the build itself when --build-id is provided', async () => {
+    mockByIdAsync.mockResolvedValue(makeBuild({ platform: AppPlatform.Android }));
+
+    const command = createCommand(['--build-id', 'build-123']);
+    await command.runAsync();
+
+    const getPathSpy = jest.spyOn(command as any, 'getPathToBuildArtifactAsync');
+    // The spy was set up after instantiation; just ensure runAsync used the build's platform
+    // by checking that no platform prompt was needed.
+    expect(getPathSpy).toBeDefined();
+  });
+
+  it('errors with a helpful message when applicationArchiveUrl is missing and other artifacts exist', async () => {
+    mockByIdAsync.mockResolvedValue(
+      makeBuild({
+        artifacts: {
+          applicationArchiveUrl: null,
+          buildArtifactsUrl: 'https://example.com/build-artifacts.tar.gz',
+          xcodeBuildLogsUrl: 'https://example.com/xcode-logs.tar.gz',
+          buildUrl: null,
+        } as any,
+      })
+    );
+
+    const command = createCommand(['--build-id', 'build-123']);
+    await expect(command.runAsync()).rejects.toThrow(
+      /Other artifacts are available \(buildArtifacts, xcodeBuildLogs\); re-run with --all-artifacts/
+    );
+  });
+
+  it('errors with the basic message when applicationArchiveUrl is missing and no other artifacts exist', async () => {
+    mockByIdAsync.mockResolvedValue(
+      makeBuild({
+        artifacts: {
+          applicationArchiveUrl: null,
+          buildArtifactsUrl: null,
+          xcodeBuildLogsUrl: null,
+          buildUrl: null,
+        } as any,
+      })
+    );
+
+    const command = createCommand(['--build-id', 'build-123']);
+    await expect(command.runAsync()).rejects.toThrow('Build does not have an application archive url');
+  });
+
+  it('does not throw when applicationArchiveUrl is missing but --all-artifacts is set', async () => {
+    mockByIdAsync.mockResolvedValue(
+      makeBuild({
+        artifacts: {
+          applicationArchiveUrl: null,
+          buildArtifactsUrl: 'https://example.com/build-artifacts.tar.gz',
+          xcodeBuildLogsUrl: null,
+          buildUrl: null,
+        } as any,
+      })
+    );
+
+    const command = createCommand(['--build-id', 'build-123', '--all-artifacts']);
+    const downloadExtrasSpy = jest
+      .spyOn(command as any, 'downloadExtraArtifactsAsync')
+      .mockResolvedValue({ buildArtifacts: '/cache/build-123-artifacts/build-artifacts.tar.gz' });
+
+    await expect(command.runAsync()).resolves.not.toThrow();
+    expect(downloadExtrasSpy).toHaveBeenCalled();
+  });
+
+  it('downloads extras only when --all-artifacts is set, regardless of --build-id vs --fingerprint', async () => {
+    mockViewBuildsOnAppAsync.mockResolvedValue([makeBuild()]);
+
+    const commandWithoutFlag = createCommand(['--fingerprint', 'fp-abc', '--platform', 'ios']);
+    const downloadExtrasSpyWithout = jest
+      .spyOn(commandWithoutFlag as any, 'downloadExtraArtifactsAsync')
+      .mockResolvedValue({});
+    await commandWithoutFlag.runAsync();
+    expect(downloadExtrasSpyWithout).not.toHaveBeenCalled();
+
+    const commandWithFlag = createCommand([
+      '--fingerprint',
+      'fp-abc',
+      '--platform',
+      'ios',
+      '--all-artifacts',
+    ]);
+    const downloadExtrasSpyWith = jest
+      .spyOn(commandWithFlag as any, 'downloadExtraArtifactsAsync')
+      .mockResolvedValue({ buildArtifacts: '/path/to/extras' });
+    await commandWithFlag.runAsync();
+    expect(downloadExtrasSpyWith).toHaveBeenCalled();
+  });
+
+  it('emits JSON with path and extras when --json --all-artifacts are set', async () => {
+    mockByIdAsync.mockResolvedValue(makeBuild());
+
+    const command = createCommand([
+      '--build-id',
+      'build-123',
+      '--all-artifacts',
+      '--json',
+      '--non-interactive',
+    ]);
+    jest
+      .spyOn(command as any, 'downloadExtraArtifactsAsync')
+      .mockResolvedValue({ buildArtifacts: '/cache/extras/build-artifacts.tar.gz' });
+
+    await command.runAsync();
+
+    expect(mockEnableJsonOutput).toHaveBeenCalled();
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
+      path: '/cache/path/to/build.app',
+      buildArtifacts: '/cache/extras/build-artifacts.tar.gz',
+    });
+  });
+});

--- a/packages/eas-cli/src/commands/build/download.ts
+++ b/packages/eas-cli/src/commands/build/download.ts
@@ -111,6 +111,12 @@ export default class Download extends EasCommand {
     if (build.artifacts?.applicationArchiveUrl) {
       buildArtifactPath = await this.getPathToBuildArtifactAsync(build, selectedPlatform);
     } else if (!allArtifacts) {
+      const availableArtifacts = listAvailableExtraArtifactNames(build);
+      if (availableArtifacts.length > 0) {
+        throw new Error(
+          `Build does not have an application archive url. Other artifacts are available (${availableArtifacts.join(', ')}); re-run with --all-artifacts to download them.`
+        );
+      }
       throw new Error('Build does not have an application archive url');
     }
 
@@ -275,6 +281,23 @@ async function resolvePlatformAsync({
     ],
   });
   return selectedPlatform;
+}
+
+function listAvailableExtraArtifactNames(build: BuildFragment): string[] {
+  const names: string[] = [];
+  if (build.artifacts?.buildArtifactsUrl) {
+    names.push('buildArtifacts');
+  }
+  if (build.artifacts?.xcodeBuildLogsUrl) {
+    names.push('xcodeBuildLogs');
+  }
+  if (
+    build.artifacts?.buildUrl &&
+    build.artifacts.buildUrl !== build.artifacts.applicationArchiveUrl
+  ) {
+    names.push('build');
+  }
+  return names;
 }
 
 function getFileNameFromUrl(url: string, fallbackName: string): string {

--- a/packages/eas-cli/src/commands/build/download.ts
+++ b/packages/eas-cli/src/commands/build/download.ts
@@ -19,20 +19,29 @@ import { downloadAndMaybeExtractAppAsync } from '../../utils/download';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class Download extends EasCommand {
-  static override description = 'download simulator/emulator builds for a given fingerprint hash';
+  static override description =
+    'download a simulator/emulator build by build ID or fingerprint hash';
+
 
   static override flags = {
+    'build-id': Flags.string({
+      description:
+        'ID of the build to download. Mutually exclusive with --fingerprint, --platform, and --dev-client; the platform is derived from the build itself.',
+      exclusive: ['fingerprint', 'platform', 'dev-client'],
+    }),
     fingerprint: Flags.string({
       description: 'Fingerprint hash of the build to download',
-      required: true,
+      exclusive: ['build-id'],
     }),
     platform: Flags.option({
       char: 'p',
       options: [Platform.IOS, Platform.ANDROID] as const,
+      exclusive: ['build-id'],
     })(),
     'dev-client': Flags.boolean({
       description: 'Filter only dev-client builds.',
       allowNo: true,
+      exclusive: ['build-id'],
     }),
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -45,6 +54,7 @@ export default class Download extends EasCommand {
   async runAsync(): Promise<void> {
     const {
       flags: {
+        'build-id': buildId,
         platform,
         fingerprint,
         'dev-client': developmentClient,
@@ -52,6 +62,10 @@ export default class Download extends EasCommand {
       },
     } = await this.parse(Download);
     const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(rawFlags);
+
+    if (!buildId && !fingerprint) {
+      throw new Errors.CLIError('Either --build-id or --fingerprint is required.');
+    }
 
     const {
       loggedIn: { graphqlClient },
@@ -64,14 +78,23 @@ export default class Download extends EasCommand {
       enableJsonOutput();
     }
 
-    const selectedPlatform = await resolvePlatformAsync({ nonInteractive, platform });
-    const build = await this.getBuildAsync({
-      graphqlClient,
-      projectId,
-      platform: selectedPlatform,
-      fingerprintHash: fingerprint,
-      developmentClient,
-    });
+    let build: BuildFragment;
+    let selectedPlatform: AppPlatform;
+    if (buildId) {
+      build = await this.getBuildByIdAsync({ graphqlClient, buildId });
+      selectedPlatform = build.platform;
+      Log.succeed(`🎯 Found build ${chalk.bold(buildId)} on EAS servers.`);
+    } else {
+      selectedPlatform = await resolvePlatformAsync({ nonInteractive, platform });
+      build = await this.getBuildByFingerprintAsync({
+        graphqlClient,
+        projectId,
+        platform: selectedPlatform,
+        fingerprintHash: fingerprint!,
+        developmentClient,
+      });
+    }
+
     const buildArtifactPath = await this.getPathToBuildArtifactAsync(build, selectedPlatform);
     if (jsonFlag) {
       const jsonResults = { path: buildArtifactPath };
@@ -81,7 +104,21 @@ export default class Download extends EasCommand {
     }
   }
 
-  private async getBuildAsync({
+  private async getBuildByIdAsync({
+    graphqlClient,
+    buildId,
+  }: {
+    graphqlClient: ExpoGraphqlClient;
+    buildId: string;
+  }): Promise<BuildFragment> {
+    try {
+      return await BuildQuery.byIdAsync(graphqlClient, buildId);
+    } catch (error: any) {
+      throw new Errors.CLIError(`Could not find build with ID ${buildId}: ${error.message}`);
+    }
+  }
+
+  private async getBuildByFingerprintAsync({
     graphqlClient,
     projectId,
     platform,

--- a/packages/eas-cli/src/commands/build/download.ts
+++ b/packages/eas-cli/src/commands/build/download.ts
@@ -32,7 +32,7 @@ export default class Download extends EasCommand {
   static override flags = {
     'build-id': Flags.string({
       description:
-        'ID of the build to download. Mutually exclusive with --fingerprint, --platform, and --dev-client; the platform is derived from the build itself. All available build artifacts (application archive, build artifacts archive, Xcode logs) are downloaded.',
+        'ID of the build to download. Mutually exclusive with --fingerprint, --platform, and --dev-client; the platform is derived from the build itself.',
       exclusive: ['fingerprint', 'platform', 'dev-client'],
     }),
     fingerprint: Flags.string({
@@ -49,6 +49,11 @@ export default class Download extends EasCommand {
       allowNo: true,
       exclusive: ['build-id'],
     }),
+    'all-artifacts': Flags.boolean({
+      description:
+        'Download all available build artifacts (build artifacts archive, Xcode logs, etc.) in addition to the application archive. Without this flag, only the application archive is downloaded and the command errors if it is missing.',
+      default: false,
+    }),
     ...EasNonInteractiveAndJsonFlags,
   };
 
@@ -64,6 +69,7 @@ export default class Download extends EasCommand {
         platform,
         fingerprint,
         'dev-client': developmentClient,
+        'all-artifacts': allArtifacts,
         ...rawFlags
       },
     } = await this.parse(Download);
@@ -104,12 +110,12 @@ export default class Download extends EasCommand {
     let buildArtifactPath: string | null = null;
     if (build.artifacts?.applicationArchiveUrl) {
       buildArtifactPath = await this.getPathToBuildArtifactAsync(build, selectedPlatform);
-    } else if (!buildId) {
+    } else if (!allArtifacts) {
       throw new Error('Build does not have an application archive url');
     }
 
     let extraArtifactPaths: Record<string, string> = {};
-    if (buildId) {
+    if (allArtifacts) {
       extraArtifactPaths = await this.downloadExtraArtifactsAsync(build);
     }
 

--- a/packages/eas-cli/src/commands/build/download.ts
+++ b/packages/eas-cli/src/commands/build/download.ts
@@ -1,7 +1,8 @@
 import { Platform } from '@expo/eas-build-job';
 import { Errors, Flags } from '@oclif/core';
 import chalk from 'chalk';
-import { pathExists } from 'fs-extra';
+import fs from 'fs-extra';
+import path from 'path';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
@@ -15,8 +16,13 @@ import { toAppPlatform } from '../../graphql/types/AppPlatform';
 import Log from '../../log';
 import { promptAsync } from '../../prompts';
 import { getEasBuildRunCachedAppPath } from '../../run/run';
-import { downloadAndMaybeExtractAppAsync } from '../../utils/download';
+import {
+  downloadAndMaybeExtractAppAsync,
+  downloadFileWithProgressTrackerAsync,
+} from '../../utils/download';
+import { formatBytes } from '../../utils/files';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+import { getEasBuildRunCacheDirectoryPath } from '../../utils/paths';
 
 export default class Download extends EasCommand {
   static override description =
@@ -26,7 +32,7 @@ export default class Download extends EasCommand {
   static override flags = {
     'build-id': Flags.string({
       description:
-        'ID of the build to download. Mutually exclusive with --fingerprint, --platform, and --dev-client; the platform is derived from the build itself.',
+        'ID of the build to download. Mutually exclusive with --fingerprint, --platform, and --dev-client; the platform is derived from the build itself. All available build artifacts (application archive, build artifacts archive, Xcode logs) are downloaded.',
       exclusive: ['fingerprint', 'platform', 'dev-client'],
     }),
     fingerprint: Flags.string({
@@ -95,13 +101,73 @@ export default class Download extends EasCommand {
       });
     }
 
-    const buildArtifactPath = await this.getPathToBuildArtifactAsync(build, selectedPlatform);
+    let buildArtifactPath: string | null = null;
+    if (build.artifacts?.applicationArchiveUrl) {
+      buildArtifactPath = await this.getPathToBuildArtifactAsync(build, selectedPlatform);
+    } else if (!buildId) {
+      throw new Error('Build does not have an application archive url');
+    }
+
+    let extraArtifactPaths: Record<string, string> = {};
+    if (buildId) {
+      extraArtifactPaths = await this.downloadExtraArtifactsAsync(build);
+    }
+
     if (jsonFlag) {
-      const jsonResults = { path: buildArtifactPath };
+      const jsonResults = {
+        ...(buildArtifactPath != null && { path: buildArtifactPath }),
+        ...extraArtifactPaths,
+      };
       printJsonOnlyOutput(jsonResults);
     } else {
-      Log.log(`Build downloaded to ${chalk.bold(buildArtifactPath)}`);
+      if (buildArtifactPath != null) {
+        Log.log(`Build downloaded to ${chalk.bold(buildArtifactPath)}`);
+      }
+      for (const [name, filePath] of Object.entries(extraArtifactPaths)) {
+        Log.log(`${name} downloaded to ${chalk.bold(filePath)}`);
+      }
     }
+  }
+
+  private async downloadExtraArtifactsAsync(build: BuildFragment): Promise<Record<string, string>> {
+    const artifacts = build.artifacts;
+    if (!artifacts) {
+      return {};
+    }
+
+    const extraArtifacts: Array<{ name: string; url: string }> = [];
+    if (artifacts.buildArtifactsUrl) {
+      extraArtifacts.push({ name: 'buildArtifacts', url: artifacts.buildArtifactsUrl });
+    }
+    if (artifacts.xcodeBuildLogsUrl) {
+      extraArtifacts.push({ name: 'xcodeBuildLogs', url: artifacts.xcodeBuildLogsUrl });
+    }
+    if (artifacts.buildUrl && artifacts.buildUrl !== artifacts.applicationArchiveUrl) {
+      extraArtifacts.push({ name: 'build', url: artifacts.buildUrl });
+    }
+
+    if (extraArtifacts.length === 0) {
+      return {};
+    }
+
+    const outputDir = path.join(getEasBuildRunCacheDirectoryPath(), `${build.id}-artifacts`);
+    await fs.ensureDir(outputDir);
+
+    const downloaded: Record<string, string> = {};
+    for (const { name, url } of extraArtifacts) {
+      const fileName = getFileNameFromUrl(url, name);
+      const outputPath = path.join(outputDir, fileName);
+      await downloadFileWithProgressTrackerAsync(
+        url,
+        outputPath,
+        (ratio, total) =>
+          `Downloading ${name} (${formatBytes(total * ratio)} / ${formatBytes(total)})`,
+        `Successfully downloaded ${name}`
+      );
+      downloaded[name] = outputPath;
+    }
+
+    return downloaded;
   }
 
   private async getBuildByIdAsync({
@@ -160,7 +226,7 @@ export default class Download extends EasCommand {
       build.id,
       platform
     );
-    if (await pathExists(cachedBuildArtifactPath)) {
+    if (await fs.pathExists(cachedBuildArtifactPath)) {
       Log.newLine();
       Log.log(`Using cached build...`);
       return cachedBuildArtifactPath;
@@ -203,4 +269,17 @@ async function resolvePlatformAsync({
     ],
   });
   return selectedPlatform;
+}
+
+function getFileNameFromUrl(url: string, fallbackName: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    const basename = path.basename(pathname);
+    if (basename) {
+      return basename;
+    }
+  } catch {
+    // fall through to default
+  }
+  return fallbackName;
 }

--- a/packages/eas-cli/src/commands/build/download.ts
+++ b/packages/eas-cli/src/commands/build/download.ts
@@ -1,5 +1,5 @@
 import { Platform } from '@expo/eas-build-job';
-import { Errors, Flags } from '@oclif/core';
+import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
@@ -76,7 +76,7 @@ export default class Download extends EasCommand {
     const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(rawFlags);
 
     if (!buildId && !fingerprint) {
-      throw new Errors.CLIError('Either --build-id or --fingerprint is required.');
+      throw new Error('Either --build-id or --fingerprint is required.');
     }
 
     const {
@@ -192,7 +192,7 @@ export default class Download extends EasCommand {
     try {
       return await BuildQuery.byIdAsync(graphqlClient, buildId);
     } catch (error: any) {
-      throw new Errors.CLIError(`Could not find build with ID ${buildId}: ${error.message}`);
+      throw new Error(`Could not find build with ID ${buildId}: ${error.message}`);
     }
   }
 
@@ -223,7 +223,7 @@ export default class Download extends EasCommand {
       limit: 1,
     });
     if (builds.length === 0) {
-      throw new Errors.CLIError(
+      throw new Error(
         `No builds available for ${platform} with fingerprint hash ${fingerprintHash}`
       );
     }

--- a/packages/eas-cli/src/utils/download.ts
+++ b/packages/eas-cli/src/utils/download.ts
@@ -70,7 +70,7 @@ function wrapFetchWithProgress(): (
   };
 }
 
-async function downloadFileWithProgressTrackerAsync(
+export async function downloadFileWithProgressTrackerAsync(
   url: string,
   outputPath: string,
   progressTrackerMessage: string | ((ratio: number, total: number) => string),


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

For certain workflows, it is useful to be able to download build artifacts for a known build ID.

# How

Added a new flag `--build-id` to the `eas build:download` command. When this flag is used,`--fingerprint`, `--dev-client`, and `--platform` are excluded.

Also added the `--all-artifacts`flag. When set, all available artifacts are downloaded. Otherwise, the previous behavior applies (only application archive URL is downloaded).

# Test Plan

- Tested in a real project
- New unit tests added