### PR TITLE
[build-tools] Upload workflow job outputs

### DIFF
--- a/packages/build-tools/src/builders/__tests__/common.test.ts
+++ b/packages/build-tools/src/builders/__tests__/common.test.ts
@@ -1,0 +1,114 @@
+import { Android } from '@expo/eas-build-job';
+import { vol } from 'memfs';
+
+import { createTestAndroidJob } from '../../__tests__/utils/job';
+import { createMockLogger } from '../../__tests__/utils/logger';
+import { BuildContext } from '../../context';
+import { maybeFindAndUploadBuildArtifacts } from '../../utils/artifacts';
+import { runHookIfPresent } from '../../utils/hooks';
+import { uploadJobOutputsFromBuildContextAsync } from '../../utils/outputs';
+import { runBuilderWithHooksAsync } from '../common';
+
+jest.mock('../../ios/xcodeBuildLogs');
+jest.mock('../../utils/artifacts');
+jest.mock('../../utils/hooks', () => ({
+  Hook: {
+    ON_BUILD_SUCCESS: 'on-build-success',
+    ON_BUILD_ERROR: 'on-build-error',
+    ON_BUILD_COMPLETE: 'on-build-complete',
+  },
+  runHookIfPresent: jest.fn(),
+}));
+jest.mock('../../utils/outputs');
+
+const maybeFindAndUploadBuildArtifactsMock = jest.mocked(maybeFindAndUploadBuildArtifacts);
+const runHookIfPresentMock = jest.mocked(runHookIfPresent);
+const uploadJobOutputsFromBuildContextAsyncMock = jest.mocked(
+  uploadJobOutputsFromBuildContextAsync
+);
+
+describe(runBuilderWithHooksAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    vol.fromJSON(
+      {
+        '/workingdir/env/.gitkeep': '',
+        '/workingdir/build/package.json': '{}',
+      },
+      '/'
+    );
+  });
+
+  it('uploads job outputs after a successful build', async () => {
+    const ctx = createBuildContext({
+      outputs: {
+        android_build_type: 'apk',
+      },
+    });
+    const buildAsync = jest.fn().mockResolvedValue(undefined);
+
+    await runBuilderWithHooksAsync(ctx, buildAsync);
+
+    expect(uploadJobOutputsFromBuildContextAsyncMock).toHaveBeenCalledWith(ctx, {
+      logger: expect.anything(),
+      buildSucceeded: true,
+    });
+    expect(maybeFindAndUploadBuildArtifactsMock).toHaveBeenCalled();
+  });
+
+  it('attempts to upload job outputs after a failed build', async () => {
+    const ctx = createBuildContext({
+      outputs: {
+        failed: '${{ failure() }}',
+      },
+    });
+    const buildAsync = jest.fn().mockRejectedValue(new Error('build failed'));
+
+    await expect(runBuilderWithHooksAsync(ctx, buildAsync)).rejects.toThrow('build failed');
+
+    expect(uploadJobOutputsFromBuildContextAsyncMock).toHaveBeenCalledWith(ctx, {
+      logger: expect.anything(),
+      buildSucceeded: false,
+    });
+    expect(runHookIfPresentMock).toHaveBeenCalled();
+  });
+
+  it('attempts to upload job outputs after a finalization failure', async () => {
+    const ctx = createBuildContext({
+      outputs: {
+        failed: '${{ failure() }}',
+      },
+    });
+    const buildAsync = jest.fn().mockResolvedValue(undefined);
+    maybeFindAndUploadBuildArtifactsMock.mockRejectedValue(new Error('artifact upload failed'));
+
+    await expect(runBuilderWithHooksAsync(ctx, buildAsync)).rejects.toThrow(
+      'Upload build artifacts'
+    );
+
+    expect(uploadJobOutputsFromBuildContextAsyncMock).toHaveBeenCalledWith(ctx, {
+      logger: expect.anything(),
+      buildSucceeded: false,
+    });
+  });
+});
+
+function createBuildContext(jobOverrides: Partial<Android.Job> = {}): BuildContext<Android.Job> {
+  return new BuildContext<Android.Job>(
+    {
+      ...createTestAndroidJob(),
+      ...jobOverrides,
+    },
+    {
+      workingdir: '/workingdir',
+      logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+      logger: createMockLogger(),
+      env: {
+        __API_SERVER_URL: 'http://api.expo.test',
+        __WORKFLOW_JOB_ID: 'test-workflow-job-id',
+      },
+      uploadArtifact: jest.fn(),
+      expoApiV2BaseUrl: 'http://exp.test/--/api/v2/',
+    }
+  );
+}

--- a/packages/build-tools/src/builders/__tests__/custom.test.ts
+++ b/packages/build-tools/src/builders/__tests__/custom.test.ts
@@ -8,17 +8,22 @@ import { prepareProjectSourcesAsync } from '../../common/projectSources';
 import { BuildContext } from '../../context';
 import { CustomBuildContext } from '../../customBuildContext';
 import { findAndUploadXcodeBuildLogsAsync } from '../../ios/xcodeBuildLogs';
+import { uploadJobOutputsToWwwAsync } from '../../utils/outputs';
 import { runCustomBuildAsync } from '../custom';
 
 jest.mock('../../common/projectSources');
 jest.mock('../../ios/xcodeBuildLogs');
+jest.mock('../../utils/outputs');
 
 const findAndUploadXcodeBuildLogsAsyncMock = jest.mocked(findAndUploadXcodeBuildLogsAsync);
+const uploadJobOutputsToWwwAsyncMock = jest.mocked(uploadJobOutputsToWwwAsync);
 
 describe(runCustomBuildAsync, () => {
   let ctx: BuildContext<BuildJob>;
 
   beforeEach(() => {
+    jest.clearAllMocks();
+
     const job = createTestIosJob();
 
     jest.mocked(prepareProjectSourcesAsync).mockImplementation(async () => {
@@ -54,6 +59,19 @@ describe(runCustomBuildAsync, () => {
         uploadArtifact: jest.fn(),
       }
     );
+  });
+
+  it('uploads job outputs after workflow execution', async () => {
+    ctx.job.outputs = {
+      ios_build_type: 'simulator',
+    };
+
+    await runCustomBuildAsync(ctx);
+
+    expect(uploadJobOutputsToWwwAsyncMock).toHaveBeenCalledWith(expect.anything(), {
+      logger: ctx.logger,
+      expoApiV2BaseUrl: undefined,
+    });
   });
 
   it('calls findAndUploadXcodeBuildLogsAsync in an iOS job if its artifacts is empty', async () => {
@@ -130,6 +148,24 @@ describe(runCustomBuildAsync, () => {
     expect(rejected).toBe(true);
 
     drainSpy.mockRestore();
+    executeSpy.mockRestore();
+  });
+
+  it('attempts to upload job outputs when workflow execution throws', async () => {
+    ctx.job.outputs = {
+      ios_build_type: '${{ failure() }}',
+    };
+
+    const executeSpy = jest
+      .spyOn(BuildWorkflow.prototype, 'executeAsync')
+      .mockRejectedValue(new Error('workflow failed'));
+
+    await expect(runCustomBuildAsync(ctx)).rejects.toThrow('workflow failed');
+    expect(uploadJobOutputsToWwwAsyncMock).toHaveBeenCalledWith(expect.anything(), {
+      logger: ctx.logger,
+      expoApiV2BaseUrl: undefined,
+    });
+
     executeSpy.mockRestore();
   });
 });

--- a/packages/build-tools/src/builders/common.ts
+++ b/packages/build-tools/src/builders/common.ts
@@ -4,6 +4,7 @@ import { Artifacts, BuildContext } from '../context';
 import { findAndUploadXcodeBuildLogsAsync } from '../ios/xcodeBuildLogs';
 import { maybeFindAndUploadBuildArtifacts } from '../utils/artifacts';
 import { Hook, runHookIfPresent } from '../utils/hooks';
+import { uploadJobOutputsFromBuildContextAsync } from '../utils/outputs';
 
 export async function runBuilderWithHooksAsync<T extends BuildJob>(
   ctx: BuildContext<T>,
@@ -31,17 +32,38 @@ export async function runBuilderWithHooksAsync<T extends BuildJob>(
         });
       });
 
-      if (ctx.job.platform === Platform.IOS) {
-        await findAndUploadXcodeBuildLogsAsync(ctx as BuildContext<Ios.Job>, {
-          logger: ctx.logger,
+      let finalizationError: any;
+      try {
+        if (ctx.job.platform === Platform.IOS) {
+          await findAndUploadXcodeBuildLogsAsync(ctx as BuildContext<Ios.Job>, {
+            logger: ctx.logger,
+          });
+        }
+
+        await ctx.runBuildPhase(BuildPhase.UPLOAD_BUILD_ARTIFACTS, async () => {
+          await maybeFindAndUploadBuildArtifacts(ctx, {
+            logger: ctx.logger,
+          });
         });
+      } catch (err: any) {
+        buildSuccess = false;
+        finalizationError = err;
       }
 
-      await ctx.runBuildPhase(BuildPhase.UPLOAD_BUILD_ARTIFACTS, async () => {
-        await maybeFindAndUploadBuildArtifacts(ctx, {
-          logger: ctx.logger,
+      try {
+        await ctx.runBuildPhase(BuildPhase.COMPLETE_JOB, async () => {
+          await uploadJobOutputsFromBuildContextAsync(ctx, {
+            logger: ctx.logger,
+            buildSucceeded: buildSuccess,
+          });
         });
-      });
+      } catch (err: any) {
+        finalizationError ??= err;
+      }
+
+      if (finalizationError) {
+        throw finalizationError;
+      }
     }
   } catch (err: any) {
     err.artifacts = ctx.artifacts;

--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -12,6 +12,7 @@ import { CustomBuildContext } from '../customBuildContext';
 import { findAndUploadXcodeBuildLogsAsync } from '../ios/xcodeBuildLogs';
 import { getEasFunctionGroups } from '../steps/easFunctionGroups';
 import { getEasFunctions } from '../steps/easFunctions';
+import { uploadJobOutputsToWwwAsync } from '../utils/outputs';
 import { retryAsync } from '../utils/retry';
 
 export async function runCustomBuildAsync(ctx: BuildContext<BuildJob>): Promise<Artifacts> {
@@ -94,7 +95,16 @@ export async function runCustomBuildAsync(ctx: BuildContext<BuildJob>): Promise<
           // do nothing, it's a non-breaking error.
         }
       }
-      await customBuildCtx.drainPendingMetricUploads();
+      const results = await Promise.allSettled([
+        uploadJobOutputsToWwwAsync(globalContext, {
+          logger: ctx.logger,
+          expoApiV2BaseUrl: ctx.expoApiV2BaseUrl,
+        }),
+        customBuildCtx.drainPendingMetricUploads(),
+      ]);
+      if (results[0].status === 'rejected') {
+        throw results[0].reason;
+      }
     }
   } catch (err: any) {
     err.artifacts = ctx.artifacts;

--- a/packages/build-tools/src/utils/__tests__/outputs.test.ts
+++ b/packages/build-tools/src/utils/__tests__/outputs.test.ts
@@ -1,4 +1,4 @@
-import { JobInterpolationContext } from '@expo/eas-build-job';
+import { Android, JobInterpolationContext } from '@expo/eas-build-job';
 import { createLogger } from '@expo/logger';
 import {
   BuildRuntimePlatform,
@@ -9,7 +9,14 @@ import {
 import { randomBytes, randomUUID } from 'crypto';
 import fetch, { Response } from 'node-fetch';
 
-import { collectJobOutputs, uploadJobOutputsToWwwAsync } from '../outputs';
+import { createTestAndroidJob } from '../../__tests__/utils/job';
+import { createMockLogger } from '../../__tests__/utils/logger';
+import { BuildContext } from '../../context';
+import {
+  collectJobOutputs,
+  uploadJobOutputsFromBuildContextAsync,
+  uploadJobOutputsToWwwAsync,
+} from '../outputs';
 import { TurtleFetchError } from '../turtleFetch';
 
 jest.mock('node-fetch');
@@ -226,6 +233,10 @@ describe(collectJobOutputs, () => {
 });
 
 describe(uploadJobOutputsToWwwAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('uploads outputs', async () => {
     const logger = createLogger({ name: 'test' }).child('test');
 
@@ -330,3 +341,125 @@ describe(uploadJobOutputsToWwwAsync, () => {
     );
   });
 });
+
+describe(uploadJobOutputsFromBuildContextAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uploads outputs from a build context', async () => {
+    const fetchMock = jest.mocked(fetch);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+    } as unknown as Response);
+
+    const ctx = createBuildContext({
+      outputs: {
+        status: '${{ success() }}',
+        failed: '${{ failure() }}',
+        build_type: 'apk',
+      },
+    });
+
+    await uploadJobOutputsFromBuildContextAsync(ctx, {
+      logger: ctx.logger,
+      buildSucceeded: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `http://exp.test/--/api/v2/workflows/${workflowJobId}`,
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${robotAccessToken}`,
+          'Content-Type': 'application/json',
+        },
+        timeout: 20000,
+        body: JSON.stringify({
+          outputs: { status: 'true', failed: 'false', build_type: 'apk' },
+        }),
+      })
+    );
+  });
+
+  it('skips upload when cloud upload context is missing', async () => {
+    const fetchMock = jest.mocked(fetch);
+    const ctx = createBuildContext(
+      {
+        outputs: {
+          build_type: 'apk',
+        },
+      },
+      {
+        expoApiV2BaseUrl: undefined,
+      }
+    );
+
+    await uploadJobOutputsFromBuildContextAsync(ctx, {
+      logger: ctx.logger,
+      buildSucceeded: true,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips upload when workflow job id is missing', async () => {
+    const fetchMock = jest.mocked(fetch);
+    const ctx = createBuildContext(
+      {
+        outputs: {
+          build_type: 'apk',
+        },
+      },
+      {
+        env: {
+          __API_SERVER_URL: 'http://api.expo.test',
+        },
+      }
+    );
+
+    await uploadJobOutputsFromBuildContextAsync(ctx, {
+      logger: ctx.logger,
+      buildSucceeded: true,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+function createBuildContext(
+  jobOverrides: Partial<Android.Job>,
+  options: {
+    expoApiV2BaseUrl?: string;
+    env?: Record<string, string>;
+  } = { expoApiV2BaseUrl: 'http://exp.test/--/api/v2/' }
+): BuildContext<Android.Job> {
+  const expoApiV2BaseUrl = Object.prototype.hasOwnProperty.call(options, 'expoApiV2BaseUrl')
+    ? options.expoApiV2BaseUrl
+    : 'http://exp.test/--/api/v2/';
+
+  return new BuildContext<Android.Job>(
+    {
+      ...createTestAndroidJob(),
+      ...jobOverrides,
+      secrets: {
+        ...createTestAndroidJob().secrets,
+        robotAccessToken,
+        ...jobOverrides.secrets,
+      },
+    },
+    {
+      workingdir: '/workingdir',
+      logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+      logger: createMockLogger(),
+      env: options.env ?? {
+        __API_SERVER_URL: 'http://api.expo.test',
+        __WORKFLOW_JOB_ID: workflowJobId,
+      },
+      uploadArtifact: jest.fn(),
+      expoApiV2BaseUrl,
+    }
+  );
+}

--- a/packages/build-tools/src/utils/outputs.ts
+++ b/packages/build-tools/src/utils/outputs.ts
@@ -1,28 +1,75 @@
-import { JobInterpolationContext } from '@expo/eas-build-job';
+import { BuildJob, Env, Job, JobInterpolationContext } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
-import { BuildStepGlobalContext, jsepEval } from '@expo/steps';
-import nullthrows from 'nullthrows';
+import { BuildStepGlobalContext, hashFiles as hashFilePaths, jsepEval } from '@expo/steps';
+import fg from 'fast-glob';
+import path from 'path';
 
+import { BuildContext } from '../context';
 import { turtleFetch } from './turtleFetch';
 
 export async function uploadJobOutputsToWwwAsync(
   ctx: BuildStepGlobalContext,
-  { logger, expoApiV2BaseUrl }: { logger: bunyan; expoApiV2BaseUrl: string }
+  { logger, expoApiV2BaseUrl }: { logger: bunyan; expoApiV2BaseUrl?: string }
 ): Promise<void> {
-  if (!ctx.staticContext.job.outputs) {
+  await uploadJobOutputsWithInterpolationContextAsync({
+    job: ctx.staticContext.job,
+    env: ctx.env as Env,
+    interpolationContext: ctx.getInterpolationContext(),
+    logger,
+    expoApiV2BaseUrl,
+  });
+}
+
+export async function uploadJobOutputsFromBuildContextAsync<TJob extends BuildJob>(
+  ctx: BuildContext<TJob>,
+  { logger, buildSucceeded }: { logger: bunyan; buildSucceeded: boolean }
+): Promise<void> {
+  await uploadJobOutputsWithInterpolationContextAsync({
+    job: ctx.job,
+    env: ctx.env,
+    interpolationContext: createBuildJobInterpolationContext(ctx, { buildSucceeded }),
+    logger,
+    expoApiV2BaseUrl: ctx.expoApiV2BaseUrl,
+  });
+}
+
+async function uploadJobOutputsWithInterpolationContextAsync({
+  job,
+  env,
+  interpolationContext,
+  logger,
+  expoApiV2BaseUrl,
+}: {
+  job: Job;
+  env: Env;
+  interpolationContext: JobInterpolationContext;
+  logger: bunyan;
+  expoApiV2BaseUrl?: string;
+}): Promise<void> {
+  if (!job.outputs) {
     logger.info('Job defines no outputs, skipping upload');
+    return;
+  }
+  if (!expoApiV2BaseUrl) {
+    logger.info('API V2 base URL is not available, skipping outputs upload');
+    return;
+  }
+  const workflowJobId = env.__WORKFLOW_JOB_ID;
+  if (!workflowJobId) {
+    logger.info('Workflow job ID is not available, skipping outputs upload');
+    return;
+  }
+  const robotAccessToken = job.secrets?.robotAccessToken;
+  if (!robotAccessToken) {
+    logger.info('Robot access token is not available, skipping outputs upload');
     return;
   }
 
   try {
-    const workflowJobId = nullthrows(ctx.env.__WORKFLOW_JOB_ID);
-    const robotAccessToken = nullthrows(ctx.staticContext.job.secrets?.robotAccessToken);
-
-    const interpolationContext = ctx.getInterpolationContext();
     logger.debug({ dynamicValues: interpolationContext }, 'Using dynamic values');
 
     const outputs = collectJobOutputs({
-      jobOutputDefinitions: ctx.staticContext.job.outputs,
+      jobOutputDefinitions: job.outputs,
       interpolationContext,
     });
     logger.info('Uploading outputs');
@@ -39,6 +86,56 @@ export async function uploadJobOutputsToWwwAsync(
     logger.error({ err }, 'Failed to upload outputs');
     throw err;
   }
+}
+
+function createBuildJobInterpolationContext<TJob extends BuildJob>(
+  ctx: BuildContext<TJob>,
+  { buildSucceeded }: { buildSucceeded: boolean }
+): JobInterpolationContext {
+  return {
+    ...ctx.job.workflowInterpolationContext,
+    expoApiServerURL: ctx.env.__API_SERVER_URL,
+    job: ctx.job,
+    metadata: ctx.metadata ?? null,
+    steps: {},
+    always: () => true,
+    never: () => false,
+    success: () => buildSucceeded,
+    failure: () => !buildSucceeded,
+    env: ctx.env,
+    fromJSON: (json: string) => JSON.parse(json),
+    toJSON: (value: unknown) => JSON.stringify(value),
+    contains: (value, substring) => value.includes(substring),
+    startsWith: (value, prefix) => value.startsWith(prefix),
+    endsWith: (value, suffix) => value.endsWith(suffix),
+    hashFiles: (...patterns: string[]) => hashFiles(ctx.getReactNativeProjectDirectory(), patterns),
+    replaceAll: (input: string, stringToReplace: string, replacementString: string) => {
+      while (input.includes(stringToReplace)) {
+        input = input.replace(stringToReplace, replacementString);
+      }
+      return input;
+    },
+    substring: (input: string, start: number, end?: number) => input.substring(start, end),
+  };
+}
+
+function hashFiles(cwd: string, patterns: string[]): string {
+  const workspacePath = path.resolve(cwd);
+  const filePaths = fg.sync(patterns, {
+    cwd,
+    absolute: true,
+    onlyFiles: true,
+  });
+  if (filePaths.length === 0) {
+    return '';
+  }
+
+  const validFilePaths = filePaths.filter(file => file.startsWith(`${workspacePath}${path.sep}`));
+  if (validFilePaths.length === 0) {
+    return '';
+  }
+
+  return hashFilePaths(validFilePaths);
 }
 
 /** Function we use to get outputs of the whole job from steps. */


### PR DESCRIPTION
## Summary

This uploads declared workflow job outputs from `@expo/build-tools` for both step-based and normal build execution paths.

This PR is stacked on top of #3704, which preserves `outputs` in Android/iOS build job payloads.

## Changes

- Add a build-context output upload path for normal Android/iOS builds.
- Reuse the existing step-context output upload path for custom/repack builds so `steps.*.outputs.*` references still work.
- Upload outputs during normal build finalization, including failure/finalization-failure paths, with `success()` and `failure()` reflecting the final result.
- Skip output upload cleanly when outputs are absent or cloud workflow upload context is unavailable.
- Add tests for custom build upload, normal build success/failure/finalization failure upload, build-context interpolation, and skip behavior.

## Validation

- `packages/build-tools`: `yarn test builders/__tests__/custom.test.ts builders/__tests__/common.test.ts utils/__tests__/outputs.test.ts`
- `packages/build-tools`: `yarn build`
- `yarn oxfmt --check ...`
