### PR TITLE
[worker] Stop logging dependency metrics failures to build output

### DIFF
--- a/packages/worker/src/external/analytics.ts
+++ b/packages/worker/src/external/analytics.ts
@@ -82,7 +82,6 @@ export async function logProjectDependenciesAsync(
     });
   } catch (error: any) {
     const msg = 'Failed to report project dependencies metrics';
-    ctx.logger.error({ err: error }, msg);
     sentry.capture(msg, error, {
       level: 'warning',
       tags: {


### PR DESCRIPTION
## Summary

- Stop reporting project dependency metrics failures to the build logger.
- Keep the existing Sentry warning capture for this failure path.

## Context

This addresses user-visible logging seen in build https://expo.dev/accounts/ammar_tripiq/projects/tripiq-client/builds/8f01c353-187b-4368-b569-94484d04220b where missing package.json caused:

```
Failed to report project dependencies metrics
ENOENT: no such file or directory, open '/Users/expo/workingdir/build/package.json'
```

## Validation

- yarn oxfmt packages/worker/src/external/analytics.ts
