### PR TITLE
[build-tools] bump xclogparser default version

### DIFF
--- a/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
+++ b/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
@@ -191,14 +191,14 @@ describe('parseAndReportXcactivitylog', () => {
     });
 
     expect(mockedDownloadFile).toHaveBeenCalledWith(
-      'https://storage.googleapis.com/turtle-v2/xclogparser/XCLogParser-macOS-x86-64-arm64-v0.2.46.zip',
-      path.join(tempDir, 'XCLogParser-macOS-x86-64-arm64-v0.2.46.zip'),
+      'https://storage.googleapis.com/turtle-v2/xclogparser/XCLogParser-macOS-x86-64-arm64-v0.2.47.zip',
+      path.join(tempDir, 'XCLogParser-macOS-x86-64-arm64-v0.2.47.zip'),
       { retry: 3, timeout: 20_000 }
     );
     expect(mockedSpawn).toHaveBeenNthCalledWith(
       1,
       'unzip',
-      ['-q', path.join(tempDir, 'XCLogParser-macOS-x86-64-arm64-v0.2.46.zip'), '-d', tempDir],
+      ['-q', path.join(tempDir, 'XCLogParser-macOS-x86-64-arm64-v0.2.47.zip'), '-d', tempDir],
       { stdio: 'pipe' }
     );
     expect(mockedSpawn).toHaveBeenNthCalledWith(
@@ -244,14 +244,14 @@ describe('parseAndReportXcactivitylog', () => {
 
     expect(mockedDownloadFile).toHaveBeenNthCalledWith(
       1,
-      'https://cache.example.com/storage.googleapis.com/turtle-v2/xclogparser/XCLogParser-macOS-x86-64-arm64-v0.2.46.zip',
-      '/tmp/xclogparser-123/XCLogParser-macOS-x86-64-arm64-v0.2.46.zip',
+      'https://cache.example.com/storage.googleapis.com/turtle-v2/xclogparser/XCLogParser-macOS-x86-64-arm64-v0.2.47.zip',
+      '/tmp/xclogparser-123/XCLogParser-macOS-x86-64-arm64-v0.2.47.zip',
       { retry: 3, timeout: 20_000 }
     );
     expect(mockedDownloadFile).toHaveBeenNthCalledWith(
       2,
-      'https://storage.googleapis.com/turtle-v2/xclogparser/XCLogParser-macOS-x86-64-arm64-v0.2.46.zip',
-      '/tmp/xclogparser-123/XCLogParser-macOS-x86-64-arm64-v0.2.46.zip',
+      'https://storage.googleapis.com/turtle-v2/xclogparser/XCLogParser-macOS-x86-64-arm64-v0.2.47.zip',
+      '/tmp/xclogparser-123/XCLogParser-macOS-x86-64-arm64-v0.2.47.zip',
       { retry: 3, timeout: 20_000 }
     );
     expect(logger.debug).toHaveBeenCalledWith(
@@ -280,14 +280,14 @@ describe('parseAndReportXcactivitylog', () => {
 
     expect(mockedDownloadFile).toHaveBeenNthCalledWith(
       1,
-      'https://cache.example.com/storage.googleapis.com/turtle-v2/xclogparser/XCLogParser-macOS-x86-64-arm64-v0.2.46.zip',
-      '/tmp/xclogparser-123/XCLogParser-macOS-x86-64-arm64-v0.2.46.zip',
+      'https://cache.example.com/storage.googleapis.com/turtle-v2/xclogparser/XCLogParser-macOS-x86-64-arm64-v0.2.47.zip',
+      '/tmp/xclogparser-123/XCLogParser-macOS-x86-64-arm64-v0.2.47.zip',
       { retry: 3, timeout: 20_000 }
     );
     expect(mockedDownloadFile).toHaveBeenNthCalledWith(
       2,
-      'https://storage.googleapis.com/turtle-v2/xclogparser/XCLogParser-macOS-x86-64-arm64-v0.2.46.zip',
-      '/tmp/xclogparser-123/XCLogParser-macOS-x86-64-arm64-v0.2.46.zip',
+      'https://storage.googleapis.com/turtle-v2/xclogparser/XCLogParser-macOS-x86-64-arm64-v0.2.47.zip',
+      '/tmp/xclogparser-123/XCLogParser-macOS-x86-64-arm64-v0.2.47.zip',
       { retry: 3, timeout: 20_000 }
     );
     expect(logger.debug).toHaveBeenCalledWith(

--- a/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
+++ b/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
@@ -7,7 +7,7 @@ import os from 'os';
 import path from 'path';
 import { z } from 'zod';
 
-const DEFAULT_XCLOGPARSER_VERSION = 'v0.2.46';
+const DEFAULT_XCLOGPARSER_VERSION = 'v0.2.47';
 const XCLOGPARSER_DOWNLOAD_URL = 'https://storage.googleapis.com/turtle-v2/xclogparser';
 const XCLOGPARSER_DOWNLOAD_TIMEOUT_MS = 20_000;
 const XCLOGPARSER_OUTPUT_FILENAME = 'xcactivitylog.json';


### PR DESCRIPTION
# Why

Bump the default xclogparser binary to v0.2.47, which is now uploaded to the GCS bucket and ready to use.

# How

Updated `DEFAULT_XCLOGPARSER_VERSION` in `packages/build-tools/src/steps/utils/ios/xcactivitylog.ts` from `v0.2.46` to `v0.2.47` and updated the matching expectations in the tests.

# Test Plan

- `yarn test` in `packages/build-tools` passes with the updated version string.