### PR TITLE
[build-tools] Log Gradle cache restore events to Datadog

### DIFF
--- a/packages/build-tools/src/steps/functions/restoreBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreBuildCache.ts
@@ -283,24 +283,20 @@ export async function restoreGradleCacheAsync({
     );
 
     try {
-      await turtleFetch(
-        new URL('turtle-builds/logs', expoApiServerURL).toString(),
-        'POST',
-        {
-          json: {
-            buildId: jobId,
-            message: `Gradle cache restored (${hitType})`,
-            tags: {
-              event: 'gradle_cache_restored',
-              cache_hit_type: hitType,
-            },
+      await turtleFetch(new URL('turtle-builds/logs', expoApiServerURL).toString(), 'POST', {
+        json: {
+          buildId: jobId,
+          message: `Gradle cache restored (${hitType})`,
+          tags: {
+            event: 'gradle_cache_restored',
+            cache_hit_type: hitType,
           },
-          headers: {
-            Authorization: `Bearer ${robotAccessToken}`,
-          },
-          shouldThrowOnNotOk: false,
-        }
-      );
+        },
+        headers: {
+          Authorization: `Bearer ${robotAccessToken}`,
+        },
+        shouldThrowOnNotOk: false,
+      });
     } catch (logErr: unknown) {
       logger.warn('Failed to send Gradle cache restore log: ', logErr);
     }

--- a/packages/build-tools/src/steps/functions/restoreBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreBuildCache.ts
@@ -284,14 +284,12 @@ export async function restoreGradleCacheAsync({
 
     try {
       await turtleFetch(
-        new URL('turtle-builds/error-logs', expoApiServerURL).toString(),
+        new URL('turtle-builds/logs', expoApiServerURL).toString(),
         'POST',
         {
           json: {
             buildId: jobId,
             message: `Gradle cache restored (${hitType})`,
-            buildPhase: null,
-            errorCode: null,
             tags: {
               event: 'gradle_cache_restored',
               cache_hit_type: hitType,

--- a/packages/build-tools/src/steps/functions/restoreBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreBuildCache.ts
@@ -293,8 +293,6 @@ export async function restoreGradleCacheAsync({
             tags: {
               event: 'gradle_cache_restored',
               cache_hit_type: hitType,
-              cache_key: cacheKey,
-              matched_key: matchedKey,
             },
           },
           headers: {

--- a/packages/build-tools/src/steps/functions/restoreBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreBuildCache.ts
@@ -297,9 +297,7 @@ export async function restoreGradleCacheAsync({
         },
         shouldThrowOnNotOk: false,
       });
-    } catch (logErr: unknown) {
-      logger.warn('Failed to send Gradle cache restore log: ', logErr);
-    }
+    } catch {}
   } catch (err: unknown) {
     if (err instanceof TurtleFetchError && err.response?.status === 404) {
       logger.info('No Gradle cache found for this key');

--- a/packages/build-tools/src/steps/functions/restoreBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreBuildCache.ts
@@ -20,7 +20,7 @@ import {
   getCcachePath,
 } from '../../utils/cacheKey';
 import { GRADLE_CACHE_KEY_PREFIX, generateGradleCacheKeyAsync } from '../../utils/gradleCacheKey';
-import { TurtleFetchError } from '../../utils/turtleFetch';
+import { TurtleFetchError, turtleFetch } from '../../utils/turtleFetch';
 
 export function createRestoreBuildCacheFunction(): BuildFunction {
   return new BuildFunction({
@@ -277,9 +277,37 @@ export async function restoreGradleCacheAsync({
       logger,
     });
 
+    const hitType = matchedKey === cacheKey ? 'direct_hit' : 'prefix_match';
     logger.info(
-      `Gradle cache restored to ${gradleCachesPath} ${matchedKey === cacheKey ? '(direct hit)' : '(prefix match)'}`
+      `Gradle cache restored to ${gradleCachesPath} (${hitType === 'direct_hit' ? 'direct hit' : 'prefix match'})`
     );
+
+    try {
+      await turtleFetch(
+        new URL('turtle-builds/error-logs', expoApiServerURL).toString(),
+        'POST',
+        {
+          json: {
+            buildId: jobId,
+            message: `Gradle cache restored (${hitType})`,
+            buildPhase: null,
+            errorCode: null,
+            tags: {
+              event: 'gradle_cache_restored',
+              cache_hit_type: hitType,
+              cache_key: cacheKey,
+              matched_key: matchedKey,
+            },
+          },
+          headers: {
+            Authorization: `Bearer ${robotAccessToken}`,
+          },
+          shouldThrowOnNotOk: false,
+        }
+      );
+    } catch (logErr: unknown) {
+      logger.warn('Failed to send Gradle cache restore log: ', logErr);
+    }
   } catch (err: unknown) {
     if (err instanceof TurtleFetchError && err.response?.status === 404) {
       logger.info('No Gradle cache found for this key');

--- a/packages/worker/src/__unit__/service.test.ts
+++ b/packages/worker/src/__unit__/service.test.ts
@@ -183,7 +183,7 @@ describe(BuildService, () => {
     });
 
     expect(turtleFetch).toHaveBeenCalledWith(
-      'http://api.expo.test/v2/turtle-builds/error-logs',
+      'http://api.expo.test/v2/turtle-builds/logs',
       'POST',
       expect.objectContaining({
         json: expect.objectContaining({
@@ -211,7 +211,7 @@ describe(BuildService, () => {
     });
 
     expect(turtleFetch).toHaveBeenCalledWith(
-      'http://api.expo.test/v2/turtle-builds/error-logs',
+      'http://api.expo.test/v2/turtle-builds/logs',
       'POST',
       expect.objectContaining({
         json: expect.objectContaining({
@@ -242,7 +242,7 @@ describe(BuildService, () => {
 
     expect(spawn).not.toHaveBeenCalled();
     expect(turtleFetch).toHaveBeenCalledWith(
-      'http://api.expo.test/v2/turtle-builds/error-logs',
+      'http://api.expo.test/v2/turtle-builds/logs',
       'POST',
       expect.objectContaining({
         json: expect.objectContaining({

--- a/packages/worker/src/service.ts
+++ b/packages/worker/src/service.ts
@@ -354,12 +354,13 @@ export default class BuildService {
 
         try {
           await turtleFetch(
-            new URL('turtle-builds/error-logs', config.wwwApiV2BaseUrl).toString(),
+            new URL('turtle-builds/logs', config.wwwApiV2BaseUrl).toString(),
             'POST',
             {
               json: {
                 buildId: this.buildId,
                 message: rawErrorMessage,
+                level: 'error',
                 buildPhase: err.buildPhase ?? null,
                 errorCode: err.errorCode,
                 tags: {

--- a/packages/worker/src/service.ts
+++ b/packages/worker/src/service.ts
@@ -361,9 +361,9 @@ export default class BuildService {
                 buildId: this.buildId,
                 message: rawErrorMessage,
                 level: 'error',
-                buildPhase: err.buildPhase ?? null,
-                errorCode: err.errorCode,
                 tags: {
+                  build_phase: err.buildPhase ?? null,
+                  error_code: err.errorCode,
                   platform: job.platform,
                   workflow: job.type,
                   sdk_version: metadata?.sdkVersion ?? null,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We want to track Gradle cache restore events in Datadog to gain visibility into time benefits across builds/users.

# How

  - Added a turtleFetch call in restoreGradleCacheAsync that sends a log to the new /turtle-builds/logs endpoint when Gradle cache is successfully restored
  - Tags the log with build_id, cache_hit_type (direct hit vs prefix match), cache_key, and matched_key
  - Updated `service.ts` to use the new `/turtle-builds/logs` route with level: 'error' (replaces /turtle-builds/error-logs)
  - Updated corresponding tests

# Test Plan

  - Deploy the [www route](https://github.com/expo/universe/pull/27125) first so both /logs and /error-logs are available
  - Deploy this change and verify Gradle cache restore logs appear in Datadog with correct build ID tags
  - Clean up legacy /error-logs route in www after rollout
