### PR TITLE
[eas-cli] Add `EXPO_NO_DOTENV` when resolving iOS entitlements back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Disable dotenv loading when resolving managed iOS entitlements. ([#3752](https://github.com/expo/eas-cli/pull/3752) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🧹 Chores
 
 ## [19.0.0](https://github.com/expo/eas-cli/releases/tag/v19.0.0) - 2026-05-19

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -17,7 +17,10 @@ export async function getManagedApplicationTargetEntitlementsAsync(
     projectDir,
     ['config', '--json', '--type', 'introspect'],
     {
-      env,
+      env: {
+        ...env,
+        EXPO_NO_DOTENV: '1',
+      },
     }
   );
   const expWithMods: ExportedConfig = JSON.parse(stdout);


### PR DESCRIPTION
## Summary
- restore `EXPO_NO_DOTENV=1` when resolving managed iOS entitlements through `expo config --type introspect`
- keep the introspection environment consistent with the regular Expo config path

## Why
`18.13.1` changed this path to call the local Expo CLI directly, but the entitlements-specific call no longer disabled dotenv loading. This can make the iOS-only entitlements introspection evaluate app config under a different environment than the rest of EAS CLI config resolution.

## Validation

CI should pass. Repacks should work.