### PR TITLE
[eas-cli] metadata:pull: print --non-interactive hint before overwrite prompt

### DIFF
--- a/packages/eas-cli/src/metadata/__tests__/download.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/download.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 
 import { downloadMetadataAsync } from '../download';
 import { MetadataValidationError } from '../errors';
+import Log from '../../log';
 
 jest.mock('../auth', () => ({
   getAppStoreAuthAsync: jest.fn(() => ({
@@ -79,6 +80,30 @@ describe(downloadMetadataAsync, () => {
     expect(confirmAsync).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.stringContaining('overwrite') })
     );
+  });
+
+  it('prints a --non-interactive hint before the overwrite prompt so a stuck invocation is self-explanatory', async () => {
+    (fs.pathExists as jest.Mock).mockResolvedValue(true);
+    (confirmAsync as jest.Mock).mockResolvedValue(true);
+
+    await downloadMetadataAsync(createArgs({ nonInteractive: false }));
+
+    const hintCall = (Log.log as jest.Mock).mock.calls.find(
+      ([msg]) => typeof msg === 'string' && msg.includes('--non-interactive')
+    );
+    expect(hintCall).toBeDefined();
+    expect(hintCall?.[0]).toContain('store.config.json');
+  });
+
+  it('does not print the --non-interactive hint when running in non-interactive mode', async () => {
+    (fs.pathExists as jest.Mock).mockResolvedValue(true);
+
+    await downloadMetadataAsync(createArgs({ nonInteractive: true }));
+
+    const hintCall = (Log.log as jest.Mock).mock.calls.find(
+      ([msg]) => typeof msg === 'string' && msg.includes('--non-interactive')
+    );
+    expect(hintCall).toBeUndefined();
   });
 
   it('throws MetadataValidationError when user declines overwrite in interactive mode', async () => {

--- a/packages/eas-cli/src/metadata/download.ts
+++ b/packages/eas-cli/src/metadata/download.ts
@@ -1,5 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { SubmitProfile } from '@expo/eas-json';
+import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -46,6 +47,15 @@ export async function downloadMetadataAsync({
       Log.log(`Overwriting existing store config at "${path.relative(projectDir, filePath)}".`);
     } else {
       const filePathRelative = path.relative(projectDir, filePath);
+      // Common pitfall: this prompt is invisible-by-default when stdout is being
+      // piped (e.g. `eas metadata:pull | tee log`) and unanswerable when running
+      // inside a wrapper such as a CI pseudo-tty or an AI-agent integrated
+      // terminal. Print an explicit hint so a stuck invocation is self-explanatory.
+      Log.log(
+        chalk.dim(
+          `Tip: pass --non-interactive to auto-overwrite "${filePathRelative}" without prompting.`
+        )
+      );
       const overwrite = await confirmAsync({
         message: `Do you want to overwrite the existing "${filePathRelative}"?`,
       });


### PR DESCRIPTION
# Why

The overwrite confirmation in `eas metadata:pull` is unanswerable in a number of common environments and indistinguishable from a hang:

- Inside an AI-agent integrated terminal (Copilot Chat, etc.) that wraps the shell in a pty: `process.stdin.isTTY === true`, so `EASNonInteractiveFlag`'s autodetect doesn't trigger, and there is no human to type `y`.
- When stdout is piped (`eas metadata:pull | tee log`): the prompt is often hidden behind the spinner/pipe.
- Inside `nohup` without `< /dev/null`.

The fix in #3691 is split into three suggestions; this PR ships the smallest one (suggestion 2) — print an explicit hint immediately before the confirm — because it's a pure log addition with no behavioral change to the default flag autodetect. The other two suggestions in the issue (auto-non-interactive when `!process.stdout.isTTY`, default-overwrite for matching `appId`) are larger UX/behavior changes and are best discussed in the issue thread before being merged.

Refs #3691. Closes #3691.

# How

Add one `Log.log(chalk.dim('Tip: pass --non-interactive to auto-overwrite ... without prompting.'))` line in `downloadMetadataAsync` immediately before `confirmAsync`. Stays inside the `else` branch so it does not print under `--non-interactive`. Uses `chalk.dim` to match the muted style of other hint lines in the codebase.

# Test Plan

Added two unit tests in [`packages/eas-cli/src/metadata/__tests__/download.test.ts`](https://github.com/Maples7/eas-cli/blob/enhance/metadata-pull-overwrite-hint/packages/eas-cli/src/metadata/__tests__/download.test.ts):

```
$ yarn test src/metadata/__tests__/download.test.ts
PASS src/metadata/__tests__/download.test.ts
  downloadMetadataAsync
    ✓ skips overwrite prompt and auto-overwrites in non-interactive mode
    ✓ prompts for overwrite in interactive mode when file exists
    ✓ prints a --non-interactive hint before the overwrite prompt so a stuck invocation is self-explanatory
    ✓ does not print the --non-interactive hint when running in non-interactive mode
    ✓ throws MetadataValidationError when user declines overwrite in interactive mode
    ✓ does not prompt when file does not exist
Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
```

Full metadata suite still passes (`yarn test src/metadata` → 15 suites, 189 tests, 187 baseline + 2 new). `yarn typecheck` clean. `yarn lint` clean (0 errors; pre-existing warning count unchanged).

Manual smoke test (against my own ASC project):

```
$ eas metadata:pull --profile production
✔ Linked to project @<owner>/<project>
EAS Metadata is in beta and subject to breaking changes.
Tip: pass --non-interactive to auto-overwrite "store.config.json" without prompting.
✔ Do you want to overwrite the existing "store.config.json"? … yes
Downloading App Store config...
🎉 Your store config is ready.
```

/changelog-entry chore [eas-cli] Print a `--non-interactive` hint before the `metadata:pull` overwrite prompt so stuck invocations under piped stdout / agent terminals are self-explanatory.