### PR TITLE
[eas-cli] use webrtc for simulator service streaming

### DIFF
--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -146,7 +146,7 @@ export async function startServeSimWithTunnelAsync({
       '--stream-quality',
       '0.55',
       '--codec',
-      'h264',
+      'webrtc',
     ],
     env,
   });


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Use webrtc for better perf

# How

Use webrtc with serve sim for better perf

# Test Plan

Looks good locally