### PR TITLE
[eas-cli] Add lockfile existence preflight check for eas build

### DIFF
--- a/packages/eas-cli/src/build/__tests__/validateLockfile-test.ts
+++ b/packages/eas-cli/src/build/__tests__/validateLockfile-test.ts
@@ -1,0 +1,81 @@
+import { vol } from 'memfs';
+
+import { ensureLockfileExistsAsync } from '../validateLockfile';
+
+jest.mock('fs');
+
+const mockResolveWorkspaceRoot = jest.fn();
+jest.mock('@expo/package-manager', () => {
+  const actual = jest.requireActual('@expo/package-manager');
+  return {
+    ...actual,
+    resolveWorkspaceRoot: (...args: unknown[]) => mockResolveWorkspaceRoot(...args),
+  };
+});
+
+beforeEach(() => {
+  vol.reset();
+  mockResolveWorkspaceRoot.mockReturnValue(null);
+});
+
+describe(ensureLockfileExistsAsync, () => {
+  it('passes when package-lock.json exists', async () => {
+    vol.fromJSON({ './package-lock.json': '' }, '/app');
+    await expect(ensureLockfileExistsAsync('/app')).resolves.not.toThrow();
+  });
+
+  it('passes when yarn.lock exists', async () => {
+    vol.fromJSON({ './yarn.lock': '' }, '/app');
+    await expect(ensureLockfileExistsAsync('/app')).resolves.not.toThrow();
+  });
+
+  it('passes when pnpm-lock.yaml exists', async () => {
+    vol.fromJSON({ './pnpm-lock.yaml': '' }, '/app');
+    await expect(ensureLockfileExistsAsync('/app')).resolves.not.toThrow();
+  });
+
+  it('passes when bun.lockb exists', async () => {
+    vol.fromJSON({ './bun.lockb': '' }, '/app');
+    await expect(ensureLockfileExistsAsync('/app')).resolves.not.toThrow();
+  });
+
+  it('passes when bun.lock exists', async () => {
+    vol.fromJSON({ './bun.lock': '' }, '/app');
+    await expect(ensureLockfileExistsAsync('/app')).resolves.not.toThrow();
+  });
+
+  it('throws when no lockfile exists', async () => {
+    vol.fromJSON({ './package.json': '{}' }, '/app');
+    await expect(ensureLockfileExistsAsync('/app')).rejects.toThrow(
+      'No lockfile found in the project directory.'
+    );
+  });
+
+  it('passes when lockfile exists in workspace root', async () => {
+    vol.fromJSON(
+      {
+        './packages/my-app/package.json': '{}',
+        './yarn.lock': '',
+      },
+      '/monorepo'
+    );
+    mockResolveWorkspaceRoot.mockReturnValue('/monorepo');
+    await expect(
+      ensureLockfileExistsAsync('/monorepo/packages/my-app')
+    ).resolves.not.toThrow();
+  });
+
+  it('throws when no lockfile in project dir or workspace root', async () => {
+    vol.fromJSON(
+      {
+        './packages/my-app/package.json': '{}',
+        './package.json': '{}',
+      },
+      '/monorepo'
+    );
+    mockResolveWorkspaceRoot.mockReturnValue('/monorepo');
+    await expect(ensureLockfileExistsAsync('/monorepo/packages/my-app')).rejects.toThrow(
+      'No lockfile found in the project directory.'
+    );
+  });
+});

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -22,6 +22,7 @@ import { createBuildContextAsync } from './createContext';
 import { evaluateConfigWithEnvVarsAsync } from './evaluateConfigWithEnvVarsAsync';
 import { prepareIosBuildAsync } from './ios/build';
 import { LocalBuildMode, LocalBuildOptions } from './local';
+import { ensureLockfileExistsAsync } from './validateLockfile';
 import { ensureExpoDevClientInstalledForDevClientBuildsAsync } from './utils/devClient';
 import { printBuildResults, printLogsUrls } from './utils/printBuildInfo';
 import { ensureRepoIsCleanAsync } from './utils/repository';
@@ -84,6 +85,7 @@ import { Client } from '../vcs/vcs';
 
 let metroConfigValidated = false;
 let sdkVersionChecked = false;
+let lockfileChecked = false;
 let hasWarnedAboutUsageOverages = false;
 
 export interface BuildFlags {
@@ -413,6 +415,13 @@ async function prepareAndStartBuildAsync({
     whatToTest: flags.whatToTest,
     env,
   });
+
+  if (!lockfileChecked && !flags.localBuildOptions.localBuildMode) {
+    if (!process.env.EAS_BUILD_SKIP_LOCKFILE_CHECK) {
+      await ensureLockfileExistsAsync(projectDir);
+    }
+    lockfileChecked = true;
+  }
 
   if (!hasWarnedAboutUsageOverages && !flags.localBuildOptions.localBuildMode) {
     hasWarnedAboutUsageOverages = true;

--- a/packages/eas-cli/src/build/validateLockfile.ts
+++ b/packages/eas-cli/src/build/validateLockfile.ts
@@ -1,0 +1,47 @@
+import {
+  BUN_LOCK_FILE,
+  BUN_TEXT_LOCK_FILE,
+  NPM_LOCK_FILE,
+  PNPM_LOCK_FILE,
+  YARN_LOCK_FILE,
+  resolveWorkspaceRoot,
+} from '@expo/package-manager';
+import { pathExists } from 'fs-extra';
+import path from 'path';
+
+const LOCKFILE_NAMES = [
+  NPM_LOCK_FILE,
+  YARN_LOCK_FILE,
+  PNPM_LOCK_FILE,
+  BUN_LOCK_FILE,
+  BUN_TEXT_LOCK_FILE,
+];
+
+async function hasLockfileAsync(dir: string): Promise<boolean> {
+  for (const lockfile of LOCKFILE_NAMES) {
+    if (await pathExists(path.join(dir, lockfile))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function ensureLockfileExistsAsync(projectDir: string): Promise<void> {
+  if (await hasLockfileAsync(projectDir)) {
+    return;
+  }
+
+  const workspaceRoot = resolveWorkspaceRoot(projectDir);
+  if (workspaceRoot && workspaceRoot !== projectDir) {
+    if (await hasLockfileAsync(workspaceRoot)) {
+      return;
+    }
+  }
+
+  throw new Error(
+    `No lockfile found in the project directory.\n` +
+      `A lockfile is required to ensure deterministic dependency installation in EAS.\n` +
+      `Run your package manager's install command (e.g. "npm install") to generate one.\n` +
+      `To skip this check, run this command with EAS_BUILD_SKIP_LOCKFILE_CHECK=1.`
+  );
+}


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

  ~3k builds fail weekly during `install_dependencies` because of lockfile issues. The most basic failure mode, a missing lockfile, can be caught before the build is even queued, giving instant feedback instead of waiting for a remote build to fail.

  This is the first of several small PRs breaking up [#3434](https://github.com/expo/eas-cli/pull/3434)

# How

Added a single preflight check in `prepareAndStartBuildAsync()` that verifies at least one known lockfile (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, `bun.lock`) exists in the project directory or workspace root (monorepo support via `resolveWorkspaceRoot`).

  - The check runs once per CLI invocation using a module-level flag, matching the existing `metroConfigValidated`/`sdkVersionChecked` pattern.
  - Skipped for local builds (`localBuildMode`), since local builds install deps locally.
  - Opt-out via `EAS_BUILD_SKIP_LOCKFILE_CHECK=1` env var.

# Test Plan

Unit tests covering all lockfile types, missing lockfile error, and monorepo scenarios

Verified cli output
```
eas build
✔ Select platform › Android

⚠️ Detected that your app uses Expo Go for development, this is not recommended when building production apps.
Learn more
To suppress this warning, set EAS_BUILD_NO_EXPO_GO_WARNING=true.

Resolved "production" environment for the build. Learn more
Environment variables with visibility "Plain text" and "Sensitive" loaded from the "production" environment on EAS: EAS_USE_CACHE, EAS_VERBOSE, EXPERIMENTAL_EAS_GRADLE_CACHE.

✔ Incremented versionCode from 17 to 18.
No lockfile found in the project directory.
A lockfile is required to ensure deterministic dependency installation in EAS.
Run your package manager's install command (e.g. "npm install") to generate one.
To skip this check, run this command with EAS_BUILD_SKIP_LOCKFILE_CHECK=1.
    Error: build command failed.
```