### PR TITLE
[eas-cli] Hold eas simulator:start until session ends or Ctrl+C

### DIFF
--- a/packages/eas-cli/src/commands/simulator/start.ts
+++ b/packages/eas-cli/src/commands/simulator/start.ts
@@ -154,21 +154,119 @@ export default class SimulatorStart extends EasCommand {
     Log.newLine();
     Log.log(result.message);
     Log.newLine();
-    Log.log(
-      `When you are done, stop the session with: eas simulator:stop --id ${deviceRunSessionId}`
+
+    if (flags['non-interactive']) {
+      Log.log(
+        `When you are done, stop the session with: eas simulator:stop --id ${deviceRunSessionId}`
+      );
+      return;
+    }
+
+    await waitForSessionEndOrInterruptAsync({
+      graphqlClient,
+      deviceRunSessionId,
+      jobRunUrl,
+    });
+  }
+}
+
+async function waitForSessionEndOrInterruptAsync({
+  graphqlClient,
+  deviceRunSessionId,
+  jobRunUrl,
+}: {
+  graphqlClient: ExpoGraphqlClient;
+  deviceRunSessionId: string;
+  jobRunUrl: string;
+}): Promise<void> {
+  const spinner = ora(
+    `Device run session active — press Ctrl+C to stop, or run \`eas simulator:stop --id ${deviceRunSessionId}\` from another shell`
+  ).start();
+
+  const abortController = new AbortController();
+  const { signal } = abortController;
+  const abortPromise = new Promise<void>(resolve => {
+    signal.addEventListener(
+      'abort',
+      () => {
+        resolve();
+      },
+      { once: true }
     );
+  });
+  const sigintHandler = (): void => {
+    if (signal.aborted) {
+      // Force exit on a second Ctrl+C in case cleanup is hanging. The session may still be
+      // running on EAS, so tell the user how to make sure it gets terminated.
+      spinner.fail(
+        `Aborted before the device run session could be stopped. Run \`eas simulator:stop --id ${deviceRunSessionId}\` to terminate it and avoid unexpected charges.`
+      );
+      process.exit(130);
+    }
+    abortController.abort();
+  };
+  process.on('SIGINT', sigintHandler);
+
+  try {
+    while (!signal.aborted) {
+      let session;
+      try {
+        session = await DeviceRunSessionQuery.byIdAsync(graphqlClient, deviceRunSessionId);
+      } catch (err) {
+        Log.debug(
+          `Failed to poll device run session: ${err instanceof Error ? err.message : String(err)}`
+        );
+        await Promise.race([sleepAsync(POLL_INTERVAL_MS), abortPromise]);
+        continue;
+      }
+
+      const jobRunStatus = session.turtleJobRun?.status;
+      if (
+        session.status === DeviceRunSessionStatus.Errored ||
+        jobRunStatus === JobRunStatus.Errored
+      ) {
+        spinner.fail(`Device run session errored. ${link(jobRunUrl)}`);
+        throw new Error(`Device run session ${deviceRunSessionId} errored.`);
+      }
+      if (
+        session.status === DeviceRunSessionStatus.Stopped ||
+        jobRunStatus === JobRunStatus.Canceled ||
+        jobRunStatus === JobRunStatus.Finished
+      ) {
+        spinner.succeed(`Device run session ended. ${link(jobRunUrl)}`);
+        return;
+      }
+
+      await Promise.race([sleepAsync(POLL_INTERVAL_MS), abortPromise]);
+    }
+
+    spinner.text = 'Stopping device run session...';
+    const stopped = await ensureDeviceRunSessionStoppedSafelyAsync(
+      graphqlClient,
+      deviceRunSessionId
+    );
+    if (stopped) {
+      spinner.succeed('Device run session stopped');
+    } else {
+      spinner.fail(
+        `Could not confirm the device run session was stopped. Run \`eas simulator:stop --id ${deviceRunSessionId}\` to terminate it and avoid unexpected charges.`
+      );
+    }
+  } finally {
+    process.removeListener('SIGINT', sigintHandler);
   }
 }
 
 async function ensureDeviceRunSessionStoppedSafelyAsync(
   graphqlClient: ExpoGraphqlClient,
   deviceRunSessionId: string
-): Promise<void> {
+): Promise<boolean> {
   try {
     await DeviceRunSessionMutation.ensureDeviceRunSessionStoppedAsync(
       graphqlClient,
       deviceRunSessionId
     );
+    return true;
   } catch (err) {
     // Cleanup is best-effort; surface the failure but don't mask the original error.
     Log.warn(
@@ -176,6 +274,7 @@ async function ensureDeviceRunSessionStoppedSafelyAsync(
         err instanceof Error ? err.message : String(err)
       }`
     );
+    return false;
   }
 }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# 

# Why

Fixes ENG-20929

`eas simulator:start` currently prints the daemon connection env vars and exits, leaving the device run session running on EAS. Users have to remember to call `eas simulator:stop --id ...` to clean up — if they just close their terminal, the session leaks. This aligns the command with how other "session-holder" dev tools work (`kubectl port-forward`, `ngrok`, `vercel dev`): hang for the duration of the session and clean up on Ctrl+C.

# How

After printing the connection env vars, in interactive mode the command now stays attached:

- A poll loop checks the session every 5s and exits cleanly when it reaches a terminal state (`Stopped`/`Canceled`/`Finished`) or fails  
(`Errored`). Errors at either layer (device run session vs. underlying turtle job run) are surfaced with the same user-facing message — the distinction is an implementation detail.
- A `SIGINT` handler flips an `interrupted` flag and resolves an interrupt promise that's raced against `sleepAsync`, so Ctrl+C wakes the loop immediately rather than after the next 5s tick. On wake-up, `ensureDeviceRunSessionStoppedSafelyAsync` cancels the session.
- A second Ctrl+C during cleanup forces `process.exit(130)` as an escape hatch in case the stop mutation hangs.
- Polling errors are downgraded to `Log.debug` and the loop continues — a transient network blip shouldn't tear down a session the user is actively using.
- `--non-interactive` keeps the prior fire-and-forget behavior, so scripts and CI are unaffected.

# Test Plan

- `eas simulator:start --platform ios` → env vars print, spinner stays up. Press Ctrl+C → session is stopped on EAS, command exits.
- `eas simulator:start --platform ios`, then `eas simulator:stop --id <id>` from another shell → spinner resolves with "Device run session
ended" and command exits.
- `eas simulator:start --platform ios --non-interactive` → env vars print and command exits immediately (existing behavior preserved).
- Press Ctrl+C twice during the cleanup mutation → process exits with code 130 right away.
- `yarn typecheck`, `yarn lint`, `yarn fmt:check` pass.![Screenshot 2026-05-05 at 15.09.46.png](https://app.graphite.com/user-attachments/assets/4de5e29c-f35b-442e-aba6-42ed0ec39bf5.png)![Screenshot 2026-05-05 at 15.09.36.png](https://app.graphite.com/user-attachments/assets/35a0c9b5-a293-419d-99a1-71d5d752aff4.png)

    