### PR TITLE
[gha] Audit workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Keep SHA-pinned GitHub Actions fresh. Without this, pins never receive
+  # upstream security patches because tag movements no longer reach us.
+  - package-ecosystem: github-actions
+    directories:
+      - /
+      - /.github/actions/setup-mise
+      - /.github/internal-actions/setup-gcloud
+      - /.github/internal-actions/notify-slack-on-fail-or-recover
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - '*'

--- a/.github/internal-actions/notify-slack-on-fail-or-recover/action.yml
+++ b/.github/internal-actions/notify-slack-on-fail-or-recover/action.yml
@@ -12,7 +12,7 @@ runs:
   using: 'composite'
   steps:
     - name: Get previous workflow run status
-      uses: actions/github-script@v6
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
       id: run-status
       with:
         script: |
@@ -28,7 +28,7 @@ runs:
 
     - name: Send Slack Success Notification
       if: fromJSON(steps.run-status.outputs.result).previous == 'failure' && fromJSON(steps.run-status.outputs.result).current == 'success'
-      uses: rtCamp/action-slack-notify@v2
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
       env:
         SLACK_CHANNEL: ${{ inputs.channel }}
         SLACK_COLOR: good
@@ -41,7 +41,7 @@ runs:
 
     - name: Send Slack Failure Notification
       if: fromJSON(steps.run-status.outputs.result).current == 'failure'
-      uses: rtCamp/action-slack-notify@v2
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
       env:
         SLACK_CHANNEL: ${{ inputs.channel }}
         SLACK_COLOR: danger

--- a/.github/internal-actions/setup-gcloud/action.yml
+++ b/.github/internal-actions/setup-gcloud/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Auth gcloud
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
       with:
         workload_identity_provider: 'projects/321830142373/locations/global/workloadIdentityPools/github/providers/expo'
         project_id: exponentjs

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,7 +18,7 @@ jobs:
     name: Check CHANGELOG.md updated
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Check if CHANGELOG.md was updated
         id: changelog-updated
         uses: tj-actions/changed-files@b1ba699b304f2083b602164e06a89b868c84f076
@@ -26,11 +26,11 @@ jobs:
           files: CHANGELOG.md
       - name: Fail if CHANGELOG.md was not updated and the "no changelog" label is absent
         if: steps.changelog-updated.outputs.any_changed == 'false' && !contains(github.event.pull_request.labels.*.name, 'no changelog')
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |
             core.setFailed('Please add a changelog entry!')
-      - uses: mshick/add-pr-comment@v2.8.2
+      - uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
         if: always()
         with:
           message-id: changelog-entry-check

--- a/.github/workflows/codemention.yml
+++ b/.github/workflows/codemention.yml
@@ -1,5 +1,8 @@
 name: codemention
 on:
+  # pull_request_target is required so fork PRs get a write token to post the
+  # mention comment. Safe because there is no checkout — the action only reads
+  # PR metadata via the GitHub API; no fork code is fetched or executed.
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
 jobs:
@@ -9,6 +12,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: tobyhs/codemention@v1.4.0
+      # Pinned to a commit SHA (not the v1.4.0 tag) because this runs under
+      # pull_request_target with a write-scoped token — a re-pointed tag from
+      # a compromised upstream account would give the attacker repo write access.
+      - uses: tobyhs/codemention@bb6bfb2c3ff1e6fee7ee37006bbee6d114057225 # v1.4.0
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'incomplete issue: missing or invalid repro') }}"
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'incomplete issue: missing info') }}"
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.label.name == 'issue accepted'
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'invalid issue: question') }}"
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'invalid issue: feature request') }}"
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/move-eas-build-tag.yml
+++ b/.github/workflows/move-eas-build-tag.yml
@@ -29,7 +29,7 @@ jobs:
       INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
       INPUT_STAGING_ONLY: ${{ github.event.inputs.staging_only }}
     steps:
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           registry-url: "https://registry.npmjs.org/"
           scope: "expo"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -29,7 +29,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/setup-mise
       - name: Install dependencies
         run: yarn install --immutable
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.EXPO_BOT_PAT }}
       - uses: ./.github/actions/setup-mise
@@ -91,7 +91,7 @@ jobs:
           cat /tmp/changelog.slack.md >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2
         env:
           SLACK_CHANNEL: eas-cli
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -8,7 +8,7 @@ jobs:
   close-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da # v4
         with:
           ascending: false
           operations-per-run: 300

--- a/.github/workflows/test-graphql.yml
+++ b/.github/workflows/test-graphql.yml
@@ -17,7 +17,7 @@ jobs:
     name: Ensure GraphQL schema and generated code is up-to-date
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Setup tools
         uses: ./.github/actions/setup-mise
       - run: yarn install --immutable

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Setup tools
         uses: ./.github/actions/setup-mise
       - run: yarn install --immutable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
             coverage: true
     name: Test with Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Setup tools
         uses: ./.github/actions/setup-mise
         env:
@@ -66,7 +66,7 @@ jobs:
         working-directory: ./scripts
         env:
           YARN_ENABLE_HARDENED_MODE: ${{ matrix.coverage == true && '1' || '0' }}
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192 # v1
         if: ${{ matrix.coverage }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -79,7 +79,7 @@ jobs:
     name: Notify Slack
     if: ${{ github.ref == 'refs/heads/main' && always() }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Notify Slack
         uses: ./.github/internal-actions/notify-slack-on-fail-or-recover
         with:

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -22,7 +22,7 @@ jobs:
       INPUT_VERSION: ${{ github.event.inputs.version }}
       INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           fetch-depth: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [ci] Audit GitHub Actions workflows: harden `pull_request_target` usage, pin all external actions to commit SHAs, and add Dependabot to refresh them. ([#3718](https://github.com/expo/eas-cli/pull/3718) by [@brentvatne](https://github.com/brentvatne))
+
 ## [18.12.1](https://github.com/expo/eas-cli/releases/tag/v18.12.1) - 2026-05-12
 
 ## [18.12.0](https://github.com/expo/eas-cli/releases/tag/v18.12.0) - 2026-05-12


### PR DESCRIPTION
In a follow up, we should bump the external action commit SHAs to the latest versions - but I didn't want to change any behavior here