### PR TITLE
[build-tools] Route Datadog metrics and logs by build vs job-run target

### DIFF
--- a/packages/build-tools/src/__tests__/datadog.test.ts
+++ b/packages/build-tools/src/__tests__/datadog.test.ts
@@ -22,13 +22,13 @@ describe('Datadog singleton', () => {
     Datadog.setup(null);
   });
 
-  it('POSTs distribution metrics to the turtle build metrics endpoint', () => {
+  it('POSTs distribution metrics to the turtle build metrics endpoint for build targets', () => {
     turtleFetchMock.mockResolvedValueOnce({} as Response);
 
     Datadog.setup({
       expoApiV2BaseUrl: 'https://api.expo.test/v2/',
-      turtleBuildId: 'build-id',
       robotAccessToken: 'token-abc',
+      target: { kind: 'build', turtleBuildId: 'build-id' },
     });
 
     Datadog.distribution('eas.build.phase_duration', 1234, {
@@ -61,13 +61,48 @@ describe('Datadog singleton', () => {
     );
   });
 
-  it('POSTs logs to the turtle build logs endpoint', () => {
+  it('POSTs distribution metrics to the turtle job run metrics endpoint for jobRun targets', () => {
     turtleFetchMock.mockResolvedValueOnce({} as Response);
 
     Datadog.setup({
       expoApiV2BaseUrl: 'https://api.expo.test/v2/',
-      turtleBuildId: 'build-id',
       robotAccessToken: 'token-abc',
+      target: { kind: 'jobRun', turtleJobRunId: 'job-run-id' },
+    });
+
+    Datadog.distribution('eas.workflow.maestro_cli_version', 1, {
+      maestro_version: '2.1.0',
+    });
+
+    expect(turtleFetchMock).toHaveBeenCalledWith(
+      'https://api.expo.test/v2/turtle-job-runs/job-run-id/metrics',
+      'POST',
+      {
+        json: {
+          metrics: [
+            {
+              name: 'eas.workflow.maestro_cli_version',
+              type: 'distribution',
+              value: 1,
+              tags: {
+                maestro_version: '2.1.0',
+              },
+            },
+          ],
+        },
+        headers: { Authorization: 'Bearer token-abc' },
+        retries: 2,
+      }
+    );
+  });
+
+  it('POSTs logs to the turtle build logs endpoint with buildId for build targets', () => {
+    turtleFetchMock.mockResolvedValueOnce({} as Response);
+
+    Datadog.setup({
+      expoApiV2BaseUrl: 'https://api.expo.test/v2/',
+      robotAccessToken: 'token-abc',
+      target: { kind: 'build', turtleBuildId: 'build-id' },
     });
 
     Datadog.log('artifact dry-run matched', {
@@ -93,6 +128,36 @@ describe('Datadog singleton', () => {
     );
   });
 
+  it('POSTs logs to the turtle job run logs endpoint with jobRunId for jobRun targets', () => {
+    turtleFetchMock.mockResolvedValueOnce({} as Response);
+
+    Datadog.setup({
+      expoApiV2BaseUrl: 'https://api.expo.test/v2/',
+      robotAccessToken: 'token-abc',
+      target: { kind: 'jobRun', turtleJobRunId: 'job-run-id' },
+    });
+
+    Datadog.log('Gradle cache restored (hit)', {
+      cache_type: 'gradle',
+    });
+
+    expect(turtleFetchMock).toHaveBeenCalledWith(
+      'https://api.expo.test/v2/turtle-job-runs/logs',
+      'POST',
+      {
+        json: {
+          jobRunId: 'job-run-id',
+          message: 'Gradle cache restored (hit)',
+          tags: {
+            cache_type: 'gradle',
+          },
+        },
+        headers: { Authorization: 'Bearer token-abc' },
+        shouldThrowOnNotOk: false,
+      }
+    );
+  });
+
   it('is a no-op when setup is null', () => {
     Datadog.setup(null);
 
@@ -102,12 +167,12 @@ describe('Datadog singleton', () => {
     expect(turtleFetchMock).not.toHaveBeenCalled();
   });
 
-  it('swallows upload failures', async () => {
+  it('swallows metric upload failures for build targets', async () => {
     turtleFetchMock.mockRejectedValueOnce(new Error('network down'));
     Datadog.setup({
       expoApiV2BaseUrl: 'https://api.expo.test/v2/',
-      turtleBuildId: 'build-id',
       robotAccessToken: 'token-abc',
+      target: { kind: 'build', turtleBuildId: 'build-id' },
     });
 
     Datadog.distribution('eas.build.phase_duration', 1);
@@ -125,12 +190,36 @@ describe('Datadog singleton', () => {
     );
   });
 
-  it('swallows log upload failures', async () => {
+  it('labels metric upload failures for jobRun targets with the jobRun kind', async () => {
     turtleFetchMock.mockRejectedValueOnce(new Error('network down'));
     Datadog.setup({
       expoApiV2BaseUrl: 'https://api.expo.test/v2/',
-      turtleBuildId: 'build-id',
       robotAccessToken: 'token-abc',
+      target: { kind: 'jobRun', turtleJobRunId: 'job-run-id' },
+    });
+
+    Datadog.distribution('eas.workflow.maestro_cli_version', 1);
+    await flushPromises();
+
+    expect(sentryCaptureMock).toHaveBeenCalledWith(
+      'Failed to report turtle jobRun metric',
+      expect.any(Error),
+      expect.objectContaining({
+        extras: {
+          metrics: [
+            { name: 'eas.workflow.maestro_cli_version', type: 'distribution', value: 1, tags: {} },
+          ],
+        },
+      })
+    );
+  });
+
+  it('swallows log upload failures for build targets', async () => {
+    turtleFetchMock.mockRejectedValueOnce(new Error('network down'));
+    Datadog.setup({
+      expoApiV2BaseUrl: 'https://api.expo.test/v2/',
+      robotAccessToken: 'token-abc',
+      target: { kind: 'build', turtleBuildId: 'build-id' },
     });
 
     Datadog.log('artifact dry-run matched');
@@ -148,18 +237,40 @@ describe('Datadog singleton', () => {
     );
   });
 
+  it('labels log upload failures for jobRun targets with the jobRun kind', async () => {
+    turtleFetchMock.mockRejectedValueOnce(new Error('network down'));
+    Datadog.setup({
+      expoApiV2BaseUrl: 'https://api.expo.test/v2/',
+      robotAccessToken: 'token-abc',
+      target: { kind: 'jobRun', turtleJobRunId: 'job-run-id' },
+    });
+
+    Datadog.log('Gradle cache restored (hit)');
+    await flushPromises();
+
+    expect(sentryCaptureMock).toHaveBeenCalledWith(
+      'Failed to report turtle jobRun log',
+      expect.any(Error),
+      expect.objectContaining({
+        extras: {
+          log: { jobRunId: 'job-run-id', message: 'Gradle cache restored (hit)', tags: {} },
+        },
+      })
+    );
+  });
+
   it('uses the latest setup options', () => {
     turtleFetchMock.mockResolvedValue({} as Response);
 
     Datadog.setup({
       expoApiV2BaseUrl: 'https://api.expo.test/v2/',
-      turtleBuildId: 'first-build-id',
       robotAccessToken: 'first-token',
+      target: { kind: 'build', turtleBuildId: 'first-build-id' },
     });
     Datadog.setup({
       expoApiV2BaseUrl: 'https://api.expo.test/v2/',
-      turtleBuildId: 'second-build-id',
       robotAccessToken: 'second-token',
+      target: { kind: 'jobRun', turtleJobRunId: 'job-run-id' },
     });
 
     Datadog.distribution('eas.build.phase_duration', 1);
@@ -167,7 +278,7 @@ describe('Datadog singleton', () => {
 
     expect(turtleFetchMock).toHaveBeenNthCalledWith(
       1,
-      'https://api.expo.test/v2/turtle-builds/second-build-id/metrics',
+      'https://api.expo.test/v2/turtle-job-runs/job-run-id/metrics',
       'POST',
       expect.objectContaining({
         headers: { Authorization: 'Bearer second-token' },
@@ -175,7 +286,7 @@ describe('Datadog singleton', () => {
     );
     expect(turtleFetchMock).toHaveBeenNthCalledWith(
       2,
-      'https://api.expo.test/v2/turtle-builds/logs',
+      'https://api.expo.test/v2/turtle-job-runs/logs',
       'POST',
       expect.objectContaining({
         headers: { Authorization: 'Bearer second-token' },
@@ -192,8 +303,8 @@ describe('Datadog singleton', () => {
     );
     Datadog.setup({
       expoApiV2BaseUrl: 'https://api.expo.test/v2/',
-      turtleBuildId: 'build-id',
       robotAccessToken: 'token-abc',
+      target: { kind: 'build', turtleBuildId: 'build-id' },
     });
 
     let flushed = false;
@@ -219,8 +330,8 @@ describe('Datadog singleton', () => {
     );
     Datadog.setup({
       expoApiV2BaseUrl: 'https://api.expo.test/v2/',
-      turtleBuildId: 'build-id',
       robotAccessToken: 'token-abc',
+      target: { kind: 'build', turtleBuildId: 'build-id' },
     });
 
     let flushed = false;
@@ -232,6 +343,35 @@ describe('Datadog singleton', () => {
     expect(flushed).toBe(false);
 
     resolveUpload({} as Response);
+    await flushPromise;
+
+    expect(flushed).toBe(true);
+  });
+
+  it('only awaits uploads enqueued since the previous flush', async () => {
+    let resolveSecondUpload!: (response: Response) => void;
+    turtleFetchMock.mockReturnValueOnce(new Promise<Response>(() => {})).mockReturnValueOnce(
+      new Promise<Response>(resolve => {
+        resolveSecondUpload = resolve;
+      })
+    );
+    Datadog.setup({
+      expoApiV2BaseUrl: 'https://api.expo.test/v2/',
+      robotAccessToken: 'token-abc',
+      target: { kind: 'build', turtleBuildId: 'build-id' },
+    });
+
+    // The first upload never settles; the first flush rotates it out of the queue.
+    Datadog.distribution('eas.build.phase_duration', 1);
+    void Datadog.flushAsync();
+
+    Datadog.distribution('eas.build.phase_duration', 2);
+    let flushed = false;
+    const flushPromise = Datadog.flushAsync().then(() => {
+      flushed = true;
+    });
+
+    resolveSecondUpload({} as Response);
     await flushPromise;
 
     expect(flushed).toBe(true);

--- a/packages/build-tools/src/datadog.ts
+++ b/packages/build-tools/src/datadog.ts
@@ -1,10 +1,14 @@
 import { Sentry } from './sentry';
 import { turtleFetch } from './utils/turtleFetch';
 
+type MetricsTarget =
+  | { kind: 'build'; turtleBuildId: string }
+  | { kind: 'jobRun'; turtleJobRunId: string };
+
 type DatadogSetupOptions = {
   expoApiV2BaseUrl: string;
-  turtleBuildId: string;
   robotAccessToken: string;
+  target: MetricsTarget;
 };
 
 let setupOptions: DatadogSetupOptions | null = null;
@@ -19,7 +23,7 @@ export const Datadog = {
     if (!setupOptions) {
       return;
     }
-    const { expoApiV2BaseUrl, turtleBuildId, robotAccessToken } = setupOptions;
+    const { expoApiV2BaseUrl, robotAccessToken, target } = setupOptions;
     const metrics = [
       {
         name,
@@ -29,18 +33,19 @@ export const Datadog = {
       },
     ];
 
-    const uploadPromise = turtleFetch(
-      new URL(`turtle-builds/${turtleBuildId}/metrics`, expoApiV2BaseUrl).toString(),
-      'POST',
-      {
-        json: { metrics },
-        headers: {
-          Authorization: `Bearer ${robotAccessToken}`,
-        },
-        retries: 2,
-      }
-    ).catch(err => {
-      Sentry.capture('Failed to report turtle build metric', err, {
+    const metricsPath =
+      target.kind === 'build'
+        ? `turtle-builds/${target.turtleBuildId}/metrics`
+        : `turtle-job-runs/${target.turtleJobRunId}/metrics`;
+
+    const uploadPromise = turtleFetch(new URL(metricsPath, expoApiV2BaseUrl).toString(), 'POST', {
+      json: { metrics },
+      headers: {
+        Authorization: `Bearer ${robotAccessToken}`,
+      },
+      retries: 2,
+    }).catch(err => {
+      Sentry.capture(`Failed to report turtle ${target.kind} metric`, err, {
         extras: { metrics },
       });
     });
@@ -52,25 +57,21 @@ export const Datadog = {
     if (!setupOptions) {
       return;
     }
-    const { expoApiV2BaseUrl, turtleBuildId, robotAccessToken } = setupOptions;
-    const log = {
-      buildId: turtleBuildId,
-      message,
-      tags,
-    };
+    const { expoApiV2BaseUrl, robotAccessToken, target } = setupOptions;
+    const log =
+      target.kind === 'build'
+        ? { buildId: target.turtleBuildId, message, tags }
+        : { jobRunId: target.turtleJobRunId, message, tags };
+    const logsPath = target.kind === 'build' ? 'turtle-builds/logs' : 'turtle-job-runs/logs';
 
-    const uploadPromise = turtleFetch(
-      new URL('turtle-builds/logs', expoApiV2BaseUrl).toString(),
-      'POST',
-      {
-        json: log,
-        headers: {
-          Authorization: `Bearer ${robotAccessToken}`,
-        },
-        shouldThrowOnNotOk: false,
-      }
-    ).catch(err => {
-      Sentry.capture('Failed to report turtle build log', err, {
+    const uploadPromise = turtleFetch(new URL(logsPath, expoApiV2BaseUrl).toString(), 'POST', {
+      json: log,
+      headers: {
+        Authorization: `Bearer ${robotAccessToken}`,
+      },
+      shouldThrowOnNotOk: false,
+    }).catch(err => {
+      Sentry.capture(`Failed to report turtle ${target.kind} log`, err, {
         extras: { log },
       });
     });
@@ -79,6 +80,10 @@ export const Datadog = {
   },
 
   async flushAsync(): Promise<void> {
-    await Promise.allSettled(pendingUploads);
+    // Rotate so each flush only awaits its own batch; uploads enqueued during the
+    // await land in the fresh array for a later flush.
+    const uploads = pendingUploads;
+    pendingUploads = [];
+    await Promise.allSettled(uploads);
   },
 };

--- a/packages/worker/src/__unit__/service.test.ts
+++ b/packages/worker/src/__unit__/service.test.ts
@@ -136,14 +136,14 @@ describe('BuildService Datadog setup', () => {
 
     expect(datadogSetupMock).toHaveBeenCalledWith({
       expoApiV2BaseUrl: expect.any(String),
-      turtleBuildId: 'build-id',
       robotAccessToken: 'token-abc',
+      target: { kind: 'build', turtleBuildId: 'build-id' },
     });
     expect(createBuildContextMock).toHaveBeenCalled();
     expect(datadogFlushAsyncMock).toHaveBeenCalled();
   });
 
-  it('configures Datadog for non-platform jobs with the turtle build id', async () => {
+  it('configures Datadog for jobRun jobs with the turtle job run id', async () => {
     const service = new BuildService();
     service.checkForHangingWorker = jest.fn(async () => {});
 
@@ -158,8 +158,8 @@ describe('BuildService Datadog setup', () => {
 
     expect(datadogSetupMock).toHaveBeenCalledWith({
       expoApiV2BaseUrl: expect.any(String),
-      turtleBuildId: 'build-id',
       robotAccessToken: 'token-abc',
+      target: { kind: 'jobRun', turtleJobRunId: 'build-id' },
     });
     expect(createBuildContextMock).toHaveBeenCalled();
   });

--- a/packages/worker/src/service.ts
+++ b/packages/worker/src/service.ts
@@ -283,8 +283,12 @@ export default class BuildService {
       if (robotAccessToken) {
         Datadog.setup({
           expoApiV2BaseUrl: config.wwwApiV2BaseUrl,
-          turtleBuildId: this.buildId,
           robotAccessToken,
+          // job.platform is set only for build jobs; for a jobRun, this.buildId is the
+          // turtle-job-run id (verified by the jobType === 'jobRun' guard in startBuild()).
+          target: job.platform
+            ? { kind: 'build', turtleBuildId: this.buildId }
+            : { kind: 'jobRun', turtleJobRunId: this.buildId },
         });
       }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The `Datadog` singleton in `build-tools` can only emit to the turtle-build proxy endpoints (`turtle-builds/{buildId}/metrics`, `turtle-builds/logs`). When running a turtle-job-run (Maestro tests, deploys, generic jobs), metrics would be silently lost (posted against a nonexistent turtle-build) and logs would be mislabeled with a `build_id` tag carrying a jobRunId. ENG-21520.

Server-side counterpart (new `turtle-job-runs/*` proxy endpoints): expo/universe#27858.

# How

- `Datadog.setup()` now takes a `target` discriminated union keyed off the execution entity: `{ kind: 'build', turtleBuildId }` | `{ kind: 'jobRun', turtleJobRunId }`.
- `distribution()`/`log()` keep their public signatures and select the endpoint (and the log body id field) from `target.kind`. Sentry failure labels are target-aware; the build-path messages stay byte-identical to preserve existing grouping.
- The worker computes the target at `setup()` from `job.platform` (set only for build jobs); for a jobRun, `this.buildId` is the turtle-job-run id.
- Adjacent cleanup: `flushAsync()` rotates `pendingUploads` so each flush only awaits its own batch.

No new emit call sites: the jobRun metrics path stays dormant until a consumer lands (ENG-21441). The logs path takes effect immediately — a jobRun running `restore_build_cache` now logs with a correct `job_run_id` tag instead of a mislabeled `build_id`.

# Test Plan

- `packages/build-tools` `datadog.test.ts` (13 tests): build/jobRun routing for metrics and logs, target-aware Sentry labels, null-setup no-op, flush rotation.
- `packages/worker` `service.test.ts`: target computation for build vs jobRun jobs, and the missing-token no-op.
- `yarn typecheck` / `yarn lint` / `yarn fmt:check` clean.
