### PR TITLE
[eas-cli] Fix invalid json for eas update with --json flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [eas-cli] Remove hardcoded `builderEnvironment.image` override in `eas build:resign`. ([#3661](https://github.com/expo/eas-cli/pull/3661) by [@hSATAC](https://github.com/hSATAC))
+- [eas-cli] Fix `eas update --json` intermittently failing with JSON parse errors during "Computing project fingerprints" by passing `silent: true` to `@expo/fingerprint` to suppress subprocess stdout pollution. ([#3659](https://github.com/expo/eas-cli/pull/3659) by [@Mookiies](https://github.com/Mookiies))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/fingerprint/cli.ts
+++ b/packages/eas-cli/src/fingerprint/cli.ts
@@ -103,6 +103,7 @@ async function createFingerprintWithoutLoggingAsync(
   if (options.debug) {
     fingerprintOptions.debug = true;
   }
+  fingerprintOptions.silent = true;
 
   return await withTemporaryEnvAsync(options.env ?? {}, () =>
     Fingerprint.createFingerprintAsync(projectDir, fingerprintOptions)


### PR DESCRIPTION
@expo/fingerprint spawns subprocesses concurrently (autolinking, react-native config, ExpoConfigLoader) that can write to stdout, corrupting the parent process's output when --json is in use. The silent option exists specifically to suppress this, but was never set. The function is already named WithoutLogging so this is the correct default regardless of --json.

<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We get this output often when running eas update with --json and --emit-metadata. The actual json conflict changes and flakes across update runs. 

```
Executing eas update --branch staging --message "message" --private-key-path ~/keys/private-key.pem --clear-cache --emit-metadata --json --non-interactive
...
- Computing project fingerprints
✖ Failed to compute project fingerprints
⏩ To skip this step, set the environment variable: EAS_SKIP_AUTO_FINGERPRINT=1
Expected ':' after property name in JSON at position 2048
    Error: update command failed.

Exited with code exit status 1
```

```
ℹ 25 iOS assets, 25 Android assets (maximum: 2000 total per update). Learn more about asset limits: https://expo.fyi/eas-update-asset-limits
- Computing project fingerprints
✖ Failed to compute project fingerprints
⏩ To skip this step, set the environment variable: EAS_SKIP_AUTO_FINGERPRINT=1
Unexpected token 'R', ..."       "D"Release",
"... is not valid JSON
    Error: update command failed.
```

## Wha'ts going on

**1. \`--json\` monkey-patches \`process.stdout\`**

[`eas-cli/src/utils/json.ts#L11-L12`](https://github.com/expo/eas-cli/blob/8229dc826513845d82ac4279d0b62394623935cf/packages/eas-cli/src/utils/json.ts#L11-L12) — when \`--json\` is passed, eas-cli redirects \`process.stdout.write → process.stderr.write\` so progress logs don't pollute the final JSON output.

**2. \`@expo/fingerprint\` spawns 5–6 subprocesses concurrently**

[`@expo/fingerprint/src/sourcer/Sourcer.ts#L44-L79`](https://github.com/expo/expo/blob/d8925c1d18e06a1cd8e36fced1a97f1fd16c0425/packages/%40expo/fingerprint/src/sourcer/Sourcer.ts#L44-L79) — fingerprinting runs \`getExpoAutolinkingAndroid\`, \`getExpoAutolinkingIos\`, \`getCoreAutolinkingFromExpoAndroid\`, \`getCoreAutolinkingFromExpoIos\`, \`getCoreAutolinkingFromRncCli\`, and \`getExpoConfig\` all via \`Promise.all()\`. Each spawns a separate OS process.

**3. Subprocess stdout is not subject to the in-process redirect**

These are separate OS processes — the \`process.stdout.write\` monkey-patch in the parent has no effect on them. Any stray \`console.log\` from those subprocesses gets captured and \`JSON.parse()\`d by the parent.

**4. There is a known IPC fallback that writes directly to stdout**

[`@expo/fingerprint/src/ExpoConfigLoader.ts#L43-L46`](https://github.com/expo/expo/blob/d8925c1d18e06a1cd8e36fced1a97f1fd16c0425/packages/%40expo/fingerprint/src/ExpoConfigLoader.ts#L43-L46) — if \`process.send\` (IPC) is unavailable, \`ExpoConfigLoader\` falls back to \`console.log(result)\`, writing a multi-KB JSON blob directly to stdout, which then contaminates the parent's JSON stream.

**5. The fix exists in \`@expo/fingerprint\` but eas-cli never uses it**

[`eas-cli/src/fingerprint/cli.ts#L89-L108`](https://github.com/expo/eas-cli/blob/8229dc826513845d82ac4279d0b62394623935cf/packages/eas-cli/src/fingerprint/cli.ts#L89-L108) — \`@expo/fingerprint\` has a \`silent: true\` option specifically to suppress subprocess stdout pollution in JSON contexts, but \`createFingerprintWithoutLoggingAsync\` never sets it.

# How

Suppress output from fingerprinting by suppressing output 

# Test Plan

Repeatedly run `eas update --branch staging --message "message" --emit-metadata --json --non-interactive` and watch for intermitent failures on fingerprinting fail due to invalid JSON. If it always works and doesn't flake good to go.
