### PR TITLE
[build-tools] Use ngrok tunnels for remote device run sessions

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -50,6 +50,7 @@
     "@expo/turtle-spawn": "19.0.0",
     "@expo/xcpretty": "^4.3.1",
     "@google-cloud/storage": "^7.11.2",
+    "@ngrok/ngrok": "1.7.0",
     "@sentry/node": "7.77.0",
     "@urql/core": "^6.0.1",
     "bplist-parser": "0.3.2",

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -13,8 +13,9 @@ import path from 'node:path';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import {
-  ensureNgrokInstalledAsync,
+  ensureNgrokCliInstalledAsync,
   getDeviceRunSessionIdOrThrow,
+  getNgrokAuthtokenOrThrow,
   getNgrokTunnelDomainOrThrow,
   spawnDetached,
   startNgrokTunnelAsync,
@@ -46,11 +47,12 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
     ],
     fn: async ({ logger, global }, { inputs, env }) => {
       // Fail fast before any expensive setup if the orchestrator-injected env
-      // vars are missing: DEVICE_RUN_SESSION_ID (needed to report the remote
-      // config back to the API server) and EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN
-      // (the base domain for the ngrok tunnels we open below).
+      // vars are missing: DEVICE_RUN_SESSION_ID (to report the remote config
+      // back to the API server), EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN (base domain
+      // for our ngrok tunnels), and NGROK_AUTHTOKEN (to authenticate them).
       const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
       const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
+      const ngrokAuthtoken = getNgrokAuthtokenOrThrow(env);
 
       const packageVersion = inputs.package_version.value as string | undefined;
       const { runtimePlatform } = global;
@@ -62,13 +64,6 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
         logger.info(`Selecting Xcode developer directory: ${XCODE_DEVELOPER_DIR}.`);
         await spawn('sudo', ['xcode-select', '-s', XCODE_DEVELOPER_DIR], { env, logger });
       }
-
-      logger.info('Ensuring ngrok is installed.');
-      const ngrokCommand = await ensureNgrokInstalledAsync({
-        runtimePlatform,
-        env,
-        logger,
-      });
 
       logger.info(
         packageVersion
@@ -102,13 +97,11 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       logger.info(`Daemon is listening on port ${daemonPort}; loaded auth token.`);
 
       const agentDeviceRemoteSessionUrl = await startNgrokTunnelAsync({
-        ngrokCommand,
         port: daemonPort,
         subdomainPrefix: 'agent-device',
         baseDomain: ngrokTunnelDomain,
-        env,
+        authtoken: ngrokAuthtoken,
         logger,
-        timeoutMs: STARTUP_TIMEOUT_MS,
       });
       logger.info(`Tunnel is ready at ${agentDeviceRemoteSessionUrl}.`);
 
@@ -116,6 +109,8 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       // on Darwin. Android sessions go without a preview URL.
       let webPreviewUrl: string | undefined;
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
+        logger.info('Ensuring ngrok CLI is installed for serve-sim.');
+        await ensureNgrokCliInstalledAsync({ env, logger });
         const { previewUrl } = await startServeSimWithTunnelAsync({
           baseDomain: ngrokTunnelDomain,
           env,

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -13,7 +13,6 @@ import path from 'node:path';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import {
-  ensureNgrokCliInstalledAsync,
   getDeviceRunSessionIdOrThrow,
   getNgrokAuthtokenOrThrow,
   getNgrokTunnelDomainOrThrow,
@@ -109,8 +108,6 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       // on Darwin. Android sessions go without a preview URL.
       let webPreviewUrl: string | undefined;
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
-        logger.info('Ensuring ngrok CLI is installed for serve-sim.');
-        await ensureNgrokCliInstalledAsync({ env, logger });
         const { previewUrl } = await startServeSimWithTunnelAsync({
           baseDomain: ngrokTunnelDomain,
           env,

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -45,7 +45,7 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       }),
     ],
     fn: async ({ logger, global }, { inputs, env }) => {
-      // Fail fast before any expensive setup if the orchestrator-injected env
+      // Fail fast before any expensive setup if the injected env
       // vars are missing: DEVICE_RUN_SESSION_ID (to report the remote config
       // back to the API server), EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN (base domain
       // for our ngrok tunnels), and NGROK_AUTHTOKEN (to authenticate them).

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -13,13 +13,14 @@ import path from 'node:path';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import {
-  ensureCloudflaredInstalledAsync,
+  ensureNgrokInstalledAsync,
   getDeviceRunSessionIdOrThrow,
+  getNgrokTunnelDomainOrThrow,
   spawnDetached,
+  startNgrokTunnelAsync,
   startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
   waitForFileAsync,
-  waitForMatchInOutputAsync,
 } from '../utils/remoteDeviceRunSession';
 
 const AGENT_DEVICE_REPO_URL = 'https://github.com/callstackincubator/agent-device.git';
@@ -44,10 +45,12 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       }),
     ],
     fn: async ({ logger, global }, { inputs, env }) => {
-      // Fail fast before any expensive setup if the orchestrator-injected
-      // DEVICE_RUN_SESSION_ID env var is missing — without it we cannot
-      // report the remote config back to the API server.
+      // Fail fast before any expensive setup if the orchestrator-injected env
+      // vars are missing: DEVICE_RUN_SESSION_ID (needed to report the remote
+      // config back to the API server) and EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN
+      // (the base domain for the ngrok tunnels we open below).
       const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
+      const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
 
       const packageVersion = inputs.package_version.value as string | undefined;
       const { runtimePlatform } = global;
@@ -60,8 +63,8 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
         await spawn('sudo', ['xcode-select', '-s', XCODE_DEVELOPER_DIR], { env, logger });
       }
 
-      logger.info('Ensuring cloudflared is installed.');
-      const cloudflaredCommand = await ensureCloudflaredInstalledAsync({
+      logger.info('Ensuring ngrok is installed.');
+      const ngrokCommand = await ensureNgrokInstalledAsync({
         runtimePlatform,
         env,
         logger,
@@ -98,19 +101,14 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       });
       logger.info(`Daemon is listening on port ${daemonPort}; loaded auth token.`);
 
-      logger.info(`Starting cloudflared tunnel to http://localhost:${daemonPort}.`);
-      const cloudflared = spawnDetached({
-        command: cloudflaredCommand,
-        args: ['tunnel', '--url', `http://localhost:${daemonPort}`],
+      const agentDeviceRemoteSessionUrl = await startNgrokTunnelAsync({
+        ngrokCommand,
+        port: daemonPort,
+        subdomainPrefix: 'agent-device',
+        baseDomain: ngrokTunnelDomain,
         env,
-      });
-
-      logger.info('Waiting for a public tunnel URL.');
-      const agentDeviceRemoteSessionUrl = await waitForMatchInOutputAsync({
-        process: cloudflared,
-        pattern: /https:\/\/[a-z0-9-]+\.trycloudflare\.com/,
+        logger,
         timeoutMs: STARTUP_TIMEOUT_MS,
-        description: 'cloudflared tunnel',
       });
       logger.info(`Tunnel is ready at ${agentDeviceRemoteSessionUrl}.`);
 
@@ -119,6 +117,7 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       let webPreviewUrl: string | undefined;
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
         const { previewUrl } = await startServeSimWithTunnelAsync({
+          baseDomain: ngrokTunnelDomain,
           env,
           logger,
           timeoutMs: STARTUP_TIMEOUT_MS,

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -13,7 +13,6 @@ import { z } from 'zod';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import {
-  ensureNgrokCliInstalledAsync,
   getDeviceRunSessionIdOrThrow,
   getNgrokAuthtokenOrThrow,
   getNgrokTunnelDomainOrThrow,
@@ -102,8 +101,6 @@ export function createStartArgentRemoteSessionBuildFunction(
       // serve-sim is iOS-only — Android sessions go without a preview URL.
       let webPreviewUrl: string | undefined;
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
-        logger.info('Ensuring ngrok CLI is installed for serve-sim.');
-        await ensureNgrokCliInstalledAsync({ env, logger });
         const serveSim = await startServeSimWithTunnelAsync({
           baseDomain: ngrokTunnelDomain,
           env,

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -13,8 +13,9 @@ import { z } from 'zod';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import {
-  ensureNgrokInstalledAsync,
+  ensureNgrokCliInstalledAsync,
   getDeviceRunSessionIdOrThrow,
+  getNgrokAuthtokenOrThrow,
   getNgrokTunnelDomainOrThrow,
   spawnDetached,
   startNgrokTunnelAsync,
@@ -47,11 +48,12 @@ export function createStartArgentRemoteSessionBuildFunction(
     ],
     fn: async ({ logger, global }, { inputs, env }) => {
       // Fail fast before any expensive setup if the orchestrator-injected env
-      // vars are missing: DEVICE_RUN_SESSION_ID (needed to report the remote
-      // config back to the API server) and EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN
-      // (the base domain for the ngrok tunnels we open below).
+      // vars are missing: DEVICE_RUN_SESSION_ID (to report the remote config
+      // back to the API server), EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN (base domain
+      // for our ngrok tunnels), and NGROK_AUTHTOKEN (to authenticate them).
       const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
       const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
+      const ngrokAuthtoken = getNgrokAuthtokenOrThrow(env);
 
       const packageVersion = inputs.package_version.value as string | undefined;
       const versionSpec = packageVersion ?? 'latest';
@@ -64,13 +66,6 @@ export function createStartArgentRemoteSessionBuildFunction(
         logger.info(`Selecting Xcode developer directory: ${XCODE_DEVELOPER_DIR}.`);
         await spawn('sudo', ['xcode-select', '-s', XCODE_DEVELOPER_DIR], { env, logger });
       }
-
-      logger.info('Ensuring ngrok is installed.');
-      const ngrokCommand = await ensureNgrokInstalledAsync({
-        runtimePlatform,
-        env,
-        logger,
-      });
 
       // Stale state from a previous run would mask the new server's port.
       await fs.promises.rm(ARGENT_STATE_FILE, { force: true });
@@ -96,19 +91,19 @@ export function createStartArgentRemoteSessionBuildFunction(
       logger.info(`Argent tool-server is listening on port ${toolServerPort}.`);
 
       const toolsUrl = await startNgrokTunnelAsync({
-        ngrokCommand,
         port: toolServerPort,
         subdomainPrefix: 'argent',
         baseDomain: ngrokTunnelDomain,
-        env,
+        authtoken: ngrokAuthtoken,
         logger,
-        timeoutMs: STARTUP_TIMEOUT_MS,
       });
       logger.info(`Tunnel is ready at ${toolsUrl}.`);
 
       // serve-sim is iOS-only — Android sessions go without a preview URL.
       let webPreviewUrl: string | undefined;
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
+        logger.info('Ensuring ngrok CLI is installed for serve-sim.');
+        await ensureNgrokCliInstalledAsync({ env, logger });
         const serveSim = await startServeSimWithTunnelAsync({
           baseDomain: ngrokTunnelDomain,
           env,

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -46,7 +46,7 @@ export function createStartArgentRemoteSessionBuildFunction(
       }),
     ],
     fn: async ({ logger, global }, { inputs, env }) => {
-      // Fail fast before any expensive setup if the orchestrator-injected env
+      // Fail fast before any expensive setup if the injected env
       // vars are missing: DEVICE_RUN_SESSION_ID (to report the remote config
       // back to the API server), EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN (base domain
       // for our ngrok tunnels), and NGROK_AUTHTOKEN (to authenticate them).

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -13,13 +13,14 @@ import { z } from 'zod';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import {
-  ensureCloudflaredInstalledAsync,
+  ensureNgrokInstalledAsync,
   getDeviceRunSessionIdOrThrow,
+  getNgrokTunnelDomainOrThrow,
   spawnDetached,
+  startNgrokTunnelAsync,
   startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
   waitForFileAsync,
-  waitForMatchInOutputAsync,
 } from '../utils/remoteDeviceRunSession';
 
 const ARGENT_PACKAGE_NAME = '@swmansion/argent';
@@ -45,10 +46,12 @@ export function createStartArgentRemoteSessionBuildFunction(
       }),
     ],
     fn: async ({ logger, global }, { inputs, env }) => {
-      // Fail fast before any expensive setup if the orchestrator-injected
-      // DEVICE_RUN_SESSION_ID env var is missing — without it we cannot
-      // report the remote config back to the API server.
+      // Fail fast before any expensive setup if the orchestrator-injected env
+      // vars are missing: DEVICE_RUN_SESSION_ID (needed to report the remote
+      // config back to the API server) and EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN
+      // (the base domain for the ngrok tunnels we open below).
       const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
+      const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
 
       const packageVersion = inputs.package_version.value as string | undefined;
       const versionSpec = packageVersion ?? 'latest';
@@ -62,8 +65,8 @@ export function createStartArgentRemoteSessionBuildFunction(
         await spawn('sudo', ['xcode-select', '-s', XCODE_DEVELOPER_DIR], { env, logger });
       }
 
-      logger.info('Ensuring cloudflared is installed.');
-      const cloudflaredCommand = await ensureCloudflaredInstalledAsync({
+      logger.info('Ensuring ngrok is installed.');
+      const ngrokCommand = await ensureNgrokInstalledAsync({
         runtimePlatform,
         env,
         logger,
@@ -92,19 +95,14 @@ export function createStartArgentRemoteSessionBuildFunction(
       });
       logger.info(`Argent tool-server is listening on port ${toolServerPort}.`);
 
-      logger.info(`Starting cloudflared tunnel to http://localhost:${toolServerPort}.`);
-      const cloudflared = spawnDetached({
-        command: cloudflaredCommand,
-        args: ['tunnel', '--url', `http://localhost:${toolServerPort}`],
+      const toolsUrl = await startNgrokTunnelAsync({
+        ngrokCommand,
+        port: toolServerPort,
+        subdomainPrefix: 'argent',
+        baseDomain: ngrokTunnelDomain,
         env,
-      });
-
-      logger.info('Waiting for a public tunnel URL.');
-      const toolsUrl = await waitForMatchInOutputAsync({
-        process: cloudflared,
-        pattern: /https:\/\/[a-z0-9-]+\.trycloudflare\.com/,
+        logger,
         timeoutMs: STARTUP_TIMEOUT_MS,
-        description: 'cloudflared tunnel',
       });
       logger.info(`Tunnel is ready at ${toolsUrl}.`);
 
@@ -112,6 +110,7 @@ export function createStartArgentRemoteSessionBuildFunction(
       let webPreviewUrl: string | undefined;
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
         const serveSim = await startServeSimWithTunnelAsync({
+          baseDomain: ngrokTunnelDomain,
           env,
           logger,
           timeoutMs: STARTUP_TIMEOUT_MS,

--- a/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
@@ -3,7 +3,7 @@ import spawn from '@expo/turtle-spawn';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import {
-  ensureNgrokInstalledAsync,
+  ensureNgrokCliInstalledAsync,
   getDeviceRunSessionIdOrThrow,
   getNgrokTunnelDomainOrThrow,
   startServeSimWithTunnelAsync,
@@ -22,18 +22,17 @@ export function createStartServeSimRemoteSessionBuildFunction(
     name: 'Start serve-sim remote session',
     __metricsId: 'eas/start_serve_sim_remote_session',
     supportedRuntimePlatforms: [BuildRuntimePlatform.DARWIN],
-    fn: async ({ logger, global }, { env }) => {
+    fn: async ({ logger }, { env }) => {
       const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
       const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
-      const { runtimePlatform } = global;
 
       logger.info('Starting serve-sim remote session.');
 
       logger.info(`Selecting Xcode developer directory: ${XCODE_DEVELOPER_DIR}.`);
       await spawn('sudo', ['xcode-select', '-s', XCODE_DEVELOPER_DIR], { env, logger });
 
-      logger.info('Ensuring ngrok is installed.');
-      await ensureNgrokInstalledAsync({ runtimePlatform, env, logger });
+      logger.info('Ensuring ngrok CLI is installed for serve-sim.');
+      await ensureNgrokCliInstalledAsync({ env, logger });
 
       const { previewUrl, streamUrl } = await startServeSimWithTunnelAsync({
         baseDomain: ngrokTunnelDomain,

--- a/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
@@ -3,7 +3,6 @@ import spawn from '@expo/turtle-spawn';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import {
-  ensureNgrokCliInstalledAsync,
   getDeviceRunSessionIdOrThrow,
   getNgrokTunnelDomainOrThrow,
   startServeSimWithTunnelAsync,
@@ -30,9 +29,6 @@ export function createStartServeSimRemoteSessionBuildFunction(
 
       logger.info(`Selecting Xcode developer directory: ${XCODE_DEVELOPER_DIR}.`);
       await spawn('sudo', ['xcode-select', '-s', XCODE_DEVELOPER_DIR], { env, logger });
-
-      logger.info('Ensuring ngrok CLI is installed for serve-sim.');
-      await ensureNgrokCliInstalledAsync({ env, logger });
 
       const { previewUrl, streamUrl } = await startServeSimWithTunnelAsync({
         baseDomain: ngrokTunnelDomain,

--- a/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
@@ -3,8 +3,9 @@ import spawn from '@expo/turtle-spawn';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import {
+  ensureNgrokInstalledAsync,
   getDeviceRunSessionIdOrThrow,
-  ensureBrewPackageInstalledAsync,
+  getNgrokTunnelDomainOrThrow,
   startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
 } from '../utils/remoteDeviceRunSession';
@@ -21,18 +22,21 @@ export function createStartServeSimRemoteSessionBuildFunction(
     name: 'Start serve-sim remote session',
     __metricsId: 'eas/start_serve_sim_remote_session',
     supportedRuntimePlatforms: [BuildRuntimePlatform.DARWIN],
-    fn: async ({ logger }, { env }) => {
+    fn: async ({ logger, global }, { env }) => {
       const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
+      const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
+      const { runtimePlatform } = global;
 
       logger.info('Starting serve-sim remote session.');
 
       logger.info(`Selecting Xcode developer directory: ${XCODE_DEVELOPER_DIR}.`);
       await spawn('sudo', ['xcode-select', '-s', XCODE_DEVELOPER_DIR], { env, logger });
 
-      logger.info('Ensuring cloudflared is installed.');
-      await ensureBrewPackageInstalledAsync({ name: 'cloudflared', env, logger });
+      logger.info('Ensuring ngrok is installed.');
+      await ensureNgrokInstalledAsync({ runtimePlatform, env, logger });
 
       const { previewUrl, streamUrl } = await startServeSimWithTunnelAsync({
+        baseDomain: ngrokTunnelDomain,
         env,
         logger,
         timeoutMs: STARTUP_TIMEOUT_MS,

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -29,7 +29,7 @@ export function getDeviceRunSessionIdOrThrow(env: BuildStepEnv): string {
   if (!deviceRunSessionId) {
     throw new SystemError(
       'DEVICE_RUN_SESSION_ID is not set. ' +
-        'This step must run as part of a device run session created by the API server, ' +
+        'This step must run as part of a device run session ' +
         'which injects DEVICE_RUN_SESSION_ID into the job environment.'
     );
   }
@@ -41,9 +41,8 @@ export function getNgrokTunnelDomainOrThrow(env: BuildStepEnv): string {
   if (!baseDomain) {
     throw new SystemError(
       'EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN is not set. ' +
-        'This step must run as part of a device run session created by the API server, ' +
-        'which injects EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN (the base domain for ngrok ' +
-        'tunnels, e.g. expo-simulator.ngrok.dev) into the job environment.'
+        'This step must run as part of a device run session ' +
+        'which injects EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN into the job environment.'
     );
   }
   return baseDomain;
@@ -54,7 +53,7 @@ export function getNgrokAuthtokenOrThrow(env: BuildStepEnv): string {
   if (!authtoken) {
     throw new SystemError(
       'NGROK_AUTHTOKEN is not set. ' +
-        'This step must run as part of a device run session created by the API server, ' +
+        'This step must run as part of a device run session ' +
         'which injects NGROK_AUTHTOKEN into the job environment.'
     );
   }
@@ -154,8 +153,8 @@ export async function startServeSimWithTunnelAsync({
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const output = serveSim.getOutput();
-    const previewUrl = matchLabeledUrl(output, 'Tunnel', baseDomain);
-    const streamUrl = matchLabeledUrl(output, 'Stream', baseDomain);
+    const previewUrl = matchLabeledUrl({ output, label: 'Tunnel', baseDomain });
+    const streamUrl = matchLabeledUrl({ output, label: 'Stream', baseDomain });
     if (previewUrl && streamUrl) {
       return { previewUrl, streamUrl };
     }
@@ -166,11 +165,19 @@ export async function startServeSimWithTunnelAsync({
   );
 }
 
-function matchLabeledUrl(content: string, label: string, baseDomain: string): string | null {
+function matchLabeledUrl({
+  output,
+  label,
+  baseDomain,
+}: {
+  output: string;
+  label: string;
+  baseDomain: string;
+}): string | null {
   const labelPattern = new RegExp(
     `${label}:\\s*(https:\\/\\/[a-z0-9-]+\\.${escapeRegExp(baseDomain)})`
   );
-  const match = labelPattern.exec(content);
+  const match = labelPattern.exec(output);
   return match ? match[1] : null;
 }
 

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -1,18 +1,14 @@
 import { SystemError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
-import { BuildRuntimePlatform, BuildStepEnv } from '@expo/steps';
+import { BuildStepEnv } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
+import * as ngrok from '@ngrok/ngrok';
 import { graphql } from 'gql.tada';
 import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import { sleepAsync } from '../../utils/retry';
-
-const NGROK_LINUX_INSTALL_DIR = '/usr/local/bin';
-const NGROK_LINUX_INSTALL_PATH = `${NGROK_LINUX_INSTALL_DIR}/ngrok`;
 
 const START_DEVICE_RUN_SESSION_MUTATION = graphql(`
   mutation StartDeviceRunSession($deviceRunSessionId: ID!, $remoteConfig: JSONObject!) {
@@ -51,6 +47,18 @@ export function getNgrokTunnelDomainOrThrow(env: BuildStepEnv): string {
     );
   }
   return baseDomain;
+}
+
+export function getNgrokAuthtokenOrThrow(env: BuildStepEnv): string {
+  const authtoken = env.NGROK_AUTHTOKEN;
+  if (!authtoken) {
+    throw new SystemError(
+      'NGROK_AUTHTOKEN is not set. ' +
+        'This step must run as part of a device run session created by the API server, ' +
+        'which injects NGROK_AUTHTOKEN into the job environment.'
+    );
+  }
+  return authtoken;
 }
 
 export async function uploadRemoteSessionConfigAsync({
@@ -166,104 +174,48 @@ function matchLabeledUrl(content: string, label: string, baseDomain: string): st
   return match ? match[1] : null;
 }
 
-export async function ensureNgrokInstalledAsync({
-  runtimePlatform,
+// serve-sim shells out to the `ngrok` CLI for `--tunnel-provider ngrok`, so it
+// needs the agent on PATH. serve-sim is macOS-only, so Homebrew suffices. Our
+// own tunnels use the in-process SDK (startNgrokTunnelAsync) and need no CLI.
+export async function ensureNgrokCliInstalledAsync({
   env,
   logger,
 }: {
-  runtimePlatform: BuildRuntimePlatform;
   env: BuildStepEnv;
   logger: bunyan;
-}): Promise<string> {
+}): Promise<void> {
   if (await isCommandAvailableAsync({ command: 'ngrok', env })) {
-    return 'ngrok';
+    return;
   }
-  if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
-    await spawn('bash', ['-c', 'HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask ngrok'], {
-      env,
-      logger,
-    });
-    return 'ngrok';
-  }
-  const arch = linuxArchForNodeArch(os.arch());
-  const downloadUrl = `https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-${arch}.tgz`;
-  logger.info(`Downloading ngrok from ${downloadUrl} to ${NGROK_LINUX_INSTALL_PATH}.`);
-  await spawn(
-    'bash',
-    ['-c', `curl -fsSL "${downloadUrl}" | sudo tar -xzf - -C "${NGROK_LINUX_INSTALL_DIR}" ngrok`],
-    { env, logger }
-  );
-  await spawn('sudo', ['chmod', '+x', NGROK_LINUX_INSTALL_PATH], { env, logger });
-  // Return the absolute install path so the tunnel command works even when
-  // /usr/local/bin is not on the step's PATH.
-  return NGROK_LINUX_INSTALL_PATH;
-}
-
-function linuxArchForNodeArch(arch: string): 'amd64' | 'arm64' {
-  if (arch === 'x64') {
-    return 'amd64';
-  }
-  if (arch === 'arm64') {
-    return 'arm64';
-  }
-  throw new SystemError(
-    `Unsupported architecture for ngrok on Linux: "${arch}". Expected "x64" or "arm64".`
-  );
+  await spawn('bash', ['-c', 'HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask ngrok'], {
+    env,
+    logger,
+  });
 }
 
 export async function startNgrokTunnelAsync({
-  ngrokCommand,
   port,
   subdomainPrefix,
   baseDomain,
-  env,
+  authtoken,
   logger,
-  timeoutMs,
 }: {
-  ngrokCommand: string;
   port: number;
   subdomainPrefix: string;
   baseDomain: string;
-  env: BuildStepEnv;
+  authtoken: string;
   logger: bunyan;
-  timeoutMs: number;
 }): Promise<string> {
-  const url = `https://${subdomainPrefix}-${randomBytes(8).toString('hex')}.${baseDomain}`;
-
-  // ngrok serves its inspection web UI on 127.0.0.1:4040 and offers no CLI flag
-  // to move it, but serve-sim runs a second ngrok agent on the same host — so
-  // two agents would fight over that port. We read the tunnel URL from the
-  // agent's stdout logs rather than the web UI, so disable it via config.
-  const configDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ngrok-'));
-  const configPath = path.join(configDir, 'ngrok.yml');
-  await fs.promises.writeFile(configPath, 'version: "3"\nagent:\n  web_addr: false\n');
-
-  logger.info(`Starting ngrok tunnel ${url} -> http://localhost:${port}.`);
-  const ngrok = spawnDetached({
-    command: ngrokCommand,
-    args: [
-      'http',
-      String(port),
-      '--url',
-      url,
-      '--log',
-      'stdout',
-      '--log-format',
-      'logfmt',
-      '--config',
-      configPath,
-    ],
-    env,
-  });
-
-  // The agent echoes the endpoint URL back once the tunnel is live; wait for it
-  // so we never report a URL the client cannot reach yet.
-  await waitForMatchInOutputAsync({
-    process: ngrok,
-    pattern: new RegExp(escapeRegExp(url)),
-    timeoutMs,
-    description: `ngrok tunnel ${url}`,
-  });
+  const domain = `${subdomainPrefix}-${randomBytes(8).toString('hex')}.${baseDomain}`;
+  logger.info(`Starting ngrok tunnel ${domain} -> http://localhost:${port}.`);
+  // Run the ngrok agent in-process via the SDK. The SDK keeps the session alive
+  // until the process exits (the step blocks forever to hold it open), and it
+  // has no local web UI, so it never collides with serve-sim's own ngrok agent.
+  const listener = await ngrok.forward({ addr: port, authtoken, domain });
+  const url = listener.url();
+  if (!url) {
+    throw new SystemError(`ngrok tunnel for ${domain} did not return a public URL.`);
+  }
   return url;
 }
 
@@ -284,30 +236,6 @@ async function isCommandAvailableAsync({
   } catch {
     return false;
   }
-}
-
-export async function waitForMatchInOutputAsync({
-  process,
-  pattern,
-  timeoutMs,
-  description,
-}: {
-  process: DetachedProcessHandle;
-  pattern: RegExp;
-  timeoutMs: number;
-  description: string;
-}): Promise<string> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const match = pattern.exec(process.getOutput());
-    if (match) {
-      return match[1] ?? match[0];
-    }
-    await sleepAsync(1_000);
-  }
-  throw new SystemError(
-    `Timed out waiting for ${description} to start. Last output:\n${process.getOutput() || '<empty>'}`
-  );
 }
 
 export async function waitForFileAsync<T>({

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -3,14 +3,16 @@ import { bunyan } from '@expo/logger';
 import { BuildRuntimePlatform, BuildStepEnv } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
 import { graphql } from 'gql.tada';
+import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
+import path from 'node:path';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import { sleepAsync } from '../../utils/retry';
 
-const TRYCLOUDFLARE_URL_PATTERN = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
-const CLOUDFLARED_LINUX_INSTALL_PATH = '/usr/local/bin/cloudflared';
+const NGROK_LINUX_INSTALL_DIR = '/usr/local/bin';
+const NGROK_LINUX_INSTALL_PATH = `${NGROK_LINUX_INSTALL_DIR}/ngrok`;
 
 const START_DEVICE_RUN_SESSION_MUTATION = graphql(`
   mutation StartDeviceRunSession($deviceRunSessionId: ID!, $remoteConfig: JSONObject!) {
@@ -38,6 +40,19 @@ export function getDeviceRunSessionIdOrThrow(env: BuildStepEnv): string {
   return deviceRunSessionId;
 }
 
+export function getNgrokTunnelDomainOrThrow(env: BuildStepEnv): string {
+  const baseDomain = env.EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN;
+  if (!baseDomain) {
+    throw new SystemError(
+      'EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN is not set. ' +
+        'This step must run as part of a device run session created by the API server, ' +
+        'which injects EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN (the base domain for ngrok ' +
+        'tunnels, e.g. expo-simulator.ngrok.dev) into the job environment.'
+    );
+  }
+  return baseDomain;
+}
+
 export async function uploadRemoteSessionConfigAsync({
   ctx,
   deviceRunSessionId,
@@ -60,22 +75,6 @@ export async function uploadRemoteSessionConfigAsync({
       `Failed to start device run session ${deviceRunSessionId}: ${result.error.message}`
     );
   }
-}
-
-export async function ensureBrewPackageInstalledAsync({
-  name,
-  env,
-  logger,
-}: {
-  name: string;
-  env: BuildStepEnv;
-  logger: bunyan;
-}): Promise<void> {
-  await spawn(
-    'bash',
-    ['-c', `command -v ${name} >/dev/null 2>&1 || HOMEBREW_NO_AUTO_UPDATE=1 brew install ${name}`],
-    { env, logger }
-  );
 }
 
 export type DetachedProcessHandle = {
@@ -115,10 +114,12 @@ export function spawnDetached({
 }
 
 export async function startServeSimWithTunnelAsync({
+  baseDomain,
   env,
   logger,
   timeoutMs,
 }: {
+  baseDomain: string;
   env: BuildStepEnv;
   logger: bunyan;
   timeoutMs: number;
@@ -129,8 +130,10 @@ export async function startServeSimWithTunnelAsync({
     args: [
       'serve-sim-szdziedzic@latest',
       '--tunnel',
-      '--tunnel-protocol',
-      'quic',
+      '--tunnel-provider',
+      'ngrok',
+      '--tunnel-domain',
+      baseDomain,
       '--stream-max-dimension',
       '1280',
       '--stream-quality',
@@ -143,8 +146,8 @@ export async function startServeSimWithTunnelAsync({
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const output = serveSim.getOutput();
-    const previewUrl = matchLabeledUrl(output, 'Tunnel');
-    const streamUrl = matchLabeledUrl(output, 'Stream');
+    const previewUrl = matchLabeledUrl(output, 'Tunnel', baseDomain);
+    const streamUrl = matchLabeledUrl(output, 'Stream', baseDomain);
     if (previewUrl && streamUrl) {
       return { previewUrl, streamUrl };
     }
@@ -155,13 +158,15 @@ export async function startServeSimWithTunnelAsync({
   );
 }
 
-function matchLabeledUrl(content: string, label: string): string | null {
-  const labelPattern = new RegExp(`${label}:\\s*(${TRYCLOUDFLARE_URL_PATTERN.source})`);
+function matchLabeledUrl(content: string, label: string, baseDomain: string): string | null {
+  const labelPattern = new RegExp(
+    `${label}:\\s*(https:\\/\\/[a-z0-9-]+\\.${escapeRegExp(baseDomain)})`
+  );
   const match = labelPattern.exec(content);
   return match ? match[1] : null;
 }
 
-export async function ensureCloudflaredInstalledAsync({
+export async function ensureNgrokInstalledAsync({
   runtimePlatform,
   env,
   logger,
@@ -170,27 +175,31 @@ export async function ensureCloudflaredInstalledAsync({
   env: BuildStepEnv;
   logger: bunyan;
 }): Promise<string> {
+  if (await isCommandAvailableAsync({ command: 'ngrok', env })) {
+    return 'ngrok';
+  }
   if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
-    await ensureBrewPackageInstalledAsync({ name: 'cloudflared', env, logger });
-    return 'cloudflared';
+    await spawn('bash', ['-c', 'HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask ngrok'], {
+      env,
+      logger,
+    });
+    return 'ngrok';
   }
-  if (await isCommandAvailableAsync({ command: 'cloudflared', env })) {
-    return 'cloudflared';
-  }
-  const cloudflaredArch = cloudflaredLinuxArchForNodeArch(os.arch());
-  const downloadUrl = `https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-${cloudflaredArch}`;
-  logger.info(`Downloading cloudflared from ${downloadUrl} to ${CLOUDFLARED_LINUX_INSTALL_PATH}.`);
-  await spawn('sudo', ['curl', '-fsSL', '-o', CLOUDFLARED_LINUX_INSTALL_PATH, downloadUrl], {
-    env,
-    logger,
-  });
-  await spawn('sudo', ['chmod', '+x', CLOUDFLARED_LINUX_INSTALL_PATH], { env, logger });
+  const arch = linuxArchForNodeArch(os.arch());
+  const downloadUrl = `https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-${arch}.tgz`;
+  logger.info(`Downloading ngrok from ${downloadUrl} to ${NGROK_LINUX_INSTALL_PATH}.`);
+  await spawn(
+    'bash',
+    ['-c', `curl -fsSL "${downloadUrl}" | sudo tar -xzf - -C "${NGROK_LINUX_INSTALL_DIR}" ngrok`],
+    { env, logger }
+  );
+  await spawn('sudo', ['chmod', '+x', NGROK_LINUX_INSTALL_PATH], { env, logger });
   // Return the absolute install path so the tunnel command works even when
   // /usr/local/bin is not on the step's PATH.
-  return CLOUDFLARED_LINUX_INSTALL_PATH;
+  return NGROK_LINUX_INSTALL_PATH;
 }
 
-function cloudflaredLinuxArchForNodeArch(arch: string): 'amd64' | 'arm64' {
+function linuxArchForNodeArch(arch: string): 'amd64' | 'arm64' {
   if (arch === 'x64') {
     return 'amd64';
   }
@@ -198,8 +207,68 @@ function cloudflaredLinuxArchForNodeArch(arch: string): 'amd64' | 'arm64' {
     return 'arm64';
   }
   throw new SystemError(
-    `Unsupported architecture for cloudflared on Linux: "${arch}". Expected "x64" or "arm64".`
+    `Unsupported architecture for ngrok on Linux: "${arch}". Expected "x64" or "arm64".`
   );
+}
+
+export async function startNgrokTunnelAsync({
+  ngrokCommand,
+  port,
+  subdomainPrefix,
+  baseDomain,
+  env,
+  logger,
+  timeoutMs,
+}: {
+  ngrokCommand: string;
+  port: number;
+  subdomainPrefix: string;
+  baseDomain: string;
+  env: BuildStepEnv;
+  logger: bunyan;
+  timeoutMs: number;
+}): Promise<string> {
+  const url = `https://${subdomainPrefix}-${randomBytes(8).toString('hex')}.${baseDomain}`;
+
+  // ngrok serves its inspection web UI on 127.0.0.1:4040 and offers no CLI flag
+  // to move it, but serve-sim runs a second ngrok agent on the same host — so
+  // two agents would fight over that port. We read the tunnel URL from the
+  // agent's stdout logs rather than the web UI, so disable it via config.
+  const configDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ngrok-'));
+  const configPath = path.join(configDir, 'ngrok.yml');
+  await fs.promises.writeFile(configPath, 'version: "3"\nagent:\n  web_addr: false\n');
+
+  logger.info(`Starting ngrok tunnel ${url} -> http://localhost:${port}.`);
+  const ngrok = spawnDetached({
+    command: ngrokCommand,
+    args: [
+      'http',
+      String(port),
+      '--url',
+      url,
+      '--log',
+      'stdout',
+      '--log-format',
+      'logfmt',
+      '--config',
+      configPath,
+    ],
+    env,
+  });
+
+  // The agent echoes the endpoint URL back once the tunnel is live; wait for it
+  // so we never report a URL the client cannot reach yet.
+  await waitForMatchInOutputAsync({
+    process: ngrok,
+    pattern: new RegExp(escapeRegExp(url)),
+    timeoutMs,
+    description: `ngrok tunnel ${url}`,
+  });
+  return url;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 async function isCommandAvailableAsync({

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -174,25 +174,6 @@ function matchLabeledUrl(content: string, label: string, baseDomain: string): st
   return match ? match[1] : null;
 }
 
-// serve-sim shells out to the `ngrok` CLI for `--tunnel-provider ngrok`, so it
-// needs the agent on PATH. serve-sim is macOS-only, so Homebrew suffices. Our
-// own tunnels use the in-process SDK (startNgrokTunnelAsync) and need no CLI.
-export async function ensureNgrokCliInstalledAsync({
-  env,
-  logger,
-}: {
-  env: BuildStepEnv;
-  logger: bunyan;
-}): Promise<void> {
-  if (await isCommandAvailableAsync({ command: 'ngrok', env })) {
-    return;
-  }
-  await spawn('bash', ['-c', 'HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask ngrok'], {
-    env,
-    logger,
-  });
-}
-
 export async function startNgrokTunnelAsync({
   port,
   subdomainPrefix,
@@ -208,9 +189,8 @@ export async function startNgrokTunnelAsync({
 }): Promise<string> {
   const domain = `${subdomainPrefix}-${randomBytes(8).toString('hex')}.${baseDomain}`;
   logger.info(`Starting ngrok tunnel ${domain} -> http://localhost:${port}.`);
-  // Run the ngrok agent in-process via the SDK. The SDK keeps the session alive
-  // until the process exits (the step blocks forever to hold it open), and it
-  // has no local web UI, so it never collides with serve-sim's own ngrok agent.
+  // Run the ngrok agent in-process via the SDK; it keeps the session alive until
+  // the process exits, and the step blocks forever to hold it open.
   const listener = await ngrok.forward({ addr: port, authtoken, domain });
   const url = listener.url();
   if (!url) {
@@ -221,21 +201,6 @@ export async function startNgrokTunnelAsync({
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-async function isCommandAvailableAsync({
-  command,
-  env,
-}: {
-  command: string;
-  env: BuildStepEnv;
-}): Promise<boolean> {
-  try {
-    await spawn('bash', ['-c', `command -v ${command}`], { env, ignoreStdio: true });
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 export async function waitForFileAsync<T>({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2876,6 +2876,7 @@ __metadata:
     "@expo/turtle-spawn": "npm:19.0.0"
     "@expo/xcpretty": "npm:^4.3.1"
     "@google-cloud/storage": "npm:^7.11.2"
+    "@ngrok/ngrok": "npm:1.7.0"
     "@sentry/node": "npm:7.77.0"
     "@types/fs-extra": "npm:^11.0.4"
     "@types/jest": "npm:^29.5.12"
@@ -5502,6 +5503,145 @@ __metadata:
     "@emnapi/runtime": "npm:^1.1.0"
     "@tybys/wasm-util": "npm:^0.9.0"
   checksum: 10c0/1040de49b2ef509db207e2517465dbf7fb3474f20e8ec32897672a962ff4f59872385666dac61dc9dbeae3cae5dad265d8dc3865da756adeb07d1634c67b03a1
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-android-arm64@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-android-arm64@npm:1.7.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-darwin-arm64@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-darwin-arm64@npm:1.7.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-darwin-universal@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-darwin-universal@npm:1.7.0"
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-darwin-x64@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-darwin-x64@npm:1.7.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-freebsd-x64@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-freebsd-x64@npm:1.7.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-linux-arm-gnueabihf@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-linux-arm-gnueabihf@npm:1.7.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-linux-arm64-gnu@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-linux-arm64-gnu@npm:1.7.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-linux-arm64-musl@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-linux-arm64-musl@npm:1.7.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-linux-x64-gnu@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-linux-x64-gnu@npm:1.7.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-linux-x64-musl@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-linux-x64-musl@npm:1.7.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-win32-arm64-msvc@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-win32-arm64-msvc@npm:1.7.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-win32-ia32-msvc@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-win32-ia32-msvc@npm:1.7.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok-win32-x64-msvc@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok-win32-x64-msvc@npm:1.7.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@ngrok/ngrok@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@ngrok/ngrok@npm:1.7.0"
+  dependencies:
+    "@ngrok/ngrok-android-arm64": "npm:1.7.0"
+    "@ngrok/ngrok-darwin-arm64": "npm:1.7.0"
+    "@ngrok/ngrok-darwin-universal": "npm:1.7.0"
+    "@ngrok/ngrok-darwin-x64": "npm:1.7.0"
+    "@ngrok/ngrok-freebsd-x64": "npm:1.7.0"
+    "@ngrok/ngrok-linux-arm-gnueabihf": "npm:1.7.0"
+    "@ngrok/ngrok-linux-arm64-gnu": "npm:1.7.0"
+    "@ngrok/ngrok-linux-arm64-musl": "npm:1.7.0"
+    "@ngrok/ngrok-linux-x64-gnu": "npm:1.7.0"
+    "@ngrok/ngrok-linux-x64-musl": "npm:1.7.0"
+    "@ngrok/ngrok-win32-arm64-msvc": "npm:1.7.0"
+    "@ngrok/ngrok-win32-ia32-msvc": "npm:1.7.0"
+    "@ngrok/ngrok-win32-x64-msvc": "npm:1.7.0"
+  dependenciesMeta:
+    "@ngrok/ngrok-android-arm64":
+      optional: true
+    "@ngrok/ngrok-darwin-arm64":
+      optional: true
+    "@ngrok/ngrok-darwin-universal":
+      optional: true
+    "@ngrok/ngrok-darwin-x64":
+      optional: true
+    "@ngrok/ngrok-freebsd-x64":
+      optional: true
+    "@ngrok/ngrok-linux-arm-gnueabihf":
+      optional: true
+    "@ngrok/ngrok-linux-arm64-gnu":
+      optional: true
+    "@ngrok/ngrok-linux-arm64-musl":
+      optional: true
+    "@ngrok/ngrok-linux-x64-gnu":
+      optional: true
+    "@ngrok/ngrok-linux-x64-musl":
+      optional: true
+    "@ngrok/ngrok-win32-arm64-msvc":
+      optional: true
+    "@ngrok/ngrok-win32-ia32-msvc":
+      optional: true
+    "@ngrok/ngrok-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/67ad258efd5797bb1bcbe75344d6fa930eab69ac7c6d72c4d9ed1e507c2e2953f5e856d803d23eeec22227adeb66f959982709dc0c73d3cb76630ac450980a06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

The remote device run session steps (`start_agent_device_remote_session`, `start_argent_remote_session`, `start_serve_sim_remote_session`) exposed their local servers over **free Cloudflare quick tunnels** (`*.trycloudflare.com`). Quick tunnels are unauthenticated, rate-limited, and hand out a random hostname per run, which makes them unreliable for real sessions.

This switches them to **ngrok** with a reserved wildcard domain (`*.expo-simulator.ngrok.dev`), so every session gets a stable, authenticated tunnel.

## How

- **Tunnels we open** (agent-device daemon, argent tool-server) use the in-process **`@ngrok/ngrok` SDK**: `forward({ addr, authtoken, domain })` → `listener.url()`. No binary install, no stdout parsing, no `web_addr`/4040 workaround. The domain is pinned to `<prefix>-<random>.<base-domain>` under the wildcard.
  - The authtoken is passed **explicitly** from the job env rather than via `authtoken_from_env`, because the SDK's env lookup reads `process.env`, which isn't the step's `BuildStepEnv`.
- **serve-sim** is launched with `--tunnel --tunnel-provider ngrok --tunnel-domain <base-domain>` and its `Tunnel:`/`Stream:` output matcher accepts `*.<base-domain>`. serve-sim embeds the `@ngrok/ngrok` SDK itself, so **no ngrok CLI is installed anywhere** — both our tunnels and serve-sim run the agent in-process. serve-sim reads `NGROK_AUTHTOKEN` from the env we pass it.
- **Dependency: `@ngrok/ngrok` (1.7.0).** First native-binding dep in `@expo/build-tools`. Only `worker` and `local-build-plugin` depend on build-tools; `eas-cli` does not, so the published CLI is unaffected. Prebuilt binaries cover all worker/dev platforms (darwin + linux, x64/arm64, gnu+musl).
- **Config:** `EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN` (base domain) and `NGROK_AUTHTOKEN` are read from the job env and validated up front alongside `DEVICE_RUN_SESSION_ID`.

## Test Plan

- `yarn typecheck`, `yarn lint` (0 errors), and `yarn fmt:check` pass.
- Confirmed the `@ngrok/ngrok` API (`forward` + `Listener.url()`, `authtoken`/`domain` options) and CommonJS compatibility from the published types; the darwin-arm64 prebuilt installs cleanly.
- **Not yet run end-to-end** — the full flow needs a device run session on EAS infra with `NGROK_AUTHTOKEN` and the reserved `*.expo-simulator.ngrok.dev` domain. To be validated on a custom build before this leaves draft.

**Depends on:**
- serve-sim ngrok support (`--tunnel-provider ngrok --tunnel-domain`, embedded `@ngrok/ngrok` SDK)
- API server injecting `EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN` and `NGROK_AUTHTOKEN`