### PR TITLE
[eas-cli] Extract shared observe flag groups into observe/flags.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Refactor observe commands to extract common flag definitions. ([#3731](https://github.com/expo/eas-cli/pull/3731) by [@douglowder](https://github.com/douglowder))
+
 ## [18.12.3](https://github.com/expo/eas-cli/releases/tag/v18.12.3) - 2026-05-13
 
 ## [18.12.2](https://github.com/expo/eas-cli/releases/tag/v18.12.2) - 2026-05-12

--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -11,13 +11,17 @@ import {
   fetchTotalEventCountAsync,
   resolveOrderBy,
 } from '../../observe/fetchEvents';
+import {
+  ObserveAfterFlag,
+  ObserveAppVersionFlag,
+  ObservePlatformFlag,
+  ObserveProjectIdFlag,
+  ObserveTimeRangeFlags,
+  ObserveUpdateIdFlag,
+} from '../../observe/flags';
 import { METRIC_ALIASES, METRIC_SHORT_NAMES, resolveMetricName } from '../../observe/metricNames';
 import { buildObserveEventsJson, buildObserveEventsTable } from '../../observe/formatEvents';
-import {
-  allowedPlatformFlagValues,
-  appObservePlatformFromFlag,
-  appPlatformsFromFlag,
-} from '../../observe/platforms';
+import { appObservePlatformFromFlag, appPlatformsFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { selectAsync } from '../../prompts';
@@ -44,40 +48,16 @@ export default class ObserveEvents extends EasCommand {
       required: false,
       default: EventsOrderPreset.Oldest.valueOf().toLowerCase(),
     })(),
-    platform: Flags.option({
-      description: 'Filter by platform',
-      options: allowedPlatformFlagValues,
-    })(),
-    after: Flags.string({
-      description:
-        'Cursor for pagination. Use the endCursor from a previous query to fetch the next page.',
-    }),
+    ...ObservePlatformFlag,
+    ...ObserveAfterFlag,
     limit: getLimitFlagWithCustomValues({
       defaultTo: DEFAULT_EVENTS_LIMIT,
       limit: 100,
     }),
-    start: Flags.string({
-      description: 'Start of time range (ISO date)',
-      exclusive: ['days'],
-    }),
-    end: Flags.string({
-      description: 'End of time range (ISO date)',
-      exclusive: ['days'],
-    }),
-    days: Flags.integer({
-      description: 'Show events from the last N days (mutually exclusive with --start/--end)',
-      min: 1,
-      exclusive: ['start', 'end'],
-    }),
-    'app-version': Flags.string({
-      description: 'Filter by app version',
-    }),
-    'update-id': Flags.string({
-      description: 'Filter by EAS update ID',
-    }),
-    'project-id': Flags.string({
-      description: 'EAS project ID (defaults to the project ID of the current directory)',
-    }),
+    ...ObserveTimeRangeFlags,
+    ...ObserveAppVersionFlag,
+    ...ObserveUpdateIdFlag,
+    ...ObserveProjectIdFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
 

--- a/packages/eas-cli/src/commands/observe/logs.ts
+++ b/packages/eas-cli/src/commands/observe/logs.ts
@@ -7,6 +7,14 @@ import Log from '../../log';
 import { ObserveQuery } from '../../graphql/queries/ObserveQuery';
 import { fetchObserveCustomEventsAsync } from '../../observe/fetchCustomEvents';
 import {
+  ObserveAfterFlag,
+  ObserveAppVersionFlag,
+  ObservePlatformFlag,
+  ObserveProjectIdFlag,
+  ObserveTimeRangeFlags,
+  ObserveUpdateIdFlag,
+} from '../../observe/flags';
+import {
   buildObserveCustomEventNamesJson,
   buildObserveCustomEventNamesTable,
   buildObserveCustomEventsEmptyWithSuggestionsJson,
@@ -14,7 +22,7 @@ import {
   buildObserveCustomEventsJson,
   buildObserveCustomEventsTable,
 } from '../../observe/formatCustomEvents';
-import { allowedPlatformFlagValues, appObservePlatformFromFlag } from '../../observe/platforms';
+import { appObservePlatformFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
@@ -34,37 +42,15 @@ export default class ObserveLogs extends EasCommand {
   };
 
   static override flags = {
-    platform: Flags.option({
-      description: 'Filter by platform',
-      options: allowedPlatformFlagValues,
-    })(),
-    after: Flags.string({
-      description:
-        'Cursor for pagination. Use the endCursor from a previous query to fetch the next page.',
-    }),
+    ...ObservePlatformFlag,
+    ...ObserveAfterFlag,
     limit: getLimitFlagWithCustomValues({
       defaultTo: DEFAULT_EVENTS_LIMIT,
       limit: 100,
     }),
-    start: Flags.string({
-      description: 'Start of time range (ISO date)',
-      exclusive: ['days'],
-    }),
-    end: Flags.string({
-      description: 'End of time range (ISO date)',
-      exclusive: ['days'],
-    }),
-    days: Flags.integer({
-      description: 'Show events from the last N days (mutually exclusive with --start/--end)',
-      min: 1,
-      exclusive: ['start', 'end'],
-    }),
-    'app-version': Flags.string({
-      description: 'Filter by app version',
-    }),
-    'update-id': Flags.string({
-      description: 'Filter by EAS update ID',
-    }),
+    ...ObserveTimeRangeFlags,
+    ...ObserveAppVersionFlag,
+    ...ObserveUpdateIdFlag,
     'session-id': Flags.string({
       description: 'Filter by session ID',
     }),
@@ -73,9 +59,7 @@ export default class ObserveLogs extends EasCommand {
         'When no event name argument is provided, list all events across all event names instead of a summary of event names + counts.',
       default: false,
     }),
-    'project-id': Flags.string({
-      description: 'EAS project ID (defaults to the project ID of the current directory)',
-    }),
+    ...ObserveProjectIdFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
 

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -5,13 +5,18 @@ import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import Log from '../../log';
 import { fetchObserveMetricsAsync } from '../../observe/fetchMetrics';
 import {
+  ObservePlatformFlag,
+  ObserveProjectIdFlag,
+  ObserveTimeRangeFlags,
+} from '../../observe/flags';
+import {
   StatisticKey,
   buildObserveMetricsJson,
   buildObserveMetricsTable,
   resolveStatKey,
 } from '../../observe/formatMetrics';
 import { METRIC_ALIASES, resolveMetricName } from '../../observe/metricNames';
-import { allowedPlatformFlagValues, appPlatformsFromFlag } from '../../observe/platforms';
+import { appPlatformsFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
@@ -41,10 +46,7 @@ export default class ObserveMetrics extends EasCommand {
   static override description = 'display app performance metrics grouped by app version';
 
   static override flags = {
-    platform: Flags.option({
-      description: 'Filter by platform',
-      options: allowedPlatformFlagValues,
-    })(),
+    ...ObservePlatformFlag,
     metric: Flags.option({
       description: 'Metric name to display (can be specified multiple times).',
       multiple: true,
@@ -55,22 +57,8 @@ export default class ObserveMetrics extends EasCommand {
       multiple: true,
       options: DEFAULT_STATS_JSON,
     })(),
-    start: Flags.string({
-      description: 'Start of time range for metrics data (ISO date).',
-      exclusive: ['days'],
-    }),
-    end: Flags.string({
-      description: 'End of time range for metrics data (ISO date).',
-      exclusive: ['days'],
-    }),
-    days: Flags.integer({
-      description: 'Show metrics from the last N days (mutually exclusive with --start/--end)',
-      min: 1,
-      exclusive: ['start', 'end'],
-    }),
-    'project-id': Flags.string({
-      description: 'EAS project ID (defaults to the project ID of the current directory)',
-    }),
+    ...ObserveTimeRangeFlags,
+    ...ObserveProjectIdFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
 

--- a/packages/eas-cli/src/commands/observe/routes.ts
+++ b/packages/eas-cli/src/commands/observe/routes.ts
@@ -6,6 +6,14 @@ import { getLimitFlagWithCustomValues } from '../../commandUtils/pagination';
 import Log from '../../log';
 import { fetchObserveNavigationRoutesAsync } from '../../observe/fetchNavigationRoutes';
 import {
+  ObserveAfterFlag,
+  ObserveAppVersionFlag,
+  ObservePlatformFlag,
+  ObserveProjectIdFlag,
+  ObserveTimeRangeFlags,
+  ObserveUpdateIdFlag,
+} from '../../observe/flags';
+import {
   NAVIGATION_METRIC_NAMES,
   NavigationStatKey,
   buildObserveNavigationRoutesJson,
@@ -13,7 +21,7 @@ import {
   resolveNavigationStatKey,
 } from '../../observe/formatNavigationRoutes';
 import { NAVIGATION_METRIC_ALIASES, resolveNavigationMetricName } from '../../observe/metricNames';
-import { allowedPlatformFlagValues, appPlatformsFromFlag } from '../../observe/platforms';
+import { appPlatformsFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
@@ -31,10 +39,7 @@ export default class ObserveRoutes extends EasCommand {
     'display app navigation route metrics (Cold TTR, Warm TTR, TTI) grouped by route name';
 
   static override flags = {
-    platform: Flags.option({
-      description: 'Filter by platform',
-      options: allowedPlatformFlagValues,
-    })(),
+    ...ObservePlatformFlag,
     metric: Flags.option({
       description:
         'Navigation metric to display (can be specified multiple times). Defaults to all three.',
@@ -46,39 +51,18 @@ export default class ObserveRoutes extends EasCommand {
       multiple: true,
       options: STAT_OPTIONS,
     })(),
-    after: Flags.string({
-      description:
-        'Cursor for pagination. Use the endCursor from a previous query to fetch the next page.',
-    }),
+    ...ObserveAfterFlag,
     limit: getLimitFlagWithCustomValues({
       defaultTo: DEFAULT_ROUTES_LIMIT,
       limit: 200,
     }),
-    start: Flags.string({
-      description: 'Start of time range (ISO date)',
-      exclusive: ['days'],
-    }),
-    end: Flags.string({
-      description: 'End of time range (ISO date)',
-      exclusive: ['days'],
-    }),
-    days: Flags.integer({
-      description: 'Show routes from the last N days (mutually exclusive with --start/--end)',
-      min: 1,
-      exclusive: ['start', 'end'],
-    }),
-    'app-version': Flags.string({
-      description: 'Filter by app version',
-    }),
-    'update-id': Flags.string({
-      description: 'Filter by EAS update ID',
-    }),
+    ...ObserveTimeRangeFlags,
+    ...ObserveAppVersionFlag,
+    ...ObserveUpdateIdFlag,
     'build-number': Flags.string({
       description: 'Filter by app build number',
     }),
-    'project-id': Flags.string({
-      description: 'EAS project ID (defaults to the project ID of the current directory)',
-    }),
+    ...ObserveProjectIdFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
 

--- a/packages/eas-cli/src/commands/observe/versions.ts
+++ b/packages/eas-cli/src/commands/observe/versions.ts
@@ -1,11 +1,14 @@
-import { Flags } from '@oclif/core';
-
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasNonInteractiveAndJsonFlags } from '../../commandUtils/flags';
 import Log from '../../log';
 import { fetchObserveVersionsAsync } from '../../observe/fetchVersions';
+import {
+  ObservePlatformFlag,
+  ObserveProjectIdFlag,
+  ObserveTimeRangeFlags,
+} from '../../observe/flags';
 import { buildObserveVersionsJson, buildObserveVersionsTable } from '../../observe/formatVersions';
-import { allowedPlatformFlagValues, appPlatformsFromFlag } from '../../observe/platforms';
+import { appPlatformsFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
@@ -15,26 +18,9 @@ export default class ObserveVersions extends EasCommand {
   static override description = 'display app versions with build and update details';
 
   static override flags = {
-    platform: Flags.option({
-      description: 'Filter by platform',
-      options: allowedPlatformFlagValues,
-    })(),
-    start: Flags.string({
-      description: 'Start of time range (ISO date)',
-      exclusive: ['days'],
-    }),
-    end: Flags.string({
-      description: 'End of time range (ISO date)',
-      exclusive: ['days'],
-    }),
-    days: Flags.integer({
-      description: 'Show versions from the last N days (mutually exclusive with --start/--end)',
-      min: 1,
-      exclusive: ['start', 'end'],
-    }),
-    'project-id': Flags.string({
-      description: 'EAS project ID (defaults to the project ID of the current directory)',
-    }),
+    ...ObservePlatformFlag,
+    ...ObserveTimeRangeFlags,
+    ...ObserveProjectIdFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
 

--- a/packages/eas-cli/src/observe/flags.ts
+++ b/packages/eas-cli/src/observe/flags.ts
@@ -1,0 +1,51 @@
+import { Flags } from '@oclif/core';
+
+import { allowedPlatformFlagValues } from './platforms';
+
+export const ObserveProjectIdFlag = {
+  'project-id': Flags.string({
+    description: 'EAS project ID (defaults to the project ID of the current directory)',
+  }),
+};
+
+export const ObservePlatformFlag = {
+  platform: Flags.option({
+    description: 'Filter by platform',
+    options: allowedPlatformFlagValues,
+  })(),
+};
+
+export const ObserveTimeRangeFlags = {
+  start: Flags.string({
+    description: 'Start of time range (ISO date)',
+    exclusive: ['days'],
+  }),
+  end: Flags.string({
+    description: 'End of time range (ISO date)',
+    exclusive: ['days'],
+  }),
+  days: Flags.integer({
+    description: 'Show results from the last N days (mutually exclusive with --start/--end)',
+    min: 1,
+    exclusive: ['start', 'end'],
+  }),
+};
+
+export const ObserveAfterFlag = {
+  after: Flags.string({
+    description:
+      'Cursor for pagination. Use the endCursor from a previous query to fetch the next page.',
+  }),
+};
+
+export const ObserveAppVersionFlag = {
+  'app-version': Flags.string({
+    description: 'Filter by app version',
+  }),
+};
+
+export const ObserveUpdateIdFlag = {
+  'update-id': Flags.string({
+    description: 'Filter by EAS update ID',
+  }),
+};


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

It was found that observe commands were using common flag definitions with duplicate code.

# How

Refactored the observe commands to extract flag definitions.

# Test Plan

Commands tested locally.

Unit tests pass.