### PR TITLE
[build-tools] Add max_idle_minutes to agent-device remote session step

### DIFF
--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -8,6 +8,7 @@ import {
   BuildStepInputValueTypeName,
 } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -21,12 +22,17 @@ import {
   waitForFileAsync,
   waitForMatchInOutputAsync,
 } from '../utils/remoteDeviceRunSession';
+import { sleepAsync } from '../../utils/retry';
 
 const AGENT_DEVICE_REPO_URL = 'https://github.com/callstackincubator/agent-device.git';
 const SRC_DIR = '/tmp/agent-device-src';
 const DAEMON_JSON_PATH = path.join(os.homedir(), '.agent-device', 'daemon.json');
 const XCODE_DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer';
 const STARTUP_TIMEOUT_MS = 60_000;
+
+const IDLE_HOOK_PATH = path.join(os.tmpdir(), 'agent-device-idle-hook.mjs');
+const IDLE_STATE_PATH = path.join(os.tmpdir(), 'agent-device-last-activity');
+const IDLE_POLL_INTERVAL_MS = 30_000;
 
 export function createStartAgentDeviceRemoteSessionBuildFunction(
   ctx: CustomBuildContext
@@ -42,6 +48,11 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
+      BuildStepInput.createProvider({
+        id: 'max_idle_minutes',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
+      }),
     ],
     fn: async ({ logger, global }, { inputs, env }) => {
       // Fail fast before any expensive setup if the orchestrator-injected
@@ -50,9 +61,16 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
 
       const packageVersion = inputs.package_version.value as string | undefined;
+      const rawMaxIdleMinutes = inputs.max_idle_minutes.value as number | undefined;
+      const maxIdleMinutes =
+        typeof rawMaxIdleMinutes === 'number' && rawMaxIdleMinutes > 0
+          ? rawMaxIdleMinutes
+          : undefined;
       const { runtimePlatform } = global;
       logger.info(
-        `Starting agent-device remote session (version: ${packageVersion ?? 'latest'}, runtime: ${runtimePlatform}).`
+        `Starting agent-device remote session (version: ${packageVersion ?? 'latest'}, runtime: ${runtimePlatform}${
+          maxIdleMinutes != null ? `, max idle: ${maxIdleMinutes}m` : ''
+        }).`
       );
 
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
@@ -81,12 +99,18 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
         logger,
       });
 
+      const idleEnv: Record<string, string> = {};
+      if (maxIdleMinutes != null) {
+        await writeIdleAuthHookAsync(logger);
+        idleEnv.AGENT_DEVICE_HTTP_AUTH_HOOK = IDLE_HOOK_PATH;
+      }
+
       logger.info('Launching agent-device daemon.');
       spawnDetached({
         command: 'bun',
         args: ['run', 'src/daemon.ts'],
         cwd: SRC_DIR,
-        env: { ...env, AGENT_DEVICE_DAEMON_SERVER_MODE: 'http' },
+        env: { ...env, ...idleEnv, AGENT_DEVICE_DAEMON_SERVER_MODE: 'http' },
       });
 
       logger.info(`Waiting for daemon credentials at ${DAEMON_JSON_PATH}.`);
@@ -138,10 +162,17 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
         logger,
       });
 
-      logger.info('Remote session is live. Keeping the job alive until the session is stopped.');
-      // Keep the turtle job alive so the daemon and tunnel stay reachable
-      // until stopDeviceRunSession cancels the run.
-      await new Promise<never>(() => {});
+      if (maxIdleMinutes != null) {
+        logger.info(
+          `Remote session is live. Watching for >= ${maxIdleMinutes}m of inactivity; otherwise keeping the job alive until the session is stopped.`
+        );
+        await waitForIdleTimeoutAsync({ maxIdleMs: maxIdleMinutes * 60_000, logger });
+      } else {
+        logger.info('Remote session is live. Keeping the job alive until the session is stopped.');
+        // Keep the turtle job alive so the daemon and tunnel stay reachable
+        // until stopDeviceRunSession cancels the run.
+        await new Promise<never>(() => {});
+      }
     },
   });
 }
@@ -176,4 +207,60 @@ function parseDaemonInfo(raw: string): { port: number; token: string } {
   }
   const { httpPort, token } = parsed as { httpPort: number; token: string };
   return { port: httpPort, token };
+}
+
+async function writeIdleAuthHookAsync(logger: bunyan): Promise<void> {
+  // Pre-seed so the first poll has a baseline; otherwise it would compute an
+  // unbounded idle window and false-positive the timeout.
+  await fs.promises.writeFile(IDLE_STATE_PATH, String(Date.now()), 'utf8');
+
+  // Loaded by agent-device's daemon http-server `loadHttpAuthHook`. Must not
+  // throw — a failing hook 401s every request.
+  const hookSource = `import { writeFileSync } from 'node:fs';
+const STATE_PATH = ${JSON.stringify(IDLE_STATE_PATH)};
+export default function recordActivityHook() {
+  try {
+    writeFileSync(STATE_PATH, String(Date.now()), 'utf8');
+  } catch {}
+  return true;
+}
+`;
+  await fs.promises.writeFile(IDLE_HOOK_PATH, hookSource, 'utf8');
+  logger.info(`Installed idle-activity auth hook at ${IDLE_HOOK_PATH}.`);
+}
+
+async function waitForIdleTimeoutAsync({
+  maxIdleMs,
+  logger,
+}: {
+  maxIdleMs: number;
+  logger: bunyan;
+}): Promise<never> {
+  while (true) {
+    await sleepAsync(IDLE_POLL_INTERVAL_MS);
+
+    let lastActivityAt: number;
+    try {
+      const raw = await fs.promises.readFile(IDLE_STATE_PATH, 'utf8');
+      lastActivityAt = Number(raw);
+    } catch {
+      // Skip this tick — the hook will re-write the file on the next request.
+      continue;
+    }
+    if (!Number.isFinite(lastActivityAt)) {
+      continue;
+    }
+
+    const idleMs = Date.now() - lastActivityAt;
+    if (idleMs >= maxIdleMs) {
+      const idleMinutes = Math.floor(idleMs / 60_000);
+      const maxIdleMinutes = Math.floor(maxIdleMs / 60_000);
+      logger.error(
+        `agent-device remote session was idle for ${idleMinutes} minute(s); the limit is ${maxIdleMinutes} minute(s). Failing the step to release the worker.`
+      );
+      throw new SystemError(
+        `agent-device remote session exceeded the max idle window (${idleMinutes} >= ${maxIdleMinutes} minute(s)). Start a new session and reconnect, or raise the maxIdleMinutes when creating the session.`
+      );
+    }
+  }
 }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The `eas/start_agent_device_remote_session` step keeps the turtle job alive indefinitely (`new Promise<never>(() => {})`) until `stopDeviceRunSession` cancels it. If a client connects, disappears, and never sends `stopDeviceRunSession`, the worker burns until the orchestrator's `max_run_time_seconds` ceiling fires. We want a tighter, activity-aware ceiling so abandoned sessions release their worker quickly.

# How

Adds an optional `max_idle_minutes` build function input. When set, the step:

1. Generates a one-file ESM auth-hook module at `${tmpdir}/agent-device-idle-hook.mjs` that stamps `Date.now()` into `${tmpdir}/agent-device-last-activity` on every authenticated daemon request, then returns `true` so the daemon's own token check remains the source of truth for authorization.
2. Launches the daemon with `AGENT_DEVICE_HTTP_AUTH_HOOK` pointing at that module. This is a documented extension point on agent-device's HTTP server (`src/daemon/http-server.ts` `loadHttpAuthHook`); it fires for `/rpc`, `/upload`, and `/artifacts/*` — every meaningful client call — while skipping `/health`, so cloudflared/health probes don't reset the timer.
3. Races a watchdog (`waitForIdleTimeoutAsync`) against the existing `await new Promise<never>(() => {})`. The watchdog polls the state file every 30s; if `Date.now() - lastActivityAt >= maxIdleMinutes * 60_000`, it throws `SystemError`. That fails the step and cascades to the device run session via the existing turtle-job-status trigger.

When `max_idle_minutes` is absent or non-positive, the step behaves exactly as before (no hook installed, no watchdog, infinite wait).

The state file is pre-seeded with the current time before the daemon starts so the first poll has a baseline; malformed/missing state is treated as fresh activity rather than firing a false-positive timeout.

The complementary www-side change that plumbs this from the GraphQL `createDeviceRunSession` mutation lives in a follow-up PR; until that ships, no caller passes the new input so the step is a no-op for everyone.

# Test Plan

- `yarn typecheck` (build-tools): clean
- `yarn lint` on the changed file: 0 errors
- `yarn fmt:check`: clean
- `yarn jest-unit` (build-tools): 522/522 pass
- Manual verification will follow once the www side is wired up and a real turtle job runs end-to-end.
