### PR TITLE
[build-tools] disable apsd in iOS simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [build-tools] Fix `eas/start_ios_simulator` hanging on Xcode 26.4 by writing the readiness screenshot to a temp file instead of `/dev/null`. ([#3794](https://github.com/expo/eas-cli/pull/3794) by [@gwdp](https://github.com/gwdp))
+- [build-tools] Disable `apsd` in the iOS Simulator after boot to stop a push-registration log storm that pegs `diagnosticd` CPU for the lifetime of the Simulator. ([#3795](https://github.com/expo/eas-cli/pull/3795) by [@gwdp](https://github.com/gwdp))
 
 ### 🧹 Chores
 

--- a/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
@@ -1,0 +1,76 @@
+import spawn from '@expo/turtle-spawn';
+
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { IosSimulatorUtils } from '../../../utils/IosSimulatorUtils';
+import { createStartIosSimulatorBuildFunction } from '../startIosSimulator';
+
+jest.mock('@expo/turtle-spawn', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../../utils/IosSimulatorUtils', () => ({
+  IosSimulatorUtils: {
+    getAvailableDevicesAsync: jest.fn(),
+    getDeviceAsync: jest.fn(),
+    cloneAsync: jest.fn(),
+    startAsync: jest.fn(),
+    waitForReadyAsync: jest.fn(),
+    disableApsdAsync: jest.fn(),
+  },
+}));
+
+const mockedSpawn = jest.mocked(spawn);
+const mockedUtils = jest.mocked(IosSimulatorUtils);
+
+function createStep(callInputs?: Record<string, unknown>) {
+  const logger = createMockLogger();
+  const fn = createStartIosSimulatorBuildFunction();
+  const globalCtx = createGlobalContextMock({ logger });
+  const step = fn.createBuildStepFromFunctionCall(globalCtx, { callInputs });
+  return Object.assign(step, { logger });
+}
+
+describe(createStartIosSimulatorBuildFunction, () => {
+  beforeEach(() => {
+    mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
+    mockedUtils.getAvailableDevicesAsync.mockResolvedValue([]);
+    mockedUtils.getDeviceAsync.mockResolvedValue(null);
+    mockedUtils.cloneAsync.mockResolvedValue(undefined);
+    mockedUtils.startAsync.mockResolvedValue({ udid: 'test-udid' as any });
+    mockedUtils.waitForReadyAsync.mockResolvedValue(undefined);
+    mockedUtils.disableApsdAsync.mockResolvedValue(undefined);
+  });
+
+  it('disables apsd on the main device and every clone', async () => {
+    mockedUtils.startAsync
+      .mockResolvedValueOnce({ udid: 'base' as any })
+      .mockResolvedValueOnce({ udid: 'clone-1' as any })
+      .mockResolvedValueOnce({ udid: 'clone-2' as any });
+
+    await createStep({ device_identifier: 'iPhone 15', count: 2 }).executeAsync();
+
+    expect(mockedUtils.disableApsdAsync).toHaveBeenCalledWith({
+      udid: 'base',
+      env: expect.any(Object),
+    });
+    expect(mockedUtils.disableApsdAsync).toHaveBeenCalledWith({
+      udid: 'clone-1',
+      env: expect.any(Object),
+    });
+    expect(mockedUtils.disableApsdAsync).toHaveBeenCalledWith({
+      udid: 'clone-2',
+      env: expect.any(Object),
+    });
+  });
+
+  it('continues when disabling apsd fails', async () => {
+    mockedUtils.disableApsdAsync.mockRejectedValue(new Error('apsd disable failed'));
+
+    await createStep({ device_identifier: 'iPhone 15', count: 2 }).executeAsync();
+
+    // Startup is not aborted: readiness is still awaited for each device.
+    expect(mockedUtils.waitForReadyAsync).toHaveBeenCalled();
+  });
+});

--- a/packages/build-tools/src/steps/functions/startIosSimulator.ts
+++ b/packages/build-tools/src/steps/functions/startIosSimulator.ts
@@ -65,6 +65,12 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
         env,
       });
 
+      try {
+        await IosSimulatorUtils.disableApsdAsync({ udid, env });
+      } catch (error) {
+        logger.warn('Failed to disable apsd in the Simulator; continuing.', error);
+      }
+
       await IosSimulatorUtils.waitForReadyAsync({ udid, env });
 
       logger.info('');
@@ -95,6 +101,12 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
             deviceIdentifier: cloneDeviceName,
             env,
           });
+
+          try {
+            await IosSimulatorUtils.disableApsdAsync({ udid: cloneUdid, env });
+          } catch (error) {
+            logger.warn('Failed to disable apsd in the Simulator; continuing.', error);
+          }
 
           await IosSimulatorUtils.waitForReadyAsync({
             udid: cloneUdid,

--- a/packages/build-tools/src/steps/functions/startIosSimulator.ts
+++ b/packages/build-tools/src/steps/functions/startIosSimulator.ts
@@ -67,8 +67,8 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
 
       try {
         await IosSimulatorUtils.disableApsdAsync({ udid, env });
-      } catch (error) {
-        logger.warn('Failed to disable apsd in the Simulator; continuing.', error);
+      } catch (err) {
+        logger.warn({ err }, 'Failed to disable apsd in the Simulator.');
       }
 
       await IosSimulatorUtils.waitForReadyAsync({ udid, env });
@@ -104,8 +104,8 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
 
           try {
             await IosSimulatorUtils.disableApsdAsync({ udid: cloneUdid, env });
-          } catch (error) {
-            logger.warn('Failed to disable apsd in the Simulator; continuing.', error);
+          } catch (err) {
+            logger.warn({ err }, 'Failed to disable apsd in the Simulator.');
           }
 
           await IosSimulatorUtils.waitForReadyAsync({

--- a/packages/build-tools/src/utils/IosSimulatorUtils.ts
+++ b/packages/build-tools/src/utils/IosSimulatorUtils.ts
@@ -157,6 +157,25 @@ export namespace IosSimulatorUtils {
     );
   }
 
+  export async function disableApsdAsync({
+    udid,
+    env,
+  }: {
+    udid: IosSimulatorUuid;
+    env: NodeJS.ProcessEnv;
+  }): Promise<void> {
+    await spawn(
+      'xcrun',
+      ['simctl', 'spawn', udid, 'launchctl', 'disable', 'system/com.apple.apsd'],
+      { env }
+    );
+    await spawn(
+      'xcrun',
+      ['simctl', 'spawn', udid, 'launchctl', 'bootout', 'system/com.apple.apsd'],
+      { env }
+    );
+  }
+
   export async function collectLogsAsync({
     deviceIdentifier,
     env,

--- a/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
@@ -41,4 +41,24 @@ describe('IosSimulatorUtils', () => {
       );
     });
   });
+
+  describe(IosSimulatorUtils.disableApsdAsync, () => {
+    it('disables and boots out apsd in the simulator', async () => {
+      await IosSimulatorUtils.disableApsdAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+      });
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        'xcrun',
+        ['simctl', 'spawn', 'test-udid', 'launchctl', 'disable', 'system/com.apple.apsd'],
+        { env: process.env }
+      );
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        'xcrun',
+        ['simctl', 'spawn', 'test-udid', 'launchctl', 'bootout', 'system/com.apple.apsd'],
+        { env: process.env }
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Why

`apsd` (the push daemon) can't get a push token in the Simulator — a fresh Simulator has no push identity — so it retries forever and floods the system log. That keeps `diagnosticd` busy for the whole life of the Simulator, eating about a CPU core. Simulators can't get real pushes anyway.

Seen on Xcode 16.4, 26.2 and 26.4.

## How

Disable `apsd` as soon as the Simulator boots, before we wait for it to be ready:

```
xcrun simctl spawn <udid> launchctl disable system/com.apple.apsd
xcrun simctl spawn <udid> launchctl bootout system/com.apple.apsd
```

If it fails, we warn and keep going. Same for cloned Simulators.

## Results

Idle Simulator, Xcode 26.4:

| | apsd on | apsd off |
| --- | --- | --- |
| apsd logs/min | ~100k | ~0 |
| diagnosticd CPU | ~30-50% | ~0% |
| Simulator CPU | ~75% | ~0% |

App launch time was the same either way (~210ms).

## Test Plan

- Unit test for `disableApsdAsync`.
- Before/after on a build (Xcode 26.4): https://expo.dev/accounts/gwdp/projects/coin-flip/workflows/019e66ad-11c5-7ae1-a5a8-f4f590b2b8f8
- Watched it stay idle for 3 min with apsd off: https://expo.dev/accounts/gwdp/projects/coin-flip/workflows/019e67e4-9a80-7416-b631-25de268b9b15
- `yarn typecheck`, `oxlint`, tests pass.

## Notes

Still not sure why iOS 26.0 didn't storm. There apsd connected once and went quiet, while 16.4, 26.2 and 26.4 all kept spamming — same missing token, same network. Haven't worked out what's different about 26.0.
