### PR TITLE
[eas-cli] Unhide observe commands

### DIFF
--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -30,7 +30,6 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 const DEFAULT_EVENTS_LIMIT = 10;
 
 export default class ObserveEvents extends EasCommand {
-  static override hidden = true;
   static override description =
     'display individual events emitted by the app via `logEvent`, filtered by the event name in the argument. With no arguments, a list of the available event names and associated event counts is returned.';
 

--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -90,8 +90,6 @@ export default class ObserveEvents extends EasCommand {
 
     if (flags.json) {
       enableJsonOutput();
-    } else {
-      Log.warn('EAS Observe is in preview and subject to breaking changes.');
     }
 
     const { daysBack, startTime, endTime } = resolveTimeRange(flags);

--- a/packages/eas-cli/src/commands/observe/metrics-summary.ts
+++ b/packages/eas-cli/src/commands/observe/metrics-summary.ts
@@ -42,7 +42,6 @@ const DEFAULT_STATS_JSON: StatisticKey[] = [
 ];
 
 export default class ObserveMetricsSummary extends EasCommand {
-  static override hidden = true;
   static override description =
     'display aggregated performance metric statistics grouped by app version';
 

--- a/packages/eas-cli/src/commands/observe/metrics-summary.ts
+++ b/packages/eas-cli/src/commands/observe/metrics-summary.ts
@@ -84,8 +84,6 @@ export default class ObserveMetricsSummary extends EasCommand {
 
     if (flags.json) {
       enableJsonOutput();
-    } else {
-      Log.warn('EAS Observe is in preview and subject to breaking changes.');
     }
 
     const metricNames = flags.metric?.length

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -30,7 +30,6 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 const DEFAULT_EVENTS_LIMIT = 10;
 
 export default class ObserveMetrics extends EasCommand {
-  static override hidden = true;
   static override description = 'display individual performance metric samples ordered by value';
 
   static override args = {

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -82,8 +82,6 @@ export default class ObserveMetrics extends EasCommand {
 
     if (flags.json) {
       enableJsonOutput();
-    } else {
-      Log.warn('EAS Observe is in preview and subject to breaking changes.');
     }
 
     let metricName: string;

--- a/packages/eas-cli/src/commands/observe/routes.ts
+++ b/packages/eas-cli/src/commands/observe/routes.ts
@@ -34,7 +34,6 @@ const DEFAULT_STATS_TABLE: NavigationStatKey[] = ['median', 'count'];
 const DEFAULT_STATS_JSON: NavigationStatKey[] = ['median', 'p90', 'count'];
 
 export default class ObserveRoutes extends EasCommand {
-  static override hidden = true;
   static override description =
     'display app navigation route metrics (Cold TTR, Warm TTR, TTI) grouped by route name';
 

--- a/packages/eas-cli/src/commands/observe/routes.ts
+++ b/packages/eas-cli/src/commands/observe/routes.ts
@@ -92,8 +92,6 @@ export default class ObserveRoutes extends EasCommand {
 
     if (flags.json) {
       enableJsonOutput();
-    } else {
-      Log.warn('EAS Observe is in preview and subject to breaking changes.');
     }
 
     const metricNames = flags.metric?.length

--- a/packages/eas-cli/src/commands/observe/versions.ts
+++ b/packages/eas-cli/src/commands/observe/versions.ts
@@ -45,8 +45,6 @@ export default class ObserveVersions extends EasCommand {
 
     if (flags.json) {
       enableJsonOutput();
-    } else {
-      Log.warn('EAS Observe is in preview and subject to breaking changes.');
     }
 
     const { startTime, endTime } = resolveTimeRange(flags);

--- a/packages/eas-cli/src/commands/observe/versions.ts
+++ b/packages/eas-cli/src/commands/observe/versions.ts
@@ -14,7 +14,6 @@ import { resolveTimeRange } from '../../observe/startAndEndTime';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class ObserveVersions extends EasCommand {
-  static override hidden = true;
   static override description = 'display app versions with build and update details';
 
   static override flags = {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Unhide the commands when ready.

# How

Remove `hidden = true` lines, clean up outdated warnings.

# Test Plan

CI should pass.