### PR TITLE
[repack] add ios signing entitlements params

### DIFF
--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -77,7 +77,7 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
-    "@expo/repack-app": "~0.4.1",
+    "@expo/repack-app": "~0.6.1",
     "@types/fs-extra": "^11.0.4",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.4",

--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -58,6 +58,16 @@ export function createRepackBuildFunction(): BuildFunction {
         required: false,
       }),
       BuildStepInput.createProvider({
+        id: 'ios_signing_use_source_app_entitlements',
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'ios_signing_app_entitlements_path',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
         id: 'repack_version',
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
         required: false,
@@ -138,6 +148,12 @@ export function createRepackBuildFunction(): BuildFunction {
             iosSigningOptions: await resolveIosSigningOptionsAsync({
               job: stepsCtx.global.staticContext.job,
               logger: stepsCtx.logger,
+              useAppEntitlements: inputs.ios_signing_use_source_app_entitlements.value as
+                | boolean
+                | undefined,
+              entitlementsPath: inputs.ios_signing_app_entitlements_path.value as
+                | string
+                | undefined,
             }),
             logger: stepsCtx.logger,
             spawnAsync: repackSpawnAsync,
@@ -275,9 +291,13 @@ export async function resolveAndroidSigningOptionsAsync({
 export async function resolveIosSigningOptionsAsync({
   job,
   logger,
+  useAppEntitlements,
+  entitlementsPath,
 }: {
   job: Job;
   logger: bunyan;
+  useAppEntitlements?: boolean;
+  entitlementsPath?: string;
 }): Promise<IosSigningOptions | undefined> {
   const iosJob = job as Ios.Job;
   const buildCredentials = iosJob.secrets?.buildCredentials;
@@ -295,5 +315,7 @@ export async function resolveIosSigningOptionsAsync({
     provisioningProfile,
     keychainPath: credentials.keychainPath,
     signingIdentity: credentials.applicationTargetProvisioningProfile.data.certificateCommonName,
+    useAppEntitlements,
+    entitlementsPath,
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2868,7 +2868,7 @@ __metadata:
     "@expo/logger": "npm:20.0.0"
     "@expo/package-manager": "npm:1.9.10"
     "@expo/plist": "npm:^0.2.0"
-    "@expo/repack-app": "npm:~0.4.1"
+    "@expo/repack-app": "npm:~0.6.1"
     "@expo/results": "npm:^1.0.0"
     "@expo/spawn-async": "npm:1.7.2"
     "@expo/steps": "npm:20.0.0"
@@ -3419,15 +3419,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/repack-app@npm:~0.4.1":
-  version: 0.4.1
-  resolution: "@expo/repack-app@npm:0.4.1"
+"@expo/repack-app@npm:~0.6.1":
+  version: 0.6.1
+  resolution: "@expo/repack-app@npm:0.6.1"
   dependencies:
     commander: "npm:^14.0.2"
     picocolors: "npm:^1.1.1"
   bin:
     repack-app: bin/cli.js
-  checksum: 10c0/4bc30a7ca95221f079026633802c32894ef25d55677212e86859194bf1a042598eaa5977510a277c3ceee6af6bd0d0a3aff3e21c4510c37b7dea584dd927ed0e
+  checksum: 10c0/fdf3088b4f327393056631270bf90a67ba949e7994892a62abc985bd9478119ab2f1d5be35fa1efb6bd1d2780c49a3dbb87cb669d9c65b44e3d9a0b41fbf091f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

allow optional app entitlements params for fastlane resign

# How

- `ios_signing_use_source_app_entitlements`: fastlane resign's `use_app_entitlements`
- `ios_signing_app_entitlements_path`: fastlane resign's `entitlements`

# Test Plan

ci passed and tested after deployment