### PR TITLE
[eas-cli] Alias --build-id to --id in build:download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Add `eas integrations:asc` commands to manage App Store Connect integrations for EAS projects. ([#3558](https://github.com/expo/eas-cli/pull/3558) by [@sswrk](https://github.com/sswrk))
 - [eas-cli] Allow `eas build:download` to accept a build ID. ([#3655](https://github.com/expo/eas-cli/pull/3655) by [@douglowder](https://github.com/douglowder))
-- [eas-cli] Add `--id` alias for `--build-id` flag in `eas build:download`. ([@brentvatne](https://github.com/brentvatne))
+- [eas-cli] Add `--id` alias for `--build-id` flag in `eas build:download`. ([#3656](https://github.com/expo/eas-cli/pull/3656) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Add `eas integrations:asc` commands to manage App Store Connect integrations for EAS projects. ([#3558](https://github.com/expo/eas-cli/pull/3558) by [@sswrk](https://github.com/sswrk))
 - [eas-cli] Allow `eas build:download` to accept a build ID. ([#3655](https://github.com/expo/eas-cli/pull/3655) by [@douglowder](https://github.com/douglowder))
+- [eas-cli] Add `--id` alias for `--build-id` flag in `eas build:download`. ([@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/build/__tests__/download.test.ts
+++ b/packages/eas-cli/src/commands/build/__tests__/download.test.ts
@@ -70,6 +70,16 @@ describe(Download, () => {
     expect(mockViewBuildsOnAppAsync).not.toHaveBeenCalled();
   });
 
+  it('fetches build by ID when --id alias is provided', async () => {
+    mockByIdAsync.mockResolvedValue(makeBuild());
+
+    const command = createCommand(['--id', 'build-123']);
+    await command.runAsync();
+
+    expect(mockByIdAsync).toHaveBeenCalledWith(graphqlClient, 'build-123');
+    expect(mockViewBuildsOnAppAsync).not.toHaveBeenCalled();
+  });
+
   it('fetches builds by fingerprint when --fingerprint is provided', async () => {
     mockViewBuildsOnAppAsync.mockResolvedValue([makeBuild()]);
 

--- a/packages/eas-cli/src/commands/build/download.ts
+++ b/packages/eas-cli/src/commands/build/download.ts
@@ -31,6 +31,7 @@ export default class Download extends EasCommand {
 
   static override flags = {
     'build-id': Flags.string({
+      aliases: ['id'],
       description:
         'ID of the build to download. Mutually exclusive with --fingerprint, --platform, and --dev-client; the platform is derived from the build itself.',
       exclusive: ['fingerprint', 'platform', 'dev-client'],


### PR DESCRIPTION
# Why

Just a little useful shorthand, it makes sense to accept as just `id` given that we are operating on the `build` command here.

# How

Alias it

# Test Plan

`easd build:download --id`
