### PR TITLE
[worker] warn on invalid resource class config when setting `GRADLE_OPTS`

### DIFF
--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -10,6 +10,7 @@ import {
   ResourceClassToPlatform,
   androidImagesWithJavaVersionLowerThen11,
 } from './external/turtle';
+import sentry from './sentry';
 import { getAccessedEnvs } from './utils/env';
 
 // keep in sync with local-build-plugin env vars
@@ -77,6 +78,8 @@ export function getBuildEnv({
   }
 
   if (config.env !== Environment.TEST) {
+    reportInvalidResourceClass();
+
     const maxHeapSize = config.resourceClass
       ? (ResourceClassToMaxHeapSize[config.resourceClass] ?? '4g')
       : '4g';
@@ -160,6 +163,24 @@ function getFilteredEnv(): Env {
 function setEnv(env: Env, key: string, value: string | null | undefined): void {
   if (value) {
     env[key] = value;
+  }
+}
+
+function reportInvalidResourceClass(): void {
+  if (!config.resourceClass) {
+    sentry.handleError(
+      'Worker did not receive a resourceClass via WORKER_RUNTIME_CONFIG_BASE64; falling back to default build environment values. This indicates a server-side configuration bug.',
+      undefined,
+      { level: 'warning' }
+    );
+    return;
+  }
+  if (!(config.resourceClass in ResourceClassToPlatform)) {
+    sentry.handleError(
+      `Worker received unknown resourceClass "${config.resourceClass}"; falling back to default build environment values. This indicates a worker/server version mismatch.`,
+      undefined,
+      { level: 'warning', extras: { resourceClass: config.resourceClass } }
+    );
   }
 }
 


### PR DESCRIPTION
# Why

This issue https://github.com/expo/eas-cli/issues/3682 is reporting that the max heap size in Gradle options is set to an incorrect value when the resource class is `large` (should be `-Xmx8g`, is `-Xmx4g`).

I suspect the worker is receiving an empty or incorrect `resourceClass` config value, as we silently fallback to `4g` in such cases. This PR adds Sentry reporting to enable us to easily track such cases. Reporting is turned off in `Environment.TEST`.

# How

Report a sentry warning on:
- No `config.resourceClass` set
- Unknown `config.resourceClass`

The reporting is plugged just before determining the Gradle options `getBuildEnv` in `packages/worker/src/env.ts`.

# Test Plan

CI passes.