### PR TITLE
[build-job] add GRADLE_PROFILE build phase enum

### DIFF
--- a/packages/eas-build-job/src/logs.ts
+++ b/packages/eas-build-job/src/logs.ts
@@ -36,6 +36,7 @@ export enum BuildPhase {
   // ANDROID
   FIX_GRADLEW = 'FIX_GRADLEW',
   RUN_GRADLEW = 'RUN_GRADLEW',
+  GRADLE_BUILD_PROFILE = 'GRADLE_BUILD_PROFILE',
 
   // IOS
   INSTALL_PODS = 'INSTALL_PODS',
@@ -104,6 +105,7 @@ export const buildPhaseDisplayName: Record<BuildPhase, string> = {
   // ANDROID
   [BuildPhase.FIX_GRADLEW]: 'Fix gradlew',
   [BuildPhase.RUN_GRADLEW]: 'Run gradlew',
+  [BuildPhase.GRADLE_BUILD_PROFILE]: 'Gradle build profile',
 
   // IOS
   [BuildPhase.INSTALL_PODS]: 'Install pods',
@@ -169,6 +171,7 @@ export const buildPhaseWebsiteId: Record<BuildPhase, string> = {
   // ANDROID
   [BuildPhase.FIX_GRADLEW]: 'fix-gradlew',
   [BuildPhase.RUN_GRADLEW]: 'run-gradlew',
+  [BuildPhase.GRADLE_BUILD_PROFILE]: 'gradle-build-profile',
 
   // IOS
   [BuildPhase.INSTALL_PODS]: 'install-pods',


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Added GRADLE_BUILD_PROFILE to all 3 places in packages/eas-build-job/src/logs.ts:
  - Enum value: GRADLE_BUILD_PROFILE = 'GRADLE_BUILD_PROFILE'
  - Display name: 'Gradle build profile'
  - Website ID: 'gradle-build-profile'
  
  merge and bump website before https://github.com/expo/eas-cli/pull/3629
