### PR TITLE
[build-tools] Dry-run add support for absolute artifact glob paths

### DIFF
--- a/packages/build-tools/src/utils/__tests__/artifacts.test.ts
+++ b/packages/build-tools/src/utils/__tests__/artifacts.test.ts
@@ -71,6 +71,26 @@ describe(findArtifacts, () => {
     expect(paths.length).toBe(2);
   });
 
+  test('with absolute glob pattern', async () => {
+    await fs.mkdirp('/tmp');
+    await fs.mkdirp('/tmp/maestro_xctestrunner_xcodebuild_output123');
+    await fs.mkdirp('/tmp/maestro_xctestrunner_xcodebuild_output456');
+    const loggerMock = {
+      info: jest.fn(),
+      error: jest.fn(),
+    };
+    const paths = await findArtifacts({
+      rootDir: '/Users/expo/build',
+      patternOrPath: '/tmp/maestro_xctestrunner_xcodebuild_output*',
+      logger: loggerMock as any,
+    });
+    expect(loggerMock.error).toHaveBeenCalledTimes(0);
+    expect(paths).toEqual([
+      '/tmp/maestro_xctestrunner_xcodebuild_output123',
+      '/tmp/maestro_xctestrunner_xcodebuild_output456',
+    ]);
+  });
+
   test('with missing file in empty directory', async () => {
     await fs.mkdirp('/dir1/dir2/dir3');
     let errMsg = '';

--- a/packages/build-tools/src/utils/__tests__/artifacts.test.ts
+++ b/packages/build-tools/src/utils/__tests__/artifacts.test.ts
@@ -1,13 +1,20 @@
 import fs from 'fs-extra';
 import { vol } from 'memfs';
 
+import { Sentry } from '../../sentry';
 import { findArtifacts } from '../artifacts';
 
 jest.mock('fs');
+jest.mock('../../sentry', () => ({
+  Sentry: {
+    capture: jest.fn(),
+  },
+}));
 
 describe(findArtifacts, () => {
   beforeEach(async () => {
     vol.reset();
+    jest.clearAllMocks();
   });
 
   test('with correct path', async () => {
@@ -69,6 +76,7 @@ describe(findArtifacts, () => {
     });
     expect(loggerMock.error).toHaveBeenCalledTimes(0);
     expect(paths.length).toBe(2);
+    expect(Sentry.capture).not.toHaveBeenCalled();
   });
 
   test('with absolute glob pattern', async () => {
@@ -79,16 +87,33 @@ describe(findArtifacts, () => {
       info: jest.fn(),
       error: jest.fn(),
     };
-    const paths = await findArtifacts({
-      rootDir: '/Users/expo/build',
-      patternOrPath: '/tmp/maestro_xctestrunner_xcodebuild_output*',
-      logger: loggerMock as any,
-    });
+    await expect(
+      findArtifacts({
+        rootDir: '/Users/expo/build',
+        patternOrPath: '/tmp/maestro_xctestrunner_xcodebuild_output*',
+        logger: loggerMock as any,
+      })
+    ).rejects.toThrow(
+      'There are no files matching pattern "/tmp/maestro_xctestrunner_xcodebuild_output*"'
+    );
     expect(loggerMock.error).toHaveBeenCalledTimes(0);
-    expect(paths).toEqual([
-      '/tmp/maestro_xctestrunner_xcodebuild_output123',
-      '/tmp/maestro_xctestrunner_xcodebuild_output456',
-    ]);
+    expect(Sentry.capture).toHaveBeenCalledWith(expect.any(Error), {
+      tags: {
+        source: 'find-artifacts',
+        reason: 'absolute_path',
+      },
+      extras: {
+        rootDir: '/Users/expo/build',
+        patternOrPath: '/tmp/maestro_xctestrunner_xcodebuild_output*',
+        currentCount: 0,
+        dryRunCount: 2,
+        currentSample: [],
+        dryRunSample: [
+          '/tmp/maestro_xctestrunner_xcodebuild_output123',
+          '/tmp/maestro_xctestrunner_xcodebuild_output456',
+        ],
+      },
+    });
   });
 
   test('with missing file in empty directory', async () => {

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -19,11 +19,12 @@ export async function findArtifacts({
   /** If provided, will log error suggesting possible files to upload. */
   logger: bunyan | null;
 }): Promise<string[]> {
-  const files = path.isAbsolute(patternOrPath)
-    ? (await fs.pathExists(patternOrPath))
-      ? [patternOrPath]
-      : []
-    : await fg(patternOrPath, { cwd: rootDir, onlyFiles: false });
+  const files =
+    path.isAbsolute(patternOrPath) && !fg.isDynamicPattern(patternOrPath)
+      ? (await fs.pathExists(patternOrPath))
+        ? [patternOrPath]
+        : []
+      : await fg(patternOrPath, { cwd: rootDir, onlyFiles: false });
   if (files.length === 0) {
     if (fg.isDynamicPattern(patternOrPath)) {
       throw new FindArtifactsError(`There are no files matching pattern "${patternOrPath}"`);

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import promiseLimit from 'promise-limit';
 
 import { BuildContext } from '../context';
+import { Sentry } from '../sentry';
 
 export class FindArtifactsError extends Error {}
 
@@ -19,12 +20,16 @@ export async function findArtifacts({
   /** If provided, will log error suggesting possible files to upload. */
   logger: bunyan | null;
 }): Promise<string[]> {
-  const files =
-    path.isAbsolute(patternOrPath) && !fg.isDynamicPattern(patternOrPath)
-      ? (await fs.pathExists(patternOrPath))
-        ? [patternOrPath]
-        : []
-      : await fg(patternOrPath, { cwd: rootDir, onlyFiles: false });
+  const files = path.isAbsolute(patternOrPath)
+    ? (await fs.pathExists(patternOrPath))
+      ? [patternOrPath]
+      : []
+    : await fg(patternOrPath, { cwd: rootDir, onlyFiles: false });
+  await maybeReportAbsoluteGlobDryRunMismatchAsync({
+    rootDir,
+    patternOrPath,
+    files,
+  });
   if (files.length === 0) {
     if (fg.isDynamicPattern(patternOrPath)) {
       throw new FindArtifactsError(`There are no files matching pattern "${patternOrPath}"`);
@@ -47,6 +52,78 @@ export async function findArtifacts({
     // fg will return a path relative to rootDir.
     return path.join(rootDir, filePath);
   });
+}
+
+async function findArtifactsWithAbsoluteGlobSupportDryRunAsync(
+  rootDir: string,
+  patternOrPath: string
+): Promise<string[]> {
+  return path.isAbsolute(patternOrPath) && !fg.isDynamicPattern(patternOrPath)
+    ? (await fs.pathExists(patternOrPath))
+      ? [patternOrPath]
+      : []
+    : await fg(patternOrPath, { cwd: rootDir, onlyFiles: false });
+}
+
+async function maybeReportAbsoluteGlobDryRunMismatchAsync({
+  rootDir,
+  patternOrPath,
+  files,
+}: {
+  rootDir: string;
+  patternOrPath: string;
+  files: string[];
+}): Promise<void> {
+  if (!path.isAbsolute(patternOrPath)) {
+    return;
+  }
+
+  try {
+    const filesWithAbsoluteGlobSupport = await findArtifactsWithAbsoluteGlobSupportDryRunAsync(
+      rootDir,
+      patternOrPath
+    );
+    if (areArtifactListsEqual(files, filesWithAbsoluteGlobSupport)) {
+      return;
+    }
+
+    Sentry.capture(new Error('findArtifacts output changed for an absolute path'), {
+      tags: {
+        source: 'find-artifacts',
+        reason: 'absolute_path',
+      },
+      extras: {
+        rootDir,
+        patternOrPath,
+        currentCount: files.length,
+        dryRunCount: filesWithAbsoluteGlobSupport.length,
+        currentSample: files.slice(0, 20),
+        dryRunSample: filesWithAbsoluteGlobSupport.slice(0, 20),
+      },
+    });
+  } catch (err: any) {
+    Sentry.capture(err, {
+      tags: {
+        source: 'find-artifacts',
+        reason: 'absolute_path_dry_run_failed',
+      },
+      extras: {
+        rootDir,
+        patternOrPath,
+        currentCount: files.length,
+        currentSample: files.slice(0, 20),
+      },
+    });
+  }
+}
+
+function areArtifactListsEqual(first: string[], second: string[]): boolean {
+  if (first.length !== second.length) {
+    return false;
+  }
+  const sortedFirst = [...first].sort();
+  const sortedSecond = [...second].sort();
+  return sortedFirst.every((artifactPath, index) => artifactPath === sortedSecond[index]);
 }
 
 async function logMissingFileError(artifactPath: string, buildLogger: bunyan): Promise<void> {


### PR DESCRIPTION
## Summary

Updates artifact path resolution so absolute paths containing glob metacharacters are treated as glob patterns instead of literal paths.

This lets `eas/upload_artifact` handle paths like `/var/folders/.../T/maestro_xctestrunner_xcodebuild_output*`, while preserving the existing literal-path behavior for non-dynamic absolute paths.

## Why

`upload_artifact.path` already accepts paths or patterns, but absolute patterns were previously short-circuited through `fs.pathExists()` and never reached `fast-glob`.

## Test Plan

- `yarn workspace @expo/build-tools jest-unit packages/build-tools/src/utils/__tests__/artifacts.test.ts`

Note: the focused test was run in the existing local checkout with the same two-file patch. The clean PR worktree did not have its own install state.
