### PR TITLE
[eas-cli] Restore iOS entitlements introspection fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [eas-cli] Disable dotenv loading when resolving managed iOS entitlements. ([#3752](https://github.com/expo/eas-cli/pull/3752) by [@sjchmiela](https://github.com/sjchmiela))
+- [eas-cli] Restore the bundled config fallback for managed iOS entitlements introspection. ([#3753](https://github.com/expo/eas-cli/pull/3753) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -1,8 +1,13 @@
-import { ExportedConfig, IOSConfig } from '@expo/config-plugins';
+import { ExportedConfig, IOSConfig, compileModsAsync } from '@expo/config-plugins';
 import { JSONObject } from '@expo/json-file';
+import { getPrebuildConfigAsync } from '@expo/prebuild-config';
 
+import Log from '../../log';
 import { spawnExpoCommand } from '../../utils/expoCli';
 import { readPlistAsync } from '../../utils/plist';
+import { Client } from '../../vcs/vcs';
+import { isExpoInstalled } from '../projectUtils';
+import { hasIgnoredIosProjectAsync } from '../workflow';
 
 interface Target {
   buildConfiguration?: string;
@@ -11,20 +16,83 @@ interface Target {
 
 export async function getManagedApplicationTargetEntitlementsAsync(
   projectDir: string,
-  env: Record<string, string>
+  env: Record<string, string>,
+  vcsClient: Client
 ): Promise<JSONObject> {
-  const { stdout } = await spawnExpoCommand(
-    projectDir,
-    ['config', '--json', '--type', 'introspect'],
-    {
-      env: {
-        ...env,
-        EXPO_NO_DOTENV: '1',
-      },
+  let expoConfigError: Error | undefined;
+  if (isExpoInstalled(projectDir)) {
+    try {
+      const { stdout } = await spawnExpoCommand(
+        projectDir,
+        ['config', '--json', '--type', 'introspect'],
+        {
+          env: {
+            ...env,
+            EXPO_NO_DOTENV: '1',
+          },
+        }
+      );
+      const expWithMods: ExportedConfig = JSON.parse(stdout);
+      return expWithMods.ios?.entitlements ?? {};
+    } catch (error: any) {
+      expoConfigError = error;
+      Log.warn(
+        `Failed to read the app config from the project using the local Expo CLI: ${formatError(error)}`
+      );
+      Log.warn('Falling back to the version of "@expo/config" shipped with the EAS CLI.');
     }
-  );
-  const expWithMods: ExportedConfig = JSON.parse(stdout);
-  return expWithMods.ios?.entitlements ?? {};
+  }
+
+  try {
+    return await resolveManagedApplicationTargetEntitlementsWithBundledConfigAsync(
+      projectDir,
+      env,
+      vcsClient
+    );
+  } catch (fallbackError: any) {
+    if (expoConfigError) {
+      throw new Error(
+        `Failed to resolve iOS entitlements from Expo config. The local Expo CLI failed with: ${formatError(
+          expoConfigError
+        )}. The bundled config fallback also failed with: ${formatError(fallbackError)}`,
+        { cause: fallbackError }
+      );
+    }
+    throw new Error(
+      `Failed to resolve iOS entitlements from Expo config using the bundled config fallback: ${formatError(
+        fallbackError
+      )}`,
+      { cause: fallbackError }
+    );
+  }
+}
+
+async function resolveManagedApplicationTargetEntitlementsWithBundledConfigAsync(
+  projectDir: string,
+  env: Record<string, string>,
+  vcsClient: Client
+): Promise<JSONObject> {
+  const originalProcessEnv = process.env;
+  try {
+    process.env = {
+      ...process.env,
+      ...env,
+    };
+    const { exp } = await getPrebuildConfigAsync(projectDir, { platforms: ['ios'] });
+    const expWithMods = await compileModsAsync(exp, {
+      projectRoot: projectDir,
+      platforms: ['ios'],
+      introspect: true,
+      ignoreExistingNativeFiles: await hasIgnoredIosProjectAsync(projectDir, vcsClient),
+    });
+    return expWithMods.ios?.entitlements ?? {};
+  } finally {
+    process.env = originalProcessEnv;
+  }
+}
+
+function formatError(error: Error & { stderr?: string; stdout?: string }): string {
+  return error.stderr?.trim() || error.stdout?.trim() || error.message;
 }
 
 export async function getNativeTargetEntitlementsAsync(

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -60,7 +60,8 @@ export async function resolveManagedProjectTargetsAsync({
   );
   const applicationTargetEntitlements = await getManagedApplicationTargetEntitlementsAsync(
     projectDir,
-    env ?? {}
+    env ?? {},
+    vcsClient
   );
   const appExtensions: UserDefinedTarget[] =
     exp.extra?.eas?.build?.experimental?.ios?.appExtensions ?? [];


### PR DESCRIPTION
## Summary
- wrap managed iOS `expo config --json --type introspect` entitlement resolution in a local Expo CLI try/catch
- fall back to bundled `getPrebuildConfigAsync` + `compileModsAsync`, matching the previous behavior
- include stderr/stdout in the thrown error when both the local CLI and fallback fail
- check `isExpoInstalled` before spawning the local Expo CLI, consistent with the regular config reader

## Why
After `18.13.1`, managed iOS builds fail hard if the local Expo CLI introspection command exits non-zero. Previously this path could still resolve entitlements through the bundled config fallback. Restoring that fallback limits the regression while preserving the local CLI path when it is available.

## Validation

CI should pass.