### PR TITLE
[eas-cli] Fix Convex invite output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Fix Convex team invite output after skipped or unnecessary invitations. ([#3672](https://github.com/expo/eas-cli/pull/3672) by [@fiberjw](https://github.com/fiberjw))
+
 ### 🧹 Chores
 
 ## [18.10.0](https://github.com/expo/eas-cli/releases/tag/v18.10.0) - 2026-05-04

--- a/packages/eas-cli/src/commandUtils/__tests__/convex-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/convex-test.ts
@@ -1,3 +1,5 @@
+import dateFormat from 'dateformat';
+
 import {
   confirmRecentConvexInviteAsync,
   formatConvexProject,
@@ -22,6 +24,7 @@ describe('Convex command utilities', () => {
     convexTeamIdentifier: 'team-123',
     convexTeamName: 'Test Team',
     convexTeamSlug: 'test team',
+    hasBeenClaimed: true,
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
     invitedAt: '2024-01-02T00:00:00.000Z',
@@ -58,8 +61,12 @@ describe('Convex command utilities', () => {
     expect(formatConvexTeamConnection(mockConnection)).toContain('Test Team / test team');
     expect(formatConvexTeamConnection(mockConnection)).not.toContain('team-123');
     expect(formatConvexTeamConnection(mockConnection)).not.toContain('connection-1');
+    expect(formatConvexTeamConnection(mockConnection)).toContain('Claimed');
+    expect(formatConvexTeamConnection(mockConnection)).toContain('Yes');
     expect(formatConvexTeamConnection(mockConnection)).toContain('user@example.com');
-    expect(formatConvexTeamConnection(mockConnection)).toContain('2024-01-02T00:00:00.000Z');
+    expect(formatConvexTeamConnection(mockConnection)).toContain(
+      dateFormat(mockConnection.invitedAt, 'mmm dd HH:MM:ss')
+    );
     expect(formatConvexProject(mockProject)).toContain('project-123');
     expect(formatConvexProject(mockProject)).not.toContain('convex-project-1');
     expect(formatConvexProject(mockProject)).toContain('Test Team / test team');
@@ -93,12 +100,13 @@ describe('Convex command utilities', () => {
 
   it('prompts before resending a recent invite in interactive mode', async () => {
     jest.mocked(confirmAsync).mockResolvedValue(false);
+    const recentInviteTimestamp = new Date(Date.now() - 5 * 60 * 1000).toISOString();
 
     await expect(
       confirmRecentConvexInviteAsync(
         {
           ...mockConnection,
-          invitedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+          invitedAt: recentInviteTimestamp,
         },
         { nonInteractive: false }
       )
@@ -106,6 +114,9 @@ describe('Convex command utilities', () => {
 
     expect(confirmAsync).toHaveBeenCalledWith({
       message: expect.stringContaining('Are you sure you want to send another invite?'),
+    });
+    expect(confirmAsync).toHaveBeenCalledWith({
+      message: expect.stringContaining(dateFormat(recentInviteTimestamp, 'mmm dd HH:MM:ss')),
     });
   });
 

--- a/packages/eas-cli/src/commandUtils/convex.ts
+++ b/packages/eas-cli/src/commandUtils/convex.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import dateFormat from 'dateformat';
 
 import { ConvexProjectData, ConvexTeamConnectionData } from '../graphql/types/ConvexTeamConnection';
 import Log, { link } from '../log';
@@ -6,6 +7,10 @@ import { confirmAsync } from '../prompts';
 
 const CONVEX_DASHBOARD_HOST = 'https://dashboard.convex.dev';
 const RECENT_INVITE_THRESHOLD_MS = 60 * 60 * 1000;
+
+export function formatConvexInviteTimestamp(timestamp: string): string {
+  return dateFormat(timestamp, 'mmm dd HH:MM:ss');
+}
 
 export function getConvexTeamDashboardUrl(connection: ConvexTeamConnectionData): string {
   return `${CONVEX_DASHBOARD_HOST}/t/${encodeURIComponent(connection.convexTeamSlug)}`;
@@ -25,13 +30,14 @@ export function formatConvexTeamConnection(connection: ConvexTeamConnectionData)
   const lines = [
     `${chalk.bold('Team')}: ${formatConvexTeam(connection)}`,
     `${chalk.bold('Dashboard')}: ${link(getConvexTeamDashboardUrl(connection), { dim: false })}`,
+    `${chalk.bold('Claimed')}: ${connection.hasBeenClaimed ? 'Yes' : 'No'}`,
   ];
 
   if (connection.invitedEmail) {
     lines.push(`${chalk.bold('Invited email')}: ${connection.invitedEmail}`);
   }
   if (connection.invitedAt) {
-    lines.push(`${chalk.bold('Invited at')}: ${connection.invitedAt}`);
+    lines.push(`${chalk.bold('Invited at')}: ${formatConvexInviteTimestamp(connection.invitedAt)}`);
   }
 
   return lines.join('\n');
@@ -69,7 +75,7 @@ export async function confirmRecentConvexInviteAsync(
     return true;
   }
 
-  const previousInvite = `A Convex team invite was already sent${connection.invitedEmail ? ` to ${connection.invitedEmail}` : ''} at ${connection.invitedAt}.`;
+  const previousInvite = `A Convex team invite was already sent${connection.invitedEmail ? ` to ${connection.invitedEmail}` : ''} at ${formatConvexInviteTimestamp(connection.invitedAt)}.`;
   if (nonInteractive) {
     Log.warn(
       `${previousInvite} Sending another invite because this command is running in non-interactive mode.`

--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/connect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/connect.test.ts
@@ -75,6 +75,7 @@ describe(IntegrationsConvexConnect, () => {
     convexTeamIdentifier: 'team-123',
     convexTeamName: 'Test Team',
     convexTeamSlug: 'test-team',
+    hasBeenClaimed: false,
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
     invitedAt: null,
@@ -152,6 +153,9 @@ describe(IntegrationsConvexConnect, () => {
     expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).toHaveBeenCalledWith(
       graphqlClient,
       { convexTeamConnectionId: 'connection-1' }
+    );
+    expect(Log.log).toHaveBeenCalledWith(
+      expect.stringContaining('Check your email for an invitation')
     );
     expect(spawnAsync).toHaveBeenCalledWith('npx', ['expo', 'install', 'convex'], {
       cwd: testProjectDir,
@@ -237,6 +241,32 @@ describe(IntegrationsConvexConnect, () => {
     });
     expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).not.toHaveBeenCalled();
     expect(Log.warn).toHaveBeenCalledWith('Skipped sending Convex team invitation.');
+    expect(Log.log).not.toHaveBeenCalledWith(
+      expect.stringContaining('Check your email for an invitation')
+    );
+  });
+
+  it('skips sending an invite when the Convex team has already been claimed', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([
+      {
+        ...mockConnection,
+        hasBeenClaimed: true,
+        invitedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      },
+    ]);
+
+    await createCommand([]).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalledWith({
+      message: expect.stringContaining('Are you sure you want to send another invite?'),
+    });
+    expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(
+      'Convex team has already been claimed. Skipping Convex team invitation.'
+    );
+    expect(Log.log).not.toHaveBeenCalledWith(
+      expect.stringContaining('Check your email for an invitation')
+    );
   });
 
   it('writes the deploy key and Convex URL to .env.local', async () => {

--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/dashboard.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/dashboard.test.ts
@@ -32,6 +32,7 @@ describe(IntegrationsConvexDashboard, () => {
     convexTeamIdentifier: 'team-123',
     convexTeamName: 'Test Team',
     convexTeamSlug: 'test team',
+    hasBeenClaimed: false,
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
     invitedAt: null,

--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/project-delete.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/project-delete.test.ts
@@ -32,6 +32,7 @@ describe(IntegrationsConvexProjectDelete, () => {
     convexTeamIdentifier: 'team-123',
     convexTeamName: 'Test Team',
     convexTeamSlug: 'test-team',
+    hasBeenClaimed: false,
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
     invitedAt: null,

--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/project.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/project.test.ts
@@ -21,6 +21,7 @@ describe(IntegrationsConvexProject, () => {
     convexTeamIdentifier: 'team-123',
     convexTeamName: 'Test Team',
     convexTeamSlug: 'test-team',
+    hasBeenClaimed: false,
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
     invitedAt: null,

--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/team-delete.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/team-delete.test.ts
@@ -40,6 +40,7 @@ describe(IntegrationsConvexTeamDelete, () => {
     convexTeamIdentifier: 'team-123',
     convexTeamName: 'Test Team',
     convexTeamSlug: 'test-team',
+    hasBeenClaimed: false,
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
     invitedAt: '2024-01-02T00:00:00.000Z',

--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/team-invite.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/team-invite.test.ts
@@ -1,3 +1,5 @@
+import dateFormat from 'dateformat';
+
 import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
 import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { testProjectId } from '../../../../credentials/__tests__/fixtures-constants';
@@ -47,6 +49,7 @@ describe(IntegrationsConvexTeamInvite, () => {
     convexTeamIdentifier: 'team-123',
     convexTeamName: 'Test Team',
     convexTeamSlug: 'test-team',
+    hasBeenClaimed: false,
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
     invitedAt: '2024-01-02T00:00:00.000Z',
@@ -98,8 +101,12 @@ describe(IntegrationsConvexTeamInvite, () => {
     expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('team-123'));
     expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('connection-1'));
     expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('Previous invite'));
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('Claimed'));
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('No'));
     expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('previous@example.com'));
-    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('2024-01-02T00:00:00.000Z'));
+    expect(Log.log).toHaveBeenCalledWith(
+      expect.stringContaining(dateFormat(mockConnection.invitedAt, 'mmm dd HH:MM:ss'))
+    );
   });
 
   it('prompts before resending a recent invite', async () => {
@@ -131,6 +138,24 @@ describe(IntegrationsConvexTeamInvite, () => {
 
     expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).not.toHaveBeenCalled();
     expect(Log.warn).toHaveBeenCalledWith('Skipped sending Convex team invitation.');
+  });
+
+  it('skips sending an invite when the Convex team has already been claimed', async () => {
+    jest.mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync).mockResolvedValue([
+      {
+        ...mockConnection,
+        hasBeenClaimed: true,
+        invitedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+      },
+    ]);
+
+    await createCommand([]).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(
+      'Convex team has already been claimed. Skipping Convex team invitation.'
+    );
   });
 
   it('resends recent invites in non-interactive mode with a warning', async () => {

--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/team.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/team.test.ts
@@ -29,6 +29,7 @@ describe(IntegrationsConvexTeam, () => {
     convexTeamIdentifier: 'team-123',
     convexTeamName: 'Test Team',
     convexTeamSlug: 'test-team',
+    hasBeenClaimed: true,
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
     invitedAt: null,
@@ -65,6 +66,8 @@ describe(IntegrationsConvexTeam, () => {
       expect.stringContaining('Convex teams linked to @testuser')
     );
     expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('Test Team / test-team'));
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('Claimed'));
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('Yes'));
     expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('team-123'));
   });
 

--- a/packages/eas-cli/src/commands/integrations/convex/connect.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/connect.ts
@@ -24,6 +24,8 @@ const CONVEX_REGIONS = [
 
 const DEFAULT_REGION = 'aws-us-east-1';
 
+type TeamInviteResult = 'sent' | 'skipped' | 'failed';
+
 export default class IntegrationsConvexConnect extends EasCommand {
   static override description = 'connect Convex to your Expo project';
 
@@ -131,7 +133,9 @@ export default class IntegrationsConvexConnect extends EasCommand {
     }
 
     // 6. Send team invite (non-fatal)
-    await this.sendTeamInviteAsync(graphqlClient, connection, actor, { nonInteractive });
+    const teamInviteResult = await this.sendTeamInviteAsync(graphqlClient, connection, actor, {
+      nonInteractive,
+    });
 
     // 7. Write deploy key and URL to .env.local
     await this.writeEnvLocalAsync(
@@ -148,7 +152,7 @@ export default class IntegrationsConvexConnect extends EasCommand {
     Log.log('Next steps:');
     Log.log(`  1. Start the Convex dev server: ${chalk.cyan('npx convex dev')}`);
     Log.newLine();
-    if (this.getActorEmail(actor)) {
+    if (teamInviteResult === 'sent') {
       Log.log(
         `Check your email for an invitation to join your Convex team. Accept it for full dashboard access.`
       );
@@ -233,7 +237,12 @@ export default class IntegrationsConvexConnect extends EasCommand {
     connection: ConvexTeamConnectionData,
     actor: Actor,
     { nonInteractive }: { nonInteractive: boolean }
-  ): Promise<void> {
+  ): Promise<TeamInviteResult> {
+    if (connection.hasBeenClaimed) {
+      Log.warn('Convex team has already been claimed. Skipping Convex team invitation.');
+      return 'skipped';
+    }
+
     const email = this.getActorEmail(actor);
     if (!email) {
       Log.warn(
@@ -241,12 +250,12 @@ export default class IntegrationsConvexConnect extends EasCommand {
           'eas integrations:convex:team:invite'
         )} after signing in with a user account.`
       );
-      return;
+      return 'skipped';
     }
 
     if (!(await confirmRecentConvexInviteAsync(connection, { nonInteractive }))) {
       Log.warn('Skipped sending Convex team invitation.');
-      return;
+      return 'skipped';
     }
 
     try {
@@ -254,6 +263,7 @@ export default class IntegrationsConvexConnect extends EasCommand {
         convexTeamConnectionId: connection.id,
       });
       Log.withTick(`Sent Convex team invitation to ${chalk.bold(email)}`);
+      return 'sent';
     } catch (error) {
       Log.warn(
         `Failed to send Convex team invitation to ${email}. Run ${chalk.cyan(
@@ -261,6 +271,7 @@ export default class IntegrationsConvexConnect extends EasCommand {
         )} to retry.`
       );
       Log.warn(error instanceof Error ? error.message : String(error));
+      return 'failed';
     }
   }
 

--- a/packages/eas-cli/src/commands/integrations/convex/team/invite.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/team/invite.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import EasCommand from '../../../../commandUtils/EasCommand';
 import {
   confirmRecentConvexInviteAsync,
+  formatConvexInviteTimestamp,
   formatConvexTeam,
   getConvexTeamDashboardUrl,
   logNoConvexTeams,
@@ -77,6 +78,11 @@ export default class IntegrationsConvexTeamInvite extends EasCommand {
     this.logPreviousInvite(connection);
     Log.newLine();
 
+    if (connection.hasBeenClaimed) {
+      Log.warn('Convex team has already been claimed. Skipping Convex team invitation.');
+      return;
+    }
+
     if (!(await confirmRecentConvexInviteAsync(connection, { nonInteractive }))) {
       Log.warn('Skipped sending Convex team invitation.');
       return;
@@ -106,6 +112,7 @@ export default class IntegrationsConvexTeamInvite extends EasCommand {
     Log.log(
       `${chalk.bold('Dashboard')}: ${link(getConvexTeamDashboardUrl(connection), { dim: false })}`
     );
+    Log.log(`${chalk.bold('Claimed')}: ${connection.hasBeenClaimed ? 'Yes' : 'No'}`);
   }
 
   private logPreviousInvite(connection: ConvexTeamConnectionData): void {
@@ -119,7 +126,7 @@ export default class IntegrationsConvexTeamInvite extends EasCommand {
       Log.log(`${chalk.bold('Email')}: ${connection.invitedEmail}`);
     }
     if (connection.invitedAt) {
-      Log.log(`${chalk.bold('Sent at')}: ${connection.invitedAt}`);
+      Log.log(`${chalk.bold('Sent at')}: ${formatConvexInviteTimestamp(connection.invitedAt)}`);
     }
   }
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -12011,21 +12011,21 @@ export type CreateConvexTeamConnectionMutationVariables = Exact<{
 }>;
 
 
-export type CreateConvexTeamConnectionMutation = { __typename?: 'RootMutation', convexTeamConnection: { __typename?: 'ConvexTeamConnectionMutation', createConvexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } };
+export type CreateConvexTeamConnectionMutation = { __typename?: 'RootMutation', convexTeamConnection: { __typename?: 'ConvexTeamConnectionMutation', createConvexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, hasBeenClaimed: boolean, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } };
 
 export type DeleteConvexTeamConnectionMutationVariables = Exact<{
   convexTeamConnectionId: Scalars['ID']['input'];
 }>;
 
 
-export type DeleteConvexTeamConnectionMutation = { __typename?: 'RootMutation', convexTeamConnection: { __typename?: 'ConvexTeamConnectionMutation', deleteConvexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } };
+export type DeleteConvexTeamConnectionMutation = { __typename?: 'RootMutation', convexTeamConnection: { __typename?: 'ConvexTeamConnectionMutation', deleteConvexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, hasBeenClaimed: boolean, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } };
 
 export type SetupConvexProjectMutationVariables = Exact<{
   input: SetupConvexProjectInput;
 }>;
 
 
-export type SetupConvexProjectMutation = { __typename?: 'RootMutation', convexProject: { __typename?: 'ConvexProjectMutation', setupConvexProject: { __typename?: 'SetupConvexProjectResult', convexDeploymentName: string, convexDeploymentUrl: string, deployKey: string, convexProject: { __typename?: 'ConvexProject', id: string, convexProjectIdentifier: string, convexProjectName: string, convexProjectSlug: string, createdAt: any, updatedAt: any, convexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } } } };
+export type SetupConvexProjectMutation = { __typename?: 'RootMutation', convexProject: { __typename?: 'ConvexProjectMutation', setupConvexProject: { __typename?: 'SetupConvexProjectResult', convexDeploymentName: string, convexDeploymentUrl: string, deployKey: string, convexProject: { __typename?: 'ConvexProject', id: string, convexProjectIdentifier: string, convexProjectName: string, convexProjectSlug: string, createdAt: any, updatedAt: any, convexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, hasBeenClaimed: boolean, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } } } };
 
 export type DeleteConvexProjectMutationVariables = Exact<{
   convexProjectId: Scalars['ID']['input'];
@@ -12527,14 +12527,14 @@ export type ConvexTeamConnectionsByAccountIdQueryVariables = Exact<{
 }>;
 
 
-export type ConvexTeamConnectionsByAccountIdQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byId: { __typename?: 'Account', id: string, convexTeamConnections: Array<{ __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null }> } } };
+export type ConvexTeamConnectionsByAccountIdQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byId: { __typename?: 'Account', id: string, convexTeamConnections: Array<{ __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, hasBeenClaimed: boolean, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null }> } } };
 
 export type ConvexProjectByAppIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];
 }>;
 
 
-export type ConvexProjectByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, convexProject?: { __typename?: 'ConvexProject', id: string, convexProjectIdentifier: string, convexProjectName: string, convexProjectSlug: string, createdAt: any, updatedAt: any, convexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } | null } } };
+export type ConvexProjectByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, convexProject?: { __typename?: 'ConvexProject', id: string, convexProjectIdentifier: string, convexProjectName: string, convexProjectSlug: string, createdAt: any, updatedAt: any, convexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, hasBeenClaimed: boolean, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } | null } } };
 
 export type DeviceRunSessionByIdQueryVariables = Exact<{
   deviceRunSessionId: Scalars['ID']['input'];
@@ -12823,11 +12823,11 @@ export type BuildWithSubmissionsFragment = { __typename?: 'Build', id: string, s
 
 export type BuildWithFingerprintFragment = { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, logFiles: Array<string>, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, fingerprint?: { __typename?: 'Fingerprint', id: string, hash: string, debugInfoUrl?: string | null, builds: { __typename?: 'AppBuildsConnection', edges: Array<{ __typename?: 'AppBuildEdge', node: { __typename?: 'Build', platform: AppPlatform, id: string } }> }, updates: { __typename?: 'AppUpdatesConnection', edges: Array<{ __typename?: 'AppUpdateEdge', node: { __typename?: 'Update', id: string, platform: string } }> } } | null, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, initiatingActor?: { __typename: 'PartnerActor', id: string, displayName: string } | { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string }, metrics?: { __typename?: 'BuildMetrics', buildWaitTime?: number | null, buildQueueTime?: number | null, buildDuration?: number | null } | null };
 
-export type ConvexTeamConnectionFragment = { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null };
+export type ConvexTeamConnectionFragment = { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, hasBeenClaimed: boolean, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null };
 
-export type ConvexProjectFragment = { __typename?: 'ConvexProject', id: string, convexProjectIdentifier: string, convexProjectName: string, convexProjectSlug: string, createdAt: any, updatedAt: any, convexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } };
+export type ConvexProjectFragment = { __typename?: 'ConvexProject', id: string, convexProjectIdentifier: string, convexProjectName: string, convexProjectSlug: string, createdAt: any, updatedAt: any, convexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, hasBeenClaimed: boolean, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } };
 
-export type SetupConvexProjectResultFragment = { __typename?: 'SetupConvexProjectResult', convexDeploymentName: string, convexDeploymentUrl: string, deployKey: string, convexProject: { __typename?: 'ConvexProject', id: string, convexProjectIdentifier: string, convexProjectName: string, convexProjectSlug: string, createdAt: any, updatedAt: any, convexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } };
+export type SetupConvexProjectResultFragment = { __typename?: 'SetupConvexProjectResult', convexDeploymentName: string, convexDeploymentUrl: string, deployKey: string, convexProject: { __typename?: 'ConvexProject', id: string, convexProjectIdentifier: string, convexProjectName: string, convexProjectSlug: string, createdAt: any, updatedAt: any, convexTeamConnection: { __typename?: 'ConvexTeamConnection', id: string, convexTeamIdentifier: string, convexTeamName: string, convexTeamSlug: string, hasBeenClaimed: boolean, createdAt: any, updatedAt: any, invitedAt?: any | null, invitedEmail?: string | null } } };
 
 export type EnvironmentSecretFragment = { __typename?: 'EnvironmentSecret', id: string, name: string, type: EnvironmentSecretType, createdAt: any };
 

--- a/packages/eas-cli/src/graphql/types/ConvexTeamConnection.ts
+++ b/packages/eas-cli/src/graphql/types/ConvexTeamConnection.ts
@@ -8,6 +8,7 @@ export type ConvexTeamConnectionData = Pick<
   | 'convexTeamIdentifier'
   | 'convexTeamName'
   | 'convexTeamSlug'
+  | 'hasBeenClaimed'
   | 'createdAt'
   | 'updatedAt'
   | 'invitedAt'
@@ -39,6 +40,7 @@ export const ConvexTeamConnectionFragmentNode = gql`
     convexTeamIdentifier
     convexTeamName
     convexTeamSlug
+    hasBeenClaimed
     createdAt
     updatedAt
     invitedAt


### PR DESCRIPTION
# Why

The Convex connect flow could tell users to check their email even when they rejected the invite resend prompt. Convex team invite timestamps were also shown as raw ISO strings, and linked team displays did not expose whether a team had already been claimed.

# How

- Track whether the connect command actually sent, skipped, or failed the team invite, and only print the email follow-up when an invite was sent.
- Select `hasBeenClaimed` in the shared Convex team connection GraphQL fragment and use it to skip invite prompts for already-claimed teams.
- Display claimed state in Convex team output and team invite output.
- Format invite timestamps as human-readable UTC strings in displays and resend prompts.

# Test Plan

Run convex team commands on a project/account that has a team that's already claimed. It shouldn't sent invitations or tell you to check your email:
 
<img width="1204" height="2100" alt="Screenshot 2026-05-05 at 04 32 07" src="https://github.com/user-attachments/assets/af67e3e2-2953-4b8b-b4e4-61d2a24e73f5" />

<img width="1192" height="764" alt="Screenshot 2026-05-05 at 04 32 29" src="https://github.com/user-attachments/assets/384698e1-ae93-474d-9b6a-8ae795841c1c" />

<img width="1370" height="624" alt="Screenshot 2026-05-05 at 04 32 25" src="https://github.com/user-attachments/assets/5e3b9362-76e9-46f7-8f2a-751ff0046add" />
