### PR TITLE
[build-tools] place gradle profile step after run gradle

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -10,6 +10,8 @@ import {
   resolveGradleCommand,
   runGradleCommand,
 } from '../android/gradle';
+import { parseGradleProfile, formatGradleProfileReport } from '../android/gradleProfile';
+import { Sentry } from '../sentry';
 import { eagerBundleAsync, shouldUseEagerBundle } from '../common/eagerBundle';
 import { prebuildAsync } from '../common/prebuild';
 import { setupAsync } from '../common/setup';
@@ -178,6 +180,20 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
           }
         : null),
     });
+  });
+
+  await ctx.runBuildPhase(BuildPhase.GRADLE_BUILD_PROFILE, async () => {
+    try {
+      const androidDir = path.join(ctx.getReactNativeProjectDirectory(), 'android');
+      const profileTasks = await parseGradleProfile(androidDir);
+      if (profileTasks.length > 0) {
+        const report = formatGradleProfileReport(profileTasks);
+        ctx.logger.info(report);
+      }
+    } catch (err: any) {
+      Sentry.capture('Failed to parse Gradle build profile', err);
+      ctx.markBuildPhaseSkipped();
+    }
   });
 
   await ctx.runBuildPhase(BuildPhase.PRE_UPLOAD_ARTIFACTS_HOOK, async () => {

--- a/packages/worker/src/build.ts
+++ b/packages/worker/src/build.ts
@@ -2,9 +2,6 @@ import {
   Artifacts,
   BuildContext,
   Builders,
-  Sentry,
-  parseGradleProfile,
-  formatGradleProfileReport,
   runGenericJobAsync,
 } from '@expo/build-tools';
 import {
@@ -21,8 +18,6 @@ import {
 } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import omit from 'lodash/omit';
-import path from 'path';
-
 import config from './config';
 import { displayWorkerRuntimeInfo } from './displayRuntimeInfo';
 import { Analytics, Event, logProjectDependenciesAsync } from './external/analytics';
@@ -91,21 +86,6 @@ export async function build({
     }
 
     analytics.logEvent(Event.WORKER_BUILD_SUCCESS, {});
-
-    if (job.platform === Platform.ANDROID) {
-      try {
-        await ctx.runBuildPhase(BuildPhase.GRADLE_BUILD_PROFILE, async () => {
-          const androidDir = path.join(ctx.getReactNativeProjectDirectory(), 'android');
-          const profileTasks = await parseGradleProfile(androidDir);
-          if (profileTasks.length > 0) {
-            const report = formatGradleProfileReport(profileTasks);
-            ctx.logger.info(report);
-          }
-        });
-      } catch (err: any) {
-        Sentry.capture('Failed to parse Gradle build profile', err);
-      }
-    }
 
     return artifacts;
   } catch (err: any) {

--- a/packages/worker/src/build.ts
+++ b/packages/worker/src/build.ts
@@ -1,9 +1,4 @@
-import {
-  Artifacts,
-  BuildContext,
-  Builders,
-  runGenericJobAsync,
-} from '@expo/build-tools';
+import { Artifacts, BuildContext, Builders, runGenericJobAsync } from '@expo/build-tools';
 import {
   Android,
   BuildJob,


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Show the profile after the run gradle step

<img width="1176" height="781" alt="Screenshot 2026-05-20 at 10 46 18 AM" src="https://github.com/user-attachments/assets/f87d5a82-6819-4880-800d-7cccc26806bd" />
