### PR TITLE
[build-tools] Re-enable 3rd party precompiled modules

### DIFF
--- a/packages/build-tools/src/ios/__tests__/pod.test.ts
+++ b/packages/build-tools/src/ios/__tests__/pod.test.ts
@@ -19,9 +19,11 @@ const IOS_DIR = path.join(PROJECT_DIR, 'ios');
 
 function makeIosBuildContext({
   expoVersion,
+  cocoapodsCacheUrl,
   usePrecompiledModules = true,
 }: {
   expoVersion?: string;
+  cocoapodsCacheUrl?: string;
   usePrecompiledModules?: boolean;
 }): BuildContext<Ios.Job> {
   vol.fromJSON({
@@ -48,7 +50,10 @@ function makeIosBuildContext({
     workingdir: WORKING_DIR,
     logger: createMockLogger(),
     logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
-    env: { __API_SERVER_URL: 'http://api.expo.test' },
+    env: {
+      __API_SERVER_URL: 'http://api.expo.test',
+      ...(cocoapodsCacheUrl ? { EAS_BUILD_COCOAPODS_CACHE_URL: cocoapodsCacheUrl } : {}),
+    },
     uploadArtifact: jest.fn(),
   });
 }
@@ -89,14 +94,38 @@ describe(installPods, () => {
         cwd: IOS_DIR,
         env: expect.objectContaining({
           EXPO_USE_PRECOMPILED_MODULES: '1',
+          EXPO_PRECOMPILED_MODULES_BASE_URL:
+            'https://storage.googleapis.com/eas-build-precompiled-modules/',
         }),
       })
     );
-    expect(
-      (spawn as jest.Mock).mock.calls[1][2].env.EXPO_PRECOMPILED_MODULES_BASE_URL
-    ).toBeUndefined();
     expect(ctx.logger.info).toHaveBeenCalledWith(
-      'Detected expo=999.0.0; enabling precompiled modules use. Installing pods with additional environment variables.\nEXPO_USE_PRECOMPILED_MODULES=1\nPrecompiled modules pod install environment is configured.'
+      'Detected expo=999.0.0; enabling precompiled modules use. Installing pods with additional environment variables.\nEXPO_USE_PRECOMPILED_MODULES=1\nEXPO_PRECOMPILED_MODULES_BASE_URL=https://storage.googleapis.com/eas-build-precompiled-modules/\nPrecompiled modules pod install environment is configured.'
+    );
+  });
+
+  it('proxies precompiled modules through CocoaPods cache when enabled', async () => {
+    const ctx = makeIosBuildContext({
+      expoVersion: '999.0.0',
+      cocoapodsCacheUrl: 'https://cocoapods-cache.expo.test/',
+    });
+
+    await installPods(ctx, {});
+
+    expect(spawn).toHaveBeenCalledWith(
+      'pod',
+      ['install'],
+      expect.objectContaining({
+        cwd: IOS_DIR,
+        env: expect.objectContaining({
+          EXPO_USE_PRECOMPILED_MODULES: '1',
+          EXPO_PRECOMPILED_MODULES_BASE_URL:
+            'https://cocoapods-cache.expo.test/storage.googleapis.com/eas-build-precompiled-modules/',
+        }),
+      })
+    );
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      'Detected expo=999.0.0; enabling precompiled modules use. Installing pods with additional environment variables.\nEXPO_USE_PRECOMPILED_MODULES=1\nEXPO_PRECOMPILED_MODULES_BASE_URL=https://cocoapods-cache.expo.test/storage.googleapis.com/eas-build-precompiled-modules/\nPrecompiled modules pod install environment is configured.'
     );
   });
 
@@ -146,6 +175,9 @@ describe(installPods, () => {
 
     expect((spawn as jest.Mock).mock.calls[0][2].env.EAS_USE_PRECOMPILED_MODULES).toBeUndefined();
     expect((spawn as jest.Mock).mock.calls[0][2].env.EXPO_USE_PRECOMPILED_MODULES).toBeUndefined();
+    expect(
+      (spawn as jest.Mock).mock.calls[0][2].env.EXPO_PRECOMPILED_MODULES_BASE_URL
+    ).toBeUndefined();
     expect(ctx.logger.info).not.toHaveBeenCalled();
   });
 });

--- a/packages/build-tools/src/ios/pod.ts
+++ b/packages/build-tools/src/ios/pod.ts
@@ -7,7 +7,8 @@ import semver from 'semver';
 import { BuildContext } from '../context';
 
 const MIN_PRECOMPILED_MODULES_EXPO_VERSION = '55.0.21';
-// const PRECOMPILED_MODULES_BASE_URL = 'https://storage.googleapis.com/eas-build-precompiled-modules/';
+const PRECOMPILED_MODULES_BASE_URL =
+  'https://storage.googleapis.com/eas-build-precompiled-modules/';
 
 export async function installPods<TJob extends Ios.Job>(
   ctx: BuildContext<TJob>,
@@ -76,10 +77,9 @@ async function resolvePrecompiledModulesPodInstallEnvAsync<TJob extends Ios.Job>
     return {};
   }
 
-  // Start rollout with Expo precompiled modules only. Add third-party modules after this is stable.
   const env: Env = {
     EXPO_USE_PRECOMPILED_MODULES: '1',
-    // EXPO_PRECOMPILED_MODULES_BASE_URL: getPrecompiledModulesBaseUrl(),
+    EXPO_PRECOMPILED_MODULES_BASE_URL: getPrecompiledModulesBaseUrl(ctx),
   };
 
   ctx.logger.info(
@@ -105,14 +105,14 @@ async function getInstalledExpoPackageVersionAsync<TJob extends Ios.Job>(
   return (await fs.readJson(expoPackageJsonPath)).version;
 }
 
-// function getPrecompiledModulesBaseUrl<TJob extends Ios.Job>(ctx: BuildContext<TJob>): string {
-//   if (!ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL) {
-//     return PRECOMPILED_MODULES_BASE_URL;
-//   }
-//
-//   const parsedUrl = new URL(PRECOMPILED_MODULES_BASE_URL);
-//   return PRECOMPILED_MODULES_BASE_URL.replace(
-//     `${parsedUrl.protocol}//${parsedUrl.host}`,
-//     `${ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL.replace(/\/$/, '')}/${parsedUrl.host}`
-//   );
-// }
+function getPrecompiledModulesBaseUrl<TJob extends Ios.Job>(ctx: BuildContext<TJob>): string {
+  if (!ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL) {
+    return PRECOMPILED_MODULES_BASE_URL;
+  }
+
+  const parsedUrl = new URL(PRECOMPILED_MODULES_BASE_URL);
+  return PRECOMPILED_MODULES_BASE_URL.replace(
+    `${parsedUrl.protocol}//${parsedUrl.host}`,
+    `${ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL.replace(/\/$/, '')}/${parsedUrl.host}`
+  );
+}


### PR DESCRIPTION
## Summary
- Re-enable `EXPO_PRECOMPILED_MODULES_BASE_URL` for iOS pod installs so third-party precompiled modules are used alongside Expo modules.
- Keep the env scoped to `pod install` only, and proxy the base URL through `EAS_BUILD_COCOAPODS_CACHE_URL` when CocoaPods cache is enabled.
- Update pod install unit coverage for the default storage URL and proxied URL behavior.

## Testing
- Added focused unit tests for direct and proxied precompiled modules base URL resolution.
- Ran `yarn exec oxfmt` on the touched files.
- Ran focused `@expo/build-tools` pod tests and package typecheck; both passed.