### PR TITLE
[worker] Size Gradle heap from runner memory

### DIFF
--- a/packages/worker/src/__unit__/env.test.ts
+++ b/packages/worker/src/__unit__/env.test.ts
@@ -1,13 +1,15 @@
 import { Platform, Workflow } from '@expo/eas-build-job';
+import os from 'os';
 
 import config from '../config';
-import { getBuildEnv } from '../env';
+import { getBuildEnv, getGradleMemoryOptions } from '../env';
 
 describe(getBuildEnv.name, () => {
   const originalSentryDsn = config.sentry.dsn;
 
   afterEach(() => {
     config.sentry.dsn = originalSentryDsn;
+    jest.restoreAllMocks();
   });
 
   it('passes the CLI sentry DSN to worker child processes', () => {
@@ -58,5 +60,27 @@ describe(getBuildEnv.name, () => {
     expect(env.EXPO_USE_PRECOMPILED_MODULES).toBeUndefined();
     expect(env.EXPO_PRECOMPILED_MODULES_BASE_URL).toBeUndefined();
     expect(env.EXPO_PRECOMPILED_MODULES_PATH).toBeUndefined();
+  });
+
+  it('sizes Gradle memory options from total memory', () => {
+    const totalMemory = jest.spyOn(os, 'totalmem');
+
+    totalMemory.mockReturnValue(16 * 1024 ** 3);
+    expect(getGradleMemoryOptions()).toEqual({
+      maxHeapSize: '4g',
+    });
+
+    totalMemory.mockReturnValue(32 * 1024 ** 3);
+    expect(getGradleMemoryOptions()).toEqual({
+      maxHeapSize: '8g',
+    });
+  });
+
+  it('keeps Gradle memory options conservative on low-memory runners', () => {
+    jest.spyOn(os, 'totalmem').mockReturnValue(4 * 1024 ** 3);
+
+    expect(getGradleMemoryOptions()).toEqual({
+      maxHeapSize: '1g',
+    });
   });
 });

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -73,7 +73,7 @@ export function getBuildEnv({
   }
 
   if (config.env !== Environment.TEST) {
-    const gradleMemoryOptions = getGradleMemoryOptions();
+    const { maxHeapSize } = getGradleMemoryOptions();
 
     setEnv(
       env,
@@ -85,7 +85,7 @@ export function getBuildEnv({
         // We need to be careful with Xmx, because the same value will be
         // used for Gradle and Kotlin compiler.
         // https://kotlinlang.org/docs/gradle-compilation-and-caches.html#gradle-daemon-arguments-inheritance
-        `-Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=1g -Xmx${gradleMemoryOptions.maxHeapSize} ${
+        `-Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=1g -Xmx${maxHeapSize} ${
           job.builderEnvironment?.image &&
           androidImagesWithJavaVersionLowerThen11.includes(job.builderEnvironment?.image)
             ? '-XX:MaxPermSize=512m '
@@ -157,11 +157,7 @@ function setEnv(env: Env, key: string, value: string | null | undefined): void {
   }
 }
 
-type GradleMemoryOptions = {
-  maxHeapSize: string;
-};
-
-export function getGradleMemoryOptions(): GradleMemoryOptions {
+export function getGradleMemoryOptions() {
   const totalMemoryGb = os.totalmem() / 1024 / 1024 / 1024;
 
   return {

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -1,15 +1,12 @@
 import { Env, Job, Metadata, Platform, Workflow } from '@expo/eas-build-job';
 import { spawnSync } from 'child_process';
 import micromatch from 'micromatch';
+import os from 'os';
 import path from 'path';
 
 import config from './config';
 import { Environment } from './constants';
-import {
-  ResourceClass,
-  ResourceClassToPlatform,
-  androidImagesWithJavaVersionLowerThen11,
-} from './external/turtle';
+import { androidImagesWithJavaVersionLowerThen11 } from './external/turtle';
 import { getAccessedEnvs } from './utils/env';
 
 // keep in sync with local-build-plugin env vars
@@ -48,8 +45,7 @@ export function getBuildEnv({
   setEnv(env, 'EAS_BUILD_WORKINGDIR', path.join(config.workingdir, 'build'));
   setEnv(env, 'EAS_BUILD_PROJECT_ID', projectId);
 
-  const runnerPlatform =
-    job.platform ?? (config.resourceClass && ResourceClassToPlatform[config.resourceClass]);
+  const runnerPlatform = job.platform;
   if (runnerPlatform === Platform.IOS) {
     setEnv(env, 'EAS_BUILD_COCOAPODS_CACHE_URL', config.cocoapodsCacheUrl);
     setEnv(env, 'COMPILER_INDEX_STORE_ENABLE', 'NO');
@@ -77,9 +73,7 @@ export function getBuildEnv({
   }
 
   if (config.env !== Environment.TEST) {
-    const maxHeapSize = config.resourceClass
-      ? (ResourceClassToMaxHeapSize[config.resourceClass] ?? '4g')
-      : '4g';
+    const gradleMemoryOptions = getGradleMemoryOptions();
 
     setEnv(
       env,
@@ -91,7 +85,7 @@ export function getBuildEnv({
         // We need to be careful with Xmx, because the same value will be
         // used for Gradle and Kotlin compiler.
         // https://kotlinlang.org/docs/gradle-compilation-and-caches.html#gradle-daemon-arguments-inheritance
-        `-Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=1g -Xmx${maxHeapSize} ${
+        `-Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=1g -Xmx${gradleMemoryOptions.maxHeapSize} ${
           job.builderEnvironment?.image &&
           androidImagesWithJavaVersionLowerThen11.includes(job.builderEnvironment?.image)
             ? '-XX:MaxPermSize=512m '
@@ -163,19 +157,14 @@ function setEnv(env: Env, key: string, value: string | null | undefined): void {
   }
 }
 
-const ResourceClassToMaxHeapSize: Record<ResourceClass, string | null> = {
-  [ResourceClass.LINUX_C3D_STANDARD_4]: '4g', // 4 out of 16 GB, 12 GB left
-  [ResourceClass.LINUX_C3D_STANDARD_8]: '8g', // 8 out of 32 GB, 24 GB left
-  [ResourceClass.LINUX_C4D_STANDARD_4]: '4g', // 4 out of 15 GB, 11 GB left
-  [ResourceClass.LINUX_C4D_STANDARD_8]: '8g', // 8 out of 31 GB, 23 GB left
-  [ResourceClass.ANDROID_N2_1_3_12]: '4g', // 4 out of 12 GB, 8 GB left
-  [ResourceClass.ANDROID_N2_2_6_24]: '8g', // 8 out of 24 GB, 16 GB left
-
-  // We don't care about Gradle heap size for macOS resource classes
-  [ResourceClass.IOS_M1_4_16]: null,
-  [ResourceClass.IOS_M2_2_8]: null,
-  [ResourceClass.IOS_M2_PRO_4_12]: null,
-  [ResourceClass.IOS_M4_PRO_5_20]: null,
-  [ResourceClass.IOS_M4_PRO_10_40]: null,
-  [ResourceClass.IOS_M2_4_22]: null,
+type GradleMemoryOptions = {
+  maxHeapSize: string;
 };
+
+export function getGradleMemoryOptions(): GradleMemoryOptions {
+  const totalMemoryGb = os.totalmem() / 1024 / 1024 / 1024;
+
+  return {
+    maxHeapSize: `${Math.max(1, Math.round(totalMemoryGb / 4))}g`,
+  };
+}


### PR DESCRIPTION
## Summary
- Replace resource-class-based Gradle heap sizing with a live calculation from runner total memory.
- Preserve existing Gradle settings for metaspace, parallel execution, daemon disablement, and old-Java MaxPermSize handling.
- Add worker unit coverage for the effective heap sizes.

## Effective heap sizing
- 15-16 GB runners resolve to `-Xmx4g`.
- 31-32 GB runners resolve to `-Xmx8g`.
- Lower-memory runners are clamped to at least `-Xmx1g`.

## Validation
- `yarn oxfmt --check packages/worker/src/env.ts packages/worker/src/__unit__/env.test.ts`
- `yarn workspace @expo/worker test:unit -- env.test.ts`
- `yarn workspace @expo/worker typecheck`
