### PR TITLE
[build-tools] Add `expo` package version to Datadog error logs

### DIFF
--- a/packages/worker/src/__unit__/service.test.ts
+++ b/packages/worker/src/__unit__/service.test.ts
@@ -1,0 +1,213 @@
+import {
+  ArchiveSourceType,
+  BuildMode,
+  BuildTrigger,
+  Platform,
+  Workflow,
+  errors,
+} from '@expo/eas-build-job';
+import spawn from '@expo/turtle-spawn';
+import { vol } from 'memfs';
+import path from 'path';
+
+import { build } from '../build';
+import { createBuildContext } from '../context';
+import BuildService, { getExpoPackageVersionAsync } from '../service';
+import { turtleFetch } from '../utils/turtleFetch';
+
+jest.mock('fs');
+jest.mock('@expo/turtle-spawn', () => jest.fn());
+jest.mock('../build', () => ({
+  build: jest.fn(),
+}));
+jest.mock('../context', () => ({
+  createBuildContext: jest.fn(),
+}));
+jest.mock('../external/analytics', () => ({
+  Analytics: jest.fn().mockImplementation(() => ({
+    flushEventsAsync: jest.fn(),
+    logEvent: jest.fn(),
+  })),
+}));
+jest.mock('../logger', () => {
+  const logger = {
+    child: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    level: jest.fn(),
+    warn: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+
+  return {
+    __esModule: true,
+    default: logger,
+    createBuildLoggerWithSecretsFilter: jest.fn(async () => ({
+      cleanUp: jest.fn(),
+      logBuffer: { getLogs: jest.fn(() => []), getPhaseLogs: jest.fn(() => []) },
+      logger,
+    })),
+  };
+});
+jest.mock('../sentry', () => ({
+  __esModule: true,
+  default: {
+    handleError: jest.fn(),
+  },
+}));
+jest.mock('../utils/turtleFetch', () => ({
+  turtleFetch: jest.fn(),
+}));
+jest.mock('../config', () => {
+  const config = jest.requireActual('../config').default;
+  return {
+    __esModule: true,
+    default: {
+      ...config,
+      buildId: 'build-id',
+      wwwApiV2BaseUrl: 'http://api.expo.test/v2/',
+    },
+  };
+});
+
+describe(getExpoPackageVersionAsync, () => {
+  const projectRoot = '/test-project';
+  const expoPackageJsonPath = path.join(projectRoot, 'node_modules/expo/package.json');
+
+  beforeEach(() => {
+    vol.reset();
+    jest.clearAllMocks();
+  });
+
+  it('returns the exact installed expo package version', async () => {
+    jest.mocked(spawn).mockResolvedValue({ stdout: Buffer.from(expoPackageJsonPath) } as any);
+    vol.fromJSON({
+      [expoPackageJsonPath]: JSON.stringify({ version: '55.0.17' }),
+    });
+
+    await expect(getExpoPackageVersionAsync(projectRoot)).resolves.toBe('55.0.17');
+  });
+
+  it('throws a user error when expo package version resolution fails', async () => {
+    jest.mocked(spawn).mockRejectedValue(new Error('Cannot find module expo/package.json'));
+
+    await expect(getExpoPackageVersionAsync(projectRoot)).rejects.toMatchObject({
+      errorCode: 'EAS_BUILD_EXPO_PACKAGE_VERSION_NOT_FOUND',
+    });
+    await expect(getExpoPackageVersionAsync(projectRoot)).rejects.toBeInstanceOf(errors.UserError);
+  });
+
+  it('throws a user error when the installed expo package version is not valid semver', async () => {
+    jest.mocked(spawn).mockResolvedValue({ stdout: Buffer.from(expoPackageJsonPath) } as any);
+    vol.fromJSON({
+      [expoPackageJsonPath]: JSON.stringify({ version: 'invalid-version' }),
+    });
+
+    await expect(getExpoPackageVersionAsync(projectRoot)).rejects.toMatchObject({
+      errorCode: 'EAS_BUILD_EXPO_PACKAGE_VERSION_INVALID',
+    });
+    await expect(getExpoPackageVersionAsync(projectRoot)).rejects.toBeInstanceOf(errors.UserError);
+  });
+});
+
+describe(BuildService, () => {
+  const projectRoot = '/test-project';
+  const job = {
+    appId: 'app-id',
+    cache: {
+      clear: false,
+      disabled: false,
+      paths: [],
+    },
+    mode: BuildMode.BUILD,
+    platform: Platform.IOS,
+    projectArchive: {
+      type: ArchiveSourceType.URL,
+      url: 'https://example.com/project.tar.gz',
+    },
+    projectRootDirectory: '.',
+    secrets: {
+      robotAccessToken: 'robot-token',
+    },
+    triggeredBy: BuildTrigger.EAS_CLI,
+    type: Workflow.GENERIC,
+  };
+
+  beforeEach(() => {
+    vol.reset();
+    jest.clearAllMocks();
+    jest.mocked(spawn).mockResolvedValue({
+      stdout: Buffer.from(path.join(projectRoot, 'node_modules/expo/package.json')),
+    } as any);
+    jest.mocked(turtleFetch).mockResolvedValue({ ok: true } as any);
+    jest.mocked(build).mockRejectedValue(new Error('raw build failure'));
+    jest.mocked(createBuildContext).mockReturnValue({
+      getReactNativeProjectDirectory: () => projectRoot,
+      job,
+      logger: {},
+    } as any);
+  });
+
+  it('sends expo_package_version to Datadog error logs without changing sdk_version', async () => {
+    vol.fromJSON({
+      [path.join(projectRoot, 'node_modules/expo/package.json')]: JSON.stringify({
+        version: '55.0.17',
+      }),
+    });
+    const service = new BuildService();
+    jest.spyOn(service, 'finishError').mockResolvedValue(undefined);
+
+    await (service as any).startBuildInternal({
+      initiatingUserId: 'user-id',
+      job,
+      metadata: {
+        buildProfile: 'production',
+        reactNativeVersion: '0.83.0',
+        sdkVersion: '55.0.0',
+      },
+      projectId: 'project-id',
+    });
+
+    expect(turtleFetch).toHaveBeenCalledWith(
+      'http://api.expo.test/v2/turtle-builds/error-logs',
+      'POST',
+      expect.objectContaining({
+        json: expect.objectContaining({
+          tags: expect.objectContaining({
+            expo_package_version: '55.0.17',
+            sdk_version: '55.0.0',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('sends null expo_package_version to Datadog error logs when expo package version resolution fails', async () => {
+    jest.mocked(spawn).mockRejectedValue(new Error('Cannot find module expo/package.json'));
+    const service = new BuildService();
+    jest.spyOn(service, 'finishError').mockResolvedValue(undefined);
+
+    await (service as any).startBuildInternal({
+      initiatingUserId: 'user-id',
+      job,
+      metadata: {
+        sdkVersion: '55.0.0',
+      },
+      projectId: 'project-id',
+    });
+
+    expect(turtleFetch).toHaveBeenCalledWith(
+      'http://api.expo.test/v2/turtle-builds/error-logs',
+      'POST',
+      expect.objectContaining({
+        json: expect.objectContaining({
+          tags: expect.objectContaining({
+            expo_package_version: null,
+            sdk_version: '55.0.0',
+          }),
+        }),
+      })
+    );
+  });
+});

--- a/packages/worker/src/__unit__/service.test.ts
+++ b/packages/worker/src/__unit__/service.test.ts
@@ -74,6 +74,10 @@ jest.mock('../config', () => {
 describe(getExpoPackageVersionAsync, () => {
   const projectRoot = '/test-project';
   const expoPackageJsonPath = path.join(projectRoot, 'node_modules/expo/package.json');
+  const buildContext = {
+    env: { PATH: '/usr/bin' },
+    getReactNativeProjectDirectory: () => projectRoot,
+  } as any;
 
   beforeEach(() => {
     vol.reset();
@@ -86,16 +90,24 @@ describe(getExpoPackageVersionAsync, () => {
       [expoPackageJsonPath]: JSON.stringify({ version: '55.0.17' }),
     });
 
-    await expect(getExpoPackageVersionAsync(projectRoot)).resolves.toBe('55.0.17');
+    await expect(getExpoPackageVersionAsync(buildContext)).resolves.toBe('55.0.17');
+    expect(spawn).toHaveBeenCalledWith(
+      'node',
+      ['--print', "require.resolve('expo/package.json')"],
+      expect.objectContaining({
+        cwd: projectRoot,
+        env: buildContext.env,
+      })
+    );
   });
 
   it('throws a user error when expo package version resolution fails', async () => {
     jest.mocked(spawn).mockRejectedValue(new Error('Cannot find module expo/package.json'));
 
-    await expect(getExpoPackageVersionAsync(projectRoot)).rejects.toMatchObject({
+    await expect(getExpoPackageVersionAsync(buildContext)).rejects.toMatchObject({
       errorCode: 'EAS_BUILD_EXPO_PACKAGE_VERSION_NOT_FOUND',
     });
-    await expect(getExpoPackageVersionAsync(projectRoot)).rejects.toBeInstanceOf(errors.UserError);
+    await expect(getExpoPackageVersionAsync(buildContext)).rejects.toBeInstanceOf(errors.UserError);
   });
 
   it('throws a user error when the installed expo package version is not valid semver', async () => {
@@ -104,10 +116,10 @@ describe(getExpoPackageVersionAsync, () => {
       [expoPackageJsonPath]: JSON.stringify({ version: 'invalid-version' }),
     });
 
-    await expect(getExpoPackageVersionAsync(projectRoot)).rejects.toMatchObject({
+    await expect(getExpoPackageVersionAsync(buildContext)).rejects.toMatchObject({
       errorCode: 'EAS_BUILD_EXPO_PACKAGE_VERSION_INVALID',
     });
-    await expect(getExpoPackageVersionAsync(projectRoot)).rejects.toBeInstanceOf(errors.UserError);
+    await expect(getExpoPackageVersionAsync(buildContext)).rejects.toBeInstanceOf(errors.UserError);
   });
 });
 
@@ -143,6 +155,7 @@ describe(BuildService, () => {
     jest.mocked(turtleFetch).mockResolvedValue({ ok: true } as any);
     jest.mocked(build).mockRejectedValue(new Error('raw build failure'));
     jest.mocked(createBuildContext).mockReturnValue({
+      env: { PATH: '/usr/bin' },
       getReactNativeProjectDirectory: () => projectRoot,
       job,
       logger: {},
@@ -197,6 +210,37 @@ describe(BuildService, () => {
       projectId: 'project-id',
     });
 
+    expect(turtleFetch).toHaveBeenCalledWith(
+      'http://api.expo.test/v2/turtle-builds/error-logs',
+      'POST',
+      expect.objectContaining({
+        json: expect.objectContaining({
+          tags: expect.objectContaining({
+            expo_package_version: null,
+            sdk_version: '55.0.0',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('does not try to resolve expo_package_version when build context setup fails', async () => {
+    jest.mocked(createBuildContext).mockImplementation(() => {
+      throw new Error('context setup failure');
+    });
+    const service = new BuildService();
+    jest.spyOn(service, 'finishError').mockResolvedValue(undefined);
+
+    await (service as any).startBuildInternal({
+      initiatingUserId: 'user-id',
+      job,
+      metadata: {
+        sdkVersion: '55.0.0',
+      },
+      projectId: 'project-id',
+    });
+
+    expect(spawn).not.toHaveBeenCalled();
     expect(turtleFetch).toHaveBeenCalledWith(
       'http://api.expo.test/v2/turtle-builds/error-logs',
       'POST',

--- a/packages/worker/src/service.ts
+++ b/packages/worker/src/service.ts
@@ -10,6 +10,7 @@ import {
   BuildMode,
   BuildPhase,
   BuildPhaseStats,
+  Env,
   Ios,
   Job,
   Metadata,
@@ -17,9 +18,12 @@ import {
   errors,
 } from '@expo/eas-build-job';
 import { LoggerLevel } from '@expo/logger';
+import { asyncResult } from '@expo/results';
+import spawn from '@expo/turtle-spawn';
 import assert from 'assert';
 import fs from 'fs-extra';
 import path from 'path';
+import semver from 'semver';
 import { setTimeout as setTimeoutAsync } from 'timers/promises';
 
 import { build } from './build';
@@ -333,6 +337,15 @@ export default class BuildService {
 
       const robotAccessToken = job.secrets?.robotAccessToken;
       if (robotAccessToken) {
+        const expoPackageVersionResult = await asyncResult(
+          getExpoPackageVersionAsync(
+            this.buildContext?.getReactNativeProjectDirectory(),
+            this.buildContext?.env
+          )
+        );
+        const expoPackageVersion = expoPackageVersionResult.ok
+          ? expoPackageVersionResult.value
+          : null;
         let rawErrorMessage: string = '';
         if (maybeRawError?.stderr) {
           rawErrorMessage += '\n' + getLastNLines(100, maybeRawError.stderr);
@@ -358,6 +371,7 @@ export default class BuildService {
                   platform: job.platform,
                   workflow: job.type,
                   sdk_version: metadata?.sdkVersion ?? null,
+                  expo_package_version: expoPackageVersion,
                   react_native_version: metadata?.reactNativeVersion ?? null,
                   app_id: job.appId ?? null,
                   build_profile: metadata?.buildProfile ?? null,
@@ -400,4 +414,51 @@ function getLastNLines(numberOfLines: number, stream: string): string {
   } else {
     return lines.slice(lines.length - numberOfLines, lines.length).join('\n');
   }
+}
+
+export async function getExpoPackageVersionAsync(
+  reactNativeProjectDirectory: string | undefined,
+  env?: Env
+): Promise<string> {
+  if (!reactNativeProjectDirectory) {
+    throw new errors.UserError(
+      'EAS_BUILD_EXPO_PACKAGE_VERSION_PROJECT_DIR_MISSING',
+      'Cannot resolve the installed expo package version because the React Native project directory is unavailable.'
+    );
+  }
+
+  const expoPackageJsonPathResult = await asyncResult(
+    spawn('node', ['--print', "require.resolve('expo/package.json')"], {
+      cwd: reactNativeProjectDirectory,
+      env,
+      stdio: 'pipe',
+    })
+  );
+  if (!expoPackageJsonPathResult.ok) {
+    throw new errors.UserError(
+      'EAS_BUILD_EXPO_PACKAGE_VERSION_NOT_FOUND',
+      'Cannot resolve the installed expo package version because require.resolve("expo/package.json") failed.',
+      { cause: expoPackageJsonPathResult.reason }
+    );
+  }
+
+  const expoPackageJsonPath = expoPackageJsonPathResult.value.stdout.toString().trim();
+  const expoPackageJsonResult = await asyncResult(fs.readJson(expoPackageJsonPath));
+  if (!expoPackageJsonResult.ok) {
+    throw new errors.UserError(
+      'EAS_BUILD_EXPO_PACKAGE_VERSION_READ_FAILED',
+      'Cannot resolve the installed expo package version because expo/package.json could not be read.',
+      { cause: expoPackageJsonResult.reason }
+    );
+  }
+
+  const expoPackageVersion = expoPackageJsonResult.value.version;
+  if (typeof expoPackageVersion !== 'string' || !semver.valid(expoPackageVersion)) {
+    throw new errors.UserError(
+      'EAS_BUILD_EXPO_PACKAGE_VERSION_INVALID',
+      'Cannot resolve the installed expo package version because expo/package.json has an invalid version.'
+    );
+  }
+
+  return expoPackageVersion;
 }

--- a/packages/worker/src/service.ts
+++ b/packages/worker/src/service.ts
@@ -10,7 +10,6 @@ import {
   BuildMode,
   BuildPhase,
   BuildPhaseStats,
-  Env,
   Ios,
   Job,
   Metadata,
@@ -337,15 +336,11 @@ export default class BuildService {
 
       const robotAccessToken = job.secrets?.robotAccessToken;
       if (robotAccessToken) {
-        const expoPackageVersionResult = await asyncResult(
-          getExpoPackageVersionAsync(
-            this.buildContext?.getReactNativeProjectDirectory(),
-            this.buildContext?.env
-          )
-        );
-        const expoPackageVersion = expoPackageVersionResult.ok
-          ? expoPackageVersionResult.value
+        const expoPackageVersionResult = this.buildContext
+          ? await asyncResult(getExpoPackageVersionAsync(this.buildContext))
           : null;
+        const expoPackageVersion =
+          expoPackageVersionResult?.ok === true ? expoPackageVersionResult.value : null;
         let rawErrorMessage: string = '';
         if (maybeRawError?.stderr) {
           rawErrorMessage += '\n' + getLastNLines(100, maybeRawError.stderr);
@@ -416,21 +411,12 @@ function getLastNLines(numberOfLines: number, stream: string): string {
   }
 }
 
-export async function getExpoPackageVersionAsync(
-  reactNativeProjectDirectory: string | undefined,
-  env?: Env
-): Promise<string> {
-  if (!reactNativeProjectDirectory) {
-    throw new errors.UserError(
-      'EAS_BUILD_EXPO_PACKAGE_VERSION_PROJECT_DIR_MISSING',
-      'Cannot resolve the installed expo package version because the React Native project directory is unavailable.'
-    );
-  }
-
+export async function getExpoPackageVersionAsync(ctx: BuildContext<Job>): Promise<string> {
+  const reactNativeProjectDirectory = ctx.getReactNativeProjectDirectory();
   const expoPackageJsonPathResult = await asyncResult(
     spawn('node', ['--print', "require.resolve('expo/package.json')"], {
       cwd: reactNativeProjectDirectory,
-      env,
+      env: ctx.env,
       stdio: 'pipe',
     })
   );


### PR DESCRIPTION
## Summary
- Resolve the installed Expo package version in the worker when sending Turtle error logs.
- Tag Datadog error logs with `expo_package_version` while leaving `sdk_version` unchanged.
- Add unit coverage for exact-version resolution, missing package resolution, invalid semver, and the error-log payload.

## Testing
- `yarn workspace @expo/worker test:unit -- service.test.ts`
- `yarn workspace @expo/worker typecheck`
- `yarn exec oxfmt .`