### PR TITLE
[build-tools] rename smart_retry to  retry_failed_only for maestro job

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
@@ -679,7 +679,7 @@ describe('parseFailedFlowsFromJUnit', () => {
 
   it('returns null when junit XML is truncated mid-tag (partial parse risk)', async () => {
     // fast-xml-parser can produce a partial parse from truncated XML — without
-    // strict validation, smart retry would only retry the visible failures and
+    // strict validation, retry-failed-only would only retry the visible failures and
     // silently skip flows that were cut off.
     vol.fromJSON({
       '/tmp/junit-reports/attempt-0.xml': `<?xml version="1.0"?>

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -208,7 +208,7 @@ describe('createMaestroTestsBuildFunction', () => {
     );
   });
 
-  it('runs all original flows on every retry when smart_retry=false', async () => {
+  it('runs all original flows on every retry when retry_failed_only=false', async () => {
     mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
     const parseSpy = jest
       .spyOn(parser, 'parseFailedFlowsFromJUnit')
@@ -218,7 +218,7 @@ describe('createMaestroTestsBuildFunction', () => {
       flow_path: ['flows/a.yaml', 'flows/b.yaml'],
       retries: 1,
       output_format: 'junit',
-      smart_retry: false,
+      retry_failed_only: false,
       platform: 'android',
     });
     await step.executeAsync();
@@ -233,7 +233,7 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(parseSpy).not.toHaveBeenCalled();
   });
 
-  it('subsets to failing flows on retry when smart_retry=true (default behaviour)', async () => {
+  it('subsets to failing flows on retry when retry_failed_only=true (default behaviour)', async () => {
     mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
     jest.spyOn(parser, 'parseFailedFlowsFromJUnit').mockResolvedValue(['flows/b.yaml']);
 
@@ -241,7 +241,7 @@ describe('createMaestroTestsBuildFunction', () => {
       flow_path: ['flows/a.yaml', 'flows/b.yaml'],
       retries: 1,
       output_format: 'junit',
-      smart_retry: true,
+      retry_failed_only: true,
       platform: 'android',
     });
     await step.executeAsync();
@@ -254,7 +254,7 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(a1).not.toContain('flows/a.yaml');
   });
 
-  it('falls back to all-flows retry when smart_retry=true but output_format!=junit', async () => {
+  it('falls back to all-flows retry when retry_failed_only=true but output_format!=junit', async () => {
     mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
     const parseSpy = jest.spyOn(parser, 'parseFailedFlowsFromJUnit');
 
@@ -262,7 +262,7 @@ describe('createMaestroTestsBuildFunction', () => {
       flow_path: ['flows/a.yaml', 'flows/b.yaml'],
       retries: 1,
       output_format: 'html',
-      smart_retry: true,
+      retry_failed_only: true,
       platform: 'android',
     });
     await step.executeAsync();
@@ -282,7 +282,7 @@ describe('createMaestroTestsBuildFunction', () => {
       flow_path: ['flows/a.yaml', 'flows/b.yaml'],
       retries: 1,
       output_format: 'junit',
-      smart_retry: true,
+      retry_failed_only: true,
       platform: 'android',
     });
     await step.executeAsync();
@@ -293,7 +293,7 @@ describe('createMaestroTestsBuildFunction', () => {
     );
   });
 
-  it('defaults smart_retry to true when omitted from inputs', async () => {
+  it('defaults retry_failed_only to true when omitted from inputs', async () => {
     mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
     jest.spyOn(parser, 'parseFailedFlowsFromJUnit').mockResolvedValue(['flows/b.yaml']);
 

--- a/packages/build-tools/src/steps/functions/maestroFlowDiscovery.ts
+++ b/packages/build-tools/src/steps/functions/maestroFlowDiscovery.ts
@@ -97,8 +97,8 @@ function dedupAndDetectDuplicates(flows: FlowEntry[], logger: bunyan): Map<strin
       logger.warn(`Duplicate Maestro flow name "${name}" across paths: ${paths.join(', ')}.`);
     }
     logger.warn(
-      'Smart retry disabled for this run; will retry all flows on failure. ' +
-        'Give each Maestro flow a unique name (file basename or top-level name) to enable smart retry.'
+      'Retry-failed-only is disabled for this run; will retry all flows on failure. ' +
+        'Give each Maestro flow a unique name (file basename or top-level name) to enable retry-failed-only.'
     );
     return null;
   }

--- a/packages/build-tools/src/steps/functions/maestroResultParser.ts
+++ b/packages/build-tools/src/steps/functions/maestroResultParser.ts
@@ -215,7 +215,7 @@ export async function parseFailedFlowsFromJUnit(args: {
   nameToPath: Map<string, string>;
 }): Promise<string[] | null> {
   // fast-xml-parser is lenient — truncated XML can produce a partial parse
-  // with some testcases dropped. Trusting that subset for smart retry would
+  // with some testcases dropped. Trusting that subset for retry-failed-only would
   // skip retries for cut-off flows; reject any malformed XML and fall back
   // to dumb retry.
   let content: string;

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -98,7 +98,7 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
         allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
       }),
       BuildStepInput.createProvider({
-        id: 'smart_retry',
+        id: 'retry_failed_only',
         required: false,
         defaultValue: true,
         allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
@@ -192,7 +192,7 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
         inputs.shards.value,
         'shards must be a positive integer.'
       );
-      const smartRetry = inputs.smart_retry.value as boolean;
+      const retryFailedOnly = inputs.retry_failed_only.value as boolean;
 
       try {
         await fs.mkdir(junitReportDirectory, { recursive: true });
@@ -200,7 +200,7 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
         throw new SystemError('Failed to create JUnit report directory', { cause: err });
       }
 
-      // null → duplicate flow names; smart retry disabled, fall through to
+      // null → duplicate flow names; retry-failed-only disabled, fall through to
       // dumb retry (re-run everything) on failure.
       const nameToPath = await buildFlowNameToPathMap({
         inputFlowPaths: flowPaths,
@@ -213,7 +213,7 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
       //   numeric err.status → maestro exited non-zero → retry.
       //   else (signal-only, OOM kill, unknown) → infra → SystemError, never
       //     downgraded to "tests failed".
-      // Smart retry (junit mode): after a failed attempt, subset to the failing
+      // Retry-failed-only (junit mode): after a failed attempt, subset to the failing
       // flows. parseFailedFlowsFromJUnit returns null when the JUnit cannot be
       // trusted; we then fall through to dumb retry (re-run everything).
       let flowsToRun: string[] = flowPaths;
@@ -263,7 +263,7 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
           break;
         }
 
-        if (smartRetry && outputFormat === 'junit' && outputPath && nameToPath) {
+        if (retryFailedOnly && outputFormat === 'junit' && outputPath && nameToPath) {
           const failed = await parseFailedFlowsFromJUnit({
             junitFile: outputPath,
             nameToPath,


### PR DESCRIPTION
# Why

Rename the `smart_retry` Maestro step input to `retry_failed_only`. The new name describes the behavior more clearly. The feature is new (ENG-21038, shipped 2026-05-07) and has no production users yet, so this is a hard rename with no compat shim. Linear: [ENG-21159](https://linear.app/expo/issue/ENG-21159/rename-smart-retry-to-retry-failed-only).

# How

Renamed in `packages/build-tools/src/steps/functions/`:

- `maestroTests.ts` — `BuildStepInput` id, local variable (`retryFailedOnly`), call site, and comments
- `maestroFlowDiscovery.ts` — user-facing warning text
- `maestroResultParser.ts` — comment
- `__tests__/maestroTests.test.ts` + `__tests__/maestroResultParser.test.ts` — fixtures, descriptions, and assertions

# Test Plan

- `yarn lint`: 0 warnings, 0 errors
- `yarn typecheck` (build-tools): pass
- `yarn test` (build-tools): 488/488 tests pass across 62 suites

Companion PRs:

- expo/universe#27434 (Zod schema + step param)
- expo/expo#45666 (docs)