### PR TITLE
[eas-cli] recommend that users read the docs after connecting Convex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [build-tools] Update the minimum Expo version required for iOS precompiled modules. ([#3677](https://github.com/expo/eas-cli/pull/3677) by [@sjchmiela](https://github.com/sjchmiela))
+- [eas-cli] recommend that users read the docs after connecting Convex ([#3683](https://github.com/expo/eas-cli/pull/3683) by [@fiberjw](https://github.com/fiberjw))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/connect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/connect.test.ts
@@ -157,6 +157,11 @@ describe(IntegrationsConvexConnect, () => {
     expect(Log.log).toHaveBeenCalledWith(
       expect.stringContaining('Check your email for an invitation')
     );
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('npx convex dev'));
+    expect(Log.log).toHaveBeenCalledWith(
+      expect.stringContaining('https://docs.expo.dev/guides/using-convex')
+    );
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('https://docs.convex.dev/'));
     expect(spawnAsync).toHaveBeenCalledWith('npx', ['expo', 'install', 'convex'], {
       cwd: testProjectDir,
       stdio: 'inherit',

--- a/packages/eas-cli/src/commands/integrations/convex/connect.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/connect.ts
@@ -151,6 +151,10 @@ export default class IntegrationsConvexConnect extends EasCommand {
     Log.newLine();
     Log.log('Next steps:');
     Log.log(`  1. Start the Convex dev server: ${chalk.cyan('npx convex dev')}`);
+    Log.log(
+      `  2. Learn how to connect to your new Convex database by following our quickstart guide: ${chalk.cyan('https://docs.expo.dev/guides/using-convex')}`
+    );
+    Log.log(`  3. Read more about Convex: ${chalk.cyan('https://docs.convex.dev/')}`);
     Log.newLine();
     if (teamInviteResult === 'sent') {
       Log.log(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We should direct users to places to learn more about using Convex after connecting the integration.   
  
Fixes ENG-21071

# How

I added some extra output that links to both our docs quickstart and the Convex docs.

# Test Plan

`yarn build` and using the local `easd` alias, run `EXPO_STAGING=true easd integrations:convex:connect`  
  
You should see the new text content at the end:

![Screenshot 2026-05-07 at 21.40.41.png](https://app.graphite.com/user-attachments/assets/132a9115-c0d5-4f2b-aaa2-c08354ac3a6d.png)

