### PR TITLE
[scripts] Add runtime settings editor

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,4 +3,6 @@ _.path = "./tools/bin"
 MISE_NODE_COREPACK = "true"
 
 [tools]
+gcloud = "570.0.0"
+jq = "1.8.1"
 node = "20.19.4"

--- a/scripts/edit-runtime-settings
+++ b/scripts/edit-runtime-settings
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 || ("$1" != "staging" && "$1" != "production") ]]; then
+  echo "Usage: scripts/edit-runtime-settings staging|production" >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required." >&2
+  exit 1
+fi
+
+for tool in gsutil jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "$tool is required. Run \`mise install\` from the repository root and try again." >&2
+    exit 1
+  fi
+done
+
+env="$1"
+object_uri="gs://eas-workflows-${env}/runtime-settings.json"
+object_url="https://storage.googleapis.com/eas-workflows-${env}/runtime-settings.json"
+cache_control="no-cache, no-store, must-revalidate"
+editor="${EDITOR:-vi}"
+
+tmpfile="$(mktemp)"
+minified_tmpfile="$(mktemp)"
+downloaded_tmpfile="$(mktemp)"
+trap 'rm -f "$tmpfile" "$minified_tmpfile" "$downloaded_tmpfile"' EXIT
+
+echo "Remote URL: $object_url"
+gsutil cat "$object_uri" | jq . >"$tmpfile"
+echo "Edit and verify the pretty-formatted JSON file before saving."
+
+while true; do
+  "$editor" "$tmpfile"
+  if jq empty "$tmpfile" >/dev/null; then
+    break
+  fi
+
+  echo "JSON is invalid. Reopening editor." >&2
+done
+
+jq -c . "$tmpfile" >"$minified_tmpfile"
+
+echo "Contents to upload:"
+cat "$minified_tmpfile"
+echo
+
+if [[ "$env" == "production" ]]; then
+  confirmation=""
+  read -r -p 'Type "production" to upload production runtime settings: ' confirmation
+  if [[ "$confirmation" != "production" ]]; then
+    echo "Production upload canceled." >&2
+    exit 1
+  fi
+fi
+
+gsutil \
+  -h "Cache-Control:${cache_control}" \
+  -h "Content-Type:application/json" \
+  cp "$minified_tmpfile" "$object_uri"
+gsutil acl ch -u AllUsers:R "$object_uri"
+
+curl -fsSL "$object_url" >"$downloaded_tmpfile"
+if ! cmp -s "$minified_tmpfile" "$downloaded_tmpfile"; then
+  echo "Read-after-write check failed: uploaded file differs from remote object." >&2
+  exit 1
+fi
+
+echo "Confirmed remote contents:"
+cat "$downloaded_tmpfile"
+echo

--- a/scripts/edit-runtime-settings
+++ b/scripts/edit-runtime-settings
@@ -12,7 +12,7 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
-for tool in gsutil jq; do
+for tool in gcloud jq; do
   if ! command -v "$tool" >/dev/null 2>&1; then
     echo "$tool is required. Run \`mise install\` from the repository root and try again." >&2
     exit 1
@@ -31,7 +31,7 @@ downloaded_tmpfile="$(mktemp)"
 trap 'rm -f "$tmpfile" "$minified_tmpfile" "$downloaded_tmpfile"' EXIT
 
 echo "Remote URL: $object_url"
-gsutil cat "$object_uri" | jq . >"$tmpfile"
+curl -fsSL "$object_url" | jq . >"$tmpfile"
 echo "Edit and verify the pretty-formatted JSON file before saving."
 
 while true; do
@@ -40,7 +40,8 @@ while true; do
     break
   fi
 
-  echo "JSON is invalid. Reopening editor." >&2
+  read -r -n 1 -s -p "JSON is invalid. Press any key to reopen editor." _
+  echo >&2
 done
 
 jq -c . "$tmpfile" >"$minified_tmpfile"
@@ -58,11 +59,12 @@ if [[ "$env" == "production" ]]; then
   fi
 fi
 
-gsutil \
-  -h "Cache-Control:${cache_control}" \
-  -h "Content-Type:application/json" \
-  cp "$minified_tmpfile" "$object_uri"
-gsutil acl ch -u AllUsers:R "$object_uri"
+gcloud storage cp \
+  --cache-control="$cache_control" \
+  --content-type=application/json \
+  --predefined-acl=publicRead \
+  "$minified_tmpfile" \
+  "$object_uri"
 
 curl -fsSL "$object_url" >"$downloaded_tmpfile"
 if ! cmp -s "$minified_tmpfile" "$downloaded_tmpfile"; then


### PR DESCRIPTION
I want us to move off of killswitches in Redis coming from `workflow-orchestration` towards fetching killswitches from a simple JSON file.

I picked GCS over R2 because it lets us make objects fully public (no `Authorization` required) and I (Stanley) found no way to achieve the same thing with R2.

This pull request adds a script `scripts/edit-runtime-settings staging | production` that is going to let us edit the file.