### PR TITLE
[build-tools] improve xcactivitylog output

### DIFF
--- a/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
+++ b/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
@@ -146,6 +146,44 @@ const FIXTURE_NESTED = {
   ],
 };
 
+// Overlapping + gapped intervals with pairwise-distinct totals
+// (taskSeconds=11, wallSpan=12, activeWallTime=8). Distinct values catch a
+// regression that leaks wallSpan or taskSeconds into the rendered Active cell.
+const FIXTURE_OVERLAP_WITH_GAP = {
+  schema: { name: 'OverlapWithGap' },
+  subSteps: [
+    {
+      title: 'Build target GappedModule',
+      subSteps: [
+        {
+          detailStepType: 'cCompilation',
+          duration: 5.0,
+          startTimestamp: 100.0,
+          endTimestamp: 105.0,
+          signature: 'CompileC a.c',
+          subSteps: [],
+        },
+        {
+          detailStepType: 'cCompilation',
+          duration: 4.0,
+          startTimestamp: 102.0,
+          endTimestamp: 106.0,
+          signature: 'CompileC b.c',
+          subSteps: [],
+        },
+        {
+          detailStepType: 'cCompilation',
+          duration: 2.0,
+          startTimestamp: 110.0,
+          endTimestamp: 112.0,
+          signature: 'CompileC c.c',
+          subSteps: [],
+        },
+      ],
+    },
+  ],
+};
+
 const mockedDownloadFile = jest.mocked(downloadFile);
 const mockedSpawn = jest.mocked(spawn);
 
@@ -478,17 +516,38 @@ describe('buildTargetMetrics', () => {
     expect(mod).toBeDefined();
     expect(mod!.taskSeconds).toBeCloseTo(3.0);
     expect(mod!.wallSpan).toBe(0); // no valid intervals
+    expect(mod!.activeWallTime).toBe(0); // no valid intervals
+  });
+
+  it('computes activeWallTime by merging overlapping intervals and excluding gaps', () => {
+    const { results } = buildTargetMetrics(FIXTURE_OVERLAP_WITH_GAP);
+    const mod = results.find(r => r.moduleName === 'GappedModule');
+    expect(mod).toBeDefined();
+    expect(mod!.taskSeconds).toBeCloseTo(11.0); // 5 + 4 + 2
+    expect(mod!.wallSpan).toBeCloseTo(12.0); // 112 - 100
+    expect(mod!.activeWallTime).toBeCloseTo(8.0); // (106-100) + (112-110)
   });
 });
 
 describe('formatReport', () => {
-  it('produces table with header and module rows', () => {
+  it('produces table with header, legend, and module rows', () => {
     const report = formatReport(FIXTURE_TWO_MODULES);
     expect(report).toContain('Xcode Build — Compile Metrics by Module');
     expect(report).toContain('ModuleA');
     expect(report).toContain('ModuleB');
     expect(report).toContain('TOTAL');
-    expect(report).toContain('% Task');
+    expect(report).toContain('% Sum');
+    expect(report).toContain('Sum = sum of compile-step wall durations');
+    expect(report).toContain('Active = merged compile-step wall time');
+    expect(report).not.toContain('% Task');
+    expect(report).not.toContain('Wall = ');
+  });
+
+  it('renders Active using activeWallTime, not wallSpan', () => {
+    const report = formatReport(FIXTURE_OVERLAP_WITH_GAP);
+    expect(report).toContain('11.0s');
+    expect(report).toContain('8.0s');
+    expect(report).not.toContain('12.0s');
   });
 
   it('does not include modules below threshold', () => {

--- a/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
+++ b/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
@@ -183,6 +183,7 @@ type XcactivitylogData = z.infer<typeof XcactivitylogDataSchemaZ>;
 interface TargetMetric {
   moduleName: string;
   taskSeconds: number;
+  // Not rendered; retained as secondary sort tie-breaker in buildTargetMetrics.
   wallSpan: number;
   activeWallTime: number;
 }
@@ -358,19 +359,22 @@ export function formatReport(data: XcactivitylogData): string {
   lines.push(
     `Schema: ${typeof data.schema === 'string' ? data.schema : (data.schema?.name ?? 'unknown')}`
   );
-  lines.push('% Task = share of total Compile Task Seconds');
-  lines.push('Wall = first compile start to last compile end');
+  lines.push(
+    'Sum = sum of compile-step wall durations within the target; overlapping steps are counted separately'
+  );
+  lines.push('% Sum = share of total Sum');
+  lines.push('Active = merged compile-step wall time, excluding idle gaps between compile steps');
   lines.push('');
   lines.push(header);
   lines.push(
     '│ ' +
       'Module'.padEnd(nameWidth) +
       ' │ ' +
-      'Task'.padStart(taskWidth) +
+      'Sum'.padStart(taskWidth) +
       ' │ ' +
-      '% Task'.padStart(pctWidth) +
+      '% Sum'.padStart(pctWidth) +
       ' │ ' +
-      'Wall'.padStart(wallWidth) +
+      'Active'.padStart(wallWidth) +
       ' │ ' +
       ' '.repeat(barMaxWidth) +
       ' │'
@@ -390,7 +394,7 @@ export function formatReport(data: XcactivitylogData): string {
         ' │ ' +
         `${pct.toFixed(1)}%`.padStart(pctWidth) +
         ' │ ' +
-        formatSeconds(result.wallSpan).padStart(wallWidth) +
+        formatSeconds(result.activeWallTime).padStart(wallWidth) +
         ' │ ' +
         bar +
         ' │'


### PR DESCRIPTION
# Why

[ENG-21145](https://linear.app/expo/issue/ENG-21145). The compile-metrics table's `Task` and `Wall` columns are misleading:

- `Task = sum(step.duration)` reads as CPU work but is just a sum of section wall durations. Inflated by whole-module Swift (Xcode reports one swiftc invocation as N per-file rows with overlapping intervals) and by I/O-bound `CompileAssetCatalogVariant`.
- `Wall = maxEnd − minStart` includes idle gaps between compile bursts (e.g. `ExpoLogBox` shows `Wall=70.85s` for 2.94s of real compile activity).

# How

Format-only diff. No algorithm changes.

- Rename columns `Task → Sum`, `% Task → % Sum`, `Wall → Active`.
- Render `result.activeWallTime` (already computed by `computeActiveWallTime`, just never displayed) instead of `result.wallSpan`.
- Replace the 2-line legend with 3 entries that match the new columns and don't imply CPU semantics.

`TargetMetric` field names and the secondary sort tie-breaker are intentionally unchanged.

# Test Plan

- New `FIXTURE_OVERLAP_WITH_GAP` with pairwise-distinct \`taskSeconds=11 / wallSpan=12 / activeWallTime=8\`; tests assert the Active cell renders \`8.0s\` and never \`12.0s\` — catches a regression that silently leaks \`wallSpan\` into the column.
- Extended the existing missing-timestamp test to also assert \`activeWallTime === 0\`.
- Verified output on 3 real xcactivitylogs: \`hellobeta Sum=280.8s / Active=71.1s\` (4× WMO over-count visible at a glance), \`ExpoLogBox Active=2.9s\` (was misleading \`Wall=70.85s\`), \`RNReanimated Sum=125.7s / Active=26.1s\` (legitimate multi-core C parallelism still readable).