### PR TITLE
[build-tools] Support absolute artifact glob paths

### DIFF
--- a/packages/build-tools/src/utils/__tests__/artifacts.test.ts
+++ b/packages/build-tools/src/utils/__tests__/artifacts.test.ts
@@ -1,20 +1,13 @@
 import fs from 'fs-extra';
 import { vol } from 'memfs';
 
-import { Datadog } from '../../datadog';
 import { findArtifacts } from '../artifacts';
 
 jest.mock('fs');
-jest.mock('../../datadog', () => ({
-  Datadog: {
-    log: jest.fn(),
-  },
-}));
 
 describe(findArtifacts, () => {
   beforeEach(async () => {
     vol.reset();
-    jest.clearAllMocks();
   });
 
   test('with correct path', async () => {
@@ -53,14 +46,6 @@ describe(findArtifacts, () => {
     expect(loggerMock.error).toHaveBeenCalledTimes(0);
     expect(paths.length).toBe(1);
     expect(paths[0]).toBe('/Users/expo/.maestro/tests');
-    expect(Datadog.log).toHaveBeenCalledWith(
-      'findArtifacts absolute path dry-run match: /Users/expo/.maestro/tests (current: 1, dry-run: 1, samples: {"current":["/Users/expo/.maestro/tests"],"dryRun":["/Users/expo/.maestro/tests"]})',
-      {
-        event: 'find_artifacts_absolute_path_dry_run',
-        status: 'match',
-        dynamic_pattern: 'false',
-      }
-    );
   });
 
   test('with glob pattern', async () => {
@@ -84,7 +69,6 @@ describe(findArtifacts, () => {
     });
     expect(loggerMock.error).toHaveBeenCalledTimes(0);
     expect(paths.length).toBe(2);
-    expect(Datadog.log).not.toHaveBeenCalled();
   });
 
   test('with absolute glob pattern', async () => {
@@ -95,24 +79,16 @@ describe(findArtifacts, () => {
       info: jest.fn(),
       error: jest.fn(),
     };
-    await expect(
-      findArtifacts({
-        rootDir: '/Users/expo/build',
-        patternOrPath: '/tmp/maestro_xctestrunner_xcodebuild_output*',
-        logger: loggerMock as any,
-      })
-    ).rejects.toThrow(
-      'There are no files matching pattern "/tmp/maestro_xctestrunner_xcodebuild_output*"'
-    );
+    const paths = await findArtifacts({
+      rootDir: '/Users/expo/build',
+      patternOrPath: '/tmp/maestro_xctestrunner_xcodebuild_output*',
+      logger: loggerMock as any,
+    });
     expect(loggerMock.error).toHaveBeenCalledTimes(0);
-    expect(Datadog.log).toHaveBeenCalledWith(
-      'findArtifacts absolute path dry-run mismatch: /tmp/maestro_xctestrunner_xcodebuild_output* (current: 0, dry-run: 2, samples: {"current":[],"dryRun":["/tmp/maestro_xctestrunner_xcodebuild_output123","/tmp/maestro_xctestrunner_xcodebuild_output456"]})',
-      {
-        event: 'find_artifacts_absolute_path_dry_run',
-        status: 'mismatch',
-        dynamic_pattern: 'true',
-      }
-    );
+    expect(paths).toEqual([
+      '/tmp/maestro_xctestrunner_xcodebuild_output123',
+      '/tmp/maestro_xctestrunner_xcodebuild_output456',
+    ]);
   });
 
   test('with missing file in empty directory', async () => {

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -6,7 +6,6 @@ import path from 'path';
 import promiseLimit from 'promise-limit';
 
 import { BuildContext } from '../context';
-import { Datadog } from '../datadog';
 
 export class FindArtifactsError extends Error {}
 
@@ -20,16 +19,12 @@ export async function findArtifacts({
   /** If provided, will log error suggesting possible files to upload. */
   logger: bunyan | null;
 }): Promise<string[]> {
-  const files = path.isAbsolute(patternOrPath)
-    ? (await fs.pathExists(patternOrPath))
-      ? [patternOrPath]
-      : []
-    : await fg(patternOrPath, { cwd: rootDir, onlyFiles: false });
-  await maybeLogAbsoluteGlobDryRunAsync({
-    rootDir,
-    patternOrPath,
-    files,
-  });
+  const files =
+    path.isAbsolute(patternOrPath) && !fg.isDynamicPattern(patternOrPath)
+      ? (await fs.pathExists(patternOrPath))
+        ? [patternOrPath]
+        : []
+      : await fg(patternOrPath, { cwd: rootDir, onlyFiles: false });
   if (files.length === 0) {
     if (fg.isDynamicPattern(patternOrPath)) {
       throw new FindArtifactsError(`There are no files matching pattern "${patternOrPath}"`);
@@ -52,82 +47,6 @@ export async function findArtifacts({
     // fg will return a path relative to rootDir.
     return path.join(rootDir, filePath);
   });
-}
-
-async function findArtifactsWithAbsoluteGlobSupportDryRunAsync(
-  rootDir: string,
-  patternOrPath: string
-): Promise<string[]> {
-  return path.isAbsolute(patternOrPath) && !fg.isDynamicPattern(patternOrPath)
-    ? (await fs.pathExists(patternOrPath))
-      ? [patternOrPath]
-      : []
-    : await fg(patternOrPath, { cwd: rootDir, onlyFiles: false });
-}
-
-async function maybeLogAbsoluteGlobDryRunAsync({
-  rootDir,
-  patternOrPath,
-  files,
-}: {
-  rootDir: string;
-  patternOrPath: string;
-  files: string[];
-}): Promise<void> {
-  if (!path.isAbsolute(patternOrPath)) {
-    return;
-  }
-
-  try {
-    const filesWithAbsoluteGlobSupport = await findArtifactsWithAbsoluteGlobSupportDryRunAsync(
-      rootDir,
-      patternOrPath
-    );
-    const status = areArtifactListsEqual(files, filesWithAbsoluteGlobSupport)
-      ? 'match'
-      : 'mismatch';
-    Datadog.log(
-      `findArtifacts absolute path dry-run ${status}: ${patternOrPath} (current: ${files.length}, dry-run: ${filesWithAbsoluteGlobSupport.length}, samples: ${formatArtifactSamples(
-        {
-          current: files,
-          dryRun: filesWithAbsoluteGlobSupport,
-        }
-      )})`,
-      {
-        event: 'find_artifacts_absolute_path_dry_run',
-        status,
-        dynamic_pattern: `${fg.isDynamicPattern(patternOrPath)}`,
-      }
-    );
-  } catch {
-    Datadog.log(`findArtifacts absolute path dry-run error: ${patternOrPath}`, {
-      event: 'find_artifacts_absolute_path_dry_run',
-      status: 'error',
-      dynamic_pattern: `${fg.isDynamicPattern(patternOrPath)}`,
-    });
-  }
-}
-
-function formatArtifactSamples({
-  current,
-  dryRun,
-}: {
-  current: string[];
-  dryRun: string[];
-}): string {
-  return JSON.stringify({
-    current: current.slice(0, 20),
-    dryRun: dryRun.slice(0, 20),
-  });
-}
-
-function areArtifactListsEqual(first: string[], second: string[]): boolean {
-  if (first.length !== second.length) {
-    return false;
-  }
-  const sortedFirst = [...first].sort();
-  const sortedSecond = [...second].sort();
-  return sortedFirst.every((artifactPath, index) => artifactPath === sortedSecond[index]);
 }
 
 async function logMissingFileError(artifactPath: string, buildLogger: bunyan): Promise<void> {


### PR DESCRIPTION
See https://app.datadoghq.com/logs?query=findArtifacts&agg_m=count&agg_m_source=base&agg_q=status%2Cservice&agg_q_source=base%2Cbase&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=hot&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&viz=pattern&x_missing=true%2Ctrue&from_ts=1779570516711&to_ts=1779743316711&live=true

---

## Summary
- applies the validated absolute-glob artifact lookup behavior directly
- keeps existing exact absolute path handling intact
- adds unit coverage for absolute glob artifact patterns

## Why
The dry-run Sentry instrumentation validated that absolute artifact glob support is the intended behavior. This PR removes the dry-run path and uses the supported lookup logic directly.

## Validation
- yarn oxfmt packages/build-tools/src/utils/artifacts.ts packages/build-tools/src/utils/__tests__/artifacts.test.ts
- yarn --cwd packages/build-tools test --runTestsByPath src/utils/__tests__/artifacts.test.ts