### PR TITLE
[build-tools] Enable build time statistics for xcodebuild

### DIFF
--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -173,18 +173,20 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
     });
   }
 
-  if (ctx.env.EXPERIMENTAL_EAS_XCACTIVITYLOG === '1') {
-    const { derivedDataPath, workspacePath } = nullthrows(fastlaneResult);
-    await ctx.runBuildPhase(BuildPhase.PARSE_XCACTIVITYLOG, async () => {
-      await parseAndReportXcactivitylog({
-        derivedDataPath,
-        workspacePath,
-        logger: ctx.logger,
-        proxyBaseUrl: ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL,
-        env: ctx.env,
-      });
+  const { derivedDataPath, workspacePath } = nullthrows(fastlaneResult);
+  await ctx.runBuildPhase(BuildPhase.PARSE_XCACTIVITYLOG, async () => {
+    if (ctx.isLocal) {
+      ctx.logger.info('Local builds skip build performance analysis.');
+      return;
+    }
+    await parseAndReportXcactivitylog({
+      derivedDataPath,
+      workspacePath,
+      logger: ctx.logger,
+      proxyBaseUrl: ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL,
+      env: ctx.env,
     });
-  }
+  });
 
   await ctx.runBuildPhase(BuildPhase.PRE_UPLOAD_ARTIFACTS_HOOK, async () => {
     await runHookIfPresent(ctx, Hook.PRE_UPLOAD_ARTIFACTS);

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -16,6 +16,7 @@ import { runFastlaneGym, runFastlaneResign } from '../ios/fastlane';
 import { installPods } from '../ios/pod';
 import { downloadApplicationArchiveAsync } from '../ios/resign';
 import { resolveArtifactPath, resolveBuildConfiguration, resolveScheme } from '../ios/resolve';
+import { Sentry } from '../sentry';
 import { parseAndReportXcactivitylog } from '../steps/utils/ios/xcactivitylog';
 import { cacheStatsAsync, restoreCcacheAsync } from '../steps/functions/restoreBuildCache';
 import { saveCcacheAsync } from '../steps/functions/saveBuildCache';
@@ -173,19 +174,24 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
     });
   }
 
-  const { derivedDataPath, workspacePath } = nullthrows(fastlaneResult);
   await ctx.runBuildPhase(BuildPhase.PARSE_XCACTIVITYLOG, async () => {
     if (ctx.isLocal) {
       ctx.logger.info('Local builds skip build performance analysis.');
       return;
     }
-    await parseAndReportXcactivitylog({
-      derivedDataPath,
-      workspacePath,
-      logger: ctx.logger,
-      proxyBaseUrl: ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL,
-      env: ctx.env,
-    });
+    try {
+      const { derivedDataPath, workspacePath } = nullthrows(fastlaneResult);
+      await parseAndReportXcactivitylog({
+        derivedDataPath,
+        workspacePath,
+        logger: ctx.logger,
+        proxyBaseUrl: ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL,
+        env: ctx.env,
+      });
+    } catch (err: any) {
+      Sentry.capture('Failed to parse xcactivitylog', err);
+      ctx.markBuildPhaseSkipped();
+    }
   });
 
   await ctx.runBuildPhase(BuildPhase.PRE_UPLOAD_ARTIFACTS_HOOK, async () => {

--- a/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
+++ b/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
@@ -462,7 +462,7 @@ export function formatReport(data: XcactivitylogData): string {
       ' │ ' +
       '100.0%'.padStart(pctWidth) +
       ' │ ' +
-      'n/a'.padStart(wallWidth) +
+      ' '.repeat(wallWidth) +
       ' │ ' +
       ' '.repeat(barMaxWidth) +
       ' │'


### PR DESCRIPTION
# Why

The `PARSE_XCACTIVITYLOG` phase was gated behind `EXPERIMENTAL_EAS_XCACTIVITYLOG=1`. The underlying `parseAndReportXcactivitylog` is documented as "Never throws — best-effort observability that does not affect build status" and routes all failures to Sentry, so it is safe to enable by default for cloud iOS builds.

Linear: ENG-21340.

# How

- Removed the `EXPERIMENTAL_EAS_XCACTIVITYLOG` env check in `packages/build-tools/src/builders/ios.ts`.
- Added a `ctx.isLocal` early-return inside the phase so `eas build --local` keeps skipping the parse, matching the existing `SAVE_CACHE` local-skip pattern in the same file.

No server-side or worker coordination is required — the env was only referenced in this single file.

# Test Plan

- `cd packages/build-tools && yarn test` — 516/516 passing.
- `yarn fmt:check` — clean.
- Existing `parseAndReportXcactivitylog` unit tests (`packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts`) continue to cover the parse/download/report paths.
- Behavior after this change:
  - Cloud iOS build → runs `PARSE_XCACTIVITYLOG` and prints the build performance report.
  - `eas build --local` → enters the phase, logs `Local builds skip build performance analysis.`, returns immediately.
  - Any error inside `parseAndReportXcactivitylog` → captured by Sentry, build status unaffected.