### PR TITLE
[eas-cli] metadata: re-throw MetadataDownloadError / MetadataUploadError so exit code reflects failure

### DIFF
--- a/packages/eas-cli/src/metadata/__tests__/errors.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/errors.test.ts
@@ -1,0 +1,48 @@
+import {
+  MetadataDownloadError,
+  MetadataUploadError,
+  MetadataValidationError,
+  handleMetadataError,
+} from '../errors';
+
+jest.mock('../../log');
+
+describe(handleMetadataError, () => {
+  it('re-throws a generic error untouched', () => {
+    const original = new Error('something exploded');
+
+    expect(() => {
+      handleMetadataError(original);
+    }).toThrow(original);
+  });
+
+  it('re-throws a MetadataValidationError so the command exits with non-zero status', () => {
+    const validation = new MetadataValidationError('validation failed', []);
+
+    expect(() => {
+      handleMetadataError(validation);
+    }).toThrow(validation);
+  });
+
+  it('re-throws a MetadataUploadError so the command exits with non-zero status', () => {
+    const uploadError = new MetadataUploadError(
+      [new Error('Failed uploading 01.png'), new Error('Failed uploading 02.png')],
+      'exec-1'
+    );
+
+    expect(() => {
+      handleMetadataError(uploadError);
+    }).toThrow(uploadError);
+  });
+
+  it('re-throws a MetadataDownloadError so the command exits with non-zero status', () => {
+    const downloadError = new MetadataDownloadError(
+      [new Error('Failed downloading screenshot.png')],
+      'exec-2'
+    );
+
+    expect(() => {
+      handleMetadataError(downloadError);
+    }).toThrow(downloadError);
+  });
+});

--- a/packages/eas-cli/src/metadata/errors.ts
+++ b/packages/eas-cli/src/metadata/errors.ts
@@ -73,11 +73,17 @@ export function logMetadataValidationError(error: MetadataValidationError): void
 /**
  * Handle a thrown metadata error by informing the user what went wrong.
  * If a normal error is thrown, this method will re-throw that error to avoid consuming it.
+ *
+ * Aggregated download/upload errors (`MetadataDownloadError`, `MetadataUploadError`)
+ * are logged in detail here and then re-thrown so the calling command exits with a
+ * non-zero status. Otherwise per-entity failures (e.g. a single screenshot upload that
+ * raised inside `logAsync`) would be visible only in the spinner output while the
+ * outer `eas metadata:push` / `eas metadata:pull` invocation still reported success.
  */
 export function handleMetadataError(error: Error): void {
   if (error instanceof MetadataValidationError) {
     logMetadataValidationError(error);
-    return;
+    throw error;
   }
 
   if (error instanceof MetadataDownloadError || error instanceof MetadataUploadError) {
@@ -92,7 +98,7 @@ export function handleMetadataError(error: Error): void {
     Log.log('If this issue persists, open a new issue at:');
     // TODO: add execution ID to the issue template link
     Log.log(link('https://github.com/expo/eas-cli'));
-    return;
+    throw error;
   }
 
   throw error;


### PR DESCRIPTION
# Why

`eas metadata:push` (and to a lesser extent `eas metadata:pull`) currently exits with status `0` even when individual entity sync operations fail. In production this means an apparently-successful run can leave App Store Connect in a partially-synced state with the user none the wiser.

Concrete repro that triggered this fix: a real `metadata:push` run printed multiple `Failed uploading <screenshot>.png (<locale>)` lines via the `logAsync` spinner (transient ASC 503s during peak hours) and still exited `0`, so the surrounding bash retry loop saw "success" and stopped.

```
✖ Failed uploading 03.png (en-US)
✖ Failed uploading 04.png (en-US)
🎉 Store configuration is synced with the app stores.
$ echo $?
0
```

Closes #3689.

## Root cause

`logAsync` correctly re-throws when the wrapped action rejects, and `uploadMetadataAsync` / `downloadMetadataAsync` correctly accumulate those errors and throw a wrapping `MetadataUploadError` / `MetadataDownloadError`. The exit code is dropped one layer up, in `handleMetadataError`:

```ts
if (error instanceof MetadataDownloadError || error instanceof MetadataUploadError) {
  Log.newLine();
  Log.error(chalk.bold(error.message));
  // ...print per-error messages and "open an issue" link...
  return; // <-- swallows the failure; oclif sees no error → exit 0
}
```

`MetadataValidationError` was swallowed the same way, even though the upstream call sites in `commands/metadata/push.ts` and `commands/metadata/pull.ts` already treat `handleMetadataError` as terminal (it's the last call in their `catch` block).

# How

Replace both `return;` branches in `handleMetadataError` with `throw error;` so the error propagates up to `EasCommand.catch`, which logs it via Sentry and re-throws a sanitized `${commandId} command failed.` error. oclif then exits non-zero. Validation errors are now also propagated (matches the existing JSDoc which already promises "this method will re-throw that error").

The friendly multi-line block (`error.message` + per-error messages + "If this issue persists, open a new issue at …") is still printed exactly as before, so the visible UX is unchanged for users who were already paying attention to the spinner output. The only user-visible change is that the process now exits `1`, which CI / wrapper scripts can finally observe.

# Test Plan

Added unit tests in [`packages/eas-cli/src/metadata/__tests__/errors.test.ts`](https://github.com/Maples7/eas-cli/blob/fix/metadata-error-exit-code/packages/eas-cli/src/metadata/__tests__/errors.test.ts) covering all four branches of `handleMetadataError` (generic, validation, upload-aggregate, download-aggregate). Each asserts the original error instance bubbles back out so the calling command exits non-zero.

```
$ yarn test src/metadata/__tests__/errors.test.ts
PASS src/metadata/__tests__/errors.test.ts
  handleMetadataError
    ✓ re-throws a generic error untouched
    ✓ re-throws a MetadataValidationError so the command exits with non-zero status
    ✓ re-throws a MetadataUploadError so the command exits with non-zero status
    ✓ re-throws a MetadataDownloadError so the command exits with non-zero status
Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```

Full metadata suite still passes (`yarn test src/metadata` → 16 suites, 191 tests, 187 baseline + 4 new). `yarn typecheck` clean. `yarn lint` clean (0 errors; the 12 pre-existing warnings are unchanged).

I haven't been able to E2E-reproduce a transient ASC 503 inside the change because I'd need to be able to deterministically force `AppScreenshot.uploadAsync` to throw — happy to add an integration-style test if there's a preferred mocking pattern in this repo.

/changelog-entry bug-fix [eas-cli] Fix `eas metadata:push` and `eas metadata:pull` exiting with status `0` even when individual screenshot, app-info, or other entity sync operations failed.