### PR TITLE
[cocoapods-proxy] Proxy requests to central.sonatype.com too

### DIFF
--- a/packages/expo-cocoapods-proxy/lib/expo_cocoapods_proxy/proxy.rb
+++ b/packages/expo-cocoapods-proxy/lib/expo_cocoapods_proxy/proxy.rb
@@ -17,6 +17,7 @@ module Pod
         %r{https?://(api\.)?github\.com/},
         %r{https?://sourceforge\.net/},
         %r{https?://repo1\.maven\.org/},
+        %r{https?://central\.sonatype\.com/},
         %r{https?://boostorg\.jfrog\.io/},
         %r{https?://www\.sqlite\.org/},
         %r{https?://download\.videolan\.org/},

--- a/packages/expo-cocoapods-proxy/spec/expo_cocoapods_proxy/proxy_spec.rb
+++ b/packages/expo-cocoapods-proxy/spec/expo_cocoapods_proxy/proxy_spec.rb
@@ -142,6 +142,17 @@ RSpec.describe ExpoCocoaPodsProxy do
       downloader.download_file(path.to_s)
     end
 
+    it 'fetches Sonatype snapshot artifacts via proxy' do
+      path = Pathname.new('some/fake/path')
+      url = 'https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/react-native-artifacts/0.82.0-SNAPSHOT/maven-metadata.xml'
+      opts = {}
+      downloader = Pod::Downloader::Http.new(path, url, opts)
+
+      expect(downloader).to receive(:download_file_via_proxy).once {}
+
+      downloader.download_file(path.to_s)
+    end
+
     it 'does not proxy when url doesn\'t match an allowlist regex' do
       path = Pathname.new('some/fake/path')
       url = 'https://not-github.com/expo/test-repo/archive/main.tar.gz'


### PR DESCRIPTION
## Summary

Adds `central.sonatype.com` support to the packaged `expo-cocoapods-proxy` gem used by iOS workers.

## Change

- Adds `central.sonatype.com` to the `Pod::Downloader::Http` proxy allowlist.
- Adds spec coverage for Sonatype repository artifact URLs.

## Code Requiring This

This PR is for CocoaPods `:http` pod source downloads. It does not proxy React Native's `Net::HTTP` metadata lookup.

React Native returns Sonatype artifact URLs to CocoaPods as `:http` pod sources here:

- RNCore returns `{:http => url}` after resolving the Sonatype nightly artifact URL: https://github.com/facebook/react-native/blob/7bbb13c9be014c0e63f0deaad809d669c15325ad/packages/react-native/scripts/cocoapods/rncore.rb#L170-L173
- ReactNativeDependencies returns `{:http => url}` after resolving the Sonatype nightly artifact URL: https://github.com/facebook/react-native/blob/7bbb13c9be014c0e63f0deaad809d669c15325ad/packages/react-native/scripts/cocoapods/rndependencies.rb#L205-L208
- Hermes returns `{:http => url}` after resolving the Sonatype nightly artifact URL: https://github.com/facebook/react-native/blob/7bbb13c9be014c0e63f0deaad809d669c15325ad/packages/react-native/sdks/hermes-engine/hermes-utils.rb#L190-L193

CocoaPods/cocoapods-downloader then uses `Pod::Downloader::Http` for those `:http` params:

- CocoaPods passes the pod source params to `Downloader.for_target(...).download`: https://github.com/CocoaPods/CocoaPods/blob/1.12.1/lib/cocoapods/downloader.rb#L107-L110
- `cocoapods-downloader` maps `:http` to `Http`: https://github.com/CocoaPods/cocoapods-downloader/blob/1.6.3/lib/cocoapods-downloader.rb#L22-L30
- `Downloader.for_target` instantiates that downloader with the `:http` URL: https://github.com/CocoaPods/cocoapods-downloader/blob/1.6.3/lib/cocoapods-downloader.rb#L51-L64
- `Pod::Downloader::Http#download_file` uses curl for that URL: https://github.com/CocoaPods/cocoapods-downloader/blob/1.6.3/lib/cocoapods-downloader/http.rb#L12-L22

## Validation

- `rspec` in `packages/expo-cocoapods-proxy`: 16 examples, 0 failures
- `git diff --check`