### PR TITLE
fix(precompile) changed min sdk-version for precompile to 5.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Update the minimum Expo version required for iOS precompiled modules to 55.0.26.
+
 ### 🧹 Chores
 
 ## [19.0.5](https://github.com/expo/eas-cli/releases/tag/v19.0.5) - 2026-05-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- [build-tools] Update the minimum Expo version required for iOS precompiled modules to 55.0.26.
+- [build-tools] Update the minimum Expo version required for iOS precompiled modules to 55.0.26. ([#3771](https://github.com/expo/eas-cli/pull/3771) by [@chrfalch](https://github.com/chrfalch))
 
 ### 🧹 Chores
 

--- a/packages/build-tools/src/ios/__tests__/pod.test.ts
+++ b/packages/build-tools/src/ios/__tests__/pod.test.ts
@@ -126,14 +126,14 @@ describe(installPods, () => {
   });
 
   it('does not add precompiled modules env vars below the minimum Expo version', async () => {
-    const ctx = makeIosBuildContext({ expoVersion: '55.0.17' });
+    const ctx = makeIosBuildContext({ expoVersion: '55.0.25' });
 
     await installPods(ctx, {});
 
     expect((spawn as jest.Mock).mock.calls[0][2].env.EXPO_USE_PRECOMPILED_MODULES).toBeUndefined();
     expect(ctx.logger.info).toHaveBeenCalledWith(
       expect.stringMatching(
-        /^Detected expo=55\.0\.17; not enabling precompiled modules use because precompiled modules require expo>=/
+        /^Detected expo=55\.0\.25; not enabling precompiled modules use because precompiled modules require expo>=55\.0\.26\./
       )
     );
   });

--- a/packages/build-tools/src/ios/pod.ts
+++ b/packages/build-tools/src/ios/pod.ts
@@ -5,7 +5,7 @@ import semver from 'semver';
 
 import { BuildContext } from '../context';
 
-const MIN_PRECOMPILED_MODULES_EXPO_VERSION = '55.0.21';
+const MIN_PRECOMPILED_MODULES_EXPO_VERSION = '55.0.26';
 const PRECOMPILED_MODULES_BASE_URL =
   'https://storage.googleapis.com/eas-build-precompiled-modules/';
 


### PR DESCRIPTION
# Why

After publishing new fixes also on SDK-55 for the precompile, we'd like to lock in on a higher version.

# How

This commit fixes this by updating the tests and implementation to require 55.0.26 as the minimum sdk version.

# Test Plan

✅ Ran unit tests red/green