### PR TITLE
[build-tools] - Fix tar extraction permission errors by not preserving archive file modes

### DIFF
--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -119,9 +119,13 @@ async function unpackTarGzAsync({
   source: string;
   destination: string;
 }): Promise<void> {
-  await spawn('tar', ['-C', destination, '--strip-components', '1', '-zxf', source], {
-    logger,
-  });
+  await spawn(
+    'tar',
+    ['-C', destination, '--strip-components', '1', '--no-same-permissions', '-zxf', source],
+    {
+      logger,
+    }
+  );
 }
 
 function uploadProjectMetadataAsFireAndForget(


### PR DESCRIPTION

<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We observe a [trend of multiple builds failing](https://app.datadoghq.com/logs?query=%22Cannot%20mkdir%3A%20Permission%20denied%22%20build_phase%3Aprepare_project&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1776967682487&to_ts=1777572482487&live=true) during the PREPARE_PROJECT phase with errors like 

```
  tar: app/(tabs): Cannot mkdir: Permission denied
  tar: src/screens/LoginScreen.js: Cannot open: No such file or directory
```
These failures are intermittent, the same app succeeds on retry with a different worker. The root cause is that some user project archives contain files with restrictive permissions, and tar preserves those modes on extraction. When a directory is extracted with read-only permissions, tar can't write files into it during the same extraction pass.
  
# How
  - Add `--no-same-permissions` flag to tar extraction to apply the umask instead of preserving archive permission bits https://man7.org/linux/man-pages/man1/tar.1.html during `PREPARE_PROJECT` phase 
  - Fixes intermittent build failures where tar fails with "Permission denied" when extracting project archives that contain files/directories with restrictive permission bits

# Test Plan

- Recreate this failure on a staging worker, and deploy this fix