### PR TITLE
[eas-cli] Add simulator:list command

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -9914,6 +9914,83 @@
             "deprecationReason": null
           },
           {
+            "name": "deviceRunSessionsPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "DeviceRunSessionFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppDeviceRunSessionsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "environmentSecrets",
             "description": "Environment secrets for an app",
             "args": [
@@ -12957,6 +13034,100 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AppDeviceRunSessionEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeviceRunSession",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppDeviceRunSessionsConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppDeviceRunSessionEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AppFingerprintEdge",
         "description": null,
         "fields": [
@@ -14492,6 +14663,22 @@
             "deprecationReason": null
           },
           {
+            "name": "lastSeenUserCount",
+            "description": "Unique users whose most recent supported-metric event in the queried\nrange ran this build's embedded bundle.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "uniqueUserCount",
             "description": null,
             "args": [],
@@ -14603,6 +14790,22 @@
             "deprecationReason": null
           },
           {
+            "name": "lastSeenUserCount",
+            "description": "Unique users whose most recent supported-metric event in the queried\nrange was on this (appVersion, appBuildNumber) tuple.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "uniqueUserCount",
             "description": null,
             "args": [],
@@ -14613,6 +14816,30 @@
                 "kind": "SCALAR",
                 "name": "Int",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updates",
+            "description": "Updates seen on this build number in the queried time range. Each\nentry's counts and EAS builds are scoped to this (appVersion,\nappBuildNumber, appUpdateId) tuple.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveAppUpdate",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -14782,6 +15009,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastSeenUserCount",
+            "description": "Unique users whose most recent supported-metric event in the queried\nrange matched this update at its current nesting level.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               }
             },
@@ -37417,6 +37660,77 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "DeviceRunSessionFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "platforms",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppPlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "statuses",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DeviceRunSessionStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "types",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "DeviceRunSessionType",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
@@ -1,0 +1,213 @@
+import { Config } from '@oclif/core';
+
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import {
+  AppPlatform,
+  DeviceRunSessionStatus,
+  DeviceRunSessionType,
+  DeviceRunSessionsByAppIdQuery,
+  JobRunStatus,
+} from '../../../graphql/generated';
+import { DeviceRunSessionQuery } from '../../../graphql/queries/DeviceRunSessionQuery';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+import SimulatorList from '../list';
+
+jest.mock('../../../graphql/queries/DeviceRunSessionQuery');
+jest.mock('../../../log');
+jest.mock('../../../ora', () => ({
+  ora: jest.fn(() => {
+    const spinner = {
+      fail: jest.fn(),
+      start: jest.fn(),
+      succeed: jest.fn(),
+    };
+    spinner.start.mockReturnValue(spinner);
+    return spinner;
+  }),
+}));
+jest.mock('../../../utils/json');
+
+type DeviceRunSessionEdge =
+  DeviceRunSessionsByAppIdQuery['app']['byId']['deviceRunSessionsPaginated']['edges'][number];
+type DeviceRunSessionNode = DeviceRunSessionEdge['node'];
+type DeviceRunSessionsPaginated =
+  DeviceRunSessionsByAppIdQuery['app']['byId']['deviceRunSessionsPaginated'];
+
+const mockListByAppIdAsync = jest.mocked(DeviceRunSessionQuery.listByAppIdAsync);
+const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
+const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
+
+function makeSession(overrides: Partial<DeviceRunSessionNode> = {}): DeviceRunSessionNode {
+  return {
+    id: 'session-123',
+    status: DeviceRunSessionStatus.InProgress,
+    type: DeviceRunSessionType.AgentDevice,
+    platform: AppPlatform.Ios,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    startedAt: '2025-01-01T00:00:05.000Z',
+    finishedAt: null,
+    app: {
+      id: 'app-123',
+      slug: 'testapp',
+      ownerAccount: {
+        id: 'account-123',
+        name: 'testuser',
+      },
+    },
+    turtleJobRun: {
+      id: 'job-123',
+      status: JobRunStatus.InProgress,
+    },
+    ...overrides,
+  };
+}
+
+function makeConnection(
+  nodes: DeviceRunSessionNode[],
+  pageInfo: Partial<DeviceRunSessionsPaginated['pageInfo']> = {}
+): DeviceRunSessionsPaginated {
+  return {
+    edges: nodes.map((node, index) => ({ cursor: `cursor-${index}`, node })),
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: nodes.length > 0 ? 'cursor-0' : null,
+      endCursor: nodes.length > 0 ? `cursor-${nodes.length - 1}` : null,
+      ...pageInfo,
+    },
+  };
+}
+
+function getMockOclifConfig(): Config {
+  const config = new Config({ root: __dirname });
+  config.runHook = async () => ({
+    failures: [],
+    successes: [],
+  });
+  return config;
+}
+
+describe(SimulatorList, () => {
+  const graphqlClient = {} as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createCommand(argv: string[]): {
+    command: SimulatorList;
+    getContextAsync: jest.SpyInstance;
+  } {
+    const command = new SimulatorList(argv, mockConfig);
+    // @ts-expect-error getContextAsync is protected
+    const getContextAsync = jest.spyOn(command, 'getContextAsync').mockResolvedValue({
+      projectId: 'app-123',
+      loggedIn: { graphqlClient },
+    });
+    return { command, getContextAsync };
+  }
+
+  it('emits JSON when --json is passed', async () => {
+    const session = makeSession();
+    mockListByAppIdAsync.mockResolvedValue(makeConnection([session]));
+
+    const { command, getContextAsync } = createCommand(['--json']);
+    await command.runAsync();
+
+    expect(mockEnableJsonOutput).toHaveBeenCalled();
+    expect(getContextAsync).toHaveBeenCalledWith(SimulatorList, {
+      nonInteractive: true,
+    });
+    expect(mockListByAppIdAsync).toHaveBeenCalledWith(graphqlClient, {
+      appId: 'app-123',
+      first: 10,
+      after: undefined,
+      filter: undefined,
+    });
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
+      sessions: [
+        {
+          id: 'session-123',
+          type: 'agent-device',
+          status: DeviceRunSessionStatus.InProgress,
+          platform: AppPlatform.Ios,
+          createdAt: '2025-01-01T00:00:00.000Z',
+          startedAt: '2025-01-01T00:00:05.000Z',
+          finishedAt: undefined,
+          jobRunUrl: 'https://expo.dev/accounts/testuser/projects/testapp/job-runs/job-123',
+        },
+      ],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: 'cursor-0',
+        endCursor: 'cursor-0',
+      },
+    });
+  });
+
+  it('passes filters and cursor to the query', async () => {
+    mockListByAppIdAsync.mockResolvedValue(makeConnection([]));
+
+    const { command } = createCommand([
+      '--json',
+      '--status',
+      'in-progress',
+      '--status',
+      'new',
+      '--type',
+      'argent',
+      '--platform',
+      'ios',
+      '--limit',
+      '25',
+      '--after',
+      'page-cursor',
+    ]);
+    await command.runAsync();
+
+    expect(mockListByAppIdAsync).toHaveBeenCalledWith(graphqlClient, {
+      appId: 'app-123',
+      first: 25,
+      after: 'page-cursor',
+      filter: {
+        statuses: [DeviceRunSessionStatus.InProgress, DeviceRunSessionStatus.New],
+        types: [DeviceRunSessionType.Argent],
+        platforms: [AppPlatform.Ios],
+      },
+    });
+  });
+
+  it('runs non-interactively without --json', async () => {
+    const session = makeSession({ id: 'session-1', turtleJobRun: null });
+    mockListByAppIdAsync.mockResolvedValue(makeConnection([session]));
+
+    const { command, getContextAsync } = createCommand(['--non-interactive']);
+    await command.runAsync();
+
+    expect(mockEnableJsonOutput).not.toHaveBeenCalled();
+    expect(mockPrintJsonOnlyOutput).not.toHaveBeenCalled();
+    expect(getContextAsync).toHaveBeenCalledWith(SimulatorList, {
+      nonInteractive: true,
+    });
+    expect(mockListByAppIdAsync).toHaveBeenCalled();
+  });
+
+  it('handles empty results', async () => {
+    mockListByAppIdAsync.mockResolvedValue(makeConnection([]));
+
+    const { command } = createCommand(['--json']);
+    await command.runAsync();
+
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
+      sessions: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: null,
+        endCursor: null,
+      },
+    });
+  });
+});

--- a/packages/eas-cli/src/commands/simulator/list.ts
+++ b/packages/eas-cli/src/commands/simulator/list.ts
@@ -1,0 +1,185 @@
+import { Flags } from '@oclif/core';
+import chalk from 'chalk';
+
+import { getBareJobRunUrl } from '../../build/utils/url';
+import EasCommand from '../../commandUtils/EasCommand';
+import {
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
+} from '../../commandUtils/flags';
+import { getLimitFlagWithCustomValues } from '../../commandUtils/pagination';
+import {
+  AppPlatform,
+  DeviceRunSessionFilterInput,
+  DeviceRunSessionStatus,
+} from '../../graphql/generated';
+import { DeviceRunSessionQuery } from '../../graphql/queries/DeviceRunSessionQuery';
+import Log, { link } from '../../log';
+import { ora } from '../../ora';
+import {
+  DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE,
+  DEVICE_RUN_SESSION_TYPE_FLAG_VALUES,
+  deviceRunSessionTypeToFlagValue,
+} from '../../simulator/utils';
+import { fromNow } from '../../utils/date';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 100;
+
+const STATUS_FLAG_VALUES: Record<DeviceRunSessionStatus, string> = {
+  [DeviceRunSessionStatus.New]: 'new',
+  [DeviceRunSessionStatus.InProgress]: 'in-progress',
+  [DeviceRunSessionStatus.Stopped]: 'stopped',
+  [DeviceRunSessionStatus.Errored]: 'errored',
+};
+const STATUS_BY_FLAG_VALUE = Object.fromEntries(
+  Object.entries(STATUS_FLAG_VALUES).map(([status, value]) => [
+    value,
+    status as DeviceRunSessionStatus,
+  ])
+);
+
+const PLATFORM_FLAG_VALUES: Record<AppPlatform, string> = {
+  [AppPlatform.Android]: 'android',
+  [AppPlatform.Ios]: 'ios',
+};
+const PLATFORM_BY_FLAG_VALUE = Object.fromEntries(
+  Object.entries(PLATFORM_FLAG_VALUES).map(([platform, value]) => [value, platform as AppPlatform])
+);
+
+export default class SimulatorList extends EasCommand {
+  static override hidden = true;
+  static override description =
+    '[EXPERIMENTAL] list remote simulator sessions for the current project';
+
+  static override flags = {
+    status: Flags.option({
+      description: 'Filter by session status (repeatable)',
+      options: Object.values(STATUS_FLAG_VALUES),
+      multiple: true,
+    })(),
+    type: Flags.option({
+      description: 'Filter by session type (repeatable)',
+      options: Object.values(DEVICE_RUN_SESSION_TYPE_FLAG_VALUES),
+      multiple: true,
+    })(),
+    platform: Flags.option({
+      description: 'Filter by device platform (repeatable)',
+      options: Object.values(PLATFORM_FLAG_VALUES),
+      multiple: true,
+    })(),
+    limit: getLimitFlagWithCustomValues({ defaultTo: DEFAULT_LIMIT, limit: MAX_LIMIT }),
+    after: Flags.string({
+      description:
+        'Cursor for pagination. Use the endCursor from a previous query to fetch the next page.',
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectId,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(SimulatorList);
+    const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    const {
+      projectId,
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(SimulatorList, {
+      nonInteractive,
+    });
+
+    const filter: DeviceRunSessionFilterInput = {};
+    if (flags.status && flags.status.length > 0) {
+      filter.statuses = flags.status.map(value => STATUS_BY_FLAG_VALUE[value]);
+    }
+    if (flags.type && flags.type.length > 0) {
+      filter.types = flags.type.map(value => DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE[value]);
+    }
+    if (flags.platform && flags.platform.length > 0) {
+      filter.platforms = flags.platform.map(value => PLATFORM_BY_FLAG_VALUE[value]);
+    }
+
+    const limit = flags.limit ?? DEFAULT_LIMIT;
+
+    const fetchSpinner = jsonFlag ? null : ora('Fetching device run sessions').start();
+    let connection;
+    try {
+      connection = await DeviceRunSessionQuery.listByAppIdAsync(graphqlClient, {
+        appId: projectId,
+        first: limit,
+        after: flags.after,
+        filter: Object.keys(filter).length > 0 ? filter : undefined,
+      });
+      fetchSpinner?.succeed(`Fetched ${connection.edges.length} device run session(s)`);
+    } catch (err) {
+      fetchSpinner?.fail('Failed to fetch device run sessions');
+      throw err;
+    }
+
+    const sessions = connection.edges.map(edge => edge.node);
+
+    if (jsonFlag) {
+      printJsonOnlyOutput({
+        sessions: sessions.map(session => ({
+          id: session.id,
+          type: deviceRunSessionTypeToFlagValue(session.type),
+          status: session.status,
+          platform: session.platform,
+          createdAt: session.createdAt,
+          startedAt: session.startedAt ?? undefined,
+          finishedAt: session.finishedAt ?? undefined,
+          jobRunUrl: session.turtleJobRun
+            ? getBareJobRunUrl(
+                session.app.ownerAccount.name,
+                session.app.slug,
+                session.turtleJobRun.id
+              )
+            : undefined,
+        })),
+        pageInfo: connection.pageInfo,
+      });
+      return;
+    }
+
+    if (sessions.length === 0) {
+      Log.newLine();
+      Log.log('No device run sessions found.');
+      return;
+    }
+
+    Log.newLine();
+    const formattedEntries = sessions.map(session => {
+      const jobRunUrl = session.turtleJobRun
+        ? getBareJobRunUrl(session.app.ownerAccount.name, session.app.slug, session.turtleJobRun.id)
+        : null;
+      const lines = [
+        `ID:       ${session.id}`,
+        `Type:     ${session.type}`,
+        `Status:   ${session.status}`,
+        `Platform: ${session.platform}`,
+        `Created:  ${fromNow(new Date(session.createdAt))} ago`,
+      ];
+      if (jobRunUrl) {
+        lines.push(`URL:      ${link(jobRunUrl)}`);
+      }
+      return lines.join('\n');
+    });
+    Log.log(formattedEntries.join(`\n\n${chalk.dim('———')}\n\n`));
+
+    if (connection.pageInfo.hasNextPage && connection.pageInfo.endCursor) {
+      Log.newLine();
+      Log.log(
+        `More results available. Re-run with --after ${connection.pageInfo.endCursor} to fetch the next page.`
+      );
+    }
+  }
+}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1458,6 +1458,7 @@ export type App = Project & {
   /** @deprecated Classic updates have been deprecated. */
   description: Scalars['String']['output'];
   devDomainName?: Maybe<AppDevDomainName>;
+  deviceRunSessionsPaginated: AppDeviceRunSessionsConnection;
   /** Environment secrets for an app */
   environmentSecrets: Array<EnvironmentSecret>;
   environmentVariableEnvironments: Array<Scalars['EnvironmentVariableEnvironment']['output']>;
@@ -1681,6 +1682,16 @@ export type AppDeploymentsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<DeploymentFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppDeviceRunSessionsPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<DeviceRunSessionFilterInput>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -2004,6 +2015,18 @@ export type AppDevDomainNameMutationChangeDevDomainNameArgs = {
   name: Scalars['DevDomainName']['input'];
 };
 
+export type AppDeviceRunSessionEdge = {
+  __typename?: 'AppDeviceRunSessionEdge';
+  cursor: Scalars['String']['output'];
+  node: DeviceRunSession;
+};
+
+export type AppDeviceRunSessionsConnection = {
+  __typename?: 'AppDeviceRunSessionsConnection';
+  edges: Array<AppDeviceRunSessionEdge>;
+  pageInfo: PageInfo;
+};
+
 export type AppFingerprintEdge = {
   __typename?: 'AppFingerprintEdge';
   cursor: Scalars['String']['output'];
@@ -2238,6 +2261,11 @@ export type AppObserveAppBuildEmbeddedSummary = {
   __typename?: 'AppObserveAppBuildEmbeddedSummary';
   eventCount: Scalars['Int']['output'];
   firstSeenAt: Scalars['DateTime']['output'];
+  /**
+   * Unique users whose most recent supported-metric event in the queried
+   * range ran this build's embedded bundle.
+   */
+  lastSeenUserCount: Scalars['Int']['output'];
   uniqueUserCount: Scalars['Int']['output'];
 };
 
@@ -2253,7 +2281,18 @@ export type AppObserveAppBuildNumber = {
   embedded?: Maybe<AppObserveAppBuildEmbeddedSummary>;
   eventCount: Scalars['Int']['output'];
   firstSeenAt: Scalars['DateTime']['output'];
+  /**
+   * Unique users whose most recent supported-metric event in the queried
+   * range was on this (appVersion, appBuildNumber) tuple.
+   */
+  lastSeenUserCount: Scalars['Int']['output'];
   uniqueUserCount: Scalars['Int']['output'];
+  /**
+   * Updates seen on this build number in the queried time range. Each
+   * entry's counts and EAS builds are scoped to this (appVersion,
+   * appBuildNumber, appUpdateId) tuple.
+   */
+  updates: Array<AppObserveAppUpdate>;
 };
 
 export type AppObserveAppEasBuild = {
@@ -2271,6 +2310,11 @@ export type AppObserveAppUpdate = {
   easBuilds: Array<AppObserveAppEasBuild>;
   eventCount: Scalars['Int']['output'];
   firstSeenAt: Scalars['DateTime']['output'];
+  /**
+   * Unique users whose most recent supported-metric event in the queried
+   * range matched this update at its current nesting level.
+   */
+  lastSeenUserCount: Scalars['Int']['output'];
   uniqueUserCount: Scalars['Int']['output'];
 };
 
@@ -5260,6 +5304,12 @@ export type DeviceRunSession = {
   turtleJobRun?: Maybe<JobRun>;
   type: DeviceRunSessionType;
   updatedAt: Scalars['DateTime']['output'];
+};
+
+export type DeviceRunSessionFilterInput = {
+  platforms?: InputMaybe<Array<AppPlatform>>;
+  statuses?: InputMaybe<Array<DeviceRunSessionStatus>>;
+  types?: InputMaybe<Array<DeviceRunSessionType>>;
 };
 
 export type DeviceRunSessionMutation = {
@@ -12932,6 +12982,16 @@ export type DeviceRunSessionByIdQueryVariables = Exact<{
 
 
 export type DeviceRunSessionByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, type: DeviceRunSessionType, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, remoteConfig?: { __typename: 'AgentDeviceRunSessionRemoteConfig', agentDeviceRemoteSessionUrl: string, agentDeviceRemoteSessionToken: string, webPreviewUrl?: string | null } | { __typename: 'ArgentRunSessionRemoteConfig', toolsUrl: string, webPreviewUrl?: string | null } | { __typename: 'ServeSimRunSessionRemoteConfig', previewUrl: string, streamUrl: string } | null, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } } };
+
+export type DeviceRunSessionsByAppIdQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<DeviceRunSessionFilterInput>;
+}>;
+
+
+export type DeviceRunSessionsByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, deviceRunSessionsPaginated: { __typename?: 'AppDeviceRunSessionsConnection', edges: Array<{ __typename?: 'AppDeviceRunSessionEdge', cursor: string, node: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, type: DeviceRunSessionType, platform: AppPlatform, createdAt: any, startedAt?: any | null, finishedAt?: any | null, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
@@ -2,7 +2,13 @@ import gql from 'graphql-tag';
 
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { withErrorHandlingAsync } from '../client';
-import { DeviceRunSessionByIdQuery, DeviceRunSessionByIdQueryVariables } from '../generated';
+import {
+  DeviceRunSessionByIdQuery,
+  DeviceRunSessionByIdQueryVariables,
+  DeviceRunSessionFilterInput,
+  DeviceRunSessionsByAppIdQuery,
+  DeviceRunSessionsByAppIdQueryVariables,
+} from '../generated';
 
 export const DeviceRunSessionQuery = {
   async byIdAsync(
@@ -57,5 +63,75 @@ export const DeviceRunSessionQuery = {
         .toPromise()
     );
     return data.deviceRunSessions.byId;
+  },
+  async listByAppIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    {
+      appId,
+      first,
+      after,
+      filter,
+    }: {
+      appId: string;
+      first?: number;
+      after?: string;
+      filter?: DeviceRunSessionFilterInput;
+    }
+  ): Promise<DeviceRunSessionsByAppIdQuery['app']['byId']['deviceRunSessionsPaginated']> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<DeviceRunSessionsByAppIdQuery, DeviceRunSessionsByAppIdQueryVariables>(
+          gql`
+            query DeviceRunSessionsByAppId(
+              $appId: String!
+              $first: Int
+              $after: String
+              $filter: DeviceRunSessionFilterInput
+            ) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  deviceRunSessionsPaginated(first: $first, after: $after, filter: $filter) {
+                    edges {
+                      cursor
+                      node {
+                        id
+                        status
+                        type
+                        platform
+                        createdAt
+                        startedAt
+                        finishedAt
+                        app {
+                          id
+                          slug
+                          ownerAccount {
+                            id
+                            name
+                          }
+                        }
+                        turtleJobRun {
+                          id
+                          status
+                        }
+                      }
+                    }
+                    pageInfo {
+                      hasNextPage
+                      hasPreviousPage
+                      startCursor
+                      endCursor
+                    }
+                  }
+                }
+              }
+            }
+          `,
+          { appId, first, after, filter },
+          { requestPolicy: 'network-only' }
+        )
+        .toPromise()
+    );
+    return data.app.byId.deviceRunSessionsPaginated;
   },
 };


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Adds an `eas simulator:list` command so users can list and filter remote simulator sessions for their project. The server-side support landed in https://github.com/expo/universe/pull/27588, which exposes a new paginated `App.deviceRunSessionsPaginated` query.

# How

- Regenerated the GraphQL schema/types so the new `deviceRunSessionsPaginated` field and `DeviceRunSessionFilterInput` are available.
- Added `DeviceRunSessionQuery.listByAppIdAsync` in `packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts` for the paginated query.
- Implemented `packages/eas-cli/src/commands/simulator/list.ts`:
  - Cursor-based pagination via `--limit` (default 10, max 100) and `--after <cursor>`. When a next page is available the command tells the user the exact `--after` value to re-run with.
  - Repeatable filters: `--status`, `--type`, `--platform`.
  - `--json` emits sessions + `pageInfo` for scripting; `--non-interactive` is also supported.
  - Marked hidden and `[EXPERIMENTAL]` to match the other simulator commands.

# Test Plan

- `yarn test src/commands/simulator/` — 5 tests pass (existing `get` + new `list` covering JSON output, filter/cursor pass-through, non-interactive output, and empty results).
- `yarn typecheck`, `yarn lint`, `yarn fmt:check` all pass.
- `yarn verify-graphql-code` confirms the regenerated schema matches production.
- Manually inspected `eas simulator:list --help` to verify flag wiring.