### PR TITLE
[build-tools] Send web preview URL in agent-device remote session config

### DIFF
--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -19,6 +19,7 @@ import {
   ensureBrewPackageInstalledAsync,
   getDeviceRunSessionIdOrThrow,
   spawnDetached,
+  startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
 } from '../utils/remoteDeviceRunSession';
 
@@ -107,18 +108,35 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       });
 
       logger.info('Waiting for a public tunnel URL.');
-      const tunnelUrl = await waitForMatchInOutputAsync({
+      const agentDeviceRemoteSessionUrl = await waitForMatchInOutputAsync({
         process: cloudflared,
         pattern: /https:\/\/[a-z0-9-]+\.trycloudflare\.com/,
         timeoutMs: STARTUP_TIMEOUT_MS,
         description: 'cloudflared tunnel',
       });
-      logger.info(`Tunnel is ready at ${tunnelUrl}.`);
+      logger.info(`Tunnel is ready at ${agentDeviceRemoteSessionUrl}.`);
+
+      // serve-sim is iOS-only — only launch it (and report a webPreviewUrl)
+      // on Darwin. Android sessions go without a preview URL.
+      let webPreviewUrl: string | undefined;
+      if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
+        const { previewUrl } = await startServeSimWithTunnelAsync({
+          env,
+          logger,
+          timeoutMs: STARTUP_TIMEOUT_MS,
+        });
+        webPreviewUrl = previewUrl;
+        logger.info(`Web preview URL: ${webPreviewUrl}`);
+      }
 
       await uploadRemoteSessionConfigAsync({
         ctx,
         deviceRunSessionId,
-        remoteConfig: { url: tunnelUrl, token: daemonToken },
+        remoteConfig: {
+          agentDeviceRemoteSessionUrl,
+          agentDeviceRemoteSessionToken: daemonToken,
+          ...(webPreviewUrl ? { webPreviewUrl } : {}),
+        },
         logger,
       });
 

--- a/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
@@ -1,20 +1,16 @@
-import { SystemError } from '@expo/eas-build-job';
 import { BuildFunction, BuildRuntimePlatform } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
 
 import { CustomBuildContext } from '../../customBuildContext';
-import { sleepAsync } from '../../utils/retry';
 import {
-  DetachedProcessHandle,
-  ensureBrewPackageInstalledAsync,
   getDeviceRunSessionIdOrThrow,
-  spawnDetached,
+  ensureBrewPackageInstalledAsync,
+  startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
 } from '../utils/remoteDeviceRunSession';
 
 const XCODE_DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer';
 const STARTUP_TIMEOUT_MS = 60_000;
-const TRYCLOUDFLARE_URL_PATTERN = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
 
 export function createStartServeSimRemoteSessionBuildFunction(
   ctx: CustomBuildContext
@@ -36,16 +32,9 @@ export function createStartServeSimRemoteSessionBuildFunction(
       logger.info('Ensuring cloudflared is installed.');
       await ensureBrewPackageInstalledAsync({ name: 'cloudflared', env, logger });
 
-      logger.info('Launching serve-sim with tunnel.');
-      const serveSim = spawnDetached({
-        command: 'npx',
-        args: ['serve-sim-szdziedzic@latest', '--tunnel'],
+      const { previewUrl, streamUrl } = await startServeSimWithTunnelAsync({
         env,
-      });
-
-      logger.info('Waiting for serve-sim to report tunnel and stream URLs.');
-      const { previewUrl, streamUrl } = await waitForServeSimUrlsAsync({
-        serveSim,
+        logger,
         timeoutMs: STARTUP_TIMEOUT_MS,
       });
       logger.info(`Preview URL: ${previewUrl}`);
@@ -64,32 +53,4 @@ export function createStartServeSimRemoteSessionBuildFunction(
       await new Promise<never>(() => {});
     },
   });
-}
-
-async function waitForServeSimUrlsAsync({
-  serveSim,
-  timeoutMs,
-}: {
-  serveSim: DetachedProcessHandle;
-  timeoutMs: number;
-}): Promise<{ previewUrl: string; streamUrl: string }> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const output = serveSim.getOutput();
-    const previewUrl = matchLabeledUrl(output, 'Tunnel');
-    const streamUrl = matchLabeledUrl(output, 'Stream');
-    if (previewUrl && streamUrl) {
-      return { previewUrl, streamUrl };
-    }
-    await sleepAsync(1_000);
-  }
-  throw new SystemError(
-    `Timed out waiting for serve-sim to report Tunnel and Stream URLs. Last output:\n${serveSim.getOutput() || '<empty>'}`
-  );
-}
-
-function matchLabeledUrl(content: string, label: string): string | null {
-  const labelPattern = new RegExp(`${label}:\\s*(${TRYCLOUDFLARE_URL_PATTERN.source})`);
-  const match = labelPattern.exec(content);
-  return match ? match[1] : null;
 }

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -5,6 +5,9 @@ import spawn from '@expo/turtle-spawn';
 import { graphql } from 'gql.tada';
 
 import { CustomBuildContext } from '../../customBuildContext';
+import { sleepAsync } from '../../utils/retry';
+
+const TRYCLOUDFLARE_URL_PATTERN = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
 
 const START_DEVICE_RUN_SESSION_MUTATION = graphql(`
   mutation StartDeviceRunSession($deviceRunSessionId: ID!, $remoteConfig: JSONObject!) {
@@ -106,4 +109,42 @@ export function spawnDetached({
   promise.child.stderr?.on('data', appendChunk);
 
   return { getOutput: () => output };
+}
+
+export async function startServeSimWithTunnelAsync({
+  env,
+  logger,
+  timeoutMs,
+}: {
+  env: BuildStepEnv;
+  logger: bunyan;
+  timeoutMs: number;
+}): Promise<{ previewUrl: string; streamUrl: string }> {
+  logger.info('Launching serve-sim with tunnel.');
+  const serveSim = spawnDetached({
+    command: 'npx',
+    args: ['serve-sim-szdziedzic@latest', '--tunnel'],
+    env,
+  });
+
+  logger.info('Waiting for serve-sim to report tunnel and stream URLs.');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const output = serveSim.getOutput();
+    const previewUrl = matchLabeledUrl(output, 'Tunnel');
+    const streamUrl = matchLabeledUrl(output, 'Stream');
+    if (previewUrl && streamUrl) {
+      return { previewUrl, streamUrl };
+    }
+    await sleepAsync(1_000);
+  }
+  throw new SystemError(
+    `Timed out waiting for serve-sim to report Tunnel and Stream URLs. Last output:\n${serveSim.getOutput() || '<empty>'}`
+  );
+}
+
+function matchLabeledUrl(content: string, label: string): string | null {
+  const labelPattern = new RegExp(`${label}:\\s*(${TRYCLOUDFLARE_URL_PATTERN.source})`);
+  const match = labelPattern.exec(content);
+  return match ? match[1] : null;
 }


### PR DESCRIPTION
# Why

Companion to https://github.com/expo/universe/pull/27461. Start both serve-sim and agent-device session.

# How

- On Darwin, after the agent-device daemon + cloudflared tunnel are up, also launch `serve-sim --tunnel` and capture its preview URL.
- Report `{ agentDeviceRemoteSessionUrl, agentDeviceRemoteSessionToken, webPreviewUrl? }` via `startDeviceRunSession`. `webPreviewUrl` is omitted on Linux/Android (serve-sim is iOS-only).
- Extract the serve-sim launch + URL-wait into a shared helper (`startServeSimWithTunnelAsync`) so `startServeSimRemoteSession` and `startAgentDeviceRemoteSession` share one implementation.

