### PR TITLE
[build-tools] keep exit code & stderr when xclogparser failed

### DIFF
--- a/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
+++ b/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
@@ -385,7 +385,7 @@ describe('parseAndReportXcactivitylog', () => {
     expect(Sentry.capture).toHaveBeenCalledWith(
       'Build performance analysis failed during "parsing_xclogparser_output"',
       expect.any(Error),
-      { tags: { phase: 'parsing_xclogparser_output' } }
+      expect.objectContaining({ tags: { phase: 'parsing_xclogparser_output' } })
     );
   });
 
@@ -416,7 +416,7 @@ describe('parseAndReportXcactivitylog', () => {
     expect(Sentry.capture).toHaveBeenCalledWith(
       'Build performance analysis failed during "parsing_xclogparser_output"',
       expect.any(Error),
-      { tags: { phase: 'parsing_xclogparser_output' } }
+      expect.objectContaining({ tags: { phase: 'parsing_xclogparser_output' } })
     );
   });
 
@@ -444,7 +444,7 @@ describe('parseAndReportXcactivitylog', () => {
     expect(Sentry.capture).toHaveBeenCalledWith(
       'Build performance analysis failed during "running_xclogparser"',
       expect.objectContaining({ message: 'spawn xclogparser ENOENT' }),
-      { tags: { phase: 'running_xclogparser' } }
+      expect.objectContaining({ tags: { phase: 'running_xclogparser' } })
     );
   });
 
@@ -477,9 +477,10 @@ describe('parseAndReportXcactivitylog', () => {
       {
         tags: { phase: 'running_xclogparser' },
         extras: {
+          exitStatus: 1,
+          signal: null,
           stderr: 'XCLogParser fatal: missing xcactivitylog\n',
           stdout: 'some stdout',
-          exitStatus: 1,
         },
       }
     );
@@ -507,7 +508,7 @@ describe('parseAndReportXcactivitylog', () => {
     expect(Sentry.capture).toHaveBeenCalledWith(
       'Build performance analysis failed during "downloading_xclogparser"',
       expect.objectContaining({ message: 'network unreachable' }),
-      { tags: { phase: 'downloading_xclogparser' } }
+      expect.objectContaining({ tags: { phase: 'downloading_xclogparser' } })
     );
   });
 

--- a/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
+++ b/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
@@ -448,6 +448,43 @@ describe('parseAndReportXcactivitylog', () => {
     );
   });
 
+  it('surfaces spawn error stderr/stdout/status/signal as Sentry extras', async () => {
+    const logger = createMockLogger();
+    mockFilesystem();
+
+    const spawnError: any = new Error('xclogparser exited with non-zero code: 1');
+    spawnError.stderr = 'XCLogParser fatal: missing xcactivitylog\n';
+    spawnError.stdout = 'some stdout';
+    spawnError.status = 1;
+    spawnError.signal = null;
+
+    mockedDownloadFile.mockResolvedValue(undefined);
+    mockedSpawn
+      .mockRejectedValueOnce(new Error('xclogparser not found')) // version detect
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as any) // unzip
+      .mockRejectedValueOnce(spawnError); // xclogparser run
+
+    await parseAndReportXcactivitylog({
+      derivedDataPath: '/tmp/derived-data',
+      workspacePath: '/tmp/workspace',
+      logger,
+      env: TEST_ENV,
+    });
+
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Build performance analysis failed during "running_xclogparser"',
+      expect.any(Error),
+      {
+        tags: { phase: 'running_xclogparser' },
+        extras: {
+          stderr: 'XCLogParser fatal: missing xcactivitylog\n',
+          stdout: 'some stdout',
+          exitStatus: 1,
+        },
+      }
+    );
+  });
+
   it('reports phase "downloading_xclogparser" when the direct download fails', async () => {
     const logger = createMockLogger();
     mockFilesystem();

--- a/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
+++ b/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
@@ -82,14 +82,14 @@ export async function parseAndReportXcactivitylog({
   } catch (err: any) {
     logger.info('Build performance analysis skipped.');
     const msg = `Build performance analysis failed during "${phase}"`;
-    const extras: Record<string, unknown> = {};
-    if (typeof err?.stderr === 'string') extras.stderr = err.stderr.slice(-4000);
-    if (typeof err?.stdout === 'string') extras.stdout = err.stdout.slice(-4000);
-    if (err?.status != null) extras.exitStatus = err.status;
-    if (err?.signal != null) extras.signal = err.signal;
     Sentry.capture(msg, err, {
       tags: { phase },
-      ...(Object.keys(extras).length > 0 ? { extras } : {}),
+      extras: {
+        exitStatus: err?.status,
+        signal: err?.signal,
+        stderr: err?.stderr?.slice(-4000),
+        stdout: err?.stdout?.slice(-4000),
+      },
     });
   } finally {
     if (tempDir) {

--- a/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
+++ b/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
@@ -82,7 +82,15 @@ export async function parseAndReportXcactivitylog({
   } catch (err: any) {
     logger.info('Build performance analysis skipped.');
     const msg = `Build performance analysis failed during "${phase}"`;
-    Sentry.capture(msg, err, { tags: { phase } });
+    const extras: Record<string, unknown> = {};
+    if (typeof err?.stderr === 'string') extras.stderr = err.stderr.slice(-4000);
+    if (typeof err?.stdout === 'string') extras.stdout = err.stdout.slice(-4000);
+    if (err?.status != null) extras.exitStatus = err.status;
+    if (err?.signal != null) extras.signal = err.signal;
+    Sentry.capture(msg, err, {
+      tags: { phase },
+      ...(Object.keys(extras).length > 0 ? { extras } : {}),
+    });
   } finally {
     if (tempDir) {
       await asyncResult(fs.rm(tempDir, { force: true, recursive: true }));


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Sentry shows ~13 events from the iOS build worker where `xclogparser` exits non-zero, but the only info captured is the spawn command line + exit code. The actual stderr is sitting on the rejected Error (`@expo/spawn-async` does `Object.assign(error, { stdout, stderr, status, signal })`), but `Sentry.captureException` only surfaces `err.message` and `err.stack`. Without stderr we can't tell whether `xclogparser` is failing on a missing log, an unsupported SLF version, an internal crash, or something else.

# How

In the `parseAndReportXcactivitylog` catch block, extract `stderr` / `stdout` / `status` / `signal` from the error and pass them as Sentry `extras`. A conditional spread keeps the `extras` key out when no spawn-shaped fields are present, so non-spawn error paths (`RangeError`, `SyntaxError`, `ZodError`) report the same payload as before. `stderr` and `stdout` are capped at the last 4000 chars to bound event payload size.

# Test Plan

- New unit test `surfaces spawn error stderr/stdout/status/signal as Sentry extras` constructs a spawn-shaped Error and asserts the expected extras land in `Sentry.capture`.
- All 37 tests in `xcactivitylog.test.ts` pass. The four existing tests for non-spawn error paths continue to assert `{ tags: { phase } }` exactly and pass unchanged because the conditional spread omits `extras` when nothing is populated.
- Real validation comes from Sentry after deploy: the ongoing `running_xclogparser` events should start showing stderr within 24–48h.