### PR TITLE
[eas-cli] remove image override in eas build:resign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Remove hardcoded `builderEnvironment.image` override in `eas build:resign`. ([#3661](https://github.com/expo/eas-cli/pull/3661) by [@hSATAC](https://github.com/hSATAC))
+
 ### 🧹 Chores
 
 ## [18.9.1](https://github.com/expo/eas-cli/releases/tag/v18.9.1) - 2026-04-30

--- a/packages/eas-cli/src/commands/build/resign.ts
+++ b/packages/eas-cli/src/commands/build/resign.ts
@@ -215,7 +215,6 @@ export default class BuildResign extends EasCommand {
         },
       },
       secrets: prepareCredentialsToResign(credentialsResult.credentials),
-      builderEnvironment: { image: 'default' },
     };
     const newBuild = await BuildMutation.retryIosBuildAsync(graphqlClient, {
       buildId: build.id,


### PR DESCRIPTION
# Why

`eas build:resign` currently passes a hardcoded `builderEnvironment: { image: 'default' }` override to the server when retrying an iOS build. It was added as a placeholder when the command was first introduced (#1575, 2022).

This override is now unnecessary at best, broken at worst:

- For **regular `eas build` parents**, the server falls back to a default image when one isn't specified, so the override is redundant.
- For **EAS Workflow-triggered parents**, the build infrastructure no longer recognizes `'default'` as a valid image alias. The hardcoded override silently replaces the parent build's resolved concrete image (e.g. `macos-sequoia-15.6-xcode-26.2`) with `'default'`, causing `eas build:resign` to fail with an `unknown image` error.

The correct behavior in both cases is "resign with the parent's image" — which is exactly what happens when this override is absent.

# How

Drop the `builderEnvironment` field from the resign `jobOverrides` payload. The server-side retry path then picks up the parent build's image automatically:

- Regular `eas build` parents: same behavior as before (server falls back to a default on its side).
- EAS Workflow-triggered parents: the parent's concrete image flows through; resign no longer fails with `unknown image`.

Android resign is explicitly unsupported (the command throws on Android), so this affects iOS only.

# Test Plan

- Automation tests