### PR TITLE
[worker] Fail silently on cache archive errors in CacheManager

### DIFF
--- a/packages/worker/src/CacheManager.ts
+++ b/packages/worker/src/CacheManager.ts
@@ -31,15 +31,20 @@ export class GCSCacheManager implements CacheManager {
       ctx.logger.info(`- ${filePath}`);
     });
     const archivePath = path.join(ctx.workingdir, 'cache-save.tar.gz');
-    await tar.create(
-      {
-        file: archivePath,
-        cwd: '/',
-        gzip: true,
-        preservePaths: true,
-      },
-      paths
-    );
+    try {
+      await tar.create(
+        {
+          file: archivePath,
+          cwd: '/',
+          gzip: true,
+          preservePaths: true,
+        },
+        paths
+      );
+    } catch (err: any) {
+      ctx.logger.error({ err }, 'Failed to create cache archive');
+      return;
+    }
 
     const archiveSize = (await fs.stat(archivePath)).size;
     const { maxSizeBytes } = this.allowedContentLengthRange;
@@ -88,16 +93,21 @@ export class GCSCacheManager implements CacheManager {
       return;
     }
 
-    await tar.extract(
-      {
-        file: archivePath,
-        cwd: '/',
-        preserveOwner: true,
-        preservePaths: true,
-        keep: true, // do not override existing files
-      },
-      paths
-    );
+    try {
+      await tar.extract(
+        {
+          file: archivePath,
+          cwd: '/',
+          preserveOwner: true,
+          preservePaths: true,
+          keep: true, // do not override existing files
+        },
+        paths
+      );
+    } catch (err: any) {
+      ctx.logger.error({ err }, 'Failed to extract cache archive');
+      this.skipCacheUpdate = true;
+    }
   }
 
   private getPaths(ctx: BuildContext<BuildJob>): string[] {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

A few builds are failing due to a regression upstream for cache bucketing. https://app.datadoghq.com/logs?query=%22TAR_BAD_ARCHIVE%3A%20Unrecognized%20archive%20format%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice%2Caccount_name&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1779393080451&to_ts=1779997880451&live=true

Failing to restore or save should never fail the build, add proper handling.