### PR TITLE
fix(eas-cli): Check if `expo` is resolvable before assuming it's installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Check that `expo` is resolvable before assuming it's installed ([#3748](https://github.com/expo/eas-cli/pull/3748) by [@kitten](https://github.com/kitten))
+
 ### 🧹 Chores
 
 ## [18.13.1](https://github.com/expo/eas-cli/releases/tag/v18.13.1) - 2026-05-18

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -10,7 +10,7 @@ import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGr
 import { AccountFragment } from '../graphql/generated';
 import { AppQuery } from '../graphql/queries/AppQuery';
 import Log, { learnMore } from '../log';
-import { expoCommandAsync } from '../utils/expoCli';
+import { expoCommandAsync, resolveExpoCli } from '../utils/expoCli';
 
 /**
  * Return a useful name describing the project config.
@@ -45,7 +45,22 @@ export function isExpoNotificationsInstalled(projectDir: string): boolean {
 
 export function isExpoInstalled(projectDir: string): boolean {
   const packageJson = getPackageJson(projectDir);
-  return !!(packageJson.dependencies && 'expo' in packageJson.dependencies);
+  if (!!(packageJson.dependencies && 'expo' in packageJson.dependencies)) {
+    // NOTE(@kitten): We usually don't apply strict checks for installed packages, but
+    // `isExpoInstalled` is often used to check if we should call the Expo CLI, so we're
+    // also checking if we can resolve `expo` here
+    try {
+      return !!resolveExpoCli(projectDir);
+    } catch (e: any) {
+      if (e.code === 'MODULE_NOT_FOUND') {
+        return false;
+      } else {
+        throw e;
+      }
+    }
+  } else {
+    return false;
+  }
 }
 
 export function isExpoUpdatesInstalledAsDevDependency(projectDir: string): boolean {

--- a/packages/eas-cli/src/utils/expoCli.ts
+++ b/packages/eas-cli/src/utils/expoCli.ts
@@ -78,6 +78,12 @@ export const shouldUseVersionedExpoCLIWithExplicitPlatforms = memoize(
   shouldUseVersionedExpoCLIWithExplicitPlatformsExpensive
 );
 
+export function resolveExpoCli(projectDir: string): string {
+  return (
+    silentResolveFrom(projectDir, 'expo/bin/cli') ?? resolveFrom(projectDir, 'expo/bin/cli.js')
+  );
+}
+
 export function spawnExpoCommand(
   projectDir: string,
   args: string[],
@@ -85,8 +91,7 @@ export function spawnExpoCommand(
 ): spawnAsync.SpawnPromise<spawnAsync.SpawnResult> {
   let expoCliPath;
   try {
-    expoCliPath =
-      silentResolveFrom(projectDir, 'expo/bin/cli') ?? resolveFrom(projectDir, 'expo/bin/cli.js');
+    expoCliPath = resolveExpoCli(projectDir);
   } catch (e: any) {
     if (e.code === 'MODULE_NOT_FOUND') {
       throw new Error(


### PR DESCRIPTION
# Summary

We'll have to share a check on whether `expo` is resolvable with `isExpoInstalled`, to make it stricter, since the check is used to see if `expo` is installed, not just to see if it's in dependencies. We often use this as a prerequisite to see if we can call the Expo CLI. The check needs to align with `spawnExpoCommand` to ensure we don't pass into `spawnExpoCommand` when we can't

# Test Plan
