### PR TITLE
[auth] Make browser-based login the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- [eas-cli] Make browser-based authentication the default for `eas login`. Use `--no-browser` for CLI-based login. ([#3746](https://github.com/expo/eas-cli/pull/3746) by [@byronkarlen](https://github.com/byronkarlen))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -177,11 +177,11 @@ log in with your Expo account
 
 ```
 USAGE
-  $ eas account:login [-s] [-b]
+  $ eas account:login [-s] [-b | --no-browser]
 
 FLAGS
-  -b, --browser  Login with your browser
-  -s, --sso      Login with SSO
+  -b, --[no-]browser  Log in with your browser (default; use --no-browser for CLI-based login)
+  -s, --sso           Log in with SSO
 
 DESCRIPTION
   log in with your Expo account
@@ -1811,11 +1811,11 @@ log in with your Expo account
 
 ```
 USAGE
-  $ eas login [-s] [-b]
+  $ eas login [-s] [-b | --no-browser]
 
 FLAGS
-  -b, --browser  Login with your browser
-  -s, --sso      Login with SSO
+  -b, --[no-]browser  Log in with your browser (default; use --no-browser for CLI-based login)
+  -s, --sso           Log in with SSO
 
 DESCRIPTION
   log in with your Expo account

--- a/packages/eas-cli/src/commands/account/login.ts
+++ b/packages/eas-cli/src/commands/account/login.ts
@@ -13,14 +13,15 @@ export default class AccountLogin extends EasCommand {
   static override flags = {
     // can pass either --sso or -s
     sso: Flags.boolean({
-      description: 'Login with SSO',
+      description: 'Log in with SSO',
       char: 's',
       default: false,
     }),
     browser: Flags.boolean({
-      description: 'Login with your browser',
+      description: 'Log in with your browser (default; use --no-browser for CLI-based login)',
       char: 'b',
-      default: false,
+      default: true,
+      allowNo: true,
     }),
   };
 

--- a/packages/eas-cli/src/user/__tests__/SessionManager-test.ts
+++ b/packages/eas-cli/src/user/__tests__/SessionManager-test.ts
@@ -294,7 +294,7 @@ describe(SessionManager, () => {
           username: 'USERNAME',
         });
 
-      await sessionManager.showLoginPromptAsync();
+      await sessionManager.showLoginPromptAsync({ browser: false });
 
       expect(sessionManagerRetryUsernamePasswordAuthWithOTPAsyncSpy).toHaveBeenCalledWith(
         'hello',
@@ -313,7 +313,7 @@ describe(SessionManager, () => {
       );
     });
 
-    it('calls regular login if the sso flag is false', async () => {
+    it('calls regular login by default', async () => {
       jest
         .mocked(promptAsync)
         .mockImplementationOnce(async () => ({ username: 'USERNAME', password: 'PASSWORD' }))
@@ -321,14 +321,19 @@ describe(SessionManager, () => {
           throw new Error("shouldn't happen");
         });
 
+      jest.mocked(fetchSessionSecretAndUserAsync).mockResolvedValue({
+        sessionSecret: 'SESSION_SECRET',
+        id: 'USER_ID',
+        username: 'USERNAME',
+      });
       const sessionManager = new SessionManager(analytics);
 
-      // Regular login
-      await sessionManager.showLoginPromptAsync({ sso: false });
+      await sessionManager.showLoginPromptAsync();
+
       expect(fetchSessionSecretAndUserAsync).toHaveBeenCalled();
     });
 
-    it('calls regular login if the sso flag is undefined', async () => {
+    it('calls regular login when browser is false', async () => {
       jest
         .mocked(promptAsync)
         .mockImplementationOnce(async () => ({ username: 'USERNAME', password: 'PASSWORD' }))
@@ -338,8 +343,21 @@ describe(SessionManager, () => {
 
       const sessionManager = new SessionManager(analytics);
 
-      // Regular login
-      await sessionManager.showLoginPromptAsync({ sso: undefined });
+      await sessionManager.showLoginPromptAsync({ browser: false });
+      expect(fetchSessionSecretAndUserAsync).toHaveBeenCalled();
+    });
+
+    it('calls regular login if the sso flag is false and browser is false', async () => {
+      jest
+        .mocked(promptAsync)
+        .mockImplementationOnce(async () => ({ username: 'USERNAME', password: 'PASSWORD' }))
+        .mockImplementation(() => {
+          throw new Error("shouldn't happen");
+        });
+
+      const sessionManager = new SessionManager(analytics);
+
+      await sessionManager.showLoginPromptAsync({ sso: false, browser: false });
       expect(fetchSessionSecretAndUserAsync).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
# Why
Now that we have many third party login users (without passwords), it should be easier for them to log in through eas-cli. 

# How
Added `--no-browser` option to keep existing functionality intact, and made the --browser option the default.
This is a potentially breaking change (although I suspect for very few users) so updated changelog as such.

# Test Plan
Manually tested `eas login`, `eas login --browser`, `eas login --no-browser`