### PR TITLE
[eas-cli] improve naming for observe commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- [eas-cli] Rename observe commands: `observe:logs` → `observe:events` (events emitted via `logEvent`), previous `observe:events` → `observe:metrics` (individual performance metric samples), previous `observe:metrics` → `observe:metric-summary` (aggregated stats by app version). ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@kadikraman](https://github.com/kadikraman))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
-- [eas-cli] Rename observe commands: `observe:logs` → `observe:events` (events emitted via `logEvent`), previous `observe:events` → `observe:metrics` (individual performance metric samples), previous `observe:metrics` → `observe:metric-summary` (aggregated stats by app version). ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@kadikraman](https://github.com/kadikraman))
+- [eas-cli] Rename observe commands: `observe:logs` → `observe:events` (events emitted via `logEvent`), previous `observe:events` → `observe:metrics` (individual performance metric samples), previous `observe:metrics` → `observe:metric-summary` (aggregated stats by app version). ([#3778](https://github.com/expo/eas-cli/pull/3778) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🎉 New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
-- [eas-cli] Rename observe commands: `observe:logs` → `observe:events` (events emitted via `logEvent`), previous `observe:events` → `observe:metrics` (individual performance metric samples), previous `observe:metrics` → `observe:metric-summary` (aggregated stats by app version). ([#3778](https://github.com/expo/eas-cli/pull/3778) by [@kadikraman](https://github.com/kadikraman))
+- [eas-cli] Rename observe commands: `observe:logs` → `observe:events` (events emitted via `logEvent`), previous `observe:events` → `observe:metrics` (individual performance metric samples), previous `observe:metrics` → `observe:metrics-summary` (aggregated stats by app version). ([#3778](https://github.com/expo/eas-cli/pull/3778) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🎉 New features
 

--- a/packages/eas-cli/src/commands/observe/__tests__/events.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/events.test.ts
@@ -10,7 +10,7 @@ import {
   buildObserveCustomEventsJson,
 } from '../../../observe/formatCustomEvents';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
-import ObserveLogs from '../logs';
+import ObserveEvents from '../events';
 
 jest.mock('../../../observe/fetchCustomEvents');
 jest.mock('../../../observe/formatCustomEvents', () => ({
@@ -49,7 +49,7 @@ const mockCustomEventNamesAsync = jest.mocked(ObserveQuery.customEventNamesAsync
 const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
 const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
 
-describe(ObserveLogs, () => {
+describe(ObserveEvents, () => {
   const graphqlClient = {} as any as ExpoGraphqlClient;
   const mockConfig = getMockOclifConfig();
   const projectId = 'test-project-id';
@@ -63,8 +63,8 @@ describe(ObserveLogs, () => {
     mockCustomEventNamesAsync.mockResolvedValue({ names: [], isTruncated: false });
   });
 
-  function createCommand(argv: string[]): ObserveLogs {
-    const command = new ObserveLogs(argv, mockConfig);
+  function createCommand(argv: string[]): ObserveEvents {
+    const command = new ObserveEvents(argv, mockConfig);
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
       projectId,

--- a/packages/eas-cli/src/commands/observe/__tests__/metric-summary.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metric-summary.test.ts
@@ -4,7 +4,7 @@ import { AppPlatform } from '../../../graphql/generated';
 import { fetchObserveMetricsAsync, validateDateFlag } from '../../../observe/fetchMetrics';
 import { buildObserveMetricsJson, buildObserveMetricsTable } from '../../../observe/formatMetrics';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
-import ObserveMetrics from '../metrics';
+import ObserveMetricSummary from '../metric-summary';
 
 jest.mock('../../../observe/fetchMetrics', () => {
   const actual = jest.requireActual('../../../observe/fetchMetrics');
@@ -21,20 +21,20 @@ jest.mock('../../../observe/formatMetrics', () => ({
 jest.mock('../../../log');
 jest.mock('../../../utils/json');
 
-const mockFetchObserveMetricsAsync = jest.mocked(fetchObserveMetricsAsync);
-const mockBuildObserveMetricsTable = jest.mocked(buildObserveMetricsTable);
-const mockBuildObserveMetricsJson = jest.mocked(buildObserveMetricsJson);
+const mockFetchObserveMetricSummaryAsync = jest.mocked(fetchObserveMetricsAsync);
+const mockBuildObserveMetricSummaryTable = jest.mocked(buildObserveMetricsTable);
+const mockBuildObserveMetricSummaryJson = jest.mocked(buildObserveMetricsJson);
 const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
 const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
 
-describe(ObserveMetrics, () => {
+describe(ObserveMetricSummary, () => {
   const graphqlClient = {} as any as ExpoGraphqlClient;
   const mockConfig = getMockOclifConfig();
   const projectId = 'test-project-id';
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockFetchObserveMetricsAsync.mockResolvedValue({
+    mockFetchObserveMetricSummaryAsync.mockResolvedValue({
       metricsMap: new Map(),
       buildNumbersMap: new Map(),
       updateIdsMap: new Map(),
@@ -42,8 +42,8 @@ describe(ObserveMetrics, () => {
     });
   });
 
-  function createCommand(argv: string[]): ObserveMetrics {
-    const command = new ObserveMetrics(argv, mockConfig);
+  function createCommand(argv: string[]): ObserveMetricSummary {
+    const command = new ObserveMetricSummary(argv, mockConfig);
     // @ts-expect-error getContextAsync is a protected method
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
       projectId,
@@ -59,8 +59,8 @@ describe(ObserveMetrics, () => {
     const command = createCommand([]);
     await command.runAsync();
 
-    expect(mockFetchObserveMetricsAsync).toHaveBeenCalledTimes(1);
-    const platforms = mockFetchObserveMetricsAsync.mock.calls[0][3];
+    expect(mockFetchObserveMetricSummaryAsync).toHaveBeenCalledTimes(1);
+    const platforms = mockFetchObserveMetricSummaryAsync.mock.calls[0][3];
     expect(platforms).toEqual([AppPlatform.Android, AppPlatform.Ios]);
 
     jest.useRealTimers();
@@ -70,7 +70,7 @@ describe(ObserveMetrics, () => {
     const command = createCommand(['--platform', 'android']);
     await command.runAsync();
 
-    const platforms = mockFetchObserveMetricsAsync.mock.calls[0][3];
+    const platforms = mockFetchObserveMetricSummaryAsync.mock.calls[0][3];
     expect(platforms).toEqual([AppPlatform.Android]);
   });
 
@@ -78,7 +78,7 @@ describe(ObserveMetrics, () => {
     const command = createCommand(['--platform', 'ios']);
     await command.runAsync();
 
-    const platforms = mockFetchObserveMetricsAsync.mock.calls[0][3];
+    const platforms = mockFetchObserveMetricSummaryAsync.mock.calls[0][3];
     expect(platforms).toEqual([AppPlatform.Ios]);
   });
 
@@ -86,7 +86,7 @@ describe(ObserveMetrics, () => {
     const command = createCommand(['--metric', 'tti', '--metric', 'cold_launch']);
     await command.runAsync();
 
-    const metricNames = mockFetchObserveMetricsAsync.mock.calls[0][2];
+    const metricNames = mockFetchObserveMetricSummaryAsync.mock.calls[0][2];
     expect(metricNames).toEqual(['expo.app_startup.tti', 'expo.app_startup.cold_launch_time']);
   });
 
@@ -97,8 +97,8 @@ describe(ObserveMetrics, () => {
     const command = createCommand([]);
     await command.runAsync();
 
-    const startTime = mockFetchObserveMetricsAsync.mock.calls[0][4];
-    const endTime = mockFetchObserveMetricsAsync.mock.calls[0][5];
+    const startTime = mockFetchObserveMetricSummaryAsync.mock.calls[0][4];
+    const endTime = mockFetchObserveMetricSummaryAsync.mock.calls[0][5];
     expect(endTime).toBe('2025-06-15T12:00:00.000Z');
     expect(startTime).toBe('2025-04-16T12:00:00.000Z');
 
@@ -114,8 +114,8 @@ describe(ObserveMetrics, () => {
     ]);
     await command.runAsync();
 
-    const startTime = mockFetchObserveMetricsAsync.mock.calls[0][4];
-    const endTime = mockFetchObserveMetricsAsync.mock.calls[0][5];
+    const startTime = mockFetchObserveMetricSummaryAsync.mock.calls[0][4];
+    const endTime = mockFetchObserveMetricSummaryAsync.mock.calls[0][5];
     expect(startTime).toBe('2025-01-01T00:00:00.000Z');
     expect(endTime).toBe('2025-02-01T00:00:00.000Z');
   });
@@ -124,7 +124,7 @@ describe(ObserveMetrics, () => {
     const command = createCommand(['--stat', 'p90', '--stat', 'eventCount']);
     await command.runAsync();
 
-    expect(mockBuildObserveMetricsTable).toHaveBeenCalledWith(
+    expect(mockBuildObserveMetricSummaryTable).toHaveBeenCalledWith(
       expect.any(Map),
       expect.any(Array),
       ['p90', 'eventCount'],
@@ -136,7 +136,7 @@ describe(ObserveMetrics, () => {
     const command = createCommand(['--stat', 'median', '--stat', 'median']);
     await command.runAsync();
 
-    expect(mockBuildObserveMetricsTable).toHaveBeenCalledWith(
+    expect(mockBuildObserveMetricSummaryTable).toHaveBeenCalledWith(
       expect.any(Map),
       expect.any(Array),
       ['median'],
@@ -151,8 +151,8 @@ describe(ObserveMetrics, () => {
     const command = createCommand(['--days', '7']);
     await command.runAsync();
 
-    const startTime = mockFetchObserveMetricsAsync.mock.calls[0][4];
-    const endTime = mockFetchObserveMetricsAsync.mock.calls[0][5];
+    const startTime = mockFetchObserveMetricSummaryAsync.mock.calls[0][4];
+    const endTime = mockFetchObserveMetricSummaryAsync.mock.calls[0][5];
     expect(endTime).toBe('2025-06-15T12:00:00.000Z');
     expect(startTime).toBe('2025-06-08T12:00:00.000Z');
 
@@ -175,7 +175,7 @@ describe(ObserveMetrics, () => {
     const command = createCommand([]);
     await command.runAsync();
 
-    expect(mockBuildObserveMetricsTable).toHaveBeenCalledWith(
+    expect(mockBuildObserveMetricSummaryTable).toHaveBeenCalledWith(
       expect.any(Map),
       expect.any(Array),
       ['median', 'eventCount'],
@@ -195,7 +195,7 @@ describe(ObserveMetrics, () => {
     await command.runAsync();
 
     expect(mockEnableJsonOutput).toHaveBeenCalled();
-    expect(mockBuildObserveMetricsJson).toHaveBeenCalledWith(
+    expect(mockBuildObserveMetricSummaryJson).toHaveBeenCalledWith(
       expect.any(Map),
       expect.any(Array),
       ['min', 'average'],

--- a/packages/eas-cli/src/commands/observe/__tests__/metric-summary.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metric-summary.test.ts
@@ -209,16 +209,20 @@ describe(ObserveMetricSummary, () => {
 
 describe(validateDateFlag, () => {
   it('throws on invalid --start date', () => {
-    expect(() => validateDateFlag('not-a-date', '--start')).toThrow(
-      'Invalid --start date: "not-a-date"'
-    );
+    expect(() => {
+      validateDateFlag('not-a-date', '--start');
+    }).toThrow('Invalid --start date: "not-a-date"');
   });
 
   it('throws on invalid --end date', () => {
-    expect(() => validateDateFlag('also-bad', '--end')).toThrow('Invalid --end date: "also-bad"');
+    expect(() => {
+      validateDateFlag('also-bad', '--end');
+    }).toThrow('Invalid --end date: "also-bad"');
   });
 
   it('accepts valid ISO date in --start', () => {
-    expect(() => validateDateFlag('2025-01-01', '--start')).not.toThrow();
+    expect(() => {
+      validateDateFlag('2025-01-01', '--start');
+    }).not.toThrow();
   });
 });

--- a/packages/eas-cli/src/commands/observe/__tests__/metrics-summary.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metrics-summary.test.ts
@@ -4,7 +4,7 @@ import { AppPlatform } from '../../../graphql/generated';
 import { fetchObserveMetricsAsync, validateDateFlag } from '../../../observe/fetchMetrics';
 import { buildObserveMetricsJson, buildObserveMetricsTable } from '../../../observe/formatMetrics';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
-import ObserveMetricSummary from '../metric-summary';
+import ObserveMetricsSummary from '../metrics-summary';
 
 jest.mock('../../../observe/fetchMetrics', () => {
   const actual = jest.requireActual('../../../observe/fetchMetrics');
@@ -21,20 +21,20 @@ jest.mock('../../../observe/formatMetrics', () => ({
 jest.mock('../../../log');
 jest.mock('../../../utils/json');
 
-const mockFetchObserveMetricSummaryAsync = jest.mocked(fetchObserveMetricsAsync);
-const mockBuildObserveMetricSummaryTable = jest.mocked(buildObserveMetricsTable);
-const mockBuildObserveMetricSummaryJson = jest.mocked(buildObserveMetricsJson);
+const mockFetchObserveMetricsSummaryAsync = jest.mocked(fetchObserveMetricsAsync);
+const mockBuildObserveMetricsSummaryTable = jest.mocked(buildObserveMetricsTable);
+const mockBuildObserveMetricsSummaryJson = jest.mocked(buildObserveMetricsJson);
 const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
 const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
 
-describe(ObserveMetricSummary, () => {
+describe(ObserveMetricsSummary, () => {
   const graphqlClient = {} as any as ExpoGraphqlClient;
   const mockConfig = getMockOclifConfig();
   const projectId = 'test-project-id';
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockFetchObserveMetricSummaryAsync.mockResolvedValue({
+    mockFetchObserveMetricsSummaryAsync.mockResolvedValue({
       metricsMap: new Map(),
       buildNumbersMap: new Map(),
       updateIdsMap: new Map(),
@@ -42,8 +42,8 @@ describe(ObserveMetricSummary, () => {
     });
   });
 
-  function createCommand(argv: string[]): ObserveMetricSummary {
-    const command = new ObserveMetricSummary(argv, mockConfig);
+  function createCommand(argv: string[]): ObserveMetricsSummary {
+    const command = new ObserveMetricsSummary(argv, mockConfig);
     // @ts-expect-error getContextAsync is a protected method
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
       projectId,
@@ -59,8 +59,8 @@ describe(ObserveMetricSummary, () => {
     const command = createCommand([]);
     await command.runAsync();
 
-    expect(mockFetchObserveMetricSummaryAsync).toHaveBeenCalledTimes(1);
-    const platforms = mockFetchObserveMetricSummaryAsync.mock.calls[0][3];
+    expect(mockFetchObserveMetricsSummaryAsync).toHaveBeenCalledTimes(1);
+    const platforms = mockFetchObserveMetricsSummaryAsync.mock.calls[0][3];
     expect(platforms).toEqual([AppPlatform.Android, AppPlatform.Ios]);
 
     jest.useRealTimers();
@@ -70,7 +70,7 @@ describe(ObserveMetricSummary, () => {
     const command = createCommand(['--platform', 'android']);
     await command.runAsync();
 
-    const platforms = mockFetchObserveMetricSummaryAsync.mock.calls[0][3];
+    const platforms = mockFetchObserveMetricsSummaryAsync.mock.calls[0][3];
     expect(platforms).toEqual([AppPlatform.Android]);
   });
 
@@ -78,7 +78,7 @@ describe(ObserveMetricSummary, () => {
     const command = createCommand(['--platform', 'ios']);
     await command.runAsync();
 
-    const platforms = mockFetchObserveMetricSummaryAsync.mock.calls[0][3];
+    const platforms = mockFetchObserveMetricsSummaryAsync.mock.calls[0][3];
     expect(platforms).toEqual([AppPlatform.Ios]);
   });
 
@@ -86,7 +86,7 @@ describe(ObserveMetricSummary, () => {
     const command = createCommand(['--metric', 'tti', '--metric', 'cold_launch']);
     await command.runAsync();
 
-    const metricNames = mockFetchObserveMetricSummaryAsync.mock.calls[0][2];
+    const metricNames = mockFetchObserveMetricsSummaryAsync.mock.calls[0][2];
     expect(metricNames).toEqual(['expo.app_startup.tti', 'expo.app_startup.cold_launch_time']);
   });
 
@@ -97,8 +97,8 @@ describe(ObserveMetricSummary, () => {
     const command = createCommand([]);
     await command.runAsync();
 
-    const startTime = mockFetchObserveMetricSummaryAsync.mock.calls[0][4];
-    const endTime = mockFetchObserveMetricSummaryAsync.mock.calls[0][5];
+    const startTime = mockFetchObserveMetricsSummaryAsync.mock.calls[0][4];
+    const endTime = mockFetchObserveMetricsSummaryAsync.mock.calls[0][5];
     expect(endTime).toBe('2025-06-15T12:00:00.000Z');
     expect(startTime).toBe('2025-04-16T12:00:00.000Z');
 
@@ -114,8 +114,8 @@ describe(ObserveMetricSummary, () => {
     ]);
     await command.runAsync();
 
-    const startTime = mockFetchObserveMetricSummaryAsync.mock.calls[0][4];
-    const endTime = mockFetchObserveMetricSummaryAsync.mock.calls[0][5];
+    const startTime = mockFetchObserveMetricsSummaryAsync.mock.calls[0][4];
+    const endTime = mockFetchObserveMetricsSummaryAsync.mock.calls[0][5];
     expect(startTime).toBe('2025-01-01T00:00:00.000Z');
     expect(endTime).toBe('2025-02-01T00:00:00.000Z');
   });
@@ -124,7 +124,7 @@ describe(ObserveMetricSummary, () => {
     const command = createCommand(['--stat', 'p90', '--stat', 'eventCount']);
     await command.runAsync();
 
-    expect(mockBuildObserveMetricSummaryTable).toHaveBeenCalledWith(
+    expect(mockBuildObserveMetricsSummaryTable).toHaveBeenCalledWith(
       expect.any(Map),
       expect.any(Array),
       ['p90', 'eventCount'],
@@ -136,7 +136,7 @@ describe(ObserveMetricSummary, () => {
     const command = createCommand(['--stat', 'median', '--stat', 'median']);
     await command.runAsync();
 
-    expect(mockBuildObserveMetricSummaryTable).toHaveBeenCalledWith(
+    expect(mockBuildObserveMetricsSummaryTable).toHaveBeenCalledWith(
       expect.any(Map),
       expect.any(Array),
       ['median'],
@@ -151,8 +151,8 @@ describe(ObserveMetricSummary, () => {
     const command = createCommand(['--days', '7']);
     await command.runAsync();
 
-    const startTime = mockFetchObserveMetricSummaryAsync.mock.calls[0][4];
-    const endTime = mockFetchObserveMetricSummaryAsync.mock.calls[0][5];
+    const startTime = mockFetchObserveMetricsSummaryAsync.mock.calls[0][4];
+    const endTime = mockFetchObserveMetricsSummaryAsync.mock.calls[0][5];
     expect(endTime).toBe('2025-06-15T12:00:00.000Z');
     expect(startTime).toBe('2025-06-08T12:00:00.000Z');
 
@@ -175,7 +175,7 @@ describe(ObserveMetricSummary, () => {
     const command = createCommand([]);
     await command.runAsync();
 
-    expect(mockBuildObserveMetricSummaryTable).toHaveBeenCalledWith(
+    expect(mockBuildObserveMetricsSummaryTable).toHaveBeenCalledWith(
       expect.any(Map),
       expect.any(Array),
       ['median', 'eventCount'],
@@ -195,7 +195,7 @@ describe(ObserveMetricSummary, () => {
     await command.runAsync();
 
     expect(mockEnableJsonOutput).toHaveBeenCalled();
-    expect(mockBuildObserveMetricSummaryJson).toHaveBeenCalledWith(
+    expect(mockBuildObserveMetricsSummaryJson).toHaveBeenCalledWith(
       expect.any(Map),
       expect.any(Array),
       ['min', 'average'],

--- a/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
@@ -8,7 +8,7 @@ import {
 import { fetchObserveEventsAsync, resolveOrderBy } from '../../../observe/fetchEvents';
 import { buildObserveEventsJson } from '../../../observe/formatEvents';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
-import ObserveEvents from '../events';
+import ObserveMetrics from '../metrics';
 
 jest.mock('../../../observe/fetchEvents', () => {
   const actual = jest.requireActual('../../../observe/fetchEvents');
@@ -29,7 +29,7 @@ const mockBuildObserveEventsJson = jest.mocked(buildObserveEventsJson);
 const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
 const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
 
-describe(ObserveEvents, () => {
+describe(ObserveMetrics, () => {
   const graphqlClient = {} as any as ExpoGraphqlClient;
   const mockConfig = getMockOclifConfig();
   const projectId = 'test-project-id';
@@ -42,8 +42,8 @@ describe(ObserveEvents, () => {
     });
   });
 
-  function createCommand(argv: string[]): ObserveEvents {
-    const command = new ObserveEvents(argv, mockConfig);
+  function createCommand(argv: string[]): ObserveMetrics {
+    const command = new ObserveMetrics(argv, mockConfig);
     // @ts-expect-error
     jest.spyOn(command, 'getContextAsync').mockReturnValue({
       projectId,

--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -29,14 +29,14 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 const DEFAULT_EVENTS_LIMIT = 10;
 
-export default class ObserveLogs extends EasCommand {
+export default class ObserveEvents extends EasCommand {
   static override hidden = true;
   static override description =
-    'display individual custom events (logs) emitted by the app, filtered by the event name in the argument. With no arguments, a list of the available event names and associated event counts is returned.';
+    'display individual events emitted by the app via `logEvent`, filtered by the event name in the argument. With no arguments, a list of the available event names and associated event counts is returned.';
 
   static override args = {
     eventName: Args.string({
-      description: 'Custom event name to filter by',
+      description: 'Event name to filter by',
       required: false,
     }),
   };
@@ -73,7 +73,7 @@ export default class ObserveLogs extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
-    const { flags, args } = await this.parse(ObserveLogs);
+    const { flags, args } = await this.parse(ObserveEvents);
 
     if (args.eventName && flags['all-events']) {
       throw new Error(
@@ -83,8 +83,8 @@ export default class ObserveLogs extends EasCommand {
 
     const { projectId, graphqlClient } = await resolveObserveCommandContextAsync({
       command: this,
-      commandClass: ObserveLogs,
-      loggedInOnlyContextDefinition: ObserveLogs.loggedInOnlyContextDefinition,
+      commandClass: ObserveEvents,
+      loggedInOnlyContextDefinition: ObserveEvents.loggedInOnlyContextDefinition,
       projectIdOverride: flags['project-id'],
       nonInteractive: flags['non-interactive'],
     });

--- a/packages/eas-cli/src/commands/observe/metric-summary.ts
+++ b/packages/eas-cli/src/commands/observe/metric-summary.ts
@@ -41,9 +41,10 @@ const DEFAULT_STATS_JSON: StatisticKey[] = [
   'eventCount',
 ];
 
-export default class ObserveMetrics extends EasCommand {
+export default class ObserveMetricSummary extends EasCommand {
   static override hidden = true;
-  static override description = 'display app performance metrics grouped by app version';
+  static override description =
+    'display aggregated performance metric statistics grouped by app version';
 
   static override flags = {
     ...ObservePlatformFlag,
@@ -72,12 +73,12 @@ export default class ObserveMetrics extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
-    const { flags } = await this.parse(ObserveMetrics);
+    const { flags } = await this.parse(ObserveMetricSummary);
 
     const { projectId, graphqlClient } = await resolveObserveCommandContextAsync({
       command: this,
-      commandClass: ObserveMetrics,
-      loggedInOnlyContextDefinition: ObserveMetrics.loggedInOnlyContextDefinition,
+      commandClass: ObserveMetricSummary,
+      loggedInOnlyContextDefinition: ObserveMetricSummary.loggedInOnlyContextDefinition,
       projectIdOverride: flags['project-id'],
       nonInteractive: flags['non-interactive'],
     });

--- a/packages/eas-cli/src/commands/observe/metrics-summary.ts
+++ b/packages/eas-cli/src/commands/observe/metrics-summary.ts
@@ -41,7 +41,7 @@ const DEFAULT_STATS_JSON: StatisticKey[] = [
   'eventCount',
 ];
 
-export default class ObserveMetricSummary extends EasCommand {
+export default class ObserveMetricsSummary extends EasCommand {
   static override hidden = true;
   static override description =
     'display aggregated performance metric statistics grouped by app version';
@@ -73,12 +73,12 @@ export default class ObserveMetricSummary extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
-    const { flags } = await this.parse(ObserveMetricSummary);
+    const { flags } = await this.parse(ObserveMetricsSummary);
 
     const { projectId, graphqlClient } = await resolveObserveCommandContextAsync({
       command: this,
-      commandClass: ObserveMetricSummary,
-      loggedInOnlyContextDefinition: ObserveMetricSummary.loggedInOnlyContextDefinition,
+      commandClass: ObserveMetricsSummary,
+      loggedInOnlyContextDefinition: ObserveMetricsSummary.loggedInOnlyContextDefinition,
       projectIdOverride: flags['project-id'],
       nonInteractive: flags['non-interactive'],
     });

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -29,9 +29,10 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 const DEFAULT_EVENTS_LIMIT = 10;
 
-export default class ObserveEvents extends EasCommand {
+export default class ObserveMetrics extends EasCommand {
   static override hidden = true;
-  static override description = 'display individual app performance events ordered by metric value';
+  static override description =
+    'display individual performance metric samples ordered by value';
 
   static override args = {
     metric: Args.string({
@@ -71,12 +72,12 @@ export default class ObserveEvents extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
-    const { flags, args } = await this.parse(ObserveEvents);
+    const { flags, args } = await this.parse(ObserveMetrics);
 
     const { projectId, graphqlClient } = await resolveObserveCommandContextAsync({
       command: this,
-      commandClass: ObserveEvents,
-      loggedInOnlyContextDefinition: ObserveEvents.loggedInOnlyContextDefinition,
+      commandClass: ObserveMetrics,
+      loggedInOnlyContextDefinition: ObserveMetrics.loggedInOnlyContextDefinition,
       projectIdOverride: flags['project-id'],
       nonInteractive: flags['non-interactive'],
     });

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -31,8 +31,7 @@ const DEFAULT_EVENTS_LIMIT = 10;
 
 export default class ObserveMetrics extends EasCommand {
   static override hidden = true;
-  static override description =
-    'display individual performance metric samples ordered by value';
+  static override description = 'display individual performance metric samples ordered by value';
 
   static override args = {
     metric: Args.string({

--- a/packages/eas-cli/src/observe/__tests__/formatCustomEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatCustomEvents.test.ts
@@ -69,7 +69,7 @@ Jan 14, 2025, 08:15:00.000 AM  checkout  1.1.0 (38)   Android 14  Pixel 8    PL 
 
   it('returns yellow warning for empty events', () => {
     const output = buildObserveCustomEventsTable([], noNextPage);
-    expect(output).toContain('No custom events found.');
+    expect(output).toContain('No events found.');
   });
 
   it('shows event name in summary header when an event name option is provided', () => {
@@ -82,13 +82,13 @@ Jan 14, 2025, 08:15:00.000 AM  checkout  1.1.0 (38)   Android 14  Pixel 8    PL 
     expect(output).toContain('login events for the last 30 days');
   });
 
-  it('shows the generic "Custom events" subject when no event name option is provided', () => {
+  it('shows the generic "Events" subject when no event name option is provided', () => {
     const events = [makeCustomEvent()];
     const output = buildObserveCustomEventsTable(events, noNextPage, {
       daysBack: 30,
     });
 
-    expect(output).toContain('Custom events for the last 30 days');
+    expect(output).toContain('Events for the last 30 days');
   });
 
   it('shows date range in summary header when start/end provided', () => {
@@ -294,7 +294,7 @@ describe(buildObserveCustomEventsJson, () => {
 describe(buildObserveCustomEventNamesTable, () => {
   it('returns yellow warning when names list is empty', () => {
     const output = buildObserveCustomEventNamesTable([]);
-    expect(output).toContain('No custom event names found.');
+    expect(output).toContain('No event names found.');
   });
 
   it('shows event names with counts', () => {
@@ -336,7 +336,7 @@ describe(buildObserveCustomEventsEmptyWithSuggestionsTable, () => {
     const output = buildObserveCustomEventsEmptyWithSuggestionsTable('login', []);
 
     expect(output).toContain('No events found matching "login"');
-    expect(output).toContain('No custom event names found in this time range.');
+    expect(output).toContain('No event names found in this time range.');
   });
 
   it('appends a truncation notice when isTruncated is set', () => {

--- a/packages/eas-cli/src/observe/__tests__/metricNames.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/metricNames.test.ts
@@ -25,6 +25,10 @@ describe(resolveMetricName, () => {
     expect(resolveMetricName('bundle_load')).toBe('expo.app_startup.bundle_load_time');
   });
 
+  it('resolves short alias "update_download" to full metric name', () => {
+    expect(resolveMetricName('update_download')).toBe('expo.updates.download_time');
+  });
+
   it('passes through full metric names unchanged', () => {
     expect(resolveMetricName('expo.app_startup.tti')).toBe('expo.app_startup.tti');
     expect(resolveMetricName('expo.app_startup.cold_launch_time')).toBe(
@@ -73,6 +77,7 @@ describe(getMetricDisplayName, () => {
     expect(getMetricDisplayName('expo.app_startup.tti')).toBe('Startup TTI');
     expect(getMetricDisplayName('expo.app_startup.ttr')).toBe('Startup TTR');
     expect(getMetricDisplayName('expo.app_startup.bundle_load_time')).toBe('Bundle Load');
+    expect(getMetricDisplayName('expo.updates.download_time')).toBe('Update Download');
   });
 
   it('returns short display name for known navigation metrics', () => {

--- a/packages/eas-cli/src/observe/formatCustomEvents.ts
+++ b/packages/eas-cli/src/observe/formatCustomEvents.ts
@@ -54,7 +54,7 @@ export function buildObserveCustomEventsTable(
   options?: BuildCustomEventsTableOptions
 ): string {
   if (events.length === 0) {
-    return chalk.yellow('No custom events found.');
+    return chalk.yellow('No events found.');
   }
 
   const showEventName = !options?.eventName;
@@ -88,7 +88,7 @@ export function buildObserveCustomEventsTable(
       options.totalEventCount != null
         ? ` — ${options.totalEventCount.toLocaleString()} total events`
         : '';
-    const subject = options.eventName ? `${options.eventName} events` : 'Custom events';
+    const subject = options.eventName ? `${options.eventName} events` : 'Events';
     lines.push(chalk.bold(`${subject} ${timeDesc}${totalDesc}`.trim()), '');
   }
 
@@ -156,7 +156,7 @@ export function buildObserveCustomEventsEmptyWithSuggestionsTable(
   lines.push(chalk.yellow(`No events found matching "${eventName}" ${timeDesc}.`.trim()));
 
   if (names.length === 0) {
-    lines.push('', chalk.yellow('No custom event names found in this time range.'));
+    lines.push('', chalk.yellow('No event names found in this time range.'));
     return lines.join('\n');
   }
 
@@ -203,7 +203,7 @@ export function buildObserveCustomEventNamesTable(
   options?: BuildCustomEventNamesTableOptions
 ): string {
   if (names.length === 0) {
-    return chalk.yellow('No custom event names found.');
+    return chalk.yellow('No event names found.');
   }
 
   const headers = ['Event Name', 'Count'];
@@ -213,7 +213,7 @@ export function buildObserveCustomEventNamesTable(
 
   if (options) {
     const timeDesc = buildTimeRangeDescription(options);
-    const subject = 'Custom event names';
+    const subject = 'Event names';
     lines.push(chalk.bold(`${subject} ${timeDesc}`.trim()), '');
   }
 

--- a/packages/eas-cli/src/observe/metricNames.ts
+++ b/packages/eas-cli/src/observe/metricNames.ts
@@ -6,6 +6,7 @@ export const METRIC_ALIASES: Record<string, string> = {
   cold_launch: 'expo.app_startup.cold_launch_time',
   warm_launch: 'expo.app_startup.warm_launch_time',
   bundle_load: 'expo.app_startup.bundle_load_time',
+  update_download: 'expo.updates.download_time',
 };
 
 export const NAVIGATION_METRIC_ALIASES: Record<string, string> = {
@@ -23,6 +24,7 @@ export const METRIC_SHORT_NAMES: Record<string, string> = {
   'expo.app_startup.tti': 'Startup TTI',
   'expo.app_startup.ttr': 'Startup TTR',
   'expo.app_startup.bundle_load_time': 'Bundle Load',
+  'expo.updates.download_time': 'Update Download',
   'expo.navigation.cold_ttr': 'Nav Cold TTR',
   'expo.navigation.warm_ttr': 'Nav Warm TTR',
   'expo.navigation.tti': 'Nav TTI',


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Part of ENG-21384

The naming of our CLI commands does not match the website.

# How

- Rename `observe:metrics` -> `observe:metrics-summary`
- Rename `observe:events` -> `observe:metrics`
- Rename `observe:logs` -> `observe:events`

# Test Plan

Manual and automated testing
