### PR TITLE
[build-tools] Pass ctx.env to parse xcactivitylog

### DIFF
--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -181,6 +181,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
         workspacePath,
         logger: ctx.logger,
         proxyBaseUrl: ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL,
+        env: ctx.env,
       });
     });
   }

--- a/packages/build-tools/src/steps/functions/parseXcactivitylog.ts
+++ b/packages/build-tools/src/steps/functions/parseXcactivitylog.ts
@@ -45,6 +45,7 @@ export function parseXcactivitylogFunction(): BuildFunction {
         xclogparserVersion: version,
         logger: stepCtx.logger,
         proxyBaseUrl: env.EAS_BUILD_COCOAPODS_CACHE_URL,
+        env,
       });
     },
   });

--- a/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
+++ b/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
@@ -195,6 +195,8 @@ const FIXTURE_OVERLAP_WITH_GAP = {
 const mockedDownloadFile = jest.mocked(downloadFile);
 const mockedSpawn = jest.mocked(spawn);
 
+const TEST_ENV = { PATH: '/custom/bin:/usr/bin' };
+
 function mockFilesystem({
   tempDir = '/tmp/xclogparser-123',
   jsonOutput = JSON.stringify(FIXTURE_TWO_MODULES),
@@ -236,10 +238,12 @@ describe('parseAndReportXcactivitylog', () => {
       derivedDataPath: '/tmp/derived-data',
       workspacePath: '/tmp/workspace',
       logger,
+      env: TEST_ENV,
     });
 
     expect(mockedSpawn).toHaveBeenNthCalledWith(1, 'xclogparser', ['version'], {
       stdio: 'pipe',
+      env: TEST_ENV,
     });
     expect(mockedDownloadFile).toHaveBeenCalledWith(
       'https://storage.googleapis.com/turtle-v2/xclogparser/XCLogParser-macOS-x86-64-arm64-v0.2.47.zip',
@@ -250,7 +254,7 @@ describe('parseAndReportXcactivitylog', () => {
       2,
       'unzip',
       ['-q', path.join(tempDir, 'XCLogParser-macOS-x86-64-arm64-v0.2.47.zip'), '-d', tempDir],
-      { stdio: 'pipe' }
+      { stdio: 'pipe', env: TEST_ENV }
     );
     expect(mockedSpawn).toHaveBeenNthCalledWith(
       3,
@@ -266,7 +270,7 @@ describe('parseAndReportXcactivitylog', () => {
         '--output',
         reportPath,
       ],
-      { stdio: 'pipe' }
+      { stdio: 'pipe', env: TEST_ENV }
     );
     expect(fs.readFile).toHaveBeenCalledWith(reportPath, 'utf8');
     expect(logger.info).toHaveBeenCalledWith('Using downloaded xclogparser v0.2.47.');
@@ -293,6 +297,7 @@ describe('parseAndReportXcactivitylog', () => {
       workspacePath: '/tmp/workspace',
       logger,
       proxyBaseUrl: 'https://cache.example.com',
+      env: TEST_ENV,
     });
 
     expect(mockedDownloadFile).toHaveBeenNthCalledWith(
@@ -330,6 +335,7 @@ describe('parseAndReportXcactivitylog', () => {
       workspacePath: '/tmp/workspace',
       logger,
       proxyBaseUrl: 'https://cache.example.com',
+      env: TEST_ENV,
     });
 
     expect(mockedDownloadFile).toHaveBeenNthCalledWith(
@@ -367,6 +373,7 @@ describe('parseAndReportXcactivitylog', () => {
         derivedDataPath: '/tmp/derived-data',
         workspacePath: '/tmp/workspace',
         logger,
+        env: TEST_ENV,
       })
     ).resolves.toBeUndefined();
 
@@ -397,6 +404,7 @@ describe('parseAndReportXcactivitylog', () => {
         derivedDataPath: '/tmp/derived-data',
         workspacePath: '/tmp/workspace',
         logger,
+        env: TEST_ENV,
       })
     ).resolves.toBeUndefined();
 
@@ -424,6 +432,7 @@ describe('parseAndReportXcactivitylog', () => {
         derivedDataPath: '/tmp/derived-data',
         workspacePath: '/tmp/workspace',
         logger,
+        env: TEST_ENV,
       })
     ).resolves.toBeUndefined();
 
@@ -449,6 +458,7 @@ describe('parseAndReportXcactivitylog', () => {
         derivedDataPath: '/tmp/derived-data',
         workspacePath: '/tmp/workspace',
         logger,
+        env: TEST_ENV,
       })
     ).resolves.toBeUndefined();
 
@@ -477,6 +487,7 @@ describe('parseAndReportXcactivitylog', () => {
         derivedDataPath: '/tmp/derived-data',
         workspacePath: '/tmp/workspace',
         logger,
+        env: TEST_ENV,
       })
     ).resolves.toBeUndefined();
 
@@ -497,6 +508,7 @@ describe('parseAndReportXcactivitylog', () => {
         derivedDataPath: '/tmp/derived-data',
         workspacePath: '/tmp/workspace',
         logger,
+        env: TEST_ENV,
       });
 
       expect(mockedDownloadFile).not.toHaveBeenCalled();
@@ -515,7 +527,7 @@ describe('parseAndReportXcactivitylog', () => {
           '--output',
           reportPath,
         ],
-        { stdio: 'pipe' }
+        { stdio: 'pipe', env: TEST_ENV }
       );
       expect(logger.info).toHaveBeenCalledWith('Using preinstalled xclogparser v0.2.50.');
       expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('downloaded'));
@@ -534,6 +546,7 @@ describe('parseAndReportXcactivitylog', () => {
         derivedDataPath: '/tmp/derived-data',
         workspacePath: '/tmp/workspace',
         logger,
+        env: TEST_ENV,
       });
 
       expect(mockedDownloadFile).toHaveBeenCalledWith(
@@ -557,6 +570,7 @@ describe('parseAndReportXcactivitylog', () => {
         workspacePath: '/tmp/workspace',
         xclogparserVersion: 'v0.2.50',
         logger,
+        env: TEST_ENV,
       });
 
       expect(mockedDownloadFile).not.toHaveBeenCalled();
@@ -579,6 +593,7 @@ describe('parseAndReportXcactivitylog', () => {
         workspacePath: '/tmp/workspace',
         xclogparserVersion: 'v0.2.50',
         logger,
+        env: TEST_ENV,
       });
 
       expect(mockedDownloadFile).toHaveBeenCalledWith(
@@ -602,6 +617,7 @@ describe('parseAndReportXcactivitylog', () => {
         workspacePath: '/tmp/workspace',
         xclogparserVersion: 'v0.2.50',
         logger,
+        env: TEST_ENV,
       });
 
       expect(mockedDownloadFile).toHaveBeenCalledWith(
@@ -625,6 +641,7 @@ describe('parseAndReportXcactivitylog', () => {
         derivedDataPath: '/tmp/derived-data',
         workspacePath: '/tmp/workspace',
         logger,
+        env: TEST_ENV,
       });
 
       expect(mockedDownloadFile).toHaveBeenCalledWith(

--- a/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
+++ b/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
@@ -1,6 +1,7 @@
 import downloadFile from '@expo/downloader';
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
+import { BuildStepEnv } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
 import fs from 'fs-extra';
 import os from 'os';
@@ -25,12 +26,14 @@ export async function parseAndReportXcactivitylog({
   xclogparserVersion,
   logger,
   proxyBaseUrl,
+  env,
 }: {
   derivedDataPath: string;
   workspacePath: string;
   xclogparserVersion?: string;
   logger: bunyan;
   proxyBaseUrl?: string;
+  env: BuildStepEnv;
 }): Promise<void> {
   let tempDir: string | undefined;
   let phase = 'creating_temp_directory';
@@ -38,7 +41,7 @@ export async function parseAndReportXcactivitylog({
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'xclogparser-'));
 
     phase = 'resolving_xclogparser';
-    const preinstalledVersion = await detectPreinstalledXclogparserVersion();
+    const preinstalledVersion = await detectPreinstalledXclogparserVersion(env);
     let binaryPath: string;
     let resolvedVersion: string;
     if (
@@ -51,7 +54,13 @@ export async function parseAndReportXcactivitylog({
     } else {
       phase = 'downloading_xclogparser';
       resolvedVersion = xclogparserVersion ?? DEFAULT_XCLOGPARSER_VERSION;
-      binaryPath = await downloadXclogparser(tempDir, resolvedVersion, logger, proxyBaseUrl);
+      binaryPath = await downloadXclogparser({
+        tempDir,
+        version: resolvedVersion,
+        logger,
+        proxyBaseUrl,
+        env,
+      });
       logger.info(`Using downloaded xclogparser ${resolvedVersion}.`);
     }
 
@@ -61,6 +70,7 @@ export async function parseAndReportXcactivitylog({
       derivedDataPath,
       workspacePath,
       outputDir: tempDir,
+      env,
     });
 
     phase = 'parsing_xclogparser_output';
@@ -80,8 +90,8 @@ export async function parseAndReportXcactivitylog({
   }
 }
 
-async function detectPreinstalledXclogparserVersion(): Promise<string | null> {
-  const result = await asyncResult(spawn('xclogparser', ['version'], { stdio: 'pipe' }));
+async function detectPreinstalledXclogparserVersion(env: BuildStepEnv): Promise<string | null> {
+  const result = await asyncResult(spawn('xclogparser', ['version'], { stdio: 'pipe', env }));
   if (!result.ok) {
     return null;
   }
@@ -89,12 +99,19 @@ async function detectPreinstalledXclogparserVersion(): Promise<string | null> {
   return match ? `v${match[1]}` : null;
 }
 
-async function downloadXclogparser(
-  tempDir: string,
-  version: string,
-  logger: bunyan,
-  proxyBaseUrl?: string
-): Promise<string> {
+async function downloadXclogparser({
+  tempDir,
+  version,
+  logger,
+  proxyBaseUrl,
+  env,
+}: {
+  tempDir: string;
+  version: string;
+  logger: bunyan;
+  proxyBaseUrl?: string;
+  env: BuildStepEnv;
+}): Promise<string> {
   const zipName = getXclogparserZipName(version);
   const zipPath = path.join(tempDir, zipName);
   const directUrl = `${XCLOGPARSER_DOWNLOAD_URL}/${zipName}`;
@@ -102,7 +119,7 @@ async function downloadXclogparser(
 
   if (proxiedUrl) {
     const proxiedDownloadResult = await asyncResult(
-      downloadAndUnpackXclogparser({ tempDir, zipPath, sourceUrl: proxiedUrl })
+      downloadAndUnpackXclogparser({ tempDir, zipPath, sourceUrl: proxiedUrl, env })
     );
     if (!proxiedDownloadResult.ok) {
       logger.debug(
@@ -115,31 +132,35 @@ async function downloadXclogparser(
     }
   }
 
-  return await downloadAndUnpackXclogparser({ tempDir, zipPath, sourceUrl: directUrl });
+  return await downloadAndUnpackXclogparser({ tempDir, zipPath, sourceUrl: directUrl, env });
 }
 
 async function downloadAndUnpackXclogparser({
   tempDir,
   zipPath,
   sourceUrl,
+  env,
 }: {
   tempDir: string;
   zipPath: string;
   sourceUrl: string;
+  env: BuildStepEnv;
 }): Promise<string> {
   await downloadFile(sourceUrl, zipPath, { retry: 3, timeout: XCLOGPARSER_DOWNLOAD_TIMEOUT_MS });
 
-  return await unpackXclogparser({ tempDir, zipPath });
+  return await unpackXclogparser({ tempDir, zipPath, env });
 }
 
 async function unpackXclogparser({
   tempDir,
   zipPath,
+  env,
 }: {
   tempDir: string;
   zipPath: string;
+  env: BuildStepEnv;
 }): Promise<string> {
-  await spawn('unzip', ['-q', zipPath, '-d', tempDir], { stdio: 'pipe' });
+  await spawn('unzip', ['-q', zipPath, '-d', tempDir], { stdio: 'pipe', env });
 
   const binaryPath = path.join(tempDir, 'xclogparser');
   await fs.chmod(binaryPath, 0o755);
@@ -162,11 +183,13 @@ async function runXclogparser({
   derivedDataPath,
   workspacePath,
   outputDir,
+  env,
 }: {
   binaryPath: string;
   derivedDataPath: string;
   workspacePath: string;
   outputDir: string;
+  env: BuildStepEnv;
 }): Promise<string> {
   const outputPath = path.join(outputDir, XCLOGPARSER_OUTPUT_FILENAME);
 
@@ -183,7 +206,7 @@ async function runXclogparser({
       '--output',
       outputPath,
     ],
-    { stdio: 'pipe' }
+    { stdio: 'pipe', env }
   );
 
   return outputPath;


### PR DESCRIPTION
# Why

The 3 `spawn()` calls inside `parseAndReportXcactivitylog` didn't pass `env`, so child processes inherited the worker's `process.env` instead of the job env on `ctx.env`. Any user-defined env (e.g. `set-env` PATH additions) was silently invisible to the spawned binaries.

# How

- Added a required `env: BuildStepEnv` param to `parseAndReportXcactivitylog` and threaded it through the internal helpers.
- Passed `env` to each of the 3 `spawn()` calls.
- Updated both callers (`builders/ios.ts` and the `parseXcactivitylog` step function) to forward their env.

# Test Plan

Unit tests in `xcactivitylog.test.ts` assert that the env passed to `parseAndReportXcactivitylog` is propagated to every spawn invocation.