### PR TITLE
[build] - preflight check for stale autolinked Android native modules

### DIFF
--- a/packages/eas-cli/src/build/android/build.ts
+++ b/packages/eas-cli/src/build/android/build.ts
@@ -29,6 +29,7 @@ import {
 import { AndroidBuildContext, BuildContext, CommonContext } from '../context';
 import { logCredentialsSource } from '../utils/credentials';
 import {
+  checkAutolinkedNativeModulesAsync,
   checkGoogleServicesFileAsync,
   checkNodeEnvVariable,
   validatePNGsForManagedProjectAsync,
@@ -58,6 +59,7 @@ This means that it will most likely produce an AAB and you will not be able to i
   checkNodeEnvVariable(ctx);
   await checkGoogleServicesFileAsync(ctx);
   await validatePNGsForManagedProjectAsync(ctx);
+  await checkAutolinkedNativeModulesAsync(ctx);
 
   const gradleContext = await resolveGradleBuildContextAsync(
     ctx.projectDir,

--- a/packages/eas-cli/src/build/validate.ts
+++ b/packages/eas-cli/src/build/validate.ts
@@ -1,4 +1,5 @@
 import { Platform, Workflow } from '@expo/eas-build-job';
+import spawnAsync from '@expo/spawn-async';
 import { Errors } from '@oclif/core';
 import fs from 'fs-extra';
 import path from 'path';
@@ -157,6 +158,90 @@ async function validateAndroidPNGsAsync(ctx: CommonContext<Platform.ANDROID>): P
 //     }
 //   }
 // }
+
+export async function checkAutolinkedNativeModulesAsync(
+  ctx: CommonContext<Platform.ANDROID>
+): Promise<void> {
+  if (ctx.workflow !== Workflow.GENERIC) {
+    return;
+  }
+
+  const settingsGradlePath = await findSettingsGradleAsync(ctx.projectDir);
+  if (!settingsGradlePath) {
+    return;
+  }
+
+  const settingsContent = await fs.readFile(settingsGradlePath, 'utf8');
+  const hasAutolinking =
+    settingsContent.includes('useReactNativeModules') ||
+    settingsContent.includes('applyNativeModulesSettingsGradle') ||
+    settingsContent.includes('native_modules.gradle');
+  if (!hasAutolinking) {
+    return;
+  }
+
+  let rnConfig: Record<string, any>;
+  try {
+    const result = await spawnAsync('npx', ['react-native', 'config'], {
+      cwd: ctx.projectDir,
+      stdio: 'pipe',
+    });
+    rnConfig = JSON.parse(result.stdout);
+  } catch {
+    return;
+  }
+
+  const dependencies = rnConfig.dependencies;
+  if (!dependencies || typeof dependencies !== 'object') {
+    return;
+  }
+
+  const misconfiguredModules: string[] = [];
+  for (const [name, dep] of Object.entries<any>(dependencies)) {
+    const androidConfig = dep?.platforms?.android;
+    if (!androidConfig || !androidConfig.sourceDir) {
+      continue;
+    }
+    const sourceDir = androidConfig.sourceDir;
+    const sourceDirExists = await fs.pathExists(sourceDir);
+    if (!sourceDirExists) {
+      misconfiguredModules.push(name);
+      continue;
+    }
+    const hasBuildGradle =
+      (await fs.pathExists(path.join(sourceDir, 'build.gradle'))) ||
+      (await fs.pathExists(path.join(sourceDir, 'build.gradle.kts')));
+    if (!hasBuildGradle) {
+      misconfiguredModules.push(name);
+    }
+  }
+
+  if (misconfiguredModules.length > 0) {
+    Log.warn(
+      'The following autolinked native modules have missing or incomplete Android build configuration:'
+    );
+    for (const mod of misconfiguredModules) {
+      Log.warn(`  - ${mod}`);
+    }
+    Log.warn('This will likely cause "No variants exist" errors during the build.');
+    Log.warn('Run "npx expo prebuild --clean" to regenerate the native project,');
+    Log.warn('or add "android/" to .gitignore to use the managed workflow.');
+    Log.newLine();
+  }
+}
+
+async function findSettingsGradleAsync(projectDir: string): Promise<string | null> {
+  const candidates = [
+    path.join(projectDir, 'android', 'settings.gradle'),
+    path.join(projectDir, 'android', 'settings.gradle.kts'),
+  ];
+  for (const candidate of candidates) {
+    if (await fs.pathExists(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
 
 async function validatePNGsAsync(configPngs: ConfigPng[]): Promise<void> {
   const validationPromises = configPngs.map(configPng => validatePNGAsync(configPng));


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why


~250+ Android builds fail per day with "No variants exist" because the user has `android/` committed to git, which triggers the GENERIC workflow and skips prebuild. 

The native project is stale (new native dependencies were added or the SDK was upgraded without re-running prebuild) so Gradle fails at config time when `useReactNativeModules()` tries to include modules that can't resolve against the stale native project.


https://app.datadoghq.com/logs?query=%22No%20variants%20exist%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1778019603930&to_ts=1778278803930&live=true

# How

Added a `checkAutolinkedNativeModulesAsync()` preflight check in `validate.ts` that runs for GENERIC workflow Android builds, wired up in `createAndroidContextAsync()` alongside the existing checks.

  The check:
  1. Gates on `Workflow.GENERIC` (managed workflow runs prebuild automatically)
  2. Reads `android/settings.gradle(.kts)` to confirm autolinking is configured
  3. Runs `npx react-native config` to discover expected autolinked Android dependencies
  4. Verifies each dependency's `sourceDir` and `build.gradle(.kts)` exist on disk
  5. Warns with actionable guidance if issues are found (run `npx expo prebuild --clean` or switch to managed workflow)

Fails silently if `react-native config` errors — this is a best-effort check that avoids blocking users when the RN CLI isn't available.


  # Test Plan

  - [ ] Verify existing builds still work (no false positives on healthy GENERIC projects)
  - [ ] Test with a stale GENERIC project: commit `android/`, add a new native dependency without rerunning prebuild, confirm warning appears
  - [ ] Test managed workflow project: confirm check is skipped
  - [ ] Test project without autolinking in `settings.gradle`: confirm check is skipped
