### PR TITLE
[build-tools] - Add additional known error categories to build error handlers

### DIFF
--- a/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
+++ b/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
@@ -76,9 +76,7 @@ describe(resolveBuildPhaseErrorAsync, () => {
     expect(err.message).toBe(
       'Unknown error. See logs of the Install dependencies build phase for more information.'
     );
-    // The specific bundler handler doesn't match (wrong phase), but the
-    // INSTALL_DEPENDENCIES_GENERIC_FAILURE catch-all now picks it up
-    expect(err.trackingCode).toBe('INSTALL_DEPENDENCIES_GENERIC_FAILURE');
+    expect(err.trackingCode).toBeUndefined();
   });
 
   it('detects npm cache error if cache is enabled', async () => {
@@ -124,9 +122,7 @@ describe(resolveBuildPhaseErrorAsync, () => {
     expect(err.message).toBe(
       'Unknown error. See logs of the Install dependencies build phase for more information.'
     );
-    // The npm cache handler doesn't match (cache disabled), but the
-    // INSTALL_DEPENDENCIES_GENERIC_FAILURE catch-all now picks it up
-    expect(err.trackingCode).toBe('INSTALL_DEPENDENCIES_GENERIC_FAILURE');
+    expect(err.trackingCode).toBeUndefined();
   });
 
   it('detects xcode line error', async () => {
@@ -335,21 +331,6 @@ Refer to "Xcode Logs" below for additional, more detailed logs.`);
     expect(err.trackingCode).toBe('NPM_ERESOLVE');
   });
 
-  it('detects NPM_ERROR tracking code for generic npm errors', async () => {
-    const err = await resolveBuildPhaseErrorAsync(
-      new Error(),
-      ['npm ERR! 404 Not Found - GET https://registry.npmjs.org/nonexistent-package'],
-      {
-        job: { platform: Platform.ANDROID } as Job,
-        phase: BuildPhase.INSTALL_DEPENDENCIES,
-        env: {},
-      },
-      '/fake/path'
-    );
-    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
-    expect(err.trackingCode).toBe('NPM_ERROR');
-  });
-
   it('detects METRO_UNABLE_TO_RESOLVE tracking code', async () => {
     const err = await resolveBuildPhaseErrorAsync(
       new Error(),
@@ -467,51 +448,6 @@ Refer to "Xcode Logs" below for additional, more detailed logs.`);
     expect(err.trackingCode).toBe('SYNTAX_ERROR');
   });
 
-  it('detects COCOAPODS_GENERIC_ERROR tracking code', async () => {
-    const err = await resolveBuildPhaseErrorAsync(
-      new Error(),
-      ['[!] Unable to find a specification for `SomeUnknownPod`'],
-      {
-        job: { platform: Platform.IOS } as Job,
-        phase: BuildPhase.INSTALL_PODS,
-        env: {},
-      },
-      '/fake/path'
-    );
-    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
-    expect(err.trackingCode).toBe('COCOAPODS_GENERIC_ERROR');
-  });
-
-  it('does not detect COCOAPODS_GENERIC_ERROR for Android', async () => {
-    const err = await resolveBuildPhaseErrorAsync(
-      new Error(),
-      ['[!] Some error'],
-      {
-        job: { platform: Platform.ANDROID } as Job,
-        phase: BuildPhase.INSTALL_PODS,
-        env: {},
-      },
-      '/fake/path'
-    );
-    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
-    expect(err.trackingCode).toBeUndefined();
-  });
-
-  it('detects INSTALL_DEPENDENCIES_GENERIC_FAILURE as catch-all', async () => {
-    const err = await resolveBuildPhaseErrorAsync(
-      new Error(),
-      ['some random error that does not match any specific pattern'],
-      {
-        job: { platform: Platform.ANDROID } as Job,
-        phase: BuildPhase.INSTALL_DEPENDENCIES,
-        env: {},
-      },
-      '/fake/path'
-    );
-    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
-    expect(err.trackingCode).toBe('INSTALL_DEPENDENCIES_GENERIC_FAILURE');
-  });
-
   it('detects MONOREPO_PACKAGE_JSON_NOT_FOUND tracking code', async () => {
     const err = await resolveBuildPhaseErrorAsync(
       new Error(),
@@ -523,7 +459,6 @@ Refer to "Xcode Logs" below for additional, more detailed logs.`);
       },
       '/fake/path'
     );
-    // MONOREPO_PACKAGE_JSON_NOT_FOUND should match before INSTALL_DEPENDENCIES_GENERIC_FAILURE
     expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
     expect(err.trackingCode).toBe('MONOREPO_PACKAGE_JSON_NOT_FOUND');
   });

--- a/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
+++ b/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
@@ -76,7 +76,9 @@ describe(resolveBuildPhaseErrorAsync, () => {
     expect(err.message).toBe(
       'Unknown error. See logs of the Install dependencies build phase for more information.'
     );
-    expect(err.trackingCode).toBeUndefined();
+    // The specific bundler handler doesn't match (wrong phase), but the
+    // INSTALL_DEPENDENCIES_GENERIC_FAILURE catch-all now picks it up
+    expect(err.trackingCode).toBe('INSTALL_DEPENDENCIES_GENERIC_FAILURE');
   });
 
   it('detects npm cache error if cache is enabled', async () => {
@@ -122,7 +124,9 @@ describe(resolveBuildPhaseErrorAsync, () => {
     expect(err.message).toBe(
       'Unknown error. See logs of the Install dependencies build phase for more information.'
     );
-    expect(err.trackingCode).toBeUndefined();
+    // The npm cache handler doesn't match (cache disabled), but the
+    // INSTALL_DEPENDENCIES_GENERIC_FAILURE catch-all now picks it up
+    expect(err.trackingCode).toBe('INSTALL_DEPENDENCIES_GENERIC_FAILURE');
   });
 
   it('detects xcode line error', async () => {
@@ -308,5 +312,277 @@ Refer to "Xcode Logs" below for additional, more detailed logs.`);
     expect(err.message).toBe(
       `Gradle build failed with unknown error. See logs for the "Run gradlew" phase for more information.`
     );
+  });
+
+  // --- Tests for new build error handlers (tracking codes) ---
+
+  it('detects NPM_ERESOLVE tracking code', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      [
+        'npm ERR! code ERESOLVE',
+        'npm ERR! ERESOLVE could not resolve',
+        'npm ERR! While resolving: react-native@0.71.0',
+      ],
+      {
+        job: { platform: Platform.ANDROID } as Job,
+        phase: BuildPhase.INSTALL_DEPENDENCIES,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('NPM_ERESOLVE');
+  });
+
+  it('detects NPM_ERROR tracking code for generic npm errors', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      ['npm ERR! 404 Not Found - GET https://registry.npmjs.org/nonexistent-package'],
+      {
+        job: { platform: Platform.ANDROID } as Job,
+        phase: BuildPhase.INSTALL_DEPENDENCIES,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('NPM_ERROR');
+  });
+
+  it('detects METRO_UNABLE_TO_RESOLVE tracking code', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      [
+        'error: Unable to resolve module ./src/missing from /home/expo/workingdir/build/index.js: ',
+        'None of these files exist:',
+      ],
+      {
+        job: { platform: Platform.ANDROID } as Job,
+        phase: BuildPhase.PREBUILD,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('METRO_UNABLE_TO_RESOLVE');
+  });
+
+  it('detects METRO_UNABLE_TO_RESOLVE without phase restriction', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      ['error: Unable to resolve module @react-native/assets from /home/expo/workingdir/build/App.js'],
+      {
+        job: { platform: Platform.ANDROID } as Job,
+        phase: BuildPhase.EAGER_BUNDLE,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('METRO_UNABLE_TO_RESOLVE');
+  });
+
+  it('detects PNPM_ERROR tracking code', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      [
+        ' ERR_PNPM_PEER_DEP_ISSUES Unmet peer dependencies',
+        'hint: If you want peer dependencies to be automatically installed, add "auto-install-peers=true" to an .npmrc file.',
+      ],
+      {
+        job: { platform: Platform.ANDROID } as Job,
+        phase: BuildPhase.INSTALL_DEPENDENCIES,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('PNPM_ERROR');
+  });
+
+  it('does not detect PNPM_ERROR outside INSTALL_DEPENDENCIES phase', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      [' ERR_PNPM_PEER_DEP_ISSUES Unmet peer dependencies'],
+      {
+        job: { platform: Platform.ANDROID } as Job,
+        phase: BuildPhase.PREBUILD,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBeUndefined();
+  });
+
+  it('detects PREBUILD_DANGEROUS_MOD_ENOENT tracking code', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      [
+        "Error: [android.dangerous]: withAndroidDangerousBaseMod: ENOENT: no such file or directory, open './assets/splash.png'",
+      ],
+      {
+        job: { platform: Platform.ANDROID } as Job,
+        phase: BuildPhase.PREBUILD,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('PREBUILD_DANGEROUS_MOD_ENOENT');
+  });
+
+  it('detects PREBUILD_DANGEROUS_MOD_ENOENT for iOS', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      [
+        "Error: [ios.dangerous]: withIosDangerousBaseMod: ENOENT: no such file or directory, open './assets/fonts/CustomFont.ttf'",
+      ],
+      {
+        job: { platform: Platform.IOS } as Job,
+        phase: BuildPhase.PREBUILD,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('PREBUILD_DANGEROUS_MOD_ENOENT');
+  });
+
+  it('detects SYNTAX_ERROR tracking code', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      ['SyntaxError: Unexpected token } in JSON at position 1234'],
+      {
+        job: { platform: Platform.ANDROID } as Job,
+        phase: BuildPhase.PREBUILD,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('SYNTAX_ERROR');
+  });
+
+  it('detects COCOAPODS_GENERIC_ERROR tracking code', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      ['[!] Unable to find a specification for `SomeUnknownPod`'],
+      {
+        job: { platform: Platform.IOS } as Job,
+        phase: BuildPhase.INSTALL_PODS,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('COCOAPODS_GENERIC_ERROR');
+  });
+
+  it('does not detect COCOAPODS_GENERIC_ERROR for Android', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      ['[!] Some error'],
+      {
+        job: { platform: Platform.ANDROID } as Job,
+        phase: BuildPhase.INSTALL_PODS,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBeUndefined();
+  });
+
+  it('detects INSTALL_DEPENDENCIES_GENERIC_FAILURE as catch-all', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      ['some random error that does not match any specific pattern'],
+      {
+        job: { platform: Platform.ANDROID } as Job,
+        phase: BuildPhase.INSTALL_DEPENDENCIES,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('INSTALL_DEPENDENCIES_GENERIC_FAILURE');
+  });
+
+  it('detects MONOREPO_PACKAGE_JSON_NOT_FOUND tracking code', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      ['Error: package.json does not exist at /home/expo/workingdir/build/packages/app'],
+      {
+        job: { platform: Platform.ANDROID } as Job,
+        phase: BuildPhase.INSTALL_DEPENDENCIES,
+        env: {},
+      },
+      '/fake/path'
+    );
+    // MONOREPO_PACKAGE_JSON_NOT_FOUND should match before INSTALL_DEPENDENCIES_GENERIC_FAILURE
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('MONOREPO_PACKAGE_JSON_NOT_FOUND');
+  });
+
+  it('detects EXPO_CONFIG_ERROR tracking code', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      ['ConfigError: Property "expo.ios.bundleIdentifier" in app.json is invalid.'],
+      {
+        job: { platform: Platform.IOS } as Job,
+        phase: BuildPhase.PREBUILD,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('EXPO_CONFIG_ERROR');
+  });
+
+  it('detects RUNTIME_VERSION_MISMATCH tracking code', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      ['Error: runtimeVersion in Expo.plist policies must be set to a valid value.'],
+      {
+        job: { platform: Platform.IOS } as Job,
+        phase: BuildPhase.CONFIGURE_EXPO_UPDATES,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('RUNTIME_VERSION_MISMATCH');
+  });
+
+  it('does not detect RUNTIME_VERSION_MISMATCH outside CONFIGURE_EXPO_UPDATES phase', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      ['Error: runtimeVersion in Expo.plist policies must be set to a valid value.'],
+      {
+        job: { platform: Platform.IOS } as Job,
+        phase: BuildPhase.PREBUILD,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBeUndefined();
+  });
+
+  it('detects CONFIG_PLUGIN_RESOLVE_ERROR tracking code', async () => {
+    const err = await resolveBuildPhaseErrorAsync(
+      new Error(),
+      ['Error: Failed to resolve plugin for module "expo-camera" relative to "/home/expo/workingdir/build"'],
+      {
+        job: { platform: Platform.ANDROID } as Job,
+        phase: BuildPhase.PREBUILD,
+        env: {},
+      },
+      '/fake/path'
+    );
+    expect(err.errorCode).toBe(errors.ErrorCode.UNKNOWN_ERROR);
+    expect(err.trackingCode).toBe('CONFIG_PLUGIN_RESOLVE_ERROR');
   });
 });

--- a/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
+++ b/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
@@ -371,7 +371,9 @@ Refer to "Xcode Logs" below for additional, more detailed logs.`);
   it('detects METRO_UNABLE_TO_RESOLVE without phase restriction', async () => {
     const err = await resolveBuildPhaseErrorAsync(
       new Error(),
-      ['error: Unable to resolve module @react-native/assets from /home/expo/workingdir/build/App.js'],
+      [
+        'error: Unable to resolve module @react-native/assets from /home/expo/workingdir/build/App.js',
+      ],
       {
         job: { platform: Platform.ANDROID } as Job,
         phase: BuildPhase.EAGER_BUNDLE,
@@ -574,7 +576,9 @@ Refer to "Xcode Logs" below for additional, more detailed logs.`);
   it('detects CONFIG_PLUGIN_RESOLVE_ERROR tracking code', async () => {
     const err = await resolveBuildPhaseErrorAsync(
       new Error(),
-      ['Error: Failed to resolve plugin for module "expo-camera" relative to "/home/expo/workingdir/build"'],
+      [
+        'Error: Failed to resolve plugin for module "expo-camera" relative to "/home/expo/workingdir/build"',
+      ],
       {
         job: { platform: Platform.ANDROID } as Job,
         phase: BuildPhase.PREBUILD,

--- a/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
+++ b/packages/build-tools/src/buildErrors/__tests__/detectError.test.ts
@@ -310,8 +310,6 @@ Refer to "Xcode Logs" below for additional, more detailed logs.`);
     );
   });
 
-  // --- Tests for new build error handlers (tracking codes) ---
-
   it('detects NPM_ERESOLVE tracking code', async () => {
     const err = await resolveBuildPhaseErrorAsync(
       new Error(),

--- a/packages/build-tools/src/buildErrors/buildErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/buildErrorHandlers.ts
@@ -361,4 +361,105 @@ export const buildErrorHandlers: ErrorHandler<TrackedBuildError>[] = [
         'fastlane: Bundle React Native code and images failed.'
       ),
   },
+  // --- Specific patterns for reducing unknown_error bucket ---
+  {
+    phase: BuildPhase.INSTALL_DEPENDENCIES,
+    // npm ERR! ERESOLVE could not resolve
+    regexp: /npm ERR!.*ERESOLVE|ERESOLVE could not resolve/,
+    createError: () => new TrackedBuildError('NPM_ERESOLVE', 'npm: ERESOLVE could not resolve.'),
+  },
+  {
+    phase: BuildPhase.INSTALL_DEPENDENCIES,
+    // ERR_PNPM_PEER_DEP_ISSUES or other pnpm errors
+    regexp: /ERR_PNPM_/,
+    createError: () => new TrackedBuildError('PNPM_ERROR', 'pnpm: error during install.'),
+  },
+  {
+    // Can occur in PREBUILD, EAGER_BUNDLE, or other phases
+    // Unable to resolve module `./src/missing` from `index.js`
+    regexp: /Unable to resolve module/,
+    createError: () =>
+      new TrackedBuildError('METRO_UNABLE_TO_RESOLVE', 'metro: Unable to resolve module.'),
+  },
+  {
+    phase: BuildPhase.PREBUILD,
+    // Error: [android.dangerous]: withAndroidDangerousBaseMod: ENOENT: no such file or directory, open './assets/splash.png'
+    // Must come AFTER EXPO_CLI_MISSING_ICON which matches the icon-specific subset
+    regexp: /with(?:Android|Ios)DangerousBaseMod:.*ENOENT/,
+    createError: () =>
+      new TrackedBuildError(
+        'PREBUILD_DANGEROUS_MOD_ENOENT',
+        'prebuild: ENOENT in dangerous base mod.'
+      ),
+  },
+  {
+    // SyntaxError: Unexpected token ...
+    regexp: /SyntaxError:/,
+    createError: () => new TrackedBuildError('SYNTAX_ERROR', 'SyntaxError encountered.'),
+  },
+  {
+    // package.json does not exist (common in monorepos with wrong working directory)
+    regexp: /package\.json does not exist/,
+    createError: () =>
+      new TrackedBuildError(
+        'MONOREPO_PACKAGE_JSON_NOT_FOUND',
+        'package.json does not exist.'
+      ),
+  },
+  {
+    // ConfigError: Property ... in app.json is invalid
+    regexp: /ConfigError:/,
+    createError: () =>
+      new TrackedBuildError('EXPO_CONFIG_ERROR', 'expo: ConfigError encountered.'),
+  },
+  {
+    phase: BuildPhase.CONFIGURE_EXPO_UPDATES,
+    // runtimeVersion policies must be set ...
+    // runtime version is not equal ...
+    regexp: /runtimeVersion.*policies.*must.*set|runtime version.*not.*equal/i,
+    createError: () =>
+      new TrackedBuildError(
+        'RUNTIME_VERSION_MISMATCH',
+        'expo-updates: runtime version mismatch.'
+      ),
+  },
+  {
+    phase: BuildPhase.PREBUILD,
+    // Failed to resolve plugin for module "expo-camera" ...
+    regexp: /Failed to resolve plugin/,
+    createError: () =>
+      new TrackedBuildError(
+        'CONFIG_PLUGIN_RESOLVE_ERROR',
+        'prebuild: Failed to resolve config plugin.'
+      ),
+  },
+  // --- Broader catch-all patterns (must come after specific patterns) ---
+  {
+    phase: BuildPhase.INSTALL_DEPENDENCIES,
+    // Catch-all for npm errors not matched by specific handlers above
+    // npm ERR! 404 Not Found - GET https://registry.npmjs.org/...
+    regexp: /npm ERR!/,
+    createError: () => new TrackedBuildError('NPM_ERROR', 'npm: generic error.'),
+  },
+  {
+    platform: Platform.IOS,
+    phase: BuildPhase.INSTALL_PODS,
+    // [!] CocoaPods error indicator - catch-all for pod errors not matched above
+    regexp: /\[!\]/,
+    createError: () =>
+      new TrackedBuildError(
+        'COCOAPODS_GENERIC_ERROR',
+        'cocoapods: generic error.'
+      ),
+  },
+  {
+    phase: BuildPhase.INSTALL_DEPENDENCIES,
+    // Catch-all for any install_dependencies failure - must be LAST handler with this phase
+    regexp: /.*/,
+    createError: () =>
+      new TrackedBuildError(
+        'INSTALL_DEPENDENCIES_GENERIC_FAILURE',
+        'install_dependencies: generic failure.'
+      ),
+  },
 ];

--- a/packages/build-tools/src/buildErrors/buildErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/buildErrorHandlers.ts
@@ -401,16 +401,12 @@ export const buildErrorHandlers: ErrorHandler<TrackedBuildError>[] = [
     // package.json does not exist (common in monorepos with wrong working directory)
     regexp: /package\.json does not exist/,
     createError: () =>
-      new TrackedBuildError(
-        'MONOREPO_PACKAGE_JSON_NOT_FOUND',
-        'package.json does not exist.'
-      ),
+      new TrackedBuildError('MONOREPO_PACKAGE_JSON_NOT_FOUND', 'package.json does not exist.'),
   },
   {
     // ConfigError: Property ... in app.json is invalid
     regexp: /ConfigError:/,
-    createError: () =>
-      new TrackedBuildError('EXPO_CONFIG_ERROR', 'expo: ConfigError encountered.'),
+    createError: () => new TrackedBuildError('EXPO_CONFIG_ERROR', 'expo: ConfigError encountered.'),
   },
   {
     phase: BuildPhase.CONFIGURE_EXPO_UPDATES,
@@ -418,10 +414,7 @@ export const buildErrorHandlers: ErrorHandler<TrackedBuildError>[] = [
     // runtime version is not equal ...
     regexp: /runtimeVersion.*policies.*must.*set|runtime version.*not.*equal/i,
     createError: () =>
-      new TrackedBuildError(
-        'RUNTIME_VERSION_MISMATCH',
-        'expo-updates: runtime version mismatch.'
-      ),
+      new TrackedBuildError('RUNTIME_VERSION_MISMATCH', 'expo-updates: runtime version mismatch.'),
   },
   {
     phase: BuildPhase.PREBUILD,
@@ -447,10 +440,7 @@ export const buildErrorHandlers: ErrorHandler<TrackedBuildError>[] = [
     // [!] CocoaPods error indicator - catch-all for pod errors not matched above
     regexp: /\[!\]/,
     createError: () =>
-      new TrackedBuildError(
-        'COCOAPODS_GENERIC_ERROR',
-        'cocoapods: generic error.'
-      ),
+      new TrackedBuildError('COCOAPODS_GENERIC_ERROR', 'cocoapods: generic error.'),
   },
   {
     phase: BuildPhase.INSTALL_DEPENDENCIES,

--- a/packages/build-tools/src/buildErrors/buildErrorHandlers.ts
+++ b/packages/build-tools/src/buildErrors/buildErrorHandlers.ts
@@ -426,30 +426,4 @@ export const buildErrorHandlers: ErrorHandler<TrackedBuildError>[] = [
         'prebuild: Failed to resolve config plugin.'
       ),
   },
-  // --- Broader catch-all patterns (must come after specific patterns) ---
-  {
-    phase: BuildPhase.INSTALL_DEPENDENCIES,
-    // Catch-all for npm errors not matched by specific handlers above
-    // npm ERR! 404 Not Found - GET https://registry.npmjs.org/...
-    regexp: /npm ERR!/,
-    createError: () => new TrackedBuildError('NPM_ERROR', 'npm: generic error.'),
-  },
-  {
-    platform: Platform.IOS,
-    phase: BuildPhase.INSTALL_PODS,
-    // [!] CocoaPods error indicator - catch-all for pod errors not matched above
-    regexp: /\[!\]/,
-    createError: () =>
-      new TrackedBuildError('COCOAPODS_GENERIC_ERROR', 'cocoapods: generic error.'),
-  },
-  {
-    phase: BuildPhase.INSTALL_DEPENDENCIES,
-    // Catch-all for any install_dependencies failure - must be LAST handler with this phase
-    regexp: /.*/,
-    createError: () =>
-      new TrackedBuildError(
-        'INSTALL_DEPENDENCIES_GENERIC_FAILURE',
-        'install_dependencies: generic failure.'
-      ),
-  },
 ];


### PR DESCRIPTION

<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

  ~49% of EAS Build errors are considered unknown because they don't match any pattern in the build error handler system. Analysis of ~9,000 events over 5 days identified 12 high-volume patterns accounting for ~5,600 of these unclassified events. Categorizing these helps us break down patterns, and catch new regressions.
  

# How

Added 9 new `buildErrorHandler` entries for internal Datadog tracking. These only set `trackingCode` — user-facing `errorCode` remains unchanged, so there is no change to user-facing behavior.

   New tracking codes (by volume):
   - `NPM_ERESOLVE` — npm peer dependency resolution failures
   - `METRO_UNABLE_TO_RESOLVE` — Metro module resolution failures
   - `PNPM_ERROR` — pnpm install errors
   - `PREBUILD_DANGEROUS_MOD_ENOENT` — missing files in dangerous base mods (non-icon)
   - `SYNTAX_ERROR` — JavaScript/JSON syntax errors
   - `MONOREPO_PACKAGE_JSON_NOT_FOUND` — missing package.json in monorepos
   - `EXPO_CONFIG_ERROR` — Expo config validation errors
   - `RUNTIME_VERSION_MISMATCH` — expo-updates runtime version issues
   - `CONFIG_PLUGIN_RESOLVE_ERROR` — failed config plugin resolution

# Test Plan

  - Added 13 test cases covering each new handler: positive matches, phase filtering, and platform filtering
   - All 26 tests pass (`yarn jest-unit src/buildErrors/__tests__/detectError.test.ts`)
