### PR TITLE
[build-tools] route to api v2 endpoint

### DIFF
--- a/packages/build-tools/src/steps/functions/restoreBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreBuildCache.ts
@@ -283,7 +283,7 @@ export async function restoreGradleCacheAsync({
     );
 
     try {
-      await turtleFetch(new URL('turtle-builds/logs', expoApiServerURL).toString(), 'POST', {
+      await turtleFetch(new URL('v2/turtle-builds/logs', expoApiServerURL).toString(), 'POST', {
         json: {
           buildId: jobId,
           message: `Gradle cache restored (${hitType})`,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I added this https://github.com/expo/eas-cli/pull/3674 but forgot to prefix with v2/. Will clean up all these routes to use expoApiV2BaseUrl after.