### PR TITLE
[eas-cli] Add --json flag to simulator:stop command

### DIFF
--- a/packages/eas-cli/src/commands/simulator/stop.ts
+++ b/packages/eas-cli/src/commands/simulator/stop.ts
@@ -1,9 +1,13 @@
 import { Flags } from '@oclif/core';
 
 import EasCommand from '../../commandUtils/EasCommand';
-import { EASNonInteractiveFlag } from '../../commandUtils/flags';
+import {
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
+} from '../../commandUtils/flags';
 import { DeviceRunSessionMutation } from '../../graphql/mutations/DeviceRunSessionMutation';
 import { ora } from '../../ora';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class SimulatorStop extends EasCommand {
   static override hidden = true;
@@ -15,7 +19,7 @@ export default class SimulatorStop extends EasCommand {
       description: 'Device run session ID',
       required: true,
     }),
-    ...EASNonInteractiveFlag,
+    ...EasNonInteractiveAndJsonFlags,
   };
 
   static override contextDefinition = {
@@ -24,11 +28,16 @@ export default class SimulatorStop extends EasCommand {
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(SimulatorStop);
+    const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
 
     const {
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(SimulatorStop, {
-      nonInteractive: flags['non-interactive'],
+      nonInteractive,
     });
 
     const stopSpinner = ora(`🛑 Stopping device run session ${flags.id}`).start();
@@ -38,6 +47,10 @@ export default class SimulatorStop extends EasCommand {
         flags.id
       );
       stopSpinner.succeed(`🎉 Device run session ${session.id} is ${session.status.toLowerCase()}`);
+
+      if (jsonFlag) {
+        printJsonOnlyOutput({ id: session.id, status: session.status });
+      }
     } catch (err) {
       stopSpinner.fail(`Failed to stop device run session ${flags.id}`);
       throw err;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`eas simulator:stop` only emitted human-readable spinner output, so wrapper scripts and automation can't consume the resulting session id and status. Sibling commands (e.g. `simulator:start`, `branch:rename`) already expose `--json` for machine-readable output.

# How

- Swap `EASNonInteractiveFlag` for `EasNonInteractiveAndJsonFlags` (adds `--json`, preserves `--non-interactive`).
- Use `resolveNonInteractiveAndJsonFlags` so `--json` implies `--non-interactive`, matching `simulator:start`.
- Call `enableJsonOutput()` before any logging so spinner output is redirected to stderr when `--json` is set.
- On successful stop, emit `{ id, status }` via `printJsonOnlyOutput`.

# Test Plan

- `yarn typecheck`, `yarn lint`, and `yarn fmt:check` pass for the modified file.
- Manual: `eas simulator:stop --id <id> --json` writes only the JSON payload to stdout; spinner/log messages are redirected to stderr.