### PR TITLE
[eas-cli] Update eas-cli observe GraphQL types

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -14383,6 +14383,39 @@
             "deprecationReason": null
           },
           {
+            "name": "uniqueActiveUserCount",
+            "description": "Approximate count of unique users (`eas_client_id`) with at least one\nsupported-metric event in `[startTime, endTime)`. Uses ClickHouse's\nHyperLogLog `uniq()`, so the value can drift by a small percent on apps\nwith very large user bases. `metricNames` on the input is currently\nignored: the count is always over all supported metrics, matching the\nuniverse used by `appVersions` headline counts.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveReleasesInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updates",
             "description": null,
             "args": [

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -14888,6 +14888,22 @@
             "deprecationReason": null
           },
           {
+            "name": "lastSeenUserCount",
+            "description": "Unique users whose most recent supported-metric event in\n`[startTime, endTime)` was on this version. Each active user\ncontributes to exactly one version, so summing this field across the\nreturned versions yields the total active users in the window (equal\nto `AppObserve.uniqueActiveUserCount` up to HyperLogLog noise).\nA version may be returned with `lastSeenUserCount = 0` when\nevery user who touched it later moved to a newer version. Users with\nno events in the window are not counted on any version.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "metrics",
             "description": null,
             "args": [],

--- a/packages/eas-cli/src/commands/observe/__tests__/versions.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/versions.test.ts
@@ -171,6 +171,7 @@ describe(ObserveVersions, () => {
             firstSeenAt: '2025-06-01T00:00:00.000Z',
             eventCount: 100,
             uniqueUserCount: 50,
+            lastSeenUserCount: 12,
             buildNumbers: [],
             updates: [],
             metrics: [],

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2280,6 +2280,17 @@ export type AppObserveAppVersion = {
   buildNumbers: Array<AppObserveAppBuildNumber>;
   eventCount: Scalars['Int']['output'];
   firstSeenAt: Scalars['DateTime']['output'];
+  /**
+   * Unique users whose most recent supported-metric event in
+   * `[startTime, endTime)` was on this version. Each active user
+   * contributes to exactly one version, so summing this field across the
+   * returned versions yields the total active users in the window (equal
+   * to `AppObserve.uniqueActiveUserCount` up to HyperLogLog noise).
+   * A version may be returned with `lastSeenUserCount = 0` when
+   * every user who touched it later moved to a newer version. Users with
+   * no events in the window are not counted on any version.
+   */
+  lastSeenUserCount: Scalars['Int']['output'];
   metrics: Array<AppObserveAppVersionMetric>;
   uniqueUserCount: Scalars['Int']['output'];
   updates: Array<AppObserveAppUpdate>;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2147,6 +2147,15 @@ export type AppObserve = {
   navigationRoutes: AppObserveNavigationRoutesConnection;
   timeSeries: AppObserveTimeSeries;
   totalEventCount: Scalars['Int']['output'];
+  /**
+   * Approximate count of unique users (`eas_client_id`) with at least one
+   * supported-metric event in `[startTime, endTime)`. Uses ClickHouse's
+   * HyperLogLog `uniq()`, so the value can drift by a small percent on apps
+   * with very large user bases. `metricNames` on the input is currently
+   * ignored: the count is always over all supported metrics, matching the
+   * universe used by `appVersions` headline counts.
+   */
+  uniqueActiveUserCount: Scalars['Int']['output'];
   updates: AppObserveUpdatesConnection;
 };
 
@@ -2213,6 +2222,11 @@ export type AppObserveNavigationRoutesArgs = {
 
 export type AppObserveTimeSeriesArgs = {
   input: AppObserveTimeSeriesInput;
+};
+
+
+export type AppObserveUniqueActiveUserCountArgs = {
+  input: AppObserveReleasesInput;
 };
 
 

--- a/packages/eas-cli/src/observe/__tests__/fetchMetrics.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchMetrics.test.ts
@@ -28,6 +28,7 @@ function makeAppVersion(
     eventCount: metrics.reduce((sum, m) => sum + m.eventCount, 0),
     uniqueUserCount: 50,
     firstSeenAt: '2025-01-01T00:00:00.000Z',
+    lastSeenUserCount: 12,
     buildNumbers: [],
     updates: [],
     metrics: metrics.map(m => ({


### PR DESCRIPTION
## Summary
- update eas-cli GraphQL schema/types for the new observe `uniqueActiveUserCount` field
- add the new `lastSeenUserCount` generated field from the PR diff

## Validation
- `yarn run -T oxfmt packages/eas-cli/src/graphql/types/Observe.ts packages/eas-cli/src/commands/observe/__tests__/versions.test.ts packages/eas-cli/src/observe/__tests__/fetchMetrics.test.ts packages/eas-cli/src/graphql/generated.ts packages/eas-cli/graphql.schema.json`
- `yarn workspace eas-cli typecheck`