### PR TITLE
[build-tools] Add start_argent_remote_session build function

### DIFF
--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -41,6 +41,7 @@ import { createSaveCacheFunction } from './functions/saveCache';
 import { createSendSlackMessageFunction } from './functions/sendSlackMessage';
 import { createStartAgentDeviceRemoteSessionBuildFunction } from './functions/startAgentDeviceRemoteSession';
 import { createStartAndroidEmulatorBuildFunction } from './functions/startAndroidEmulator';
+import { createStartArgentRemoteSessionBuildFunction } from './functions/startArgentRemoteSession';
 import { createStartCuttlefishDeviceBuildFunction } from './functions/startCuttlefishDevice';
 import { createStartIosSimulatorBuildFunction } from './functions/startIosSimulator';
 import { createStartServeSimRemoteSessionBuildFunction } from './functions/startServeSimRemoteSession';
@@ -81,6 +82,7 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     runFastlaneFunction(),
     parseXcactivitylogFunction(),
     createStartAgentDeviceRemoteSessionBuildFunction(ctx),
+    createStartArgentRemoteSessionBuildFunction(ctx),
     createStartAndroidEmulatorBuildFunction(),
     createStartCuttlefishDeviceBuildFunction(),
     createStartIosSimulatorBuildFunction(),

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -8,26 +8,24 @@ import {
   BuildStepInputValueTypeName,
 } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
-import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
 import { CustomBuildContext } from '../../customBuildContext';
-import { sleepAsync } from '../../utils/retry';
 import {
-  DetachedProcessHandle,
-  ensureBrewPackageInstalledAsync,
+  ensureCloudflaredInstalledAsync,
   getDeviceRunSessionIdOrThrow,
   spawnDetached,
   startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
+  waitForFileAsync,
+  waitForMatchInOutputAsync,
 } from '../utils/remoteDeviceRunSession';
 
 const AGENT_DEVICE_REPO_URL = 'https://github.com/callstackincubator/agent-device.git';
 const SRC_DIR = '/tmp/agent-device-src';
 const DAEMON_JSON_PATH = path.join(os.homedir(), '.agent-device', 'daemon.json');
 const XCODE_DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer';
-const CLOUDFLARED_LINUX_INSTALL_PATH = '/usr/local/bin/cloudflared';
 const STARTUP_TIMEOUT_MS = 60_000;
 
 export function createStartAgentDeviceRemoteSessionBuildFunction(
@@ -92,12 +90,12 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       });
 
       logger.info(`Waiting for daemon credentials at ${DAEMON_JSON_PATH}.`);
-      await waitForFileAsync({
+      const { port: daemonPort, token: daemonToken } = await waitForFileAsync({
         filePath: DAEMON_JSON_PATH,
         timeoutMs: STARTUP_TIMEOUT_MS,
-        description: 'agent-device daemon',
+        description: 'agent-device daemon credentials',
+        parse: parseDaemonInfo,
       });
-      const { port: daemonPort, token: daemonToken } = readDaemonInfo(DAEMON_JSON_PATH);
       logger.info(`Daemon is listening on port ${daemonPort}; loaded auth token.`);
 
       logger.info(`Starting cloudflared tunnel to http://localhost:${daemonPort}.`);
@@ -148,62 +146,6 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
   });
 }
 
-async function ensureCloudflaredInstalledAsync({
-  runtimePlatform,
-  env,
-  logger,
-}: {
-  runtimePlatform: BuildRuntimePlatform;
-  env: BuildStepEnv;
-  logger: bunyan;
-}): Promise<string> {
-  if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
-    await ensureBrewPackageInstalledAsync({ name: 'cloudflared', env, logger });
-    return 'cloudflared';
-  }
-  if (await isCommandAvailableAsync({ command: 'cloudflared', env })) {
-    return 'cloudflared';
-  }
-  const cloudflaredArch = cloudflaredLinuxArchForNodeArch(os.arch());
-  const downloadUrl = `https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${cloudflaredArch}`;
-  logger.info(`Downloading cloudflared from ${downloadUrl} to ${CLOUDFLARED_LINUX_INSTALL_PATH}.`);
-  await spawn('sudo', ['curl', '-fsSL', '-o', CLOUDFLARED_LINUX_INSTALL_PATH, downloadUrl], {
-    env,
-    logger,
-  });
-  await spawn('sudo', ['chmod', '+x', CLOUDFLARED_LINUX_INSTALL_PATH], { env, logger });
-  // Return the absolute install path so the tunnel command works even when
-  // /usr/local/bin is not on the step's PATH.
-  return CLOUDFLARED_LINUX_INSTALL_PATH;
-}
-
-function cloudflaredLinuxArchForNodeArch(arch: string): 'amd64' | 'arm64' {
-  if (arch === 'x64') {
-    return 'amd64';
-  }
-  if (arch === 'arm64') {
-    return 'arm64';
-  }
-  throw new SystemError(
-    `Unsupported architecture for cloudflared on Linux: "${arch}". Expected "x64" or "arm64".`
-  );
-}
-
-async function isCommandAvailableAsync({
-  command,
-  env,
-}: {
-  command: string;
-  env: BuildStepEnv;
-}): Promise<boolean> {
-  try {
-    await spawn('bash', ['-c', `command -v ${command}`], { env, ignoreStdio: true });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function cloneAgentDeviceAsync({
   packageVersion,
   env,
@@ -220,54 +162,7 @@ async function cloneAgentDeviceAsync({
   });
 }
 
-async function waitForMatchInOutputAsync({
-  process,
-  pattern,
-  timeoutMs,
-  description,
-}: {
-  process: DetachedProcessHandle;
-  pattern: RegExp;
-  timeoutMs: number;
-  description: string;
-}): Promise<string> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const match = pattern.exec(process.getOutput());
-    if (match) {
-      return match[1] ?? match[0];
-    }
-    await sleepAsync(1_000);
-  }
-  throw new SystemError(
-    `Timed out waiting for ${description} to start. Last output:\n${process.getOutput() || '<empty>'}`
-  );
-}
-
-async function waitForFileAsync({
-  filePath,
-  timeoutMs,
-  description,
-}: {
-  filePath: string;
-  timeoutMs: number;
-  description: string;
-}): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      await fs.promises.access(filePath);
-      return;
-    } catch {
-      // not yet; keep polling
-    }
-    await sleepAsync(1_000);
-  }
-  throw new SystemError(`Timed out waiting for ${description} to write ${filePath}.`);
-}
-
-function readDaemonInfo(filePath: string): { port: number; token: string } {
-  const raw = fs.readFileSync(filePath, 'utf8');
+function parseDaemonInfo(raw: string): { port: number; token: string } {
   const parsed = JSON.parse(raw) as unknown;
   if (
     !parsed ||
@@ -276,7 +171,7 @@ function readDaemonInfo(filePath: string): { port: number; token: string } {
     typeof (parsed as { token: unknown }).token !== 'string'
   ) {
     throw new SystemError(
-      `Expected ${filePath} to contain { "httpPort": <number>, "token": "..." }.`
+      'Expected daemon credentials to contain { "httpPort": <number>, "token": "..." }.'
     );
   }
   const { httpPort, token } = parsed as { httpPort: number; token: string };

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -1,0 +1,149 @@
+import { SystemError } from '@expo/eas-build-job';
+import {
+  BuildFunction,
+  BuildRuntimePlatform,
+  BuildStepInput,
+  BuildStepInputValueTypeName,
+} from '@expo/steps';
+import spawn from '@expo/turtle-spawn';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { z } from 'zod';
+
+import { CustomBuildContext } from '../../customBuildContext';
+import {
+  ensureCloudflaredInstalledAsync,
+  getDeviceRunSessionIdOrThrow,
+  spawnDetached,
+  startServeSimWithTunnelAsync,
+  uploadRemoteSessionConfigAsync,
+  waitForFileAsync,
+  waitForMatchInOutputAsync,
+} from '../utils/remoteDeviceRunSession';
+
+const ARGENT_PACKAGE_NAME = '@swmansion/argent';
+const ARGENT_STATE_FILE = path.join(os.homedir(), '.argent', 'tool-server.json');
+const XCODE_DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer';
+const STARTUP_TIMEOUT_MS = 60_000;
+
+const ArgentToolServerStateSchema = z.object({ port: z.number() });
+
+export function createStartArgentRemoteSessionBuildFunction(
+  ctx: CustomBuildContext
+): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'start_argent_remote_session',
+    name: 'Start argent remote session',
+    __metricsId: 'eas/start_argent_remote_session',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'package_version',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+    ],
+    fn: async ({ logger, global }, { inputs, env }) => {
+      // Fail fast before any expensive setup if the orchestrator-injected
+      // DEVICE_RUN_SESSION_ID env var is missing — without it we cannot
+      // report the remote config back to the API server.
+      const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
+
+      const packageVersion = inputs.package_version.value as string | undefined;
+      const versionSpec = packageVersion ?? 'latest';
+      const { runtimePlatform } = global;
+      logger.info(
+        `Starting argent remote session (version: ${versionSpec}, runtime: ${runtimePlatform}).`
+      );
+
+      if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
+        logger.info(`Selecting Xcode developer directory: ${XCODE_DEVELOPER_DIR}.`);
+        await spawn('sudo', ['xcode-select', '-s', XCODE_DEVELOPER_DIR], { env, logger });
+      }
+
+      logger.info('Ensuring cloudflared is installed.');
+      const cloudflaredCommand = await ensureCloudflaredInstalledAsync({
+        runtimePlatform,
+        env,
+        logger,
+      });
+
+      // Stale state from a previous run would mask the new server's port.
+      await fs.promises.rm(ARGENT_STATE_FILE, { force: true });
+
+      logger.info(`Launching ${ARGENT_PACKAGE_NAME}@${versionSpec} via bunx.`);
+      // `argent mcp` is the public entry that triggers @argent/tools-client
+      // to spawn the tool-server detached + unref'd, so the tool-server
+      // outlives this MCP process. ARGENT_IDLE_TIMEOUT_MINUTES=0 disables the
+      // 30-min idle shutdown that would otherwise tear the tunnel down.
+      spawnDetached({
+        command: 'bunx',
+        args: [`${ARGENT_PACKAGE_NAME}@${versionSpec}`, 'mcp'],
+        env: { ...env, ARGENT_IDLE_TIMEOUT_MINUTES: '0' },
+      });
+
+      logger.info(`Waiting for argent tool-server state at ${ARGENT_STATE_FILE}.`);
+      const { port: toolServerPort } = await waitForFileAsync({
+        filePath: ARGENT_STATE_FILE,
+        timeoutMs: STARTUP_TIMEOUT_MS,
+        description: 'argent tool-server state',
+        parse: parseArgentToolServerState,
+      });
+      logger.info(`Argent tool-server is listening on port ${toolServerPort}.`);
+
+      logger.info(`Starting cloudflared tunnel to http://localhost:${toolServerPort}.`);
+      const cloudflared = spawnDetached({
+        command: cloudflaredCommand,
+        args: ['tunnel', '--url', `http://localhost:${toolServerPort}`],
+        env,
+      });
+
+      logger.info('Waiting for a public tunnel URL.');
+      const toolsUrl = await waitForMatchInOutputAsync({
+        process: cloudflared,
+        pattern: /https:\/\/[a-z0-9-]+\.trycloudflare\.com/,
+        timeoutMs: STARTUP_TIMEOUT_MS,
+        description: 'cloudflared tunnel',
+      });
+      logger.info(`Tunnel is ready at ${toolsUrl}.`);
+
+      // serve-sim is iOS-only — Android sessions go without a preview URL.
+      let webPreviewUrl: string | undefined;
+      if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
+        const serveSim = await startServeSimWithTunnelAsync({
+          env,
+          logger,
+          timeoutMs: STARTUP_TIMEOUT_MS,
+        });
+        webPreviewUrl = serveSim.previewUrl;
+        logger.info(`Web preview URL: ${webPreviewUrl}`);
+      }
+
+      await uploadRemoteSessionConfigAsync({
+        ctx,
+        deviceRunSessionId,
+        remoteConfig: {
+          toolsUrl,
+          ...(webPreviewUrl ? { webPreviewUrl } : {}),
+        },
+        logger,
+      });
+
+      logger.info('Remote session is live. Keeping the job alive until the session is stopped.');
+      // Keep the turtle job alive so the tool-server and tunnel stay reachable
+      // until stopDeviceRunSession cancels the run.
+      await new Promise<never>(() => {});
+    },
+  });
+}
+
+function parseArgentToolServerState(raw: string): { port: number } {
+  const result = ArgentToolServerStateSchema.safeParse(JSON.parse(raw));
+  if (!result.success) {
+    throw new SystemError(
+      `Expected tool-server state to contain { "port": <number>, ... }: ${result.error.message}`
+    );
+  }
+  return result.data;
+}

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -1,13 +1,16 @@
 import { SystemError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
-import { BuildStepEnv } from '@expo/steps';
+import { BuildRuntimePlatform, BuildStepEnv } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
 import { graphql } from 'gql.tada';
+import fs from 'node:fs';
+import os from 'node:os';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import { sleepAsync } from '../../utils/retry';
 
 const TRYCLOUDFLARE_URL_PATTERN = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
+const CLOUDFLARED_LINUX_INSTALL_PATH = '/usr/local/bin/cloudflared';
 
 const START_DEVICE_RUN_SESSION_MUTATION = graphql(`
   mutation StartDeviceRunSession($deviceRunSessionId: ID!, $remoteConfig: JSONObject!) {
@@ -156,4 +159,113 @@ function matchLabeledUrl(content: string, label: string): string | null {
   const labelPattern = new RegExp(`${label}:\\s*(${TRYCLOUDFLARE_URL_PATTERN.source})`);
   const match = labelPattern.exec(content);
   return match ? match[1] : null;
+}
+
+export async function ensureCloudflaredInstalledAsync({
+  runtimePlatform,
+  env,
+  logger,
+}: {
+  runtimePlatform: BuildRuntimePlatform;
+  env: BuildStepEnv;
+  logger: bunyan;
+}): Promise<string> {
+  if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
+    await ensureBrewPackageInstalledAsync({ name: 'cloudflared', env, logger });
+    return 'cloudflared';
+  }
+  if (await isCommandAvailableAsync({ command: 'cloudflared', env })) {
+    return 'cloudflared';
+  }
+  const cloudflaredArch = cloudflaredLinuxArchForNodeArch(os.arch());
+  const downloadUrl = `https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${cloudflaredArch}`;
+  logger.info(`Downloading cloudflared from ${downloadUrl} to ${CLOUDFLARED_LINUX_INSTALL_PATH}.`);
+  await spawn('sudo', ['curl', '-fsSL', '-o', CLOUDFLARED_LINUX_INSTALL_PATH, downloadUrl], {
+    env,
+    logger,
+  });
+  await spawn('sudo', ['chmod', '+x', CLOUDFLARED_LINUX_INSTALL_PATH], { env, logger });
+  // Return the absolute install path so the tunnel command works even when
+  // /usr/local/bin is not on the step's PATH.
+  return CLOUDFLARED_LINUX_INSTALL_PATH;
+}
+
+function cloudflaredLinuxArchForNodeArch(arch: string): 'amd64' | 'arm64' {
+  if (arch === 'x64') {
+    return 'amd64';
+  }
+  if (arch === 'arm64') {
+    return 'arm64';
+  }
+  throw new SystemError(
+    `Unsupported architecture for cloudflared on Linux: "${arch}". Expected "x64" or "arm64".`
+  );
+}
+
+async function isCommandAvailableAsync({
+  command,
+  env,
+}: {
+  command: string;
+  env: BuildStepEnv;
+}): Promise<boolean> {
+  try {
+    await spawn('bash', ['-c', `command -v ${command}`], { env, ignoreStdio: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function waitForMatchInOutputAsync({
+  process,
+  pattern,
+  timeoutMs,
+  description,
+}: {
+  process: DetachedProcessHandle;
+  pattern: RegExp;
+  timeoutMs: number;
+  description: string;
+}): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const match = pattern.exec(process.getOutput());
+    if (match) {
+      return match[1] ?? match[0];
+    }
+    await sleepAsync(1_000);
+  }
+  throw new SystemError(
+    `Timed out waiting for ${description} to start. Last output:\n${process.getOutput() || '<empty>'}`
+  );
+}
+
+export async function waitForFileAsync<T>({
+  filePath,
+  timeoutMs,
+  description,
+  parse,
+}: {
+  filePath: string;
+  timeoutMs: number;
+  description: string;
+  parse: (raw: string) => T;
+}): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const raw = await fs.promises.readFile(filePath, 'utf8');
+      return parse(raw);
+    } catch (err) {
+      lastError = err;
+    }
+    await sleepAsync(1_000);
+  }
+  throw new SystemError(
+    `Timed out waiting for ${description} to be ready at ${filePath}${
+      lastError instanceof Error ? `: ${lastError.message}` : ''
+    }.`
+  );
 }


### PR DESCRIPTION
# Why

Adds a build function that boots [`@swmansion/argent`](https://github.com/software-mansion/argent) inside an EAS Build VM and exposes its HTTP tool-server through a Cloudflare quick-tunnel, so an agent on a developer's machine can drive an iOS simulator / Android emulator running on EAS. This is the argent equivalent of `start_agent_device_remote_session`.

Pairs with the backend in expo/universe#27554, which adds the `ARGENT` `DeviceRunSessionType` and the matching `ArgentRunSessionRemoteConfig` GraphQL type. The `remoteConfig` shape produced by this step matches the Zod schema on the server: `{ toolsUrl: string, webPreviewUrl?: string }`.

# How

New file `packages/build-tools/src/steps/functions/startArgentRemoteSession.ts`:

- Installs `@swmansion/argent@<package_version|latest>` into a `mkdtemp` scratch dir via `bun add`. The published npm package ships pre-built JS, so there's no source clone or build step.
- Spawns `argent mcp`, which auto-spawns the tool-server detached + unref'd through `@argent/tools-client`'s launcher. Passes `ARGENT_IDLE_TIMEOUT_MINUTES=0` so the tool-server doesn't self-shut-down during quiet stretches and tear the tunnel down.
- Polls `~/.argent/tool-server.json` for the port, then starts a cloudflared quick-tunnel pointing at `http://localhost:<port>`.
- On Darwin only, additionally starts `serve-sim` (via the shared `startServeSimWithTunnelAsync`) for the `webPreviewUrl`.
- Posts the tunnel URL back via `uploadRemoteSessionConfigAsync` as `{ toolsUrl, webPreviewUrl? }` — matches `ArgentRunSessionRemoteConfig` on the server. No auth token: argent's tool-server has none today.
- Keeps the turtle job alive with `new Promise<never>(() => {})` so the tunnel and tool-server stay reachable until `stopDeviceRunSession` cancels the run.

Registered as `eas/start_argent_remote_session` in `packages/build-tools/src/steps/easFunctions.ts`, matching the action name the server expects in `DeviceRunSessionUtils.buildArgentStartSteps`.

## Notes

- Cross-platform contract identical to `start_agent_device_remote_session`: Darwin runs the full argent + serve-sim stack; Linux runs argent only (no `webPreviewUrl`).
- Cloudflared install path + `waitFor*` helpers are duplicated from `startAgentDeviceRemoteSession.ts`. Easy to extract to `remoteDeviceRunSession.ts` later if we want to dedupe.
- The proprietary argent binaries (`simulator-server`, `ax-service`, native devtools `.dylib`s) are licensed for use only "within this project" — running them inside ephemeral EAS Build VMs from an npm-time install is defensible as runtime use rather than redistribution, but written sign-off from Software Mansion should land before this is exposed as a paid product.

## Follow-up (not in this PR)

Only one CLI-side change remains to make this selectable end-to-end via `eas simulator:start --type argent`:

- Update `formatRemoteSessionInstructions` in `packages/eas-cli/src/simulator/utils.ts` to add an `ArgentRunSessionRemoteConfig` case that prints the MCP-config snippet (`ARGENT_TOOLS_URL=<toolsUrl>`) and the optional `webPreviewUrl`. The CLI's `DEVICE_RUN_SESSION_TYPE_FLAG_VALUES` map will also need an `Argent` entry once the GraphQL types regenerate from the backend.

# Test Plan

- [x] `yarn typecheck` clean
- [x] `yarn lint` on touched files — no new warnings
- [x] `yarn fmt:check` on touched files — clean
- [ ] Manual: trigger a device run session backed by this step on a Darwin EAS Build VM and confirm:
  - [ ] `@swmansion/argent` installs cleanly via `bun add`
  - [ ] `~/.argent/tool-server.json` is written and contains a numeric port
  - [ ] cloudflared emits a `https://*.trycloudflare.com` URL within the 60s timeout
  - [ ] `curl https://<tunnel>/tools` returns the argent tool list
  - [ ] serve-sim `webPreviewUrl` is reachable
  - [ ] `startDeviceRunSession` mutation accepts the `{ toolsUrl, webPreviewUrl }` payload (Zod schema from expo/universe#27554 validates server-side)
- [ ] Manual: same on a Linux build VM (Android, no serve-sim path), confirm the argent tunnel still resolves and the payload without `webPreviewUrl` is accepted.
- [ ] Manual: configure `argent mcp` locally with `ARGENT_TOOLS_URL=<toolsUrl>` in a Claude Code / Cursor MCP config and confirm tool calls reach the remote simulator.
