### PR TITLE
[eas-cli] Capture iOS config introspection fallback in Sentry

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -24411,6 +24411,45 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "ArgentRunSessionRemoteConfig",
+        "description": null,
+        "fields": [
+          {
+            "name": "toolsUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webPreviewUrl",
+            "description": "URL of the web preview surface for the session. Null when web previews are\nnot available for the platform (e.g. Android).",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "AscApiKeyInput",
         "description": null,
@@ -29906,6 +29945,12 @@
           },
           {
             "name": "FIX_GRADLEW",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GRADLE_BUILD_PROFILE",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -37512,6 +37557,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "ArgentRunSessionRemoteConfig",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "ServeSimRunSessionRemoteConfig",
             "ofType": null
           }
@@ -37562,6 +37612,12 @@
         "enumValues": [
           {
             "name": "AGENT_DEVICE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ARGENT",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -42509,6 +42565,216 @@
       },
       {
         "kind": "OBJECT",
+        "name": "EmbeddedUpdate",
+        "description": null,
+        "fields": [
+          {
+            "name": "channel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "The manifest UUID baked into the binary by expo-updates at build time.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "launchAsset",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EmbeddedUpdateAsset",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPlatform",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "runtimeVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EmbeddedUpdateAsset",
+        "description": null,
+        "fields": [
+          {
+            "name": "contentType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fileSHA256",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fileSize",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "finalFileSize",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "storageKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "EmbeddedUpdateAssetMutation",
         "description": null,
         "fields": [
@@ -42630,6 +42896,50 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EmbeddedUpdateMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "uploadEmbeddedUpdate",
+            "description": "Register an embedded bundle as the launch asset for a given app/platform/channel.\nReturns EMBEDDED_UPDATE_ASSET_NOT_AVAILABLE if the asset has not been finalized yet.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UploadEmbeddedUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EmbeddedUpdate",
                 "ofType": null
               }
             },
@@ -52002,6 +52312,18 @@
             "deprecationReason": null
           },
           {
+            "name": "enqueuedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "errors",
             "description": null,
             "args": [],
@@ -58468,6 +58790,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "EchoVersionMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "embeddedUpdate",
+            "description": "Mutations that register embedded update bundles for bundle diffing.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EmbeddedUpdateMutation",
                 "ofType": null
               }
             },
@@ -69635,6 +69973,109 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "UploadEmbeddedUpdateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "channel",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "embeddedUpdateId",
+            "description": "UUID baked into the binary by expo-updates at build time (from app.manifest id field).",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPlatform",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "runtimeVersion",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "turtleBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/eas-cli/src/commands/simulator/start.ts
+++ b/packages/eas-cli/src/commands/simulator/start.ts
@@ -32,6 +32,7 @@ const POLL_TIMEOUT_MS = 15 * 60 * 1_000; // 15 minutes
 // so adding a new enum value in codegen fails the build until it is wired up here.
 const DEVICE_RUN_SESSION_TYPE_FLAG_VALUES: Record<DeviceRunSessionType, string> = {
   [DeviceRunSessionType.AgentDevice]: 'agent-device',
+  [DeviceRunSessionType.Argent]: 'argent',
   [DeviceRunSessionType.ServeSim]: 'serve-sim',
 };
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -3503,6 +3503,16 @@ export enum AppsFilter {
   New = 'NEW'
 }
 
+export type ArgentRunSessionRemoteConfig = {
+  __typename?: 'ArgentRunSessionRemoteConfig';
+  toolsUrl: Scalars['String']['output'];
+  /**
+   * URL of the web preview surface for the session. Null when web previews are
+   * not available for the platform (e.g. Android).
+   */
+  webPreviewUrl?: Maybe<Scalars['String']['output']>;
+};
+
 export type AscApiKeyInput = {
   issuerIdentifier: Scalars['String']['input'];
   keyIdentifier: Scalars['String']['input'];
@@ -4212,6 +4222,7 @@ export enum BuildPhase {
   EasBuildInternal = 'EAS_BUILD_INTERNAL',
   FailBuild = 'FAIL_BUILD',
   FixGradlew = 'FIX_GRADLEW',
+  GradleBuildProfile = 'GRADLE_BUILD_PROFILE',
   InstallCustomTools = 'INSTALL_CUSTOM_TOOLS',
   InstallDependencies = 'INSTALL_DEPENDENCIES',
   InstallPods = 'INSTALL_PODS',
@@ -5266,7 +5277,7 @@ export type DeviceRunSessionQueryByIdArgs = {
   deviceRunSessionId: Scalars['ID']['input'];
 };
 
-export type DeviceRunSessionRemoteConfig = AgentDeviceRunSessionRemoteConfig | ServeSimRunSessionRemoteConfig;
+export type DeviceRunSessionRemoteConfig = AgentDeviceRunSessionRemoteConfig | ArgentRunSessionRemoteConfig | ServeSimRunSessionRemoteConfig;
 
 export enum DeviceRunSessionStatus {
   Errored = 'ERRORED',
@@ -5277,6 +5288,7 @@ export enum DeviceRunSessionStatus {
 
 export enum DeviceRunSessionType {
   AgentDevice = 'AGENT_DEVICE',
+  Argent = 'ARGENT',
   ServeSim = 'SERVE_SIM'
 }
 
@@ -6036,6 +6048,27 @@ export type EditUpdateBranchInput = {
   newName: Scalars['String']['input'];
 };
 
+export type EmbeddedUpdate = {
+  __typename?: 'EmbeddedUpdate';
+  channel: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  /** The manifest UUID baked into the binary by expo-updates at build time. */
+  id: Scalars['ID']['output'];
+  launchAsset: EmbeddedUpdateAsset;
+  platform: AppPlatform;
+  runtimeVersion: Scalars['String']['output'];
+};
+
+export type EmbeddedUpdateAsset = {
+  __typename?: 'EmbeddedUpdateAsset';
+  contentType: Scalars['String']['output'];
+  fileSHA256: Scalars['String']['output'];
+  fileSize: Scalars['Int']['output'];
+  finalFileSize?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  storageKey: Scalars['String']['output'];
+};
+
 export type EmbeddedUpdateAssetMutation = {
   __typename?: 'EmbeddedUpdateAssetMutation';
   /**
@@ -6060,6 +6093,20 @@ export type EmbeddedUpdateAssetUploadSpec = {
   presignedUrl: Scalars['String']['output'];
   /** Storage key (`{appId}/{embeddedUpdateId}`). Same key in both upload and destination buckets. */
   storageKey: Scalars['String']['output'];
+};
+
+export type EmbeddedUpdateMutation = {
+  __typename?: 'EmbeddedUpdateMutation';
+  /**
+   * Register an embedded bundle as the launch asset for a given app/platform/channel.
+   * Returns EMBEDDED_UPDATE_ASSET_NOT_AVAILABLE if the asset has not been finalized yet.
+   */
+  uploadEmbeddedUpdate: EmbeddedUpdate;
+};
+
+
+export type EmbeddedUpdateMutationUploadEmbeddedUpdateArgs = {
+  input: UploadEmbeddedUpdateInput;
 };
 
 export enum EntityTypeName {
@@ -7326,6 +7373,7 @@ export type JobRun = {
   createdAt: Scalars['DateTime']['output'];
   displayName?: Maybe<Scalars['String']['output']>;
   endedAt?: Maybe<Scalars['DateTime']['output']>;
+  enqueuedAt?: Maybe<Scalars['DateTime']['output']>;
   errors: Array<JobRunError>;
   expiresAt: Scalars['DateTime']['output'];
   gitCommitHash?: Maybe<Scalars['String']['output']>;
@@ -8218,6 +8266,8 @@ export type RootMutation = {
   echoTurn: EchoTurnMutation;
   /** Mutations for Echo versions */
   echoVersion: EchoVersionMutation;
+  /** Mutations that register embedded update bundles for bundle diffing. */
+  embeddedUpdate: EmbeddedUpdateMutation;
   embeddedUpdateAsset: EmbeddedUpdateAssetMutation;
   /** Mutations that create and delete EnvironmentSecrets */
   environmentSecret: EnvironmentSecretMutation;
@@ -9764,6 +9814,16 @@ export type UpdatesMetricsData = {
   failedInstallsDataset: CumulativeUpdatesDataset;
   installsDataset: CumulativeUpdatesDataset;
   labels: Array<Scalars['String']['output']>;
+};
+
+export type UploadEmbeddedUpdateInput = {
+  appId: Scalars['ID']['input'];
+  channel: Scalars['String']['input'];
+  /** UUID baked into the binary by expo-updates at build time (from app.manifest id field). */
+  embeddedUpdateId: Scalars['ID']['input'];
+  platform: AppPlatform;
+  runtimeVersion: Scalars['String']['input'];
+  turtleBuildId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type UploadSession = {
@@ -12846,7 +12906,7 @@ export type DeviceRunSessionByIdQueryVariables = Exact<{
 }>;
 
 
-export type DeviceRunSessionByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, type: DeviceRunSessionType, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, remoteConfig?: { __typename: 'AgentDeviceRunSessionRemoteConfig', agentDeviceRemoteSessionUrl: string, agentDeviceRemoteSessionToken: string, webPreviewUrl?: string | null } | { __typename: 'ServeSimRunSessionRemoteConfig', previewUrl: string, streamUrl: string } | null, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } } };
+export type DeviceRunSessionByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, type: DeviceRunSessionType, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, remoteConfig?: { __typename: 'AgentDeviceRunSessionRemoteConfig', agentDeviceRemoteSessionUrl: string, agentDeviceRemoteSessionToken: string, webPreviewUrl?: string | null } | { __typename: 'ArgentRunSessionRemoteConfig', toolsUrl: string, webPreviewUrl?: string | null } | { __typename: 'ServeSimRunSessionRemoteConfig', previewUrl: string, streamUrl: string } | null, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } } };
 
 export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
@@ -34,6 +34,10 @@ export const DeviceRunSessionQuery = {
                       agentDeviceRemoteSessionToken
                       webPreviewUrl
                     }
+                    ... on ArgentRunSessionRemoteConfig {
+                      toolsUrl
+                      webPreviewUrl
+                    }
                     ... on ServeSimRunSessionRemoteConfig {
                       previewUrl
                       streamUrl

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -3,6 +3,7 @@ import { JSONObject } from '@expo/json-file';
 import { getPrebuildConfigAsync } from '@expo/prebuild-config';
 
 import Log from '../../log';
+import Sentry from '../../sentry';
 import { spawnExpoCommand } from '../../utils/expoCli';
 import { readPlistAsync } from '../../utils/plist';
 import { Client } from '../../vcs/vcs';
@@ -35,6 +36,24 @@ export async function getManagedApplicationTargetEntitlementsAsync(
       const expWithMods: ExportedConfig = JSON.parse(stdout);
       return expWithMods.ios?.entitlements ?? {};
     } catch (error: any) {
+      try {
+        Sentry.withScope(scope => {
+          if (process.env.EAS_BUILD_PROJECT_ID) {
+            scope.setTag('app_id', process.env.EAS_BUILD_PROJECT_ID);
+          }
+          if (process.env.EAS_BUILD_ID) {
+            scope.setTag('build_id', process.env.EAS_BUILD_ID);
+          }
+          scope.setTag('config_resolution', 'ios_entitlements_introspection');
+          scope.setExtra('message', 'iOS entitlements config fallback');
+          scope.setExtra('stdout', error.stdout);
+          scope.setExtra('stderr', error.stderr);
+          Sentry.captureException(error);
+        });
+      } catch {
+        // do nothing
+      }
+
       expoConfigError = error;
       Log.warn(
         `Failed to read the app config from the project using the local Expo CLI: ${formatError(error)}`

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -24,6 +24,22 @@ export function formatRemoteSessionInstructions(
       }
       return lines.join('\n');
     }
+    case 'ArgentRunSessionRemoteConfig': {
+      const lines = [
+        '🔑 Open the following URL to access the Argent tools for this session:',
+        '',
+        remoteConfig.toolsUrl,
+      ];
+      if (remoteConfig.webPreviewUrl) {
+        lines.push(
+          '',
+          '🌐 Open the following URL in your browser to preview the simulator:',
+          '',
+          remoteConfig.webPreviewUrl
+        );
+      }
+      return lines.join('\n');
+    }
     case 'ServeSimRunSessionRemoteConfig':
       return [
         '🌐 Open the following URL in your browser to access the simulator:',


### PR DESCRIPTION
## Summary
- capture local Expo CLI iOS entitlements introspection failures in Sentry before falling back to bundled config resolution
- tag the event with `app_id` from `EAS_BUILD_PROJECT_ID` and the config resolution path
- capture a short fallback message so this is easier to distinguish from generic spawn failures
- include the failed command stdout, stderr, and exit status as Sentry extras

## Why
If `expo config --json --type introspect` fails but the bundled config fallback succeeds, users no longer hit a hard failure. Capturing the original command failure gives us visibility into the remaining fallback cases without breaking builds, and the explicit message makes these events easier to identify.

## Validation

CI should pass.