### PR TITLE
[eas-cli] Add Expo Go download commands

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -203,6 +203,9 @@
       "env": {
         "description": "manage project and account environment variables"
       },
+      "go": {
+        "description": "manage Expo Go downloads"
+      },
       "integrations": {
         "description": "manage third-party service integrations"
       },

--- a/packages/eas-cli/src/__tests__/commands/go-url-download-test.ts
+++ b/packages/eas-cli/src/__tests__/commands/go-url-download-test.ts
@@ -1,0 +1,96 @@
+import GoDownload from '../../commands/go/download';
+import GoUrl from '../../commands/go/url';
+import Log from '../../log';
+import {
+  copyExpoGoToPathAsync,
+  downloadExpoGoAsync,
+  getExpoGoDownloadUrlAsync,
+} from '../../utils/expoGo';
+import { getMockOclifConfig } from './utils';
+
+jest.mock('../../log', () => ({
+  __esModule: true,
+  default: {
+    log: jest.fn(),
+  },
+}));
+jest.mock('../../utils/expoGo', () => ({
+  ...jest.requireActual('../../utils/expoGo'),
+  copyExpoGoToPathAsync: jest.fn(),
+  downloadExpoGoAsync: jest.fn(),
+  getExpoGoDownloadUrlAsync: jest.fn(),
+}));
+
+const mockGetExpoGoDownloadUrlAsync = jest.mocked(getExpoGoDownloadUrlAsync);
+const mockDownloadExpoGoAsync = jest.mocked(downloadExpoGoAsync);
+const mockCopyExpoGoToPathAsync = jest.mocked(copyExpoGoToPathAsync);
+
+describe('go:url', () => {
+  beforeEach(() => {
+    mockGetExpoGoDownloadUrlAsync.mockResolvedValue({
+      sdkVersion: '55.0.0',
+      url: 'https://example.com/Exponent-55.apk',
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('prints the resolved Expo Go URL for the platform and SDK version', async () => {
+    await new GoUrl(['android', '55'], getMockOclifConfig()).runAsync();
+
+    expect(mockGetExpoGoDownloadUrlAsync).toHaveBeenCalledWith('android', {
+      sdkVersion: '55',
+    });
+    expect(Log.log).toHaveBeenCalledWith('https://example.com/Exponent-55.apk');
+  });
+});
+
+describe('go:download', () => {
+  beforeEach(() => {
+    mockDownloadExpoGoAsync.mockResolvedValue({
+      path: '/cache/Exponent-55.apk',
+      sdkVersion: '55.0.0',
+      url: 'https://example.com/Exponent-55.apk',
+    });
+    mockCopyExpoGoToPathAsync.mockResolvedValue('/output/Exponent-55.apk');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('downloads an explicit SDK version to an explicit output path', async () => {
+    await new GoDownload(['android', '55', '/output'], getMockOclifConfig()).runAsync();
+
+    expect(mockDownloadExpoGoAsync).toHaveBeenCalledWith('android', {
+      sdkVersion: '55',
+    });
+    expect(mockCopyExpoGoToPathAsync).toHaveBeenCalledWith({
+      destinationPath: '/output',
+      platform: 'android',
+      sourcePath: '/cache/Exponent-55.apk',
+    });
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('/output/Exponent-55.apk'));
+  });
+
+  it('downloads the latest Expo Go to an output path when "latest" is passed', async () => {
+    await new GoDownload(['ios', 'latest', '/output'], getMockOclifConfig()).runAsync();
+
+    expect(mockDownloadExpoGoAsync).toHaveBeenCalledWith('ios', {
+      sdkVersion: 'latest',
+    });
+    expect(mockCopyExpoGoToPathAsync).toHaveBeenCalledWith({
+      destinationPath: '/output',
+      platform: 'ios',
+      sourcePath: '/cache/Exponent-55.apk',
+    });
+  });
+
+  it('rejects a second argument that is not an SDK version', async () => {
+    await expect(
+      new GoDownload(['ios', '/output'], getMockOclifConfig()).runAsync()
+    ).rejects.toThrow('Expected "/output" to be an Expo SDK version or "latest"');
+  });
+});

--- a/packages/eas-cli/src/commands/go.ts
+++ b/packages/eas-cli/src/commands/go.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig, getConfigFilePaths } from '@expo/config';
+import { ExpoConfig } from '@expo/config';
 import { App, User, UserRole } from '@expo/apple-utils';
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
@@ -28,7 +28,6 @@ import { WorkflowRunQuery } from '../graphql/queries/WorkflowRunQuery';
 import Log, { learnMore } from '../log';
 import { confirmAsync, selectAsync } from '../prompts';
 import { ora } from '../ora';
-import { getPrivateExpoConfigAsync } from '../project/expoConfig';
 import { findProjectIdByAccountNameAndSlugNullableAsync } from '../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
 import { uploadAccountScopedFileAsync } from '../project/uploadAccountScopedFileAsync';
 import { uploadAccountScopedProjectSourceAsync } from '../project/uploadAccountScopedProjectSourceAsync';
@@ -41,23 +40,12 @@ import {
   INVALID_BUNDLE_IDENTIFIER_MESSAGE,
   isBundleIdentifierValid,
 } from '../project/ios/bundleIdentifier';
+import { detectProjectSdkVersionAsync } from '../utils/expoGo';
+
+export { detectProjectSdkVersionAsync };
 
 function deriveBundleIdSlug(bundleId: string): string {
   return bundleId.split('.').filter(Boolean).pop()!;
-}
-
-export async function detectProjectSdkVersionAsync(
-  projectDir: string
-): Promise<string | undefined> {
-  const paths = getConfigFilePaths(projectDir);
-  if (!paths.staticConfigPath && !paths.dynamicConfigPath) {
-    return;
-  }
-  try {
-    return (await getPrivateExpoConfigAsync(projectDir)).sdkVersion;
-  } catch {
-    return;
-  }
 }
 
 const TESTFLIGHT_GROUP_NAME = 'Team (Expo)';

--- a/packages/eas-cli/src/commands/go/download.ts
+++ b/packages/eas-cli/src/commands/go/download.ts
@@ -1,0 +1,54 @@
+import { Args } from '@oclif/core';
+import chalk from 'chalk';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import Log from '../../log';
+import {
+  ExpoGoPlatform,
+  copyExpoGoToPathAsync,
+  downloadExpoGoAsync,
+  isSdkVersionInput,
+} from '../../utils/expoGo';
+
+export default class GoDownload extends EasCommand {
+  static override description = 'download Expo Go for a platform';
+
+  static override args = {
+    platform: Args.string({
+      description: 'Platform to download Expo Go for',
+      options: ['ios', 'android'],
+      required: true,
+    }),
+    sdkVersion: Args.string({
+      description:
+        'Expo SDK version to download, or "latest". Defaults to the current project SDK, or latest.',
+      required: false,
+    }),
+    outputPath: Args.string({
+      description:
+        'Output path. Defaults to the current directory. Pass an SDK version (or "latest") to use it.',
+      required: false,
+    }),
+  };
+
+  async runAsync(): Promise<void> {
+    const { args } = await this.parse(GoDownload);
+    const platform = args.platform as ExpoGoPlatform;
+    if (args.sdkVersion && !isSdkVersionInput(args.sdkVersion)) {
+      throw new Error(
+        `Expected "${args.sdkVersion}" to be an Expo SDK version or "latest". Pass "latest" as the SDK version to download the default Expo Go to a specific output path.`
+      );
+    }
+
+    const download = await downloadExpoGoAsync(platform, {
+      sdkVersion: args.sdkVersion,
+    });
+    const copiedPath = await copyExpoGoToPathAsync({
+      destinationPath: args.outputPath,
+      platform,
+      sourcePath: download.path,
+    });
+
+    Log.log(`Expo Go downloaded to ${chalk.bold(copiedPath)}`);
+  }
+}

--- a/packages/eas-cli/src/commands/go/url.ts
+++ b/packages/eas-cli/src/commands/go/url.ts
@@ -1,0 +1,30 @@
+import { Args } from '@oclif/core';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import Log from '../../log';
+import { ExpoGoPlatform, getExpoGoDownloadUrlAsync } from '../../utils/expoGo';
+
+export default class GoUrl extends EasCommand {
+  static override description = 'print the Expo Go download URL for a platform';
+
+  static override args = {
+    platform: Args.string({
+      description: 'Platform to get the Expo Go download URL for',
+      options: ['ios', 'android'],
+      required: true,
+    }),
+    sdkVersion: Args.string({
+      description: 'Expo SDK version, or "latest". Defaults to the current project SDK, or latest.',
+      required: false,
+    }),
+  };
+
+  async runAsync(): Promise<void> {
+    const { args } = await this.parse(GoUrl);
+    const { url } = await getExpoGoDownloadUrlAsync(args.platform as ExpoGoPlatform, {
+      sdkVersion: args.sdkVersion,
+    });
+
+    Log.log(url);
+  }
+}

--- a/packages/eas-cli/src/utils/__tests__/expoGo-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/expoGo-test.ts
@@ -1,0 +1,169 @@
+import { getConfigFilePaths } from '@expo/config';
+import fs from 'fs-extra';
+
+import { ApiV2Client } from '../../api';
+import Log from '../../log';
+import { getPrivateExpoConfigAsync } from '../../project/expoConfig';
+import * as downloadUtils from '../download';
+import {
+  ExpoVersions,
+  downloadExpoGoAsync,
+  getExpoGoDownloadUrlAsync,
+  getExpoGoVersionEntryFromVersions,
+  getLatestSdkVersion,
+  normalizeSdkVersion,
+} from '../expoGo';
+
+jest.mock('@expo/config', () => ({
+  ...jest.requireActual('@expo/config'),
+  getConfigFilePaths: jest.fn(),
+}));
+jest.mock('../../project/expoConfig');
+jest.mock('../../log', () => ({
+  __esModule: true,
+  default: {
+    debug: jest.fn(),
+    log: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+const mockGetConfigFilePaths = jest.mocked(getConfigFilePaths);
+const mockGetPrivateExpoConfigAsync = jest.mocked(getPrivateExpoConfigAsync);
+
+const versions: ExpoVersions = {
+  sdkVersions: {
+    '54.0.0': {
+      androidClientUrl: 'https://example.com/Exponent-54.apk',
+      iosClientUrl: 'https://example.com/Exponent-54.tar.gz',
+    },
+    '55.0.0': {
+      androidClientUrl: 'https://example.com/Exponent-55.apk',
+      iosClientUrl: 'https://example.com/Exponent-55.tar.gz',
+    },
+  },
+};
+
+describe('expoGo utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(ApiV2Client.prototype, 'getAsync').mockResolvedValue({ data: versions });
+    mockGetConfigFilePaths.mockReturnValue({ staticConfigPath: null, dynamicConfigPath: null });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe(normalizeSdkVersion, () => {
+    it('normalizes SDK major versions', () => {
+      expect(normalizeSdkVersion('55')).toBe('55.0.0');
+      expect(normalizeSdkVersion('55.1')).toBe('55.1.0');
+      expect(normalizeSdkVersion('55.0.0')).toBe('55.0.0');
+      expect(normalizeSdkVersion('UNVERSIONED')).toBe('UNVERSIONED');
+    });
+  });
+
+  describe(getLatestSdkVersion, () => {
+    it('returns the highest semver SDK version', () => {
+      expect(getLatestSdkVersion(versions.sdkVersions)).toBe('55.0.0');
+    });
+  });
+
+  describe(getExpoGoVersionEntryFromVersions, () => {
+    it('supports UNVERSIONED by resolving to the latest SDK version', () => {
+      const result = getExpoGoVersionEntryFromVersions('UNVERSIONED', versions);
+
+      expect(result.sdkVersion).toBe('55.0.0');
+      expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('55.0.0'));
+    });
+
+    it('supports "latest" by resolving to the latest SDK version without warning', () => {
+      const result = getExpoGoVersionEntryFromVersions('latest', versions);
+
+      expect(result.sdkVersion).toBe('55.0.0');
+      expect(Log.warn).not.toHaveBeenCalled();
+    });
+
+    it('throws when the SDK version is missing', () => {
+      expect(() => getExpoGoVersionEntryFromVersions('53', versions)).toThrow(
+        'Unable to find a version of Expo Go for SDK 53.0.0'
+      );
+    });
+  });
+
+  describe(getExpoGoDownloadUrlAsync, () => {
+    it('resolves the platform URL for an explicit SDK major version', async () => {
+      await expect(getExpoGoDownloadUrlAsync('ios', { sdkVersion: '55' })).resolves.toEqual({
+        sdkVersion: '55.0.0',
+        url: 'https://example.com/Exponent-55.tar.gz',
+      });
+    });
+
+    it('uses the current project SDK version when no SDK argument is provided', async () => {
+      mockGetConfigFilePaths.mockReturnValue({
+        staticConfigPath: '/project/app.json',
+        dynamicConfigPath: null,
+      });
+      mockGetPrivateExpoConfigAsync.mockResolvedValue({ sdkVersion: '54.0.0' } as any);
+
+      await expect(
+        getExpoGoDownloadUrlAsync('android', { projectDir: '/project' })
+      ).resolves.toEqual({
+        sdkVersion: '54.0.0',
+        url: 'https://example.com/Exponent-54.apk',
+      });
+    });
+
+    it('falls back to the latest SDK version when no project SDK is available', async () => {
+      await expect(getExpoGoDownloadUrlAsync('android')).resolves.toEqual({
+        sdkVersion: '55.0.0',
+        url: 'https://example.com/Exponent-55.apk',
+      });
+    });
+
+    it('resolves the latest SDK version when "latest" is provided', async () => {
+      await expect(getExpoGoDownloadUrlAsync('ios', { sdkVersion: 'latest' })).resolves.toEqual({
+        sdkVersion: '55.0.0',
+        url: 'https://example.com/Exponent-55.tar.gz',
+      });
+    });
+  });
+
+  describe(downloadExpoGoAsync, () => {
+    it('extracts iOS tarballs directly into the app cache directory', async () => {
+      jest.spyOn(fs, 'readdir').mockRejectedValue(new Error('missing') as never);
+      jest.spyOn(fs, 'pathExists').mockResolvedValue(false as never);
+      jest.spyOn(fs, 'ensureDir').mockResolvedValue(undefined as never);
+      jest.spyOn(fs, 'remove').mockResolvedValue(undefined as never);
+      jest.spyOn(downloadUtils, 'downloadFileWithProgressTrackerAsync').mockResolvedValue();
+      const extractArchiveSpy = jest
+        .spyOn(downloadUtils, 'extractArchiveAsync')
+        .mockResolvedValue();
+
+      await expect(downloadExpoGoAsync('ios', { sdkVersion: '55' })).resolves.toMatchObject({
+        sdkVersion: '55.0.0',
+        url: 'https://example.com/Exponent-55.tar.gz',
+      });
+
+      expect(extractArchiveSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Exponent-55.tar.gz'),
+        expect.stringContaining('Exponent-55.tar.app')
+      );
+    });
+
+    it('logs the cache directory instead of the cached app path', async () => {
+      jest.spyOn(fs, 'readdir').mockRejectedValue(new Error('missing') as never);
+      jest.spyOn(fs, 'pathExists').mockResolvedValue(true as never);
+
+      await expect(downloadExpoGoAsync('ios', { sdkVersion: '55' })).resolves.toMatchObject({
+        sdkVersion: '55.0.0',
+      });
+
+      expect(Log.log).toHaveBeenCalledWith(
+        expect.stringMatching(/^Using cached version from .*ios-simulator-app-cache/)
+      );
+      expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('Exponent-55.tar.app'));
+    });
+  });
+});

--- a/packages/eas-cli/src/utils/__tests__/expoGo-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/expoGo-test.ts
@@ -165,5 +165,31 @@ describe('expoGo utils', () => {
       );
       expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('Exponent-55.tar.app'));
     });
+
+    it('writes the Android apk straight to the platform cache without an intermediate copy', async () => {
+      jest.spyOn(fs, 'readdir').mockRejectedValue(new Error('missing') as never);
+      jest.spyOn(fs, 'pathExists').mockResolvedValue(false as never);
+      jest.spyOn(fs, 'ensureDir').mockResolvedValue(undefined as never);
+      const downloadSpy = jest
+        .spyOn(downloadUtils, 'downloadFileWithProgressTrackerAsync')
+        .mockResolvedValue();
+      const extractArchiveSpy = jest
+        .spyOn(downloadUtils, 'extractArchiveAsync')
+        .mockResolvedValue();
+
+      await expect(downloadExpoGoAsync('android', { sdkVersion: '55' })).resolves.toMatchObject({
+        sdkVersion: '55.0.0',
+        url: 'https://example.com/Exponent-55.apk',
+      });
+
+      expect(downloadSpy).toHaveBeenCalledWith(
+        'https://example.com/Exponent-55.apk',
+        expect.stringMatching(/android-apk-cache.*Exponent-55\.apk$/),
+        expect.any(Function),
+        'Successfully downloaded Expo Go',
+        expect.objectContaining({ showNewLine: false })
+      );
+      expect(extractArchiveSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/eas-cli/src/utils/cache/FileSystemResponseCache.ts
+++ b/packages/eas-cli/src/utils/cache/FileSystemResponseCache.ts
@@ -1,0 +1,132 @@
+// Ported from @expo/cli.
+// Source: https://github.com/expo/expo/blob/2c21e2f96ce6aede3d6bb5c780f0964d2116d37b/packages/%40expo/cli/src/api/rest/cache/FileSystemResponseCache.ts
+//
+// Adapted for eas-cli:
+//   - `ResponseCacheEntry.body` is a Node `Readable` instead of a web `ReadableStream`
+//     (node-fetch v2 vs fetch-nodeshim). Reading the cache opens `fs.createReadStream`
+//     directly instead of going through `Readable.toWeb`.
+//   - Storing a response no longer needs `body.tee()` to peek for emptiness: with a
+//     single-consumer Node `Readable` we just pipe the entire response straight to disk
+//     and then check the resulting file size to set the `empty` marker. Functionally
+//     identical, but works on node-fetch's stream type.
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { Readable, pipeline } from 'stream';
+import { promisify } from 'util';
+
+import type { ResponseCache, ResponseCacheEntry } from './ResponseCache';
+
+const pipelineAsync = promisify(pipeline);
+
+type FileSystemResponseCacheInfo = ResponseCacheEntry['info'] & {
+  /** The path to the cached body file */
+  bodyPath?: string;
+  /** If there is no response body */
+  empty?: boolean;
+  /** The expiration time, in milliseconds, when the response should be invalidated */
+  expiration?: number;
+};
+
+export class FileSystemResponseCache implements ResponseCache {
+  /** The absolute path to the directory used to store responses */
+  private cacheDirectory: string;
+  /** Optional auto-expiration for all stored responses */
+  private timeToLive?: number;
+
+  constructor(options: { cacheDirectory: string; ttl?: number }) {
+    this.cacheDirectory = options.cacheDirectory;
+    this.timeToLive = options.ttl;
+  }
+
+  private getFilePaths(cacheKey: string): { info: string; body: string } {
+    const hash = crypto.createHash('sha256').update(cacheKey).digest('hex');
+    return {
+      info: path.join(this.cacheDirectory, `${hash}-info.json`),
+      body: path.join(this.cacheDirectory, `${hash}-body.bin`),
+    };
+  }
+
+  async get(cacheKey: string): Promise<ResponseCacheEntry | undefined> {
+    const paths = this.getFilePaths(cacheKey);
+
+    try {
+      await fs.promises.access(paths.info);
+    } catch {
+      return undefined;
+    }
+
+    try {
+      const infoBuffer = await fs.promises.readFile(paths.info);
+      const responseInfo: FileSystemResponseCacheInfo = JSON.parse(infoBuffer.toString());
+
+      // Check if the response has expired
+      if (responseInfo.expiration && responseInfo.expiration < Date.now()) {
+        await this.remove(cacheKey);
+        return undefined;
+      }
+
+      // Remove cache-specific data from the response info
+      const { empty, expiration: _expiration, bodyPath: _bodyPath, ...cleanInfo } = responseInfo;
+
+      // Create response body stream. Adapted: open a `fs.createReadStream` directly
+      // instead of routing through `Readable.toWeb` since the consumer expects a Node
+      // `Readable` (see `Adapted for eas-cli` in `ResponseCache.ts`).
+      const body: Readable = empty
+        ? Readable.from(Buffer.alloc(0))
+        : fs.createReadStream(paths.body);
+
+      return { body, info: cleanInfo };
+    } catch {
+      return undefined;
+    }
+  }
+
+  async set(
+    cacheKey: string,
+    response: ResponseCacheEntry
+  ): Promise<ResponseCacheEntry | undefined> {
+    await fs.promises.mkdir(this.cacheDirectory, { recursive: true });
+    const paths = this.getFilePaths(cacheKey);
+
+    const responseInfo: FileSystemResponseCacheInfo = { ...response.info };
+    if (typeof this.timeToLive === 'number') {
+      responseInfo.expiration = Date.now() + this.timeToLive;
+    }
+
+    try {
+      // Adapted: upstream tees a web `ReadableStream` into "peek for emptiness" + "write
+      // to file" branches. node-fetch's `Readable` is single-consumer, so we pipe the
+      // body straight to disk and then check the resulting file size to detect an empty
+      // body. Net effect is the same.
+      await pipelineAsync(response.body, fs.createWriteStream(paths.body));
+      const stat = await fs.promises.stat(paths.body);
+      if (stat.size === 0) {
+        responseInfo.empty = true;
+        await fs.promises.unlink(paths.body).catch(() => {});
+      } else {
+        responseInfo.bodyPath = paths.body;
+      }
+
+      await fs.promises.writeFile(paths.info, JSON.stringify(responseInfo));
+
+      return await this.get(cacheKey);
+    } catch (error) {
+      // Clean up any partially written files
+      await this.remove(cacheKey);
+      throw error;
+    }
+  }
+
+  async remove(cacheKey: string): Promise<void> {
+    const paths = this.getFilePaths(cacheKey);
+    await removeAllAsync(paths.info, paths.body);
+  }
+}
+
+function removeAllAsync(...paths: string[]): Promise<unknown> {
+  return Promise.all(
+    paths.map(p => fs.promises.rm(p, { recursive: true, force: true }).catch(() => {}))
+  );
+}

--- a/packages/eas-cli/src/utils/cache/ResponseCache.ts
+++ b/packages/eas-cli/src/utils/cache/ResponseCache.ts
@@ -1,0 +1,101 @@
+// Ported from @expo/cli.
+// Source: https://github.com/expo/expo/blob/2c21e2f96ce6aede3d6bb5c780f0964d2116d37b/packages/%40expo/cli/src/api/rest/cache/ResponseCache.ts
+//
+// Adapted for eas-cli:
+//   - Uses eas-cli's node-fetch types (`Response`, `RequestInfo`, `RequestInit`, `Headers`)
+//     re-exported from `src/fetch.ts`. The upstream uses fetch-nodeshim, which exposes
+//     web-standard `ReadableStream` bodies — here `ResponseCacheEntry.body` is a Node
+//     `Readable` because node-fetch v2 returns Node streams.
+//   - `getRequestInfoCacheData` only handles `string` and `URL` inputs. node-fetch's
+//     `RequestInfo` is `string | Request` (no `URL`), and node-fetch's `Request` does
+//     not expose all the web-standard fields (`credentials`, `destination`, `integrity`,
+//     `redirect`, `referrer`, `referrerPolicy`) that upstream hashes; the Expo Go
+//     download path only ever passes a string URL, so the simpler shape is sufficient.
+
+import crypto from 'crypto';
+
+import { RequestInfo, RequestInit, Response } from '../../fetch';
+
+const GLOBAL_CACHE_VERSION = 4;
+
+export type ResponseCacheEntry = {
+  // Widened to `NodeJS.ReadableStream` (vs the upstream `ReadableStream`) so a
+  // node-fetch `response.body` (typed `NodeJS.ReadableStream`) flows in directly,
+  // while concrete `Readable`/`ReadStream` instances returned by the cache still
+  // satisfy it.
+  body: NodeJS.ReadableStream;
+  info: ReturnType<typeof getResponseInfo>;
+};
+
+export interface ResponseCache {
+  /** Load the response info from cache, if any */
+  get(cacheKey: string): Promise<ResponseCacheEntry | undefined>;
+  /** Store the response info to cache, and return the cached info */
+  set(cacheKey: string, response: ResponseCacheEntry): Promise<ResponseCacheEntry | undefined>;
+  /** Remove a response entry from the cache */
+  remove(cacheKey: string): Promise<void>;
+}
+
+export function getResponseInfo(response: Response): {
+  url: string;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+} {
+  const headers = Object.fromEntries(response.headers.entries());
+  delete headers['set-cookie'];
+  return {
+    url: response.url,
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  };
+}
+
+export function getRequestCacheKey(info: RequestInfo, init?: RequestInit): string {
+  const infoKeyData = getRequestInfoCacheData(info);
+  const initKeyData = { body: init?.body ? getRequestBodyCacheData(init.body) : undefined };
+
+  return crypto
+    .createHash('md5')
+    .update(JSON.stringify([infoKeyData, initKeyData, GLOBAL_CACHE_VERSION]))
+    .digest('hex');
+}
+
+/** @internal Exposed for testing */
+export function getRequestInfoCacheData(info: RequestInfo): { url: string } {
+  if (typeof info === 'string') {
+    return { url: info };
+  }
+  // node-fetch's `RequestInfo = string | URLLike | Request`. `URLLike` only has
+  // `href`; `Request` has `url`. Discriminate by property — using `instanceof` would
+  // miss the plain-object `URLLike` shape.
+  if ('url' in info) {
+    return { url: info.url.toString() };
+  }
+  // Upstream also hashes `credentials`, `destination`, `integrity`, `redirect`,
+  // `referrer`, `referrerPolicy`, `headers`, and `method` for `Request` inputs; those
+  // fields either don't exist on node-fetch's `Request` or aren't varied in eas-cli's
+  // usage of this cache, so we keep the key minimal.
+  return { url: info.href };
+}
+
+/** @internal Exposed for testing */
+export function getRequestBodyCacheData(body: RequestInit['body']): unknown {
+  if (!body) {
+    return body;
+  }
+  if (typeof body === 'string') {
+    return body;
+  }
+  if (body instanceof URLSearchParams) {
+    return body.toString();
+  }
+  if (body instanceof Buffer) {
+    return body.toString();
+  }
+  // Upstream also handles `fs.ReadStream` and `FormData`. eas-cli never sends those
+  // through the cached fetch, so we omit the branches and surface unknown bodies
+  // loudly rather than silently mis-keying them.
+  throw new Error(`Unsupported request body type for caching: ${typeof body}`);
+}

--- a/packages/eas-cli/src/utils/cache/__tests__/cache-test.ts
+++ b/packages/eas-cli/src/utils/cache/__tests__/cache-test.ts
@@ -1,0 +1,144 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Readable } from 'stream';
+
+import { Response } from '../../../fetch';
+import { FileSystemResponseCache } from '../FileSystemResponseCache';
+import {
+  getRequestCacheKey,
+  getRequestInfoCacheData,
+  type ResponseCacheEntry,
+} from '../ResponseCache';
+import { wrapFetchWithCache } from '../wrapFetchWithCache';
+
+function bufferStream(buf: Buffer): Readable {
+  return new Readable({
+    read() {
+      this.push(buf);
+      this.push(null);
+    },
+  });
+}
+
+function makeEntry(body: Buffer | string): ResponseCacheEntry {
+  const buf = typeof body === 'string' ? Buffer.from(body) : body;
+  return {
+    body:
+      buf.length === 0
+        ? new Readable({
+            read() {
+              this.push(null);
+            },
+          })
+        : bufferStream(buf),
+    info: {
+      url: 'https://example.com/file.bin',
+      status: 200,
+      statusText: 'OK',
+      headers: { 'content-type': 'application/octet-stream' },
+    },
+  };
+}
+
+async function readToString(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString();
+}
+
+describe('getRequestInfoCacheData', () => {
+  it('returns the url for a string', () => {
+    expect(getRequestInfoCacheData('https://example.com/x')).toEqual({
+      url: 'https://example.com/x',
+    });
+  });
+
+  it('reads `href` from a URLLike', () => {
+    expect(getRequestInfoCacheData(new URL('https://example.com/x'))).toEqual({
+      url: 'https://example.com/x',
+    });
+  });
+
+  it('hashes identical strings to identical keys', () => {
+    expect(getRequestCacheKey('https://example.com/x')).toEqual(
+      getRequestCacheKey('https://example.com/x')
+    );
+  });
+
+  it('hashes different strings to different keys', () => {
+    expect(getRequestCacheKey('https://example.com/x')).not.toEqual(
+      getRequestCacheKey('https://example.com/y')
+    );
+  });
+});
+
+describe('FileSystemResponseCache', () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eas-cli-cache-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it('round-trips a response body through the cache', async () => {
+    const cache = new FileSystemResponseCache({ cacheDirectory: cacheDir });
+    await cache.set('key', makeEntry('hello cache'));
+
+    const entry = await cache.get('key');
+    expect(entry).toBeDefined();
+    expect(await readToString(entry!.body)).toBe('hello cache');
+    expect(entry!.info.status).toBe(200);
+    expect(entry!.info.headers['content-type']).toBe('application/octet-stream');
+  });
+
+  it('returns undefined and removes the entry after the TTL elapses', async () => {
+    const cache = new FileSystemResponseCache({ cacheDirectory: cacheDir, ttl: 1 });
+    await cache.set('key', makeEntry('temp'));
+
+    await new Promise(resolve => setTimeout(resolve, 5));
+    expect(await cache.get('key')).toBeUndefined();
+    // The expired entry's info file should have been removed by the get() call.
+    expect(fs.readdirSync(cacheDir)).toHaveLength(0);
+  });
+
+  it('marks zero-byte responses as empty', async () => {
+    const cache = new FileSystemResponseCache({ cacheDirectory: cacheDir });
+    await cache.set('empty', makeEntry(Buffer.alloc(0)));
+    const entry = await cache.get('empty');
+    expect(entry).toBeDefined();
+    expect(await readToString(entry!.body)).toBe('');
+  });
+});
+
+describe('wrapFetchWithCache', () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eas-cli-cache-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it('hits the underlying fetch once, then serves repeat calls from cache', async () => {
+    const cache = new FileSystemResponseCache({ cacheDirectory: cacheDir });
+    const upstream = jest.fn(
+      async () => new Response(bufferStream(Buffer.from('payload')), { status: 200 })
+    );
+    const cachedFetch = wrapFetchWithCache(upstream, cache);
+
+    const first = await cachedFetch('https://example.com/x');
+    expect(await readToString(first.body)).toBe('payload');
+
+    const second = await cachedFetch('https://example.com/x');
+    expect(await readToString(second.body)).toBe('payload');
+    expect(upstream).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/eas-cli/src/utils/cache/createCachedFetch.ts
+++ b/packages/eas-cli/src/utils/cache/createCachedFetch.ts
@@ -1,0 +1,55 @@
+// Ported from @expo/cli.
+// Source: https://github.com/expo/expo/blob/2c21e2f96ce6aede3d6bb5c780f0964d2116d37b/packages/%40expo/cli/src/api/rest/client.ts#L160-L190
+//
+// Adapted for eas-cli:
+//   - The default fetch is eas-cli's `src/fetch.ts` (node-fetch + proxy agent +
+//     `RequestError` on HTTP >= 400). Upstream defaults to its own multi-layer fetch
+//     (offline → baseURL → credentials → progress), which eas-cli's fetch doesn't need
+//     for the Expo Go download flow.
+//   - `EXPO_NO_CACHE` and `EXPO_BETA` are read directly from `process.env`. Upstream
+//     reads them through `@expo/cli`'s `env` helper; eas-cli doesn't have an equivalent,
+//     so we inline a small `boolish` parser with the same truthy-value semantics.
+
+import path from 'path';
+
+import { FileSystemResponseCache } from './FileSystemResponseCache';
+import { type FetchLike, wrapFetchWithCache } from './wrapFetchWithCache';
+import defaultFetch from '../../fetch';
+import { getExpoHomeDirectory } from '../paths';
+
+function boolish(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.toLowerCase();
+  return normalized !== '0' && normalized !== 'false' && normalized !== 'no';
+}
+
+/**
+ * Create an instance of fetch with a `FileSystemResponseCache` rooted under
+ * `~/.expo/<cacheDirectory>`. Caching is disabled automatically if `EXPO_NO_CACHE` or
+ * `EXPO_BETA` is set, matching upstream behavior.
+ */
+export function createCachedFetch({
+  fetch = defaultFetch,
+  cacheDirectory,
+  ttl,
+  skipCache,
+}: {
+  fetch?: FetchLike;
+  cacheDirectory: string;
+  ttl?: number;
+  skipCache?: boolean;
+}): FetchLike {
+  if (skipCache || boolish(process.env.EXPO_BETA) || boolish(process.env.EXPO_NO_CACHE)) {
+    return fetch;
+  }
+
+  return wrapFetchWithCache(
+    fetch,
+    new FileSystemResponseCache({
+      cacheDirectory: path.join(getExpoHomeDirectory(), cacheDirectory),
+      ttl,
+    })
+  );
+}

--- a/packages/eas-cli/src/utils/cache/wrapFetchWithCache.ts
+++ b/packages/eas-cli/src/utils/cache/wrapFetchWithCache.ts
@@ -1,0 +1,103 @@
+// Ported from @expo/cli.
+// Source: https://github.com/expo/expo/blob/2c21e2f96ce6aede3d6bb5c780f0964d2116d37b/packages/%40expo/cli/src/api/rest/cache/wrapFetchWithCache.ts
+//
+// Adapted for eas-cli:
+//   - Constructs a node-fetch v2 `Response` (the eas-cli `src/fetch.ts` export) instead
+//     of a fetch-nodeshim `Response`. The cached body is a Node `Readable` which
+//     node-fetch accepts directly as a Response body. The cached `url` field is preserved
+//     in `info` but not threaded into node-fetch's init (node-fetch v2's `ResponseInit`
+//     only exposes `status`, `statusText`, and `headers`); for the eas-cli download flow
+//     `response.url` isn't read after the fetch.
+//   - eas-cli's default fetch throws on HTTP >= 400 (see `src/fetch.ts`), so the
+//     `!response.ok` short-circuit upstream relies on is effectively superseded by the
+//     thrown error. The guard is kept for symmetry with upstream and to remain correct
+//     if a future caller passes a fetch that doesn't throw.
+
+import { RequestInfo, RequestInit, Response } from '../../fetch';
+import Log from '../../log';
+import {
+  getRequestCacheKey,
+  getResponseInfo,
+  type ResponseCache,
+  type ResponseCacheEntry,
+} from './ResponseCache';
+
+export type FetchLike = (url: RequestInfo, init?: RequestInit) => Promise<Response>;
+
+export function wrapFetchWithCache(fetch: FetchLike, cache: ResponseCache): FetchLike {
+  return async function cachedFetch(url, init) {
+    const cacheKey = getRequestCacheKey(url, init);
+    const cachedResponse = await cache.get(cacheKey);
+    if (cachedResponse) {
+      return responseFromCacheEntry(cachedResponse);
+    }
+
+    await lock(cacheKey);
+
+    try {
+      // Retry loading from cache, in case it was stored while we were waiting for the lock.
+      let entry = await cache.get(cacheKey);
+      if (entry) {
+        return responseFromCacheEntry(entry);
+      }
+
+      // Execute the fetch request
+      const response = await fetch(url, init);
+      if (!response.ok || !response.body) {
+        return response;
+      }
+
+      // Cache the response
+      entry = await cache.set(cacheKey, {
+        body: response.body,
+        info: getResponseInfo(response),
+      });
+
+      // Warn through debug logs that caching failed
+      if (!entry) {
+        Log.debug(`Failed to cache response for: ${url.toString()}`);
+        await cache.remove(cacheKey);
+        return response;
+      }
+
+      // Return the cached response
+      return responseFromCacheEntry(entry);
+    } finally {
+      unlock(cacheKey);
+    }
+  };
+}
+
+function responseFromCacheEntry(entry: ResponseCacheEntry): Response {
+  return new Response(entry.body, {
+    status: entry.info.status,
+    statusText: entry.info.statusText,
+    headers: entry.info.headers,
+  });
+}
+
+const lockPromiseForKey: Record<string, Promise<unknown>> = {};
+const unlockFunctionForKey: Record<string, () => void> = {};
+
+async function lock(key: string): Promise<unknown> {
+  if (!lockPromiseForKey[key]) {
+    lockPromiseForKey[key] = Promise.resolve();
+  }
+
+  const takeLockPromise = lockPromiseForKey[key];
+  lockPromiseForKey[key] = takeLockPromise.then(
+    () =>
+      new Promise<void>(fulfill => {
+        unlockFunctionForKey[key] = fulfill;
+      })
+  );
+
+  return await takeLockPromise;
+}
+
+function unlock(key: string): void {
+  if (unlockFunctionForKey[key]) {
+    unlockFunctionForKey[key]();
+    delete unlockFunctionForKey[key];
+  }
+}

--- a/packages/eas-cli/src/utils/download.ts
+++ b/packages/eas-cli/src/utils/download.ts
@@ -10,21 +10,21 @@ import { v4 as uuidv4 } from 'uuid';
 import { formatBytes } from './files';
 import { getTmpDirectory } from './paths';
 import { ProgressHandler, createProgressTracker } from './progress';
-import fetch, { RequestInit, Response } from '../fetch';
+import defaultFetch, { RequestInfo, RequestInit, Response } from '../fetch';
 import { AppPlatform } from '../graphql/generated';
 import Log from '../log';
 import { promptAsync } from '../prompts';
 
 const pipeline = promisify(Stream.pipeline);
 
-function wrapFetchWithProgress(): (
-  url: string,
-  init: RequestInit,
-  progressHandler: ProgressHandler
-) => Promise<Response> {
+type RawFetch = (url: RequestInfo, init?: RequestInit) => Promise<Response>;
+
+function wrapFetchWithProgress(
+  fetchInstance: RawFetch = defaultFetch
+): (url: string, init: RequestInit, progressHandler: ProgressHandler) => Promise<Response> {
   let didProgressBarFinish = false;
   return async (url: string, init: RequestInit, progressHandler: ProgressHandler) => {
-    const response = await fetch(url, init);
+    const response = await fetchInstance(url, init);
 
     if (response.ok) {
       const totalDownloadSize = response.headers.get('Content-Length');
@@ -75,14 +75,14 @@ export async function downloadFileWithProgressTrackerAsync(
   outputPath: string,
   progressTrackerMessage: string | ((ratio: number, total: number) => string),
   progressTrackerCompletedMessage: string,
-  { showNewLine = true }: { showNewLine?: boolean } = {}
+  { showNewLine = true, fetch: fetchInstance }: { showNewLine?: boolean; fetch?: RawFetch } = {}
 ): Promise<void> {
   if (showNewLine) {
     Log.newLine();
   }
 
   try {
-    const response = await wrapFetchWithProgress()(
+    const response = await wrapFetchWithProgress(fetchInstance)(
       url,
       {
         timeout: 1000 * 60 * 5, // 5 minutes

--- a/packages/eas-cli/src/utils/download.ts
+++ b/packages/eas-cli/src/utils/download.ts
@@ -74,9 +74,12 @@ export async function downloadFileWithProgressTrackerAsync(
   url: string,
   outputPath: string,
   progressTrackerMessage: string | ((ratio: number, total: number) => string),
-  progressTrackerCompletedMessage: string
+  progressTrackerCompletedMessage: string,
+  { showNewLine = true }: { showNewLine?: boolean } = {}
 ): Promise<void> {
-  Log.newLine();
+  if (showNewLine) {
+    Log.newLine();
+  }
 
   try {
     const response = await wrapFetchWithProgress()(
@@ -142,7 +145,7 @@ export async function downloadAndMaybeExtractAppAsync(
         `Downloading app archive (${formatBytes(total * ratio)} / ${formatBytes(total)})`,
       'Successfully downloaded app archive'
     );
-    await tarExtractAsync(tmpArchivePath, outputDir);
+    await extractArchiveAsync(tmpArchivePath, outputDir);
 
     const appPath = await getAppPathAsync(outputDir, platform === AppPlatform.Ios ? 'app' : 'apk');
 
@@ -157,7 +160,7 @@ export async function extractAppFromLocalArchiveAsync(
   const outputDir = path.join(getTmpDirectory(), uuidv4());
   await fs.promises.mkdir(outputDir, { recursive: true });
 
-  await tarExtractAsync(appArchivePath, outputDir);
+  await extractArchiveAsync(appArchivePath, outputDir);
 
   return await getAppPathAsync(outputDir, platform === AppPlatform.Android ? 'apk' : 'app');
 }
@@ -194,7 +197,7 @@ async function getAppPathAsync(outputDir: string, applicationExtension: string):
   return path.join(outputDir, selectedFile);
 }
 
-async function tarExtractAsync(input: string, output: string): Promise<void> {
+export async function extractArchiveAsync(input: string, output: string): Promise<void> {
   try {
     if (process.platform !== 'win32') {
       await spawnAsync('tar', ['-xf', input, '-C', output], {

--- a/packages/eas-cli/src/utils/expoGo.ts
+++ b/packages/eas-cli/src/utils/expoGo.ts
@@ -1,0 +1,307 @@
+import { getConfigFilePaths } from '@expo/config';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import semver from 'semver';
+
+import { ApiV2Client } from '../api';
+import Log from '../log';
+import { getPrivateExpoConfigAsync } from '../project/expoConfig';
+import { downloadFileWithProgressTrackerAsync, extractArchiveAsync } from './download';
+import { formatBytes } from './files';
+import { getExpoHomeDirectory } from './paths';
+
+export type ExpoGoPlatform = 'ios' | 'android';
+
+export type SDKVersion = {
+  iosClientUrl?: string;
+  androidClientUrl?: string;
+  iosClientVersion?: string;
+  androidClientVersion?: string;
+  beta?: boolean;
+  [key: string]: unknown;
+};
+
+export type ExpoVersions = {
+  sdkVersions: Record<string, SDKVersion>;
+};
+
+const SIX_MONTHS_IN_MS = 6 * 30 * 24 * 60 * 60 * 1000;
+
+const platformSettings = {
+  ios: {
+    versionsKey: 'iosClientUrl',
+    extension: 'app',
+    getFilePath: (filename: string) =>
+      path.join(getExpoHomeDirectory(), 'ios-simulator-app-cache', `${filename}.app`),
+  },
+  android: {
+    versionsKey: 'androidClientUrl',
+    extension: 'apk',
+    getFilePath: (filename: string) =>
+      path.join(getExpoHomeDirectory(), 'android-apk-cache', `${filename}.apk`),
+  },
+} as const;
+
+function getUrlBasename(url: string): string {
+  try {
+    return path.basename(new URL(url).pathname);
+  } catch {
+    return path.basename(url.split('?')[0]);
+  }
+}
+
+function formatHomePath(filePath: string): string {
+  const homeDirectory = os.homedir();
+  if (!homeDirectory || !filePath.startsWith(homeDirectory)) {
+    return filePath;
+  }
+  return path.join('~', path.relative(homeDirectory, filePath));
+}
+
+export async function detectProjectSdkVersionAsync(
+  projectDir: string
+): Promise<string | undefined> {
+  const paths = getConfigFilePaths(projectDir);
+  if (!paths.staticConfigPath && !paths.dynamicConfigPath) {
+    return;
+  }
+  try {
+    return (await getPrivateExpoConfigAsync(projectDir)).sdkVersion;
+  } catch {
+    return;
+  }
+}
+
+export function normalizeSdkVersion(sdkVersion: string): string {
+  if (sdkVersion.toUpperCase() === 'UNVERSIONED') {
+    return 'UNVERSIONED';
+  } else if (/^\d+$/.test(sdkVersion)) {
+    return `${sdkVersion}.0.0`;
+  } else if (/^\d+\.\d+$/.test(sdkVersion)) {
+    return `${sdkVersion}.0`;
+  }
+  return sdkVersion;
+}
+
+export function isSdkVersionInput(value: string): boolean {
+  const normalized = value.toUpperCase();
+  return normalized === 'UNVERSIONED' || normalized === 'LATEST' || /^\d+(\.\d+){0,2}$/.test(value);
+}
+
+export async function getVersionsAsync(): Promise<ExpoVersions> {
+  const response = await new ApiV2Client({
+    accessToken: null,
+    sessionSecret: null,
+  }).getAsync('versions/latest');
+  const data = response?.data ?? response;
+  if (!data?.sdkVersions) {
+    throw new Error('Unexpected response when fetching version info from Expo servers.');
+  }
+  return data as ExpoVersions;
+}
+
+export function getLatestSdkVersion(sdkVersions: Record<string, SDKVersion>): string {
+  const latestVersion = Object.keys(sdkVersions)
+    .filter(version => semver.valid(version))
+    .reduce((latest, version) => (semver.gt(version, latest) ? version : latest), '0.0.0');
+
+  if (latestVersion === '0.0.0') {
+    throw new Error('Unable to find a version of Expo Go.');
+  }
+  return latestVersion;
+}
+
+export function getExpoGoVersionEntryFromVersions(
+  sdkVersion: string,
+  versions: ExpoVersions
+): { sdkVersion: string; version: SDKVersion } {
+  const normalizedSdkVersion = normalizeSdkVersion(sdkVersion);
+  const upperSdkVersion = normalizedSdkVersion.toUpperCase();
+  const resolvesToLatest = upperSdkVersion === 'UNVERSIONED' || upperSdkVersion === 'LATEST';
+  const resolvedSdkVersion = resolvesToLatest
+    ? getLatestSdkVersion(versions.sdkVersions)
+    : normalizedSdkVersion;
+
+  if (upperSdkVersion === 'UNVERSIONED') {
+    Log.warn(
+      `Downloading the latest Expo Go client (${resolvedSdkVersion}). This will not fully conform to UNVERSIONED.`
+    );
+  }
+
+  const version = versions.sdkVersions[resolvedSdkVersion];
+  if (!version) {
+    throw new Error(`Unable to find a version of Expo Go for SDK ${normalizedSdkVersion}`);
+  }
+  return { sdkVersion: resolvedSdkVersion, version };
+}
+
+export async function getExpoGoVersionEntryAsync(
+  sdkVersion: string
+): Promise<{ sdkVersion: string; version: SDKVersion }> {
+  return getExpoGoVersionEntryFromVersions(sdkVersion, await getVersionsAsync());
+}
+
+export async function getExpoGoDownloadUrlAsync(
+  platform: ExpoGoPlatform,
+  {
+    projectDir = process.cwd(),
+    sdkVersion,
+  }: {
+    projectDir?: string;
+    sdkVersion?: string;
+  } = {}
+): Promise<{ sdkVersion: string; url: string }> {
+  const versions = await getVersionsAsync();
+  const resolvedSdkVersion = sdkVersion
+    ? normalizeSdkVersion(sdkVersion)
+    : normalizeSdkVersion(
+        (await detectProjectSdkVersionAsync(projectDir)) ??
+          getLatestSdkVersion(versions.sdkVersions)
+      );
+  const { sdkVersion: matchingSdkVersion, version } = getExpoGoVersionEntryFromVersions(
+    resolvedSdkVersion,
+    versions
+  );
+  const versionsKey = platformSettings[platform].versionsKey;
+  const url = version[versionsKey];
+  if (typeof url !== 'string' || !url) {
+    throw new Error(
+      `Unable to find an Expo Go ${platform} download URL for SDK ${matchingSdkVersion}`
+    );
+  }
+  return { sdkVersion: matchingSdkVersion, url };
+}
+
+export async function cleanupOldExpoGoCacheEntriesAsync(
+  cacheDirectory: string,
+  maxAgeMs: number = SIX_MONTHS_IN_MS
+): Promise<void> {
+  let cacheEntries: string[];
+  try {
+    cacheEntries = await fs.readdir(cacheDirectory);
+  } catch {
+    return;
+  }
+
+  const now = Date.now();
+  for (const entry of cacheEntries) {
+    const filePath = path.join(cacheDirectory, entry);
+    try {
+      const stat = await fs.lstat(filePath);
+      if (now - stat.mtimeMs > maxAgeMs) {
+        Log.debug(`Removing old Expo Go cache entry: ${filePath}`);
+        await fs.remove(filePath);
+      }
+    } catch {
+      // Keep cleanup best-effort so a stale entry never blocks a download.
+    }
+  }
+}
+
+export async function downloadExpoGoAsync(
+  platform: ExpoGoPlatform,
+  {
+    projectDir = process.cwd(),
+    sdkVersion,
+    url,
+  }: {
+    projectDir?: string;
+    sdkVersion?: string;
+    url?: string;
+  } = {}
+): Promise<{ path: string; sdkVersion: string; url: string }> {
+  const result = url
+    ? { sdkVersion: sdkVersion ? normalizeSdkVersion(sdkVersion) : 'unknown', url }
+    : await getExpoGoDownloadUrlAsync(platform, { projectDir, sdkVersion });
+  const filename = path.parse(result.url).name;
+  const outputPath = platformSettings[platform].getFilePath(filename);
+
+  await cleanupOldExpoGoCacheEntriesAsync(path.dirname(outputPath));
+  if (await fs.pathExists(outputPath)) {
+    Log.log(`Using cached version from ${chalk.bold(formatHomePath(path.dirname(outputPath)))}`);
+    return { ...result, path: outputPath };
+  }
+
+  if (platform === 'android') {
+    await fs.ensureDir(path.dirname(outputPath));
+    await fs.copy(await downloadExpoGoFileToCacheAsync(result.url), outputPath);
+  } else {
+    await fs.ensureDir(path.dirname(outputPath));
+    await fs.remove(outputPath);
+    await fs.ensureDir(outputPath);
+    await extractArchiveAsync(await downloadExpoGoFileToCacheAsync(result.url), outputPath);
+  }
+
+  return { ...result, path: outputPath };
+}
+
+async function downloadExpoGoFileToCacheAsync(url: string): Promise<string> {
+  const outputPath = path.join(getExpoHomeDirectory(), 'expo-go', getUrlBasename(url));
+  if (await fs.pathExists(outputPath)) {
+    return outputPath;
+  }
+
+  await fs.ensureDir(path.dirname(outputPath));
+  await downloadFileWithProgressTrackerAsync(
+    url,
+    outputPath,
+    (ratio, total) => `Downloading Expo Go (${formatBytes(total * ratio)} / ${formatBytes(total)})`,
+    'Successfully downloaded Expo Go',
+    { showNewLine: false }
+  );
+  return outputPath;
+}
+
+export async function copyExpoGoToPathAsync({
+  destinationPath,
+  platform,
+  sourcePath,
+}: {
+  destinationPath?: string;
+  platform: ExpoGoPlatform;
+  sourcePath: string;
+}): Promise<string> {
+  const outputPath = await resolveExpoGoOutputPathAsync({
+    destinationPath,
+    platform,
+    sourcePath,
+  });
+
+  if (path.resolve(sourcePath) === path.resolve(outputPath)) {
+    return outputPath;
+  }
+
+  await fs.ensureDir(path.dirname(outputPath));
+  await fs.remove(outputPath);
+  await fs.copy(sourcePath, outputPath);
+  return outputPath;
+}
+
+async function resolveExpoGoOutputPathAsync({
+  destinationPath,
+  platform,
+  sourcePath,
+}: {
+  destinationPath?: string;
+  platform: ExpoGoPlatform;
+  sourcePath: string;
+}): Promise<string> {
+  if (!destinationPath) {
+    return path.join(process.cwd(), path.basename(sourcePath));
+  }
+
+  const resolvedDestinationPath = path.resolve(destinationPath);
+  const extension = platformSettings[platform].extension;
+  if (resolvedDestinationPath.endsWith(`.${extension}`)) {
+    return resolvedDestinationPath;
+  }
+
+  const stat = await fs.stat(resolvedDestinationPath).catch(() => null);
+  if (!stat || stat.isDirectory()) {
+    return path.join(resolvedDestinationPath, path.basename(sourcePath));
+  }
+
+  return resolvedDestinationPath;
+}

--- a/packages/eas-cli/src/utils/expoGo.ts
+++ b/packages/eas-cli/src/utils/expoGo.ts
@@ -5,12 +5,16 @@ import os from 'os';
 import path from 'path';
 import semver from 'semver';
 
+import { v4 as uuidv4 } from 'uuid';
+
 import { ApiV2Client } from '../api';
 import Log from '../log';
 import { getPrivateExpoConfigAsync } from '../project/expoConfig';
+import { createCachedFetch } from './cache/createCachedFetch';
+import type { FetchLike } from './cache/wrapFetchWithCache';
 import { downloadFileWithProgressTrackerAsync, extractArchiveAsync } from './download';
 import { formatBytes } from './files';
-import { getExpoHomeDirectory } from './paths';
+import { getExpoHomeDirectory, getTmpDirectory } from './paths';
 
 export type ExpoGoPlatform = 'ios' | 'android';
 
@@ -29,16 +33,24 @@ export type ExpoVersions = {
 
 const SIX_MONTHS_IN_MS = 6 * 30 * 24 * 60 * 60 * 1000;
 
+// Mirrors @expo/cli's `platformSettings`.
+// Source: https://github.com/expo/expo/blob/2c21e2f96ce6aede3d6bb5c780f0964d2116d37b/packages/%40expo/cli/src/utils/downloadExpoGoAsync.ts#L18-L31
+//
+// Adapted for eas-cli:
+//   - Adds `extension` for `copyExpoGoToPathAsync` (a feature upstream doesn't have:
+//     the `eas go:download` command lets the user pick an output path).
 const platformSettings = {
   ios: {
     versionsKey: 'iosClientUrl',
     extension: 'app',
+    shouldExtractResults: true,
     getFilePath: (filename: string) =>
       path.join(getExpoHomeDirectory(), 'ios-simulator-app-cache', `${filename}.app`),
   },
   android: {
     versionsKey: 'androidClientUrl',
     extension: 'apk',
+    shouldExtractResults: false,
     getFilePath: (filename: string) =>
       path.join(getExpoHomeDirectory(), 'android-apk-cache', `${filename}.apk`),
   },
@@ -113,6 +125,16 @@ export function getLatestSdkVersion(sdkVersions: Record<string, SDKVersion>): st
   return latestVersion;
 }
 
+// Resolves a single `SDKVersion` entry. Distilled from @expo/cli's
+// `getExpoGoVersionEntryAsync` (inline version-map lookup + UNVERSIONED handling).
+// Source: https://github.com/expo/expo/blob/2c21e2f96ce6aede3d6bb5c780f0964d2116d37b/packages/%40expo/cli/src/utils/downloadExpoGoAsync.ts#L37-L61
+//
+// Adapted for eas-cli:
+//   - Pure (takes a `versions` map) so the network fetch can be cached separately and
+//     the function is trivially testable; upstream fetches inline.
+//   - Accepts the literal token `"latest"` in addition to `"UNVERSIONED"`. The
+//     `eas go:download <platform> latest <output>` syntax uses it to skip the
+//     project-detection / explicit-version path.
 export function getExpoGoVersionEntryFromVersions(
   sdkVersion: string,
   versions: ExpoVersions
@@ -174,6 +196,13 @@ export async function getExpoGoDownloadUrlAsync(
   return { sdkVersion: matchingSdkVersion, url };
 }
 
+// Direct port of @expo/cli's `cleanupOldExpoGoCacheEntriesAsync`.
+// Source: https://github.com/expo/expo/blob/2c21e2f96ce6aede3d6bb5c780f0964d2116d37b/packages/%40expo/cli/src/utils/downloadExpoGoAsync.ts#L63-L90
+//
+// Adapted for eas-cli:
+//   - Uses `fs-extra`'s `lstat`/`remove` instead of `fs.promises.lstat`/`fs.promises.rm`
+//     to match eas-cli's existing fs idioms; behaviour is equivalent (recursive remove,
+//     mtime-based pruning).
 export async function cleanupOldExpoGoCacheEntriesAsync(
   cacheDirectory: string,
   maxAgeMs: number = SIX_MONTHS_IN_MS
@@ -200,6 +229,15 @@ export async function cleanupOldExpoGoCacheEntriesAsync(
   }
 }
 
+// Mirrors @expo/cli's `downloadExpoGoAsync`.
+// Source: https://github.com/expo/expo/blob/2c21e2f96ce6aede3d6bb5c780f0964d2116d37b/packages/%40expo/cli/src/utils/downloadExpoGoAsync.ts#L92-L160
+//
+// Adapted for eas-cli:
+//   - Accepts an optional `projectDir` + `url` and returns the resolved `sdkVersion`
+//     and `url` alongside the cached path. The `eas go:download` and `eas go:url`
+//     commands need both pieces of metadata; upstream only returns the path.
+//   - Progress is rendered by `downloadFileWithProgressTrackerAsync` (eas-cli's
+//     existing ora-based progress tracker) instead of upstream's custom `ProgressBar`.
 export async function downloadExpoGoAsync(
   platform: ExpoGoPlatform,
   {
@@ -215,8 +253,10 @@ export async function downloadExpoGoAsync(
   const result = url
     ? { sdkVersion: sdkVersion ? normalizeSdkVersion(sdkVersion) : 'unknown', url }
     : await getExpoGoDownloadUrlAsync(platform, { projectDir, sdkVersion });
+
+  const { getFilePath, shouldExtractResults } = platformSettings[platform];
   const filename = path.parse(result.url).name;
-  const outputPath = platformSettings[platform].getFilePath(filename);
+  const outputPath = getFilePath(filename);
 
   await cleanupOldExpoGoCacheEntriesAsync(path.dirname(outputPath));
   if (await fs.pathExists(outputPath)) {
@@ -224,34 +264,76 @@ export async function downloadExpoGoAsync(
     return { ...result, path: outputPath };
   }
 
-  if (platform === 'android') {
-    await fs.ensureDir(path.dirname(outputPath));
-    await fs.copy(await downloadExpoGoFileToCacheAsync(result.url), outputPath);
-  } else {
-    await fs.ensureDir(path.dirname(outputPath));
-    await fs.remove(outputPath);
-    await fs.ensureDir(outputPath);
-    await extractArchiveAsync(await downloadExpoGoFileToCacheAsync(result.url), outputPath);
-  }
+  await downloadAppAsync({
+    url: result.url,
+    outputPath,
+    extract: shouldExtractResults,
+  });
 
   return { ...result, path: outputPath };
 }
 
-async function downloadExpoGoFileToCacheAsync(url: string): Promise<string> {
-  const outputPath = path.join(getExpoHomeDirectory(), 'expo-go', getUrlBasename(url));
-  if (await fs.pathExists(outputPath)) {
-    return outputPath;
-  }
+// Mirrors @expo/cli's `downloadAppAsync`.
+// Source: https://github.com/expo/expo/blob/2c21e2f96ce6aede3d6bb5c780f0964d2116d37b/packages/%40expo/cli/src/utils/downloadAppAsync.ts#L53-L80
+//
+// Adapted for eas-cli:
+//   - Uses `downloadFileWithProgressTrackerAsync` (which wraps eas-cli's
+//     proxy/error-aware `fetch`) and threads a cached fetch into it, instead of
+//     upstream's `downloadAsync` helper.
+//   - Reuses `getTmpDirectory()` (env-paths-based OS temp dir) for the intermediate
+//     iOS archive, mirroring upstream's `os.tmpdir()` via `createTempFilePath`.
+//   - Defensively removes any stale `outputPath` before iOS extraction so a partial
+//     bundle from a previous failed run doesn't get mixed with the new contents.
+async function downloadAppAsync({
+  url,
+  outputPath,
+  extract,
+}: {
+  url: string;
+  outputPath: string;
+  extract: boolean;
+}): Promise<void> {
+  const fetchInstance: FetchLike = createCachedFetch({
+    // Persist the cached HTTP responses under `~/.expo/expo-go/`. Matches upstream.
+    cacheDirectory: 'expo-go',
+    // 1 week TTL, mirroring upstream:
+    // https://github.com/expo/expo/blob/2c21e2f96ce6aede3d6bb5c780f0964d2116d37b/packages/%40expo/cli/src/api/rest/client.ts#L184
+    ttl: 1000 * 60 * 60 * 24 * 7,
+  });
 
-  await fs.ensureDir(path.dirname(outputPath));
-  await downloadFileWithProgressTrackerAsync(
-    url,
-    outputPath,
-    (ratio, total) => `Downloading Expo Go (${formatBytes(total * ratio)} / ${formatBytes(total)})`,
-    'Successfully downloaded Expo Go',
-    { showNewLine: false }
-  );
-  return outputPath;
+  const progressMessage = (ratio: number, total: number): string =>
+    `Downloading Expo Go (${formatBytes(total * ratio)} / ${formatBytes(total)})`;
+
+  if (extract) {
+    // iOS: download the archive into the OS tmp dir, then extract into the
+    // `<name>.app` cache directory. Nothing is persisted under `~/.expo/expo-go`
+    // as a raw archive — the only long-lived cache layers are (a) the HTTP
+    // response cache (TTL-evicted) and (b) the platform `.app` cache (mtime-evicted).
+    const tmpDir = path.join(getTmpDirectory(), uuidv4());
+    await fs.ensureDir(tmpDir);
+    const tmpPath = path.join(tmpDir, getUrlBasename(url));
+    await downloadFileWithProgressTrackerAsync(
+      url,
+      tmpPath,
+      progressMessage,
+      'Successfully downloaded Expo Go',
+      { showNewLine: false, fetch: fetchInstance }
+    );
+
+    await fs.remove(outputPath);
+    await fs.ensureDir(outputPath);
+    await extractArchiveAsync(tmpPath, outputPath);
+  } else {
+    // Android: write the .apk straight to its final location in `android-apk-cache/`.
+    await fs.ensureDir(path.dirname(outputPath));
+    await downloadFileWithProgressTrackerAsync(
+      url,
+      outputPath,
+      progressMessage,
+      'Successfully downloaded Expo Go',
+      { showNewLine: false, fetch: fetchInstance }
+    );
+  }
 }
 
 export async function copyExpoGoToPathAsync({

--- a/packages/eas-cli/src/utils/paths.ts
+++ b/packages/eas-cli/src/utils/paths.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 // The ~/.expo directory is used to store authentication sessions,
 // which are shared between EAS CLI and Expo CLI.
-function dotExpoHomeDirectory(): string {
+export function getExpoHomeDirectory(): string {
   const home = homedir();
   if (!home) {
     throw new Error(
@@ -23,7 +23,7 @@ function dotExpoHomeDirectory(): string {
   return dirPath;
 }
 
-export const getStateJsonPath = (): string => path.join(dotExpoHomeDirectory(), 'state.json');
+export const getStateJsonPath = (): string => path.join(getExpoHomeDirectory(), 'state.json');
 
 export const getEasBuildRunCacheDirectoryPath = (): string =>
   path.join(getTmpDirectory(), 'eas-build-run-cache');


### PR DESCRIPTION
- add `eas go:url` to print Expo Go download URLs
- add `eas go:download` to download/copy Expo Go for iOS simulator or Android

<img width="918" height="359" alt="Screenshot 2026-05-27 at 17 20 54" src="https://github.com/user-attachments/assets/3d02e36b-1fa2-4ae2-8650-7315c74c39e7" />
