### PR TITLE
[build-tools] Fix iOS local build on macOS Tahoe — drop `-v` from find-identity in `findIdentitiesByTeamId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- [build-tools] Fix `eas build --local` for iOS on macOS 26 (Tahoe) where `Keychain.findIdentitiesByTeamId` falsely reported the dist certificate as not imported. The `-v` flag on `security find-identity` requires the full trust chain to resolve from the build keychain alone, but the build keychain only holds the cert + private key — Apple Root CA lives in `/Library/Keychains/System.keychain` and `find-identity` does not aggregate trust resolution across keychains. Dropped `-v`; presence check now works across macOS versions and codesign continues to resolve trust downstream via `Security.framework`. ([#TODO](https://github.com/expo/eas-cli/pull/TODO) by [@kearnsm293-afk](https://github.com/kearnsm293-afk))
+- [build-tools] Fix `eas build --local` for iOS on macOS 26 (Tahoe) where `Keychain.findIdentitiesByTeamId` falsely reported the dist certificate as not imported. The `-v` flag on `security find-identity` requires the full trust chain to resolve from the build keychain alone, but the build keychain only holds the cert + private key — Apple Root CA lives in `/Library/Keychains/System.keychain` and `find-identity` does not aggregate trust resolution across keychains. Dropped `-v`; presence check now works across macOS versions and codesign continues to resolve trust downstream via `Security.framework`. ([#3679](https://github.com/expo/eas-cli/pull/3679) by [@kearnsm293-afk](https://github.com/kearnsm293-afk))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Fix `eas build --local` for iOS on macOS 26 (Tahoe) where `Keychain.findIdentitiesByTeamId` falsely reported the dist certificate as not imported. The `-v` flag on `security find-identity` requires the full trust chain to resolve from the build keychain alone, but the build keychain only holds the cert + private key — Apple Root CA lives in `/Library/Keychains/System.keychain` and `find-identity` does not aggregate trust resolution across keychains. Dropped `-v`; presence check now works across macOS versions and codesign continues to resolve trust downstream via `Security.framework`. ([#TODO](https://github.com/expo/eas-cli/pull/TODO) by [@kearnsm293-afk](https://github.com/kearnsm293-afk))
+
 ### 🧹 Chores
 
 ## [18.11.0](https://github.com/expo/eas-cli/releases/tag/v18.11.0) - 2026-05-05

--- a/packages/build-tools/src/ios/credentials/keychain.ts
+++ b/packages/build-tools/src/ios/credentials/keychain.ts
@@ -97,9 +97,23 @@ export default class Keychain<TJob extends Ios.Job> {
   }
 
   private async findIdentitiesByTeamId(teamId: string): Promise<string> {
+    // Note: no `-v` flag. `-v` ("valid identities only") requires the full
+    // trust chain (dist cert -> Apple WWDR Intermediate -> Apple Root CA) to
+    // resolve from the keychain(s) in the search list. The build keychain
+    // created above only holds the dist cert + private key; Apple Root CA
+    // lives in /Library/Keychains/System.keychain. `security find-identity`
+    // does not aggregate trust resolution across keychains passed as
+    // positional args (only `security list-keychains -s` does, and that's
+    // session-wide and undesirable). On macOS 26 (Tahoe), this caused
+    // `find-identity -v -s "(<teamId>)" <buildKeychainPath>` to return 0
+    // identities even when the cert+key were correctly imported, falsely
+    // tripping `ensureCertificateImported`. Without `-v`, the presence
+    // check works correctly across macOS versions; codesign performs its
+    // own trust resolution downstream via Security.framework (which does
+    // aggregate across keychains), so signing still succeeds.
     const { output } = await spawn(
       'security',
-      ['find-identity', '-v', '-s', `(${teamId})`, this.keychainPath],
+      ['find-identity', '-s', `(${teamId})`, this.keychainPath],
       {
         stdio: 'pipe',
       }


### PR DESCRIPTION
## Why

Closes #3678. On macOS 26 (Tahoe), `eas build --profile development --platform ios --local` fails at `Prepare credentials` with `Distribution certificate ... hasn't been imported successfully` even when the cert+key are correctly imported into the build keychain.

`Keychain.findIdentitiesByTeamId` runs:

```
security find-identity -v -s "(<teamId>)" <buildKeychainPath>
```

The `-v` ("valid identities only") flag requires the full trust chain (dist cert → Apple WWDR Intermediate → Apple Root CA) to resolve from the keychain(s) in the search list. The build keychain (created in `Keychain.create()`) only holds the cert + private key; Apple Root CA lives in `/Library/Keychains/System.keychain` and Apple WWDR G3 lives in the user's login keychain. `security find-identity` does **not** aggregate trust resolution across keychains passed as positional args — only `security list-keychains -s` does, and that change would be session-wide and undesirable.

On macOS 26 (Tahoe), this trust gate causes `find-identity -v -s "(<teamId>)" <buildKeychainPath>` to return 0 identities even when the cert+key were correctly imported, falsely tripping `ensureCertificateImported`.

## How

Drop `-v` from the `find-identity` call. The remaining flags (`-s "(<teamId>)" <buildKeychainPath>`) still constrain the match to the right team and keychain, so the `includes(fingerprint)` check in `ensureCertificateImported` correctly answers \"is the cert+key pair present in this keychain?\" The cert appears in the output annotated `(CSSMERR_TP_NOT_TRUSTED)` — that's expected and ignored. Codesign performs its own trust resolution downstream via `Security.framework` (which does aggregate across keychains), so signing still succeeds end-to-end.

The change is one line in `packages/build-tools/src/ios/credentials/keychain.ts` plus a comment block explaining the reasoning so a future reader doesn't add `-v` back.

## Test Plan

- The existing integration test [`packages/build-tools/src/ios/credentials/__integration-tests__/keychain.test.ios.ts`](https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/ios/credentials/__integration-tests__/keychain.test.ios.ts) (\"shouldn't throw any error if the certificate has been imported successfully\") covers exactly this scenario. It currently fails on macOS 26 (Tahoe) due to this bug; the fix makes it pass.
- Manually verified end-to-end: `eas build --profile development --platform ios --local` against an Expo-managed dist cert + ad-hoc provisioning profile completes successfully on macOS 26.0 (Tahoe) with the patch applied. Produces a signed `.ipa` that installs and runs on a registered iOS 26 device.
- No regression risk on older macOS: dropping `-v` is strictly more permissive in what `find-identity` reports back. On systems where `-v` worked (older macOS, or systems where Apple Root CA happens to be visible in the build keychain's effective search list), the same cert+key pair still appears in the output without `-v`. The `includes(fingerprint)` check passes in both cases.

## Checklist

- [x] CHANGELOG.md updated under `## main` → `### 🐛 Bug fixes`. (PR URL placeholder will be replaced with the real PR number once this is opened.)
- [x] Commit message follows the `[package] Description` format.
- [x] No public API change. No breaking change.