### PR TITLE
[eas-cli] eas go: prompt for SDK version interactively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] `eas go` now pre-selects the SDK version from the current project's `app.json` or `app.config.js` when available. ([#3776](https://github.com/expo/eas-cli/pull/3776) by [@gwdp](https://github.com/gwdp))
+
 ### 🧹 Chores
 
 ## [19.1.0](https://github.com/expo/eas-cli/releases/tag/v19.1.0) - 2026-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- [eas-cli] `eas go` now pre-selects the SDK version from the current project's `app.json` or `app.config.js` when available. ([#3776](https://github.com/expo/eas-cli/pull/3776) by [@gwdp](https://github.com/gwdp))
-
 ### 🧹 Chores
 
 ## [19.1.0](https://github.com/expo/eas-cli/releases/tag/v19.1.0) - 2026-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] `eas go` now prompts to select an Expo SDK version interactively when `--sdk-version` is not provided. ([#3768](https://github.com/expo/eas-cli/pull/3768) by [@gwdp](https://github.com/gwdp))
+
 ### 🐛 Bug fixes
 
 - [eas-cli] `eas go` now pre-selects the SDK version from the current project's `app.json` or `app.config.js` when available. ([#3776](https://github.com/expo/eas-cli/pull/3776) by [@gwdp](https://github.com/gwdp))

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -32919,6 +32919,18 @@
             "deprecationReason": null
           },
           {
+            "name": "maxRunTimeMinutes",
+            "description": "Override for the underlying turtle job run's max run time, in minutes. Must\nbe non-negative and smaller than 120 (2 hours). Only customizable on paid\nplans. If omitted, the default is derived based on the job run's priority.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "packageVersion",
             "description": "The version of the package backing the device run session (e.g. \"0.1.3-alpha.3\").\nIf omitted, consumers treat the session as pinned to \"latest\".",
             "type": {
@@ -43278,7 +43290,7 @@
         "fields": [
           {
             "name": "uploadEmbeddedUpdate",
-            "description": "Register an embedded bundle as the launch asset for a given app/platform/channel.\nReturns EMBEDDED_UPDATE_ASSET_NOT_AVAILABLE if the asset has not been finalized yet.",
+            "description": "Register an embedded bundle as the launch asset for a given app/platform/channel.\nReturns EMBEDDED_UPDATE_ASSET_NOT_AVAILABLE if the asset has not been finalized yet,\nor EMBEDDED_UPDATE_ALREADY_EXISTS if an embedded update with this id is already registered.",
             "args": [
               {
                 "name": "input",
@@ -52954,6 +52966,18 @@
             "deprecationReason": null
           },
           {
+            "name": "maxRunTimeSeconds",
+            "description": "Max run time in seconds for this job run.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "name",
             "description": null,
             "args": [],
@@ -53057,6 +53081,18 @@
                   }
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflowJob",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "WorkflowJob",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -45372,6 +45372,54 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "supportedSdkVersionKeys",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "supportedSdkVersions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ExpoGoSdkVersion",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -45553,6 +45601,81 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ExpoGoSdkVersion",
+        "description": null,
+        "fields": [
+          {
+            "name": "isBeta",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isDeprecated",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isLatest",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sdkVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/eas-cli/src/__tests__/commands/go-test.ts
+++ b/packages/eas-cli/src/__tests__/commands/go-test.ts
@@ -164,8 +164,8 @@ describe('Go command', () => {
       'Select an Expo SDK version',
       expect.arrayContaining([
         expect.objectContaining({ title: 'SDK 54', value: '54.0.0' }),
-        expect.objectContaining({ title: 'Latest (SDK 55)', value: '55.0.0' }),
-        expect.objectContaining({ title: 'Beta (SDK 56)', value: '56.0.0' }),
+        expect.objectContaining({ title: 'SDK 55 (latest)', value: '55.0.0' }),
+        expect.objectContaining({ title: 'SDK 56 (beta)', value: '56.0.0' }),
       ]),
       expect.objectContaining({ initial: '55.0.0' })
     );

--- a/packages/eas-cli/src/__tests__/commands/go-test.ts
+++ b/packages/eas-cli/src/__tests__/commands/go-test.ts
@@ -6,6 +6,7 @@ import { WorkflowRunStatus } from '../../graphql/generated';
 import { WorkflowRunMutation } from '../../graphql/mutations/WorkflowRunMutation';
 import { WorkflowRunQuery } from '../../graphql/queries/WorkflowRunQuery';
 import Log from '../../log';
+import { selectAsync } from '../../prompts';
 import { getPrivateExpoConfigAsync } from '../../project/expoConfig';
 import { uploadAccountScopedFileAsync } from '../../project/uploadAccountScopedFileAsync';
 import { uploadAccountScopedProjectSourceAsync } from '../../project/uploadAccountScopedProjectSourceAsync';
@@ -50,6 +51,7 @@ jest.mock('../../graphql/mutations/WorkflowRunMutation');
 jest.mock('../../project/uploadAccountScopedFileAsync');
 jest.mock('../../project/uploadAccountScopedProjectSourceAsync');
 jest.mock('../../build/utils/url');
+jest.mock('../../prompts');
 
 const mockGetConfigFilePaths = jest.mocked(getConfigFilePaths);
 const mockGetPrivateExpoConfigAsync = jest.mocked(getPrivateExpoConfigAsync);
@@ -145,5 +147,51 @@ describe('Go command', () => {
     await makeCmd(['--sdk-version', '55.0.0']).run();
 
     expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('Auto-selected'));
+  });
+
+  it('prompts for SDK version when no project config is found', async () => {
+    mockGetConfigFilePaths.mockReturnValue({ staticConfigPath: null, dynamicConfigPath: null });
+    jest.mocked(WorkflowRunQuery.expoGoSupportedSdkVersionsAsync).mockResolvedValue([
+      { sdkVersion: '54.0.0', isLatest: false, isBeta: false, isDeprecated: false },
+      { sdkVersion: '55.0.0', isLatest: true, isBeta: false, isDeprecated: false },
+      { sdkVersion: '56.0.0', isLatest: false, isBeta: true, isDeprecated: false },
+    ]);
+    jest.mocked(selectAsync).mockResolvedValue('55.0.0');
+
+    await makeCmd().run();
+
+    expect(selectAsync).toHaveBeenCalledWith(
+      'Select an Expo SDK version',
+      expect.arrayContaining([
+        expect.objectContaining({ title: 'SDK 54', value: '54.0.0' }),
+        expect.objectContaining({ title: 'Latest (SDK 55)', value: '55.0.0' }),
+        expect.objectContaining({ title: 'Beta (SDK 56)', value: '56.0.0' }),
+      ]),
+      expect.objectContaining({ initial: '55.0.0' })
+    );
+  });
+
+  it('skips prompt when all versions are deprecated', async () => {
+    mockGetConfigFilePaths.mockReturnValue({ staticConfigPath: null, dynamicConfigPath: null });
+    jest
+      .mocked(WorkflowRunQuery.expoGoSupportedSdkVersionsAsync)
+      .mockResolvedValue([
+        { sdkVersion: '54.0.0', isLatest: false, isBeta: false, isDeprecated: true },
+      ]);
+
+    await makeCmd().run();
+
+    expect(selectAsync).not.toHaveBeenCalled();
+  });
+
+  it('falls back gracefully when supportedSdkVersions fetch fails', async () => {
+    mockGetConfigFilePaths.mockReturnValue({ staticConfigPath: null, dynamicConfigPath: null });
+    jest
+      .mocked(WorkflowRunQuery.expoGoSupportedSdkVersionsAsync)
+      .mockRejectedValue(new Error('network error'));
+
+    await makeCmd().run();
+
+    expect(selectAsync).not.toHaveBeenCalled();
   });
 });

--- a/packages/eas-cli/src/commands/go.ts
+++ b/packages/eas-cli/src/commands/go.ts
@@ -306,7 +306,7 @@ export default class Go extends EasCommand {
 
   private async selectSdkVersionAsync(
     graphqlClient: ExpoGraphqlClient
-  ): Promise<string | undefined> {
+  ): Promise<{ sdkVersion: string | undefined }> {
     let versions;
     try {
       versions = await WorkflowRunQuery.expoGoSupportedSdkVersionsAsync(graphqlClient);

--- a/packages/eas-cli/src/commands/go.ts
+++ b/packages/eas-cli/src/commands/go.ts
@@ -212,7 +212,7 @@ export default class Go extends EasCommand {
     }
     let sdkVersion = flags['sdk-version'] ?? detectedSdkVersion;
     if (!sdkVersion) {
-      sdkVersion = await this.selectSdkVersionAsync(graphqlClient);
+      ({ sdkVersion } = await this.selectSdkVersionAsync(graphqlClient));
     }
     const bundleId = flags['bundle-id'] ?? this.generateBundleId(actor);
     if (!isBundleIdentifierValid(bundleId)) {
@@ -311,26 +311,28 @@ export default class Go extends EasCommand {
     try {
       versions = await WorkflowRunQuery.expoGoSupportedSdkVersionsAsync(graphqlClient);
     } catch {
-      return;
+      return { sdkVersion: undefined };
     }
     const selectable = versions.filter(v => !v.isDeprecated);
     if (selectable.length === 0) {
-      return;
+      return { sdkVersion: undefined };
     }
     const defaultVersion = selectable.find(v => v.isLatest) ?? selectable.at(-1);
-    return selectAsync(
-      'Select an Expo SDK version',
-      selectable.map(v => {
-        const major = v.sdkVersion.split('.')[0];
-        const title = v.isLatest
-          ? `Latest (SDK ${major})`
-          : v.isBeta
-            ? `Beta (SDK ${major})`
-            : `SDK ${major}`;
-        return { title, value: v.sdkVersion };
-      }),
-      { initial: defaultVersion?.sdkVersion }
-    );
+    return {
+      sdkVersion: await selectAsync(
+        'Select an Expo SDK version',
+        selectable.map(v => {
+          const major = v.sdkVersion.split('.')[0];
+          const title = v.isLatest
+            ? `SDK ${major} (latest)`
+            : v.isBeta
+              ? `SDK ${major} (beta)`
+              : `SDK ${major}`;
+          return { title, value: v.sdkVersion };
+        }),
+        { initial: defaultVersion?.sdkVersion }
+      ),
+    };
   }
 
   private generateBundleId(actor: Actor): string {

--- a/packages/eas-cli/src/commands/go.ts
+++ b/packages/eas-cli/src/commands/go.ts
@@ -26,7 +26,7 @@ import { AppMutation } from '../graphql/mutations/AppMutation';
 import { WorkflowRunMutation } from '../graphql/mutations/WorkflowRunMutation';
 import { WorkflowRunQuery } from '../graphql/queries/WorkflowRunQuery';
 import Log, { learnMore } from '../log';
-import { confirmAsync } from '../prompts';
+import { confirmAsync, selectAsync } from '../prompts';
 import { ora } from '../ora';
 import { getPrivateExpoConfigAsync } from '../project/expoConfig';
 import { findProjectIdByAccountNameAndSlugNullableAsync } from '../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
@@ -210,7 +210,10 @@ export default class Go extends EasCommand {
         `Current project using SDK ${detectedSdkVersion.split('.')[0]}. Auto-selected same version. To use a different version, pass --sdk-version.`
       );
     }
-    const sdkVersion = flags['sdk-version'] ?? detectedSdkVersion;
+    let sdkVersion = flags['sdk-version'] ?? detectedSdkVersion;
+    if (!sdkVersion) {
+      sdkVersion = await this.selectSdkVersionAsync(graphqlClient);
+    }
     const bundleId = flags['bundle-id'] ?? this.generateBundleId(actor);
     if (!isBundleIdentifierValid(bundleId)) {
       throw new Error(
@@ -299,6 +302,35 @@ export default class Go extends EasCommand {
     } finally {
       await fs.remove(tmpDir);
     }
+  }
+
+  private async selectSdkVersionAsync(
+    graphqlClient: ExpoGraphqlClient
+  ): Promise<string | undefined> {
+    let versions;
+    try {
+      versions = await WorkflowRunQuery.expoGoSupportedSdkVersionsAsync(graphqlClient);
+    } catch {
+      return;
+    }
+    const selectable = versions.filter(v => !v.isDeprecated);
+    if (selectable.length === 0) {
+      return;
+    }
+    const defaultVersion = selectable.find(v => v.isLatest) ?? selectable.at(-1);
+    return selectAsync(
+      'Select an Expo SDK version',
+      selectable.map(v => {
+        const major = v.sdkVersion.split('.')[0];
+        const title = v.isLatest
+          ? `Latest (SDK ${major})`
+          : v.isBeta
+            ? `Beta (SDK ${major})`
+            : `SDK ${major}`;
+        return { title, value: v.sdkVersion };
+      }),
+      { initial: defaultVersion?.sdkVersion }
+    );
   }
 
   private generateBundleId(actor: Actor): string {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4680,6 +4680,12 @@ export type CreateConvexTeamConnectionInput = {
 export type CreateDeviceRunSessionInput = {
   appId: Scalars['ID']['input'];
   /**
+   * Override for the underlying turtle job run's max run time, in minutes. Must
+   * be non-negative and smaller than 120 (2 hours). Only customizable on paid
+   * plans. If omitted, the default is derived based on the job run's priority.
+   */
+  maxRunTimeMinutes?: InputMaybe<Scalars['Int']['input']>;
+  /**
    * The version of the package backing the device run session (e.g. "0.1.3-alpha.3").
    * If omitted, consumers treat the session as pinned to "latest".
    */
@@ -6174,7 +6180,8 @@ export type EmbeddedUpdateMutation = {
   __typename?: 'EmbeddedUpdateMutation';
   /**
    * Register an embedded bundle as the launch asset for a given app/platform/channel.
-   * Returns EMBEDDED_UPDATE_ASSET_NOT_AVAILABLE if the asset has not been finalized yet.
+   * Returns EMBEDDED_UPDATE_ASSET_NOT_AVAILABLE if the asset has not been finalized yet,
+   * or EMBEDDED_UPDATE_ALREADY_EXISTS if an embedded update with this id is already registered.
    */
   uploadEmbeddedUpdate: EmbeddedUpdate;
 };
@@ -7468,6 +7475,8 @@ export type JobRun = {
   initiatingActor?: Maybe<Actor>;
   isWaived: Scalars['Boolean']['output'];
   logFileUrls: Array<Scalars['String']['output']>;
+  /** Max run time in seconds for this job run. */
+  maxRunTimeSeconds?: Maybe<Scalars['Int']['output']>;
   name: Scalars['String']['output'];
   priority: JobRunPriority;
   /** String describing the worker profile used to run this job run. */
@@ -7475,6 +7484,7 @@ export type JobRun = {
   startedAt?: Maybe<Scalars['DateTime']['output']>;
   status: JobRunStatus;
   updateGroups: Array<Array<Update>>;
+  workflowJob?: Maybe<WorkflowJob>;
 };
 
 export type JobRunError = {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -6470,6 +6470,8 @@ export type ExperimentationQuery = {
 export type ExpoGoBuildQuery = {
   __typename?: 'ExpoGoBuildQuery';
   repackConfiguration: ExpoGoProjectConfiguration;
+  supportedSdkVersionKeys: Array<Scalars['String']['output']>;
+  supportedSdkVersions: Array<ExpoGoSdkVersion>;
 };
 
 
@@ -6495,6 +6497,14 @@ export type ExpoGoRepackInput = {
   ascAppId: Scalars['String']['input'];
   bundleId: Scalars['String']['input'];
   sdkVersion?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ExpoGoSdkVersion = {
+  __typename?: 'ExpoGoSdkVersion';
+  isBeta: Scalars['Boolean']['output'];
+  isDeprecated: Scalars['Boolean']['output'];
+  isLatest: Scalars['Boolean']['output'];
+  sdkVersion: Scalars['String']['output'];
 };
 
 export type FcmSnippet = FcmSnippetLegacy | FcmSnippetV1;
@@ -13246,6 +13256,11 @@ export type WorkflowJobByIdQueryVariables = Exact<{
 
 
 export type WorkflowJobByIdQuery = { __typename?: 'RootQuery', workflowJobs: { __typename?: 'WorkflowJobQuery', byId: { __typename?: 'WorkflowJob', id: string, key: string, name: string, status: WorkflowJobStatus, type: WorkflowJobType, outputs: any, createdAt: any, updatedAt: any, workflowRun: { __typename?: 'WorkflowRun', id: string }, turtleJobRun?: { __typename?: 'JobRun', id: string, logFileUrls: Array<string>, artifacts: Array<{ __typename?: 'WorkflowArtifact', id: string, name: string, contentType?: string | null, fileSizeBytes?: number | null, filename: string, downloadUrl?: string | null }>, errors: Array<{ __typename?: 'JobRunError', errorCode: string, message: string }> } | null, turtleBuild?: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, logFiles: Array<string>, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, fingerprint?: { __typename?: 'Fingerprint', id: string, hash: string } | null, initiatingActor?: { __typename: 'PartnerActor', id: string, displayName: string } | { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string }, metrics?: { __typename?: 'BuildMetrics', buildWaitTime?: number | null, buildQueueTime?: number | null, buildDuration?: number | null } | null } | null, errors: Array<{ __typename?: 'WorkflowJobError', title: string, message: string }> } } };
+
+export type ExpoGoSupportedSdkVersionsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ExpoGoSupportedSdkVersionsQuery = { __typename?: 'RootQuery', expoGoBuild: { __typename?: 'ExpoGoBuildQuery', supportedSdkVersions: Array<{ __typename?: 'ExpoGoSdkVersion', sdkVersion: string, isLatest: boolean, isBeta: boolean, isDeprecated: boolean }> } };
 
 export type ExpoGoRepackConfigurationQueryVariables = Exact<{
   input: ExpoGoRepackInput;

--- a/packages/eas-cli/src/graphql/queries/WorkflowRunQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/WorkflowRunQuery.ts
@@ -6,7 +6,12 @@ import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/creat
 import { withErrorHandlingAsync } from '../client';
 import {
   ExpoGoProjectConfiguration,
+  ExpoGoRepackConfigurationQuery,
+  ExpoGoRepackConfigurationQueryVariables,
   ExpoGoRepackInput,
+  ExpoGoSdkVersion,
+  ExpoGoSupportedSdkVersionsQuery,
+  ExpoGoSupportedSdkVersionsQueryVariables,
   WorkflowRunByIdQuery,
   WorkflowRunByIdQueryVariables,
   WorkflowRunByIdWithJobsQuery,
@@ -18,24 +23,13 @@ import {
 import { WorkflowJobFragmentNode } from '../types/WorkflowJob';
 import { WorkflowRunFragmentNode } from '../types/WorkflowRun';
 
-type ExpoGoSdkVersion = {
-  sdkVersion: string;
-  isLatest: boolean;
-  isBeta: boolean;
-  isDeprecated: boolean;
-};
-
 export const WorkflowRunQuery = {
   async expoGoSupportedSdkVersionsAsync(
     graphqlClient: ExpoGraphqlClient
   ): Promise<ExpoGoSdkVersion[]> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<
-          { expoGoBuild: { supportedSdkVersions: ExpoGoSdkVersion[] } },
-          Record<string, never>
-        >(
-          /* eslint-disable graphql/template-strings */
+        .query<ExpoGoSupportedSdkVersionsQuery, ExpoGoSupportedSdkVersionsQueryVariables>(
           gql`
             query ExpoGoSupportedSdkVersions {
               expoGoBuild {
@@ -48,7 +42,6 @@ export const WorkflowRunQuery = {
               }
             }
           `,
-          /* eslint-enable graphql/template-strings */
           {},
           { requestPolicy: 'network-only' }
         )
@@ -62,11 +55,7 @@ export const WorkflowRunQuery = {
   ): Promise<ExpoGoProjectConfiguration> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<
-          { expoGoBuild: { repackConfiguration: ExpoGoProjectConfiguration } },
-          { input: ExpoGoRepackInput }
-        >(
-          /* eslint-disable graphql/template-strings */
+        .query<ExpoGoRepackConfigurationQuery, ExpoGoRepackConfigurationQueryVariables>(
           gql`
             query ExpoGoRepackConfiguration($input: ExpoGoRepackInput!) {
               expoGoBuild {
@@ -80,7 +69,6 @@ export const WorkflowRunQuery = {
               }
             }
           `,
-          /* eslint-enable graphql/template-strings */
           { input },
           { requestPolicy: 'network-only' }
         )

--- a/packages/eas-cli/src/graphql/queries/WorkflowRunQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/WorkflowRunQuery.ts
@@ -18,7 +18,44 @@ import {
 import { WorkflowJobFragmentNode } from '../types/WorkflowJob';
 import { WorkflowRunFragmentNode } from '../types/WorkflowRun';
 
+type ExpoGoSdkVersion = {
+  sdkVersion: string;
+  isLatest: boolean;
+  isBeta: boolean;
+  isDeprecated: boolean;
+};
+
 export const WorkflowRunQuery = {
+  async expoGoSupportedSdkVersionsAsync(
+    graphqlClient: ExpoGraphqlClient
+  ): Promise<ExpoGoSdkVersion[]> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<
+          { expoGoBuild: { supportedSdkVersions: ExpoGoSdkVersion[] } },
+          Record<string, never>
+        >(
+          /* eslint-disable graphql/template-strings */
+          gql`
+            query ExpoGoSupportedSdkVersions {
+              expoGoBuild {
+                supportedSdkVersions {
+                  sdkVersion
+                  isLatest
+                  isBeta
+                  isDeprecated
+                }
+              }
+            }
+          `,
+          /* eslint-enable graphql/template-strings */
+          {},
+          { requestPolicy: 'network-only' }
+        )
+        .toPromise()
+    );
+    return data.expoGoBuild.supportedSdkVersions;
+  },
   async expoGoRepackConfigurationAsync(
     graphqlClient: ExpoGraphqlClient,
     input: ExpoGoRepackInput


### PR DESCRIPTION
## Summary

- Adds an interactive SDK version select prompt to `eas go` when `--sdk-version` is not passed.
- Fetches `supportedSdkVersions` from the GraphQL API (expo/universe#27451) — returns only versions with an actual repack target, labeled as Latest, Beta, or by major version number.
- Defaults the cursor to the latest released version; falls back to the last entry if no version is marked latest.
- `--sdk-version` and current project scope bypasses the prompt entirely

## Validation

- Ran `eas go` without `--sdk-version` — prompted with SDK list, latest selected by default.
- Ran `eas go --sdk-version 55.0.0` — no prompt, proceeds directly.
- Ran `eas go` within a 55.x project, auto-selected, no prompt