### PR TITLE
[eas-cli] Add observe:routes for navigation metrics by route name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] New command `observe:routes` for navigation metrics. ([#3730](https://github.com/expo/eas-cli/pull/3730) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -28668,6 +28668,18 @@
             "deprecationReason": null
           },
           {
+            "name": "expoPackageVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "fingerprintHash",
             "description": null,
             "type": {

--- a/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
@@ -1,0 +1,167 @@
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { getMockOclifConfig } from '../../../__tests__/commands/utils';
+import { AppPlatform } from '../../../graphql/generated';
+import { fetchObserveNavigationRoutesAsync } from '../../../observe/fetchNavigationRoutes';
+import {
+  buildObserveNavigationRoutesJson,
+  buildObserveNavigationRoutesTable,
+} from '../../../observe/formatNavigationRoutes';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+import ObserveRoutes from '../routes';
+
+jest.mock('../../../observe/fetchNavigationRoutes');
+jest.mock('../../../observe/formatNavigationRoutes', () => {
+  const actual = jest.requireActual('../../../observe/formatNavigationRoutes');
+  return {
+    ...actual,
+    buildObserveNavigationRoutesTable: jest.fn().mockReturnValue('table'),
+    buildObserveNavigationRoutesJson: jest.fn().mockReturnValue({}),
+  };
+});
+jest.mock('../../../log');
+jest.mock('../../../utils/json');
+
+const mockFetchObserveNavigationRoutesAsync = jest.mocked(fetchObserveNavigationRoutesAsync);
+const mockBuildObserveNavigationRoutesTable = jest.mocked(buildObserveNavigationRoutesTable);
+const mockBuildObserveNavigationRoutesJson = jest.mocked(buildObserveNavigationRoutesJson);
+const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
+const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
+
+describe(ObserveRoutes, () => {
+  const graphqlClient = {} as any as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+  const projectId = 'test-project-id';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchObserveNavigationRoutesAsync.mockResolvedValue({
+      routes: [],
+      pageInfoByPlatform: new Map(),
+    });
+  });
+
+  function createCommand(argv: string[]): ObserveRoutes {
+    const command = new ObserveRoutes(argv, mockConfig);
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      projectId,
+      loggedIn: { graphqlClient },
+    });
+    return command;
+  }
+
+  it('queries both platforms by default with default metric keys', async () => {
+    const command = createCommand([]);
+    await command.runAsync();
+
+    expect(mockFetchObserveNavigationRoutesAsync).toHaveBeenCalledTimes(1);
+    const options = mockFetchObserveNavigationRoutesAsync.mock.calls[0][2];
+    expect(options.platforms).toEqual([AppPlatform.Android, AppPlatform.Ios]);
+    expect(options.limit).toBe(50);
+
+    const tableCall = mockBuildObserveNavigationRoutesTable.mock.calls[0];
+    expect(tableCall[1]).toEqual(['coldTtr', 'warmTtr', 'tti']);
+    expect(tableCall[2]).toEqual(['median', 'count']);
+  });
+
+  it('filters platform when --platform ios is provided', async () => {
+    const command = createCommand(['--platform', 'ios']);
+    await command.runAsync();
+
+    const options = mockFetchObserveNavigationRoutesAsync.mock.calls[0][2];
+    expect(options.platforms).toEqual([AppPlatform.Ios]);
+  });
+
+  it('resolves --metric aliases to navigation metric keys and deduplicates', async () => {
+    const command = createCommand([
+      '--metric',
+      'cold_ttr',
+      '--metric',
+      'expo.navigation.cold_ttr',
+      '--metric',
+      'tti',
+    ]);
+    await command.runAsync();
+
+    expect(mockBuildObserveNavigationRoutesTable.mock.calls[0][1]).toEqual(['coldTtr', 'tti']);
+  });
+
+  it('passes --limit and --after through to the fetcher', async () => {
+    const command = createCommand(['--limit', '25', '--after', 'cursor-abc']);
+    await command.runAsync();
+
+    const options = mockFetchObserveNavigationRoutesAsync.mock.calls[0][2];
+    expect(options.limit).toBe(25);
+    expect(options.after).toBe('cursor-abc');
+  });
+
+  it('uses --days to compute start/end time range', async () => {
+    const now = new Date('2025-06-15T12:00:00.000Z');
+    jest.useFakeTimers({ now });
+
+    const command = createCommand(['--days', '7']);
+    await command.runAsync();
+
+    const options = mockFetchObserveNavigationRoutesAsync.mock.calls[0][2];
+    expect(options.endTime).toBe('2025-06-15T12:00:00.000Z');
+    expect(options.startTime).toBe('2025-06-08T12:00:00.000Z');
+
+    jest.useRealTimers();
+  });
+
+  it('uses explicit --start and --end when provided', async () => {
+    const command = createCommand([
+      '--start',
+      '2025-01-01T00:00:00.000Z',
+      '--end',
+      '2025-02-01T00:00:00.000Z',
+    ]);
+    await command.runAsync();
+
+    const options = mockFetchObserveNavigationRoutesAsync.mock.calls[0][2];
+    expect(options.startTime).toBe('2025-01-01T00:00:00.000Z');
+    expect(options.endTime).toBe('2025-02-01T00:00:00.000Z');
+  });
+
+  it('rejects --days combined with --start', async () => {
+    const command = createCommand(['--days', '7', '--start', '2025-01-01T00:00:00.000Z']);
+    await expect(command.runAsync()).rejects.toThrow();
+  });
+
+  it('passes app-version, update-id, and build-number filters', async () => {
+    const command = createCommand([
+      '--app-version',
+      '2.1.0',
+      '--update-id',
+      'update-xyz',
+      '--build-number',
+      '42',
+    ]);
+    await command.runAsync();
+
+    const options = mockFetchObserveNavigationRoutesAsync.mock.calls[0][2];
+    expect(options.appVersion).toBe('2.1.0');
+    expect(options.updateId).toBe('update-xyz');
+    expect(options.buildNumber).toBe('42');
+  });
+
+  it('resolves --stat aliases and passes them through', async () => {
+    const command = createCommand(['--stat', 'p90', '--stat', 'eventCount']);
+    await command.runAsync();
+
+    expect(mockBuildObserveNavigationRoutesTable.mock.calls[0][2]).toEqual(['p90', 'count']);
+  });
+
+  it('uses default JSON stats (median, p90, count) when --json is set without --stat', async () => {
+    const command = createCommand(['--json', '--non-interactive']);
+    await command.runAsync();
+
+    expect(mockEnableJsonOutput).toHaveBeenCalled();
+    expect(mockBuildObserveNavigationRoutesJson.mock.calls[0][2]).toEqual([
+      'median',
+      'p90',
+      'count',
+    ]);
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
@@ -50,7 +50,7 @@ describe(ObserveRoutes, () => {
     return command;
   }
 
-  it('queries both platforms by default with default metric keys', async () => {
+  it('queries both platforms by default with all three navigation metric full names', async () => {
     const command = createCommand([]);
     await command.runAsync();
 
@@ -60,7 +60,11 @@ describe(ObserveRoutes, () => {
     expect(options.limit).toBe(50);
 
     const tableCall = mockBuildObserveNavigationRoutesTable.mock.calls[0];
-    expect(tableCall[1]).toEqual(['coldTtr', 'warmTtr', 'tti']);
+    expect(tableCall[1]).toEqual([
+      'expo.navigation.cold_ttr',
+      'expo.navigation.warm_ttr',
+      'expo.navigation.tti',
+    ]);
     expect(tableCall[2]).toEqual(['median', 'count']);
   });
 
@@ -72,18 +76,21 @@ describe(ObserveRoutes, () => {
     expect(options.platforms).toEqual([AppPlatform.Ios]);
   });
 
-  it('resolves --metric aliases to navigation metric keys and deduplicates', async () => {
+  it('resolves --metric short aliases to navigation metric full names and deduplicates', async () => {
     const command = createCommand([
       '--metric',
       'cold_ttr',
       '--metric',
-      'expo.navigation.cold_ttr',
+      'cold_ttr',
       '--metric',
-      'tti',
+      'nav_tti',
     ]);
     await command.runAsync();
 
-    expect(mockBuildObserveNavigationRoutesTable.mock.calls[0][1]).toEqual(['coldTtr', 'tti']);
+    expect(mockBuildObserveNavigationRoutesTable.mock.calls[0][1]).toEqual([
+      'expo.navigation.cold_ttr',
+      'expo.navigation.tti',
+    ]);
   });
 
   it('passes --limit and --after through to the fetcher', async () => {

--- a/packages/eas-cli/src/commands/observe/routes.ts
+++ b/packages/eas-cli/src/commands/observe/routes.ts
@@ -1,0 +1,170 @@
+import { Flags } from '@oclif/core';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
+import { getLimitFlagWithCustomValues } from '../../commandUtils/pagination';
+import Log from '../../log';
+import { fetchObserveNavigationRoutesAsync } from '../../observe/fetchNavigationRoutes';
+import {
+  NAVIGATION_METRICS,
+  NavigationMetricKey,
+  NavigationStatKey,
+  buildObserveNavigationRoutesJson,
+  buildObserveNavigationRoutesTable,
+  resolveNavigationMetricKey,
+  resolveNavigationStatKey,
+} from '../../observe/formatNavigationRoutes';
+import { allowedPlatformFlagValues, appPlatformsFromFlag } from '../../observe/platforms';
+import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
+import { resolveTimeRange } from '../../observe/startAndEndTime';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+
+const DEFAULT_ROUTES_LIMIT = 50;
+
+const DEFAULT_METRIC_KEYS: NavigationMetricKey[] = NAVIGATION_METRICS.map(m => m.key);
+
+const METRIC_ALIAS_OPTIONS = [
+  'cold_ttr',
+  'warm_ttr',
+  'tti',
+  'nav_cold_ttr',
+  'nav_warm_ttr',
+  'nav_tti',
+  'expo.navigation.cold_ttr',
+  'expo.navigation.warm_ttr',
+  'expo.navigation.tti',
+];
+
+const STAT_OPTIONS = ['median', 'med', 'p90', 'count', 'event_count', 'eventCount'];
+
+const DEFAULT_STATS_TABLE: NavigationStatKey[] = ['median', 'count'];
+const DEFAULT_STATS_JSON: NavigationStatKey[] = ['median', 'p90', 'count'];
+
+export default class ObserveRoutes extends EasCommand {
+  static override hidden = true;
+  static override description =
+    'display app navigation route metrics (Cold TTR, Warm TTR, TTI) grouped by route name';
+
+  static override flags = {
+    platform: Flags.option({
+      description: 'Filter by platform',
+      options: allowedPlatformFlagValues,
+    })(),
+    metric: Flags.option({
+      description:
+        'Navigation metric to display (can be specified multiple times). Defaults to all three.',
+      multiple: true,
+      options: METRIC_ALIAS_OPTIONS,
+    })(),
+    stat: Flags.option({
+      description: 'Statistic to display per metric (can be specified multiple times)',
+      multiple: true,
+      options: STAT_OPTIONS,
+    })(),
+    after: Flags.string({
+      description:
+        'Cursor for pagination. Use the endCursor from a previous query to fetch the next page.',
+    }),
+    limit: getLimitFlagWithCustomValues({
+      defaultTo: DEFAULT_ROUTES_LIMIT,
+      limit: 200,
+    }),
+    start: Flags.string({
+      description: 'Start of time range (ISO date)',
+      exclusive: ['days'],
+    }),
+    end: Flags.string({
+      description: 'End of time range (ISO date)',
+      exclusive: ['days'],
+    }),
+    days: Flags.integer({
+      description: 'Show routes from the last N days (mutually exclusive with --start/--end)',
+      min: 1,
+      exclusive: ['start', 'end'],
+    }),
+    'app-version': Flags.string({
+      description: 'Filter by app version',
+    }),
+    'update-id': Flags.string({
+      description: 'Filter by EAS update ID',
+    }),
+    'build-number': Flags.string({
+      description: 'Filter by app build number',
+    }),
+    'project-id': Flags.string({
+      description: 'EAS project ID (defaults to the project ID of the current directory)',
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectId,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  private static loggedInOnlyContextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(ObserveRoutes);
+
+    const { projectId, graphqlClient } = await resolveObserveCommandContextAsync({
+      command: this,
+      commandClass: ObserveRoutes,
+      loggedInOnlyContextDefinition: ObserveRoutes.loggedInOnlyContextDefinition,
+      projectIdOverride: flags['project-id'],
+      nonInteractive: flags['non-interactive'],
+    });
+
+    if (flags.json) {
+      enableJsonOutput();
+    } else {
+      Log.warn('EAS Observe is in preview and subject to breaking changes.');
+    }
+
+    const metricKeys: NavigationMetricKey[] = flags.metric?.length
+      ? Array.from(new Set(flags.metric.map(resolveNavigationMetricKey)))
+      : DEFAULT_METRIC_KEYS;
+
+    const argumentsStat = flags.stat?.length
+      ? Array.from(new Set(flags.stat.map(resolveNavigationStatKey)))
+      : undefined;
+
+    const { daysBack, startTime, endTime } = resolveTimeRange(flags);
+    const platforms = appPlatformsFromFlag(flags.platform);
+
+    const { routes, pageInfoByPlatform } = await fetchObserveNavigationRoutesAsync(
+      graphqlClient,
+      projectId,
+      {
+        startTime,
+        endTime,
+        platforms,
+        limit: flags.limit ?? DEFAULT_ROUTES_LIMIT,
+        ...(flags.after && { after: flags.after }),
+        appVersion: flags['app-version'],
+        updateId: flags['update-id'],
+        buildNumber: flags['build-number'],
+      }
+    );
+
+    if (flags.json) {
+      const stats = argumentsStat ?? DEFAULT_STATS_JSON;
+      printJsonOnlyOutput(
+        buildObserveNavigationRoutesJson(routes, metricKeys, stats, pageInfoByPlatform)
+      );
+    } else {
+      const stats = argumentsStat ?? DEFAULT_STATS_TABLE;
+      Log.addNewLineIfNone();
+      Log.log(
+        buildObserveNavigationRoutesTable(routes, metricKeys, stats, {
+          daysBack,
+          startTime,
+          endTime,
+          pageInfoByPlatform,
+        })
+      );
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/observe/routes.ts
+++ b/packages/eas-cli/src/commands/observe/routes.ts
@@ -6,34 +6,19 @@ import { getLimitFlagWithCustomValues } from '../../commandUtils/pagination';
 import Log from '../../log';
 import { fetchObserveNavigationRoutesAsync } from '../../observe/fetchNavigationRoutes';
 import {
-  NAVIGATION_METRICS,
-  NavigationMetricKey,
+  NAVIGATION_METRIC_NAMES,
   NavigationStatKey,
   buildObserveNavigationRoutesJson,
   buildObserveNavigationRoutesTable,
-  resolveNavigationMetricKey,
   resolveNavigationStatKey,
 } from '../../observe/formatNavigationRoutes';
+import { NAVIGATION_METRIC_ALIASES, resolveNavigationMetricName } from '../../observe/metricNames';
 import { allowedPlatformFlagValues, appPlatformsFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 const DEFAULT_ROUTES_LIMIT = 50;
-
-const DEFAULT_METRIC_KEYS: NavigationMetricKey[] = NAVIGATION_METRICS.map(m => m.key);
-
-const METRIC_ALIAS_OPTIONS = [
-  'cold_ttr',
-  'warm_ttr',
-  'tti',
-  'nav_cold_ttr',
-  'nav_warm_ttr',
-  'nav_tti',
-  'expo.navigation.cold_ttr',
-  'expo.navigation.warm_ttr',
-  'expo.navigation.tti',
-];
 
 const STAT_OPTIONS = ['median', 'med', 'p90', 'count', 'event_count', 'eventCount'];
 
@@ -54,7 +39,7 @@ export default class ObserveRoutes extends EasCommand {
       description:
         'Navigation metric to display (can be specified multiple times). Defaults to all three.',
       multiple: true,
-      options: METRIC_ALIAS_OPTIONS,
+      options: Object.keys(NAVIGATION_METRIC_ALIASES),
     })(),
     stat: Flags.option({
       description: 'Statistic to display per metric (can be specified multiple times)',
@@ -123,9 +108,9 @@ export default class ObserveRoutes extends EasCommand {
       Log.warn('EAS Observe is in preview and subject to breaking changes.');
     }
 
-    const metricKeys: NavigationMetricKey[] = flags.metric?.length
-      ? Array.from(new Set(flags.metric.map(resolveNavigationMetricKey)))
-      : DEFAULT_METRIC_KEYS;
+    const metricNames = flags.metric?.length
+      ? Array.from(new Set(flags.metric.map(resolveNavigationMetricName)))
+      : NAVIGATION_METRIC_NAMES;
 
     const argumentsStat = flags.stat?.length
       ? Array.from(new Set(flags.stat.map(resolveNavigationStatKey)))
@@ -152,13 +137,13 @@ export default class ObserveRoutes extends EasCommand {
     if (flags.json) {
       const stats = argumentsStat ?? DEFAULT_STATS_JSON;
       printJsonOnlyOutput(
-        buildObserveNavigationRoutesJson(routes, metricKeys, stats, pageInfoByPlatform)
+        buildObserveNavigationRoutesJson(routes, metricNames, stats, pageInfoByPlatform)
       );
     } else {
       const stats = argumentsStat ?? DEFAULT_STATS_TABLE;
       Log.addNewLineIfNone();
       Log.log(
-        buildObserveNavigationRoutesTable(routes, metricKeys, stats, {
+        buildObserveNavigationRoutesTable(routes, metricNames, stats, {
           daysBack,
           startTime,
           endTime,

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4029,6 +4029,7 @@ export type BuildMetadataInput = {
   developmentClient?: InputMaybe<Scalars['Boolean']['input']>;
   distribution?: InputMaybe<DistributionType>;
   environment?: InputMaybe<Scalars['String']['input']>;
+  expoPackageVersion?: InputMaybe<Scalars['String']['input']>;
   fingerprintHash?: InputMaybe<Scalars['String']['input']>;
   fingerprintSource?: InputMaybe<FingerprintSourceInput>;
   gitCommitHash?: InputMaybe<Scalars['String']['input']>;
@@ -12902,6 +12903,17 @@ export type AppObserveCustomEventNamesQueryVariables = Exact<{
 
 
 export type AppObserveCustomEventNamesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', customEventNames: { __typename?: 'AppObserveCustomEventNames', isTruncated: boolean, names: Array<{ __typename?: 'AppObserveCustomEventName', eventName: string, count: number }> } } } } };
+
+export type AppObserveNavigationRoutesQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+  filter: AppObserveNavigationRoutesFilter;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  orderBy?: InputMaybe<AppObserveNavigationRoutesOrderBy>;
+}>;
+
+
+export type AppObserveNavigationRoutesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', navigationRoutes: { __typename?: 'AppObserveNavigationRoutesConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveNavigationRouteEdge', cursor: string, node: { __typename?: 'AppObserveNavigationRoute', routeName: string, coldTtr: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null }, warmTtr: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null }, tti: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null } } }> } } } } };
 
 export type GetAssetMetadataQueryVariables = Exact<{
   storageKeys: Array<Scalars['String']['input']> | Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
@@ -10,6 +10,9 @@ import {
   AppObserveEvent,
   AppObserveEventsFilter,
   AppObserveEventsOrderBy,
+  AppObserveNavigationRoute,
+  AppObserveNavigationRoutesFilter,
+  AppObserveNavigationRoutesOrderBy,
   AppObservePlatform,
   AppObserveReleasesInput,
   AppObserveTimeSeriesInput,
@@ -131,6 +134,31 @@ type AppObserveCustomEventNamesQueryVariables = {
   endTime: string;
   platform?: AppObservePlatform;
   environment?: string;
+};
+
+type AppObserveNavigationRoutesQuery = {
+  app: {
+    byId: {
+      id: string;
+      observe: {
+        navigationRoutes: {
+          pageInfo: PageInfo;
+          edges: Array<{
+            cursor: string;
+            node: AppObserveNavigationRoute;
+          }>;
+        };
+      };
+    };
+  };
+};
+
+type AppObserveNavigationRoutesQueryVariables = {
+  appId: string;
+  filter: AppObserveNavigationRoutesFilter;
+  first?: number;
+  after?: string;
+  orderBy?: AppObserveNavigationRoutesOrderBy;
 };
 
 export const ObserveQuery = {
@@ -397,5 +425,69 @@ export const ObserveQuery = {
     );
 
     return data.app.byId.observe.customEventNames;
+  },
+
+  async navigationRoutesAsync(
+    graphqlClient: ExpoGraphqlClient,
+    variables: AppObserveNavigationRoutesQueryVariables
+  ): Promise<{ routes: AppObserveNavigationRoute[]; pageInfo: PageInfo }> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<AppObserveNavigationRoutesQuery, AppObserveNavigationRoutesQueryVariables>(
+          gql`
+            query AppObserveNavigationRoutes(
+              $appId: String!
+              $filter: AppObserveNavigationRoutesFilter!
+              $first: Int
+              $after: String
+              $orderBy: AppObserveNavigationRoutesOrderBy
+            ) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  observe {
+                    navigationRoutes(filter: $filter, first: $first, after: $after, orderBy: $orderBy) {
+                      pageInfo {
+                        hasNextPage
+                        hasPreviousPage
+                        endCursor
+                      }
+                      edges {
+                        cursor
+                        node {
+                          routeName
+                          coldTtr {
+                            count
+                            median
+                            p90
+                          }
+                          warmTtr {
+                            count
+                            median
+                            p90
+                          }
+                          tti {
+                            count
+                            median
+                            p90
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          `,
+          variables
+        )
+        .toPromise()
+    );
+
+    const { edges, pageInfo } = data.app.byId.observe.navigationRoutes;
+    return {
+      routes: edges.map(edge => edge.node),
+      pageInfo,
+    };
   },
 };

--- a/packages/eas-cli/src/observe/__tests__/fetchNavigationRoutes.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchNavigationRoutes.test.ts
@@ -1,0 +1,162 @@
+import {
+  AppObserveEventsOrderByDirection,
+  AppObserveNavigationRoute,
+  AppObserveNavigationRoutesOrderByField,
+  AppObservePlatform,
+  AppPlatform,
+} from '../../graphql/generated';
+import { ObserveQuery } from '../../graphql/queries/ObserveQuery';
+import { fetchObserveNavigationRoutesAsync } from '../fetchNavigationRoutes';
+
+jest.mock('../../graphql/queries/ObserveQuery');
+jest.mock('../../log');
+
+function makeRoute(routeName: string): AppObserveNavigationRoute {
+  return {
+    __typename: 'AppObserveNavigationRoute' as const,
+    routeName,
+    coldTtr: { __typename: 'AppObserveNavigationStat' as const, count: 10, median: 0.5, p90: 0.9 },
+    warmTtr: { __typename: 'AppObserveNavigationStat' as const, count: 8, median: 0.3, p90: 0.6 },
+    tti: { __typename: 'AppObserveNavigationStat' as const, count: 12, median: 0.45, p90: 0.7 },
+  };
+}
+
+describe('fetchObserveNavigationRoutesAsync', () => {
+  const mockNavigationRoutesAsync = jest.mocked(ObserveQuery.navigationRoutesAsync);
+  const mockGraphqlClient = {} as any;
+
+  beforeEach(() => {
+    mockNavigationRoutesAsync.mockClear();
+    mockNavigationRoutesAsync.mockResolvedValue({
+      routes: [],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    });
+  });
+
+  it('passes appId, time range, limit, and filter values for each platform', async () => {
+    await fetchObserveNavigationRoutesAsync(mockGraphqlClient, 'project-123', {
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+      platforms: [AppPlatform.Ios],
+      limit: 25,
+      appVersion: '2.1.0',
+      updateId: 'update-xyz',
+      buildNumber: '42',
+    });
+
+    expect(mockNavigationRoutesAsync).toHaveBeenCalledTimes(1);
+    const call = mockNavigationRoutesAsync.mock.calls[0][1];
+    expect(call.appId).toBe('project-123');
+    expect(call.first).toBe(25);
+    expect(call.filter).toEqual({
+      platform: AppObservePlatform.Ios,
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+      appVersion: '2.1.0',
+      appUpdateId: 'update-xyz',
+      appBuildNumber: '42',
+    });
+  });
+
+  it('defaults orderBy to NAVIGATION_COUNT DESC', async () => {
+    await fetchObserveNavigationRoutesAsync(mockGraphqlClient, 'project-123', {
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+      platforms: [AppPlatform.Ios],
+      limit: 50,
+    });
+
+    const call = mockNavigationRoutesAsync.mock.calls[0][1];
+    expect(call.orderBy).toEqual({
+      field: AppObserveNavigationRoutesOrderByField.NavigationCount,
+      direction: AppObserveEventsOrderByDirection.Desc,
+    });
+  });
+
+  it('does not send optional filters when not provided', async () => {
+    await fetchObserveNavigationRoutesAsync(mockGraphqlClient, 'project-123', {
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+      platforms: [AppPlatform.Ios],
+      limit: 50,
+    });
+
+    const filter = mockNavigationRoutesAsync.mock.calls[0][1].filter;
+    expect(filter).not.toHaveProperty('appVersion');
+    expect(filter).not.toHaveProperty('appUpdateId');
+    expect(filter).not.toHaveProperty('appBuildNumber');
+  });
+
+  it('forwards after cursor when provided', async () => {
+    await fetchObserveNavigationRoutesAsync(mockGraphqlClient, 'project-123', {
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+      platforms: [AppPlatform.Ios],
+      limit: 50,
+      after: 'cursor-abc',
+    });
+
+    expect(mockNavigationRoutesAsync.mock.calls[0][1].after).toBe('cursor-abc');
+  });
+
+  it('fans out across multiple platforms and tags each route with its platform', async () => {
+    mockNavigationRoutesAsync.mockImplementation(async (_client, vars) => {
+      if (vars.filter.platform === AppObservePlatform.Android) {
+        return {
+          routes: [makeRoute('/android-home')],
+          pageInfo: { hasNextPage: false, hasPreviousPage: false },
+        };
+      }
+      return {
+        routes: [makeRoute('/ios-home')],
+        pageInfo: { hasNextPage: true, hasPreviousPage: false, endCursor: 'ios-cursor' },
+      };
+    });
+
+    const { routes, pageInfoByPlatform } = await fetchObserveNavigationRoutesAsync(
+      mockGraphqlClient,
+      'project-123',
+      {
+        startTime: '2025-01-01T00:00:00.000Z',
+        endTime: '2025-03-01T00:00:00.000Z',
+        platforms: [AppPlatform.Ios, AppPlatform.Android],
+        limit: 50,
+      }
+    );
+
+    expect(mockNavigationRoutesAsync).toHaveBeenCalledTimes(2);
+    expect(routes).toHaveLength(2);
+    const byName = new Map(routes.map(r => [r.route.routeName, r.platform]));
+    expect(byName.get('/android-home')).toBe(AppPlatform.Android);
+    expect(byName.get('/ios-home')).toBe(AppPlatform.Ios);
+    expect(pageInfoByPlatform.get(AppPlatform.Ios)?.hasNextPage).toBe(true);
+    expect(pageInfoByPlatform.get(AppPlatform.Android)?.hasNextPage).toBe(false);
+  });
+
+  it('handles partial failures gracefully', async () => {
+    mockNavigationRoutesAsync.mockImplementation(async (_client, vars) => {
+      if (vars.filter.platform === AppObservePlatform.Android) {
+        throw new Error('Network error');
+      }
+      return {
+        routes: [makeRoute('/home')],
+        pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      };
+    });
+
+    const { routes, pageInfoByPlatform } = await fetchObserveNavigationRoutesAsync(
+      mockGraphqlClient,
+      'project-123',
+      {
+        startTime: '2025-01-01T00:00:00.000Z',
+        endTime: '2025-03-01T00:00:00.000Z',
+        platforms: [AppPlatform.Ios, AppPlatform.Android],
+        limit: 50,
+      }
+    );
+
+    expect(routes).toHaveLength(1);
+    expect(routes[0].platform).toBe(AppPlatform.Ios);
+    expect(pageInfoByPlatform.has(AppPlatform.Android)).toBe(false);
+  });
+});

--- a/packages/eas-cli/src/observe/__tests__/formatMetrics.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatMetrics.test.ts
@@ -71,12 +71,12 @@ describe(buildObserveMetricsTable, () => {
 "[1mMed values (event count)[22m
 
 [1miOS[22m
-[1mApp Version  Cold Launch  TTI       [22m
------------  -----------  ----------
-1.2.0        0.35s (110)  1.32s (90)
+[1mApp Version  Cold Launch  Startup TTI[22m
+-----------  -----------  -----------
+1.2.0        0.35s (110)  1.32s (90) 
 
 [1mAndroid[22m
-[1mApp Version  Cold Launch  TTI        [22m
+[1mApp Version  Cold Launch  Startup TTI[22m
 -----------  -----------  -----------
 1.1.0        0.25s (120)  1.12s (100)"
 `);
@@ -93,9 +93,9 @@ describe(buildObserveMetricsTable, () => {
 "[1mMed values (event count)[22m
 
 [1miOS[22m
-[1mApp Version  Cold Launch  TTI  [22m
------------  -----------  -----
-2.0.0        - (-)        - (-)"
+[1mApp Version  Cold Launch  Startup TTI[22m
+-----------  -----------  -----------
+2.0.0        - (-)        - (-)      "
 `);
   });
 

--- a/packages/eas-cli/src/observe/__tests__/formatNavigationRoutes.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatNavigationRoutes.test.ts
@@ -1,0 +1,199 @@
+import { AppPlatform } from '../../graphql/generated';
+import { NavigationRouteWithPlatform } from '../fetchNavigationRoutes';
+import {
+  buildObserveNavigationRoutesJson,
+  buildObserveNavigationRoutesTable,
+  resolveNavigationMetricKey,
+  resolveNavigationStatKey,
+} from '../formatNavigationRoutes';
+
+function makeRoute(
+  routeName: string,
+  platform: AppPlatform,
+  overrides?: Partial<{
+    coldTtr: { count: number; median: number | null; p90: number | null };
+    warmTtr: { count: number; median: number | null; p90: number | null };
+    tti: { count: number; median: number | null; p90: number | null };
+  }>
+): NavigationRouteWithPlatform {
+  return {
+    platform,
+    route: {
+      __typename: 'AppObserveNavigationRoute' as const,
+      routeName,
+      coldTtr: {
+        __typename: 'AppObserveNavigationStat' as const,
+        count: 10,
+        median: 0.5,
+        p90: 0.9,
+        ...overrides?.coldTtr,
+      },
+      warmTtr: {
+        __typename: 'AppObserveNavigationStat' as const,
+        count: 8,
+        median: 0.3,
+        p90: 0.6,
+        ...overrides?.warmTtr,
+      },
+      tti: {
+        __typename: 'AppObserveNavigationStat' as const,
+        count: 12,
+        median: 0.45,
+        p90: 0.7,
+        ...overrides?.tti,
+      },
+    },
+  };
+}
+
+describe(resolveNavigationMetricKey, () => {
+  it('resolves short, alias, and full names to canonical keys', () => {
+    expect(resolveNavigationMetricKey('cold_ttr')).toBe('coldTtr');
+    expect(resolveNavigationMetricKey('nav_cold_ttr')).toBe('coldTtr');
+    expect(resolveNavigationMetricKey('expo.navigation.cold_ttr')).toBe('coldTtr');
+    expect(resolveNavigationMetricKey('warm_ttr')).toBe('warmTtr');
+    expect(resolveNavigationMetricKey('nav_warm_ttr')).toBe('warmTtr');
+    expect(resolveNavigationMetricKey('expo.navigation.warm_ttr')).toBe('warmTtr');
+    expect(resolveNavigationMetricKey('tti')).toBe('tti');
+    expect(resolveNavigationMetricKey('nav_tti')).toBe('tti');
+    expect(resolveNavigationMetricKey('expo.navigation.tti')).toBe('tti');
+  });
+
+  it('throws on unknown metric', () => {
+    expect(() => resolveNavigationMetricKey('foo')).toThrow('Unknown navigation metric');
+  });
+});
+
+describe(resolveNavigationStatKey, () => {
+  it('resolves aliases', () => {
+    expect(resolveNavigationStatKey('med')).toBe('median');
+    expect(resolveNavigationStatKey('median')).toBe('median');
+    expect(resolveNavigationStatKey('p90')).toBe('p90');
+    expect(resolveNavigationStatKey('count')).toBe('count');
+    expect(resolveNavigationStatKey('eventCount')).toBe('count');
+    expect(resolveNavigationStatKey('event_count')).toBe('count');
+  });
+
+  it('throws on unknown stat', () => {
+    expect(() => resolveNavigationStatKey('min')).toThrow('Unknown statistic');
+  });
+});
+
+describe(buildObserveNavigationRoutesTable, () => {
+  it('returns a yellow warning when no routes are present', () => {
+    const output = buildObserveNavigationRoutesTable([], ['coldTtr'], ['median', 'count']);
+    expect(output).toContain('No navigation routes found.');
+  });
+
+  it('formats routes grouped by platform with merged (med + count) cells', () => {
+    const routes = [
+      makeRoute('/home', AppPlatform.Ios),
+      makeRoute('/profile', AppPlatform.Ios, {
+        coldTtr: { count: 5, median: 0.7, p90: 1.0 },
+      }),
+      makeRoute('/home', AppPlatform.Android),
+    ];
+
+    const output = buildObserveNavigationRoutesTable(
+      routes,
+      ['coldTtr', 'warmTtr', 'tti'],
+      ['median', 'count'],
+      { daysBack: 7 }
+    );
+
+    expect(output).toContain('Med values (navigation count) for the last 7 days');
+    expect(output).toContain('Cold TTR');
+    expect(output).toContain('Warm TTR');
+    expect(output).toContain('TTI');
+    expect(output).toContain('/home');
+    expect(output).toContain('/profile');
+    expect(output).toContain('0.50s (10)');
+    expect(output).toContain('0.70s (5)');
+    expect(output).toContain('iOS');
+    expect(output).toContain('Android');
+  });
+
+  it('renders separate columns when count is omitted from stats', () => {
+    const routes = [makeRoute('/home', AppPlatform.Ios)];
+    const output = buildObserveNavigationRoutesTable(routes, ['coldTtr'], ['median', 'p90']);
+
+    expect(output).toContain('Med, P90 values');
+    expect(output).toContain('Cold TTR Med');
+    expect(output).toContain('Cold TTR P90');
+    expect(output).toContain('0.50s');
+    expect(output).toContain('0.90s');
+  });
+
+  it('renders count-only column when only count stat is requested', () => {
+    const routes = [makeRoute('/home', AppPlatform.Ios)];
+    const output = buildObserveNavigationRoutesTable(routes, ['coldTtr'], ['count']);
+
+    expect(output).toContain('Navigation count values');
+    expect(output).toContain('Cold TTR Count');
+    expect(output).toContain('10');
+  });
+
+  it('shows a next-page hint per platform when hasNextPage is true', () => {
+    const routes = [makeRoute('/home', AppPlatform.Ios)];
+    const pageInfoByPlatform = new Map([
+      [AppPlatform.Ios, { hasNextPage: true, endCursor: 'cursor-ios' }],
+    ]);
+
+    const output = buildObserveNavigationRoutesTable(routes, ['coldTtr'], ['median', 'count'], {
+      pageInfoByPlatform,
+    });
+
+    expect(output).toContain('Next page (iOS): --after cursor-ios');
+  });
+});
+
+describe(buildObserveNavigationRoutesJson, () => {
+  it('maps routes to the requested metrics and stats, including pageInfoByPlatform', () => {
+    const routes = [makeRoute('/home', AppPlatform.Ios)];
+    const pageInfoByPlatform = new Map([
+      [AppPlatform.Ios, { hasNextPage: true, endCursor: 'cursor-ios' }],
+    ]);
+
+    const result = buildObserveNavigationRoutesJson(
+      routes,
+      ['coldTtr', 'tti'],
+      ['median', 'p90', 'count'],
+      pageInfoByPlatform
+    );
+
+    expect(result.routes).toEqual([
+      {
+        routeName: '/home',
+        platform: AppPlatform.Ios,
+        metrics: {
+          'expo.navigation.cold_ttr': { median: 0.5, p90: 0.9, count: 10 },
+          'expo.navigation.tti': { median: 0.45, p90: 0.7, count: 12 },
+        },
+      },
+    ]);
+    expect(result.pageInfoByPlatform).toEqual({
+      [AppPlatform.Ios]: { hasNextPage: true, endCursor: 'cursor-ios' },
+    });
+  });
+
+  it('returns null for stats when the underlying value is null', () => {
+    const routes = [
+      makeRoute('/home', AppPlatform.Ios, {
+        coldTtr: { count: 0, median: null, p90: null },
+      }),
+    ];
+
+    const result = buildObserveNavigationRoutesJson(
+      routes,
+      ['coldTtr'],
+      ['median', 'p90', 'count'],
+      new Map()
+    );
+
+    expect(result.routes[0].metrics['expo.navigation.cold_ttr']).toEqual({
+      median: null,
+      p90: null,
+      count: 0,
+    });
+  });
+});

--- a/packages/eas-cli/src/observe/__tests__/formatNavigationRoutes.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatNavigationRoutes.test.ts
@@ -3,7 +3,7 @@ import { NavigationRouteWithPlatform } from '../fetchNavigationRoutes';
 import {
   buildObserveNavigationRoutesJson,
   buildObserveNavigationRoutesTable,
-  resolveNavigationMetricKey,
+  isNavigationMetric,
   resolveNavigationStatKey,
 } from '../formatNavigationRoutes';
 
@@ -46,21 +46,17 @@ function makeRoute(
   };
 }
 
-describe(resolveNavigationMetricKey, () => {
-  it('resolves short, alias, and full names to canonical keys', () => {
-    expect(resolveNavigationMetricKey('cold_ttr')).toBe('coldTtr');
-    expect(resolveNavigationMetricKey('nav_cold_ttr')).toBe('coldTtr');
-    expect(resolveNavigationMetricKey('expo.navigation.cold_ttr')).toBe('coldTtr');
-    expect(resolveNavigationMetricKey('warm_ttr')).toBe('warmTtr');
-    expect(resolveNavigationMetricKey('nav_warm_ttr')).toBe('warmTtr');
-    expect(resolveNavigationMetricKey('expo.navigation.warm_ttr')).toBe('warmTtr');
-    expect(resolveNavigationMetricKey('tti')).toBe('tti');
-    expect(resolveNavigationMetricKey('nav_tti')).toBe('tti');
-    expect(resolveNavigationMetricKey('expo.navigation.tti')).toBe('tti');
+describe(isNavigationMetric, () => {
+  it('returns true for each known navigation metric full name', () => {
+    expect(isNavigationMetric('expo.navigation.cold_ttr')).toBe(true);
+    expect(isNavigationMetric('expo.navigation.warm_ttr')).toBe(true);
+    expect(isNavigationMetric('expo.navigation.tti')).toBe(true);
   });
 
-  it('throws on unknown metric', () => {
-    expect(() => resolveNavigationMetricKey('foo')).toThrow('Unknown navigation metric');
+  it('returns false for app-startup metrics or unknown names', () => {
+    expect(isNavigationMetric('expo.app_startup.tti')).toBe(false);
+    expect(isNavigationMetric('cold_ttr')).toBe(false);
+    expect(isNavigationMetric('unknown')).toBe(false);
   });
 });
 
@@ -81,7 +77,11 @@ describe(resolveNavigationStatKey, () => {
 
 describe(buildObserveNavigationRoutesTable, () => {
   it('returns a yellow warning when no routes are present', () => {
-    const output = buildObserveNavigationRoutesTable([], ['coldTtr'], ['median', 'count']);
+    const output = buildObserveNavigationRoutesTable(
+      [],
+      ['expo.navigation.cold_ttr'],
+      ['median', 'count']
+    );
     expect(output).toContain('No navigation routes found.');
   });
 
@@ -96,7 +96,7 @@ describe(buildObserveNavigationRoutesTable, () => {
 
     const output = buildObserveNavigationRoutesTable(
       routes,
-      ['coldTtr', 'warmTtr', 'tti'],
+      ['expo.navigation.cold_ttr', 'expo.navigation.warm_ttr', 'expo.navigation.tti'],
       ['median', 'count'],
       { daysBack: 7 }
     );
@@ -104,7 +104,7 @@ describe(buildObserveNavigationRoutesTable, () => {
     expect(output).toContain('Med values (navigation count) for the last 7 days');
     expect(output).toContain('Cold TTR');
     expect(output).toContain('Warm TTR');
-    expect(output).toContain('TTI');
+    expect(output).toContain('Nav TTI');
     expect(output).toContain('/home');
     expect(output).toContain('/profile');
     expect(output).toContain('0.50s (10)');
@@ -115,7 +115,11 @@ describe(buildObserveNavigationRoutesTable, () => {
 
   it('renders separate columns when count is omitted from stats', () => {
     const routes = [makeRoute('/home', AppPlatform.Ios)];
-    const output = buildObserveNavigationRoutesTable(routes, ['coldTtr'], ['median', 'p90']);
+    const output = buildObserveNavigationRoutesTable(
+      routes,
+      ['expo.navigation.cold_ttr'],
+      ['median', 'p90']
+    );
 
     expect(output).toContain('Med, P90 values');
     expect(output).toContain('Cold TTR Med');
@@ -126,7 +130,11 @@ describe(buildObserveNavigationRoutesTable, () => {
 
   it('renders count-only column when only count stat is requested', () => {
     const routes = [makeRoute('/home', AppPlatform.Ios)];
-    const output = buildObserveNavigationRoutesTable(routes, ['coldTtr'], ['count']);
+    const output = buildObserveNavigationRoutesTable(
+      routes,
+      ['expo.navigation.cold_ttr'],
+      ['count']
+    );
 
     expect(output).toContain('Navigation count values');
     expect(output).toContain('Cold TTR Count');
@@ -139,9 +147,12 @@ describe(buildObserveNavigationRoutesTable, () => {
       [AppPlatform.Ios, { hasNextPage: true, endCursor: 'cursor-ios' }],
     ]);
 
-    const output = buildObserveNavigationRoutesTable(routes, ['coldTtr'], ['median', 'count'], {
-      pageInfoByPlatform,
-    });
+    const output = buildObserveNavigationRoutesTable(
+      routes,
+      ['expo.navigation.cold_ttr'],
+      ['median', 'count'],
+      { pageInfoByPlatform }
+    );
 
     expect(output).toContain('Next page (iOS): --after cursor-ios');
   });
@@ -156,7 +167,7 @@ describe(buildObserveNavigationRoutesJson, () => {
 
     const result = buildObserveNavigationRoutesJson(
       routes,
-      ['coldTtr', 'tti'],
+      ['expo.navigation.cold_ttr', 'expo.navigation.tti'],
       ['median', 'p90', 'count'],
       pageInfoByPlatform
     );
@@ -185,7 +196,7 @@ describe(buildObserveNavigationRoutesJson, () => {
 
     const result = buildObserveNavigationRoutesJson(
       routes,
-      ['coldTtr'],
+      ['expo.navigation.cold_ttr'],
       ['median', 'p90', 'count'],
       new Map()
     );

--- a/packages/eas-cli/src/observe/__tests__/metricNames.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/metricNames.test.ts
@@ -1,4 +1,8 @@
-import { getMetricDisplayName, resolveMetricName } from '../metricNames';
+import {
+  getMetricDisplayName,
+  resolveMetricName,
+  resolveNavigationMetricName,
+} from '../metricNames';
 
 describe(resolveMetricName, () => {
   it('resolves short alias "tti" to full metric name', () => {
@@ -37,13 +41,44 @@ describe(resolveMetricName, () => {
   });
 });
 
+describe(resolveNavigationMetricName, () => {
+  it('resolves short aliases to navigation metric full names', () => {
+    expect(resolveNavigationMetricName('cold_ttr')).toBe('expo.navigation.cold_ttr');
+    expect(resolveNavigationMetricName('warm_ttr')).toBe('expo.navigation.warm_ttr');
+    expect(resolveNavigationMetricName('nav_tti')).toBe('expo.navigation.tti');
+  });
+
+  it('passes through full navigation metric names unchanged', () => {
+    expect(resolveNavigationMetricName('expo.navigation.cold_ttr')).toBe(
+      'expo.navigation.cold_ttr'
+    );
+    expect(resolveNavigationMetricName('expo.navigation.warm_ttr')).toBe(
+      'expo.navigation.warm_ttr'
+    );
+    expect(resolveNavigationMetricName('expo.navigation.tti')).toBe('expo.navigation.tti');
+  });
+
+  it('throws on unknown alias or non-navigation metric', () => {
+    expect(() => resolveNavigationMetricName('unknown')).toThrow('Unknown navigation metric');
+    expect(() => resolveNavigationMetricName('expo.app_startup.tti')).toThrow(
+      'Unknown navigation metric'
+    );
+  });
+});
+
 describe(getMetricDisplayName, () => {
-  it('returns short display name for known metrics', () => {
+  it('returns short display name for known app-startup metrics', () => {
     expect(getMetricDisplayName('expo.app_startup.cold_launch_time')).toBe('Cold Launch');
     expect(getMetricDisplayName('expo.app_startup.warm_launch_time')).toBe('Warm Launch');
     expect(getMetricDisplayName('expo.app_startup.tti')).toBe('TTI');
     expect(getMetricDisplayName('expo.app_startup.ttr')).toBe('TTR');
     expect(getMetricDisplayName('expo.app_startup.bundle_load_time')).toBe('Bundle Load');
+  });
+
+  it('returns short display name for known navigation metrics', () => {
+    expect(getMetricDisplayName('expo.navigation.cold_ttr')).toBe('Cold TTR');
+    expect(getMetricDisplayName('expo.navigation.warm_ttr')).toBe('Warm TTR');
+    expect(getMetricDisplayName('expo.navigation.tti')).toBe('Nav TTI');
   });
 
   it('returns the full metric name for unknown metrics', () => {

--- a/packages/eas-cli/src/observe/__tests__/metricNames.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/metricNames.test.ts
@@ -70,14 +70,14 @@ describe(getMetricDisplayName, () => {
   it('returns short display name for known app-startup metrics', () => {
     expect(getMetricDisplayName('expo.app_startup.cold_launch_time')).toBe('Cold Launch');
     expect(getMetricDisplayName('expo.app_startup.warm_launch_time')).toBe('Warm Launch');
-    expect(getMetricDisplayName('expo.app_startup.tti')).toBe('TTI');
-    expect(getMetricDisplayName('expo.app_startup.ttr')).toBe('TTR');
+    expect(getMetricDisplayName('expo.app_startup.tti')).toBe('Startup TTI');
+    expect(getMetricDisplayName('expo.app_startup.ttr')).toBe('Startup TTR');
     expect(getMetricDisplayName('expo.app_startup.bundle_load_time')).toBe('Bundle Load');
   });
 
   it('returns short display name for known navigation metrics', () => {
-    expect(getMetricDisplayName('expo.navigation.cold_ttr')).toBe('Cold TTR');
-    expect(getMetricDisplayName('expo.navigation.warm_ttr')).toBe('Warm TTR');
+    expect(getMetricDisplayName('expo.navigation.cold_ttr')).toBe('Nav Cold TTR');
+    expect(getMetricDisplayName('expo.navigation.warm_ttr')).toBe('Nav Warm TTR');
     expect(getMetricDisplayName('expo.navigation.tti')).toBe('Nav TTI');
   });
 

--- a/packages/eas-cli/src/observe/fetchMetrics.ts
+++ b/packages/eas-cli/src/observe/fetchMetrics.ts
@@ -1,6 +1,6 @@
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import { EasCommandError } from '../commandUtils/errors';
-import { AppObservePlatform, AppPlatform } from '../graphql/generated';
+import { AppPlatform } from '../graphql/generated';
 import { ObserveQuery } from '../graphql/queries/ObserveQuery';
 import Log from '../log';
 import {
@@ -10,11 +10,7 @@ import {
   UpdateIdsMap,
   makeMetricsKey,
 } from './formatMetrics';
-
-const appPlatformToObservePlatform: Record<AppPlatform, AppObservePlatform> = {
-  [AppPlatform.Android]: AppObservePlatform.Android,
-  [AppPlatform.Ios]: AppObservePlatform.Ios,
-};
+import { appPlatformToObservePlatform } from './platforms';
 
 export function validateDateFlag(value: string, flagName: string): void {
   const parsed = new Date(value);

--- a/packages/eas-cli/src/observe/fetchNavigationRoutes.ts
+++ b/packages/eas-cli/src/observe/fetchNavigationRoutes.ts
@@ -4,17 +4,12 @@ import {
   AppObserveNavigationRoute,
   AppObserveNavigationRoutesOrderBy,
   AppObserveNavigationRoutesOrderByField,
-  AppObservePlatform,
   AppPlatform,
   PageInfo,
 } from '../graphql/generated';
 import { ObserveQuery } from '../graphql/queries/ObserveQuery';
 import Log from '../log';
-
-const appPlatformToObservePlatform: Record<AppPlatform, AppObservePlatform> = {
-  [AppPlatform.Android]: AppObservePlatform.Android,
-  [AppPlatform.Ios]: AppObservePlatform.Ios,
-};
+import { appPlatformToObservePlatform } from './platforms';
 
 export interface NavigationRouteWithPlatform {
   platform: AppPlatform;

--- a/packages/eas-cli/src/observe/fetchNavigationRoutes.ts
+++ b/packages/eas-cli/src/observe/fetchNavigationRoutes.ts
@@ -1,0 +1,91 @@
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import {
+  AppObserveEventsOrderByDirection,
+  AppObserveNavigationRoute,
+  AppObserveNavigationRoutesOrderBy,
+  AppObserveNavigationRoutesOrderByField,
+  AppObservePlatform,
+  AppPlatform,
+  PageInfo,
+} from '../graphql/generated';
+import { ObserveQuery } from '../graphql/queries/ObserveQuery';
+import Log from '../log';
+
+const appPlatformToObservePlatform: Record<AppPlatform, AppObservePlatform> = {
+  [AppPlatform.Android]: AppObservePlatform.Android,
+  [AppPlatform.Ios]: AppObservePlatform.Ios,
+};
+
+export interface NavigationRouteWithPlatform {
+  platform: AppPlatform;
+  route: AppObserveNavigationRoute;
+}
+
+export interface FetchNavigationRoutesOptions {
+  startTime: string;
+  endTime: string;
+  platforms: AppPlatform[];
+  limit: number;
+  after?: string;
+  appVersion?: string;
+  updateId?: string;
+  buildNumber?: string;
+  orderBy?: AppObserveNavigationRoutesOrderBy;
+}
+
+export interface FetchNavigationRoutesResult {
+  routes: NavigationRouteWithPlatform[];
+  pageInfoByPlatform: Map<AppPlatform, PageInfo>;
+}
+
+export async function fetchObserveNavigationRoutesAsync(
+  graphqlClient: ExpoGraphqlClient,
+  appId: string,
+  options: FetchNavigationRoutesOptions
+): Promise<FetchNavigationRoutesResult> {
+  const orderBy: AppObserveNavigationRoutesOrderBy = options.orderBy ?? {
+    field: AppObserveNavigationRoutesOrderByField.NavigationCount,
+    direction: AppObserveEventsOrderByDirection.Desc,
+  };
+
+  const queries = options.platforms.map(async appPlatform => {
+    const observePlatform = appPlatformToObservePlatform[appPlatform];
+    try {
+      const result = await ObserveQuery.navigationRoutesAsync(graphqlClient, {
+        appId,
+        filter: {
+          platform: observePlatform,
+          startTime: options.startTime,
+          endTime: options.endTime,
+          ...(options.appVersion && { appVersion: options.appVersion }),
+          ...(options.updateId && { appUpdateId: options.updateId }),
+          ...(options.buildNumber && { appBuildNumber: options.buildNumber }),
+        },
+        first: options.limit,
+        ...(options.after && { after: options.after }),
+        orderBy,
+      });
+      return { appPlatform, ...result };
+    } catch (error: any) {
+      Log.warn(`Failed to fetch navigation routes on ${observePlatform}: ${error.message}`);
+      return null;
+    }
+  });
+
+  const results = await Promise.all(queries);
+
+  const routes: NavigationRouteWithPlatform[] = [];
+  const pageInfoByPlatform = new Map<AppPlatform, PageInfo>();
+
+  for (const result of results) {
+    if (!result) {
+      continue;
+    }
+    pageInfoByPlatform.set(result.appPlatform, result.pageInfo);
+    for (const route of result.routes) {
+      routes.push({ platform: result.appPlatform, route });
+    }
+  }
+
+  return { routes, pageInfoByPlatform };
+}

--- a/packages/eas-cli/src/observe/formatNavigationRoutes.ts
+++ b/packages/eas-cli/src/observe/formatNavigationRoutes.ts
@@ -1,0 +1,262 @@
+import chalk from 'chalk';
+
+import { EasCommandError } from '../commandUtils/errors';
+import { AppPlatform } from '../graphql/generated';
+import { appPlatformDisplayNames } from '../platform';
+import renderTextTable from '../utils/renderTextTable';
+import { NavigationRouteWithPlatform } from './fetchNavigationRoutes';
+import { buildTimeRangeDescription } from './formatUtils';
+
+export type NavigationStatKey = 'median' | 'p90' | 'count';
+
+export const NAVIGATION_STAT_ALIASES: Record<string, NavigationStatKey> = {
+  med: 'median',
+  median: 'median',
+  p90: 'p90',
+  count: 'count',
+  event_count: 'count',
+  eventCount: 'count',
+};
+
+export const NAVIGATION_STAT_DISPLAY_NAMES: Record<NavigationStatKey, string> = {
+  median: 'Med',
+  p90: 'P90',
+  count: 'Count',
+};
+
+export function resolveNavigationStatKey(input: string): NavigationStatKey {
+  const resolved = NAVIGATION_STAT_ALIASES[input];
+  if (resolved) {
+    return resolved;
+  }
+  throw new EasCommandError(
+    `Unknown statistic: "${input}". Valid options: ${Object.keys(NAVIGATION_STAT_ALIASES).join(
+      ', '
+    )}`
+  );
+}
+
+export type NavigationMetricKey = 'coldTtr' | 'warmTtr' | 'tti';
+
+export interface NavigationMetricSpec {
+  key: NavigationMetricKey;
+  fullName: string;
+  displayName: string;
+}
+
+export const NAVIGATION_METRICS: NavigationMetricSpec[] = [
+  { key: 'coldTtr', fullName: 'expo.navigation.cold_ttr', displayName: 'Cold TTR' },
+  { key: 'warmTtr', fullName: 'expo.navigation.warm_ttr', displayName: 'Warm TTR' },
+  { key: 'tti', fullName: 'expo.navigation.tti', displayName: 'TTI' },
+];
+
+const NAVIGATION_METRIC_ALIASES: Record<string, NavigationMetricKey> = {
+  cold_ttr: 'coldTtr',
+  nav_cold_ttr: 'coldTtr',
+  coldTtr: 'coldTtr',
+  'expo.navigation.cold_ttr': 'coldTtr',
+  warm_ttr: 'warmTtr',
+  nav_warm_ttr: 'warmTtr',
+  warmTtr: 'warmTtr',
+  'expo.navigation.warm_ttr': 'warmTtr',
+  tti: 'tti',
+  nav_tti: 'tti',
+  'expo.navigation.tti': 'tti',
+};
+
+export function resolveNavigationMetricKey(input: string): NavigationMetricKey {
+  const resolved = NAVIGATION_METRIC_ALIASES[input];
+  if (resolved) {
+    return resolved;
+  }
+  throw new EasCommandError(
+    `Unknown navigation metric: "${input}". Valid options: ${Object.keys(
+      NAVIGATION_METRIC_ALIASES
+    ).join(', ')}`
+  );
+}
+
+function formatStatValue(stat: NavigationStatKey, value: number | null | undefined): string {
+  if (value == null) {
+    return '-';
+  }
+  if (stat === 'count') {
+    return String(value);
+  }
+  return `${value.toFixed(2)}s`;
+}
+
+function formatMergedCell(
+  stat: NavigationStatKey,
+  statValue: number | null | undefined,
+  count: number | null | undefined
+): string {
+  const formatted = formatStatValue(stat, statValue);
+  const countStr = count != null ? String(count) : '-';
+  return `${formatted} (${countStr})`;
+}
+
+export interface NavigationRouteValuesJson {
+  routeName: string;
+  platform: AppPlatform;
+  metrics: Record<string, Partial<Record<NavigationStatKey, number | null>>>;
+}
+
+export interface ObserveNavigationRoutesJsonOutput {
+  routes: NavigationRouteValuesJson[];
+  pageInfoByPlatform: Record<string, { hasNextPage: boolean; endCursor: string | null }>;
+}
+
+function metricStat(
+  node: NavigationRouteWithPlatform,
+  metricKey: NavigationMetricKey
+): { count: number; median: number | null; p90: number | null } {
+  const stat = node.route[metricKey];
+  return {
+    count: stat.count,
+    median: stat.median ?? null,
+    p90: stat.p90 ?? null,
+  };
+}
+
+export function buildObserveNavigationRoutesJson(
+  routes: NavigationRouteWithPlatform[],
+  metricKeys: NavigationMetricKey[],
+  stats: NavigationStatKey[],
+  pageInfoByPlatform: Map<AppPlatform, { hasNextPage: boolean; endCursor?: string | null }>
+): ObserveNavigationRoutesJsonOutput {
+  const jsonRoutes: NavigationRouteValuesJson[] = routes.map(node => {
+    const metrics: Record<string, Partial<Record<NavigationStatKey, number | null>>> = {};
+    for (const metricKey of metricKeys) {
+      const spec = NAVIGATION_METRICS.find(m => m.key === metricKey)!;
+      const values = metricStat(node, metricKey);
+      const statValues: Partial<Record<NavigationStatKey, number | null>> = {};
+      for (const stat of stats) {
+        statValues[stat] = values[stat] ?? null;
+      }
+      metrics[spec.fullName] = statValues;
+    }
+    return {
+      routeName: node.route.routeName,
+      platform: node.platform,
+      metrics,
+    };
+  });
+
+  const pageInfoByPlatformOutput: Record<
+    string,
+    { hasNextPage: boolean; endCursor: string | null }
+  > = {};
+  for (const [platform, pageInfo] of pageInfoByPlatform) {
+    pageInfoByPlatformOutput[platform] = {
+      hasNextPage: pageInfo.hasNextPage,
+      endCursor: pageInfo.endCursor ?? null,
+    };
+  }
+
+  return { routes: jsonRoutes, pageInfoByPlatform: pageInfoByPlatformOutput };
+}
+
+export interface BuildNavigationRoutesTableOptions {
+  daysBack?: number;
+  startTime?: string;
+  endTime?: string;
+  pageInfoByPlatform?: Map<AppPlatform, { hasNextPage: boolean; endCursor?: string | null }>;
+}
+
+export function buildObserveNavigationRoutesTable(
+  routes: NavigationRouteWithPlatform[],
+  metricKeys: NavigationMetricKey[],
+  stats: NavigationStatKey[],
+  options?: BuildNavigationRoutesTableOptions
+): string {
+  if (routes.length === 0) {
+    return chalk.yellow('No navigation routes found.');
+  }
+
+  const displayStats = stats.filter(s => s !== 'count');
+  const hasCount = stats.includes('count');
+
+  const statsDesc =
+    displayStats.length > 0
+      ? displayStats.map(s => NAVIGATION_STAT_DISPLAY_NAMES[s]).join(', ')
+      : 'Navigation count';
+  const timeDesc = buildTimeRangeDescription({
+    daysBack: options?.daysBack,
+    startTime: options?.startTime,
+    endTime: options?.endTime,
+  });
+  const countSuffix = hasCount && displayStats.length > 0 ? ' (navigation count)' : '';
+  const summaryLine = `${statsDesc} values${countSuffix}${timeDesc ? ` ${timeDesc}` : ''}`;
+
+  const byPlatform = new Map<AppPlatform, NavigationRouteWithPlatform[]>();
+  for (const node of routes) {
+    if (!byPlatform.has(node.platform)) {
+      byPlatform.set(node.platform, []);
+    }
+    byPlatform.get(node.platform)!.push(node);
+  }
+
+  const metricHeaders: string[] = [];
+  for (const key of metricKeys) {
+    const spec = NAVIGATION_METRICS.find(m => m.key === key)!;
+    if (displayStats.length > 0 && hasCount) {
+      // Merged mode: one column per displayStat (combined with count)
+      for (const stat of displayStats) {
+        metricHeaders.push(
+          displayStats.length > 1
+            ? `${spec.displayName} ${NAVIGATION_STAT_DISPLAY_NAMES[stat]}`
+            : spec.displayName
+        );
+      }
+    } else {
+      for (const stat of displayStats.length > 0
+        ? displayStats
+        : (['count'] as NavigationStatKey[])) {
+        metricHeaders.push(
+          displayStats.length === 0
+            ? `${spec.displayName} Count`
+            : `${spec.displayName} ${NAVIGATION_STAT_DISPLAY_NAMES[stat]}`
+        );
+      }
+    }
+  }
+  const headers = ['Route', ...metricHeaders];
+
+  const sections: string[] = [chalk.bold(summaryLine)];
+
+  for (const [platform, platformRoutes] of byPlatform) {
+    sections.push('');
+    sections.push(chalk.bold(appPlatformDisplayNames[platform]));
+
+    const rows: string[][] = platformRoutes.map(node => {
+      const cells: string[] = [];
+      for (const key of metricKeys) {
+        const values = metricStat(node, key);
+        if (displayStats.length > 0 && hasCount) {
+          for (const stat of displayStats) {
+            cells.push(formatMergedCell(stat, values[stat], values.count));
+          }
+        } else {
+          for (const stat of displayStats.length > 0
+            ? displayStats
+            : (['count'] as NavigationStatKey[])) {
+            cells.push(formatStatValue(stat, values[stat]));
+          }
+        }
+      }
+      return [node.route.routeName, ...cells];
+    });
+
+    sections.push(renderTextTable(headers, rows));
+
+    const pageInfo = options?.pageInfoByPlatform?.get(platform);
+    if (pageInfo?.hasNextPage && pageInfo.endCursor) {
+      sections.push(
+        `Next page (${appPlatformDisplayNames[platform]}): --after ${pageInfo.endCursor}`
+      );
+    }
+  }
+
+  return sections.join('\n');
+}

--- a/packages/eas-cli/src/observe/formatNavigationRoutes.ts
+++ b/packages/eas-cli/src/observe/formatNavigationRoutes.ts
@@ -6,6 +6,7 @@ import { appPlatformDisplayNames } from '../platform';
 import renderTextTable from '../utils/renderTextTable';
 import { NavigationRouteWithPlatform } from './fetchNavigationRoutes';
 import { buildTimeRangeDescription } from './formatUtils';
+import { getMetricDisplayName } from './metricNames';
 
 export type NavigationStatKey = 'median' | 'p90' | 'count';
 
@@ -36,44 +37,18 @@ export function resolveNavigationStatKey(input: string): NavigationStatKey {
   );
 }
 
-export type NavigationMetricKey = 'coldTtr' | 'warmTtr' | 'tti';
+type NavigationRouteField = 'coldTtr' | 'warmTtr' | 'tti';
 
-export interface NavigationMetricSpec {
-  key: NavigationMetricKey;
-  fullName: string;
-  displayName: string;
-}
-
-export const NAVIGATION_METRICS: NavigationMetricSpec[] = [
-  { key: 'coldTtr', fullName: 'expo.navigation.cold_ttr', displayName: 'Cold TTR' },
-  { key: 'warmTtr', fullName: 'expo.navigation.warm_ttr', displayName: 'Warm TTR' },
-  { key: 'tti', fullName: 'expo.navigation.tti', displayName: 'TTI' },
-];
-
-const NAVIGATION_METRIC_ALIASES: Record<string, NavigationMetricKey> = {
-  cold_ttr: 'coldTtr',
-  nav_cold_ttr: 'coldTtr',
-  coldTtr: 'coldTtr',
+const FULL_METRIC_NAME_TO_FIELD: Record<string, NavigationRouteField> = {
   'expo.navigation.cold_ttr': 'coldTtr',
-  warm_ttr: 'warmTtr',
-  nav_warm_ttr: 'warmTtr',
-  warmTtr: 'warmTtr',
   'expo.navigation.warm_ttr': 'warmTtr',
-  tti: 'tti',
-  nav_tti: 'tti',
   'expo.navigation.tti': 'tti',
 };
 
-export function resolveNavigationMetricKey(input: string): NavigationMetricKey {
-  const resolved = NAVIGATION_METRIC_ALIASES[input];
-  if (resolved) {
-    return resolved;
-  }
-  throw new EasCommandError(
-    `Unknown navigation metric: "${input}". Valid options: ${Object.keys(
-      NAVIGATION_METRIC_ALIASES
-    ).join(', ')}`
-  );
+export const NAVIGATION_METRIC_NAMES = Object.keys(FULL_METRIC_NAME_TO_FIELD);
+
+export function isNavigationMetric(metricName: string): boolean {
+  return metricName in FULL_METRIC_NAME_TO_FIELD;
 }
 
 function formatStatValue(stat: NavigationStatKey, value: number | null | undefined): string {
@@ -109,9 +84,13 @@ export interface ObserveNavigationRoutesJsonOutput {
 
 function metricStat(
   node: NavigationRouteWithPlatform,
-  metricKey: NavigationMetricKey
+  metricName: string
 ): { count: number; median: number | null; p90: number | null } {
-  const stat = node.route[metricKey];
+  const field = FULL_METRIC_NAME_TO_FIELD[metricName];
+  if (!field) {
+    throw new EasCommandError(`Unknown navigation metric: "${metricName}"`);
+  }
+  const stat = node.route[field];
   return {
     count: stat.count,
     median: stat.median ?? null,
@@ -121,20 +100,19 @@ function metricStat(
 
 export function buildObserveNavigationRoutesJson(
   routes: NavigationRouteWithPlatform[],
-  metricKeys: NavigationMetricKey[],
+  metricNames: string[],
   stats: NavigationStatKey[],
   pageInfoByPlatform: Map<AppPlatform, { hasNextPage: boolean; endCursor?: string | null }>
 ): ObserveNavigationRoutesJsonOutput {
   const jsonRoutes: NavigationRouteValuesJson[] = routes.map(node => {
     const metrics: Record<string, Partial<Record<NavigationStatKey, number | null>>> = {};
-    for (const metricKey of metricKeys) {
-      const spec = NAVIGATION_METRICS.find(m => m.key === metricKey)!;
-      const values = metricStat(node, metricKey);
+    for (const metricName of metricNames) {
+      const values = metricStat(node, metricName);
       const statValues: Partial<Record<NavigationStatKey, number | null>> = {};
       for (const stat of stats) {
         statValues[stat] = values[stat] ?? null;
       }
-      metrics[spec.fullName] = statValues;
+      metrics[metricName] = statValues;
     }
     return {
       routeName: node.route.routeName,
@@ -166,7 +144,7 @@ export interface BuildNavigationRoutesTableOptions {
 
 export function buildObserveNavigationRoutesTable(
   routes: NavigationRouteWithPlatform[],
-  metricKeys: NavigationMetricKey[],
+  metricNames: string[],
   stats: NavigationStatKey[],
   options?: BuildNavigationRoutesTableOptions
 ): string {
@@ -198,15 +176,14 @@ export function buildObserveNavigationRoutesTable(
   }
 
   const metricHeaders: string[] = [];
-  for (const key of metricKeys) {
-    const spec = NAVIGATION_METRICS.find(m => m.key === key)!;
+  for (const metricName of metricNames) {
+    const displayName = getMetricDisplayName(metricName);
     if (displayStats.length > 0 && hasCount) {
-      // Merged mode: one column per displayStat (combined with count)
       for (const stat of displayStats) {
         metricHeaders.push(
           displayStats.length > 1
-            ? `${spec.displayName} ${NAVIGATION_STAT_DISPLAY_NAMES[stat]}`
-            : spec.displayName
+            ? `${displayName} ${NAVIGATION_STAT_DISPLAY_NAMES[stat]}`
+            : displayName
         );
       }
     } else {
@@ -215,8 +192,8 @@ export function buildObserveNavigationRoutesTable(
         : (['count'] as NavigationStatKey[])) {
         metricHeaders.push(
           displayStats.length === 0
-            ? `${spec.displayName} Count`
-            : `${spec.displayName} ${NAVIGATION_STAT_DISPLAY_NAMES[stat]}`
+            ? `${displayName} Count`
+            : `${displayName} ${NAVIGATION_STAT_DISPLAY_NAMES[stat]}`
         );
       }
     }
@@ -231,8 +208,8 @@ export function buildObserveNavigationRoutesTable(
 
     const rows: string[][] = platformRoutes.map(node => {
       const cells: string[] = [];
-      for (const key of metricKeys) {
-        const values = metricStat(node, key);
+      for (const metricName of metricNames) {
+        const values = metricStat(node, metricName);
         if (displayStats.length > 0 && hasCount) {
           for (const stat of displayStats) {
             cells.push(formatMergedCell(stat, values[stat], values.count));

--- a/packages/eas-cli/src/observe/metricNames.ts
+++ b/packages/eas-cli/src/observe/metricNames.ts
@@ -8,7 +8,14 @@ export const METRIC_ALIASES: Record<string, string> = {
   bundle_load: 'expo.app_startup.bundle_load_time',
 };
 
+export const NAVIGATION_METRIC_ALIASES: Record<string, string> = {
+  cold_ttr: 'expo.navigation.cold_ttr',
+  warm_ttr: 'expo.navigation.warm_ttr',
+  nav_tti: 'expo.navigation.tti',
+};
+
 const KNOWN_FULL_NAMES = new Set(Object.values(METRIC_ALIASES));
+const KNOWN_FULL_NAVIGATION_NAMES = new Set(Object.values(NAVIGATION_METRIC_ALIASES));
 
 export const METRIC_SHORT_NAMES: Record<string, string> = {
   'expo.app_startup.cold_launch_time': 'Cold Launch',
@@ -16,6 +23,9 @@ export const METRIC_SHORT_NAMES: Record<string, string> = {
   'expo.app_startup.tti': 'TTI',
   'expo.app_startup.ttr': 'TTR',
   'expo.app_startup.bundle_load_time': 'Bundle Load',
+  'expo.navigation.cold_ttr': 'Cold TTR',
+  'expo.navigation.warm_ttr': 'Warm TTR',
+  'expo.navigation.tti': 'Nav TTI',
 };
 
 export function resolveMetricName(input: string): string {
@@ -27,6 +37,20 @@ export function resolveMetricName(input: string): string {
   }
   throw new EasCommandError(
     `Unknown metric: "${input}". Use a full metric name (e.g. expo.app_startup.tti) or a short alias: ${Object.keys(METRIC_ALIASES).join(', ')}`
+  );
+}
+
+export function resolveNavigationMetricName(input: string): string {
+  if (NAVIGATION_METRIC_ALIASES[input]) {
+    return NAVIGATION_METRIC_ALIASES[input];
+  }
+  if (KNOWN_FULL_NAVIGATION_NAMES.has(input)) {
+    return input;
+  }
+  throw new EasCommandError(
+    `Unknown navigation metric: "${input}". Use a full metric name (e.g. expo.navigation.cold_ttr) or a short alias: ${Object.keys(
+      NAVIGATION_METRIC_ALIASES
+    ).join(', ')}`
   );
 }
 

--- a/packages/eas-cli/src/observe/metricNames.ts
+++ b/packages/eas-cli/src/observe/metricNames.ts
@@ -20,11 +20,11 @@ const KNOWN_FULL_NAVIGATION_NAMES = new Set(Object.values(NAVIGATION_METRIC_ALIA
 export const METRIC_SHORT_NAMES: Record<string, string> = {
   'expo.app_startup.cold_launch_time': 'Cold Launch',
   'expo.app_startup.warm_launch_time': 'Warm Launch',
-  'expo.app_startup.tti': 'TTI',
-  'expo.app_startup.ttr': 'TTR',
+  'expo.app_startup.tti': 'Startup TTI',
+  'expo.app_startup.ttr': 'Startup TTR',
   'expo.app_startup.bundle_load_time': 'Bundle Load',
-  'expo.navigation.cold_ttr': 'Cold TTR',
-  'expo.navigation.warm_ttr': 'Warm TTR',
+  'expo.navigation.cold_ttr': 'Nav Cold TTR',
+  'expo.navigation.warm_ttr': 'Nav Warm TTR',
   'expo.navigation.tti': 'Nav TTI',
 };
 

--- a/packages/eas-cli/src/observe/platforms.ts
+++ b/packages/eas-cli/src/observe/platforms.ts
@@ -51,3 +51,8 @@ export function appPlatformsFromFlag(flag: PlatformFlagValue | undefined): AppPl
   }
   return [defaultAppPlatform];
 }
+
+export const appPlatformToObservePlatform: Record<AppPlatform, AppObservePlatform> = {
+  [AppPlatform.Android]: AppObservePlatform.Android,
+  [AppPlatform.Ios]: AppObservePlatform.Ios,
+};


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

New command `observe:routes` to get navigation metrics by route.

```
USAGE
  $ eas observe:routes [--platform android|ios] [--metric cold_ttr|warm_ttr|nav_tti...] [--stat
    median|med|p90|count|event_count|eventCount...] [--after <value>] [--limit <value>] [--start <value> | --days
    <value>] [--end <value> | ] [--app-version <value>] [--update-id <value>] [--build-number <value>] [--project-id
    <value>] [--json] [--non-interactive]

FLAGS
  --after=<value>         Cursor for pagination. Use the endCursor from a previous query to fetch the next page.
  --app-version=<value>   Filter by app version
  --build-number=<value>  Filter by app build number
  --days=<value>          Show results from the last N days (mutually exclusive with --start/--end)
  --end=<value>           End of time range (ISO date)
  --json                  Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.
  --limit=<value>         The number of items to fetch each query. Defaults to 50 and is capped at 200.
  --metric=<option>...    Navigation metric to display (can be specified multiple times). Defaults to all three.
                          <options: cold_ttr|warm_ttr|nav_tti>
  --non-interactive       Run the command in non-interactive mode.
  --platform=<option>     Filter by platform
                          <options: android|ios>
  --project-id=<value>    EAS project ID (defaults to the project ID of the current directory)
  --start=<value>         Start of time range (ISO date)
  --stat=<option>...      Statistic to display per metric (can be specified multiple times)
                          <options: median|med|p90|count|event_count|eventCount>
  --update-id=<value>     Filter by EAS update ID

DESCRIPTION
  display app navigation route metrics (Cold TTR, Warm TTR, TTI) grouped by route name

```

# How

Added a new command that that queries the new navigationRoutes GraphQL field to display Cold TTR, Warm TTR, and TTI, broken down per route name and platform.

# Test Plan

Tested with staging data in `@expokadi/cadence` project.

New unit tests added.