### PR TITLE
[build-tools] handle custom Gymfile err in xcactivitylog

### DIFF
--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -181,13 +181,16 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
     }
     try {
       const { derivedDataPath, workspacePath } = nullthrows(fastlaneResult);
-      await parseAndReportXcactivitylog({
+      const { skipped } = await parseAndReportXcactivitylog({
         derivedDataPath,
         workspacePath,
         logger: ctx.logger,
         proxyBaseUrl: ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL,
         env: ctx.env,
       });
+      if (skipped) {
+        ctx.markBuildPhaseSkipped();
+      }
     } catch (err: any) {
       Sentry.capture('Failed to parse xcactivitylog', err);
       ctx.markBuildPhaseSkipped();

--- a/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
+++ b/packages/build-tools/src/steps/utils/ios/__tests__/xcactivitylog.test.ts
@@ -200,13 +200,21 @@ const TEST_ENV = { PATH: '/custom/bin:/usr/bin' };
 function mockFilesystem({
   tempDir = '/tmp/xclogparser-123',
   jsonOutput = JSON.stringify(FIXTURE_TWO_MODULES),
+  buildLogEntries = ['12345-abc.xcactivitylog'] as string[] | Error,
 }: {
   tempDir?: string;
   jsonOutput?: string;
+  buildLogEntries?: string[] | Error;
 } = {}) {
   jest.spyOn(fs, 'mkdtemp').mockImplementation(async () => tempDir);
   jest.spyOn(fs, 'chmod').mockImplementation(async () => undefined);
   jest.spyOn(fs, 'readFile').mockImplementation(async () => jsonOutput);
+  jest.spyOn(fs, 'readdir').mockImplementation((async () => {
+    if (buildLogEntries instanceof Error) {
+      throw buildLogEntries;
+    }
+    return buildLogEntries;
+  }) as any);
   jest.spyOn(fs, 'rm').mockImplementation(async () => undefined);
 
   return {
@@ -234,13 +242,14 @@ describe('parseAndReportXcactivitylog', () => {
     mockedSpawn.mockRejectedValueOnce(new Error('xclogparser not found'));
     mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
 
-    await parseAndReportXcactivitylog({
+    const result = await parseAndReportXcactivitylog({
       derivedDataPath: '/tmp/derived-data',
       workspacePath: '/tmp/workspace',
       logger,
       env: TEST_ENV,
     });
 
+    expect(result).toEqual({ skipped: false });
     expect(mockedSpawn).toHaveBeenNthCalledWith(1, 'xclogparser', ['version'], {
       stdio: 'pipe',
       env: TEST_ENV,
@@ -378,7 +387,7 @@ describe('parseAndReportXcactivitylog', () => {
         logger,
         env: TEST_ENV,
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ skipped: true });
 
     expect(logger.info).toHaveBeenCalledWith('Build performance analysis skipped.');
     expect(logger.warn).not.toHaveBeenCalled();
@@ -409,7 +418,7 @@ describe('parseAndReportXcactivitylog', () => {
         logger,
         env: TEST_ENV,
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ skipped: true });
 
     expect(logger.info).toHaveBeenCalledWith('Build performance analysis skipped.');
     expect(logger.warn).not.toHaveBeenCalled();
@@ -437,7 +446,7 @@ describe('parseAndReportXcactivitylog', () => {
         logger,
         env: TEST_ENV,
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ skipped: true });
 
     expect(logger.info).toHaveBeenCalledWith('Build performance analysis skipped.');
     expect(logger.warn).not.toHaveBeenCalled();
@@ -486,6 +495,108 @@ describe('parseAndReportXcactivitylog', () => {
     );
   });
 
+  it('skips with actionable guidance when Logs/Build has no .xcactivitylog files', async () => {
+    const logger = createMockLogger();
+    mockFilesystem({ buildLogEntries: [] });
+
+    const result = await parseAndReportXcactivitylog({
+      derivedDataPath: '/tmp/derived-data',
+      workspacePath: '/tmp/workspace',
+      logger,
+      env: TEST_ENV,
+    });
+
+    expect(result).toEqual({ skipped: true });
+    expect(mockedSpawn).not.toHaveBeenCalled();
+    expect(mockedDownloadFile).not.toHaveBeenCalled();
+    expect(Sentry.capture).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Build performance analysis skipped: no .xcactivitylog files found at ${path.join(
+          '/tmp/derived-data',
+          'Logs',
+          'Build'
+        )}.`
+      )
+    );
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('custom ios/Gymfile'));
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('derived_data_path("./build")')
+    );
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('result_bundle(true)'));
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('result_bundle_path("./build/result-bundle.xcresult")')
+    );
+  });
+
+  it('skips when Logs/Build directory does not exist', async () => {
+    const logger = createMockLogger();
+    const enoent: any = new Error('ENOENT');
+    enoent.code = 'ENOENT';
+    mockFilesystem({ buildLogEntries: enoent });
+
+    const result = await parseAndReportXcactivitylog({
+      derivedDataPath: '/tmp/derived-data',
+      workspacePath: '/tmp/workspace',
+      logger,
+      env: TEST_ENV,
+    });
+
+    expect(result).toEqual({ skipped: true });
+    expect(mockedSpawn).not.toHaveBeenCalled();
+    expect(mockedDownloadFile).not.toHaveBeenCalled();
+    expect(Sentry.capture).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('Build performance analysis skipped: no .xcactivitylog files found')
+    );
+  });
+
+  it('captures to Sentry and skips when readdir fails with a non-ENOENT error', async () => {
+    const logger = createMockLogger();
+    const eacces: any = new Error('EACCES: permission denied');
+    eacces.code = 'EACCES';
+    mockFilesystem({ buildLogEntries: eacces });
+
+    const result = await parseAndReportXcactivitylog({
+      derivedDataPath: '/tmp/derived-data',
+      workspacePath: '/tmp/workspace',
+      logger,
+      env: TEST_ENV,
+    });
+
+    expect(result).toEqual({ skipped: true });
+    expect(mockedSpawn).not.toHaveBeenCalled();
+    expect(mockedDownloadFile).not.toHaveBeenCalled();
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Build performance analysis failed during "checking_xcactivitylog_existence"',
+      expect.objectContaining({ code: 'EACCES' }),
+      expect.objectContaining({
+        tags: { phase: 'checking_xcactivitylog_existence' },
+      })
+    );
+    expect(logger.info).toHaveBeenCalledWith('Build performance analysis skipped.');
+    expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('custom ios/Gymfile'));
+  });
+
+  it('ignores non-xcactivitylog entries in Logs/Build when deciding to skip', async () => {
+    const logger = createMockLogger();
+    mockFilesystem({ buildLogEntries: ['LogStoreManifest.plist', 'some-other-file.txt'] });
+
+    const result = await parseAndReportXcactivitylog({
+      derivedDataPath: '/tmp/derived-data',
+      workspacePath: '/tmp/workspace',
+      logger,
+      env: TEST_ENV,
+    });
+
+    expect(result).toEqual({ skipped: true });
+    expect(mockedSpawn).not.toHaveBeenCalled();
+    expect(Sentry.capture).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('Build performance analysis skipped: no .xcactivitylog files found')
+    );
+  });
+
   it('reports phase "downloading_xclogparser" when the direct download fails', async () => {
     const logger = createMockLogger();
     mockFilesystem();
@@ -501,7 +612,7 @@ describe('parseAndReportXcactivitylog', () => {
         logger,
         env: TEST_ENV,
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ skipped: true });
 
     expect(logger.info).toHaveBeenCalledWith('Build performance analysis skipped.');
     expect(logger.warn).not.toHaveBeenCalled();
@@ -530,7 +641,7 @@ describe('parseAndReportXcactivitylog', () => {
         logger,
         env: TEST_ENV,
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ skipped: false });
 
     expect(logger.debug).not.toHaveBeenCalled();
     expect(logger.warn).not.toHaveBeenCalled();

--- a/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
+++ b/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
@@ -16,9 +16,9 @@ const XCLOGPARSER_DOWNLOAD_TIMEOUT_MS = 20_000;
 const XCLOGPARSER_OUTPUT_FILENAME = 'xcactivitylog.json';
 
 /**
- * Never throws — best-effort observability that does not affect build status.
- * Failures route to Sentry via `Sentry.capture` for engineering triage;
- * users see only a generic skip message.
+ * Catches all internal failures (logged + routed to Sentry); returns
+ * `{ skipped: true }` when analysis did not produce a report so callers can
+ * mark the build phase skipped.
  */
 export async function parseAndReportXcactivitylog({
   derivedDataPath,
@@ -34,10 +34,38 @@ export async function parseAndReportXcactivitylog({
   logger: bunyan;
   proxyBaseUrl?: string;
   env: BuildStepEnv;
-}): Promise<void> {
+}): Promise<{ skipped: boolean }> {
   let tempDir: string | undefined;
-  let phase = 'creating_temp_directory';
+  let phase = 'checking_xcactivitylog_existence';
   try {
+    const logsBuildDir = path.join(derivedDataPath, 'Logs', 'Build');
+    let buildLogEntries: string[];
+    try {
+      buildLogEntries = await fs.readdir(logsBuildDir);
+    } catch (err: any) {
+      if (err?.code !== 'ENOENT') {
+        throw err;
+      }
+      buildLogEntries = [];
+    }
+    const hasActivityLog = buildLogEntries.some(entry => entry.endsWith('.xcactivitylog'));
+    if (!hasActivityLog) {
+      logger.info(
+        [
+          `Build performance analysis skipped: no .xcactivitylog files found at ${logsBuildDir}.`,
+          '',
+          'This typically happens when your project has a custom ios/Gymfile. To enable',
+          'build performance analysis, add the following lines to your Gymfile:',
+          '',
+          '    derived_data_path("./build")',
+          '    result_bundle(true)',
+          '    result_bundle_path("./build/result-bundle.xcresult")',
+        ].join('\n')
+      );
+      return { skipped: true };
+    }
+
+    phase = 'creating_temp_directory';
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'xclogparser-'));
 
     phase = 'resolving_xclogparser';
@@ -79,6 +107,7 @@ export async function parseAndReportXcactivitylog({
     );
 
     logger.info(formatReport(data));
+    return { skipped: false };
   } catch (err: any) {
     logger.info('Build performance analysis skipped.');
     const msg = `Build performance analysis failed during "${phase}"`;
@@ -91,6 +120,7 @@ export async function parseAndReportXcactivitylog({
         stdout: err?.stdout?.slice(-4000),
       },
     });
+    return { skipped: true };
   } finally {
     if (tempDir) {
       await asyncResult(fs.rm(tempDir, { force: true, recursive: true }));


### PR DESCRIPTION
# Why

Fix Sentry [TURTLE-V2-WORKER-1WT](https://expoio.sentry.io/issues/TURTLE-V2-WORKER-1WT) (ENG-21383) — 48 events of `xclogparser` failing during the `PARSE_XCACTIVITYLOG` phase with stderr:

```
Error: The file "Build" couldn't be opened because there is no such file.
```

`runFastlaneGym` always returns `derivedDataPath = <ios>/build`, but projects with a custom `ios/Gymfile` can set a different `derived_data_path` (or omit it entirely, in which case Xcode uses its default DerivedData location). xclogparser then runs against a directory that has no `.xcactivitylog` files and fails.

# How

Added a pre-flight check in `parseAndReportXcactivitylog` that lists `<derivedDataPath>/Logs/Build/`:

- If no `.xcactivitylog` files are present, log actionable guidance pointing users at the Gymfile lines they need and skip the analysis (no Sentry — this is user config, not an engineering bug).
- If `readdir` fails with anything other than `ENOENT` (e.g. `EACCES`, `EMFILE`), rethrow so it still lands in Sentry under a new `checking_xcactivitylog_existence` phase tag — real infra problems are not masked by the swallow.

Return type changed from `Promise<void>` to `Promise<{ skipped: boolean }>` so the caller in `builders/ios.ts` can call `ctx.markBuildPhaseSkipped()` and reflect the correct phase status in the build summary.

# Test Plan

Unit tests in `xcactivitylog.test.ts` cover the four pre-check branches:

- `Logs/Build` exists but has no `.xcactivitylog` files → skipped + actionable Gymfile log, no Sentry
- `Logs/Build` does not exist (`ENOENT`) → skipped, no Sentry
- `Logs/Build` has only non-`.xcactivitylog` entries (e.g. `LogStoreManifest.plist`) → skipped
- `readdir` fails with `EACCES` → Sentry captured with `checking_xcactivitylog_existence` phase tag, no misleading Gymfile message logged

Existing tests updated to assert the new `{ skipped }` return shape. 41/41 tests pass; typecheck/lint/fmt clean.