### PR TITLE
[eas-cli] Support --type serve-sim in eas simulator:start

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -36660,6 +36660,11 @@
             "kind": "OBJECT",
             "name": "AgentDeviceRunSessionRemoteConfig",
             "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ServeSimRunSessionRemoteConfig",
+            "ofType": null
           }
         ]
       },
@@ -36708,6 +36713,12 @@
         "enumValues": [
           {
             "name": "AGENT_DEVICE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SERVE_SIM",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -61574,6 +61585,49 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "DeleteSentryProjectResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ServeSimRunSessionRemoteConfig",
+        "description": null,
+        "fields": [
+          {
+            "name": "previewUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "streamUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },

--- a/packages/eas-cli/src/commands/simulator/get.ts
+++ b/packages/eas-cli/src/commands/simulator/get.ts
@@ -7,7 +7,7 @@ import { DeviceRunSessionStatus } from '../../graphql/generated';
 import { DeviceRunSessionQuery } from '../../graphql/queries/DeviceRunSessionQuery';
 import Log, { link } from '../../log';
 import { ora } from '../../ora';
-import { formatRemoteConfigShellSnippet } from '../../simulator/utils';
+import { formatRemoteSessionInstructions } from '../../simulator/utils';
 
 export default class SimulatorGet extends EasCommand {
   static override hidden = true;
@@ -58,9 +58,7 @@ export default class SimulatorGet extends EasCommand {
     if (session.status === DeviceRunSessionStatus.InProgress) {
       Log.newLine();
       if (session.remoteConfig) {
-        Log.log('🔑 Run the following in your shell to attach to the session:');
-        Log.newLine();
-        Log.log(formatRemoteConfigShellSnippet(session.remoteConfig));
+        Log.log(formatRemoteSessionInstructions(session.remoteConfig));
       } else {
         Log.log(
           '⏳ Session is starting up — remote config is not available yet. Re-run this command in a moment.'

--- a/packages/eas-cli/src/commands/simulator/start.ts
+++ b/packages/eas-cli/src/commands/simulator/start.ts
@@ -16,7 +16,7 @@ import Log, { link } from '../../log';
 import { ora } from '../../ora';
 import {
   DeviceRunSessionRemoteConfig,
-  formatRemoteConfigShellSnippet,
+  formatRemoteSessionInstructions,
 } from '../../simulator/utils';
 import { sleepAsync } from '../../utils/promise';
 import nullthrows from 'nullthrows';
@@ -28,6 +28,7 @@ const POLL_TIMEOUT_MS = 15 * 60 * 1_000; // 15 minutes
 // so adding a new enum value in codegen fails the build until it is wired up here.
 const DEVICE_RUN_SESSION_TYPE_FLAG_VALUES: Record<DeviceRunSessionType, string> = {
   [DeviceRunSessionType.AgentDevice]: 'agent-device',
+  [DeviceRunSessionType.ServeSim]: 'serve-sim',
 };
 
 const DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE = Object.fromEntries(
@@ -39,7 +40,7 @@ const DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE = Object.fromEntries(
 export default class SimulatorStart extends EasCommand {
   static override hidden = true;
   static override description =
-    '[EXPERIMENTAL] start a remote simulator session on EAS and get the credentials to connect to it with the CLI tool of your choice';
+    '[EXPERIMENTAL] start a remote simulator session on EAS and get instructions to connect to it';
 
   static override flags = {
     platform: Flags.option({
@@ -97,7 +98,7 @@ export default class SimulatorStart extends EasCommand {
       throw err;
     }
 
-    const pollSpinner = ora(`⏳ Waiting for ${flags.type} daemon to start`).start();
+    const pollSpinner = ora(`⏳ Waiting for ${flags.type} session to be ready`).start();
     const deadline = Date.now() + POLL_TIMEOUT_MS;
     let remoteConfig: DeviceRunSessionRemoteConfig | undefined;
 
@@ -110,7 +111,7 @@ export default class SimulatorStart extends EasCommand {
           session.status === DeviceRunSessionStatus.Stopped
         ) {
           throw new Error(
-            `Device run session ${deviceRunSessionId} ${session.status.toLowerCase()} before the ${flags.type} daemon was ready. ${link(jobRunUrl)}`
+            `Device run session ${deviceRunSessionId} ${session.status.toLowerCase()} before the ${flags.type} session was ready. ${link(jobRunUrl)}`
           );
         }
 
@@ -121,36 +122,34 @@ export default class SimulatorStart extends EasCommand {
           jobRunStatus === JobRunStatus.Finished
         ) {
           throw new Error(
-            `Turtle job run for device run session ${deviceRunSessionId} ${jobRunStatus.toLowerCase()} before the ${flags.type} daemon was ready. ${link(jobRunUrl)}`
+            `Turtle job run for device run session ${deviceRunSessionId} ${jobRunStatus.toLowerCase()} before the ${flags.type} session was ready. ${link(jobRunUrl)}`
           );
         }
 
         if (session.remoteConfig) {
           remoteConfig = session.remoteConfig;
-          pollSpinner.succeed(`🎉 ${flags.type} daemon is ready`);
+          pollSpinner.succeed(`🎉 ${flags.type} session is ready`);
           break;
         }
 
         await sleepAsync(POLL_INTERVAL_MS);
       }
     } catch (err) {
-      pollSpinner.fail(`Failed while polling for ${flags.type} daemon to start`);
+      pollSpinner.fail(`Failed while polling for ${flags.type} session to be ready`);
       await ensureDeviceRunSessionStoppedSafelyAsync(graphqlClient, deviceRunSessionId);
       throw err;
     }
 
     if (!remoteConfig) {
-      pollSpinner.fail(`Timed out waiting for ${flags.type} daemon to start`);
+      pollSpinner.fail(`Timed out waiting for ${flags.type} session to be ready`);
       await ensureDeviceRunSessionStoppedSafelyAsync(graphqlClient, deviceRunSessionId);
       throw new Error(
-        `Timed out after ${Math.round(POLL_TIMEOUT_MS / 1000)}s waiting for ${flags.type} daemon to start. ${link(jobRunUrl)}`
+        `Timed out after ${Math.round(POLL_TIMEOUT_MS / 1000)}s waiting for ${flags.type} session to be ready. ${link(jobRunUrl)}`
       );
     }
 
     Log.newLine();
-    Log.log(`🔑 Run the following in your shell to attach to ${flags.type}:`);
-    Log.newLine();
-    Log.log(formatRemoteConfigShellSnippet(remoteConfig));
+    Log.log(formatRemoteSessionInstructions(remoteConfig));
     Log.newLine();
 
     if (flags['non-interactive']) {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -5151,7 +5151,7 @@ export type DeviceRunSessionQueryByIdArgs = {
   deviceRunSessionId: Scalars['ID']['input'];
 };
 
-export type DeviceRunSessionRemoteConfig = AgentDeviceRunSessionRemoteConfig;
+export type DeviceRunSessionRemoteConfig = AgentDeviceRunSessionRemoteConfig | ServeSimRunSessionRemoteConfig;
 
 export enum DeviceRunSessionStatus {
   Errored = 'ERRORED',
@@ -5161,7 +5161,8 @@ export enum DeviceRunSessionStatus {
 }
 
 export enum DeviceRunSessionType {
-  AgentDevice = 'AGENT_DEVICE'
+  AgentDevice = 'AGENT_DEVICE',
+  ServeSim = 'SERVE_SIM'
 }
 
 export type DiscordUser = {
@@ -8649,6 +8650,12 @@ export type SentryProjectMutationCreateSentryProjectArgs = {
 
 export type SentryProjectMutationDeleteSentryProjectArgs = {
   sentryProjectId: Scalars['ID']['input'];
+};
+
+export type ServeSimRunSessionRemoteConfig = {
+  __typename?: 'ServeSimRunSessionRemoteConfig';
+  previewUrl: Scalars['String']['output'];
+  streamUrl: Scalars['String']['output'];
 };
 
 export type SetupConvexProjectInput = {
@@ -12694,7 +12701,7 @@ export type DeviceRunSessionByIdQueryVariables = Exact<{
 }>;
 
 
-export type DeviceRunSessionByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, type: DeviceRunSessionType, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, remoteConfig?: { __typename: 'AgentDeviceRunSessionRemoteConfig', url: string, token: string } | null, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } } };
+export type DeviceRunSessionByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, type: DeviceRunSessionType, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, remoteConfig?: { __typename: 'AgentDeviceRunSessionRemoteConfig', url: string, token: string } | { __typename: 'ServeSimRunSessionRemoteConfig', previewUrl: string, streamUrl: string } | null, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } } };
 
 export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
@@ -33,6 +33,10 @@ export const DeviceRunSessionQuery = {
                       url
                       token
                     }
+                    ... on ServeSimRunSessionRemoteConfig {
+                      previewUrl
+                      streamUrl
+                    }
                   }
                   turtleJobRun {
                     id

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -3,12 +3,22 @@ import { DeviceRunSessionByIdQuery } from '../graphql/generated';
 type DeviceRunSessionByIdResult = DeviceRunSessionByIdQuery['deviceRunSessions']['byId'];
 export type DeviceRunSessionRemoteConfig = NonNullable<DeviceRunSessionByIdResult['remoteConfig']>;
 
-export function formatRemoteConfigShellSnippet(remoteConfig: DeviceRunSessionRemoteConfig): string {
+export function formatRemoteSessionInstructions(
+  remoteConfig: DeviceRunSessionRemoteConfig
+): string {
   switch (remoteConfig.__typename) {
     case 'AgentDeviceRunSessionRemoteConfig':
       return [
+        '🔑 Run the following in your shell to attach to the agent-device daemon:',
+        '',
         `export AGENT_DEVICE_DAEMON_BASE_URL='${remoteConfig.url}'`,
         `export AGENT_DEVICE_DAEMON_AUTH_TOKEN='${remoteConfig.token}'`,
+      ].join('\n');
+    case 'ServeSimRunSessionRemoteConfig':
+      return [
+        '🌐 Open the following URL in your browser to access the simulator:',
+        '',
+        remoteConfig.previewUrl,
       ].join('\n');
   }
 }


### PR DESCRIPTION
Stacked on #3711.

# Why

Now that the API server exposes `DeviceRunSessionType.ServeSim` and `ServeSimRunSessionRemoteConfig` (`previewUrl`, `streamUrl`), wire up the CLI to actually launch a serve-sim session and tell the user how to use it. Companion to the build-tools step function in #3711.

# How

- Add `... on ServeSimRunSessionRemoteConfig { previewUrl streamUrl }` to `DeviceRunSessionByIdQuery` and regenerate types.
- Register `DeviceRunSessionType.ServeSim → 'serve-sim'` in the flag-value map in `eas simulator:start`. Because the map is typed `Record<DeviceRunSessionType, string>`, the build was already failing on the missing entry — this is what was breaking `verify-graphql-code` on the parent PR.
- Replace `formatRemoteConfigShellSnippet` with `formatRemoteSessionInstructions` in `simulator/utils.ts`. The switch over `remoteConfig.__typename` is now exhaustive:
  - agent-device returns the `export …` shell snippet (unchanged).
  - serve-sim returns `🌐 Open the following URL in your browser to access the simulator:` followed by `previewUrl`.
- `start.ts` and `get.ts` call the new function, so the headline now lives inside the formatter and stays variant-appropriate (no more hardcoded "Run the following in your shell" for serve-sim).
- Rename the user-facing `${type} daemon` copy to `${type} session` so it reads naturally for both agent-device and serve-sim.
- Tweak the command description to drop the agent-device-specific phrasing.

# Test Plan

- `yarn typecheck`, `yarn lint`, `yarn fmt:check`, `yarn verify-graphql-code` all pass locally.
- Smoke test by running `eas simulator:start --platform ios --type serve-sim` once the server side has rolled out and the build-tools step from #3711 is published. Verify the CLI prints the preview URL and that opening it in a browser loads the simulator.