### PR TITLE
[build-tools] Route xcactivitylog parser failures to Sentry

### DIFF
--- a/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
+++ b/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import { createMockLogger } from '../../../../__tests__/utils/logger';
+import { Sentry } from '../../../../sentry';
 import {
   buildTargetMetrics,
   isCompileStep,
@@ -16,6 +17,13 @@ jest.mock('@expo/downloader');
 jest.mock('@expo/turtle-spawn', () => ({
   __esModule: true,
   default: jest.fn(),
+}));
+jest.mock('../../../../sentry', () => ({
+  Sentry: {
+    setup: jest.fn(),
+    capture: jest.fn(),
+    flush: jest.fn(),
+  },
 }));
 
 // Minimal fixture: two modules with compile steps
@@ -209,6 +217,7 @@ describe('parseAndReportXcactivitylog', () => {
   beforeEach(() => {
     mockedDownloadFile.mockReset();
     mockedSpawn.mockReset();
+    jest.mocked(Sentry.capture).mockClear();
   });
 
   afterEach(() => {
@@ -262,6 +271,7 @@ describe('parseAndReportXcactivitylog', () => {
     );
     expect(logger.debug).not.toHaveBeenCalled();
     expect(logger.warn).not.toHaveBeenCalled();
+    expect(Sentry.capture).not.toHaveBeenCalled();
   });
 
   it('tries the proxy URL first and falls back to the direct GCS URL', async () => {
@@ -338,7 +348,7 @@ describe('parseAndReportXcactivitylog', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it('skips reporting and logs debug when the JSON output is invalid', async () => {
+  it('reports phase "parsing_xclogparser_output" when the JSON output is invalid', async () => {
     const logger = createMockLogger();
     mockFilesystem({ jsonOutput: '{not valid json' });
 
@@ -353,15 +363,16 @@ describe('parseAndReportXcactivitylog', () => {
       })
     ).resolves.toBeUndefined();
 
-    expect(logger.info).not.toHaveBeenCalled();
-    expect(logger.debug).toHaveBeenCalledWith(
-      expect.objectContaining({ err: expect.any(Error) }),
-      'Failed to analyze build performance; continuing without a report'
-    );
+    expect(logger.info).toHaveBeenCalledWith('Build performance analysis skipped.');
     expect(logger.warn).not.toHaveBeenCalled();
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Build performance analysis failed during "parsing_xclogparser_output"',
+      expect.any(Error),
+      { tags: { phase: 'parsing_xclogparser_output' } }
+    );
   });
 
-  it('skips reporting and logs debug when the JSON output does not match the expected schema', async () => {
+  it('reports phase "parsing_xclogparser_output" when the JSON output does not match the expected schema', async () => {
     const logger = createMockLogger();
     mockFilesystem({
       jsonOutput: JSON.stringify({
@@ -381,12 +392,63 @@ describe('parseAndReportXcactivitylog', () => {
       })
     ).resolves.toBeUndefined();
 
-    expect(logger.info).not.toHaveBeenCalled();
-    expect(logger.debug).toHaveBeenCalledWith(
-      expect.objectContaining({ err: expect.any(Error) }),
-      'Failed to analyze build performance; continuing without a report'
-    );
+    expect(logger.info).toHaveBeenCalledWith('Build performance analysis skipped.');
     expect(logger.warn).not.toHaveBeenCalled();
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Build performance analysis failed during "parsing_xclogparser_output"',
+      expect.any(Error),
+      { tags: { phase: 'parsing_xclogparser_output' } }
+    );
+  });
+
+  it('reports phase "running_xclogparser" when the xclogparser invocation fails', async () => {
+    const logger = createMockLogger();
+    mockFilesystem();
+
+    mockedDownloadFile.mockResolvedValue(undefined);
+    mockedSpawn
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as any) // unzip
+      .mockRejectedValueOnce(new Error('spawn xclogparser ENOENT')); // xclogparser run
+
+    await expect(
+      parseAndReportXcactivitylog({
+        derivedDataPath: '/tmp/derived-data',
+        workspacePath: '/tmp/workspace',
+        logger,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(logger.info).toHaveBeenCalledWith('Build performance analysis skipped.');
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Build performance analysis failed during "running_xclogparser"',
+      expect.objectContaining({ message: 'spawn xclogparser ENOENT' }),
+      { tags: { phase: 'running_xclogparser' } }
+    );
+  });
+
+  it('reports phase "downloading_xclogparser" when the direct download fails', async () => {
+    const logger = createMockLogger();
+    mockFilesystem();
+
+    mockedDownloadFile.mockRejectedValue(new Error('network unreachable'));
+    mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
+
+    await expect(
+      parseAndReportXcactivitylog({
+        derivedDataPath: '/tmp/derived-data',
+        workspacePath: '/tmp/workspace',
+        logger,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(logger.info).toHaveBeenCalledWith('Build performance analysis skipped.');
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Build performance analysis failed during "downloading_xclogparser"',
+      expect.objectContaining({ message: 'network unreachable' }),
+      { tags: { phase: 'downloading_xclogparser' } }
+    );
   });
 
   it('swallows cleanup failures without emitting additional logs', async () => {

--- a/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
+++ b/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
@@ -7,17 +7,17 @@ import os from 'os';
 import path from 'path';
 import { z } from 'zod';
 
+import { Sentry } from '../../../sentry';
+
 const DEFAULT_XCLOGPARSER_VERSION = 'v0.2.47';
 const XCLOGPARSER_DOWNLOAD_URL = 'https://storage.googleapis.com/turtle-v2/xclogparser';
 const XCLOGPARSER_DOWNLOAD_TIMEOUT_MS = 20_000;
 const XCLOGPARSER_OUTPUT_FILENAME = 'xcactivitylog.json';
 
 /**
- * Download xclogparser, parse xcactivitylog from derived data, and log a
- * compile metrics report. Never throws — all errors are logged at debug level.
- *
- * Can be called from both the step-based flow (BuildFunction) and the
- * traditional builder flow (runBuildPhase).
+ * Never throws — best-effort observability that does not affect build status.
+ * Failures route to Sentry via `Sentry.capture` for engineering triage;
+ * users see only a generic skip message.
  */
 export async function parseAndReportXcactivitylog({
   derivedDataPath,
@@ -33,26 +33,36 @@ export async function parseAndReportXcactivitylog({
   proxyBaseUrl?: string;
 }): Promise<void> {
   let tempDir: string | undefined;
+  let phase = 'creating_temp_directory';
   try {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'xclogparser-'));
+
+    phase = 'downloading_xclogparser';
     const xclogparserPath = await downloadXclogparser(
       tempDir,
       xclogparserVersion,
       logger,
       proxyBaseUrl
     );
+
+    phase = 'running_xclogparser';
     const jsonOutputPath = await runXclogparser({
       binaryPath: xclogparserPath,
       derivedDataPath,
       workspacePath,
       outputDir: tempDir,
     });
+
+    phase = 'parsing_xclogparser_output';
     const data = XcactivitylogDataSchemaZ.parse(
       JSON.parse(await fs.readFile(jsonOutputPath, 'utf8'))
     );
+
     logger.info(formatReport(data));
-  } catch (err: unknown) {
-    logger.debug({ err }, 'Failed to analyze build performance; continuing without a report');
+  } catch (err: any) {
+    logger.info('Build performance analysis skipped.');
+    const msg = `Build performance analysis failed during "${phase}"`;
+    Sentry.capture(msg, err, { tags: { phase } });
   } finally {
     if (tempDir) {
       await asyncResult(fs.rm(tempDir, { force: true, recursive: true }));


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The xcactivitylog parser silently swallowed all internal failures at `debug` level. Users saw no report and we had no signal to triage. [ENG-21157](https://linear.app/expo/issue/ENG-21157)

These failures (Zod schema, spawn, download) are non-actionable for users and don't affect build artifacts. They should be silent for users, but visible to engineers via Sentry.

# How

- `parseAndReportXcactivitylog` tracks the current phase in a local variable: `creating_temp_directory` / `downloading_xclogparser` / `running_xclogparser` / `parsing_xclogparser_output`.
- On failure: user sees only `Build performance analysis skipped.` (info); the phase identifier + full error details routed to Sentry via `Sentry.capture(msg, err, { tags: { phase } })`.
- Phase values are stored in snake_case from the start (matching the existing Sentry tag convention in `worker/src/service.ts` / `restoreBuildCache.ts`) — no runtime transform at the call site.
- Tests assert the right phase tag fires per failure mode, and the happy path doesn't invoke Sentry.

# Test Plan

- `packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts` — each failure path (invalid JSON, Zod schema mismatch, spawn failure, download failure) asserts `Sentry.capture` invoked with the correct phase tag; happy path asserts not invoked.
- Full monorepo `yarn typecheck`, `yarn run -T lerna run test`, `yarn lint`, `yarn fmt:check` green.

---

⬇️ Stacked on top of #3712 (Sentry singleton). Merge #3712 first.