### PR TITLE
[eas-build-job] Preserve workflow job outputs

### DIFF
--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -266,6 +266,9 @@ describe('Android.JobSchema', () => {
       customBuildConfig: {
         path: 'production.android.yml',
       },
+      outputs: {
+        android_build_type: 'apk',
+      },
       initiatingUserId: randomUUID(),
       appId: randomUUID(),
     };
@@ -337,6 +340,28 @@ describe('Android.JobSchema', () => {
 
     const { value, error } = Android.JobSchema.validate(customBuildJob, joiOptions);
     expect(value).toMatchObject(customBuildJob);
+    expect(error).toBeFalsy();
+  });
+
+  test('preserves outputs for build jobs', () => {
+    const job = {
+      mode: BuildMode.BUILD,
+      type: Workflow.GENERIC,
+      platform: Platform.ANDROID,
+      projectArchive: {
+        type: ArchiveSourceType.URL,
+        url: 'https://expo.dev/builds/123',
+      },
+      projectRootDirectory: '.',
+      outputs: {
+        android_build_type: 'apk',
+      },
+      secrets,
+      initiatingUserId: randomUUID(),
+      appId: randomUUID(),
+    };
+    const { value, error } = Android.JobSchema.validate(job, joiOptions);
+    expect(value).toMatchObject(job);
     expect(error).toBeFalsy();
   });
 

--- a/packages/eas-build-job/src/__tests__/ios.test.ts
+++ b/packages/eas-build-job/src/__tests__/ios.test.ts
@@ -77,6 +77,9 @@ describe('Ios.JobSchema', () => {
       },
       initiatingUserId: randomUUID(),
       appId: randomUUID(),
+      outputs: {
+        resign_job: 'true',
+      },
     };
 
     const { value, error } = Ios.JobSchema.validate(genericJob, joiOptions);
@@ -180,6 +183,9 @@ describe('Ios.JobSchema', () => {
       customBuildConfig: {
         path: 'production.ios.yml',
       },
+      outputs: {
+        ios_build_type: 'simulator',
+      },
       initiatingUserId: randomUUID(),
       appId: randomUUID(),
     };
@@ -251,6 +257,30 @@ describe('Ios.JobSchema', () => {
 
     const { value, error } = Ios.JobSchema.validate(customBuildJob, joiOptions);
     expect(value).toMatchObject(customBuildJob);
+    expect(error).toBeFalsy();
+  });
+
+  test('preserves outputs for build jobs', () => {
+    const job = {
+      mode: BuildMode.BUILD,
+      type: Workflow.UNKNOWN,
+      platform: Platform.IOS,
+      projectArchive: {
+        type: ArchiveSourceType.URL,
+        url: 'https://expo.dev/builds/123',
+      },
+      projectRootDirectory: '.',
+      outputs: {
+        ios_build_type: 'simulator',
+      },
+      secrets: {
+        buildCredentials,
+      },
+      initiatingUserId: randomUUID(),
+      appId: randomUUID(),
+    };
+    const { value, error } = Ios.JobSchema.validate(job, joiOptions);
+    expect(value).toMatchObject(job);
     expect(error).toBeFalsy();
   });
 

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -15,6 +15,8 @@ import {
   EnvironmentSecretsSchema,
   Hooks,
   HooksSchema,
+  JobOutputs,
+  JobOutputsSchema,
   Platform,
   StaticWorkflowInterpolationContext,
   StaticWorkflowInterpolationContextZ,
@@ -110,7 +112,7 @@ export interface Job {
   };
   hooks?: Hooks;
   steps?: Step[];
-  outputs?: Record<string, string>;
+  outputs?: JobOutputs;
 
   experimental?: {
     prebuildCommand?: string;
@@ -176,6 +178,7 @@ export const JobSchema = Joi.object({
   buildType: Joi.string().valid(...Object.values(BuildType)),
   username: Joi.string(),
   hooks: HooksSchema,
+  outputs: JobOutputsSchema,
 
   experimental: Joi.object({
     prebuildCommand: Joi.string(),

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -352,6 +352,10 @@ export type DynamicInterpolationContext = {
 export type WorkflowInterpolationContext = StaticWorkflowInterpolationContext &
   DynamicInterpolationContext;
 
+export type JobOutputs = Record<string, string>;
+export const JobOutputsSchema = Joi.object<JobOutputs>().pattern(Joi.string(), Joi.string());
+export const JobOutputsSchemaZ = z.record(z.string(), z.string());
+
 export const CustomBuildConfigSchema = Joi.object().when('.mode', {
   is: [BuildMode.CUSTOM, BuildMode.REPACK],
   then: Joi.object().when('.customBuildConfig.path', {
@@ -361,7 +365,6 @@ export const CustomBuildConfigSchema = Joi.object().when('.mode', {
         path: Joi.string().required(),
       }).required(),
       steps: Joi.any().strip(),
-      outputs: Joi.any().strip(),
     }),
     otherwise: Joi.object({
       customBuildConfig: Joi.any().strip(),
@@ -369,13 +372,11 @@ export const CustomBuildConfigSchema = Joi.object().when('.mode', {
         .items(Joi.any())
         .required()
         .custom(steps => validateSteps(steps), 'steps validation'),
-      outputs: Joi.object().pattern(Joi.string(), Joi.string()).required(),
     }),
   }),
   otherwise: Joi.object({
     customBuildConfig: Joi.any().strip(),
     steps: Joi.any().strip(),
-    outputs: Joi.any().strip(),
   }),
 });
 

--- a/packages/eas-build-job/src/generic.ts
+++ b/packages/eas-build-job/src/generic.ts
@@ -6,6 +6,7 @@ import {
   BuildTrigger,
   EnvironmentSecretZ,
   HooksZ,
+  JobOutputsSchemaZ,
   StaticWorkflowInterpolationContextZ,
 } from './common';
 import { StepZ } from './step';
@@ -48,7 +49,7 @@ export namespace Generic {
 
     hooks: HooksZ.optional(),
     steps: z.array(StepZ).min(1),
-    outputs: z.record(z.string(), z.string()).optional(),
+    outputs: JobOutputsSchemaZ.optional(),
   });
 
   export type PartialJob = z.infer<typeof PartialJobZ>;

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -15,6 +15,8 @@ import {
   EnvironmentSecretsSchema,
   Hooks,
   HooksSchema,
+  JobOutputs,
+  JobOutputsSchema,
   Platform,
   StaticWorkflowInterpolationContext,
   StaticWorkflowInterpolationContextZ,
@@ -124,7 +126,7 @@ export interface Job {
   };
   hooks?: Hooks;
   steps?: Step[];
-  outputs?: Record<string, string>;
+  outputs?: JobOutputs;
 
   experimental?: {
     prebuildCommand?: string;
@@ -210,6 +212,7 @@ export const JobSchema = Joi.object({
 
   username: Joi.string(),
   hooks: HooksSchema,
+  outputs: JobOutputsSchema,
 
   experimental: Joi.object({
     prebuildCommand: Joi.string(),


### PR DESCRIPTION
## Summary

This adds a shared `JobOutputs` type/schema and preserves declared workflow job outputs in Android, iOS, and generic job definitions.

Before this change, `outputs` was stripped from several build job shapes during Joi validation, including normal build jobs and custom builds that use `customBuildConfig.path`. That meant downstream worker code could not upload `jobs.<name>.outputs` for workflow `type: build` jobs.

## Changes

- Add shared `JobOutputs`, `JobOutputsSchema`, and `JobOutputsSchemaZ` definitions in `common.ts`.
- Use the shared output type/schema from Android, iOS, and Generic job definitions.
- Validate `outputs` directly on the Android and iOS top-level job schemas.
- Remove output handling from `CustomBuildConfigSchema`, so that schema only controls custom config vs inline step shape.
- Add Android and iOS schema coverage for normal build jobs, config-path custom jobs, and iOS resign jobs.

## Validation

- `packages/eas-build-job`: `yarn test android.test.ts ios.test.ts generic.test.ts`
- `packages/eas-build-job`: `yarn build`
- `yarn oxfmt --check ...`
