### PR TITLE
[build-tools] Preserve app entitlements when resigning iOS builds

### DIFF
--- a/packages/build-tools/src/ios/__tests__/__snapshots__/fastfile.test.ts.snap
+++ b/packages/build-tools/src/ios/__tests__/__snapshots__/fastfile.test.ts.snap
@@ -9,6 +9,7 @@ exports[`fastfile createFastfileForResigningBuild should create Fastfile with al
       "com.example.app" => "/path/to/profiles/main.mobileprovision",
       "com.example.app.widget" => "/path/to/profiles/widget.mobileprovision",
     },
+    use_app_entitlements: true,
     keychain_path: "/Users/expo/Library/Keychains/login.keychain"
   )
 end
@@ -22,6 +23,7 @@ exports[`fastfile createFastfileForResigningBuild should handle empty provisioni
     signing_identity: "iPhone Distribution",
     provisioning_profile: {
     },
+    use_app_entitlements: true,
     keychain_path: "/tmp/keychain"
   )
 end
@@ -39,6 +41,7 @@ exports[`fastfile createFastfileForResigningBuild should handle multiple provisi
       "com.example.app.extension" => "/profiles/extension.mobileprovision",
       "com.example.app.intents" => "/profiles/intents.mobileprovision",
     },
+    use_app_entitlements: true,
     keychain_path: "/tmp/keychain"
   )
 end
@@ -53,6 +56,7 @@ exports[`fastfile createFastfileForResigningBuild should handle paths with speci
     provisioning_profile: {
       "com.example.app" => "/path/with spaces/profile (1).mobileprovision",
     },
+    use_app_entitlements: true,
     keychain_path: "/Users/expo/Library/Keychains/login keychain.keychain"
   )
 end
@@ -67,6 +71,7 @@ exports[`fastfile createFastfileForResigningBuild should handle single provision
     provisioning_profile: {
       "com.example.app" => "/tmp/profile.mobileprovision",
     },
+    use_app_entitlements: true,
     keychain_path: "/tmp/keychain"
   )
 end
@@ -81,6 +86,7 @@ exports[`fastfile createFastfileForResigningBuild should produce valid Ruby synt
     provisioning_profile: {
       "com.example.app" => "/path/to/profile.mobileprovision",
     },
+    use_app_entitlements: true,
     keychain_path: "/tmp/keychain"
   )
 end

--- a/packages/build-tools/src/templates/FastfileResign.ts
+++ b/packages/build-tools/src/templates/FastfileResign.ts
@@ -5,6 +5,7 @@ export const FastfileResignTemplate = `lane :do_resign do
     provisioning_profile: {<% _.forEach(PROFILES, function(profile) { %>
       "<%- profile.BUNDLE_ID %>" => "<%- profile.PATH %>",<% }); %>
     },
+    use_app_entitlements: true,
     keychain_path: "<%- KEYCHAIN_PATH %>"
   )
 end


### PR DESCRIPTION
Not sure if this is the right fix, but sounds right?

## Summary

Updates the iOS build resign Fastfile to pass `use_app_entitlements: true` to Fastlane's `resign` action.

This makes EAS preserve and merge the app's existing code-signing entitlements when re-signing an IPA with a new provisioning profile, instead of signing directly with the broader provisioning-profile entitlements. This matters for capabilities like associated domains, where the profile may contain `*` but the app signature needs concrete values such as `applinks:...` for universal links to keep working.

Context: https://exponent-internal.slack.com/archives/C09H6RFAX27/p1779446992844929

## Validation

- `yarn install`
- `yarn workspace @expo/template-file build`
- `yarn workspace @expo/build-tools jest-unit fastfile.test.ts`
- `yarn oxfmt packages/build-tools/src/templates/FastfileResign.ts packages/build-tools/src/ios/__tests__/__snapshots__/fastfile.test.ts.snap`
