### PR TITLE
[build-internal] - handle errors when running internal build

### DIFF
--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -43,40 +43,41 @@ export async function runEasBuildInternalAsync<TJob extends BuildJob>({
   }
 
   try {
-  const result = await spawn(
-    cmd,
-    [
-      ...args,
-      'build:internal',
-      '--platform',
-      job.platform,
-      '--profile',
-      buildProfile,
-      ...autoSubmitArgs,
-    ],
-    {
-      cwd,
-      env: {
-        ...env,
-        EXPO_TOKEN: nullthrows(job.secrets, 'Secrets must be defined for non-custom builds')
-          .robotAccessToken,
-        ...extraEnv,
-        EAS_PROJECT_ROOT: projectRootOverride,
-      },
-      logger,
-      // This prevents printing stdout with job secrets and credentials to logs.
-      mode: PipeMode.STDERR_ONLY_AS_STDOUT,
-    }
-  );
+    const result = await spawn(
+      cmd,
+      [
+        ...args,
+        'build:internal',
+        '--platform',
+        job.platform,
+        '--profile',
+        buildProfile,
+        ...autoSubmitArgs,
+      ],
+      {
+        cwd,
+        env: {
+          ...env,
+          EXPO_TOKEN: nullthrows(job.secrets, 'Secrets must be defined for non-custom builds')
+            .robotAccessToken,
+          ...extraEnv,
+          EAS_PROJECT_ROOT: projectRootOverride,
+        },
+        logger,
+        // This prevents printing stdout with job secrets and credentials to logs.
+        mode: PipeMode.STDERR_ONLY_AS_STDOUT,
+      }
+    );
 
-  const stdout = result.stdout.toString();
-  const parsed = JSON.parse(stdout);
-  return validateEasBuildInternalResult({
-    result: parsed,
-    oldJob: job,
-  });
-} catch (err: any) {
-  throw new Error(`Failed to run eas build:internal: ${err.message}`);
+    const stdout = result.stdout.toString();
+    const parsed = JSON.parse(stdout);
+    return validateEasBuildInternalResult({
+      result: parsed,
+      oldJob: job,
+    });
+  } catch (err: any) {
+    throw new Error('Failed to run eas build:internal');
+  }
 }
 
 export async function resolveEnvFromBuildProfileAsync<TJob extends BuildJob>(

--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -42,6 +42,7 @@ export async function runEasBuildInternalAsync<TJob extends BuildJob>({
     autoSubmitArgs.push('--auto-submit');
   }
 
+  try {
   const result = await spawn(
     cmd,
     [
@@ -74,6 +75,8 @@ export async function runEasBuildInternalAsync<TJob extends BuildJob>({
     result: parsed,
     oldJob: job,
   });
+} catch (err: any) {
+  throw new Error(`Failed to run eas build:internal`);
 }
 
 export async function resolveEnvFromBuildProfileAsync<TJob extends BuildJob>(

--- a/packages/build-tools/src/common/easBuildInternal.ts
+++ b/packages/build-tools/src/common/easBuildInternal.ts
@@ -76,7 +76,7 @@ export async function runEasBuildInternalAsync<TJob extends BuildJob>({
     oldJob: job,
   });
 } catch (err: any) {
-  throw new Error(`Failed to run eas build:internal`);
+  throw new Error(`Failed to run eas build:internal: ${err.message}`);
 }
 
 export async function resolveEnvFromBuildProfileAsync<TJob extends BuildJob>(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Previously an error on the internal build would result in piping the full result to std out. We will now wrap that and log an error message only

