### PR TITLE
[build-tools] Add Android support to start_agent_device_remote_session

### DIFF
--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -1,5 +1,10 @@
 import { bunyan } from '@expo/logger';
-import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
+import {
+  BuildFunction,
+  BuildRuntimePlatform,
+  BuildStepInput,
+  BuildStepInputValueTypeName,
+} from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
 import childProcess from 'node:child_process';
 import fs from 'node:fs';
@@ -15,6 +20,7 @@ const DAEMON_LOG = path.join(RUN_DIR, 'daemon.log');
 const TUNNEL_LOG = path.join(RUN_DIR, 'cloudflared.log');
 const DAEMON_JSON_PATH = path.join(os.homedir(), '.agent-device', 'daemon.json');
 const XCODE_DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer';
+const CLOUDFLARED_LINUX_INSTALL_PATH = '/usr/local/bin/cloudflared';
 const STARTUP_TIMEOUT_MS = 60_000;
 
 export function createStartAgentDeviceRemoteSessionBuildFunction(): BuildFunction {
@@ -30,21 +36,23 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(): BuildFunctio
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
     ],
-    fn: async ({ logger }, { inputs, env }) => {
+    fn: async ({ logger, global }, { inputs, env }) => {
       const packageVersion = inputs.package_version.value as string | undefined;
-      logger.info(`Starting agent-device remote session (version: ${packageVersion ?? 'latest'}).`);
+      const { runtimePlatform } = global;
+      logger.info(
+        `Starting agent-device remote session (version: ${packageVersion ?? 'latest'}, runtime: ${runtimePlatform}).`
+      );
 
       logger.info(`Preparing runtime directory at ${RUN_DIR}.`);
       await fs.promises.mkdir(RUN_DIR, { recursive: true });
 
-      logger.info(`Selecting Xcode developer directory: ${XCODE_DEVELOPER_DIR}.`);
-      await spawn('sudo', ['xcode-select', '-s', XCODE_DEVELOPER_DIR], { env, logger });
+      if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
+        logger.info(`Selecting Xcode developer directory: ${XCODE_DEVELOPER_DIR}.`);
+        await spawn('sudo', ['xcode-select', '-s', XCODE_DEVELOPER_DIR], { env, logger });
+      }
 
       logger.info('Ensuring cloudflared is installed.');
-      await ensureCloudflaredInstalledAsync({ env, logger });
-
-      logger.info('Ensuring bun is installed.');
-      await ensureBunInstalledAsync({ env, logger });
+      await ensureCloudflaredInstalledAsync({ runtimePlatform, env, logger });
 
       logger.info(
         packageVersion
@@ -110,23 +118,29 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(): BuildFunctio
 }
 
 async function ensureCloudflaredInstalledAsync({
+  runtimePlatform,
   env,
   logger,
 }: {
+  runtimePlatform: BuildRuntimePlatform;
   env: NodeJS.ProcessEnv;
   logger: bunyan;
 }): Promise<void> {
-  await ensureBrewPackageInstalledAsync({ name: 'cloudflared', env, logger });
-}
-
-async function ensureBunInstalledAsync({
-  env,
-  logger,
-}: {
-  env: NodeJS.ProcessEnv;
-  logger: bunyan;
-}): Promise<void> {
-  await ensureBrewPackageInstalledAsync({ name: 'bun', env, logger });
+  if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
+    await ensureBrewPackageInstalledAsync({ name: 'cloudflared', env, logger });
+    return;
+  }
+  if (await isCommandAvailableAsync({ command: 'cloudflared', env })) {
+    return;
+  }
+  const arch = os.arch() === 'arm64' ? 'arm64' : 'amd64';
+  const downloadUrl = `https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${arch}`;
+  logger.info(`Downloading cloudflared from ${downloadUrl} to ${CLOUDFLARED_LINUX_INSTALL_PATH}.`);
+  await spawn('sudo', ['curl', '-fsSL', '-o', CLOUDFLARED_LINUX_INSTALL_PATH, downloadUrl], {
+    env,
+    logger,
+  });
+  await spawn('sudo', ['chmod', '+x', CLOUDFLARED_LINUX_INSTALL_PATH], { env, logger });
 }
 
 async function ensureBrewPackageInstalledAsync({
@@ -143,6 +157,21 @@ async function ensureBrewPackageInstalledAsync({
     ['-c', `command -v ${name} >/dev/null 2>&1 || HOMEBREW_NO_AUTO_UPDATE=1 brew install ${name}`],
     { env, logger }
   );
+}
+
+async function isCommandAvailableAsync({
+  command,
+  env,
+}: {
+  command: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<boolean> {
+  try {
+    await spawn('bash', ['-c', `command -v ${command}`], { env, ignoreStdio: true });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function cloneAgentDeviceAsync({

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -52,7 +52,11 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(): BuildFunctio
       }
 
       logger.info('Ensuring cloudflared is installed.');
-      await ensureCloudflaredInstalledAsync({ runtimePlatform, env, logger });
+      const cloudflaredCommand = await ensureCloudflaredInstalledAsync({
+        runtimePlatform,
+        env,
+        logger,
+      });
 
       logger.info(
         packageVersion
@@ -90,7 +94,7 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(): BuildFunctio
         `Starting cloudflared tunnel to http://localhost:${daemonPort} (log file: ${TUNNEL_LOG}).`
       );
       await spawnDetachedAsync({
-        command: `cloudflared tunnel --url "http://localhost:${daemonPort}"`,
+        command: `${cloudflaredCommand} tunnel --url "http://localhost:${daemonPort}"`,
         logFile: TUNNEL_LOG,
         env,
         logger,
@@ -125,22 +129,37 @@ async function ensureCloudflaredInstalledAsync({
   runtimePlatform: BuildRuntimePlatform;
   env: NodeJS.ProcessEnv;
   logger: bunyan;
-}): Promise<void> {
+}): Promise<string> {
   if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
     await ensureBrewPackageInstalledAsync({ name: 'cloudflared', env, logger });
-    return;
+    return 'cloudflared';
   }
   if (await isCommandAvailableAsync({ command: 'cloudflared', env })) {
-    return;
+    return 'cloudflared';
   }
-  const arch = os.arch() === 'arm64' ? 'arm64' : 'amd64';
-  const downloadUrl = `https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${arch}`;
+  const cloudflaredArch = cloudflaredLinuxArchForNodeArch(os.arch());
+  const downloadUrl = `https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${cloudflaredArch}`;
   logger.info(`Downloading cloudflared from ${downloadUrl} to ${CLOUDFLARED_LINUX_INSTALL_PATH}.`);
   await spawn('sudo', ['curl', '-fsSL', '-o', CLOUDFLARED_LINUX_INSTALL_PATH, downloadUrl], {
     env,
     logger,
   });
   await spawn('sudo', ['chmod', '+x', CLOUDFLARED_LINUX_INSTALL_PATH], { env, logger });
+  // Return the absolute install path so the tunnel command works even when
+  // /usr/local/bin is not on the step's PATH.
+  return CLOUDFLARED_LINUX_INSTALL_PATH;
+}
+
+function cloudflaredLinuxArchForNodeArch(arch: string): 'amd64' | 'arm64' {
+  if (arch === 'x64') {
+    return 'amd64';
+  }
+  if (arch === 'arm64') {
+    return 'arm64';
+  }
+  throw new Error(
+    `Unsupported architecture for cloudflared on Linux: "${arch}". Expected "x64" or "arm64".`
+  );
 }
 
 async function ensureBrewPackageInstalledAsync({


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`eas/start_agent_device_remote_session` only worked on macOS (iOS) workers — it ran `xcode-select` and used `brew` to install `cloudflared`, so an Android workflow that tried to call it would fail. We want the same agent-device remote session functionality on Android (Linux) workers so a single step can drive both platforms with identical outputs.

# How

- Made the function platform-aware by reading `global.runtimePlatform`.
- Darwin path is unchanged: `xcode-select`, then `brew install cloudflared`.
- Linux path: skip `xcode-select` and, if `cloudflared` isn't already on `PATH`, download it from GitHub releases via `sudo curl` into `/usr/local/bin/cloudflared` (arch-aware: `linux-amd64` / `linux-arm64`) and `chmod +x`.
- `bun` is pre-installed on both worker images, so no install logic is needed.
- Daemon launch (`bun run src/daemon.ts`), `~/.agent-device/daemon.json` polling, the cloudflared tunnel, and the emitted `AGENT_DEVICE_DAEMON_BASE_URL` / `AGENT_DEVICE_DAEMON_AUTH_TOKEN` are unchanged — same final effect on both platforms.

# Test Plan

- `yarn typecheck` — clean
- `yarn lint` — 0 new errors (pre-existing warnings only)
- `yarn fmt:check` — clean
- `yarn test` in `packages/build-tools` — 480 tests pass
- Still to verify on a real Android worker: confirm `cloudflared` gets installed on a fresh image, the daemon writes credentials, the tunnel returns a `*.trycloudflare.com` URL, and the exported env vars work end-to-end against a connected Android device/emulator.
- iOS path on macOS workers should be unaffected (no behavioral change).