### PR TITLE
[build-tools] Fix iOS Simulator readiness hang on Xcode 26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Fix `eas/start_ios_simulator` hanging on Xcode 26.4 by writing the readiness screenshot to a temp file instead of `/dev/null`. ([#3794](https://github.com/expo/eas-cli/pull/3794) by [@gwdp](https://github.com/gwdp))
+
 ### 🧹 Chores
 
 ## [19.1.0](https://github.com/expo/eas-cli/releases/tag/v19.1.0) - 2026-05-25

--- a/packages/build-tools/src/utils/IosSimulatorUtils.ts
+++ b/packages/build-tools/src/utils/IosSimulatorUtils.ts
@@ -1,5 +1,5 @@
 import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
-import fs from 'node:fs';
+import fs from 'fs-extra';
 import os from 'node:os';
 import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
@@ -122,9 +122,10 @@ export namespace IosSimulatorUtils {
     udid: IosSimulatorUuid;
     env: NodeJS.ProcessEnv;
   }): Promise<void> {
+    const readinessScreenshotPath = '/tmp/shot.png';
     await retryAsync(
       async () => {
-        await spawn('xcrun', ['simctl', 'io', udid, 'screenshot', '/dev/null'], {
+        await spawn('xcrun', ['simctl', 'io', udid, 'screenshot', readinessScreenshotPath], {
           env,
         });
       },
@@ -136,6 +137,7 @@ export namespace IosSimulatorUtils {
         },
       }
     );
+    await fs.remove(readinessScreenshotPath);
 
     // Wait for data migration to complete before declaring the simulator ready
     // Based on WebKit's approach: https://trac.webkit.org/changeset/231452/webkit

--- a/packages/build-tools/src/utils/IosSimulatorUtils.ts
+++ b/packages/build-tools/src/utils/IosSimulatorUtils.ts
@@ -1,5 +1,5 @@
 import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
-import fs from 'fs-extra';
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
@@ -122,7 +122,7 @@ export namespace IosSimulatorUtils {
     udid: IosSimulatorUuid;
     env: NodeJS.ProcessEnv;
   }): Promise<void> {
-    const readinessScreenshotPath = '/tmp/shot.png';
+    const readinessScreenshotPath = path.join(os.tmpdir(), 'eas-simulator-readiness.png');
     await retryAsync(
       async () => {
         await spawn('xcrun', ['simctl', 'io', udid, 'screenshot', readinessScreenshotPath], {
@@ -137,7 +137,7 @@ export namespace IosSimulatorUtils {
         },
       }
     );
-    await fs.remove(readinessScreenshotPath);
+    await fs.promises.rm(readinessScreenshotPath, { force: true });
 
     // Wait for data migration to complete before declaring the simulator ready
     // Based on WebKit's approach: https://trac.webkit.org/changeset/231452/webkit

--- a/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
@@ -1,0 +1,44 @@
+import spawn from '@expo/turtle-spawn';
+import os from 'node:os';
+import path from 'node:path';
+
+import { IosSimulatorUtils } from '../IosSimulatorUtils';
+import { retryAsync } from '../retry';
+
+jest.mock('@expo/turtle-spawn', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../retry', () => ({
+  retryAsync: jest.fn(async fn => await fn(0)),
+}));
+
+const mockedSpawn = jest.mocked(spawn);
+
+describe('IosSimulatorUtils', () => {
+  beforeEach(() => {
+    mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
+  });
+
+  describe(IosSimulatorUtils.waitForReadyAsync, () => {
+    it('takes the readiness screenshot into a writable temp file, not /dev/null', async () => {
+      await IosSimulatorUtils.waitForReadyAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+      });
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        'xcrun',
+        [
+          'simctl',
+          'io',
+          'test-udid',
+          'screenshot',
+          path.join(os.tmpdir(), 'eas-simulator-readiness.png'),
+        ],
+        { env: process.env }
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Why

`eas/start_ios_simulator` never starts on the Xcode 26.4 image — it hangs ~30 min then fails.

`waitForReadyAsync` polls `xcrun simctl io <udid> screenshot /dev/null`. Since Xcode 26.4 `simctl io screenshot` writes the file atomically (temp file + rename in the destination's directory), so `/dev/null` fails — it tries to create a file in `/dev`, which the build user can't:

```
NSCocoaErrorDomain code=513: You don't have permission to save the file "null" in the folder "dev"
```

It fails every attempt, so the readiness retry burns its full 30-minute budget. Worked on Xcode 26.2 (which wrote directly to the path).

## How

Write the readiness screenshot to a real temp file (`/tmp/shot.png`) and remove it after. Works across Xcode versions.

## Test Plan

Reproduced on a custom build with the real `eas/start_ios_simulator`:

- Xcode 26.4 — hangs (cancelled after ~2.5 min): https://expo.dev/accounts/gwdp/projects/coin-flip/workflows/019e6802-de7d-71b7-9bd5-7bf811d6574c
- Xcode 26.2 — succeeds: https://expo.dev/accounts/gwdp/projects/coin-flip/workflows/019e6809-c230-7d68-9b18-6625951038c8
- `screenshot /dev/null` fails on 26.4 but a real path works (diagnostic): https://expo.dev/accounts/gwdp/projects/coin-flip/workflows/019e6802-d14d-763e-bd49-5365208727d1

`yarn typecheck` and `oxlint` pass.