### PR TITLE
[worker] Derive worker runtime info from `os`

### DIFF
--- a/packages/worker/src/config.ts
+++ b/packages/worker/src/config.ts
@@ -2,7 +2,7 @@ import { GCS, GCSLoggerStream } from '@expo/build-tools';
 import path from 'path';
 
 import { Environment } from './constants';
-import { ResourceClass, Worker } from './external/turtle';
+import { Worker } from './external/turtle';
 import env from './utils/env';
 
 type ReplaceUndefinedWithNull<T> = undefined extends T ? Exclude<T, undefined> | null : T;
@@ -100,10 +100,6 @@ export default {
   }),
   runMetricsServer: env<boolean | null>('WORKER_RUNTIME_CONFIG_BASE64', {
     transform: createBase64EnvTransformer('runMetricsServer'),
-    defaultValue: null,
-  }),
-  resourceClass: env<ResourceClass | null>('WORKER_RUNTIME_CONFIG_BASE64', {
-    transform: createBase64EnvTransformer('resourceClass'),
     defaultValue: null,
   }),
   buildId: env<string>('WORKER_RUNTIME_CONFIG_BASE64', {

--- a/packages/worker/src/displayRuntimeInfo.ts
+++ b/packages/worker/src/displayRuntimeInfo.ts
@@ -1,25 +1,11 @@
 import { BuildContext } from '@expo/build-tools';
 import { EnvironmentSecretType, Job } from '@expo/eas-build-job';
+import formatBytes from 'filesize';
 import fs from 'fs-extra';
+import os from 'os';
 
 import config from './config';
 import { Environment } from './constants';
-import { ResourceClass } from './external/turtle';
-
-const RESOURCE_CLASS_DESCRIPTION: Record<ResourceClass, string> = {
-  [ResourceClass.ANDROID_N2_1_3_12]: 'Intel, 4 vCPUs, 16 GB RAM',
-  [ResourceClass.ANDROID_N2_2_6_24]: 'Intel, 8 vCPUs, 32 GB RAM',
-  [ResourceClass.IOS_M1_4_16]: 'M1, 2 cores, 8 GB RAM',
-  [ResourceClass.IOS_M2_2_8]: 'M2, 2 cores, 8 GB RAM',
-  [ResourceClass.IOS_M2_PRO_4_12]: 'M2 Pro, 4 cores, 12 GB RAM',
-  [ResourceClass.IOS_M4_PRO_5_20]: 'M4 Pro, 5 cores, 20 GB RAM',
-  [ResourceClass.IOS_M4_PRO_10_40]: 'M4 Pro, 10 cores, 40 GB RAM',
-  [ResourceClass.IOS_M2_4_22]: 'M2, 4 cores, 22 GB RAM',
-  [ResourceClass.LINUX_C3D_STANDARD_4]: 'AMD, 4 vCPUs, 16 GB RAM',
-  [ResourceClass.LINUX_C3D_STANDARD_8]: 'AMD, 8 vCPUs, 32 GB RAM',
-  [ResourceClass.LINUX_C4D_STANDARD_4]: 'AMD, 4 vCPUs, 15 GB RAM',
-  [ResourceClass.LINUX_C4D_STANDARD_8]: 'AMD, 8 vCPUs, 31 GB RAM',
-};
 
 export function displayWorkerRuntimeInfo(ctx: BuildContext<Job>): void {
   printVMSpecs(ctx);
@@ -29,22 +15,29 @@ export function displayWorkerRuntimeInfo(ctx: BuildContext<Job>): void {
 }
 
 function printVMSpecs(ctx: BuildContext<Job>): void {
-  const { resourceClass } = config;
+  const specs = [
+    getCpuModelDescription(),
+    `${os.cpus().length} vCPUs`,
+    `${formatBytes(os.totalmem())} RAM`,
+  ].flatMap(spec => spec || []);
 
-  if (resourceClass) {
-    const resourceClassDescription = RESOURCE_CLASS_DESCRIPTION[resourceClass];
+  ctx.logger.info(specs.join(', '));
+  ctx.logger.info('');
+}
 
-    if (resourceClassDescription) {
-      ctx.logger.info(resourceClassDescription);
-    } else {
-      ctx.logger.debug(
-        `Resource class is unsupported: ${resourceClass}, valid values: ${Object.keys(
-          RESOURCE_CLASS_DESCRIPTION
-        )}}`
-      );
-    }
-    ctx.logger.info('');
+function getCpuModelDescription(): string | null {
+  const cpuModel = os.cpus()[0]?.model.trim().replaceAll(/\s+/g, ' ').replace(' (Virtual)', '');
+  if (!cpuModel) {
+    return null;
   }
+
+  if (cpuModel.toLowerCase().includes('intel')) {
+    return 'Intel';
+  } else if (cpuModel.toLowerCase().includes('amd')) {
+    return 'AMD';
+  }
+
+  return cpuModel;
 }
 
 function printImageMessage(ctx: BuildContext<Job>): void {

--- a/packages/worker/src/external/turtle.ts
+++ b/packages/worker/src/external/turtle.ts
@@ -5,39 +5,8 @@ import {
   BuildPhaseResult,
   Generic,
   Metadata,
-  Platform,
   errors,
 } from '@expo/eas-build-job';
-
-export enum ResourceClass {
-  ANDROID_N2_1_3_12 = 'android-n2-1.3-12',
-  ANDROID_N2_2_6_24 = 'android-n2-2.6-24',
-  IOS_M1_4_16 = 'ios-m1-4-16',
-  IOS_M2_2_8 = 'ios-m2-2-8',
-  IOS_M2_PRO_4_12 = 'ios-m2-pro-4-12',
-  IOS_M2_4_22 = 'ios-m2-4-22',
-  IOS_M4_PRO_5_20 = 'ios-m4-pro-5-20',
-  IOS_M4_PRO_10_40 = 'ios-m4-pro-10-40',
-  LINUX_C3D_STANDARD_4 = 'linux-c3d-standard-4',
-  LINUX_C3D_STANDARD_8 = 'linux-c3d-standard-8',
-  LINUX_C4D_STANDARD_4 = 'linux-c4d-standard-4',
-  LINUX_C4D_STANDARD_8 = 'linux-c4d-standard-8',
-}
-
-export const ResourceClassToPlatform: Record<ResourceClass, Platform> = {
-  'android-n2-1.3-12': Platform.ANDROID,
-  'android-n2-2.6-24': Platform.ANDROID,
-  'ios-m1-4-16': Platform.IOS,
-  'ios-m2-2-8': Platform.IOS,
-  'ios-m2-4-22': Platform.IOS,
-  'ios-m2-pro-4-12': Platform.IOS,
-  'ios-m4-pro-5-20': Platform.IOS,
-  'ios-m4-pro-10-40': Platform.IOS,
-  [ResourceClass.LINUX_C3D_STANDARD_4]: Platform.ANDROID,
-  [ResourceClass.LINUX_C3D_STANDARD_8]: Platform.ANDROID,
-  [ResourceClass.LINUX_C4D_STANDARD_4]: Platform.ANDROID,
-  [ResourceClass.LINUX_C4D_STANDARD_8]: Platform.ANDROID,
-};
 
 export const androidImagesWithJavaVersionLowerThen11 = [
   'ubuntu-20.04-jdk-8-ndk-r19c',
@@ -67,7 +36,6 @@ export namespace Worker {
     mavenCacheUrl: string | undefined;
     cocoapodsCacheUrl: string | undefined;
     runMetricsServer: boolean;
-    resourceClass: ResourceClass;
 
     type: 'jobRun';
     buildId: string;
@@ -86,7 +54,6 @@ export namespace Worker {
     mavenCacheUrl: string | undefined;
     cocoapodsCacheUrl: string | undefined;
     runMetricsServer: boolean;
-    resourceClass: ResourceClass;
 
     type?: never;
     buildId: string;


### PR DESCRIPTION
## Summary
- Remove worker-side `resourceClass` parsing and types from runtime config.
- Remove `ResourceClassToPlatform`, since worker env setup now uses the job platform directly.
- Replace resource-class VM spec logging with OS-derived CPU model, vCPU count, and total RAM.

## Notes
- CPU model is normalized to `Apple M4 Pro` (from "Apple M4 Pro (Virtual)") for Apple chips and `Intel`/`AMD` for cloud CPU models.

## Validation
- `yarn oxfmt --check packages/worker/src/config.ts packages/worker/src/displayRuntimeInfo.ts packages/worker/src/external/turtle.ts packages/worker/src/env.ts packages/worker/src/__unit__/env.test.ts`
- `yarn workspace @expo/worker test:unit -- env.test.ts`
- `yarn workspace @expo/worker typecheck`
- verified `os.cpus().length` is 4 for 4 CPU tart VM and `os.totalmem() / 1024 / 1024 / 1024` is `8` for 8 GB RAM tart VM