### PR TITLE
[eas-cli] Add eas update:embedded:list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [eas-cli] Add `eas update:embedded:view` command. ([#3810](https://github.com/expo/eas-cli/pull/3810) by [@gwdp](https://github.com/gwdp))
+- [eas-cli] Add `eas update:embedded:list` command. ([#3811](https://github.com/expo/eas-cli/pull/3811) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Auto-upload embedded bundle after build when `EAS_UPDATE_EXPERIMENTAL_UPLOAD_EMBEDDED_BUNDLE` is set. ([#3767](https://github.com/expo/eas-cli/pull/3767) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -9991,6 +9991,83 @@
             "deprecationReason": null
           },
           {
+            "name": "embeddedUpdatesPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "EmbeddedUpdateFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppEmbeddedUpdatesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "environmentSecrets",
             "description": "Environment secrets for an app",
             "args": [
@@ -13202,6 +13279,100 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "AppDeviceRunSessionEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppEmbeddedUpdateEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "EmbeddedUpdate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppEmbeddedUpdatesConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppEmbeddedUpdateEdge",
                     "ofType": null
                   }
                 }
@@ -43386,6 +43557,53 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "EmbeddedUpdateFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "channel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AppPlatform",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "runtimeVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -15798,6 +15798,18 @@
             "deprecationReason": null
           },
           {
+            "name": "ingestedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "properties",
             "description": null,
             "args": [],
@@ -16656,6 +16668,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -36325,6 +36349,33 @@
       },
       {
         "kind": "OBJECT",
+        "name": "DeleteEmbeddedUpdateResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "DeleteEnvironmentSecretResult",
         "description": null,
         "fields": [
@@ -43612,6 +43663,39 @@
         "name": "EmbeddedUpdateMutation",
         "description": null,
         "fields": [
+          {
+            "name": "deleteEmbeddedUpdate",
+            "description": "Delete an embedded update by id. Best-effort: deleting an unknown id succeeds\n(mirrors background deletion jobs). The linked asset row and underlying GCS\nobject are cleaned up via the entity's afterDelete trigger chain.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteEmbeddedUpdateResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "uploadEmbeddedUpdate",
             "description": "Register an embedded bundle as the launch asset for a given app/platform/channel.\nReturns EMBEDDED_UPDATE_ASSET_NOT_AVAILABLE if the asset has not been finalized yet,\nor EMBEDDED_UPDATE_ALREADY_EXISTS if an embedded update with this id is already registered.",
@@ -62917,9 +63001,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -72230,9 +72318,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -72989,9 +73081,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -73231,7 +73327,7 @@
             "deprecationReason": null
           },
           {
-            "name": "profilePhoto",
+            "name": "primaryAccountProfileImageUrl",
             "description": null,
             "args": [],
             "type": {
@@ -73245,6 +73341,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "profilePhoto",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use primaryAccountProfileImageUrl instead"
           },
           {
             "name": "snacks",

--- a/packages/eas-cli/src/commands/update/embedded/__tests__/list.test.ts
+++ b/packages/eas-cli/src/commands/update/embedded/__tests__/list.test.ts
@@ -1,0 +1,280 @@
+import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { AppPlatform } from '../../../../graphql/generated';
+import { ChannelQuery } from '../../../../graphql/queries/ChannelQuery';
+import {
+  EmbeddedUpdateFragment,
+  EmbeddedUpdateQuery,
+} from '../../../../graphql/queries/EmbeddedUpdateQuery';
+import Log from '../../../../log';
+import { selectAsync } from '../../../../prompts';
+import * as json from '../../../../utils/json';
+import UpdateEmbeddedList from '../list';
+
+jest.mock('../../../../graphql/queries/EmbeddedUpdateQuery', () => ({
+  EmbeddedUpdateQuery: { viewPaginatedAsync: jest.fn() },
+}));
+jest.mock('../../../../graphql/queries/ChannelQuery', () => ({
+  ChannelQuery: { viewUpdateChannelsOnAppAsync: jest.fn() },
+}));
+jest.mock('../../../../prompts');
+jest.mock('../../../../log');
+jest.mock('../../../../utils/json');
+
+const mockPaginated = jest.mocked(EmbeddedUpdateQuery.viewPaginatedAsync);
+const mockViewChannels = jest.mocked(ChannelQuery.viewUpdateChannelsOnAppAsync);
+const mockSelectAsync = jest.mocked(selectAsync);
+const mockLogLog = jest.mocked(Log.log);
+const mockEnableJsonOutput = jest.mocked(json.enableJsonOutput);
+const mockPrintJson = jest.mocked(json.printJsonOnlyOutput);
+
+const MOCK_CONTEXT = {
+  projectId: 'project-123',
+  loggedIn: { graphqlClient: {} as ExpoGraphqlClient },
+};
+
+const ROW_A: EmbeddedUpdateFragment = {
+  id: 'aaaaaaaa-1111-4000-8000-000000000001',
+  platform: AppPlatform.Ios,
+  runtimeVersion: '1.0.0',
+  channel: 'production',
+  createdAt: '2026-05-29T00:00:00Z',
+  launchAsset: { id: 'asset-a', fileSize: 1024, finalFileSize: 768, fileSHA256: 'abc123' },
+};
+const ROW_B: EmbeddedUpdateFragment = {
+  id: 'bbbbbbbb-2222-4000-8000-000000000002',
+  platform: AppPlatform.Android,
+  runtimeVersion: '1.0.1',
+  channel: 'preview',
+  createdAt: '2026-05-30T00:00:00Z',
+  launchAsset: { id: 'asset-b', fileSize: 2048, finalFileSize: null, fileSHA256: 'def456' },
+};
+
+function emptyConnection(): {
+  edges: { cursor: string; node: EmbeddedUpdateFragment }[];
+  pageInfo: {
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    startCursor: string | null;
+    endCursor: string | null;
+  };
+} {
+  return {
+    edges: [],
+    pageInfo: { hasNextPage: false, hasPreviousPage: false, startCursor: null, endCursor: null },
+  };
+}
+
+describe(UpdateEmbeddedList, () => {
+  const mockConfig = getMockOclifConfig();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: no channels on the project (skips the prompt).
+    mockViewChannels.mockResolvedValue([]);
+  });
+
+  function createCommand(argv: string[]): UpdateEmbeddedList {
+    const command = new UpdateEmbeddedList(argv, mockConfig);
+    // @ts-expect-error getContextAsync is protected
+    jest.spyOn(command, 'getContextAsync').mockResolvedValue(MOCK_CONTEXT);
+    return command;
+  }
+
+  it('prints each row when results exist', async () => {
+    mockPaginated.mockResolvedValue({
+      edges: [
+        { cursor: 'c1', node: ROW_A },
+        { cursor: 'c2', node: ROW_B },
+      ],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false, startCursor: 'c1', endCursor: 'c2' },
+    });
+    await createCommand(['--non-interactive']).run();
+
+    expect(mockPaginated).toHaveBeenCalledWith(MOCK_CONTEXT.loggedIn.graphqlClient, {
+      appId: MOCK_CONTEXT.projectId,
+      filter: undefined,
+      first: 25,
+      after: undefined,
+    });
+    expect(mockLogLog.mock.calls.some(c => String(c[0]).includes(ROW_A.id))).toBe(true);
+    expect(mockLogLog.mock.calls.some(c => String(c[0]).includes(ROW_B.id))).toBe(true);
+  });
+
+  it('prints empty message when no results', async () => {
+    mockPaginated.mockResolvedValue(emptyConnection());
+    await createCommand(['--non-interactive']).run();
+    expect(mockLogLog).toHaveBeenCalledWith('No embedded updates found.');
+  });
+
+  it('--json prints connection payload and skips formatted output', async () => {
+    mockPaginated.mockResolvedValue({
+      edges: [{ cursor: 'c1', node: ROW_A }],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false, startCursor: 'c1', endCursor: 'c1' },
+    });
+    await createCommand(['--json', '--non-interactive']).run();
+
+    expect(mockEnableJsonOutput).toHaveBeenCalled();
+    expect(mockPrintJson).toHaveBeenCalledWith({
+      embeddedUpdates: [ROW_A],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false, startCursor: 'c1', endCursor: 'c1' },
+    });
+    expect(mockLogLog.mock.calls.every(c => !String(c[0]).includes(ROW_A.id))).toBe(true);
+  });
+
+  it('passes filter when flags supplied', async () => {
+    mockPaginated.mockResolvedValue(emptyConnection());
+    await createCommand([
+      '--non-interactive',
+      '--platform',
+      'ios',
+      '--runtime-version',
+      '1.2.0',
+      '--channel',
+      'preview',
+    ]).run();
+
+    expect(mockPaginated).toHaveBeenCalledWith(MOCK_CONTEXT.loggedIn.graphqlClient, {
+      appId: MOCK_CONTEXT.projectId,
+      filter: { platform: AppPlatform.Ios, runtimeVersion: '1.2.0', channel: 'preview' },
+      first: 25,
+      after: undefined,
+    });
+  });
+
+  it('shows next-page hint when hasNextPage', async () => {
+    mockPaginated.mockResolvedValue({
+      edges: [{ cursor: 'c1', node: ROW_A }],
+      pageInfo: { hasNextPage: true, hasPreviousPage: false, startCursor: 'c1', endCursor: 'c1' },
+    });
+    await createCommand(['--non-interactive']).run();
+
+    expect(mockLogLog.mock.calls.some(c => String(c[0]).includes('--after-cursor c1'))).toBe(true);
+  });
+
+  it('prompts for channel in interactive mode and applies the selected channel', async () => {
+    mockViewChannels.mockResolvedValue([
+      { id: 'ch1', name: 'production' } as any,
+      { id: 'ch2', name: 'preview' } as any,
+    ]);
+    mockSelectAsync.mockResolvedValue('preview');
+    mockPaginated.mockResolvedValue(emptyConnection());
+
+    await createCommand([]).run();
+
+    expect(mockSelectAsync).toHaveBeenCalledTimes(1);
+    expect(mockPaginated).toHaveBeenCalledWith(MOCK_CONTEXT.loggedIn.graphqlClient, {
+      appId: MOCK_CONTEXT.projectId,
+      filter: { platform: undefined, runtimeVersion: undefined, channel: 'preview' },
+      first: 25,
+      after: undefined,
+    });
+  });
+
+  it('skips channel filter when "All channels" is selected', async () => {
+    mockViewChannels.mockResolvedValue([{ id: 'ch1', name: 'production' } as any]);
+    // The sentinel value returned by selectAsync for the "All channels" option.
+    mockSelectAsync.mockResolvedValue('__embedded_update_list__all_channels__');
+    mockPaginated.mockResolvedValue(emptyConnection());
+
+    await createCommand([]).run();
+
+    expect(mockPaginated).toHaveBeenCalledWith(MOCK_CONTEXT.loggedIn.graphqlClient, {
+      appId: MOCK_CONTEXT.projectId,
+      filter: undefined,
+      first: 25,
+      after: undefined,
+    });
+  });
+
+  it('skips the channel prompt when --channel is supplied', async () => {
+    mockPaginated.mockResolvedValue(emptyConnection());
+    await createCommand(['--channel', 'preview']).run();
+    expect(mockSelectAsync).not.toHaveBeenCalled();
+    expect(mockViewChannels).not.toHaveBeenCalled();
+  });
+
+  it('treats --channel all as no channel filter', async () => {
+    mockPaginated.mockResolvedValue(emptyConnection());
+    await createCommand(['--channel', 'all']).run();
+    expect(mockPaginated).toHaveBeenCalledWith(MOCK_CONTEXT.loggedIn.graphqlClient, {
+      appId: MOCK_CONTEXT.projectId,
+      filter: undefined,
+      first: 25,
+      after: undefined,
+    });
+  });
+
+  it('skips the channel prompt when the project has no channels', async () => {
+    mockViewChannels.mockResolvedValue([]);
+    mockPaginated.mockResolvedValue(emptyConnection());
+    await createCommand([]).run();
+    expect(mockSelectAsync).not.toHaveBeenCalled();
+  });
+
+  it('passes --after-cursor through to viewPaginatedAsync', async () => {
+    mockPaginated.mockResolvedValue(emptyConnection());
+    await createCommand(['--non-interactive', '--after-cursor', 'cursor-123']).run();
+    expect(mockPaginated).toHaveBeenCalledWith(MOCK_CONTEXT.loggedIn.graphqlClient, {
+      appId: MOCK_CONTEXT.projectId,
+      filter: undefined,
+      first: 25,
+      after: 'cursor-123',
+    });
+  });
+
+  it('honors --limit', async () => {
+    mockPaginated.mockResolvedValue(emptyConnection());
+    await createCommand(['--non-interactive', '--limit', '5']).run();
+    expect(mockPaginated).toHaveBeenCalledWith(
+      MOCK_CONTEXT.loggedIn.graphqlClient,
+      expect.objectContaining({ first: 5 })
+    );
+  });
+
+  it('prints the section header with row count', async () => {
+    mockPaginated.mockResolvedValue({
+      edges: [{ cursor: 'c1', node: ROW_A }],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false, startCursor: 'c1', endCursor: 'c1' },
+    });
+    await createCommand(['--non-interactive']).run();
+    expect(mockLogLog.mock.calls.some(c => String(c[0]).includes('Embedded updates (1)'))).toBe(
+      true
+    );
+  });
+
+  it('suffixes the section header count with "+" when hasNextPage', async () => {
+    mockPaginated.mockResolvedValue({
+      edges: [{ cursor: 'c1', node: ROW_A }],
+      pageInfo: { hasNextPage: true, hasPreviousPage: false, startCursor: 'c1', endCursor: 'c1' },
+    });
+    await createCommand(['--non-interactive']).run();
+    expect(mockLogLog.mock.calls.some(c => String(c[0]).includes('Embedded updates (1+)'))).toBe(
+      true
+    );
+  });
+
+  it('shows relative-time "ago" hints in formatted rows', async () => {
+    mockPaginated.mockResolvedValue({
+      edges: [{ cursor: 'c1', node: ROW_A }],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false, startCursor: 'c1', endCursor: 'c1' },
+    });
+    await createCommand(['--non-interactive']).run();
+    expect(mockLogLog.mock.calls.some(c => /ago/.test(String(c[0])))).toBe(true);
+  });
+
+  it('builds the prompt choices in channel-order then "All channels"', async () => {
+    mockViewChannels.mockResolvedValue([
+      { id: 'ch1', name: 'production' } as any,
+      { id: 'ch2', name: 'preview' } as any,
+    ]);
+    mockSelectAsync.mockResolvedValue('production');
+    mockPaginated.mockResolvedValue(emptyConnection());
+
+    await createCommand([]).run();
+
+    const [, choices] = mockSelectAsync.mock.calls[0];
+    const titles = (choices as any[]).map(c => c.title);
+    expect(titles).toEqual(['production', 'preview', 'All channels']);
+  });
+});

--- a/packages/eas-cli/src/commands/update/embedded/__tests__/list.test.ts
+++ b/packages/eas-cli/src/commands/update/embedded/__tests__/list.test.ts
@@ -263,7 +263,7 @@ describe(UpdateEmbeddedList, () => {
     expect(mockLogLog.mock.calls.some(c => /ago/.test(String(c[0])))).toBe(true);
   });
 
-  it('builds the prompt choices in channel-order then "All channels"', async () => {
+  it('puts "All channels" first in the prompt, then channels in order', async () => {
     mockViewChannels.mockResolvedValue([
       { id: 'ch1', name: 'production' } as any,
       { id: 'ch2', name: 'preview' } as any,
@@ -275,6 +275,6 @@ describe(UpdateEmbeddedList, () => {
 
     const [, choices] = mockSelectAsync.mock.calls[0];
     const titles = (choices as any[]).map(c => c.title);
-    expect(titles).toEqual(['production', 'preview', 'All channels']);
+    expect(titles).toEqual(['All channels', 'production', 'preview']);
   });
 });

--- a/packages/eas-cli/src/commands/update/embedded/list.ts
+++ b/packages/eas-cli/src/commands/update/embedded/list.ts
@@ -154,8 +154,8 @@ async function promptForChannelAsync(
   }
 
   const selected = await selectAsync<string>('Filter embedded updates by which channel?', [
-    ...channels.map(c => ({ title: c.name, value: c.name })),
     { title: 'All channels', value: ALL_CHANNELS },
+    ...channels.map(c => ({ title: c.name, value: c.name })),
   ]);
   return selected === ALL_CHANNELS ? undefined : selected;
 }

--- a/packages/eas-cli/src/commands/update/embedded/list.ts
+++ b/packages/eas-cli/src/commands/update/embedded/list.ts
@@ -1,0 +1,172 @@
+import { Platform } from '@expo/eas-build-job';
+import { Flags } from '@oclif/core';
+import chalk from 'chalk';
+
+import EasCommand from '../../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import {
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
+} from '../../../commandUtils/flags';
+import { getLimitFlagWithCustomValues } from '../../../commandUtils/pagination';
+import { AppPlatform } from '../../../graphql/generated';
+import { ChannelQuery } from '../../../graphql/queries/ChannelQuery';
+import {
+  EmbeddedUpdateFragment,
+  EmbeddedUpdateQuery,
+} from '../../../graphql/queries/EmbeddedUpdateQuery';
+import { toAppPlatform } from '../../../graphql/types/AppPlatform';
+import Log from '../../../log';
+import { selectAsync } from '../../../prompts';
+import { fromNow } from '../../../utils/date';
+import formatFields from '../../../utils/formatFields';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 50;
+const CHANNELS_LIMIT = 50;
+
+export default class UpdateEmbeddedList extends EasCommand {
+  static override description = 'list embedded updates registered with EAS Update for this project';
+
+  static override flags = {
+    platform: Flags.option({
+      char: 'p',
+      description: 'Filter by platform',
+      options: [Platform.IOS, Platform.ANDROID] as const,
+    })(),
+    'runtime-version': Flags.string({
+      description: 'Filter by runtime version',
+    }),
+    channel: Flags.string({
+      description: 'Filter by channel name (pass "all" to skip the channel prompt)',
+    }),
+    limit: getLimitFlagWithCustomValues({ defaultTo: DEFAULT_LIMIT, limit: MAX_LIMIT }),
+    'after-cursor': Flags.string({
+      description: 'Return items after this cursor (for pagination)',
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectId,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(UpdateEmbeddedList);
+    const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+
+    const {
+      projectId,
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(UpdateEmbeddedList, { nonInteractive });
+
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    const platform: AppPlatform | undefined = flags.platform
+      ? toAppPlatform(flags.platform)
+      : undefined;
+
+    // Resolve channel filter:
+    // - `--channel <name>`: use it
+    // - `--channel all` (or no flag in non-interactive / json): no channel filter
+    // - no flag in interactive: prompt with the project's channels + "All channels"
+    let channel: string | undefined;
+    if (flags.channel) {
+      channel = flags.channel.toLowerCase() === 'all' ? undefined : flags.channel;
+    } else if (!nonInteractive && !jsonFlag) {
+      channel = await promptForChannelAsync(graphqlClient, projectId);
+    }
+
+    const filter =
+      platform || flags['runtime-version'] || channel
+        ? {
+            platform,
+            runtimeVersion: flags['runtime-version'],
+            channel,
+          }
+        : undefined;
+
+    const limit = flags.limit ?? DEFAULT_LIMIT;
+    const connection = await EmbeddedUpdateQuery.viewPaginatedAsync(graphqlClient, {
+      appId: projectId,
+      filter,
+      first: limit,
+      after: flags['after-cursor'],
+    });
+
+    const embeddedUpdates = connection.edges.map(e => e.node);
+
+    if (jsonFlag) {
+      printJsonOnlyOutput({
+        embeddedUpdates,
+        pageInfo: connection.pageInfo,
+      });
+      return;
+    }
+
+    if (embeddedUpdates.length === 0) {
+      Log.log('No embedded updates found.');
+      return;
+    }
+
+    Log.addNewLineIfNone();
+    Log.log(
+      chalk.bold(
+        `Embedded updates (${embeddedUpdates.length}${connection.pageInfo.hasNextPage ? '+' : ''}):`
+      )
+    );
+    Log.newLine();
+    Log.log(embeddedUpdates.map(formatEmbeddedUpdateRow).join(`\n\n${chalk.dim('———')}\n\n`));
+
+    if (connection.pageInfo.hasNextPage && connection.pageInfo.endCursor) {
+      Log.newLine();
+      Log.log(
+        chalk.dim(
+          `Showing ${embeddedUpdates.length}. For the next page, run with --after-cursor ${connection.pageInfo.endCursor}`
+        )
+      );
+    }
+  }
+}
+
+// Sentinel for the "All channels" option. We can't use `undefined` here because
+// the underlying `prompts` library substitutes a choice's index when its value
+// is undefined, which then leaks into the GraphQL filter.
+const ALL_CHANNELS = '__embedded_update_list__all_channels__';
+
+async function promptForChannelAsync(
+  graphqlClient: ExpoGraphqlClient,
+  projectId: string
+): Promise<string | undefined> {
+  const channels = await ChannelQuery.viewUpdateChannelsOnAppAsync(graphqlClient, {
+    appId: projectId,
+    offset: 0,
+    limit: CHANNELS_LIMIT,
+  });
+
+  if (channels.length === 0) {
+    // Nothing to choose from — fall back to listing everything.
+    return undefined;
+  }
+
+  const selected = await selectAsync<string>('Filter embedded updates by which channel?', [
+    ...channels.map(c => ({ title: c.name, value: c.name })),
+    { title: 'All channels', value: ALL_CHANNELS },
+  ]);
+  return selected === ALL_CHANNELS ? undefined : selected;
+}
+
+function formatEmbeddedUpdateRow(embeddedUpdate: EmbeddedUpdateFragment): string {
+  const createdAt = new Date(embeddedUpdate.createdAt);
+  return formatFields([
+    { label: 'ID', value: embeddedUpdate.id },
+    { label: 'Platform', value: embeddedUpdate.platform.toLowerCase() },
+    { label: 'Runtime version', value: embeddedUpdate.runtimeVersion },
+    { label: 'Channel', value: embeddedUpdate.channel },
+    { label: 'Created', value: `${fromNow(createdAt)} ago` },
+  ]);
+}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2406,6 +2406,7 @@ export type AppObserveCustomEvent = {
   eventName: Scalars['String']['output'];
   expoSdkVersion?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
+  ingestedAt?: Maybe<Scalars['DateTime']['output']>;
   properties: Array<AppObserveEventProperty>;
   reactNativeVersion?: Maybe<Scalars['String']['output']>;
   sessionId?: Maybe<Scalars['String']['output']>;
@@ -2503,6 +2504,7 @@ export type AppObserveCustomEventPropertyFilter = {
 export type AppObserveEvent = {
   __typename?: 'AppObserveEvent';
   appBuildNumber: Scalars['String']['output'];
+  appEasBuildId?: Maybe<Scalars['String']['output']>;
   appIdentifier: Scalars['String']['output'];
   appName: Scalars['String']['output'];
   appUpdateId?: Maybe<Scalars['String']['output']>;
@@ -5103,6 +5105,11 @@ export type DeleteDiscordUserResult = {
   id: Scalars['ID']['output'];
 };
 
+export type DeleteEmbeddedUpdateResult = {
+  __typename?: 'DeleteEmbeddedUpdateResult';
+  id: Scalars['ID']['output'];
+};
+
 export type DeleteEnvironmentSecretResult = {
   __typename?: 'DeleteEnvironmentSecretResult';
   id: Scalars['ID']['output'];
@@ -6225,11 +6232,22 @@ export type EmbeddedUpdateFilterInput = {
 export type EmbeddedUpdateMutation = {
   __typename?: 'EmbeddedUpdateMutation';
   /**
+   * Delete an embedded update by id. Best-effort: deleting an unknown id succeeds
+   * (mirrors background deletion jobs). The linked asset row and underlying GCS
+   * object are cleaned up via the entity's afterDelete trigger chain.
+   */
+  deleteEmbeddedUpdate: DeleteEmbeddedUpdateResult;
+  /**
    * Register an embedded bundle as the launch asset for a given app/platform/channel.
    * Returns EMBEDDED_UPDATE_ASSET_NOT_AVAILABLE if the asset has not been finalized yet,
    * or EMBEDDED_UPDATE_ALREADY_EXISTS if an embedded update with this id is already registered.
    */
   uploadEmbeddedUpdate: EmbeddedUpdate;
+};
+
+
+export type EmbeddedUpdateMutationDeleteEmbeddedUpdateArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -8839,7 +8857,7 @@ export type SsoUser = Actor & UserActor & {
   preferences: UserPreferences;
   /** Associated accounts */
   primaryAccount: Account;
-  primaryAccountProfileImageUrl?: Maybe<Scalars['String']['output']>;
+  primaryAccountProfileImageUrl: Scalars['String']['output'];
   /** @deprecated Use primaryAccountProfileImageUrl instead */
   profilePhoto: Scalars['String']['output'];
   /** Snacks associated with this account */
@@ -10125,7 +10143,7 @@ export type User = Actor & UserActor & {
   preferences: UserPreferences;
   /** Associated accounts */
   primaryAccount: Account;
-  primaryAccountProfileImageUrl?: Maybe<Scalars['String']['output']>;
+  primaryAccountProfileImageUrl: Scalars['String']['output'];
   /** @deprecated Use primaryAccountProfileImageUrl instead */
   profilePhoto: Scalars['String']['output'];
   /** Get all certified second factor authentication methods */
@@ -10229,7 +10247,7 @@ export type UserActor = {
   preferences: UserPreferences;
   /** Associated accounts */
   primaryAccount: Account;
-  primaryAccountProfileImageUrl?: Maybe<Scalars['String']['output']>;
+  primaryAccountProfileImageUrl: Scalars['String']['output'];
   /** @deprecated Use primaryAccountProfileImageUrl instead */
   profilePhoto: Scalars['String']['output'];
   /** Snacks associated with this user's personal account */
@@ -10284,6 +10302,8 @@ export type UserActorPublicData = {
   firstName?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   lastName?: Maybe<Scalars['String']['output']>;
+  primaryAccountProfileImageUrl: Scalars['String']['output'];
+  /** @deprecated Use primaryAccountProfileImageUrl instead */
   profilePhoto: Scalars['String']['output'];
   /** Snacks associated with this user's personal account */
   snacks: Array<Snack>;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1459,6 +1459,7 @@ export type App = Project & {
   description: Scalars['String']['output'];
   devDomainName?: Maybe<AppDevDomainName>;
   deviceRunSessionsPaginated: AppDeviceRunSessionsConnection;
+  embeddedUpdatesPaginated: AppEmbeddedUpdatesConnection;
   /** Environment secrets for an app */
   environmentSecrets: Array<EnvironmentSecret>;
   environmentVariableEnvironments: Array<Scalars['EnvironmentVariableEnvironment']['output']>;
@@ -1694,6 +1695,16 @@ export type AppDeviceRunSessionsPaginatedArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   filter?: InputMaybe<DeviceRunSessionFilterInput>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppEmbeddedUpdatesPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<EmbeddedUpdateFilterInput>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -2041,6 +2052,18 @@ export type AppDeviceRunSessionEdge = {
 export type AppDeviceRunSessionsConnection = {
   __typename?: 'AppDeviceRunSessionsConnection';
   edges: Array<AppDeviceRunSessionEdge>;
+  pageInfo: PageInfo;
+};
+
+export type AppEmbeddedUpdateEdge = {
+  __typename?: 'AppEmbeddedUpdateEdge';
+  cursor: Scalars['String']['output'];
+  node: EmbeddedUpdate;
+};
+
+export type AppEmbeddedUpdatesConnection = {
+  __typename?: 'AppEmbeddedUpdatesConnection';
+  edges: Array<AppEmbeddedUpdateEdge>;
   pageInfo: PageInfo;
 };
 
@@ -6191,6 +6214,12 @@ export type EmbeddedUpdateAssetUploadSpec = {
   presignedUrl: Scalars['String']['output'];
   /** Storage key (`{appId}/{embeddedUpdateId}`). Same key in both upload and destination buckets. */
   storageKey: Scalars['String']['output'];
+};
+
+export type EmbeddedUpdateFilterInput = {
+  channel?: InputMaybe<Scalars['String']['input']>;
+  platform?: InputMaybe<AppPlatform>;
+  runtimeVersion?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type EmbeddedUpdateMutation = {
@@ -13312,6 +13341,16 @@ export type ViewEmbeddedUpdateByIdQueryVariables = Exact<{
 
 
 export type ViewEmbeddedUpdateByIdQuery = { __typename?: 'RootQuery', embeddedUpdates: { __typename?: 'EmbeddedUpdateQuery', byId: { __typename?: 'EmbeddedUpdate', id: string, platform: AppPlatform, runtimeVersion: string, channel: string, createdAt: any, launchAsset: { __typename?: 'EmbeddedUpdateAsset', id: string, fileSize: number, finalFileSize?: number | null, fileSHA256: string } } } };
+
+export type ViewEmbeddedUpdatesPaginatedQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+  first: Scalars['Int']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<EmbeddedUpdateFilterInput>;
+}>;
+
+
+export type ViewEmbeddedUpdatesPaginatedQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, embeddedUpdatesPaginated: { __typename?: 'AppEmbeddedUpdatesConnection', edges: Array<{ __typename?: 'AppEmbeddedUpdateEdge', cursor: string, node: { __typename?: 'EmbeddedUpdate', id: string, platform: AppPlatform, runtimeVersion: string, channel: string, createdAt: any, launchAsset: { __typename?: 'EmbeddedUpdateAsset', id: string, fileSize: number, finalFileSize?: number | null, fileSHA256: string } } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type EnvironmentSecretsByAppIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/queries/EmbeddedUpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/EmbeddedUpdateQuery.ts
@@ -2,8 +2,15 @@ import { CombinedError } from '@urql/core';
 import gql from 'graphql-tag';
 
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { Connection } from '../../utils/relay';
+import {
+  EmbeddedUpdateFilterInput,
+  ViewEmbeddedUpdateByIdQuery,
+  ViewEmbeddedUpdateByIdQueryVariables,
+  ViewEmbeddedUpdatesPaginatedQuery,
+  ViewEmbeddedUpdatesPaginatedQueryVariables,
+} from '../generated';
 import { withErrorHandlingAsync } from '../client';
-import { ViewEmbeddedUpdateByIdQuery, ViewEmbeddedUpdateByIdQueryVariables } from '../generated';
 
 export function isEmbeddedUpdateNotFoundError(error: unknown): boolean {
   return (
@@ -13,6 +20,8 @@ export function isEmbeddedUpdateNotFoundError(error: unknown): boolean {
 }
 
 export type EmbeddedUpdateFragment = ViewEmbeddedUpdateByIdQuery['embeddedUpdates']['byId'];
+
+export type EmbeddedUpdateFilter = EmbeddedUpdateFilterInput;
 
 export const EmbeddedUpdateQuery = {
   async viewByIdAsync(
@@ -47,5 +56,63 @@ export const EmbeddedUpdateQuery = {
         .toPromise()
     );
     return data.embeddedUpdates.byId;
+  },
+
+  async viewPaginatedAsync(
+    graphqlClient: ExpoGraphqlClient,
+    {
+      appId,
+      filter,
+      first,
+      after,
+    }: { appId: string; filter?: EmbeddedUpdateFilter; first: number; after?: string }
+  ): Promise<Connection<EmbeddedUpdateFragment>> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<ViewEmbeddedUpdatesPaginatedQuery, ViewEmbeddedUpdatesPaginatedQueryVariables>(
+          gql`
+            query ViewEmbeddedUpdatesPaginated(
+              $appId: String!
+              $first: Int!
+              $after: String
+              $filter: EmbeddedUpdateFilterInput
+            ) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  embeddedUpdatesPaginated(first: $first, after: $after, filter: $filter) {
+                    edges {
+                      cursor
+                      node {
+                        id
+                        platform
+                        runtimeVersion
+                        channel
+                        createdAt
+                        launchAsset {
+                          id
+                          fileSize
+                          finalFileSize
+                          fileSHA256
+                        }
+                      }
+                    }
+                    pageInfo {
+                      hasNextPage
+                      hasPreviousPage
+                      startCursor
+                      endCursor
+                    }
+                  }
+                }
+              }
+            }
+          `,
+          { appId, first, after, filter },
+          { additionalTypenames: ['EmbeddedUpdate'] }
+        )
+        .toPromise()
+    );
+    return data.app.byId.embeddedUpdatesPaginated;
   },
 };

--- a/packages/eas-cli/src/graphql/queries/__tests__/EmbeddedUpdateQuery-test.ts
+++ b/packages/eas-cli/src/graphql/queries/__tests__/EmbeddedUpdateQuery-test.ts
@@ -104,3 +104,75 @@ describe('EmbeddedUpdateQuery.viewByIdAsync', () => {
     );
   });
 });
+
+describe('EmbeddedUpdateQuery.viewPaginatedAsync', () => {
+  function makeConnection(): {
+    edges: { cursor: string; node: any }[];
+    pageInfo: {
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor: string | null;
+      endCursor: string | null;
+    };
+  } {
+    return {
+      edges: [
+        {
+          cursor: 'c1',
+          node: {
+            id: 'update-1',
+            platform: AppPlatform.Ios,
+            runtimeVersion: '1.0.0',
+            channel: 'production',
+            createdAt: '2024-01-01T00:00:00Z',
+            launchAsset: {
+              id: 'asset-1',
+              fileSize: 1024,
+              finalFileSize: null,
+              fileSHA256: 'abc',
+            },
+          },
+        },
+      ],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false, startCursor: 'c1', endCursor: 'c1' },
+    };
+  }
+
+  it('returns the connection from the GraphQL response', async () => {
+    const connection = makeConnection();
+    const client = makeGraphqlClient({
+      app: { byId: { id: 'app-1', embeddedUpdatesPaginated: connection } },
+    });
+
+    const result = await EmbeddedUpdateQuery.viewPaginatedAsync(client, {
+      appId: 'app-1',
+      first: 25,
+    });
+
+    expect(result).toEqual(connection);
+  });
+
+  it('forwards filter / first / after to the query variables', async () => {
+    const client = makeGraphqlClient({
+      app: { byId: { id: 'app-1', embeddedUpdatesPaginated: makeConnection() } },
+    });
+
+    await EmbeddedUpdateQuery.viewPaginatedAsync(client, {
+      appId: 'app-1',
+      first: 10,
+      after: 'cursor-99',
+      filter: { platform: AppPlatform.Ios, runtimeVersion: '1.0.0', channel: 'production' },
+    });
+
+    expect(client.query).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        appId: 'app-1',
+        first: 10,
+        after: 'cursor-99',
+        filter: { platform: AppPlatform.Ios, runtimeVersion: '1.0.0', channel: 'production' },
+      },
+      expect.objectContaining({ additionalTypenames: ['EmbeddedUpdate'] })
+    );
+  });
+});


### PR DESCRIPTION
## Why

Lets users list the embedded updates they've uploaded for a project from the CLI, with platform / runtime / channel filters. Pairs with expo/universe#27770. Ref ENG-21468.

## How

`--platform`, `--runtime-version`, `--channel` for filtering; `--limit` + `--after-cursor` for pagination. When `--channel` is omitted in interactive mode, prompts to pick a channel with an "All channels" option (or `--channel all` to bypass). `--json` returns the full connection payload; otherwise prints a header with row count and each row as a formatted block, separated by dim dividers, with a next-page hint when more results exist.

## Test Plan

- CI
- Local CLI against universe `yarn start:staging`

#### all channels selected
<img width="601" height="48" alt="Screenshot 2026-06-02 at 11 36 30 PM" src="https://github.com/user-attachments/assets/1fde9a6f-f885-4166-865b-565edbca399f" />
<img width="533" height="257" alt="Screenshot 2026-06-02 at 11 36 35 PM" src="https://github.com/user-attachments/assets/15497d68-0f81-42a6-a6f1-1b818ed60756" />

#### single channel selected
<img width="553" height="148" alt="Screenshot 2026-06-02 at 11 36 22 PM" src="https://github.com/user-attachments/assets/3c4e0eb2-367e-4fe2-8844-860c0b9c1d61" />