### PR TITLE
[build-tools] ignore no Gradle profile found error

### DIFF
--- a/packages/build-tools/src/android/gradleProfile.ts
+++ b/packages/build-tools/src/android/gradleProfile.ts
@@ -10,9 +10,8 @@ export interface GradleProfileTask {
 
 export async function parseGradleProfile(androidDir: string): Promise<GradleProfileTask[]> {
   const profileDir = path.join(androidDir, 'build', 'reports', 'profile');
-  // Gradle profile may not exist for all builds (e.g. custom gradle
-  // commands or builds that fail before producing a profile). We just
-  // short circuit and don't log.
+  // Gradle profile may not exist for all builds (e.g. custom, repack
+  // jobs). We should short circuit and not unnecessarily log.
   if (!(await fs.pathExists(profileDir))) {
     return [];
   }

--- a/packages/build-tools/src/android/gradleProfile.ts
+++ b/packages/build-tools/src/android/gradleProfile.ts
@@ -2,8 +2,6 @@ import { XMLParser } from 'fast-xml-parser';
 import fs from 'fs-extra';
 import path from 'path';
 
-export class GradleProfileNotFoundError extends Error {}
-
 export interface GradleProfileTask {
   path: string;
   durationMs: number;
@@ -12,8 +10,11 @@ export interface GradleProfileTask {
 
 export async function parseGradleProfile(androidDir: string): Promise<GradleProfileTask[]> {
   const profileDir = path.join(androidDir, 'build', 'reports', 'profile');
+  // Gradle profile may not exist for all builds (e.g. custom gradle
+  // commands or builds that fail before producing a profile). We just
+  // short circuit and don't log.
   if (!(await fs.pathExists(profileDir))) {
-    throw new GradleProfileNotFoundError(`Gradle profile directory not found at ${profileDir}`);
+    return [];
   }
 
   const files = await fs.readdir(profileDir);

--- a/packages/build-tools/src/android/gradleProfile.ts
+++ b/packages/build-tools/src/android/gradleProfile.ts
@@ -2,6 +2,8 @@ import { XMLParser } from 'fast-xml-parser';
 import fs from 'fs-extra';
 import path from 'path';
 
+export class GradleProfileNotFoundError extends Error {}
+
 export interface GradleProfileTask {
   path: string;
   durationMs: number;
@@ -11,7 +13,7 @@ export interface GradleProfileTask {
 export async function parseGradleProfile(androidDir: string): Promise<GradleProfileTask[]> {
   const profileDir = path.join(androidDir, 'build', 'reports', 'profile');
   if (!(await fs.pathExists(profileDir))) {
-    throw new Error(`Gradle profile directory not found at ${profileDir}`);
+    throw new GradleProfileNotFoundError(`Gradle profile directory not found at ${profileDir}`);
   }
 
   const files = await fs.readdir(profileDir);

--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -20,11 +20,7 @@ export { findAndUploadXcodeBuildLogsAsync } from './ios/xcodeBuildLogs';
 
 export { Hook, runHookIfPresent } from './utils/hooks';
 
-export {
-  parseGradleProfile,
-  formatGradleProfileReport,
-  GradleProfileNotFoundError,
-} from './android/gradleProfile';
+export { parseGradleProfile, formatGradleProfileReport } from './android/gradleProfile';
 export type { GradleProfileTask } from './android/gradleProfile';
 
 export * from './generic';

--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -20,7 +20,11 @@ export { findAndUploadXcodeBuildLogsAsync } from './ios/xcodeBuildLogs';
 
 export { Hook, runHookIfPresent } from './utils/hooks';
 
-export { parseGradleProfile, formatGradleProfileReport } from './android/gradleProfile';
+export {
+  parseGradleProfile,
+  formatGradleProfileReport,
+  GradleProfileNotFoundError,
+} from './android/gradleProfile';
 export type { GradleProfileTask } from './android/gradleProfile';
 
 export * from './generic';

--- a/packages/worker/src/build.ts
+++ b/packages/worker/src/build.ts
@@ -5,6 +5,7 @@ import {
   Sentry,
   parseGradleProfile,
   formatGradleProfileReport,
+  GradleProfileNotFoundError,
   runGenericJobAsync,
 } from '@expo/build-tools';
 import {
@@ -103,8 +104,12 @@ export async function build({
           }
         });
       } catch (err: any) {
-        logger.error({ err }, 'Failed to parse Gradle build profile');
-        Sentry.capture('Failed to parse Gradle build profile', err);
+        // Gradle profile may not exist for all builds (e.g. custom gradle
+        // commands or builds that fail before producing a profile). This is
+        // expected, so we silently ignore the error.
+        if (!(err instanceof GradleProfileNotFoundError)) {
+          Sentry.capture('Failed to parse Gradle build profile', err);
+        }
       }
     }
 

--- a/packages/worker/src/build.ts
+++ b/packages/worker/src/build.ts
@@ -5,7 +5,6 @@ import {
   Sentry,
   parseGradleProfile,
   formatGradleProfileReport,
-  GradleProfileNotFoundError,
   runGenericJobAsync,
 } from '@expo/build-tools';
 import {
@@ -104,12 +103,7 @@ export async function build({
           }
         });
       } catch (err: any) {
-        // Gradle profile may not exist for all builds (e.g. custom gradle
-        // commands or builds that fail before producing a profile). This is
-        // expected, so we silently ignore the error.
-        if (!(err instanceof GradleProfileNotFoundError)) {
-          Sentry.capture('Failed to parse Gradle build profile', err);
-        }
+        Sentry.capture('Failed to parse Gradle build profile', err);
       }
     }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I did not accommodate for the fact some android build jobs do not actually run gradle, resulting in no profile to parse. This is not an actual error and we should just skip this when the profile is unavailable.

<img width="1242" height="316" alt="Screenshot 2026-05-19 at 3 13 01 PM" src="https://github.com/user-attachments/assets/3a81d7b5-fa50-4e8c-b8bf-19ebbc7f5196" />

# How

Short circuit when no gradle profile is found. This is not a critical phase so skip error logging to to the user but still send unknowns to sentry 

