### PR TITLE
[eas-cli] Fix metadata:push silently skipping screenshot reorder when set already matches by (filename, fileSize)

### DIFF
--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/screenshots.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/screenshots.test.ts
@@ -388,5 +388,87 @@ describe(ScreenshotsTask, () => {
       // Reorder is skipped because the current order already matches
       expect(reorderMock).not.toHaveBeenCalled();
     });
+
+    // Regression test for https://github.com/expo/eas-cli/issues/3690.
+    //
+    // The App Store Connect API does NOT return `relationships.appScreenshots`
+    // on `GET /v1/appScreenshotSets/{id}` unless `?include=appScreenshots` is
+    // passed, and `@expo/apple-utils` <= 2.1.21 does not pass it from
+    // `AppScreenshotSet.infoAsync`. Without an explicit `query.includes` here
+    // we would refresh the set with `attributes.appScreenshots === undefined`,
+    // build an empty `screenshotsByFilename` map, end up with an empty
+    // `orderedIds`, and silently skip `reorderScreenshotsAsync` — leaving the
+    // live store with a stale order even though every (filename, fileSize)
+    // pair already matched the local config and no upload was needed.
+    it('passes `includes: ["appScreenshots"]` to `AppScreenshotSet.infoAsync` and reorders when the live order differs (#3690)', async () => {
+      const existing1 = new AppScreenshot(requestContext, 'SS_1', {
+        fileName: '01-home.png',
+        fileSize: 1024,
+        assetDeliveryState: { state: 'COMPLETE', errors: [], warnings: [] },
+      } as any);
+      const existing2 = new AppScreenshot(requestContext, 'SS_2', {
+        fileName: '02-detail.png',
+        fileSize: 1024,
+        assetDeliveryState: { state: 'COMPLETE', errors: [], warnings: [] },
+      } as any);
+
+      const config = new AppleConfigReader({
+        info: {
+          'en-US': {
+            title: 'My App',
+            screenshots: {
+              // Local config wants 01-home, 02-detail in that order.
+              APP_IPHONE_67: ['./screenshots/01-home.png', './screenshots/02-detail.png'],
+            },
+          },
+        },
+      });
+
+      const locale = new AppStoreVersionLocalization(requestContext, 'LOC_1', {
+        locale: 'en-US',
+      } as any);
+
+      // The set already has both screenshots (so nothing is uploaded), but the
+      // live order on App Store Connect is reversed.
+      const screenshotSet = new AppScreenshotSet(requestContext, 'SET_1', {
+        screenshotDisplayType: ScreenshotDisplayType.APP_IPHONE_67,
+        appScreenshots: [existing2, existing1],
+      } as any);
+
+      const displayTypeMap = new Map<ScreenshotDisplayType, AppScreenshotSet>();
+      displayTypeMap.set(ScreenshotDisplayType.APP_IPHONE_67, screenshotSet);
+      const screenshotSets = new Map([['en-US', displayTypeMap]]);
+
+      const infoSpy = jest.spyOn(AppScreenshotSet, 'infoAsync').mockResolvedValue(
+        new AppScreenshotSet(requestContext, 'SET_1', {
+          screenshotDisplayType: ScreenshotDisplayType.APP_IPHONE_67,
+          // Refresh returns the stale (reversed) live order.
+          appScreenshots: [existing2, existing1],
+        } as any)
+      );
+      const reorderMock = jest.fn().mockResolvedValue([]);
+      AppScreenshotSet.prototype.reorderScreenshotsAsync = reorderMock;
+
+      await new ScreenshotsTask().uploadAsync({
+        config,
+        context: {
+          screenshotSets,
+          versionLocales: [locale],
+          projectDir: '/test/project',
+        } as any,
+      });
+
+      // The infoAsync call MUST request the appScreenshots relationship,
+      // otherwise ASC returns no data and the reorder check is a no-op.
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          id: 'SET_1',
+          query: expect.objectContaining({ includes: ['appScreenshots'] }),
+        })
+      );
+      // Live order was [SS_2, SS_1]; config wants [SS_1, SS_2]. Reorder must run.
+      expect(reorderMock).toHaveBeenCalledWith({ appScreenshots: ['SS_1', 'SS_2'] });
+    });
   });
 });

--- a/packages/eas-cli/src/metadata/apple/tasks/screenshots.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/screenshots.ts
@@ -250,8 +250,16 @@ async function syncScreenshotSetAsync(
 
   // Reorder screenshots to match config order
   if (screenshotIdsToKeep.length > 0) {
+    // `AppScreenshotSet.infoAsync` from @expo/apple-utils does not pass an
+    // `includes` query by default, so the App Store Connect API responds
+    // without `relationships.appScreenshots.data` and `attributes.appScreenshots`
+    // ends up undefined. We must request `appScreenshots` explicitly, otherwise
+    // the reorder check below sees an empty list and silently skips the PATCH —
+    // which is how a partial run can leave the live store with a stale order
+    // even though every (filename, fileSize) pair already matches the config.
     const refreshedSet = await AppScreenshotSet.infoAsync(localization.context, {
       id: screenshotSet.id,
+      query: { includes: ['appScreenshots'] },
     });
     const refreshedScreenshots = refreshedSet.attributes.appScreenshots || [];
     const screenshotsByFilename = new Map<string, AppScreenshot>();


### PR DESCRIPTION
## Why

Refs #3690. Closes #3690.

`eas metadata:push` can finish reporting success while App Store Connect still shows screenshots in a different order than the local `store.config.json`. This happens when every (filename, fileSize) pair in a screenshot set already matches what's live, so eas-cli skips upload — but the reorder step that should still run is silently a no-op, locking in whatever order ASC currently has (often stale from an earlier transient failure).

### Root cause

In [`packages/eas-cli/src/metadata/apple/tasks/screenshots.ts`](https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/metadata/apple/tasks/screenshots.ts), after the upload pass, eas-cli refreshes the set to read the live order:

```ts
const refreshedSet = await AppScreenshotSet.infoAsync(localization.context, {
  id: screenshotSet.id,
});
const refreshedScreenshots = refreshedSet.attributes.appScreenshots || [];
```

`AppScreenshotSet.infoAsync` is defined in `@expo/apple-utils` (≤ 2.1.21) without a `defaultQuery`, so the underlying request is `GET /v1/appScreenshotSets/{id}` with no `?include=appScreenshots`.

I verified empirically against a live ASC app:

| Call | `relationships.appScreenshots.data` |
|---|---|
| `GET /v1/appScreenshotSets/{id}` (no `?include`) | **completely missing** |
| `GET /v1/appScreenshotSets/{id}?include=appScreenshots` | 10 entries, canonical order |
| `GET /v1/appScreenshotSets/{id}/relationships/appScreenshots` | 10 entries, canonical order |

The JSON:API parser in `@expo/apple-utils` skips relationships with no `data`:

```js
for (const [t, a] of Object.entries(r)) {
  const r = a?.data;
  if (!r) continue;   // ← include omitted → data undefined → relationship dropped
  ...
}
```

So `refreshedSet.attributes.appScreenshots` ends up `undefined` → `refreshedScreenshots = []` → `screenshotsByFilename` is empty → `orderedIds` is empty → the `if (orderedIds.length > 0 && …)` reorder guard is never satisfied → `reorderScreenshotsAsync` is never called → live order stays stale.

It's worth noting `AppStoreVersionLocalization.getAppScreenshotSetsAsync` (the call eas-cli uses to populate the initial `screenshotSets` map in `prepareAsync`) hardcodes `includes: [..., 'appScreenshots']`, which is why everything else in this file works. Only the post-upload refresh was affected.

## How

`AppScreenshotSet.infoAsync` accepts `query?: ConnectQueryParams`, so we can compensate from eas-cli without waiting for an `@expo/apple-utils` release:

```ts
const refreshedSet = await AppScreenshotSet.infoAsync(localization.context, {
  id: screenshotSet.id,
  query: { includes: ['appScreenshots'] },
});
```

The longer-term fix is to add `defaultQuery: { includes: ['appScreenshots'] }` to `AppScreenshotSet.infoAsync` inside `@expo/apple-utils` (it's already done for similar models like `CustomerReview`, which uses `DEFAULT_INCLUDES`). I'm filing that suggestion separately on #3690 so the maintainers of the package can route it.

## Test Plan

- Added a regression test in `screenshots.test.ts`:
  - asserts `AppScreenshotSet.infoAsync` is called with `query: { includes: ['appScreenshots'] }`,
  - simulates a live store whose order is reversed compared to the local config,
  - asserts `reorderScreenshotsAsync` is called with the desired order.

Local results:

- `yarn build` → green (lerna build for 13 projects).
- `yarn lint` → no new errors (12 pre-existing warnings unrelated to this change).
- `yarn jest --testPathPattern='metadata'` → **191 / 191 passing** (16 suites).

/changelog-entry bug-fix [eas-cli] Fix `metadata:push` silently skipping screenshot reorder when every (filename, fileSize) already matches the live set.
