### PR TITLE
[eas-cli] Improve iOS config fallback Sentry diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- [eas-cli] Improve Sentry diagnostics for managed iOS entitlements config fallback.
+- [eas-cli] Improve Sentry diagnostics for managed iOS entitlements config fallback. ([#3763](https://github.com/expo/eas-cli/pull/3763) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Improve Sentry diagnostics for managed iOS entitlements config fallback.
+
 ### 🧹 Chores
 
 ## [19.0.4](https://github.com/expo/eas-cli/releases/tag/v19.0.4) - 2026-05-20

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -20,7 +20,7 @@ export async function getManagedApplicationTargetEntitlementsAsync(
   env: Record<string, string>,
   vcsClient: Client
 ): Promise<JSONObject> {
-  let expoConfigError: Error | undefined;
+  let expoConfigError: any;
   if (isExpoInstalled(projectDir)) {
     try {
       const { stdout } = await spawnExpoCommand(
@@ -45,15 +45,22 @@ export async function getManagedApplicationTargetEntitlementsAsync(
             scope.setTag('build_id', process.env.EAS_BUILD_ID);
           }
           scope.setTag('config_resolution', 'ios_entitlements_introspection');
-          scope.setExtra('message', 'iOS entitlements config fallback');
-          scope.setExtra('stdout', error.stdout);
-          scope.setExtra('stderr', error.stderr);
-          Sentry.captureException(error);
+          scope.setExtra(
+            'expo_config_command_error',
+            JSON.stringify({
+              message: error.message,
+              output: error.output,
+              signal: error.signal,
+              status: error.status,
+              stderr: error.stderr,
+              stdout: error.stdout,
+            })
+          );
+          Sentry.captureMessage('iOS entitlements config fallback', 'error');
         });
       } catch {
         // do nothing
       }
-
       expoConfigError = error;
       Log.warn(
         `Failed to read the app config from the project using the local Expo CLI: ${formatError(error)}`
@@ -110,7 +117,7 @@ async function resolveManagedApplicationTargetEntitlementsWithBundledConfigAsync
   }
 }
 
-function formatError(error: Error & { stderr?: string; stdout?: string }): string {
+function formatError(error: any): string {
   return error.stderr?.trim() || error.stdout?.trim() || error.message;
 }
 


### PR DESCRIPTION
## Summary
- capture an explicit `iOS entitlements config fallback` Sentry message so this fallback is easier to find than the generic spawn error
- tag the event with app/build/config-resolution metadata
- include spawn failure details in a JSON extra, preserving empty stdout/stderr as `""`
- add a changelog entry

## Test plan
- `yarn workspace eas-cli typecheck`
- `git diff --check`