### PR TITLE
[eas-cli] Read agent device remote config from API instead of scraping logs

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -2217,6 +2217,71 @@
                 }
               }
             },
+            "isDeprecated": true,
+            "deprecationReason": "Use snacksPaginated"
+          },
+          {
+            "name": "snacksPaginated",
+            "description": "Paginated list of Snacks associated with this account, sorted by most recent activity.",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AccountSnacksConnection",
+                "ofType": null
+              }
+            },
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -5258,6 +5323,100 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "AccountSnacksConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AccountSnacksEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AccountSnacksEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Snack",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "AccountUploadSessionType",
         "description": null,
@@ -6277,6 +6436,49 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AgentDeviceRunSessionRemoteConfig",
+        "description": null,
+        "fields": [
+          {
+            "name": "token",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -13695,6 +13897,54 @@
             "description": null,
             "args": [
               {
+                "name": "appBuildNumber",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "appEasBuildId",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "appUpdateId",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "appVersion",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "endTime",
                 "description": null,
                 "type": {
@@ -13716,6 +13966,18 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveCustomEventNamesOrderBy",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -15333,6 +15595,95 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveCustomEventNamesOrderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveCustomEventNamesOrderByDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveCustomEventNamesOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppObserveCustomEventNamesOrderByDirection",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppObserveCustomEventNamesOrderByField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "COUNT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EVENT_NAME",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -17068,6 +17419,42 @@
         "inputFields": [
           {
             "name": "after",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -35901,6 +36288,18 @@
             "deprecationReason": null
           },
           {
+            "name": "remoteConfig",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "DeviceRunSessionRemoteConfig",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "startedAt",
             "description": null,
             "args": [],
@@ -36048,6 +36447,55 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "startDeviceRunSession",
+            "description": "Mark a device run session as started and persist remote connection details",
+            "args": [
+              {
+                "name": "deviceRunSessionId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "remoteConfig",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "JSONObject",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeviceRunSession",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -36098,6 +36546,22 @@
         "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
+      },
+      {
+        "kind": "UNION",
+        "name": "DeviceRunSessionRemoteConfig",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "AgentDeviceRunSessionRemoteConfig",
+            "ofType": null
+          }
+        ]
       },
       {
         "kind": "ENUM",
@@ -39934,6 +40398,18 @@
             "deprecationReason": null
           },
           {
+            "name": "completionStatus",
+            "description": "Terminal status of the turn (null if still in progress)",
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "EchoTurnCompletionStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createdAt",
             "description": null,
             "args": [],
@@ -39985,6 +40461,18 @@
                   }
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "Error message when completionStatus is ERROR",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -40059,14 +40547,67 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "EchoTurnCompletionStatus",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CANCELLED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COMPLETED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ERROR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "EchoTurnMutation",
         "description": null,
         "fields": [
           {
             "name": "completeTurn",
-            "description": "Mark a turn as completed and create a billing ledger entry",
+            "description": "Mark a turn as completed and create a billing ledger entry.\n\ncompletionStatus defaults to COMPLETED for backward compatibility with\nclients that do not yet send a status. error may be set when\ncompletionStatus is ERROR to record the failure reason.",
             "args": [
+              {
+                "name": "completionStatus",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "EchoTurnCompletionStatus",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "error",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
               {
                 "name": "id",
                 "description": null,
@@ -43023,6 +43564,227 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ExpoGoBuildQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "repackConfiguration",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ExpoGoRepackInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ExpoGoProjectConfiguration",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ExpoGoProjectConfiguration",
+        "description": null,
+        "fields": [
+          {
+            "name": "files",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ExpoGoProjectFile",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sdkVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ExpoGoProjectFile",
+        "description": null,
+        "fields": [
+          {
+            "name": "fileContents",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fileName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ExpoGoRepackInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ascAppId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bundleId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sdkVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -56443,7 +57205,7 @@
           },
           {
             "name": "deviceRunSession",
-            "description": "Mutations that create and stop device run sessions",
+            "description": "Mutations that create, start, and stop device run sessions",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -57800,6 +58562,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "ExperimentationQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expoGoBuild",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ExpoGoBuildQuery",
                 "ofType": null
               }
             },
@@ -81091,6 +81869,18 @@
                     "name": "WorkflowProjectSourceInput",
                     "ofType": null
                   }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sdkVersion",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,

--- a/packages/eas-cli/src/commands/simulator/start.ts
+++ b/packages/eas-cli/src/commands/simulator/start.ts
@@ -33,9 +33,6 @@ const DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE = Object.fromEntries(
   )
 ) as Record<string, DeviceRunSessionType>;
 
-const AGENT_DEVICE_BASE_URL_ENV_VAR = 'AGENT_DEVICE_DAEMON_BASE_URL';
-const AGENT_DEVICE_AUTH_TOKEN_ENV_VAR = 'AGENT_DEVICE_DAEMON_AUTH_TOKEN';
-
 type DeviceRunSessionByIdResult = DeviceRunSessionByIdQuery['deviceRunSessions']['byId'];
 type RemoteConfig = NonNullable<DeviceRunSessionByIdResult['remoteConfig']>;
 
@@ -283,15 +280,8 @@ function formatRemoteConfigShellSnippet(remoteConfig: RemoteConfig): string {
   switch (remoteConfig.__typename) {
     case 'AgentDeviceRunSessionRemoteConfig':
       return [
-        `export ${AGENT_DEVICE_BASE_URL_ENV_VAR}='${remoteConfig.url}'`,
-        `export ${AGENT_DEVICE_AUTH_TOKEN_ENV_VAR}='${remoteConfig.token}'`,
+        `export AGENT_DEVICE_DAEMON_BASE_URL='${remoteConfig.url}'`,
+        `export AGENT_DEVICE_DAEMON_AUTH_TOKEN='${remoteConfig.token}'`,
       ].join('\n');
-    default:
-      // Exhaustiveness guard: a new `DeviceRunSessionRemoteConfig` union member
-      // must be wired up here before the eas-cli build will compile against the
-      // updated GraphQL schema.
-      throw new Error(
-        `Unsupported device run session remote config type: ${(remoteConfig as { __typename: string }).__typename}`
-      );
   }
 }

--- a/packages/eas-cli/src/commands/simulator/start.ts
+++ b/packages/eas-cli/src/commands/simulator/start.ts
@@ -6,6 +6,7 @@ import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/creat
 import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import {
   AppPlatform,
+  DeviceRunSessionByIdQuery,
   DeviceRunSessionStatus,
   DeviceRunSessionType,
   JobRunStatus,
@@ -32,8 +33,11 @@ const DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE = Object.fromEntries(
   )
 ) as Record<string, DeviceRunSessionType>;
 
-type ReadinessResult = { ready: true; message: string } | { ready: false };
-type ReadinessChecker = (logMessages: readonly string[]) => ReadinessResult;
+const AGENT_DEVICE_BASE_URL_ENV_VAR = 'AGENT_DEVICE_DAEMON_BASE_URL';
+const AGENT_DEVICE_AUTH_TOKEN_ENV_VAR = 'AGENT_DEVICE_DAEMON_AUTH_TOKEN';
+
+type DeviceRunSessionByIdResult = DeviceRunSessionByIdQuery['deviceRunSessions']['byId'];
+type RemoteConfig = NonNullable<DeviceRunSessionByIdResult['remoteConfig']>;
 
 export default class SimulatorStart extends EasCommand {
   static override hidden = true;
@@ -96,11 +100,9 @@ export default class SimulatorStart extends EasCommand {
       throw err;
     }
 
-    const checkReadiness = getReadinessCheckerForType(flags.type);
-
     const pollSpinner = ora(`⏳ Waiting for ${flags.type} daemon to start`).start();
     const deadline = Date.now() + POLL_TIMEOUT_MS;
-    let result: ReadinessResult = { ready: false };
+    let remoteConfig: RemoteConfig | undefined;
 
     try {
       while (Date.now() < deadline) {
@@ -126,9 +128,8 @@ export default class SimulatorStart extends EasCommand {
           );
         }
 
-        const logMessages = await fetchLogMessagesAsync(session.turtleJobRun?.logFileUrls ?? []);
-        result = checkReadiness(logMessages);
-        if (result.ready) {
+        if (session.remoteConfig) {
+          remoteConfig = session.remoteConfig;
           pollSpinner.succeed(`🎉 ${flags.type} daemon is ready`);
           break;
         }
@@ -136,12 +137,12 @@ export default class SimulatorStart extends EasCommand {
         await sleepAsync(POLL_INTERVAL_MS);
       }
     } catch (err) {
-      pollSpinner.fail(`Failed while polling for ${flags.type} daemon logs`);
+      pollSpinner.fail(`Failed while polling for ${flags.type} daemon to start`);
       await ensureDeviceRunSessionStoppedSafelyAsync(graphqlClient, deviceRunSessionId);
       throw err;
     }
 
-    if (!result.ready) {
+    if (!remoteConfig) {
       pollSpinner.fail(`Timed out waiting for ${flags.type} daemon to start`);
       await ensureDeviceRunSessionStoppedSafelyAsync(graphqlClient, deviceRunSessionId);
       throw new Error(
@@ -152,7 +153,7 @@ export default class SimulatorStart extends EasCommand {
     Log.newLine();
     Log.log(`🔑 Run the following in your shell to attach to ${flags.type}:`);
     Log.newLine();
-    Log.log(result.message);
+    Log.log(formatRemoteConfigShellSnippet(remoteConfig));
     Log.newLine();
 
     if (flags['non-interactive']) {
@@ -278,101 +279,19 @@ async function ensureDeviceRunSessionStoppedSafelyAsync(
   }
 }
 
-function getReadinessCheckerForType(type: string): ReadinessChecker {
-  switch (type) {
-    case DEVICE_RUN_SESSION_TYPE_FLAG_VALUES[DeviceRunSessionType.AgentDevice]:
-      return checkAgentDeviceReadiness;
+function formatRemoteConfigShellSnippet(remoteConfig: RemoteConfig): string {
+  switch (remoteConfig.__typename) {
+    case 'AgentDeviceRunSessionRemoteConfig':
+      return [
+        `export ${AGENT_DEVICE_BASE_URL_ENV_VAR}='${remoteConfig.url}'`,
+        `export ${AGENT_DEVICE_AUTH_TOKEN_ENV_VAR}='${remoteConfig.token}'`,
+      ].join('\n');
     default:
-      throw new Error(`Unsupported device run session type: ${type}`);
+      // Exhaustiveness guard: a new `DeviceRunSessionRemoteConfig` union member
+      // must be wired up here before the eas-cli build will compile against the
+      // updated GraphQL schema.
+      throw new Error(
+        `Unsupported device run session remote config type: ${(remoteConfig as { __typename: string }).__typename}`
+      );
   }
-}
-
-const AGENT_DEVICE_BASE_URL_ENV_VAR = 'AGENT_DEVICE_DAEMON_BASE_URL';
-const AGENT_DEVICE_AUTH_TOKEN_ENV_VAR = 'AGENT_DEVICE_DAEMON_AUTH_TOKEN';
-
-function checkAgentDeviceReadiness(logMessages: readonly string[]): ReadinessResult {
-  let baseUrl: string | undefined;
-  let authToken: string | undefined;
-  for (const msg of logMessages) {
-    baseUrl = baseUrl ?? extractExportedEnvValue(msg, AGENT_DEVICE_BASE_URL_ENV_VAR);
-    authToken = authToken ?? extractExportedEnvValue(msg, AGENT_DEVICE_AUTH_TOKEN_ENV_VAR);
-    if (baseUrl && authToken) {
-      break;
-    }
-  }
-  if (baseUrl && authToken) {
-    return {
-      ready: true,
-      message: [
-        `export ${AGENT_DEVICE_BASE_URL_ENV_VAR}='${baseUrl}'`,
-        `export ${AGENT_DEVICE_AUTH_TOKEN_ENV_VAR}='${authToken}'`,
-      ].join('\n'),
-    };
-  }
-  return { ready: false };
-}
-
-async function fetchLogMessagesAsync(logUrls: readonly string[]): Promise<string[]> {
-  const messages: string[] = [];
-  for (const url of logUrls) {
-    const text = await fetchLogTextAsync(url);
-    if (!text) {
-      continue;
-    }
-    for (const line of text.split('\n')) {
-      if (!line.trim()) {
-        continue;
-      }
-      messages.push(extractLogMessage(line));
-    }
-  }
-  return messages;
-}
-
-async function fetchLogTextAsync(url: string): Promise<string | undefined> {
-  try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      return undefined;
-    }
-    return await response.text();
-  } catch {
-    return undefined;
-  }
-}
-
-function extractLogMessage(line: string): string {
-  // Turtle job run logs are JSONL (bunyan-shaped), e.g.
-  //   {"msg":"export FOO=\"bar\"","time":"...","logId":"..."}
-  // Fall back to the raw line if it's not JSON or doesn't have a string msg.
-  const trimmed = line.trim();
-  if (!trimmed.startsWith('{')) {
-    return line;
-  }
-  try {
-    const parsed = JSON.parse(trimmed) as unknown;
-    if (parsed && typeof parsed === 'object' && 'msg' in parsed) {
-      const msg = (parsed as { msg: unknown }).msg;
-      if (typeof msg === 'string') {
-        return msg;
-      }
-    }
-  } catch {
-    // not JSON, fall through
-  }
-  return line;
-}
-
-function extractExportedEnvValue(text: string, varName: string): string | undefined {
-  // Matches: export NAME=value | export NAME="value" | export NAME='value'
-  const pattern = new RegExp(`export\\s+${escapeRegExp(varName)}=(?:"([^"]*)"|'([^']*)'|(\\S+))`);
-  const match = pattern.exec(text);
-  if (!match) {
-    return undefined;
-  }
-  return match[1] ?? match[2] ?? match[3];
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -173,8 +173,13 @@ export type Account = {
   /** @deprecated Legacy access tokens are deprecated */
   requiresAccessTokenForPushSecurity: Scalars['Boolean']['output'];
   sentryInstallation?: Maybe<SentryInstallation>;
-  /** Snacks associated with this account */
+  /**
+   * Snacks associated with this account
+   * @deprecated Use snacksPaginated
+   */
   snacks: Array<Snack>;
+  /** Paginated list of Snacks associated with this account, sorted by most recent activity. */
+  snacksPaginated: AccountSnacksConnection;
   /** Allowed SSO providers for this account */
   ssoAllowedAuthProviders: Array<AuthProviderIdentifier>;
   /** SSO configuration for this account */
@@ -465,6 +470,18 @@ export type AccountMembersPaginatedArgs = {
 export type AccountSnacksArgs = {
   limit: Scalars['Int']['input'];
   offset: Scalars['Int']['input'];
+};
+
+
+/**
+ * An account is a container owning projects, credentials, billing and other organization
+ * data and settings. Actors may own and be members of accounts.
+ */
+export type AccountSnacksPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -886,6 +903,18 @@ export type AccountSsoConfigurationPublicDataQueryPublicDataByAccountNameArgs = 
   accountName: Scalars['String']['input'];
 };
 
+export type AccountSnacksConnection = {
+  __typename?: 'AccountSnacksConnection';
+  edges: Array<AccountSnacksEdge>;
+  pageInfo: PageInfo;
+};
+
+export type AccountSnacksEdge = {
+  __typename?: 'AccountSnacksEdge';
+  cursor: Scalars['String']['output'];
+  node: Snack;
+};
+
 export enum AccountUploadSessionType {
   ProfileImageUpload = 'PROFILE_IMAGE_UPLOAD',
   WorkflowsProjectSources = 'WORKFLOWS_PROJECT_SOURCES'
@@ -1026,6 +1055,12 @@ export type Address = {
   line1?: Maybe<Scalars['String']['output']>;
   state?: Maybe<Scalars['String']['output']>;
   zip?: Maybe<Scalars['String']['output']>;
+};
+
+export type AgentDeviceRunSessionRemoteConfig = {
+  __typename?: 'AgentDeviceRunSessionRemoteConfig';
+  token: Scalars['String']['output'];
+  url: Scalars['String']['output'];
 };
 
 export type AndroidAppBuildCredentials = {
@@ -2118,8 +2153,13 @@ export type AppObserveCustomEventListArgs = {
 
 
 export type AppObserveCustomEventNamesArgs = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
   endTime: Scalars['DateTime']['input'];
   environment?: InputMaybe<Scalars['String']['input']>;
+  orderBy?: InputMaybe<AppObserveCustomEventNamesOrderBy>;
   platform?: InputMaybe<AppObservePlatform>;
   startTime: Scalars['DateTime']['input'];
 };
@@ -2279,6 +2319,21 @@ export type AppObserveCustomEventNames = {
   isTruncated: Scalars['Boolean']['output'];
   names: Array<AppObserveCustomEventName>;
 };
+
+export type AppObserveCustomEventNamesOrderBy = {
+  direction: AppObserveCustomEventNamesOrderByDirection;
+  field: AppObserveCustomEventNamesOrderByField;
+};
+
+export enum AppObserveCustomEventNamesOrderByDirection {
+  Asc = 'ASC',
+  Desc = 'DESC'
+}
+
+export enum AppObserveCustomEventNamesOrderByField {
+  Count = 'COUNT',
+  EventName = 'EVENT_NAME'
+}
 
 export type AppObserveCustomEventPropertyFilter = {
   key: Scalars['String']['input'];
@@ -2460,6 +2515,9 @@ export type AppObserveUpdatesConnection = {
 
 export type AppObserveUpdatesInput = {
   after?: InputMaybe<Scalars['String']['input']>;
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
   endTime: Scalars['DateTime']['input'];
   environment?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -5033,6 +5091,7 @@ export type DeviceRunSession = {
    */
   packageVersion?: Maybe<Scalars['String']['output']>;
   platform: AppPlatform;
+  remoteConfig?: Maybe<DeviceRunSessionRemoteConfig>;
   startedAt?: Maybe<Scalars['DateTime']['output']>;
   status: DeviceRunSessionStatus;
   turtleJobRun?: Maybe<JobRun>;
@@ -5050,6 +5109,8 @@ export type DeviceRunSessionMutation = {
    * ERRORED).
    */
   ensureDeviceRunSessionStopped: DeviceRunSession;
+  /** Mark a device run session as started and persist remote connection details */
+  startDeviceRunSession: DeviceRunSession;
 };
 
 
@@ -5062,6 +5123,12 @@ export type DeviceRunSessionMutationEnsureDeviceRunSessionStoppedArgs = {
   deviceRunSessionId: Scalars['ID']['input'];
 };
 
+
+export type DeviceRunSessionMutationStartDeviceRunSessionArgs = {
+  deviceRunSessionId: Scalars['ID']['input'];
+  remoteConfig: Scalars['JSONObject']['input'];
+};
+
 export type DeviceRunSessionQuery = {
   __typename?: 'DeviceRunSessionQuery';
   byId: DeviceRunSession;
@@ -5071,6 +5138,8 @@ export type DeviceRunSessionQuery = {
 export type DeviceRunSessionQueryByIdArgs = {
   deviceRunSessionId: Scalars['ID']['input'];
 };
+
+export type DeviceRunSessionRemoteConfig = AgentDeviceRunSessionRemoteConfig;
 
 export enum DeviceRunSessionStatus {
   Errored = 'ERRORED',
@@ -5674,11 +5743,15 @@ export type EchoRepositoryResult = {
 export type EchoTurn = {
   __typename?: 'EchoTurn';
   completedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** Terminal status of the turn (null if still in progress) */
+  completionStatus?: Maybe<EchoTurnCompletionStatus>;
   createdAt: Scalars['DateTime']['output'];
   /** Parent chat */
   echoChat: EchoChat;
   /** Messages in this turn */
   echoMessages: Array<EchoMessage>;
+  /** Error message when completionStatus is ERROR */
+  error?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
 };
 
@@ -5689,14 +5762,28 @@ export type EchoTurnCacheWriteInput = {
   ttl24h?: InputMaybe<Scalars['Int']['input']>;
 };
 
+export enum EchoTurnCompletionStatus {
+  Cancelled = 'CANCELLED',
+  Completed = 'COMPLETED',
+  Error = 'ERROR'
+}
+
 export type EchoTurnMutation = {
   __typename?: 'EchoTurnMutation';
-  /** Mark a turn as completed and create a billing ledger entry */
+  /**
+   * Mark a turn as completed and create a billing ledger entry.
+   *
+   * completionStatus defaults to COMPLETED for backward compatibility with
+   * clients that do not yet send a status. error may be set when
+   * completionStatus is ERROR to record the failure reason.
+   */
   completeTurn: EchoTurn;
 };
 
 
 export type EchoTurnMutationCompleteTurnArgs = {
+  completionStatus?: InputMaybe<EchoTurnCompletionStatus>;
+  error?: InputMaybe<Scalars['String']['input']>;
   id: Scalars['ID']['input'];
   usage: EchoTurnUsageInput;
 };
@@ -6102,6 +6189,36 @@ export type ExperimentationQuery = {
   deviceExperimentationUnit: Scalars['ID']['output'];
   /** Get user experimentation config */
   userConfig: Scalars['JSONObject']['output'];
+};
+
+export type ExpoGoBuildQuery = {
+  __typename?: 'ExpoGoBuildQuery';
+  repackConfiguration: ExpoGoProjectConfiguration;
+};
+
+
+export type ExpoGoBuildQueryRepackConfigurationArgs = {
+  input: ExpoGoRepackInput;
+};
+
+export type ExpoGoProjectConfiguration = {
+  __typename?: 'ExpoGoProjectConfiguration';
+  files: Array<ExpoGoProjectFile>;
+  sdkVersion: Scalars['String']['output'];
+};
+
+export type ExpoGoProjectFile = {
+  __typename?: 'ExpoGoProjectFile';
+  fileContents: Scalars['String']['output'];
+  fileName: Scalars['String']['output'];
+};
+
+export type ExpoGoRepackInput = {
+  appId: Scalars['ID']['input'];
+  appName?: InputMaybe<Scalars['String']['input']>;
+  ascAppId: Scalars['String']['input'];
+  bundleId: Scalars['String']['input'];
+  sdkVersion?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type FcmSnippet = FcmSnippetLegacy | FcmSnippetV1;
@@ -7926,7 +8043,7 @@ export type RootMutation = {
   deployments: DeploymentsMutation;
   /** Mutations that assign or modify DevDomainNames for apps */
   devDomainName: AppDevDomainNameMutation;
-  /** Mutations that create and stop device run sessions */
+  /** Mutations that create, start, and stop device run sessions */
   deviceRunSession: DeviceRunSessionMutation;
   /** Mutations for Discord users */
   discordUser: DiscordUserMutation;
@@ -8101,6 +8218,7 @@ export type RootQuery = {
   echoVersion: EchoVersionQuery;
   /** Top-level query object for querying Experimentation configuration. */
   experimentation: ExperimentationQuery;
+  expoGoBuild: ExpoGoBuildQuery;
   /** Top-level query object for querying GitHub App information and resources it has access to. */
   githubApp: GitHubAppQuery;
   /** Top-level query object for querying Google Service Account Keys. */
@@ -11252,6 +11370,7 @@ export type WorkflowRunMutationCancelWorkflowRunArgs = {
 export type WorkflowRunMutationCreateExpoGoRepackWorkflowRunArgs = {
   appId: Scalars['ID']['input'];
   projectSource: WorkflowProjectSourceInput;
+  sdkVersion?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -12541,7 +12660,7 @@ export type DeviceRunSessionByIdQueryVariables = Exact<{
 }>;
 
 
-export type DeviceRunSessionByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus, logFileUrls: Array<string> } | null } } };
+export type DeviceRunSessionByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, type: DeviceRunSessionType, remoteConfig?: { __typename: 'AgentDeviceRunSessionRemoteConfig', url: string, token: string } | null, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } } };
 
 export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
@@ -18,10 +18,17 @@ export const DeviceRunSessionQuery = {
                 byId(deviceRunSessionId: $deviceRunSessionId) {
                   id
                   status
+                  type
+                  remoteConfig {
+                    __typename
+                    ... on AgentDeviceRunSessionRemoteConfig {
+                      url
+                      token
+                    }
+                  }
                   turtleJobRun {
                     id
                     status
-                    logFileUrls
                   }
                 }
               }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

# Why

`eas simulator:start` currently learns the agent-device daemon URL/token by downloading the turtle job's log file and grepping for `export AGENT_DEVICE_DAEMON_BASE_URL=…` / `export AGENT_DEVICE_DAEMON_AUTH_TOKEN=…`. With [expo/universe#26900](https://github.com/expo/universe/pull/26900), the API now exposes those credentials directly as a typed `remoteConfig` field on `DeviceRunSession`, so we can drop the log-scraping path entirely.

This is also a hard dependency for [expo/eas-cli#3696](https://github.com/expo/eas-cli/pull/3696) (the producer-side migration): #3696 removes the `logger.info('export AGENT_DEVICE_DAEMON_*=…')` lines that this command currently scrapes, so once a worker image with #3696 ships, `eas simulator:start` would hit `POLL_TIMEOUT_MS` waiting for log lines that no longer exist. **#3696 should not be merged before this PR.**

# How

- Extend `DeviceRunSessionByIdQuery` to select `remoteConfig { __typename ... on AgentDeviceRunSessionRemoteConfig { url token } }`. (Drop `logFileUrls` from this query — no longer needed.)
- Replace the readiness poll in `simulator/start.ts`: it now succeeds as soon as `session.remoteConfig` is non-null, with no log fetching/parsing.
- Remove the per-type `ReadinessChecker` indirection (`getReadinessCheckerForType`, `checkAgentDeviceReadiness`) and all log helpers (`fetchLogMessagesAsync`, `fetchLogTextAsync`, `extractLogMessage`, `extractExportedEnvValue`, `escapeRegExp`).
- Add a small `formatRemoteConfigShellSnippet` that switches on `remoteConfig.__typename` and preserves the existing user-facing `export AGENT_DEVICE_DAEMON_BASE_URL='…'` / `..._AUTH_TOKEN='…'` shell snippet output. The `default` arm throws so adding a new `DeviceRunSessionRemoteConfig` union member fails the build until it's wired up.
- Includes an incidental `yarn generate-graphql-code` regen of `generated.ts` / `graphql.schema.json` (picks up adjacent schema additions since the last regen).

# Test Plan

- `yarn typecheck` passes in `packages/eas-cli`.
- `yarn lint` reports no new warnings on touched files.
- End-to-end verification needs all three changes deployed:
  - universe [#26900](https://github.com/expo/universe/pull/26900) (merged) — schema + mutation
  - universe [#27305](https://github.com/expo/universe/pull/27305) — `DEVICE_RUN_SESSION_ID` env var
  - eas-cli [#3696](https://github.com/expo/eas-cli/pull/3696) — producer migration
  Once the next worker image ships with #3696, running `eas simulator:start --platform ios --type agent-device` against staging should print the same `export AGENT_DEVICE_DAEMON_BASE_URL='…'` / `..._AUTH_TOKEN='…'` snippet as today, sourced from `remoteConfig` instead of logs.