### PR TITLE
[build-tools] pass env to repack spawnAsync

### DIFF
--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -10,6 +10,7 @@ import {
 } from '@expo/repack-app';
 import {
   BuildFunction,
+  BuildStepEnv,
   BuildStepInput,
   BuildStepInputValueTypeName,
   BuildStepOutput,
@@ -89,8 +90,9 @@ export function createRepackBuildFunction(): BuildFunction {
       }
 
       const repackSpawnAsync = createSpawnAsyncStepAdapter({
-        verbose,
+        env: stepsCtx.global.env,
         logger: stepsCtx.logger,
+        verbose,
       });
 
       const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), `repack-`));
@@ -208,11 +210,13 @@ async function installAndImportRepackAsync({
  * Creates `@expo/steps` based spawnAsync for repack.
  */
 function createSpawnAsyncStepAdapter({
-  verbose,
+  env,
   logger,
+  verbose,
 }: {
-  verbose: boolean;
+  env: BuildStepEnv;
   logger: bunyan;
+  verbose: boolean;
 }): SpawnProcessAsync {
   return function repackSpawnAsync(
     command: string,
@@ -220,6 +224,7 @@ function createSpawnAsyncStepAdapter({
     options?: SpawnProcessOptions
   ): SpawnProcessPromise<SpawnProcessResult> {
     const promise = spawnAsync(command, args, {
+      env,
       ...options,
       ...(verbose ? { logger, stdio: 'pipe' } : { logger: undefined }),
     });


### PR DESCRIPTION
# Why

support nvm for repack job

# How

pass context env into repack's spawnAsync

# Test Plan

deploy and test
