### PR TITLE
Security: Unsafe Buffer Construction from Base64 Credentials

### DIFF
--- a/packages/build-tools/src/android/credentials.ts
+++ b/packages/build-tools/src/android/credentials.ts
@@ -6,6 +6,8 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { BuildContext } from '../context';
 
+const MAX_KEYSTORE_SIZE = 10 * 1024 * 1024; // 10MB
+
 async function restoreCredentials(ctx: BuildContext<Android.Job>): Promise<void> {
   const { buildCredentials } = nullthrows(
     ctx.job.secrets,
@@ -16,11 +18,12 @@ async function restoreCredentials(ctx: BuildContext<Android.Job>): Promise<void>
     throw new Error('secrets are missing in the job object');
   }
   ctx.logger.info("Writing secrets to the project's directory");
+  const keystoreBuffer = Buffer.from(buildCredentials.keystore.dataBase64, 'base64');
+  if (keystoreBuffer.length > MAX_KEYSTORE_SIZE) {
+    throw new Error('Keystore data exceeds maximum allowed size');
+  }
   const keystorePath = path.join(ctx.buildDirectory, `keystore-${uuidv4()}`);
-  await fs.writeFile(
-    keystorePath,
-    new Uint8Array(Buffer.from(buildCredentials.keystore.dataBase64, 'base64'))
-  );
+  await fs.writeFile(keystorePath, new Uint8Array(keystoreBuffer), { mode: 0o600 });
   const credentialsJson = {
     android: {
       keystore: {
@@ -33,7 +36,8 @@ async function restoreCredentials(ctx: BuildContext<Android.Job>): Promise<void>
   };
   await fs.writeFile(
     path.join(ctx.buildDirectory, 'credentials.json'),
-    JSON.stringify(credentialsJson)
+    JSON.stringify(credentialsJson),
+    { mode: 0o600 }
   );
 }
 


### PR DESCRIPTION
## Summary

Security: Unsafe Buffer Construction from Base64 Credentials

## Problem

**Severity**: `Medium` | **File**: `packages/build-tools/src/android/credentials.ts:L18`

In `restoreCredentials`, `buildCredentials.keystore.dataBase64` is decoded using `Buffer.from(..., 'base64')` and written to a file. While base64 decoding itself is safe, there's no validation of the decoded data size or format before writing. More critically, the keystore password and key passwords are written in plaintext to `credentials.json`. Additionally, in `injectAndroidCredentialsFunction`, the same pattern is used with Joi validation but the `dataBase64` field is not validated for maximum length, potentially allowing memory exhaustion attacks.

## Solution

Add maximum size validation for base64-decoded data. Use secure temporary file permissions (0600) when writing keystores. Consider using `fs.writeFile` with explicit mode options. For credentials.json, ensure it's written with restrictive permissions and cleaned up promptly after use.

## Changes

- `packages/build-tools/src/android/credentials.ts` (modified)