### PR TITLE
[eas-cli] set the Convex env var on EAS automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Automatically save the Convex deployment URL as an EAS environment variable when connecting a Convex project. ([#3685](https://github.com/expo/eas-cli/pull/3685) by [@fiberjw](https://github.com/fiberjw))
+
 ### 🐛 Bug fixes
 
 - [build-tools] Update the minimum Expo version required for iOS precompiled modules. ([#3677](https://github.com/expo/eas-cli/pull/3677) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/eas-cli/src/commands/integrations/convex/__tests__/connect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/__tests__/connect.test.ts
@@ -2,10 +2,18 @@ import spawnAsync from '@expo/spawn-async';
 import * as fs from 'fs-extra';
 
 import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
+import { DefaultEnvironment } from '../../../../build/utils/environment';
 import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { testProjectId } from '../../../../credentials/__tests__/fixtures-constants';
+import {
+  EnvironmentSecretType,
+  EnvironmentVariableScope,
+  EnvironmentVariableVisibility,
+} from '../../../../graphql/generated';
 import { ConvexMutation } from '../../../../graphql/mutations/ConvexMutation';
+import { EnvironmentVariableMutation } from '../../../../graphql/mutations/EnvironmentVariableMutation';
 import { ConvexQuery } from '../../../../graphql/queries/ConvexQuery';
+import { EnvironmentVariablesQuery } from '../../../../graphql/queries/EnvironmentVariablesQuery';
 import {
   ConvexTeamConnectionData,
   SetupConvexProjectResultData,
@@ -17,7 +25,9 @@ import { Actor } from '../../../../user/User';
 import IntegrationsConvexConnect from '../connect';
 
 jest.mock('../../../../graphql/queries/ConvexQuery');
+jest.mock('../../../../graphql/queries/EnvironmentVariablesQuery');
 jest.mock('../../../../graphql/mutations/ConvexMutation');
+jest.mock('../../../../graphql/mutations/EnvironmentVariableMutation');
 jest.mock('../../../../project/projectUtils');
 jest.mock('../../../../prompts');
 jest.mock('@expo/spawn-async');
@@ -132,6 +142,37 @@ describe(IntegrationsConvexConnect, () => {
     jest.mocked(ConvexMutation.createConvexTeamConnectionAsync).mockResolvedValue(mockConnection);
     jest.mocked(ConvexMutation.setupConvexProjectAsync).mockResolvedValue(mockSetupResult);
     jest.mocked(ConvexMutation.sendConvexTeamInviteToVerifiedEmailAsync).mockResolvedValue(true);
+    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValue([]);
+    jest.mocked(EnvironmentVariableMutation.createForAppAsync).mockResolvedValue({
+      id: 'env-var-1',
+      name: 'EXPO_PUBLIC_CONVEX_URL',
+      value: mockSetupResult.convexDeploymentUrl,
+      environments: [
+        DefaultEnvironment.Production,
+        DefaultEnvironment.Preview,
+        DefaultEnvironment.Development,
+      ],
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
+      type: EnvironmentSecretType.String,
+    });
+    jest.mocked(EnvironmentVariableMutation.updateAsync).mockResolvedValue({
+      id: 'env-var-1',
+      name: 'EXPO_PUBLIC_CONVEX_URL',
+      value: mockSetupResult.convexDeploymentUrl,
+      environments: [
+        DefaultEnvironment.Production,
+        DefaultEnvironment.Preview,
+        DefaultEnvironment.Development,
+      ],
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
+      type: EnvironmentSecretType.String,
+    });
   });
 
   it('creates a Convex team and project with the new mutation shape', async () => {
@@ -285,6 +326,108 @@ describe(IntegrationsConvexConnect, () => {
     const writeCall = jest.mocked(fs.writeFile).mock.calls.find(call => call[0] === envPath);
     expect(writeCall?.[1]).toContain('CONVEX_DEPLOY_KEY=dev:happy-otter-123|abc123token');
     expect(writeCall?.[1]).toContain('EXPO_PUBLIC_CONVEX_URL=https://happy-otter-123.convex.cloud');
+  });
+
+  it('creates the Convex URL as a project EAS environment variable for all default environments', async () => {
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection]);
+
+    await createCommand([]).runAsync();
+
+    expect(EnvironmentVariablesQuery.byAppIdAsync).toHaveBeenCalledWith(graphqlClient, {
+      appId: testProjectId,
+      filterNames: ['EXPO_PUBLIC_CONVEX_URL'],
+    });
+    expect(EnvironmentVariableMutation.createForAppAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      {
+        name: 'EXPO_PUBLIC_CONVEX_URL',
+        value: 'https://happy-otter-123.convex.cloud',
+        environments: [
+          DefaultEnvironment.Production,
+          DefaultEnvironment.Preview,
+          DefaultEnvironment.Development,
+        ],
+        visibility: EnvironmentVariableVisibility.Public,
+        type: EnvironmentSecretType.String,
+      },
+      testProjectId
+    );
+    expect(EnvironmentVariableMutation.updateAsync).not.toHaveBeenCalled();
+  });
+
+  it('updates an existing project EAS environment variable for the Convex URL', async () => {
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection]);
+    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValue([
+      {
+        id: 'env-var-1',
+        name: 'EXPO_PUBLIC_CONVEX_URL',
+        value: 'https://old-deployment.convex.cloud',
+        environments: [DefaultEnvironment.Production],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        scope: EnvironmentVariableScope.Project,
+        visibility: EnvironmentVariableVisibility.Public,
+        type: EnvironmentSecretType.String,
+      },
+    ]);
+
+    await createCommand([]).runAsync();
+
+    expect(confirmAsync).toHaveBeenCalledWith({
+      message: expect.stringContaining(
+        'EAS already has an EXPO_PUBLIC_CONVEX_URL environment variable'
+      ),
+    });
+    expect(EnvironmentVariableMutation.updateAsync).toHaveBeenCalledWith(graphqlClient, {
+      id: 'env-var-1',
+      name: 'EXPO_PUBLIC_CONVEX_URL',
+      value: 'https://happy-otter-123.convex.cloud',
+      environments: [
+        DefaultEnvironment.Production,
+        DefaultEnvironment.Preview,
+        DefaultEnvironment.Development,
+      ],
+      visibility: EnvironmentVariableVisibility.Public,
+      type: EnvironmentSecretType.String,
+    });
+    expect(EnvironmentVariableMutation.createForAppAsync).not.toHaveBeenCalled();
+  });
+
+  it('skips updating an existing project EAS environment variable for the Convex URL when declined', async () => {
+    jest
+      .mocked(ConvexQuery.getConvexTeamConnectionsByAccountIdAsync)
+      .mockResolvedValue([mockConnection]);
+    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValue([
+      {
+        id: 'env-var-1',
+        name: 'EXPO_PUBLIC_CONVEX_URL',
+        value: 'https://old-deployment.convex.cloud',
+        environments: [DefaultEnvironment.Production],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        scope: EnvironmentVariableScope.Project,
+        visibility: EnvironmentVariableVisibility.Public,
+        type: EnvironmentSecretType.String,
+      },
+    ]);
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+
+    await createCommand([]).runAsync();
+
+    expect(confirmAsync).toHaveBeenCalledWith({
+      message: expect.stringContaining(
+        'EAS already has an EXPO_PUBLIC_CONVEX_URL environment variable'
+      ),
+    });
+    expect(EnvironmentVariableMutation.updateAsync).not.toHaveBeenCalled();
+    expect(EnvironmentVariableMutation.createForAppAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Skipped updating EAS environment variable')
+    );
   });
 
   it('prompts before overwriting existing Convex .env.local values', async () => {

--- a/packages/eas-cli/src/commands/integrations/convex/connect.ts
+++ b/packages/eas-cli/src/commands/integrations/convex/connect.ts
@@ -5,11 +5,20 @@ import dotenv from 'dotenv';
 import * as fs from 'fs-extra';
 import path from 'path';
 
+import { DefaultEnvironment } from '../../../build/utils/environment';
 import EasCommand from '../../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { confirmRecentConvexInviteAsync, formatConvexTeam } from '../../../commandUtils/convex';
 import { EASNonInteractiveFlag } from '../../../commandUtils/flags';
+import {
+  EnvironmentSecretType,
+  EnvironmentVariableScope,
+  EnvironmentVariableVisibility,
+} from '../../../graphql/generated';
 import { ConvexMutation } from '../../../graphql/mutations/ConvexMutation';
+import { EnvironmentVariableMutation } from '../../../graphql/mutations/EnvironmentVariableMutation';
 import { ConvexQuery } from '../../../graphql/queries/ConvexQuery';
+import { EnvironmentVariablesQuery } from '../../../graphql/queries/EnvironmentVariablesQuery';
 import { ConvexTeamConnectionData } from '../../../graphql/types/ConvexTeamConnection';
 import Log from '../../../log';
 import { ora } from '../../../ora';
@@ -23,6 +32,12 @@ const CONVEX_REGIONS = [
 ];
 
 const DEFAULT_REGION = 'aws-us-east-1';
+const EAS_CONVEX_ENV_VAR_NAME = 'EXPO_PUBLIC_CONVEX_URL';
+const EAS_CONVEX_ENVIRONMENTS = [
+  DefaultEnvironment.Production,
+  DefaultEnvironment.Preview,
+  DefaultEnvironment.Development,
+];
 
 type TeamInviteResult = 'sent' | 'skipped' | 'failed';
 
@@ -132,12 +147,20 @@ export default class IntegrationsConvexConnect extends EasCommand {
       throw error;
     }
 
-    // 6. Send team invite (non-fatal)
+    // 6. Save the Convex URL as an EAS environment variable for builds
+    await this.upsertConvexUrlEasEnvVarAsync(
+      graphqlClient,
+      projectId,
+      setupResult.convexDeploymentUrl,
+      nonInteractive
+    );
+
+    // 7. Send team invite (non-fatal)
     const teamInviteResult = await this.sendTeamInviteAsync(graphqlClient, connection, actor, {
       nonInteractive,
     });
 
-    // 7. Write deploy key and URL to .env.local
+    // 8. Write deploy key and URL to .env.local
     await this.writeEnvLocalAsync(
       projectDir,
       setupResult.deployKey,
@@ -145,7 +168,7 @@ export default class IntegrationsConvexConnect extends EasCommand {
       nonInteractive
     );
 
-    // 8. Success message
+    // 9. Success message
     Log.addNewLineIfNone();
     Log.log(chalk.green('Convex is ready!'));
     Log.newLine();
@@ -161,6 +184,63 @@ export default class IntegrationsConvexConnect extends EasCommand {
         `Check your email for an invitation to join your Convex team. Accept it for full dashboard access.`
       );
     }
+  }
+
+  private async upsertConvexUrlEasEnvVarAsync(
+    graphqlClient: ExpoGraphqlClient,
+    projectId: string,
+    convexUrl: string,
+    nonInteractive: boolean
+  ): Promise<void> {
+    const existingVariables = await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, {
+      appId: projectId,
+      filterNames: [EAS_CONVEX_ENV_VAR_NAME],
+    });
+    const existingProjectVariable = existingVariables.find(
+      variable => variable.scope === EnvironmentVariableScope.Project
+    );
+
+    if (existingProjectVariable) {
+      if (!nonInteractive) {
+        const overwrite = await confirmAsync({
+          message: `EAS already has an ${EAS_CONVEX_ENV_VAR_NAME} environment variable for this project. Overwrite it?`,
+        });
+        if (!overwrite) {
+          Log.warn(
+            `Skipped updating EAS environment variable ${chalk.bold(EAS_CONVEX_ENV_VAR_NAME)}.`
+          );
+          return;
+        }
+      }
+
+      await EnvironmentVariableMutation.updateAsync(graphqlClient, {
+        id: existingProjectVariable.id,
+        name: EAS_CONVEX_ENV_VAR_NAME,
+        value: convexUrl,
+        environments: EAS_CONVEX_ENVIRONMENTS,
+        visibility: EnvironmentVariableVisibility.Public,
+        type: EnvironmentSecretType.String,
+      });
+      Log.withTick(
+        `Updated EAS environment variable ${chalk.bold(EAS_CONVEX_ENV_VAR_NAME)} for builds`
+      );
+      return;
+    }
+
+    await EnvironmentVariableMutation.createForAppAsync(
+      graphqlClient,
+      {
+        name: EAS_CONVEX_ENV_VAR_NAME,
+        value: convexUrl,
+        environments: EAS_CONVEX_ENVIRONMENTS,
+        visibility: EnvironmentVariableVisibility.Public,
+        type: EnvironmentSecretType.String,
+      },
+      projectId
+    );
+    Log.withTick(
+      `Created EAS environment variable ${chalk.bold(EAS_CONVEX_ENV_VAR_NAME)} for builds`
+    );
   }
 
   private async resolveRegionAsync(


### PR DESCRIPTION
# Why

In our Convex docs (https://docs.expo.dev/guides/using-convex/#save-the-convex-url-as-an-eas-environment-variable), we tell people to set an ENV var with EAS to use in their deployments. With our Convex integration, we can automate this step and make the setup UX even smoother. 

Fixes ENG-21068

# How

I added a step to the convex:connect command to set the `EXPO_PUBLIC_CONVEX_URL` EAS env var. If it already exists, we prompt the user to prevent accidental rewrites. 

# Test Plan

`yarn build` and using the local `easd` alias, run `EXPO_STAGING=true easd integrations:convex:connect`

You should see the new output talking about the env var, and the env var should also be visible in the env var dashboard page:

<img width="1564" height="264" alt="Screenshot 2026-05-08 at 04 29 16" src="https://github.com/user-attachments/assets/b9a0340b-8993-4198-b9c0-971fabe464e0" />

<img width="656" height="162" alt="Screenshot 2026-05-08 at 04 29 35" src="https://github.com/user-attachments/assets/a3721b98-30b3-4055-b8a2-276760605c4c" />
