### PR TITLE
[eas-cli] Add eas update:embedded:view command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add `eas update:embedded:view` command. ([#3810](https://github.com/expo/eas-cli/pull/3810) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Auto-upload embedded bundle after build when `EAS_UPDATE_EXPERIMENTAL_UPLOAD_EMBEDDED_BUNDLE` is set. ([#3767](https://github.com/expo/eas-cli/pull/3767) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -12317,6 +12317,112 @@
             "deprecationReason": null
           },
           {
+            "name": "workflowDeviceTestCaseHistory",
+            "description": null,
+            "args": [
+              {
+                "name": "filters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "WorkflowDeviceTestCaseHistoryFiltersInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "path",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "WorkflowDeviceTestCaseInsightsTimespanInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseHistory",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflowDeviceTestCaseInsights",
+            "description": null,
+            "args": [
+              {
+                "name": "filters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "WorkflowDeviceTestCaseInsightsFiltersInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "WorkflowDeviceTestCaseInsightsTimespanInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseInsights",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "workflowRunGitBranchesPaginated",
             "description": null,
             "args": [
@@ -43328,6 +43434,66 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "EmbeddedUpdateQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "byId",
+            "description": "Look up an embedded update by its id and the owning app's id.\nThrows EMBEDDED_UPDATE_NOT_FOUND when no embedded update with this id exists on\nthe given app within the caller's account.",
+            "args": [
+              {
+                "name": "appId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "embeddedUpdateId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EmbeddedUpdate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "EntityTypeName",
         "description": null,
@@ -52970,9 +53136,13 @@
             "description": "Max run time in seconds for this job run.",
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -60565,6 +60735,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "EchoVersionQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "embeddedUpdates",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EmbeddedUpdateQuery",
                 "ofType": null
               }
             },
@@ -81579,6 +81765,1226 @@
       },
       {
         "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseErrorPattern",
+        "description": "Grouping key from the [shard N] prefix-stripped error_message. `count` is\ncomputed with uniqExact(test_case_result_id) so RMT pre-merge duplicates do\nnot inflate it. Scope: scans ALL status='failed' rows (NOT just\nis_final_attempt=1) so failures from runs that ultimately passed on retry\nstill surface.",
+        "fields": [
+          {
+            "name": "count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastSeenAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "patternKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sampleMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseHistory",
+        "description": null,
+        "fields": [
+          {
+            "name": "errorPatterns",
+            "description": null,
+            "args": [
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkflowDeviceTestCaseErrorPattern",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "recentRuns",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseRecentRunConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timeSeries",
+            "description": null,
+            "args": [
+              {
+                "name": "granularity",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "WorkflowDeviceTestCaseInsightsTimeSeriesGranularity",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkflowDeviceTestCaseInsightsBucket",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totals",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseInsightsTotals",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "WorkflowDeviceTestCaseHistoryFiltersInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "gitRefs",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflowIds",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseInsights",
+        "description": null,
+        "fields": [
+          {
+            "name": "facets",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseInsightsFacets",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tests",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "search",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortDirection",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "WorkflowDeviceTestCaseSortDirection",
+                  "ofType": null
+                },
+                "defaultValue": "DESC",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortField",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "WorkflowDeviceTestCaseStatSortField",
+                  "ofType": null
+                },
+                "defaultValue": "FAILS",
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseStatConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timeSeries",
+            "description": null,
+            "args": [
+              {
+                "name": "granularity",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "WorkflowDeviceTestCaseInsightsTimeSeriesGranularity",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkflowDeviceTestCaseInsightsBucket",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totals",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseInsightsTotals",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseInsightsBucket",
+        "description": "Mutually exclusive bucket counts (passedClean + flaky + failed = totalRuns for the bucket).\nBuckets are aligned to the UTC start of the requested granularity interval\n(minute / hour / day).",
+        "fields": [
+          {
+            "name": "bucketStartAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "failed",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "flaky",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "passedClean",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseInsightsFacets",
+        "description": null,
+        "fields": [
+          {
+            "name": "gitRefs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tags",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflows",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkflowDeviceTestCaseWorkflowFacet",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "WorkflowDeviceTestCaseInsightsFiltersInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "gitRefs",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "statuses",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "WorkflowDeviceTestCaseStatusFilter",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tags",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflowIds",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseInsightsMetric",
+        "description": "A count metric returned for the current window AND the equivalent prior window\n(start − duration → start). The frontend uses (current, previous) to compute\ntrend deltas. Trend ratios are NOT pre-computed server-side — see\nWorkflowsInsightsMetric for the equivalent convention.\n\nFloat (not Int) to match WorkflowsInsightsMetric and avoid the GraphQL Int32\nceiling: 90-day uniqExact counts on a high-volume project can plausibly\nexceed 2.1B. Values are integer-valued; the frontend reads them as JS numbers.",
+        "fields": [
+          {
+            "name": "currentValue",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "previousValue",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseInsightsNullableMetric",
+        "description": "Same shape as WorkflowDeviceTestCaseInsightsMetric but nullable on both sides —\nused for metrics like avgDurationMs / p90DurationMs where \"no data in the\nwindow\" is meaningful and must not collapse to 0.",
+        "fields": [
+          {
+            "name": "currentValue",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "previousValue",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WorkflowDeviceTestCaseInsightsTimeSeriesGranularity",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DAY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HOUR",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MINUTE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "WorkflowDeviceTestCaseInsightsTimespanInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "end",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "start",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseInsightsTotals",
+        "description": "Raw counts only (paired with previous-window values). Pass rate, flake rate,\nand trends are computed in the frontend from the (currentValue, previousValue)\npair on each metric.\n\ntotalRuns = passedCleanCount + flakyCount + failedCount (over is_final_attempt=1 rows).\ndistinctFlakyTestCount cannot be derived in the frontend from per-test rows\nbecause pagination means the frontend doesn't see all test paths.",
+        "fields": [
+          {
+            "name": "avgDurationMs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseInsightsNullableMetric",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "distinctFlakyTestCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseInsightsMetric",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "failedCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseInsightsMetric",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "flakyCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseInsightsMetric",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "p90DurationMs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseInsightsNullableMetric",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "passedCleanCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseInsightsMetric",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalRuns",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseInsightsMetric",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseRecentRun",
+        "description": "One row per execution (is_final_attempt=1). The is_flaky boolean drives the\nFLAKY pill — no per-attempt timeline is exposed in v1.",
+        "fields": [
+          {
+            "name": "commitSha",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "durationMs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "gitRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isFlaky",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "WorkflowDeviceTestCaseStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflowRunId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflowRunName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseRecentRunConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkflowDeviceTestCaseRecentRunEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseRecentRunEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseRecentRun",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "WorkflowDeviceTestCaseResult",
         "description": "A device test case result from a Maestro test execution.",
         "fields": [
@@ -81933,6 +83339,371 @@
       },
       {
         "kind": "ENUM",
+        "name": "WorkflowDeviceTestCaseSortDirection",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseStat",
+        "description": null,
+        "fields": [
+          {
+            "name": "avgDurationMs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "failedCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "flakyCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastRunAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastRunIsFlaky",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastRunStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "WorkflowDeviceTestCaseStatus",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "p90DurationMs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "passedCleanCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "path",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalRuns",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseStatConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkflowDeviceTestCaseStatEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseStatEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "WorkflowDeviceTestCaseStat",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WorkflowDeviceTestCaseStatSortField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "FAILS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FLAKES",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FLAKE_RATE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LAST_RUN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "P90_DURATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PASS_RATE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RUNS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
         "name": "WorkflowDeviceTestCaseStatus",
         "description": "Status of a device test case execution.",
         "fields": null,
@@ -81952,6 +83723,78 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WorkflowDeviceTestCaseStatusFilter",
+        "description": "Mutually exclusive — matches the chart bucket semantics (passedClean / flaky / failed).\nPASSED_CLEAN  = is_final_attempt=1 AND status=passed AND is_flaky=0\nFLAKY         = is_final_attempt=1 AND is_flaky=1 (still a pass, just with retries)\nFAILED        = is_final_attempt=1 AND status=failed",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "FAILED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FLAKY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PASSED_CLEAN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "WorkflowDeviceTestCaseWorkflowFacet",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {

--- a/packages/eas-cli/src/commands/update/embedded/__tests__/view.test.ts
+++ b/packages/eas-cli/src/commands/update/embedded/__tests__/view.test.ts
@@ -1,0 +1,144 @@
+import { CombinedError } from '@urql/core';
+
+import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { AppPlatform } from '../../../../graphql/generated';
+import {
+  EmbeddedUpdateFragment,
+  EmbeddedUpdateQuery,
+  isEmbeddedUpdateNotFoundError,
+} from '../../../../graphql/queries/EmbeddedUpdateQuery';
+import Log from '../../../../log';
+import * as json from '../../../../utils/json';
+import UpdateEmbeddedView from '../view';
+
+jest.mock('../../../../graphql/queries/EmbeddedUpdateQuery', () => ({
+  EmbeddedUpdateQuery: { viewByIdAsync: jest.fn() },
+  isEmbeddedUpdateNotFoundError: jest.fn(),
+}));
+jest.mock('../../../../log');
+jest.mock('../../../../utils/json');
+
+const mockView = jest.mocked(EmbeddedUpdateQuery.viewByIdAsync);
+const mockIsNotFound = jest.mocked(isEmbeddedUpdateNotFoundError);
+const mockLogLog = jest.mocked(Log.log);
+const mockEnableJsonOutput = jest.mocked(json.enableJsonOutput);
+const mockPrintJson = jest.mocked(json.printJsonOnlyOutput);
+
+const VALID_UUID = 'a1b2c3d4-1234-4000-8000-000000000000';
+
+const MOCK_CONTEXT = {
+  projectId: 'project-123',
+  loggedIn: { graphqlClient: {} as ExpoGraphqlClient },
+};
+
+const MOCK_EMBEDDED_UPDATE: EmbeddedUpdateFragment = {
+  id: VALID_UUID,
+  platform: AppPlatform.Ios,
+  runtimeVersion: '1.0.0',
+  channel: 'production',
+  createdAt: '2026-05-29T00:00:00Z',
+  launchAsset: {
+    id: 'asset-1',
+    fileSize: 1024,
+    finalFileSize: 768,
+    fileSHA256: 'abc123',
+  },
+};
+
+describe(UpdateEmbeddedView, () => {
+  const mockConfig = getMockOclifConfig();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockView.mockResolvedValue(MOCK_EMBEDDED_UPDATE);
+    mockIsNotFound.mockReturnValue(false);
+  });
+
+  function createCommand(argv: string[]): UpdateEmbeddedView {
+    const command = new UpdateEmbeddedView(argv, mockConfig);
+    // @ts-expect-error getContextAsync is protected
+    jest.spyOn(command, 'getContextAsync').mockResolvedValue(MOCK_CONTEXT);
+    return command;
+  }
+
+  it('prints formatted details on success', async () => {
+    await createCommand([VALID_UUID]).run();
+
+    expect(mockView).toHaveBeenCalledWith(MOCK_CONTEXT.loggedIn.graphqlClient, {
+      embeddedUpdateId: VALID_UUID,
+      appId: MOCK_CONTEXT.projectId,
+    });
+    // Header line + body line
+    expect(mockLogLog).toHaveBeenCalledTimes(2);
+    expect(mockLogLog.mock.calls[0][0]).toContain('Embedded update');
+    expect(mockLogLog.mock.calls[1][0]).toContain(VALID_UUID);
+    expect(mockLogLog.mock.calls[1][0]).toContain('Bundle size');
+    expect(mockLogLog.mock.calls[1][0]).toContain('Bundle SHA-256');
+  });
+
+  it('--json prints the raw embedded update and skips formatted output', async () => {
+    await createCommand([VALID_UUID, '--json']).run();
+
+    expect(mockEnableJsonOutput).toHaveBeenCalled();
+    expect(mockPrintJson).toHaveBeenCalledWith(MOCK_EMBEDDED_UPDATE);
+    expect(mockLogLog).not.toHaveBeenCalled();
+  });
+
+  it('exits with a friendly message when the server returns NOT_FOUND', async () => {
+    const notFound = new CombinedError({ graphQLErrors: [] });
+    mockView.mockRejectedValue(notFound);
+    mockIsNotFound.mockReturnValue(true);
+
+    await expect(createCommand([VALID_UUID]).run()).rejects.toThrow();
+    expect(mockIsNotFound).toHaveBeenCalledWith(notFound);
+  });
+
+  it('rethrows unexpected errors', async () => {
+    const boom = new Error('boom');
+    mockView.mockRejectedValue(boom);
+    mockIsNotFound.mockReturnValue(false);
+
+    await expect(createCommand([VALID_UUID]).run()).rejects.toThrow('boom');
+  });
+
+  it('renders bundle size from finalFileSize when present', async () => {
+    mockView.mockResolvedValue({
+      ...MOCK_EMBEDDED_UPDATE,
+      launchAsset: { id: 'asset-x', fileSize: 2048, finalFileSize: 768, fileSHA256: 'abc' },
+    });
+    await createCommand([VALID_UUID]).run();
+    // 768 B; not 2.0 KB (which would be fileSize).
+    expect(mockLogLog.mock.calls[1][0]).toContain('768 B');
+  });
+
+  it('falls back to fileSize when finalFileSize is null', async () => {
+    mockView.mockResolvedValue({
+      ...MOCK_EMBEDDED_UPDATE,
+      launchAsset: { id: 'asset-y', fileSize: 2048, finalFileSize: null, fileSHA256: 'abc' },
+    });
+    await createCommand([VALID_UUID]).run();
+    expect(mockLogLog.mock.calls[1][0]).toContain('2.0 KB');
+  });
+
+  it('shows runtime version, channel, and SHA-256 in the body', async () => {
+    await createCommand([VALID_UUID]).run();
+    const body = String(mockLogLog.mock.calls[1][0]);
+    expect(body).toContain('1.0.0');
+    expect(body).toContain('production');
+    expect(body).toContain('abc123');
+  });
+
+  it('shows a relative-time hint in the Created at row', async () => {
+    await createCommand([VALID_UUID]).run();
+    expect(mockLogLog.mock.calls[1][0]).toMatch(/\(.+ago\)/);
+  });
+
+  it('passes the project id and uuid through to viewByIdAsync', async () => {
+    await createCommand([VALID_UUID]).run();
+    expect(mockView).toHaveBeenCalledWith(MOCK_CONTEXT.loggedIn.graphqlClient, {
+      embeddedUpdateId: VALID_UUID,
+      appId: MOCK_CONTEXT.projectId,
+    });
+  });
+});

--- a/packages/eas-cli/src/commands/update/embedded/view.ts
+++ b/packages/eas-cli/src/commands/update/embedded/view.ts
@@ -1,0 +1,95 @@
+import { Args, Errors } from '@oclif/core';
+import chalk from 'chalk';
+
+import EasCommand from '../../../commandUtils/EasCommand';
+import { EasJsonOnlyFlag } from '../../../commandUtils/flags';
+import {
+  EmbeddedUpdateFragment,
+  EmbeddedUpdateQuery,
+  isEmbeddedUpdateNotFoundError,
+} from '../../../graphql/queries/EmbeddedUpdateQuery';
+import Log from '../../../log';
+import { fromNow } from '../../../utils/date';
+import { formatBytes } from '../../../utils/files';
+import formatFields from '../../../utils/formatFields';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+
+export default class UpdateEmbeddedView extends EasCommand {
+  static override description = 'view details of an embedded update registered with EAS Update';
+
+  static override args = {
+    id: Args.string({
+      required: true,
+      description: 'The ID of the embedded update (manifest UUID from app.manifest).',
+    }),
+  };
+
+  static override flags = {
+    ...EasJsonOnlyFlag,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectId,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      args: { id: embeddedUpdateId },
+      flags: { json: jsonFlag },
+    } = await this.parse(UpdateEmbeddedView);
+
+    const {
+      projectId,
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(UpdateEmbeddedView, { nonInteractive: true });
+
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    let embeddedUpdate;
+    try {
+      embeddedUpdate = await EmbeddedUpdateQuery.viewByIdAsync(graphqlClient, {
+        embeddedUpdateId,
+        appId: projectId,
+      });
+    } catch (e: unknown) {
+      if (isEmbeddedUpdateNotFoundError(e)) {
+        Errors.error(
+          `No embedded update found with id "${embeddedUpdateId}" for this project. ` +
+            `Run "eas update:embedded:list" to see the embedded updates registered for this app.`,
+          { exit: 1 }
+        );
+      }
+      throw e;
+    }
+
+    if (jsonFlag) {
+      printJsonOnlyOutput(embeddedUpdate);
+      return;
+    }
+
+    Log.addNewLineIfNone();
+    Log.log(chalk.bold('Embedded update:'));
+    Log.log(formatEmbeddedUpdate(embeddedUpdate));
+  }
+}
+
+export function formatEmbeddedUpdate(embeddedUpdate: EmbeddedUpdateFragment): string {
+  const createdAt = new Date(embeddedUpdate.createdAt);
+  const bundleSize =
+    embeddedUpdate.launchAsset.finalFileSize ?? embeddedUpdate.launchAsset.fileSize;
+  return formatFields([
+    { label: 'ID', value: embeddedUpdate.id },
+    { label: 'Platform', value: embeddedUpdate.platform.toLowerCase() },
+    { label: 'Runtime version', value: embeddedUpdate.runtimeVersion },
+    { label: 'Channel', value: embeddedUpdate.channel },
+    { label: 'Bundle size', value: formatBytes(bundleSize) },
+    { label: 'Bundle SHA-256', value: embeddedUpdate.launchAsset.fileSHA256 },
+    {
+      label: 'Created at',
+      value: `${createdAt.toLocaleString()} (${fromNow(createdAt)} ago)`,
+    },
+  ]);
+}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1607,6 +1607,8 @@ export type App = Project & {
   workerDeploymentsCrashes?: Maybe<WorkerDeploymentCrashes>;
   workerDeploymentsRequest: WorkerDeploymentRequestEdge;
   workerDeploymentsRequests?: Maybe<WorkerDeploymentRequests>;
+  workflowDeviceTestCaseHistory: WorkflowDeviceTestCaseHistory;
+  workflowDeviceTestCaseInsights: WorkflowDeviceTestCaseInsights;
   workflowRunGitBranchesPaginated: AppWorkflowRunGitBranchesConnection;
   workflowRunsPaginated: AppWorkflowRunsConnection;
   workflows: Array<Workflow>;
@@ -1918,6 +1920,21 @@ export type AppWorkerDeploymentsRequestArgs = {
 export type AppWorkerDeploymentsRequestsArgs = {
   filters?: InputMaybe<RequestsFilters>;
   timespan: DatasetTimespan;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppWorkflowDeviceTestCaseHistoryArgs = {
+  filters?: InputMaybe<WorkflowDeviceTestCaseHistoryFiltersInput>;
+  path: Scalars['String']['input'];
+  timespan: WorkflowDeviceTestCaseInsightsTimespanInput;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppWorkflowDeviceTestCaseInsightsArgs = {
+  filters?: InputMaybe<WorkflowDeviceTestCaseInsightsFiltersInput>;
+  timespan: WorkflowDeviceTestCaseInsightsTimespanInput;
 };
 
 
@@ -6191,6 +6208,22 @@ export type EmbeddedUpdateMutationUploadEmbeddedUpdateArgs = {
   input: UploadEmbeddedUpdateInput;
 };
 
+export type EmbeddedUpdateQuery = {
+  __typename?: 'EmbeddedUpdateQuery';
+  /**
+   * Look up an embedded update by its id and the owning app's id.
+   * Throws EMBEDDED_UPDATE_NOT_FOUND when no embedded update with this id exists on
+   * the given app within the caller's account.
+   */
+  byId: EmbeddedUpdate;
+};
+
+
+export type EmbeddedUpdateQueryByIdArgs = {
+  appId: Scalars['ID']['input'];
+  embeddedUpdateId: Scalars['ID']['input'];
+};
+
 export enum EntityTypeName {
   AccountEntity = 'AccountEntity',
   AccountSsoConfigurationEntity = 'AccountSSOConfigurationEntity',
@@ -7476,7 +7509,7 @@ export type JobRun = {
   isWaived: Scalars['Boolean']['output'];
   logFileUrls: Array<Scalars['String']['output']>;
   /** Max run time in seconds for this job run. */
-  maxRunTimeSeconds?: Maybe<Scalars['Int']['output']>;
+  maxRunTimeSeconds: Scalars['Int']['output'];
   name: Scalars['String']['output'];
   priority: JobRunPriority;
   /** String describing the worker profile used to run this job run. */
@@ -8520,6 +8553,7 @@ export type RootQuery = {
   echoProject: EchoProjectQuery;
   /** Top-level query object for querying Echo versions. */
   echoVersion: EchoVersionQuery;
+  embeddedUpdates: EmbeddedUpdateQuery;
   /** Top-level query object for querying Experimentation configuration. */
   experimentation: ExperimentationQuery;
   expoGoBuild: ExpoGoBuildQuery;
@@ -11367,6 +11401,187 @@ export enum WorkflowArtifactStorageType {
   R2 = 'R2'
 }
 
+/**
+ * Grouping key from the [shard N] prefix-stripped error_message. `count` is
+ * computed with uniqExact(test_case_result_id) so RMT pre-merge duplicates do
+ * not inflate it. Scope: scans ALL status='failed' rows (NOT just
+ * is_final_attempt=1) so failures from runs that ultimately passed on retry
+ * still surface.
+ */
+export type WorkflowDeviceTestCaseErrorPattern = {
+  __typename?: 'WorkflowDeviceTestCaseErrorPattern';
+  count: Scalars['Int']['output'];
+  lastSeenAt: Scalars['DateTime']['output'];
+  patternKey: Scalars['String']['output'];
+  sampleMessage: Scalars['String']['output'];
+};
+
+export type WorkflowDeviceTestCaseHistory = {
+  __typename?: 'WorkflowDeviceTestCaseHistory';
+  errorPatterns: Array<WorkflowDeviceTestCaseErrorPattern>;
+  recentRuns: WorkflowDeviceTestCaseRecentRunConnection;
+  timeSeries: Array<WorkflowDeviceTestCaseInsightsBucket>;
+  totals: WorkflowDeviceTestCaseInsightsTotals;
+};
+
+
+export type WorkflowDeviceTestCaseHistoryErrorPatternsArgs = {
+  first: Scalars['Int']['input'];
+};
+
+
+export type WorkflowDeviceTestCaseHistoryRecentRunsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+};
+
+
+export type WorkflowDeviceTestCaseHistoryTimeSeriesArgs = {
+  granularity: WorkflowDeviceTestCaseInsightsTimeSeriesGranularity;
+};
+
+export type WorkflowDeviceTestCaseHistoryFiltersInput = {
+  gitRefs?: InputMaybe<Array<Scalars['String']['input']>>;
+  workflowIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+export type WorkflowDeviceTestCaseInsights = {
+  __typename?: 'WorkflowDeviceTestCaseInsights';
+  facets: WorkflowDeviceTestCaseInsightsFacets;
+  tests: WorkflowDeviceTestCaseStatConnection;
+  timeSeries: Array<WorkflowDeviceTestCaseInsightsBucket>;
+  totals: WorkflowDeviceTestCaseInsightsTotals;
+};
+
+
+export type WorkflowDeviceTestCaseInsightsTestsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  search?: InputMaybe<Scalars['String']['input']>;
+  sortDirection?: InputMaybe<WorkflowDeviceTestCaseSortDirection>;
+  sortField?: InputMaybe<WorkflowDeviceTestCaseStatSortField>;
+};
+
+
+export type WorkflowDeviceTestCaseInsightsTimeSeriesArgs = {
+  granularity: WorkflowDeviceTestCaseInsightsTimeSeriesGranularity;
+};
+
+/**
+ * Mutually exclusive bucket counts (passedClean + flaky + failed = totalRuns for the bucket).
+ * Buckets are aligned to the UTC start of the requested granularity interval
+ * (minute / hour / day).
+ */
+export type WorkflowDeviceTestCaseInsightsBucket = {
+  __typename?: 'WorkflowDeviceTestCaseInsightsBucket';
+  bucketStartAt: Scalars['DateTime']['output'];
+  failed: Scalars['Int']['output'];
+  flaky: Scalars['Int']['output'];
+  passedClean: Scalars['Int']['output'];
+};
+
+export type WorkflowDeviceTestCaseInsightsFacets = {
+  __typename?: 'WorkflowDeviceTestCaseInsightsFacets';
+  gitRefs: Array<Scalars['String']['output']>;
+  tags: Array<Scalars['String']['output']>;
+  workflows: Array<WorkflowDeviceTestCaseWorkflowFacet>;
+};
+
+export type WorkflowDeviceTestCaseInsightsFiltersInput = {
+  gitRefs?: InputMaybe<Array<Scalars['String']['input']>>;
+  statuses?: InputMaybe<Array<WorkflowDeviceTestCaseStatusFilter>>;
+  tags?: InputMaybe<Array<Scalars['String']['input']>>;
+  workflowIds?: InputMaybe<Array<Scalars['ID']['input']>>;
+};
+
+/**
+ * A count metric returned for the current window AND the equivalent prior window
+ * (start − duration → start). The frontend uses (current, previous) to compute
+ * trend deltas. Trend ratios are NOT pre-computed server-side — see
+ * WorkflowsInsightsMetric for the equivalent convention.
+ *
+ * Float (not Int) to match WorkflowsInsightsMetric and avoid the GraphQL Int32
+ * ceiling: 90-day uniqExact counts on a high-volume project can plausibly
+ * exceed 2.1B. Values are integer-valued; the frontend reads them as JS numbers.
+ */
+export type WorkflowDeviceTestCaseInsightsMetric = {
+  __typename?: 'WorkflowDeviceTestCaseInsightsMetric';
+  currentValue: Scalars['Float']['output'];
+  previousValue: Scalars['Float']['output'];
+};
+
+/**
+ * Same shape as WorkflowDeviceTestCaseInsightsMetric but nullable on both sides —
+ * used for metrics like avgDurationMs / p90DurationMs where "no data in the
+ * window" is meaningful and must not collapse to 0.
+ */
+export type WorkflowDeviceTestCaseInsightsNullableMetric = {
+  __typename?: 'WorkflowDeviceTestCaseInsightsNullableMetric';
+  currentValue?: Maybe<Scalars['Float']['output']>;
+  previousValue?: Maybe<Scalars['Float']['output']>;
+};
+
+export enum WorkflowDeviceTestCaseInsightsTimeSeriesGranularity {
+  Day = 'DAY',
+  Hour = 'HOUR',
+  Minute = 'MINUTE'
+}
+
+export type WorkflowDeviceTestCaseInsightsTimespanInput = {
+  end: Scalars['DateTime']['input'];
+  start: Scalars['DateTime']['input'];
+};
+
+/**
+ * Raw counts only (paired with previous-window values). Pass rate, flake rate,
+ * and trends are computed in the frontend from the (currentValue, previousValue)
+ * pair on each metric.
+ *
+ * totalRuns = passedCleanCount + flakyCount + failedCount (over is_final_attempt=1 rows).
+ * distinctFlakyTestCount cannot be derived in the frontend from per-test rows
+ * because pagination means the frontend doesn't see all test paths.
+ */
+export type WorkflowDeviceTestCaseInsightsTotals = {
+  __typename?: 'WorkflowDeviceTestCaseInsightsTotals';
+  avgDurationMs: WorkflowDeviceTestCaseInsightsNullableMetric;
+  distinctFlakyTestCount: WorkflowDeviceTestCaseInsightsMetric;
+  failedCount: WorkflowDeviceTestCaseInsightsMetric;
+  flakyCount: WorkflowDeviceTestCaseInsightsMetric;
+  p90DurationMs: WorkflowDeviceTestCaseInsightsNullableMetric;
+  passedCleanCount: WorkflowDeviceTestCaseInsightsMetric;
+  totalRuns: WorkflowDeviceTestCaseInsightsMetric;
+};
+
+/**
+ * One row per execution (is_final_attempt=1). The is_flaky boolean drives the
+ * FLAKY pill — no per-attempt timeline is exposed in v1.
+ */
+export type WorkflowDeviceTestCaseRecentRun = {
+  __typename?: 'WorkflowDeviceTestCaseRecentRun';
+  commitSha?: Maybe<Scalars['String']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  durationMs?: Maybe<Scalars['Int']['output']>;
+  gitRef?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  isFlaky: Scalars['Boolean']['output'];
+  status: WorkflowDeviceTestCaseStatus;
+  workflowRunId: Scalars['ID']['output'];
+  workflowRunName: Scalars['String']['output'];
+};
+
+export type WorkflowDeviceTestCaseRecentRunConnection = {
+  __typename?: 'WorkflowDeviceTestCaseRecentRunConnection';
+  edges: Array<WorkflowDeviceTestCaseRecentRunEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type WorkflowDeviceTestCaseRecentRunEdge = {
+  __typename?: 'WorkflowDeviceTestCaseRecentRunEdge';
+  cursor: Scalars['String']['output'];
+  node: WorkflowDeviceTestCaseRecentRun;
+};
+
 /** A device test case result from a Maestro test execution. */
 export type WorkflowDeviceTestCaseResult = {
   __typename?: 'WorkflowDeviceTestCaseResult';
@@ -11420,11 +11635,72 @@ export type WorkflowDeviceTestCaseResultMutationCreateWorkflowDeviceTestCaseResu
   input: CreateWorkflowDeviceTestCaseResultsInput;
 };
 
+export enum WorkflowDeviceTestCaseSortDirection {
+  Asc = 'ASC',
+  Desc = 'DESC'
+}
+
+export type WorkflowDeviceTestCaseStat = {
+  __typename?: 'WorkflowDeviceTestCaseStat';
+  avgDurationMs?: Maybe<Scalars['Int']['output']>;
+  failedCount: Scalars['Int']['output'];
+  flakyCount: Scalars['Int']['output'];
+  lastRunAt: Scalars['DateTime']['output'];
+  lastRunIsFlaky: Scalars['Boolean']['output'];
+  lastRunStatus: WorkflowDeviceTestCaseStatus;
+  name: Scalars['String']['output'];
+  p90DurationMs?: Maybe<Scalars['Int']['output']>;
+  passedCleanCount: Scalars['Int']['output'];
+  path: Scalars['String']['output'];
+  totalRuns: Scalars['Int']['output'];
+};
+
+export type WorkflowDeviceTestCaseStatConnection = {
+  __typename?: 'WorkflowDeviceTestCaseStatConnection';
+  edges: Array<WorkflowDeviceTestCaseStatEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type WorkflowDeviceTestCaseStatEdge = {
+  __typename?: 'WorkflowDeviceTestCaseStatEdge';
+  cursor: Scalars['String']['output'];
+  node: WorkflowDeviceTestCaseStat;
+};
+
+export enum WorkflowDeviceTestCaseStatSortField {
+  Fails = 'FAILS',
+  Flakes = 'FLAKES',
+  FlakeRate = 'FLAKE_RATE',
+  LastRun = 'LAST_RUN',
+  P90Duration = 'P90_DURATION',
+  PassRate = 'PASS_RATE',
+  Runs = 'RUNS'
+}
+
 /** Status of a device test case execution. */
 export enum WorkflowDeviceTestCaseStatus {
   Failed = 'FAILED',
   Passed = 'PASSED'
 }
+
+/**
+ * Mutually exclusive — matches the chart bucket semantics (passedClean / flaky / failed).
+ * PASSED_CLEAN  = is_final_attempt=1 AND status=passed AND is_flaky=0
+ * FLAKY         = is_final_attempt=1 AND is_flaky=1 (still a pass, just with retries)
+ * FAILED        = is_final_attempt=1 AND status=failed
+ */
+export enum WorkflowDeviceTestCaseStatusFilter {
+  Failed = 'FAILED',
+  Flaky = 'FLAKY',
+  PassedClean = 'PASSED_CLEAN'
+}
+
+export type WorkflowDeviceTestCaseWorkflowFacet = {
+  __typename?: 'WorkflowDeviceTestCaseWorkflowFacet';
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+};
 
 export type WorkflowJob = {
   __typename?: 'WorkflowJob';
@@ -13028,6 +13304,14 @@ export type DeviceRunSessionsByAppIdQueryVariables = Exact<{
 
 
 export type DeviceRunSessionsByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, deviceRunSessionsPaginated: { __typename?: 'AppDeviceRunSessionsConnection', edges: Array<{ __typename?: 'AppDeviceRunSessionEdge', cursor: string, node: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, type: DeviceRunSessionType, platform: AppPlatform, createdAt: any, startedAt?: any | null, finishedAt?: any | null, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
+
+export type ViewEmbeddedUpdateByIdQueryVariables = Exact<{
+  embeddedUpdateId: Scalars['ID']['input'];
+  appId: Scalars['ID']['input'];
+}>;
+
+
+export type ViewEmbeddedUpdateByIdQuery = { __typename?: 'RootQuery', embeddedUpdates: { __typename?: 'EmbeddedUpdateQuery', byId: { __typename?: 'EmbeddedUpdate', id: string, platform: AppPlatform, runtimeVersion: string, channel: string, createdAt: any, launchAsset: { __typename?: 'EmbeddedUpdateAsset', id: string, fileSize: number, finalFileSize?: number | null, fileSHA256: string } } } };
 
 export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/queries/EmbeddedUpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/EmbeddedUpdateQuery.ts
@@ -6,13 +6,10 @@ import { withErrorHandlingAsync } from '../client';
 import { ViewEmbeddedUpdateByIdQuery, ViewEmbeddedUpdateByIdQueryVariables } from '../generated';
 
 export function isEmbeddedUpdateNotFoundError(error: unknown): boolean {
-  if (!(error instanceof CombinedError)) {
-    return false;
-  }
-  return error.graphQLErrors.some(e => {
-    const code = e.extensions?.['errorCode'];
-    return code === 'EMBEDDED_UPDATE_NOT_FOUND' || code === 'NOT_FOUND_ERROR';
-  });
+  return (
+    error instanceof CombinedError &&
+    error.graphQLErrors.some(e => e.extensions?.['errorCode'] === 'EMBEDDED_UPDATE_NOT_FOUND')
+  );
 }
 
 export type EmbeddedUpdateFragment = ViewEmbeddedUpdateByIdQuery['embeddedUpdates']['byId'];

--- a/packages/eas-cli/src/graphql/queries/EmbeddedUpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/EmbeddedUpdateQuery.ts
@@ -1,0 +1,54 @@
+import { CombinedError } from '@urql/core';
+import gql from 'graphql-tag';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
+import { ViewEmbeddedUpdateByIdQuery, ViewEmbeddedUpdateByIdQueryVariables } from '../generated';
+
+export function isEmbeddedUpdateNotFoundError(error: unknown): boolean {
+  if (!(error instanceof CombinedError)) {
+    return false;
+  }
+  return error.graphQLErrors.some(e => {
+    const code = e.extensions?.['errorCode'];
+    return code === 'EMBEDDED_UPDATE_NOT_FOUND' || code === 'NOT_FOUND_ERROR';
+  });
+}
+
+export type EmbeddedUpdateFragment = ViewEmbeddedUpdateByIdQuery['embeddedUpdates']['byId'];
+
+export const EmbeddedUpdateQuery = {
+  async viewByIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { embeddedUpdateId, appId }: { embeddedUpdateId: string; appId: string }
+  ): Promise<EmbeddedUpdateFragment> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<ViewEmbeddedUpdateByIdQuery, ViewEmbeddedUpdateByIdQueryVariables>(
+          gql`
+            query ViewEmbeddedUpdateById($embeddedUpdateId: ID!, $appId: ID!) {
+              embeddedUpdates {
+                byId(embeddedUpdateId: $embeddedUpdateId, appId: $appId) {
+                  id
+                  platform
+                  runtimeVersion
+                  channel
+                  createdAt
+                  launchAsset {
+                    id
+                    fileSize
+                    finalFileSize
+                    fileSHA256
+                  }
+                }
+              }
+            }
+          `,
+          { embeddedUpdateId, appId },
+          { additionalTypenames: ['EmbeddedUpdate'] }
+        )
+        .toPromise()
+    );
+    return data.embeddedUpdates.byId;
+  },
+};

--- a/packages/eas-cli/src/graphql/queries/__tests__/EmbeddedUpdateQuery-test.ts
+++ b/packages/eas-cli/src/graphql/queries/__tests__/EmbeddedUpdateQuery-test.ts
@@ -1,0 +1,106 @@
+import { CombinedError } from '@urql/core';
+
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { AppPlatform } from '../../generated';
+import { EmbeddedUpdateQuery, isEmbeddedUpdateNotFoundError } from '../EmbeddedUpdateQuery';
+
+function makeGraphqlClient(data: unknown): ExpoGraphqlClient {
+  return {
+    query: jest.fn().mockReturnValue({
+      toPromise: jest.fn().mockResolvedValue({ data }),
+    }),
+  } as unknown as ExpoGraphqlClient;
+}
+
+function makeCombinedError(errorCode: string): CombinedError {
+  return new CombinedError({
+    graphQLErrors: [{ message: 'error', extensions: { errorCode } }],
+  });
+}
+
+describe('isEmbeddedUpdateNotFoundError', () => {
+  it('returns true for CombinedError with EMBEDDED_UPDATE_NOT_FOUND errorCode', () => {
+    expect(isEmbeddedUpdateNotFoundError(makeCombinedError('EMBEDDED_UPDATE_NOT_FOUND'))).toBe(
+      true
+    );
+  });
+
+  it('returns false for CombinedError with a different errorCode', () => {
+    expect(isEmbeddedUpdateNotFoundError(makeCombinedError('SOME_OTHER_ERROR'))).toBe(false);
+  });
+
+  it('returns false for CombinedError with no extensions', () => {
+    expect(
+      isEmbeddedUpdateNotFoundError(new CombinedError({ graphQLErrors: [{ message: 'oops' }] }))
+    ).toBe(false);
+  });
+
+  it('returns false for a plain Error', () => {
+    expect(isEmbeddedUpdateNotFoundError(new Error('plain error'))).toBe(false);
+  });
+
+  it('returns false for null and non-error values', () => {
+    expect(isEmbeddedUpdateNotFoundError(null)).toBe(false);
+    expect(isEmbeddedUpdateNotFoundError('string')).toBe(false);
+    expect(isEmbeddedUpdateNotFoundError(42)).toBe(false);
+  });
+});
+
+describe('EmbeddedUpdateQuery.viewByIdAsync', () => {
+  it('returns the embedded update from the GraphQL response', async () => {
+    const expected = {
+      id: 'update-1',
+      platform: AppPlatform.Ios,
+      runtimeVersion: '1.0.0',
+      channel: 'production',
+      createdAt: '2024-01-01T00:00:00Z',
+      launchAsset: {
+        id: 'asset-1',
+        fileSize: 1024,
+        finalFileSize: 768,
+        fileSHA256: 'abc123',
+      },
+    };
+    const client = makeGraphqlClient({
+      embeddedUpdates: { byId: expected },
+    });
+
+    const result = await EmbeddedUpdateQuery.viewByIdAsync(client, {
+      embeddedUpdateId: 'update-1',
+      appId: 'app-1',
+    });
+
+    expect(result).toEqual(expected);
+  });
+
+  it('passes the embeddedUpdateId and appId to the query', async () => {
+    const client = makeGraphqlClient({
+      embeddedUpdates: {
+        byId: {
+          id: 'update-1',
+          platform: AppPlatform.Ios,
+          runtimeVersion: '1.0.0',
+          channel: 'production',
+          createdAt: '2024-01-01T00:00:00Z',
+          launchAsset: {
+            id: 'asset-1',
+            fileSize: 1024,
+            finalFileSize: null,
+            fileSHA256: 'abc',
+          },
+        },
+      },
+    });
+
+    await EmbeddedUpdateQuery.viewByIdAsync(client, {
+      embeddedUpdateId: 'update-1',
+      appId: 'app-1',
+    });
+
+    expect(client.query).toHaveBeenCalledWith(
+      expect.anything(),
+      { embeddedUpdateId: 'update-1', appId: 'app-1' },
+      expect.objectContaining({ additionalTypenames: ['EmbeddedUpdate'] })
+    );
+  });
+});


### PR DESCRIPTION
## Why

Lets users inspect an embedded update they've uploaded from the CLI. Ref ENG-21467.

## How

New `eas update:embedded:view <id>` command. Prints a formatted summary (id, platform, runtime version, channel, bundle size, SHA-256, created at + relative time), or the raw payload with `--json`. NOT_FOUND on an unknown id (or one belonging to a different app) surfaces a friendly message.

## Test Plan

- CI
- Local CLI against universe `yarn start:staging`
<img width="965" height="318" alt="Screenshot 2026-06-02 at 11 36 00 PM" src="https://github.com/user-attachments/assets/4cda27fe-2dd1-47f1-ac38-d58b65fed21a" />
 