### PR TITLE
[worker] Remove build phase stats websocket reporting

### DIFF
--- a/packages/build-tools/src/builders/__tests__/android.test.ts
+++ b/packages/build-tools/src/builders/__tests__/android.test.ts
@@ -4,6 +4,7 @@ import { vol } from 'memfs';
 import { createTestAndroidJob } from '../../__tests__/utils/job';
 import { createMockLogger } from '../../__tests__/utils/logger';
 import { BuildContext } from '../../context';
+import { Datadog } from '../../datadog';
 import { restoreCredentials } from '../../android/credentials';
 import androidBuilder from '../android';
 import { runBuilderWithHooksAsync } from '../common';
@@ -67,8 +68,11 @@ jest.mock('../../utils/prepareBuildExecutable', () => ({
   prepareExecutableAsync: jest.fn(),
 }));
 
+const datadogDistributionMock = jest.spyOn(Datadog, 'distribution');
+
 describe(androidBuilder, () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     vol.fromJSON(
       {
         '/workingdir/env/.gitkeep': '',
@@ -138,7 +142,6 @@ describe(androidBuilder, () => {
   });
 
   it('marks the configure Android version phase as warning for legacy eas-build.gradle', async () => {
-    const reportBuildPhaseStats = jest.fn();
     const job: Android.Job = {
       ...createTestAndroidJob(),
       secrets: {
@@ -157,23 +160,23 @@ describe(androidBuilder, () => {
         __API_SERVER_URL: 'http://api.expo.test',
       },
       uploadArtifact: jest.fn(),
-      reportBuildPhaseStats,
     });
     vol.mkdirSync('/workingdir/build/android/app', { recursive: true });
     vol.writeFileSync('/workingdir/build/android/app/eas-build.gradle', '// Legacy content');
 
     await androidBuilder(ctx);
 
-    expect(reportBuildPhaseStats).toHaveBeenCalledWith(
+    expect(datadogDistributionMock).toHaveBeenCalledWith(
+      'eas.build.phase_duration',
+      expect.any(Number),
       expect.objectContaining({
-        buildPhase: BuildPhase.CONFIGURE_ANDROID_VERSION,
+        build_phase: BuildPhase.CONFIGURE_ANDROID_VERSION.toLowerCase(),
         result: BuildPhaseResult.WARNING,
       })
     );
   });
 
   it('marks the prepare credentials phase as warning for legacy eas-build.gradle', async () => {
-    const reportBuildPhaseStats = jest.fn();
     const ctx = new BuildContext(createTestAndroidJob(), {
       workingdir: '/workingdir',
       logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
@@ -182,23 +185,23 @@ describe(androidBuilder, () => {
         __API_SERVER_URL: 'http://api.expo.test',
       },
       uploadArtifact: jest.fn(),
-      reportBuildPhaseStats,
     });
     vol.mkdirSync('/workingdir/build/android/app', { recursive: true });
     vol.writeFileSync('/workingdir/build/android/app/eas-build.gradle', '// Legacy content');
 
     await androidBuilder(ctx);
 
-    expect(reportBuildPhaseStats).toHaveBeenCalledWith(
+    expect(datadogDistributionMock).toHaveBeenCalledWith(
+      'eas.build.phase_duration',
+      expect.any(Number),
       expect.objectContaining({
-        buildPhase: BuildPhase.PREPARE_CREDENTIALS,
+        build_phase: BuildPhase.PREPARE_CREDENTIALS.toLowerCase(),
         result: BuildPhaseResult.WARNING,
       })
     );
   });
 
   it('injects credentials and version config when both are configured', async () => {
-    const reportBuildPhaseStats = jest.fn();
     const job: Android.Job = {
       ...createTestAndroidJob(),
       version: {
@@ -214,7 +217,6 @@ describe(androidBuilder, () => {
         __API_SERVER_URL: 'http://api.expo.test',
       },
       uploadArtifact: jest.fn(),
-      reportBuildPhaseStats,
     });
     vol.mkdirSync('/workingdir/build/android/app', { recursive: true });
     vol.writeFileSync('/workingdir/build/android/app/eas-build.gradle', '// Legacy content');
@@ -234,15 +236,19 @@ describe(androidBuilder, () => {
         versionName: '1.2.3',
       }
     );
-    expect(reportBuildPhaseStats).toHaveBeenCalledWith(
+    expect(datadogDistributionMock).toHaveBeenCalledWith(
+      'eas.build.phase_duration',
+      expect.any(Number),
       expect.objectContaining({
-        buildPhase: BuildPhase.PREPARE_CREDENTIALS,
+        build_phase: BuildPhase.PREPARE_CREDENTIALS.toLowerCase(),
         result: BuildPhaseResult.WARNING,
       })
     );
-    expect(reportBuildPhaseStats).toHaveBeenCalledWith(
+    expect(datadogDistributionMock).toHaveBeenCalledWith(
+      'eas.build.phase_duration',
+      expect.any(Number),
       expect.objectContaining({
-        buildPhase: BuildPhase.CONFIGURE_ANDROID_VERSION,
+        build_phase: BuildPhase.CONFIGURE_ANDROID_VERSION.toLowerCase(),
         result: BuildPhaseResult.WARNING,
       })
     );

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -2,7 +2,6 @@ import { ExpoConfig } from '@expo/config';
 import {
   BuildPhase,
   BuildPhaseResult,
-  BuildPhaseStats,
   Env,
   EnvironmentSecretType,
   GenericArtifactType,
@@ -65,7 +64,6 @@ export interface BuildContextOptions {
     err?: Error,
     options?: { tags?: Record<string, string>; extras?: Record<string, string> }
   ) => void;
-  reportBuildPhaseStats?: (stats: BuildPhaseStats) => void;
   skipNativeBuild?: boolean;
   metadata?: Metadata;
   expoApiV2BaseUrl?: string;
@@ -98,7 +96,6 @@ export class BuildContext<TJob extends Job = Job> {
   private buildPhaseSkipped = false;
   private buildPhaseHasWarnings = false;
   private _appConfig?: Promise<ExpoConfig>;
-  private readonly reportBuildPhaseStats?: (stats: BuildPhaseStats) => void;
   public readonly graphqlClient: Client;
 
   constructor(job: TJob, options: BuildContextOptions) {
@@ -114,7 +111,6 @@ export class BuildContext<TJob extends Job = Job> {
     this._metadata = options.metadata;
     this.skipNativeBuild = options.skipNativeBuild;
     this.expoApiV2BaseUrl = options.expoApiV2BaseUrl;
-    this.reportBuildPhaseStats = options.reportBuildPhaseStats;
 
     const environmentSecrets = this.getEnvironmentSecrets(job);
     this._env = {
@@ -355,7 +351,6 @@ export class BuildContext<TJob extends Job = Job> {
     }
     await this.collectAndUpdateEnvVariablesAsync();
 
-    this.reportBuildPhaseStats?.({ buildPhase: this.buildPhase, result, durationMs });
     if (this.job.platform) {
       Datadog.distribution('eas.build.phase_duration', durationMs, {
         build_phase: this.buildPhase.toLowerCase(),

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -181,12 +181,6 @@ export const CacheSchema = Joi.object({
   paths: Joi.array().items(Joi.string()).default([]),
 });
 
-export interface BuildPhaseStats {
-  buildPhase: BuildPhase;
-  result: BuildPhaseResult;
-  durationMs: number;
-}
-
 const GitHubContextZ = z.object({
   triggering_actor: z.string().optional(),
   event_name: z.enum(['push', 'pull_request', 'workflow_dispatch', 'schedule']),

--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -5,7 +5,6 @@ export {
   ArchiveSource,
   ArchiveSourceSchemaZ,
   BuildMode,
-  BuildPhaseStats,
   BuildTrigger,
   EasCliNpmTags,
   Env,

--- a/packages/worker/src/__integration__/utils.ts
+++ b/packages/worker/src/__integration__/utils.ts
@@ -49,10 +49,7 @@ export class WsHelper {
   public onMessage(cb: (message: any) => void): void {
     this.onMessageCb = jest.fn(raw => {
       logger.debug({ raw }, 'ws message');
-      const parsed = JSON.parse(raw);
-      if (parsed.type !== 'build-phase-stats') {
-        cb(parsed);
-      }
+      cb(JSON.parse(raw));
     });
     this.ws.on('message', this.onMessageCb);
   }

--- a/packages/worker/src/__unit__/service.test.ts
+++ b/packages/worker/src/__unit__/service.test.ts
@@ -1,5 +1,5 @@
 import { Datadog } from '@expo/build-tools';
-import { BuildPhase, BuildPhaseResult, Job, errors } from '@expo/eas-build-job';
+import { Job, errors } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 import { vol } from 'memfs';
 import path from 'path';
@@ -105,42 +105,6 @@ describe(getExpoPackageVersionAsync, () => {
   });
 });
 
-describe('BuildService.reportBuildPhaseStats', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('sends phase stats to the launcher websocket', () => {
-    const send = jest.fn();
-    const service = new BuildService();
-    service.setWS({ send } as any);
-
-    const stats = {
-      buildPhase: BuildPhase.RUN_FASTLANE,
-      result: BuildPhaseResult.SUCCESS,
-      durationMs: 1234,
-    };
-    service.reportBuildPhaseStats(stats);
-
-    expect(send).toHaveBeenCalledWith({
-      type: 'build-phase-stats',
-      ...stats,
-    });
-  });
-
-  it('does not send phase stats when there is no launcher websocket', () => {
-    const service = new BuildService();
-
-    service.reportBuildPhaseStats({
-      buildPhase: BuildPhase.PREPARE_PROJECT,
-      result: BuildPhaseResult.SUCCESS,
-      durationMs: 1,
-    });
-
-    expect(datadogSetupMock).not.toHaveBeenCalled();
-  });
-});
-
 describe('BuildService Datadog setup', () => {
   const buildLogger = { child: jest.fn(() => buildLogger) } as any;
 
@@ -175,11 +139,7 @@ describe('BuildService Datadog setup', () => {
       turtleBuildId: 'build-id',
       robotAccessToken: 'token-abc',
     });
-    expect(createBuildContextMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        reportBuildPhaseStatsFn: expect.any(Function),
-      })
-    );
+    expect(createBuildContextMock).toHaveBeenCalled();
     expect(datadogFlushAsyncMock).toHaveBeenCalled();
   });
 
@@ -201,11 +161,7 @@ describe('BuildService Datadog setup', () => {
       turtleBuildId: 'build-id',
       robotAccessToken: 'token-abc',
     });
-    expect(createBuildContextMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        reportBuildPhaseStatsFn: expect.any(Function),
-      })
-    );
+    expect(createBuildContextMock).toHaveBeenCalled();
   });
 
   it('leaves Datadog unconfigured when the robot access token is unavailable', async () => {

--- a/packages/worker/src/context.ts
+++ b/packages/worker/src/context.ts
@@ -1,5 +1,5 @@
 import { BuildContext, BuildContextOptions, LogBuffer } from '@expo/build-tools';
-import { BuildPhaseStats, Job, ManagedArtifactType, Metadata, Platform } from '@expo/eas-build-job';
+import { Job, ManagedArtifactType, Metadata, Platform } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import assert from 'assert';
 
@@ -24,7 +24,6 @@ export function createBuildContext<TJob extends Job>({
   projectId,
   buildId,
   buildLogger,
-  reportBuildPhaseStatsFn,
 }: {
   job: TJob;
   logBuffer: LogBuffer;
@@ -33,7 +32,6 @@ export function createBuildContext<TJob extends Job>({
   projectId: string;
   buildId: string;
   buildLogger: bunyan;
-  reportBuildPhaseStatsFn: (stats: BuildPhaseStats) => void;
 }): BuildContext<TJob> {
   const env = getBuildEnv({ job, projectId, metadata, buildId });
   const childLogger = buildLogger.child({ buildId });
@@ -89,7 +87,6 @@ export function createBuildContext<TJob extends Job>({
     },
     cacheManager: new GCSCacheManager(),
     metadata,
-    reportBuildPhaseStats: reportBuildPhaseStatsFn,
     expoApiV2BaseUrl: config.wwwApiV2BaseUrl,
   });
   return ctx;

--- a/packages/worker/src/external/turtle.ts
+++ b/packages/worker/src/external/turtle.ts
@@ -1,12 +1,5 @@
 import { GCS } from '@expo/build-tools';
-import {
-  BuildJob,
-  BuildPhase,
-  BuildPhaseResult,
-  Generic,
-  Metadata,
-  errors,
-} from '@expo/eas-build-job';
+import { BuildJob, Generic, Metadata, errors } from '@expo/eas-build-job';
 
 export const androidImagesWithJavaVersionLowerThen11 = [
   'ubuntu-20.04-jdk-8-ndk-r19c',
@@ -67,7 +60,6 @@ export namespace WorkerMessage {
     STATE_RESPONSE = 'state-response',
     SUCCESS = 'success',
     ERROR = 'error',
-    BUILD_PHASE_STATS = 'build-phase-stats',
     ABORTED = 'aborted',
   }
 
@@ -76,7 +68,7 @@ export namespace WorkerMessage {
     TIMEOUT = 'timeout',
   }
 
-  export type Message = StateResponse | BuildSuccess | BuildError | BuildPhaseStats | BuildAborted;
+  export type Message = StateResponse | BuildSuccess | BuildError | BuildAborted;
   export interface StateResponse {
     type: MessageType.STATE_RESPONSE;
     status: Worker.Status;
@@ -97,12 +89,6 @@ export namespace WorkerMessage {
     internalErrorCode?: string;
     applicationArchiveName: string | null;
     buildArtifactsName: string | null;
-  }
-  export interface BuildPhaseStats {
-    type: MessageType.BUILD_PHASE_STATS;
-    buildPhase: BuildPhase;
-    result: BuildPhaseResult;
-    durationMs: number;
   }
   export interface BuildAborted {
     type: MessageType.ABORTED;

--- a/packages/worker/src/service.ts
+++ b/packages/worker/src/service.ts
@@ -10,7 +10,6 @@ import {
   BuildJob,
   BuildMode,
   BuildPhase,
-  BuildPhaseStats,
   Ios,
   Job,
   Metadata,
@@ -241,16 +240,6 @@ export default class BuildService {
     });
   }
 
-  public reportBuildPhaseStats(stats: BuildPhaseStats): void {
-    if (this.ws) {
-      logger.info(stats, 'Sending build phase stats');
-      this.ws.send({
-        type: WorkerMessage.MessageType.BUILD_PHASE_STATS,
-        ...stats,
-      });
-    }
-  }
-
   public syncLauncherState({ buildId }: LauncherMessage.StateQuery): void {
     if (this.buildId !== buildId) {
       // should not happen (malicious or invalid connection)
@@ -307,9 +296,6 @@ export default class BuildService {
         projectId,
         buildId: this.buildId,
         buildLogger,
-        reportBuildPhaseStatsFn: stats => {
-          this.reportBuildPhaseStats(stats);
-        },
       });
       this.buildContext = ctx;
 


### PR DESCRIPTION
We now send build phases through `Datadog`!

---

## Summary
- remove the stale BuildPhaseStats type and BuildContext reporting callback
- drop the worker BUILD_PHASE_STATS websocket message and service forwarding path
- update tests to assert the remaining Datadog phase duration metrics path

## Why
Build phase metrics now flow from worker to www to Datadog, so the old worker to launcher to Datadog reporting path was dead code.

## Validation
- yarn run -T oxfmt --check packages/eas-build-job/src/common.ts packages/eas-build-job/src/index.ts packages/build-tools/src/context.ts packages/build-tools/src/builders/__tests__/android.test.ts packages/worker/src/context.ts packages/worker/src/service.ts packages/worker/src/external/turtle.ts packages/worker/src/__integration__/utils.ts packages/worker/src/__unit__/service.test.ts
- yarn jest --config jest/unit-config.ts src/builders/__tests__/android.test.ts src/__tests__/context.test.ts --runInBand --no-cache (from packages/build-tools)
- yarn jest --config jest.config.unit.ts src/__unit__/service.test.ts --runInBand (from packages/worker)
- yarn typecheck
