### PR TITLE
[build-tools] Log artifact dry-run results to Datadog

### DIFF
--- a/packages/build-tools/src/__tests__/datadog.test.ts
+++ b/packages/build-tools/src/__tests__/datadog.test.ts
@@ -61,10 +61,43 @@ describe('Datadog singleton', () => {
     );
   });
 
+  it('POSTs logs to the turtle build logs endpoint', () => {
+    turtleFetchMock.mockResolvedValueOnce({} as Response);
+
+    Datadog.setup({
+      expoApiV2BaseUrl: 'https://api.expo.test/v2/',
+      turtleBuildId: 'build-id',
+      robotAccessToken: 'token-abc',
+    });
+
+    Datadog.log('artifact dry-run matched', {
+      event: 'find_artifacts_absolute_path_dry_run',
+      status: 'match',
+    });
+
+    expect(turtleFetchMock).toHaveBeenCalledWith(
+      'https://api.expo.test/v2/turtle-builds/logs',
+      'POST',
+      {
+        json: {
+          buildId: 'build-id',
+          message: 'artifact dry-run matched',
+          tags: {
+            event: 'find_artifacts_absolute_path_dry_run',
+            status: 'match',
+          },
+        },
+        headers: { Authorization: 'Bearer token-abc' },
+        shouldThrowOnNotOk: false,
+      }
+    );
+  });
+
   it('is a no-op when setup is null', () => {
     Datadog.setup(null);
 
     Datadog.distribution('eas.build.phase_duration', 1);
+    Datadog.log('artifact dry-run matched');
 
     expect(turtleFetchMock).not.toHaveBeenCalled();
   });
@@ -92,6 +125,29 @@ describe('Datadog singleton', () => {
     );
   });
 
+  it('swallows log upload failures', async () => {
+    turtleFetchMock.mockRejectedValueOnce(new Error('network down'));
+    Datadog.setup({
+      expoApiV2BaseUrl: 'https://api.expo.test/v2/',
+      turtleBuildId: 'build-id',
+      robotAccessToken: 'token-abc',
+    });
+
+    Datadog.log('artifact dry-run matched');
+    await flushPromises();
+
+    expect(turtleFetchMock).toHaveBeenCalled();
+    expect(sentryCaptureMock).toHaveBeenCalledWith(
+      'Failed to report turtle build log',
+      expect.any(Error),
+      expect.objectContaining({
+        extras: {
+          log: { buildId: 'build-id', message: 'artifact dry-run matched', tags: {} },
+        },
+      })
+    );
+  });
+
   it('uses the latest setup options', () => {
     turtleFetchMock.mockResolvedValue({} as Response);
 
@@ -107,9 +163,19 @@ describe('Datadog singleton', () => {
     });
 
     Datadog.distribution('eas.build.phase_duration', 1);
+    Datadog.log('artifact dry-run matched');
 
-    expect(turtleFetchMock).toHaveBeenCalledWith(
+    expect(turtleFetchMock).toHaveBeenNthCalledWith(
+      1,
       'https://api.expo.test/v2/turtle-builds/second-build-id/metrics',
+      'POST',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer second-token' },
+      })
+    );
+    expect(turtleFetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://api.expo.test/v2/turtle-builds/logs',
       'POST',
       expect.objectContaining({
         headers: { Authorization: 'Bearer second-token' },
@@ -132,6 +198,33 @@ describe('Datadog singleton', () => {
 
     let flushed = false;
     Datadog.distribution('eas.build.phase_duration', 1);
+    const flushPromise = Datadog.flushAsync().then(() => {
+      flushed = true;
+    });
+    await Promise.resolve();
+    expect(flushed).toBe(false);
+
+    resolveUpload({} as Response);
+    await flushPromise;
+
+    expect(flushed).toBe(true);
+  });
+
+  it('flushes pending log uploads', async () => {
+    let resolveUpload!: (response: Response) => void;
+    turtleFetchMock.mockReturnValueOnce(
+      new Promise<Response>(resolve => {
+        resolveUpload = resolve;
+      })
+    );
+    Datadog.setup({
+      expoApiV2BaseUrl: 'https://api.expo.test/v2/',
+      turtleBuildId: 'build-id',
+      robotAccessToken: 'token-abc',
+    });
+
+    let flushed = false;
+    Datadog.log('artifact dry-run matched');
     const flushPromise = Datadog.flushAsync().then(() => {
       flushed = true;
     });

--- a/packages/build-tools/src/datadog.ts
+++ b/packages/build-tools/src/datadog.ts
@@ -8,7 +8,7 @@ type DatadogSetupOptions = {
 };
 
 let setupOptions: DatadogSetupOptions | null = null;
-let pendingMetricUploads: Promise<unknown>[] = [];
+let pendingUploads: Promise<unknown>[] = [];
 
 export const Datadog = {
   setup(opts: DatadogSetupOptions | null): void {
@@ -45,10 +45,40 @@ export const Datadog = {
       });
     });
 
-    pendingMetricUploads.push(uploadPromise);
+    pendingUploads.push(uploadPromise);
+  },
+
+  log(message: string, tags: Record<string, string> = {}): void {
+    if (!setupOptions) {
+      return;
+    }
+    const { expoApiV2BaseUrl, turtleBuildId, robotAccessToken } = setupOptions;
+    const log = {
+      buildId: turtleBuildId,
+      message,
+      tags,
+    };
+
+    const uploadPromise = turtleFetch(
+      new URL('turtle-builds/logs', expoApiV2BaseUrl).toString(),
+      'POST',
+      {
+        json: log,
+        headers: {
+          Authorization: `Bearer ${robotAccessToken}`,
+        },
+        shouldThrowOnNotOk: false,
+      }
+    ).catch(err => {
+      Sentry.capture('Failed to report turtle build log', err, {
+        extras: { log },
+      });
+    });
+
+    pendingUploads.push(uploadPromise);
   },
 
   async flushAsync(): Promise<void> {
-    await Promise.allSettled(pendingMetricUploads);
+    await Promise.allSettled(pendingUploads);
   },
 };

--- a/packages/build-tools/src/steps/functions/restoreBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreBuildCache.ts
@@ -19,6 +19,7 @@ import {
   generateDefaultBuildCacheKeyAsync,
   getCcachePath,
 } from '../../utils/cacheKey';
+import { Datadog } from '../../datadog';
 import { GRADLE_CACHE_KEY_PREFIX, generateGradleCacheKeyAsync } from '../../utils/gradleCacheKey';
 import { TurtleFetchError, turtleFetch } from '../../utils/turtleFetch';
 
@@ -282,22 +283,10 @@ export async function restoreGradleCacheAsync({
       `Gradle cache restored to ${gradleCachesPath} (${hitType === 'direct_hit' ? 'direct hit' : 'prefix match'})`
     );
 
-    try {
-      await turtleFetch(new URL('v2/turtle-builds/logs', expoApiServerURL).toString(), 'POST', {
-        json: {
-          buildId: jobId,
-          message: `Gradle cache restored (${hitType})`,
-          tags: {
-            event: 'gradle_cache_restored',
-            cache_hit_type: hitType,
-          },
-        },
-        headers: {
-          Authorization: `Bearer ${robotAccessToken}`,
-        },
-        shouldThrowOnNotOk: false,
-      });
-    } catch {}
+    Datadog.log(`Gradle cache restored (${hitType})`, {
+      event: 'gradle_cache_restored',
+      cache_hit_type: hitType,
+    });
   } catch (err: unknown) {
     if (err instanceof TurtleFetchError && err.response?.status === 404) {
       logger.info('No Gradle cache found for this key');

--- a/packages/build-tools/src/utils/__tests__/artifacts.test.ts
+++ b/packages/build-tools/src/utils/__tests__/artifacts.test.ts
@@ -1,13 +1,13 @@
 import fs from 'fs-extra';
 import { vol } from 'memfs';
 
-import { Sentry } from '../../sentry';
+import { Datadog } from '../../datadog';
 import { findArtifacts } from '../artifacts';
 
 jest.mock('fs');
-jest.mock('../../sentry', () => ({
-  Sentry: {
-    capture: jest.fn(),
+jest.mock('../../datadog', () => ({
+  Datadog: {
+    log: jest.fn(),
   },
 }));
 
@@ -53,6 +53,14 @@ describe(findArtifacts, () => {
     expect(loggerMock.error).toHaveBeenCalledTimes(0);
     expect(paths.length).toBe(1);
     expect(paths[0]).toBe('/Users/expo/.maestro/tests');
+    expect(Datadog.log).toHaveBeenCalledWith(
+      'findArtifacts absolute path dry-run match: /Users/expo/.maestro/tests (current: 1, dry-run: 1)',
+      {
+        event: 'find_artifacts_absolute_path_dry_run',
+        status: 'match',
+        dynamic_pattern: 'false',
+      }
+    );
   });
 
   test('with glob pattern', async () => {
@@ -76,7 +84,7 @@ describe(findArtifacts, () => {
     });
     expect(loggerMock.error).toHaveBeenCalledTimes(0);
     expect(paths.length).toBe(2);
-    expect(Sentry.capture).not.toHaveBeenCalled();
+    expect(Datadog.log).not.toHaveBeenCalled();
   });
 
   test('with absolute glob pattern', async () => {
@@ -97,23 +105,14 @@ describe(findArtifacts, () => {
       'There are no files matching pattern "/tmp/maestro_xctestrunner_xcodebuild_output*"'
     );
     expect(loggerMock.error).toHaveBeenCalledTimes(0);
-    expect(Sentry.capture).toHaveBeenCalledWith(expect.any(Error), {
-      tags: {
-        source: 'find-artifacts',
-        reason: 'absolute_path',
-      },
-      extras: {
-        rootDir: '/Users/expo/build',
-        patternOrPath: '/tmp/maestro_xctestrunner_xcodebuild_output*',
-        currentCount: 0,
-        dryRunCount: 2,
-        currentSample: [],
-        dryRunSample: [
-          '/tmp/maestro_xctestrunner_xcodebuild_output123',
-          '/tmp/maestro_xctestrunner_xcodebuild_output456',
-        ],
-      },
-    });
+    expect(Datadog.log).toHaveBeenCalledWith(
+      'findArtifacts absolute path dry-run mismatch: /tmp/maestro_xctestrunner_xcodebuild_output* (current: 0, dry-run: 2)',
+      {
+        event: 'find_artifacts_absolute_path_dry_run',
+        status: 'mismatch',
+        dynamic_pattern: 'true',
+      }
+    );
   });
 
   test('with missing file in empty directory', async () => {

--- a/packages/build-tools/src/utils/__tests__/artifacts.test.ts
+++ b/packages/build-tools/src/utils/__tests__/artifacts.test.ts
@@ -54,7 +54,7 @@ describe(findArtifacts, () => {
     expect(paths.length).toBe(1);
     expect(paths[0]).toBe('/Users/expo/.maestro/tests');
     expect(Datadog.log).toHaveBeenCalledWith(
-      'findArtifacts absolute path dry-run match: /Users/expo/.maestro/tests (current: 1, dry-run: 1)',
+      'findArtifacts absolute path dry-run match: /Users/expo/.maestro/tests (current: 1, dry-run: 1, samples: {"current":["/Users/expo/.maestro/tests"],"dryRun":["/Users/expo/.maestro/tests"]})',
       {
         event: 'find_artifacts_absolute_path_dry_run',
         status: 'match',
@@ -106,7 +106,7 @@ describe(findArtifacts, () => {
     );
     expect(loggerMock.error).toHaveBeenCalledTimes(0);
     expect(Datadog.log).toHaveBeenCalledWith(
-      'findArtifacts absolute path dry-run mismatch: /tmp/maestro_xctestrunner_xcodebuild_output* (current: 0, dry-run: 2)',
+      'findArtifacts absolute path dry-run mismatch: /tmp/maestro_xctestrunner_xcodebuild_output* (current: 0, dry-run: 2, samples: {"current":[],"dryRun":["/tmp/maestro_xctestrunner_xcodebuild_output123","/tmp/maestro_xctestrunner_xcodebuild_output456"]})',
       {
         event: 'find_artifacts_absolute_path_dry_run',
         status: 'mismatch',

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -87,7 +87,12 @@ async function maybeLogAbsoluteGlobDryRunAsync({
       ? 'match'
       : 'mismatch';
     Datadog.log(
-      `findArtifacts absolute path dry-run ${status}: ${patternOrPath} (current: ${files.length}, dry-run: ${filesWithAbsoluteGlobSupport.length})`,
+      `findArtifacts absolute path dry-run ${status}: ${patternOrPath} (current: ${files.length}, dry-run: ${filesWithAbsoluteGlobSupport.length}, samples: ${formatArtifactSamples(
+        {
+          current: files,
+          dryRun: filesWithAbsoluteGlobSupport,
+        }
+      )})`,
       {
         event: 'find_artifacts_absolute_path_dry_run',
         status,
@@ -101,6 +106,19 @@ async function maybeLogAbsoluteGlobDryRunAsync({
       dynamic_pattern: `${fg.isDynamicPattern(patternOrPath)}`,
     });
   }
+}
+
+function formatArtifactSamples({
+  current,
+  dryRun,
+}: {
+  current: string[];
+  dryRun: string[];
+}): string {
+  return JSON.stringify({
+    current: current.slice(0, 20),
+    dryRun: dryRun.slice(0, 20),
+  });
 }
 
 function areArtifactListsEqual(first: string[], second: string[]): boolean {

--- a/packages/build-tools/src/utils/artifacts.ts
+++ b/packages/build-tools/src/utils/artifacts.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import promiseLimit from 'promise-limit';
 
 import { BuildContext } from '../context';
-import { Sentry } from '../sentry';
+import { Datadog } from '../datadog';
 
 export class FindArtifactsError extends Error {}
 
@@ -25,7 +25,7 @@ export async function findArtifacts({
       ? [patternOrPath]
       : []
     : await fg(patternOrPath, { cwd: rootDir, onlyFiles: false });
-  await maybeReportAbsoluteGlobDryRunMismatchAsync({
+  await maybeLogAbsoluteGlobDryRunAsync({
     rootDir,
     patternOrPath,
     files,
@@ -65,7 +65,7 @@ async function findArtifactsWithAbsoluteGlobSupportDryRunAsync(
     : await fg(patternOrPath, { cwd: rootDir, onlyFiles: false });
 }
 
-async function maybeReportAbsoluteGlobDryRunMismatchAsync({
+async function maybeLogAbsoluteGlobDryRunAsync({
   rootDir,
   patternOrPath,
   files,
@@ -83,36 +83,22 @@ async function maybeReportAbsoluteGlobDryRunMismatchAsync({
       rootDir,
       patternOrPath
     );
-    if (areArtifactListsEqual(files, filesWithAbsoluteGlobSupport)) {
-      return;
-    }
-
-    Sentry.capture(new Error('findArtifacts output changed for an absolute path'), {
-      tags: {
-        source: 'find-artifacts',
-        reason: 'absolute_path',
-      },
-      extras: {
-        rootDir,
-        patternOrPath,
-        currentCount: files.length,
-        dryRunCount: filesWithAbsoluteGlobSupport.length,
-        currentSample: files.slice(0, 20),
-        dryRunSample: filesWithAbsoluteGlobSupport.slice(0, 20),
-      },
-    });
-  } catch (err: any) {
-    Sentry.capture(err, {
-      tags: {
-        source: 'find-artifacts',
-        reason: 'absolute_path_dry_run_failed',
-      },
-      extras: {
-        rootDir,
-        patternOrPath,
-        currentCount: files.length,
-        currentSample: files.slice(0, 20),
-      },
+    const status = areArtifactListsEqual(files, filesWithAbsoluteGlobSupport)
+      ? 'match'
+      : 'mismatch';
+    Datadog.log(
+      `findArtifacts absolute path dry-run ${status}: ${patternOrPath} (current: ${files.length}, dry-run: ${filesWithAbsoluteGlobSupport.length})`,
+      {
+        event: 'find_artifacts_absolute_path_dry_run',
+        status,
+        dynamic_pattern: `${fg.isDynamicPattern(patternOrPath)}`,
+      }
+    );
+  } catch {
+    Datadog.log(`findArtifacts absolute path dry-run error: ${patternOrPath}`, {
+      event: 'find_artifacts_absolute_path_dry_run',
+      status: 'error',
+      dynamic_pattern: `${fg.isDynamicPattern(patternOrPath)}`,
     });
   }
 }


### PR DESCRIPTION
## Summary
- adds `Datadog.log` for posting build-scoped log events to Datadog
- moves the Gradle cache restore log emission onto the shared Datadog helper
- replaces artifact dry-run Sentry reporting with Datadog logs for match, mismatch, and error outcomes

## Why
The absolute artifact glob validation should show both positive and negative dry-run outcomes. Sentry only surfaced mismatches/errors, while Datadog logs let us count successful matches as well.

## Validation

CI should pass. Going to review Datadog logs post-merge.
