### PR TITLE
[eas-cli] filter observe:routes results by route names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Allow command `observe:routes` to filter results to specific route names. ([#3744](https://github.com/expo/eas-cli/pull/3744) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -1398,6 +1398,47 @@
             "deprecationReason": null
           },
           {
+            "name": "concurrencyConsumers",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": "500",
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "UNION",
+                    "name": "ConcurrencyConsumer",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "convexTeamConnections",
             "description": "Convex team connections for this account",
             "args": [],
@@ -13985,6 +14026,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "isEmbeddedUpdate",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "orderBy",
                 "description": null,
                 "type": {
@@ -14370,6 +14423,65 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AppObserveAppBuildEmbeddedSummary",
+        "description": null,
+        "fields": [
+          {
+            "name": "eventCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstSeenAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uniqueUserCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AppObserveAppBuildNumber",
         "description": null,
         "fields": [
@@ -14409,6 +14521,18 @@
                   }
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "embedded",
+            "description": "Summary restricted to events running this build's embedded bundle\n(no OTA update applied). Null when the build has no such events\nin the queried time range.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AppObserveAppBuildEmbeddedSummary",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -14559,6 +14683,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -14898,6 +15034,18 @@
           },
           {
             "name": "appUpdateId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateMessage",
             "description": null,
             "args": [],
             "type": {
@@ -15379,6 +15527,18 @@
             "deprecationReason": null
           },
           {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "platform",
             "description": null,
             "type": {
@@ -15605,6 +15765,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -15953,6 +16125,18 @@
           },
           {
             "name": "appUpdateId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateMessage",
             "description": null,
             "args": [],
             "type": {
@@ -16557,6 +16741,18 @@
             "deprecationReason": null
           },
           {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "metricName",
             "description": null,
             "type": {
@@ -16971,6 +17167,26 @@
                 "kind": "ENUM",
                 "name": "AppObservePlatform",
                 "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "routeNames",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             "defaultValue": null,
@@ -17637,6 +17853,18 @@
             "deprecationReason": null
           },
           {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "metricName",
             "description": null,
             "type": {
@@ -17829,6 +18057,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -29719,6 +29959,12 @@
             "deprecationReason": null
           },
           {
+            "name": "PARSE_XCACTIVITYLOG",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "POST_INSTALL_HOOK",
             "description": null,
             "isDeprecated": false,
@@ -31154,6 +31400,27 @@
         "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
+      },
+      {
+        "kind": "UNION",
+        "name": "ConcurrencyConsumer",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "Build",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "JobRun",
+            "ofType": null
+          }
+        ]
       },
       {
         "kind": "ENUM",
@@ -42241,6 +42508,141 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "EmbeddedUpdateAssetMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "getSignedEmbeddedUpdateAssetUploadSpecifications",
+            "description": "Returns a presigned POST URL for uploading an embedded update bundle.\nRequires PUBLISH permission on the app.",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "contentType",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "embeddedUpdateId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EmbeddedUpdateAssetUploadSpec",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EmbeddedUpdateAssetUploadSpec",
+        "description": null,
+        "fields": [
+          {
+            "name": "fields",
+            "description": "Form fields that must be included with the POST request alongside the file.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "presignedUrl",
+            "description": "Presigned POST URL targeting the upload bucket. Valid for one hour.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storageKey",
+            "description": "Storage key (`{appId}/{embeddedUpdateId}`). Same key in both upload and destination buckets.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "EntityTypeName",
         "description": null,
@@ -51776,6 +52178,22 @@
             "deprecationReason": null
           },
           {
+            "name": "resourceClassDisplayName",
+            "description": "String describing the worker profile used to run this job run.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "startedAt",
             "description": null,
             "args": [],
@@ -58050,6 +58468,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "EchoVersionMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "embeddedUpdateAsset",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EmbeddedUpdateAssetMutation",
                 "ofType": null
               }
             },

--- a/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
@@ -152,6 +152,22 @@ describe(ObserveRoutes, () => {
     expect(options.buildNumber).toBe('42');
   });
 
+  it('passes --route-name flags through as routeNames array', async () => {
+    const command = createCommand(['--route-name', '/home', '--route-name', '/profile']);
+    await command.runAsync();
+
+    const options = mockFetchObserveNavigationRoutesAsync.mock.calls[0][2];
+    expect(options.routeNames).toEqual(['/home', '/profile']);
+  });
+
+  it('does not pass routeNames when --route-name is not provided', async () => {
+    const command = createCommand([]);
+    await command.runAsync();
+
+    const options = mockFetchObserveNavigationRoutesAsync.mock.calls[0][2];
+    expect(options.routeNames).toBeUndefined();
+  });
+
   it('resolves --stat aliases and passes them through', async () => {
     const command = createCommand(['--stat', 'p90', '--stat', 'eventCount']);
     await command.runAsync();

--- a/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
@@ -160,6 +160,21 @@ describe(ObserveRoutes, () => {
     expect(options.routeNames).toEqual(['/home', '/profile']);
   });
 
+  it('dedupes duplicate --route-name flags', async () => {
+    const command = createCommand([
+      '--route-name',
+      '/home',
+      '--route-name',
+      '/profile',
+      '--route-name',
+      '/home',
+    ]);
+    await command.runAsync();
+
+    const options = mockFetchObserveNavigationRoutesAsync.mock.calls[0][2];
+    expect(options.routeNames).toEqual(['/home', '/profile']);
+  });
+
   it('does not pass routeNames when --route-name is not provided', async () => {
     const command = createCommand([]);
     await command.runAsync();

--- a/packages/eas-cli/src/commands/observe/routes.ts
+++ b/packages/eas-cli/src/commands/observe/routes.ts
@@ -105,6 +105,10 @@ export default class ObserveRoutes extends EasCommand {
       ? Array.from(new Set(flags.stat.map(resolveNavigationStatKey)))
       : undefined;
 
+    const routeNames = flags['route-name']?.length
+      ? Array.from(new Set(flags['route-name']))
+      : undefined;
+
     const { daysBack, startTime, endTime } = resolveTimeRange(flags);
     const platforms = appPlatformsFromFlag(flags.platform);
 
@@ -120,7 +124,7 @@ export default class ObserveRoutes extends EasCommand {
         appVersion: flags['app-version'],
         updateId: flags['update-id'],
         buildNumber: flags['build-number'],
-        routeNames: flags['route-name'],
+        routeNames,
       }
     );
 

--- a/packages/eas-cli/src/commands/observe/routes.ts
+++ b/packages/eas-cli/src/commands/observe/routes.ts
@@ -62,6 +62,11 @@ export default class ObserveRoutes extends EasCommand {
     'build-number': Flags.string({
       description: 'Filter by app build number',
     }),
+    'route-name': Flags.string({
+      description:
+        'Filter by route name (can be specified multiple times to include several routes)',
+      multiple: true,
+    }),
     ...ObserveProjectIdFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -115,6 +120,7 @@ export default class ObserveRoutes extends EasCommand {
         appVersion: flags['app-version'],
         updateId: flags['update-id'],
         buildNumber: flags['build-number'],
+        routeNames: flags['route-name'],
       }
     );
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -120,6 +120,7 @@ export type Account = {
   /** Billing information. Only visible to members with the ADMIN or OWNER role. */
   billing?: Maybe<Billing>;
   billingPeriod: BillingPeriod;
+  concurrencyConsumers: Array<ConcurrencyConsumer>;
   /** Convex team connections for this account */
   convexTeamConnections: Array<ConvexTeamConnection>;
   createdAt: Scalars['DateTime']['output'];
@@ -396,6 +397,15 @@ export type AccountAuditLogsPaginatedArgs = {
  */
 export type AccountBillingPeriodArgs = {
   date: Scalars['DateTime']['input'];
+};
+
+
+/**
+ * An account is a container owning projects, credentials, billing and other organization
+ * data and settings. Actors may own and be members of accounts.
+ */
+export type AccountConcurrencyConsumersArgs = {
+  limit?: Scalars['Int']['input'];
 };
 
 
@@ -2167,6 +2177,7 @@ export type AppObserveCustomEventNamesArgs = {
   appVersion?: InputMaybe<Scalars['String']['input']>;
   endTime: Scalars['DateTime']['input'];
   environment?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
   orderBy?: InputMaybe<AppObserveCustomEventNamesOrderBy>;
   platform?: InputMaybe<AppObservePlatform>;
   startTime: Scalars['DateTime']['input'];
@@ -2209,10 +2220,23 @@ export type AppObserveUpdatesArgs = {
   input: AppObserveUpdatesInput;
 };
 
+export type AppObserveAppBuildEmbeddedSummary = {
+  __typename?: 'AppObserveAppBuildEmbeddedSummary';
+  eventCount: Scalars['Int']['output'];
+  firstSeenAt: Scalars['DateTime']['output'];
+  uniqueUserCount: Scalars['Int']['output'];
+};
+
 export type AppObserveAppBuildNumber = {
   __typename?: 'AppObserveAppBuildNumber';
   appBuildNumber: Scalars['String']['output'];
   easBuilds: Array<AppObserveAppEasBuild>;
+  /**
+   * Summary restricted to events running this build's embedded bundle
+   * (no OTA update applied). Null when the build has no such events
+   * in the queried time range.
+   */
+  embedded?: Maybe<AppObserveAppBuildEmbeddedSummary>;
   eventCount: Scalars['Int']['output'];
   firstSeenAt: Scalars['DateTime']['output'];
   uniqueUserCount: Scalars['Int']['output'];
@@ -2229,6 +2253,7 @@ export type AppObserveAppEasBuild = {
 export type AppObserveAppUpdate = {
   __typename?: 'AppObserveAppUpdate';
   appUpdateId: Scalars['String']['output'];
+  appUpdateMessage?: Maybe<Scalars['String']['output']>;
   easBuilds: Array<AppObserveAppEasBuild>;
   eventCount: Scalars['Int']['output'];
   firstSeenAt: Scalars['DateTime']['output'];
@@ -2259,6 +2284,7 @@ export type AppObserveCustomEvent = {
   appEasBuildId?: Maybe<Scalars['String']['output']>;
   appIdentifier: Scalars['String']['output'];
   appUpdateId?: Maybe<Scalars['String']['output']>;
+  appUpdateMessage?: Maybe<Scalars['String']['output']>;
   appVersion: Scalars['String']['output'];
   clientVersion?: Maybe<Scalars['String']['output']>;
   countryCode?: Maybe<Scalars['String']['output']>;
@@ -2300,6 +2326,7 @@ export type AppObserveCustomEventCountsInput = {
   endTime: Scalars['DateTime']['input'];
   environment?: InputMaybe<Scalars['String']['input']>;
   eventName: Scalars['String']['input'];
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
   platform: AppObservePlatform;
   startTime: Scalars['DateTime']['input'];
 };
@@ -2325,6 +2352,7 @@ export type AppObserveCustomEventListFilter = {
   endTime?: InputMaybe<Scalars['DateTime']['input']>;
   environment?: InputMaybe<Scalars['String']['input']>;
   eventName?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
   platform?: InputMaybe<AppObservePlatform>;
   propertyFilters?: InputMaybe<Array<AppObserveCustomEventPropertyFilter>>;
   sessionId?: InputMaybe<Scalars['String']['input']>;
@@ -2369,6 +2397,7 @@ export type AppObserveEvent = {
   appIdentifier: Scalars['String']['output'];
   appName: Scalars['String']['output'];
   appUpdateId?: Maybe<Scalars['String']['output']>;
+  appUpdateMessage?: Maybe<Scalars['String']['output']>;
   appVersion: Scalars['String']['output'];
   clientVersion?: Maybe<Scalars['String']['output']>;
   countryCode?: Maybe<Scalars['String']['output']>;
@@ -2423,6 +2452,7 @@ export type AppObserveEventsFilter = {
   easClientId?: InputMaybe<Scalars['String']['input']>;
   endTime?: InputMaybe<Scalars['DateTime']['input']>;
   environment?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
   metricName?: InputMaybe<Scalars['String']['input']>;
   platform?: InputMaybe<AppObservePlatform>;
   routeName?: InputMaybe<Scalars['String']['input']>;
@@ -2479,6 +2509,7 @@ export type AppObserveNavigationRoutesFilter = {
   endTime: Scalars['DateTime']['input'];
   environment?: InputMaybe<Scalars['String']['input']>;
   platform: AppObservePlatform;
+  routeNames?: InputMaybe<Array<Scalars['String']['input']>>;
   startTime: Scalars['DateTime']['input'];
 };
 
@@ -2556,6 +2587,7 @@ export type AppObserveTimeSeriesInput = {
   bucketIntervalMinutes?: InputMaybe<Scalars['Int']['input']>;
   endTime: Scalars['DateTime']['input'];
   environment?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
   metricName: Scalars['String']['input'];
   platform: AppObservePlatform;
   routeName?: InputMaybe<Scalars['String']['input']>;
@@ -2577,6 +2609,7 @@ export type AppObserveTimeSeriesStatistics = {
 export type AppObserveUpdate = {
   __typename?: 'AppObserveUpdate';
   appUpdateId: Scalars['String']['output'];
+  appUpdateMessage?: Maybe<Scalars['String']['output']>;
   appVersion: Scalars['String']['output'];
   downloadCount: Scalars['Int']['output'];
   firstSeenAt: Scalars['DateTime']['output'];
@@ -4187,6 +4220,7 @@ export enum BuildPhase {
   OnBuildErrorHook = 'ON_BUILD_ERROR_HOOK',
   OnBuildSuccessHook = 'ON_BUILD_SUCCESS_HOOK',
   ParseCustomWorkflowConfig = 'PARSE_CUSTOM_WORKFLOW_CONFIG',
+  ParseXcactivitylog = 'PARSE_XCACTIVITYLOG',
   PostInstallHook = 'POST_INSTALL_HOOK',
   Prebuild = 'PREBUILD',
   PrepareArtifacts = 'PREPARE_ARTIFACTS',
@@ -4409,6 +4443,8 @@ export type Concurrencies = {
   ios: Scalars['Int']['output'];
   total: Scalars['Int']['output'];
 };
+
+export type ConcurrencyConsumer = Build | JobRun;
 
 export enum ContinentCode {
   Af = 'AF',
@@ -6000,6 +6036,32 @@ export type EditUpdateBranchInput = {
   newName: Scalars['String']['input'];
 };
 
+export type EmbeddedUpdateAssetMutation = {
+  __typename?: 'EmbeddedUpdateAssetMutation';
+  /**
+   * Returns a presigned POST URL for uploading an embedded update bundle.
+   * Requires PUBLISH permission on the app.
+   */
+  getSignedEmbeddedUpdateAssetUploadSpecifications: EmbeddedUpdateAssetUploadSpec;
+};
+
+
+export type EmbeddedUpdateAssetMutationGetSignedEmbeddedUpdateAssetUploadSpecificationsArgs = {
+  appId: Scalars['ID']['input'];
+  contentType: Scalars['String']['input'];
+  embeddedUpdateId: Scalars['ID']['input'];
+};
+
+export type EmbeddedUpdateAssetUploadSpec = {
+  __typename?: 'EmbeddedUpdateAssetUploadSpec';
+  /** Form fields that must be included with the POST request alongside the file. */
+  fields: Scalars['JSONObject']['output'];
+  /** Presigned POST URL targeting the upload bucket. Valid for one hour. */
+  presignedUrl: Scalars['String']['output'];
+  /** Storage key (`{appId}/{embeddedUpdateId}`). Same key in both upload and destination buckets. */
+  storageKey: Scalars['String']['output'];
+};
+
 export enum EntityTypeName {
   AccountEntity = 'AccountEntity',
   AccountSsoConfigurationEntity = 'AccountSSOConfigurationEntity',
@@ -7275,6 +7337,8 @@ export type JobRun = {
   logFileUrls: Array<Scalars['String']['output']>;
   name: Scalars['String']['output'];
   priority: JobRunPriority;
+  /** String describing the worker profile used to run this job run. */
+  resourceClassDisplayName: Scalars['String']['output'];
   startedAt?: Maybe<Scalars['DateTime']['output']>;
   status: JobRunStatus;
   updateGroups: Array<Array<Update>>;
@@ -8154,6 +8218,7 @@ export type RootMutation = {
   echoTurn: EchoTurnMutation;
   /** Mutations for Echo versions */
   echoVersion: EchoVersionMutation;
+  embeddedUpdateAsset: EmbeddedUpdateAssetMutation;
   /** Mutations that create and delete EnvironmentSecrets */
   environmentSecret: EnvironmentSecretMutation;
   /** Mutations that create and delete EnvironmentVariables */

--- a/packages/eas-cli/src/observe/__tests__/fetchNavigationRoutes.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchNavigationRoutes.test.ts
@@ -85,6 +85,34 @@ describe('fetchObserveNavigationRoutesAsync', () => {
     expect(filter).not.toHaveProperty('appVersion');
     expect(filter).not.toHaveProperty('appUpdateId');
     expect(filter).not.toHaveProperty('appBuildNumber');
+    expect(filter).not.toHaveProperty('routeNames');
+  });
+
+  it('forwards routeNames filter when provided', async () => {
+    await fetchObserveNavigationRoutesAsync(mockGraphqlClient, 'project-123', {
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+      platforms: [AppPlatform.Ios],
+      limit: 50,
+      routeNames: ['/home', '/profile'],
+    });
+
+    expect(mockNavigationRoutesAsync.mock.calls[0][1].filter.routeNames).toEqual([
+      '/home',
+      '/profile',
+    ]);
+  });
+
+  it('does not send routeNames when array is empty', async () => {
+    await fetchObserveNavigationRoutesAsync(mockGraphqlClient, 'project-123', {
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+      platforms: [AppPlatform.Ios],
+      limit: 50,
+      routeNames: [],
+    });
+
+    expect(mockNavigationRoutesAsync.mock.calls[0][1].filter).not.toHaveProperty('routeNames');
   });
 
   it('forwards after cursor when provided', async () => {

--- a/packages/eas-cli/src/observe/fetchNavigationRoutes.ts
+++ b/packages/eas-cli/src/observe/fetchNavigationRoutes.ts
@@ -25,6 +25,7 @@ export interface FetchNavigationRoutesOptions {
   appVersion?: string;
   updateId?: string;
   buildNumber?: string;
+  routeNames?: string[];
   orderBy?: AppObserveNavigationRoutesOrderBy;
 }
 
@@ -55,6 +56,7 @@ export async function fetchObserveNavigationRoutesAsync(
           ...(options.appVersion && { appVersion: options.appVersion }),
           ...(options.updateId && { appUpdateId: options.updateId }),
           ...(options.buildNumber && { appBuildNumber: options.buildNumber }),
+          ...(options.routeNames?.length && { routeNames: options.routeNames }),
         },
         first: options.limit,
         ...(options.after && { after: options.after }),


### PR DESCRIPTION
# Why

The `eas observe:routes` command lacked the ability to filter navigation route results by specific route names. Users had no way to narrow down the routes data to only the routes they cared about.

# How

A new `--route-name` flag (repeatable) was added to the command. When one or more values are provided, they are collected into a `routeNames` array and forwarded to the `fetchObserveNavigationRoutesAsync` function, which passes them along in the GraphQL filter. An empty array is treated the same as omitting the flag — no `routeNames` key is sent in the filter.

Example:

```
$ easd observe:routes 
EAS Observe is in preview and subject to breaking changes.

Med values (navigation count) for the last 60 days

Android
Route           Nav Cold TTR  Nav Warm TTR  Nav TTI    
--------------  ------------  ------------  -----------
/               0.18s (63)    0.08s (217)   0.22s (280)
/task/[taskId]  0.55s (39)    0.17s (139)   0.35s (178)
/new            0.37s (20)    0.13s (83)    0.26s (103)
/stats          0.88s (19)    0.36s (94)    0.64s (113)
/settings       0.15s (13)    0.06s (41)    0.12s (54) 

iOS
Route           Nav Cold TTR  Nav Warm TTR  Nav TTI    
--------------  ------------  ------------  -----------
/               0.18s (106)   0.08s (504)   0.22s (610)
/task/[taskId]  0.51s (88)    0.18s (325)   0.34s (413)
/stats          1.06s (68)    0.34s (243)   0.62s (311)
/new            0.32s (67)    0.13s (219)   0.27s (286)
/settings       0.16s (17)    0.06s (87)    0.13s (104)

$ easd observe:routes --route-name /new --route-name /settings
EAS Observe is in preview and subject to breaking changes.

Med values (navigation count) for the last 60 days

Android
Route      Nav Cold TTR  Nav Warm TTR  Nav TTI    
---------  ------------  ------------  -----------
/new       0.37s (20)    0.13s (83)    0.26s (103)
/settings  0.15s (13)    0.06s (41)    0.12s (54) 

iOS
Route      Nav Cold TTR  Nav Warm TTR  Nav TTI    
---------  ------------  ------------  -----------
/new       0.32s (67)    0.13s (219)   0.27s (286)
/settings  0.16s (17)    0.06s (87)    0.13s (104)
```

# Test Plan

- New unit tests cover both the command flag parsing and the fetch function behavior
- Manual testing with the kadiexpo/cadence app in staging