### PR TITLE
[build-tools] add smart_retry to maestro job

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -3,6 +3,7 @@ import spawn from '@expo/turtle-spawn';
 
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createMockLogger } from '../../../__tests__/utils/logger';
+import * as discovery from '../maestroFlowDiscovery';
 import * as parser from '../maestroResultParser';
 import { createMaestroTestsBuildFunction } from '../maestroTests';
 
@@ -205,6 +206,108 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(spawnMock.mock.calls[1][1]).toEqual(
       expect.arrayContaining(['flows/a.yaml', 'flows/b.yaml'])
     );
+  });
+
+  it('runs all original flows on every retry when smart_retry=false', async () => {
+    mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
+    const parseSpy = jest
+      .spyOn(parser, 'parseFailedFlowsFromJUnit')
+      .mockResolvedValue(['flows/b.yaml']);
+
+    const step = createStep({
+      flow_path: ['flows/a.yaml', 'flows/b.yaml'],
+      retries: 1,
+      output_format: 'junit',
+      smart_retry: false,
+      platform: 'android',
+    });
+    await step.executeAsync();
+
+    // Both attempts must see both flows in the original input order. Tail-slice
+    // equality locks order, not just membership — guards against any future
+    // failed-first reshuffling of the dumb-retry list.
+    const a0 = mockedSpawn.mock.calls[0][1]!;
+    const a1 = mockedSpawn.mock.calls[1][1]!;
+    expect(a0.slice(-2)).toEqual(['flows/a.yaml', 'flows/b.yaml']);
+    expect(a1.slice(-2)).toEqual(['flows/a.yaml', 'flows/b.yaml']);
+    expect(parseSpy).not.toHaveBeenCalled();
+  });
+
+  it('subsets to failing flows on retry when smart_retry=true (default behaviour)', async () => {
+    mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
+    jest.spyOn(parser, 'parseFailedFlowsFromJUnit').mockResolvedValue(['flows/b.yaml']);
+
+    const step = createStep({
+      flow_path: ['flows/a.yaml', 'flows/b.yaml'],
+      retries: 1,
+      output_format: 'junit',
+      smart_retry: true,
+      platform: 'android',
+    });
+    await step.executeAsync();
+
+    expect(mockedSpawn.mock.calls[0][1]).toEqual(
+      expect.arrayContaining(['flows/a.yaml', 'flows/b.yaml'])
+    );
+    const a1 = mockedSpawn.mock.calls[1][1]!;
+    expect(a1).toContain('flows/b.yaml');
+    expect(a1).not.toContain('flows/a.yaml');
+  });
+
+  it('falls back to all-flows retry when smart_retry=true but output_format!=junit', async () => {
+    mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
+    const parseSpy = jest.spyOn(parser, 'parseFailedFlowsFromJUnit');
+
+    const step = createStep({
+      flow_path: ['flows/a.yaml', 'flows/b.yaml'],
+      retries: 1,
+      output_format: 'html',
+      smart_retry: true,
+      platform: 'android',
+    });
+    await step.executeAsync();
+
+    expect(parseSpy).not.toHaveBeenCalled();
+    expect(mockedSpawn.mock.calls[1][1]).toEqual(
+      expect.arrayContaining(['flows/a.yaml', 'flows/b.yaml'])
+    );
+  });
+
+  it('falls back to all-flows retry when nameToPath is null (duplicate flow names)', async () => {
+    mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
+    jest.spyOn(discovery, 'buildFlowNameToPathMap').mockResolvedValue(null);
+    const parseSpy = jest.spyOn(parser, 'parseFailedFlowsFromJUnit');
+
+    const step = createStep({
+      flow_path: ['flows/a.yaml', 'flows/b.yaml'],
+      retries: 1,
+      output_format: 'junit',
+      smart_retry: true,
+      platform: 'android',
+    });
+    await step.executeAsync();
+
+    expect(parseSpy).not.toHaveBeenCalled();
+    expect(mockedSpawn.mock.calls[1][1]).toEqual(
+      expect.arrayContaining(['flows/a.yaml', 'flows/b.yaml'])
+    );
+  });
+
+  it('defaults smart_retry to true when omitted from inputs', async () => {
+    mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
+    jest.spyOn(parser, 'parseFailedFlowsFromJUnit').mockResolvedValue(['flows/b.yaml']);
+
+    const step = createStep({
+      flow_path: ['flows/a.yaml', 'flows/b.yaml'],
+      retries: 1,
+      output_format: 'junit',
+      platform: 'android',
+    });
+    await step.executeAsync();
+
+    const a1 = mockedSpawn.mock.calls[1][1]!;
+    expect(a1).toContain('flows/b.yaml');
+    expect(a1).not.toContain('flows/a.yaml');
   });
 
   it('writes merged junit on success', async () => {

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -98,6 +98,12 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
         allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
       }),
       BuildStepInput.createProvider({
+        id: 'smart_retry',
+        required: false,
+        defaultValue: true,
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+      }),
+      BuildStepInput.createProvider({
         id: 'shards',
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
@@ -186,6 +192,7 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
         inputs.shards.value,
         'shards must be a positive integer.'
       );
+      const smartRetry = inputs.smart_retry.value as boolean;
 
       try {
         await fs.mkdir(junitReportDirectory, { recursive: true });
@@ -256,7 +263,7 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
           break;
         }
 
-        if (outputFormat === 'junit' && outputPath && nameToPath) {
+        if (smartRetry && outputFormat === 'junit' && outputPath && nameToPath) {
           const failed = await parseFailedFlowsFromJUnit({
             junitFile: outputPath,
             nameToPath,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Part of [ENG-21038](https://linear.app/expo/issue/ENG-21038). Provide an opt-out for smart retry on `eas/maestro_tests`.

# How

Adds a `smart_retry: boolean` step input (defaultValue: `true`) and gates the JUnit-failed-flow-subset path on it.

# Test Plan

Added 5 unit tests covering `smart_retry` false / true+junit / true+non-junit / null-nameToPath / omitted.

```
$ yarn jest-unit src/steps/functions/__tests__/maestroTests.test.ts
Tests:       37 passed, 37 total
```
