### PR TITLE
[eas-cli] ref(env:*): Validate all required flags at one in non-interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- [eas-cli] Improve `eas env:*` non-interactive required input help and error messages. ([4c793530](https://github.com/expo/eas-cli/commit/4c7935302124eb09ee27bb6ab47a2650fec46705) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- [eas-cli] Improve `eas env:*` non-interactive required input help and error messages. ([#3820](https://github.com/expo/eas-cli/pull/3820) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- [eas-cli] Reject conflicting positional `ENVIRONMENT` and `--variable-environment` inputs in `eas env:update` and `eas env:delete`. ([#3820](https://github.com/expo/eas-cli/pull/3820) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Improve `eas env:*` non-interactive required input help and error messages. ([4c793530](https://github.com/expo/eas-cli/commit/4c7935302124eb09ee27bb6ab47a2650fec46705) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+
 ### 🧹 Chores
 
 ## [20.0.0](https://github.com/expo/eas-cli/releases/tag/v20.0.0) - 2026-05-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
-- [eas-cli] Improve `eas env:*` non-interactive required input help and error messages. ([4c793530](https://github.com/expo/eas-cli/commit/4c7935302124eb09ee27bb6ab47a2650fec46705) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- [eas-cli] Improve `eas env:*` non-interactive required input help and error messages. ([#3820](https://github.com/expo/eas-cli/pull/3820) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- [eas-cli] Reject conflicting positional `ENVIRONMENT` and `--variable-environment` inputs in `eas env:update` and `eas env:delete`. ([#3820](https://github.com/expo/eas-cli/pull/3820) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
+- [eas-cli] Improve `eas env:*` non-interactive required input help and error messages. ([4c793530](https://github.com/expo/eas-cli/commit/4c7935302124eb09ee27bb6ab47a2650fec46705) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -27,16 +27,25 @@ export function resolveNonInteractiveAndJsonFlags(flags: {
   return { json, nonInteractive };
 }
 
-export function extendFlagDescription<T extends { description?: string }>(
-  flag: T,
+export function extendFlagDescription<T extends Record<string, { description?: string }>>(
+  flags: T,
   extraDescription: string
 ): T {
-  const description = flag.description ?? '';
-  const separator = !description || description.match(/[.!?]$/) ? ' ' : '. ';
-  return {
-    ...flag,
-    description: description ? `${description}${separator}${extraDescription}` : extraDescription,
-  };
+  return Object.fromEntries(
+    Object.entries(flags).map(([name, flag]) => {
+      const description = flag.description ?? '';
+      const separator = !description || description.match(/[.!?]$/) ? ' ' : '. ';
+      return [
+        name,
+        {
+          ...flag,
+          description: description
+            ? `${description}${separator}${extraDescription}`
+            : extraDescription,
+        },
+      ];
+    })
+  ) as T;
 }
 
 export function validateNonInteractiveRequiredInputs({

--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -39,6 +39,11 @@ export function extendFlagDescription<T extends { description?: string }>(
   };
 }
 
+export function isFlagProvided(argv: string[], flagName: string): boolean {
+  const normalizedFlagName = flagName.startsWith('--') ? flagName : `--${flagName}`;
+  return argv.some(arg => arg === normalizedFlagName || arg.startsWith(`${normalizedFlagName}=`));
+}
+
 export function validateNonInteractiveRequiredInputs({
   nonInteractive,
   requiredInputs,

--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -27,25 +27,26 @@ export function resolveNonInteractiveAndJsonFlags(flags: {
   return { json, nonInteractive };
 }
 
-export function extendFlagDescription<T extends Record<string, { description?: string }>>(
+export function prependFlagDescription<T extends Record<string, { description?: string }>>(
   flags: T,
   extraDescription: string
 ): T {
   return Object.fromEntries(
     Object.entries(flags).map(([name, flag]) => {
       const description = flag.description ?? '';
-      const separator = !description || description.match(/[.!?]$/) ? ' ' : '. ';
       return [
         name,
         {
           ...flag,
-          description: description
-            ? `${description}${separator}${extraDescription}`
-            : extraDescription,
+          description: description ? `${extraDescription} ${description}` : extraDescription,
         },
       ];
     })
   ) as T;
+}
+
+export function markRequired<T extends Record<string, { description?: string }>>(flags: T): T {
+  return prependFlagDescription(flags, '(required)');
 }
 
 export function validateNonInteractiveRequiredInputs({
@@ -54,7 +55,7 @@ export function validateNonInteractiveRequiredInputs({
   helpCommand,
 }: {
   nonInteractive: boolean;
-  requiredInputs: { name: string; value: unknown }[];
+  requiredInputs: { if?: boolean; name: string; value: unknown }[];
   helpCommand: string;
 }): void {
   if (!nonInteractive) {
@@ -62,7 +63,10 @@ export function validateNonInteractiveRequiredInputs({
   }
 
   const missingInputs = requiredInputs
-    .filter(({ value }) => {
+    .filter(({ if: condition = true, value }) => {
+      if (!condition) {
+        return false;
+      }
       if (Array.isArray(value)) {
         return value.length === 0;
       }

--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -1,4 +1,5 @@
 import { Flags } from '@oclif/core';
+import chalk from 'chalk';
 import { boolish } from 'getenv';
 
 export function isNonInteractiveByDefault(): boolean {
@@ -24,6 +25,50 @@ export function resolveNonInteractiveAndJsonFlags(flags: {
   const json = flags.json ?? false;
   const nonInteractive = flags['non-interactive'] || json;
   return { json, nonInteractive };
+}
+
+export function extendFlagDescription<T extends { description?: string }>(
+  flag: T,
+  extraDescription: string
+): T {
+  const description = flag.description ?? '';
+  const separator = !description || description.match(/[.!?]$/) ? ' ' : '. ';
+  return {
+    ...flag,
+    description: description ? `${description}${separator}${extraDescription}` : extraDescription,
+  };
+}
+
+export function validateNonInteractiveRequiredInputs({
+  nonInteractive,
+  requiredInputs,
+  helpCommand,
+}: {
+  nonInteractive: boolean;
+  requiredInputs: { name: string; value: unknown }[];
+  helpCommand: string;
+}): void {
+  if (!nonInteractive) {
+    return;
+  }
+
+  const missingInputs = requiredInputs
+    .filter(({ value }) => {
+      if (Array.isArray(value)) {
+        return value.length === 0;
+      }
+      return !value;
+    })
+    .map(({ name }) => name);
+
+  if (missingInputs.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Missing required inputs for non-interactive mode: ${missingInputs.join(', ')}.\n` +
+      `Run ${chalk.bold(helpCommand)} for usage and examples.`
+  );
 }
 
 export const EasEnvironmentFlagParameters = {

--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -39,11 +39,6 @@ export function extendFlagDescription<T extends { description?: string }>(
   };
 }
 
-export function isFlagProvided(argv: string[], flagName: string): boolean {
-  const normalizedFlagName = flagName.startsWith('--') ? flagName : `--${flagName}`;
-  return argv.some(arg => arg === normalizedFlagName || arg.startsWith(`${normalizedFlagName}=`));
-}
-
 export function validateNonInteractiveRequiredInputs({
   nonInteractive,
   requiredInputs,

--- a/packages/eas-cli/src/commandUtils/flags.ts
+++ b/packages/eas-cli/src/commandUtils/flags.ts
@@ -45,8 +45,10 @@ export function prependFlagDescription<T extends Record<string, { description?: 
   ) as T;
 }
 
-export function markRequired<T extends Record<string, { description?: string }>>(flags: T): T {
-  return prependFlagDescription(flags, '(required)');
+export function markRequiredInNonInteractiveMode<
+  T extends Record<string, { description?: string }>,
+>(flags: T): T {
+  return prependFlagDescription(flags, '(required in non-interactive mode)');
 }
 
 export function validateNonInteractiveRequiredInputs({

--- a/packages/eas-cli/src/commands/env/__tests__/EnvCreate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvCreate.test.ts
@@ -365,6 +365,19 @@ describe(EnvCreate, () => {
     });
   });
 
+  describe('in non-interactive mode', () => {
+    it('reports missing required inputs before loading command context', async () => {
+      const command = new EnvCreate(['--non-interactive'], mockConfig);
+      // @ts-expect-error
+      const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync');
+
+      await expect(command.runAsync()).rejects.toThrow(
+        /Missing required inputs for non-interactive mode: --name, --value, --visibility, ENVIRONMENT or --environment\.[\s\S]*eas env:create --help/
+      );
+      expect(getContextAsyncSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it('accepts development environment when using positional argument', async () => {
     const command = new EnvCreate(
       [

--- a/packages/eas-cli/src/commands/env/__tests__/EnvCreate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvCreate.test.ts
@@ -372,7 +372,7 @@ describe(EnvCreate, () => {
       const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync');
 
       await expect(command.runAsync()).rejects.toThrow(
-        /Missing required inputs for non-interactive mode: --name, --value, --visibility, ENVIRONMENT or --environment\.[\s\S]*eas env:create --help/
+        /Missing required inputs for non-interactive mode: --name, --value, --visibility, --environment\.[\s\S]*eas env:create --help/
       );
       expect(getContextAsyncSpy).not.toHaveBeenCalled();
     });

--- a/packages/eas-cli/src/commands/env/__tests__/EnvDelete.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvDelete.test.ts
@@ -106,7 +106,7 @@ describe(EnvDelete, () => {
     );
   });
 
-  it('cancels deletion when user does not confirm', async () => {
+  it('reports missing variable name in non-interactive mode before loading command context', async () => {
     const mockVariables = [
       { id: variableId, name: 'TEST_VARIABLE', scope: EnvironmentVariableScope.Project },
     ];
@@ -117,9 +117,12 @@ describe(EnvDelete, () => {
     const command = new EnvDelete(['--non-interactive'], mockConfig);
 
     // @ts-expect-error
-    jest.spyOn(command, 'getContextAsync').mockReturnValue(mockContext);
-    await expect(command.runAsync()).rejects.toThrowErrorMatchingSnapshot();
+    const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync').mockReturnValue(mockContext);
+    await expect(command.runAsync()).rejects.toThrow(
+      /Missing required inputs for non-interactive mode: --variable-name\.[\s\S]*eas env:delete --help/
+    );
 
+    expect(getContextAsyncSpy).not.toHaveBeenCalled();
     expect(EnvironmentVariableMutation.deleteAsync).not.toHaveBeenCalled();
   });
 

--- a/packages/eas-cli/src/commands/env/__tests__/EnvDelete.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvDelete.test.ts
@@ -161,4 +161,46 @@ describe(EnvDelete, () => {
       environment: DefaultEnvironment.Development,
     });
   });
+
+  it('rejects positional environment and --variable-environment used together', async () => {
+    const mockVariable = {
+      id: 'var1',
+      name: 'TEST_VAR_1',
+      value: 'value1',
+      environments: [DefaultEnvironment.Development],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
+      type: EnvironmentSecretType.String,
+    };
+
+    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValueOnce([mockVariable]);
+    jest.mocked(EnvironmentVariableMutation.deleteAsync).mockResolvedValueOnce({ id: 'var1' });
+
+    const command = new EnvDelete(
+      [
+        'development',
+        '--variable-name',
+        'TEST_VAR_1',
+        '--variable-environment',
+        'production',
+        '--scope',
+        'project',
+        '--non-interactive',
+      ],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId,
+    });
+
+    await expect(command.runAsync()).rejects.toThrow(
+      "You can't use both --variable-environment flag when environment is passed as an argument. Run `eas env:delete --help` for more information."
+    );
+    expect(getContextAsyncSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/eas-cli/src/commands/env/__tests__/EnvDelete.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvDelete.test.ts
@@ -199,7 +199,7 @@ describe(EnvDelete, () => {
     });
 
     await expect(command.runAsync()).rejects.toThrow(
-      "You can't use both --variable-environment flag when environment is passed as an argument. Run `eas env:delete --help` for more information."
+      "You can't use the --variable-environment flag when the environment is passed as a positional argument. Run `eas env:delete --help` for more information."
     );
     expect(getContextAsyncSpy).not.toHaveBeenCalled();
   });

--- a/packages/eas-cli/src/commands/env/__tests__/EnvGet.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvGet.test.ts
@@ -111,6 +111,21 @@ describe(EnvGet, () => {
     expect(promptVariableNameAsync).toHaveBeenCalled();
   });
 
+  it('requires scope in non-interactive mode', async () => {
+    const command = new EnvGet(
+      ['development', '--variable-name', 'TEST_VAR_1', '--non-interactive'],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync');
+
+    await expect(command.runAsync()).rejects.toThrow(
+      /Missing required inputs for non-interactive mode: --scope\.[\s\S]*eas env:get --help/
+    );
+    expect(getContextAsyncSpy).not.toHaveBeenCalled();
+  });
+
   it('accepts development environment when using positional argument', async () => {
     jest
       .mocked(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync)

--- a/packages/eas-cli/src/commands/env/__tests__/EnvGet.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvGet.test.ts
@@ -111,21 +111,6 @@ describe(EnvGet, () => {
     expect(promptVariableNameAsync).toHaveBeenCalled();
   });
 
-  it('requires scope in non-interactive mode', async () => {
-    const command = new EnvGet(
-      ['development', '--variable-name', 'TEST_VAR_1', '--non-interactive'],
-      mockConfig
-    );
-
-    // @ts-expect-error
-    const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync');
-
-    await expect(command.runAsync()).rejects.toThrow(
-      /Missing required inputs for non-interactive mode: --scope\.[\s\S]*eas env:get --help/
-    );
-    expect(getContextAsyncSpy).not.toHaveBeenCalled();
-  });
-
   it('accepts development environment when using positional argument', async () => {
     jest
       .mocked(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync)

--- a/packages/eas-cli/src/commands/env/__tests__/EnvList.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvList.test.ts
@@ -66,6 +66,18 @@ describe(EnvList, () => {
     );
   });
 
+  it('reports missing environment in non-interactive mode before loading command context', async () => {
+    const command = new EnvList(['--non-interactive'], mockConfig);
+
+    // @ts-expect-error
+    const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync');
+
+    await expect(command.runAsync()).rejects.toThrow(
+      /Missing required inputs for non-interactive mode: ENVIRONMENT or --environment\.[\s\S]*eas env:list --help/
+    );
+    expect(getContextAsyncSpy).not.toHaveBeenCalled();
+  });
+
   it('lists project environment variables in specified environments', async () => {
     jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValueOnce(mockVariables);
 

--- a/packages/eas-cli/src/commands/env/__tests__/EnvList.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvList.test.ts
@@ -66,16 +66,19 @@ describe(EnvList, () => {
     );
   });
 
-  it('reports missing environment in non-interactive mode before loading command context', async () => {
+  it('reports missing environment in non-interactive mode', async () => {
     const command = new EnvList(['--non-interactive'], mockConfig);
 
     // @ts-expect-error
-    const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync');
+    const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
 
     await expect(command.runAsync()).rejects.toThrow(
-      /Missing required inputs for non-interactive mode: ENVIRONMENT or --environment\.[\s\S]*eas env:list --help/
+      'The `--environment` flag must be set when running in `--non-interactive` mode.'
     );
-    expect(getContextAsyncSpy).not.toHaveBeenCalled();
+    expect(getContextAsyncSpy).toHaveBeenCalled();
   });
 
   it('lists project environment variables in specified environments', async () => {

--- a/packages/eas-cli/src/commands/env/__tests__/EnvPull.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvPull.test.ts
@@ -288,9 +288,9 @@ describe(EnvPull, () => {
       });
 
       await expect(command.runAsync()).rejects.toThrow(
-        /Missing required inputs for non-interactive mode: ENVIRONMENT or --environment\.[\s\S]*eas env:pull --help/
+        'The `--environment` flag must be set when running in `--non-interactive` mode.'
       );
-      expect(getContextAsyncSpy).not.toHaveBeenCalled();
+      expect(getContextAsyncSpy).toHaveBeenCalled();
     });
   });
 

--- a/packages/eas-cli/src/commands/env/__tests__/EnvPull.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvPull.test.ts
@@ -281,15 +281,16 @@ describe(EnvPull, () => {
       const command = new EnvPull(['--non-interactive'], mockConfig);
 
       // @ts-expect-error
-      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync').mockReturnValue({
         loggedIn: { graphqlClient },
         projectId: testProjectId,
         projectDir: testProjectDir,
       });
 
       await expect(command.runAsync()).rejects.toThrow(
-        'The `--environment` flag must be set when running in `--non-interactive` mode.'
+        /Missing required inputs for non-interactive mode: ENVIRONMENT or --environment\.[\s\S]*eas env:pull --help/
       );
+      expect(getContextAsyncSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/eas-cli/src/commands/env/__tests__/EnvPush.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvPush.test.ts
@@ -89,16 +89,50 @@ SECRET_KEY=super-secret-key`;
     });
   });
 
-  it('reports missing environment in non-interactive mode before loading command context', async () => {
+  it('reports missing environment in non-interactive mode', async () => {
     const command = new EnvPush(['--non-interactive', '--path', testEnvPath], mockConfig);
 
     // @ts-expect-error
-    const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync');
+    const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+      projectDir: testProjectDir,
+    });
 
     await expect(command.runAsync()).rejects.toThrow(
-      /Missing required inputs for non-interactive mode: ENVIRONMENT or --environment\.[\s\S]*eas env:push --help/
+      /The `--environment` flag must be set when running in `--non-interactive` mode/
     );
-    expect(getContextAsyncSpy).not.toHaveBeenCalled();
+    expect(getContextAsyncSpy).toHaveBeenCalled();
+  });
+
+  it('allows non-interactive mode without --force when nothing needs confirmation', async () => {
+    const command = new EnvPush(
+      ['--environment', 'development', '--path', testEnvPath, '--non-interactive'],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+      projectDir: testProjectDir,
+    });
+
+    await command.runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(
+      EnvironmentVariableMutation.createBulkEnvironmentVariablesForAppAsync
+    ).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'VARIABLE_NAME',
+          environments: [DefaultEnvironment.Development],
+        }),
+      ]),
+      testProjectId
+    );
   });
 
   describe('--force option', () => {
@@ -288,7 +322,7 @@ SECRET_KEY=super-secret-key`;
       );
     });
 
-    it('requires --force when overwriting in non-interactive mode', async () => {
+    it('throws before confirming overwrite in non-interactive mode when --force is not used', async () => {
       const existingVariable = {
         id: 'var1',
         name: 'VARIABLE_NAME',
@@ -297,14 +331,14 @@ SECRET_KEY=super-secret-key`;
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         scope: EnvironmentVariableScope.Project,
-        visibility: EnvironmentVariableVisibility.Sensitive,
+        visibility: EnvironmentVariableVisibility.Public,
         type: EnvironmentSecretType.String,
       };
 
       jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValue([existingVariable]);
 
       const command = new EnvPush(
-        ['development', '--path', testEnvPath, '--non-interactive'],
+        ['--environment', 'development', '--path', testEnvPath, '--non-interactive'],
         mockConfig
       );
 
@@ -316,9 +350,50 @@ SECRET_KEY=super-secret-key`;
       });
 
       await expect(command.runAsync()).rejects.toThrow(
-        /Missing required inputs for non-interactive mode: --force\.[\s\S]*eas env:push --help/
+        'Cannot confirm overwriting existing variables in non-interactive mode. Use --force to overwrite them.'
       );
       expect(confirmAsync).not.toHaveBeenCalled();
+      expect(
+        EnvironmentVariableMutation.createBulkEnvironmentVariablesForAppAsync
+      ).not.toHaveBeenCalled();
+    });
+
+    it('throws before confirming sensitive overwrite in non-interactive mode when --force is not used', async () => {
+      const existingSensitiveVariable = {
+        id: 'var1',
+        name: 'SECRET_KEY',
+        value: 'super-secret-key',
+        environments: [DefaultEnvironment.Development],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        scope: EnvironmentVariableScope.Project,
+        visibility: EnvironmentVariableVisibility.Sensitive,
+        type: EnvironmentSecretType.String,
+      };
+
+      jest
+        .mocked(EnvironmentVariablesQuery.byAppIdAsync)
+        .mockResolvedValue([existingSensitiveVariable]);
+
+      const command = new EnvPush(
+        ['--environment', 'development', '--path', testEnvPath, '--non-interactive'],
+        mockConfig
+      );
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await expect(command.runAsync()).rejects.toThrow(
+        'Cannot confirm overwriting sensitive variables in non-interactive mode. Use --force to overwrite them.'
+      );
+      expect(confirmAsync).not.toHaveBeenCalled();
+      expect(
+        EnvironmentVariableMutation.createBulkEnvironmentVariablesForAppAsync
+      ).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/eas-cli/src/commands/env/__tests__/EnvPush.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvPush.test.ts
@@ -89,6 +89,18 @@ SECRET_KEY=super-secret-key`;
     });
   });
 
+  it('reports missing environment in non-interactive mode before loading command context', async () => {
+    const command = new EnvPush(['--non-interactive', '--path', testEnvPath], mockConfig);
+
+    // @ts-expect-error
+    const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync');
+
+    await expect(command.runAsync()).rejects.toThrow(
+      /Missing required inputs for non-interactive mode: ENVIRONMENT or --environment\.[\s\S]*eas env:push --help/
+    );
+    expect(getContextAsyncSpy).not.toHaveBeenCalled();
+  });
+
   describe('--force option', () => {
     it('automatically overrides existing variables without confirmation when --force is used', async () => {
       const existingVariable = {
@@ -274,6 +286,39 @@ SECRET_KEY=super-secret-key`;
       expect(Log.log).not.toHaveBeenCalledWith(
         'Using --force flag: automatically overriding sensitive variables.'
       );
+    });
+
+    it('requires --force when overwriting in non-interactive mode', async () => {
+      const existingVariable = {
+        id: 'var1',
+        name: 'VARIABLE_NAME',
+        value: 'old variable value',
+        environments: [DefaultEnvironment.Development],
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        scope: EnvironmentVariableScope.Project,
+        visibility: EnvironmentVariableVisibility.Sensitive,
+        type: EnvironmentSecretType.String,
+      };
+
+      jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValue([existingVariable]);
+
+      const command = new EnvPush(
+        ['development', '--path', testEnvPath, '--non-interactive'],
+        mockConfig
+      );
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await expect(command.runAsync()).rejects.toThrow(
+        /Missing required inputs for non-interactive mode: --force\.[\s\S]*eas env:push --help/
+      );
+      expect(confirmAsync).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/eas-cli/src/commands/env/__tests__/EnvUpdate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvUpdate.test.ts
@@ -253,6 +253,50 @@ describe(EnvUpdate, () => {
     });
   });
 
+  it('rejects positional environment and --variable-environment used together', async () => {
+    const mockVariable = {
+      id: 'var1',
+      name: 'TEST_VAR_1',
+      value: 'value1',
+      environments: [DefaultEnvironment.Development],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
+      type: EnvironmentSecretType.String,
+    };
+
+    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValueOnce([mockVariable]);
+    jest.mocked(EnvironmentVariableMutation.updateAsync).mockResolvedValueOnce(mockVariable);
+
+    const command = new EnvUpdate(
+      [
+        'development',
+        '--variable-name',
+        'TEST_VAR_1',
+        '--variable-environment',
+        'production',
+        '--value',
+        'new-value',
+        '--scope',
+        'project',
+        '--non-interactive',
+      ],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    const getContextAsyncSpy = jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId,
+    });
+
+    await expect(command.runAsync()).rejects.toThrow(
+      "You can't use both --variable-environment flag when environment is passed as an argument. Run `eas env:update --help` for more information."
+    );
+    expect(getContextAsyncSpy).not.toHaveBeenCalled();
+  });
+
   it('processes file type variable in non-interactive mode with --type file and --value', async () => {
     const testFilePath = '/path/to/test-file.json';
     const testFileBase64 = 'dGVzdCBmaWxlIGNvbnRlbnQ=';

--- a/packages/eas-cli/src/commands/env/__tests__/EnvUpdate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvUpdate.test.ts
@@ -253,6 +253,17 @@ describe(EnvUpdate, () => {
     });
   });
 
+  it('throws an error when current environment is not provided in non-interactive mode', async () => {
+    const command = new EnvUpdate(
+      ['--variable-name', 'TEST_VARIABLE', '--non-interactive', '--value', 'new-value'],
+      mockConfig
+    );
+
+    await expect(command.runAsync()).rejects.toThrow(
+      /Missing required inputs for non-interactive mode: --variable-environment\.[\s\S]*eas env:update --help/
+    );
+  });
+
   it('processes file type variable in non-interactive mode with --type file and --value', async () => {
     const testFilePath = '/path/to/test-file.json';
     const testFileBase64 = 'dGVzdCBmaWxlIGNvbnRlbnQ=';

--- a/packages/eas-cli/src/commands/env/__tests__/EnvUpdate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvUpdate.test.ts
@@ -253,17 +253,6 @@ describe(EnvUpdate, () => {
     });
   });
 
-  it('throws an error when current environment is not provided in non-interactive mode', async () => {
-    const command = new EnvUpdate(
-      ['--variable-name', 'TEST_VARIABLE', '--non-interactive', '--value', 'new-value'],
-      mockConfig
-    );
-
-    await expect(command.runAsync()).rejects.toThrow(
-      /Missing required inputs for non-interactive mode: --variable-environment\.[\s\S]*eas env:update --help/
-    );
-  });
-
   it('processes file type variable in non-interactive mode with --type file and --value', async () => {
     const testFilePath = '/path/to/test-file.json';
     const testFileBase64 = 'dGVzdCBmaWxlIGNvbnRlbnQ=';

--- a/packages/eas-cli/src/commands/env/__tests__/EnvUpdate.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvUpdate.test.ts
@@ -292,7 +292,7 @@ describe(EnvUpdate, () => {
     });
 
     await expect(command.runAsync()).rejects.toThrow(
-      "You can't use both --variable-environment flag when environment is passed as an argument. Run `eas env:update --help` for more information."
+      "You can't use the --variable-environment flag when the environment is passed as a positional argument. Run `eas env:update --help` for more information."
     );
     expect(getContextAsyncSpy).not.toHaveBeenCalled();
   });

--- a/packages/eas-cli/src/commands/env/__tests__/__snapshots__/EnvDelete.test.ts.snap
+++ b/packages/eas-cli/src/commands/env/__tests__/__snapshots__/EnvDelete.test.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`EnvDelete cancels deletion when user does not confirm 1`] = `"Environment variable needs 'name' to be specified when running in non-interactive mode. Run the command with [1m--variable-name VARIABLE_NAME[22m flag to fix the issue"`;

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -11,6 +11,8 @@ import {
   EASMultiEnvironmentFlag,
   EASNonInteractiveFlag,
   EASVariableVisibilityFlag,
+  extendFlagDescription,
+  validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
   EnvironmentSecretType,
@@ -57,35 +59,53 @@ interface CreateFlags {
 }
 
 export default class EnvCreate extends EasCommand {
-  static override description = 'create an environment variable for the current project or account';
+  static override description = `create an environment variable for the current project or account
+
+In non-interactive mode, provide --name, --value, --visibility, and --environment.
+Use --force in non-interactive mode when overwriting an existing variable.`;
+
+  static override examples = [
+    '$ eas env:create --environment production --environment preview --name API_TOKEN --value "$API_TOKEN" --visibility sensitive --non-interactive',
+    '$ eas env:create production --scope account --name SHARED_TOKEN --value "$SHARED_TOKEN" --visibility secret --non-interactive',
+  ];
 
   static override args = {
     environment: Args.string({
       description:
-        "Environment to create the variable in. Default environments are 'production', 'preview', and 'development'.",
+        "Environment to create the variable in. Required in non-interactive mode unless --environment is provided. Default environments are 'production', 'preview', and 'development'.",
       required: false,
     }),
   };
 
   static override flags = {
     name: Flags.string({
-      description: 'Name of the variable',
+      description: 'Name of the variable. Required in non-interactive mode.',
     }),
     value: Flags.string({
-      description: 'Text value or the variable',
+      description:
+        'Text value for the variable, or a file path when --type=file. Required in non-interactive mode.',
     }),
     force: Flags.boolean({
-      description: 'Overwrite existing variable',
+      description: 'Overwrite existing variable. Required in non-interactive mode to overwrite.',
       default: false,
     }),
     type: Flags.option({
       description: 'The type of variable',
       options: ['string', 'file'] as const,
     })(),
-    ...EASVariableVisibilityFlag,
+    visibility: extendFlagDescription(
+      EASVariableVisibilityFlag.visibility,
+      'Required in non-interactive mode.'
+    ),
     ...EASEnvironmentVariableScopeFlag,
-    ...EASMultiEnvironmentFlag,
-    ...EASNonInteractiveFlag,
+    environment: extendFlagDescription(
+      EASMultiEnvironmentFlag.environment,
+      'Required in non-interactive mode unless ENVIRONMENT is provided.'
+    ),
+    'non-interactive': extendFlagDescription(
+      EASNonInteractiveFlag['non-interactive'],
+      'Requires --name, --value, --visibility, and an environment via ENVIRONMENT or --environment.'
+    ),
   };
 
   static override contextDefinition = {
@@ -98,6 +118,19 @@ export default class EnvCreate extends EasCommand {
     const { args, flags } = await this.parse(EnvCreate);
 
     const validatedFlags = this.sanitizeFlags(flags);
+    validateNonInteractiveRequiredInputs({
+      nonInteractive: validatedFlags['non-interactive'],
+      requiredInputs: [
+        { name: '--name', value: validatedFlags.name },
+        { name: '--value', value: validatedFlags.value },
+        { name: '--visibility', value: validatedFlags.visibility },
+        {
+          name: 'ENVIRONMENT or --environment',
+          value: args.environment ?? validatedFlags.environment,
+        },
+      ],
+      helpCommand: 'eas env:create --help',
+    });
 
     const {
       projectId,

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -61,7 +61,7 @@ interface CreateFlags {
 export default class EnvCreate extends EasCommand {
   static override description = `create an environment variable for the current project or account
 
-In non-interactive mode, provide --name, --value, --visibility, and --environment.
+In non-interactive mode, provide --name, --value, --visibility, and an environment via ENVIRONMENT or --environment.
 Use --force in non-interactive mode when overwriting an existing variable.`;
 
   static override examples = [

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -11,7 +11,7 @@ import {
   EASMultiEnvironmentFlag,
   EASNonInteractiveFlag,
   EASVariableVisibilityFlag,
-  extendFlagDescription,
+  markRequired,
   validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
@@ -59,50 +59,40 @@ interface CreateFlags {
 }
 
 export default class EnvCreate extends EasCommand {
-  static override description = `create an environment variable for the current project or account
-
-In non-interactive mode, provide --name, --value, --visibility, and an environment via ENVIRONMENT or --environment.
-Use --force in non-interactive mode when overwriting an existing variable.`;
+  static override description = 'create an environment variable for the current project or account';
 
   static override examples = [
-    '$ eas env:create --environment production --environment preview --name API_TOKEN --value "$API_TOKEN" --visibility sensitive --non-interactive',
-    '$ eas env:create production --scope account --name SHARED_TOKEN --value "$SHARED_TOKEN" --visibility secret --non-interactive',
+    '$ eas env:create --environment production --environment preview --name API_TOKEN --value "$API_TOKEN" --visibility sensitive',
+    '$ eas env:create --environment production --scope account --name SHARED_TOKEN --value "$SHARED_TOKEN" --visibility secret',
   ];
 
   static override args = {
     environment: Args.string({
       description:
-        "Environment to create the variable in. Required in non-interactive mode unless --environment is provided. Default environments are 'production', 'preview', and 'development'.",
+        "Environment to create the variable in. Default environments are 'production', 'preview', and 'development'.",
       required: false,
     }),
   };
 
   static override flags = {
     name: Flags.string({
-      description: 'Name of the variable. Required in non-interactive mode.',
+      description: '(required) Name of the variable',
     }),
     value: Flags.string({
-      description:
-        'Text value for the variable, or a file path when --type=file. Required in non-interactive mode.',
+      description: '(required) Text value of the variable, or a file path when --type=file',
     }),
     force: Flags.boolean({
-      description: 'Overwrite existing variable. Required in non-interactive mode to overwrite.',
+      description: '(required when overwriting) Overwrite existing variable',
       default: false,
     }),
     type: Flags.option({
       description: 'The type of variable',
       options: ['string', 'file'] as const,
     })(),
-    ...extendFlagDescription(EASVariableVisibilityFlag, 'Required in non-interactive mode.'),
+    ...markRequired(EASVariableVisibilityFlag),
     ...EASEnvironmentVariableScopeFlag,
-    ...extendFlagDescription(
-      EASMultiEnvironmentFlag,
-      'Required in non-interactive mode unless ENVIRONMENT is provided.'
-    ),
-    ...extendFlagDescription(
-      EASNonInteractiveFlag,
-      'Requires --name, --value, --visibility, and an environment via ENVIRONMENT or --environment.'
-    ),
+    ...markRequired(EASMultiEnvironmentFlag),
+    ...EASNonInteractiveFlag,
   };
 
   static override contextDefinition = {
@@ -122,7 +112,7 @@ Use --force in non-interactive mode when overwriting an existing variable.`;
         { name: '--value', value: validatedFlags.value },
         { name: '--visibility', value: validatedFlags.visibility },
         {
-          name: 'ENVIRONMENT or --environment',
+          name: '--environment',
           value: args.environment ?? validatedFlags.environment,
         },
       ],

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -93,17 +93,14 @@ Use --force in non-interactive mode when overwriting an existing variable.`;
       description: 'The type of variable',
       options: ['string', 'file'] as const,
     })(),
-    visibility: extendFlagDescription(
-      EASVariableVisibilityFlag.visibility,
-      'Required in non-interactive mode.'
-    ),
+    ...extendFlagDescription(EASVariableVisibilityFlag, 'Required in non-interactive mode.'),
     ...EASEnvironmentVariableScopeFlag,
-    environment: extendFlagDescription(
-      EASMultiEnvironmentFlag.environment,
+    ...extendFlagDescription(
+      EASMultiEnvironmentFlag,
       'Required in non-interactive mode unless ENVIRONMENT is provided.'
     ),
-    'non-interactive': extendFlagDescription(
-      EASNonInteractiveFlag['non-interactive'],
+    ...extendFlagDescription(
+      EASNonInteractiveFlag,
       'Requires --name, --value, --visibility, and an environment via ENVIRONMENT or --environment.'
     ),
   };

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -11,7 +11,7 @@ import {
   EASMultiEnvironmentFlag,
   EASNonInteractiveFlag,
   EASVariableVisibilityFlag,
-  markRequired,
+  markRequiredInNonInteractiveMode,
   validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
@@ -78,22 +78,24 @@ export default class EnvCreate extends EasCommand {
 
   static override flags = {
     name: Flags.string({
-      description: '(required) Name of the variable',
+      description: '(required in non-interactive mode) Name of the variable',
     }),
     value: Flags.string({
-      description: '(required) Text value of the variable, or a file path when --type=file',
+      description:
+        '(required in non-interactive mode) Text value of the variable, or a file path when --type=file',
     }),
     force: Flags.boolean({
-      description: '(required when overwriting) Overwrite existing variable',
+      description:
+        '(required when overwriting in non-interactive mode) Overwrite existing variable',
       default: false,
     }),
     type: Flags.option({
       description: 'The type of variable',
       options: ['string', 'file'] as const,
     })(),
-    ...markRequired(EASVariableVisibilityFlag),
+    ...markRequiredInNonInteractiveMode(EASVariableVisibilityFlag),
     ...EASEnvironmentVariableScopeFlag,
-    ...markRequired(EASMultiEnvironmentFlag),
+    ...markRequiredInNonInteractiveMode(EASMultiEnvironmentFlag),
     ...EASNonInteractiveFlag,
   };
 

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -61,7 +61,7 @@ interface CreateFlags {
 export default class EnvCreate extends EasCommand {
   static override description = `create an environment variable for the current project or account (deprecated, use eas env:set)
 
-In non-interactive mode, provide --name, --value, --visibility, and --environment.
+In non-interactive mode, provide --name, --value, --visibility, and an environment via ENVIRONMENT or --environment.
 Use --force in non-interactive mode when overwriting an existing variable.`;
   static override hidden = true;
 

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -94,17 +94,14 @@ Use --force in non-interactive mode when overwriting an existing variable.`;
       description: 'The type of variable',
       options: ['string', 'file'] as const,
     })(),
-    visibility: extendFlagDescription(
-      EASVariableVisibilityFlag.visibility,
-      'Required in non-interactive mode.'
-    ),
+    ...extendFlagDescription(EASVariableVisibilityFlag, 'Required in non-interactive mode.'),
     ...EASEnvironmentVariableScopeFlag,
-    environment: extendFlagDescription(
-      EASMultiEnvironmentFlag.environment,
+    ...extendFlagDescription(
+      EASMultiEnvironmentFlag,
       'Required in non-interactive mode unless ENVIRONMENT is provided.'
     ),
-    'non-interactive': extendFlagDescription(
-      EASNonInteractiveFlag['non-interactive'],
+    ...extendFlagDescription(
+      EASNonInteractiveFlag,
       'Requires --name, --value, --visibility, and an environment via ENVIRONMENT or --environment.'
     ),
   };

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -11,6 +11,8 @@ import {
   EASMultiEnvironmentFlag,
   EASNonInteractiveFlag,
   EASVariableVisibilityFlag,
+  extendFlagDescription,
+  validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
   EnvironmentSecretType,
@@ -57,37 +59,54 @@ interface CreateFlags {
 }
 
 export default class EnvCreate extends EasCommand {
-  static override description =
-    'create an environment variable for the current project or account (deprecated, use eas env:set)';
+  static override description = `create an environment variable for the current project or account (deprecated, use eas env:set)
+
+In non-interactive mode, provide --name, --value, --visibility, and --environment.
+Use --force in non-interactive mode when overwriting an existing variable.`;
   static override hidden = true;
+
+  static override examples = [
+    '$ eas env:create --environment production --environment preview --name API_TOKEN --value "$API_TOKEN" --visibility sensitive --non-interactive',
+    '$ eas env:create production --scope account --name SHARED_TOKEN --value "$SHARED_TOKEN" --visibility secret --non-interactive',
+  ];
 
   static override args = {
     environment: Args.string({
       description:
-        "Environment to create the variable in. Default environments are 'production', 'preview', and 'development'.",
+        "Environment to create the variable in. Required in non-interactive mode unless --environment is provided. Default environments are 'production', 'preview', and 'development'.",
       required: false,
     }),
   };
 
   static override flags = {
     name: Flags.string({
-      description: 'Name of the variable',
+      description: 'Name of the variable. Required in non-interactive mode.',
     }),
     value: Flags.string({
-      description: 'Text value or the variable',
+      description:
+        'Text value for the variable, or a file path when --type=file. Required in non-interactive mode.',
     }),
     force: Flags.boolean({
-      description: 'Overwrite existing variable',
+      description: 'Overwrite existing variable. Required in non-interactive mode to overwrite.',
       default: false,
     }),
     type: Flags.option({
       description: 'The type of variable',
       options: ['string', 'file'] as const,
     })(),
-    ...EASVariableVisibilityFlag,
+    visibility: extendFlagDescription(
+      EASVariableVisibilityFlag.visibility,
+      'Required in non-interactive mode.'
+    ),
     ...EASEnvironmentVariableScopeFlag,
-    ...EASMultiEnvironmentFlag,
-    ...EASNonInteractiveFlag,
+    environment: extendFlagDescription(
+      EASMultiEnvironmentFlag.environment,
+      'Required in non-interactive mode unless ENVIRONMENT is provided.'
+    ),
+    'non-interactive': extendFlagDescription(
+      EASNonInteractiveFlag['non-interactive'],
+      'Requires --name, --value, --visibility, and an environment via ENVIRONMENT or --environment.'
+    ),
   };
 
   static override contextDefinition = {
@@ -103,6 +122,19 @@ export default class EnvCreate extends EasCommand {
     const { args, flags } = await this.parse(EnvCreate);
 
     const validatedFlags = this.sanitizeFlags(flags);
+    validateNonInteractiveRequiredInputs({
+      nonInteractive: validatedFlags['non-interactive'],
+      requiredInputs: [
+        { name: '--name', value: validatedFlags.name },
+        { name: '--value', value: validatedFlags.value },
+        { name: '--visibility', value: validatedFlags.visibility },
+        {
+          name: 'ENVIRONMENT or --environment',
+          value: args.environment ?? validatedFlags.environment,
+        },
+      ],
+      helpCommand: 'eas env:create --help',
+    });
 
     const {
       projectId,

--- a/packages/eas-cli/src/commands/env/create.ts
+++ b/packages/eas-cli/src/commands/env/create.ts
@@ -11,7 +11,7 @@ import {
   EASMultiEnvironmentFlag,
   EASNonInteractiveFlag,
   EASVariableVisibilityFlag,
-  extendFlagDescription,
+  markRequired,
   validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
@@ -59,51 +59,42 @@ interface CreateFlags {
 }
 
 export default class EnvCreate extends EasCommand {
-  static override description = `create an environment variable for the current project or account (deprecated, use eas env:set)
-
-In non-interactive mode, provide --name, --value, --visibility, and an environment via ENVIRONMENT or --environment.
-Use --force in non-interactive mode when overwriting an existing variable.`;
+  static override description =
+    'create an environment variable for the current project or account (deprecated, use eas env:set)';
   static override hidden = true;
 
   static override examples = [
-    '$ eas env:create --environment production --environment preview --name API_TOKEN --value "$API_TOKEN" --visibility sensitive --non-interactive',
-    '$ eas env:create production --scope account --name SHARED_TOKEN --value "$SHARED_TOKEN" --visibility secret --non-interactive',
+    '$ eas env:create --environment production --environment preview --name API_TOKEN --value "$API_TOKEN" --visibility sensitive',
+    '$ eas env:create --environment production --scope account --name SHARED_TOKEN --value "$SHARED_TOKEN" --visibility secret',
   ];
 
   static override args = {
     environment: Args.string({
       description:
-        "Environment to create the variable in. Required in non-interactive mode unless --environment is provided. Default environments are 'production', 'preview', and 'development'.",
+        "Environment to create the variable in. Default environments are 'production', 'preview', and 'development'.",
       required: false,
     }),
   };
 
   static override flags = {
     name: Flags.string({
-      description: 'Name of the variable. Required in non-interactive mode.',
+      description: '(required) Name of the variable',
     }),
     value: Flags.string({
-      description:
-        'Text value for the variable, or a file path when --type=file. Required in non-interactive mode.',
+      description: '(required) Text value of the variable, or a file path when --type=file',
     }),
     force: Flags.boolean({
-      description: 'Overwrite existing variable. Required in non-interactive mode to overwrite.',
+      description: '(required when overwriting) Overwrite existing variable',
       default: false,
     }),
     type: Flags.option({
       description: 'The type of variable',
       options: ['string', 'file'] as const,
     })(),
-    ...extendFlagDescription(EASVariableVisibilityFlag, 'Required in non-interactive mode.'),
+    ...markRequired(EASVariableVisibilityFlag),
     ...EASEnvironmentVariableScopeFlag,
-    ...extendFlagDescription(
-      EASMultiEnvironmentFlag,
-      'Required in non-interactive mode unless ENVIRONMENT is provided.'
-    ),
-    ...extendFlagDescription(
-      EASNonInteractiveFlag,
-      'Requires --name, --value, --visibility, and an environment via ENVIRONMENT or --environment.'
-    ),
+    ...markRequired(EASMultiEnvironmentFlag),
+    ...EASNonInteractiveFlag,
   };
 
   static override contextDefinition = {
@@ -126,7 +117,7 @@ Use --force in non-interactive mode when overwriting an existing variable.`;
         { name: '--value', value: validatedFlags.value },
         { name: '--visibility', value: validatedFlags.visibility },
         {
-          name: 'ENVIRONMENT or --environment',
+          name: '--environment',
           value: args.environment ?? validatedFlags.environment,
         },
       ],

--- a/packages/eas-cli/src/commands/env/delete.ts
+++ b/packages/eas-cli/src/commands/env/delete.ts
@@ -158,6 +158,11 @@ export default class EnvDelete extends EasCommand {
       requiredInputs: [{ name: '--variable-name', value: flags['variable-name'] }],
       helpCommand: 'eas env:delete --help',
     });
+    if (environment && flags['variable-environment']) {
+      throw new Error(
+        "You can't use both --variable-environment flag when environment is passed as an argument. Run `eas env:delete --help` for more information."
+      );
+    }
 
     const scope =
       flags.scope === 'account'

--- a/packages/eas-cli/src/commands/env/delete.ts
+++ b/packages/eas-cli/src/commands/env/delete.ts
@@ -50,10 +50,7 @@ In non-interactive mode, provide --variable-name. Use ENVIRONMENT or --variable-
       description: 'Current environment of the variable to delete. Helps disambiguate variables.',
     }),
     ...EASEnvironmentVariableScopeFlag,
-    'non-interactive': extendFlagDescription(
-      EASNonInteractiveFlag['non-interactive'],
-      'Requires --variable-name.'
-    ),
+    ...extendFlagDescription(EASNonInteractiveFlag, 'Requires --variable-name.'),
   };
 
   static override args = {

--- a/packages/eas-cli/src/commands/env/delete.ts
+++ b/packages/eas-cli/src/commands/env/delete.ts
@@ -1,6 +1,5 @@
 import { Args, Flags } from '@oclif/core';
 import assert from 'assert';
-import chalk from 'chalk';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import {
@@ -8,6 +7,8 @@ import {
   EASEnvironmentVariableScopeFlagValue,
   EASNonInteractiveFlag,
   EasEnvironmentFlagParameters,
+  extendFlagDescription,
+  validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import { EnvironmentVariableScope } from '../../graphql/generated';
 import { EnvironmentVariableMutation } from '../../graphql/mutations/EnvironmentVariableMutation';
@@ -31,18 +32,28 @@ interface RawDeleteFlags {
 }
 
 export default class EnvDelete extends EasCommand {
-  static override description = 'delete an environment variable for the current project or account';
+  static override description = `delete an environment variable for the current project or account
+
+In non-interactive mode, provide --variable-name. Use ENVIRONMENT or --variable-environment to disambiguate variables that share a name.`;
+
+  static override examples = [
+    '$ eas env:delete production --variable-name API_TOKEN --non-interactive',
+    '$ eas env:delete --scope account --variable-name SHARED_TOKEN --non-interactive',
+  ];
 
   static override flags = {
     'variable-name': Flags.string({
-      description: 'Name of the variable to delete',
+      description: 'Name of the variable to delete. Required in non-interactive mode.',
     }),
     'variable-environment': Flags.string({
       ...EasEnvironmentFlagParameters,
-      description: 'Current environment of the variable to delete',
+      description: 'Current environment of the variable to delete. Helps disambiguate variables.',
     }),
     ...EASEnvironmentVariableScopeFlag,
-    ...EASNonInteractiveFlag,
+    'non-interactive': extendFlagDescription(
+      EASNonInteractiveFlag['non-interactive'],
+      'Requires --variable-name.'
+    ),
   };
 
   static override args = {
@@ -148,15 +159,11 @@ export default class EnvDelete extends EasCommand {
     flags: RawDeleteFlags,
     { environment }: { environment?: string }
   ): DeleteFlags {
-    if (flags['non-interactive']) {
-      if (!flags['variable-name']) {
-        throw new Error(
-          `Environment variable needs 'name' to be specified when running in non-interactive mode. Run the command with ${chalk.bold(
-            '--variable-name VARIABLE_NAME'
-          )} flag to fix the issue`
-        );
-      }
-    }
+    validateNonInteractiveRequiredInputs({
+      nonInteractive: flags['non-interactive'],
+      requiredInputs: [{ name: '--variable-name', value: flags['variable-name'] }],
+      helpCommand: 'eas env:delete --help',
+    });
 
     const scope =
       flags.scope === 'account'

--- a/packages/eas-cli/src/commands/env/delete.ts
+++ b/packages/eas-cli/src/commands/env/delete.ts
@@ -7,7 +7,6 @@ import {
   EASEnvironmentVariableScopeFlagValue,
   EASNonInteractiveFlag,
   EasEnvironmentFlagParameters,
-  extendFlagDescription,
   validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import { EnvironmentVariableScope } from '../../graphql/generated';
@@ -32,25 +31,23 @@ interface RawDeleteFlags {
 }
 
 export default class EnvDelete extends EasCommand {
-  static override description = `delete an environment variable for the current project or account
-
-In non-interactive mode, provide --variable-name. Use ENVIRONMENT or --variable-environment to disambiguate variables that share a name.`;
+  static override description = 'delete an environment variable for the current project or account';
 
   static override examples = [
-    '$ eas env:delete production --variable-name API_TOKEN --non-interactive',
-    '$ eas env:delete --scope account --variable-name SHARED_TOKEN --non-interactive',
+    '$ eas env:delete --variable-environment production --variable-name API_TOKEN',
+    '$ eas env:delete --scope account --variable-name SHARED_TOKEN',
   ];
 
   static override flags = {
     'variable-name': Flags.string({
-      description: 'Name of the variable to delete. Required in non-interactive mode.',
+      description: '(required) Name of the variable to delete',
     }),
     'variable-environment': Flags.string({
       ...EasEnvironmentFlagParameters,
-      description: 'Current environment of the variable to delete. Helps disambiguate variables.',
+      description: 'Current environment of the variable to delete',
     }),
     ...EASEnvironmentVariableScopeFlag,
-    ...extendFlagDescription(EASNonInteractiveFlag, 'Requires --variable-name.'),
+    ...EASNonInteractiveFlag,
   };
 
   static override args = {

--- a/packages/eas-cli/src/commands/env/delete.ts
+++ b/packages/eas-cli/src/commands/env/delete.ts
@@ -40,7 +40,7 @@ export default class EnvDelete extends EasCommand {
 
   static override flags = {
     'variable-name': Flags.string({
-      description: '(required) Name of the variable to delete',
+      description: '(required in non-interactive mode) Name of the variable to delete',
     }),
     'variable-environment': Flags.string({
       ...EasEnvironmentFlagParameters,
@@ -160,7 +160,7 @@ export default class EnvDelete extends EasCommand {
     });
     if (environment && flags['variable-environment']) {
       throw new Error(
-        "You can't use both --variable-environment flag when environment is passed as an argument. Run `eas env:delete --help` for more information."
+        "You can't use the --variable-environment flag when the environment is passed as a positional argument. Run `eas env:delete --help` for more information."
       );
     }
 

--- a/packages/eas-cli/src/commands/env/exec.ts
+++ b/packages/eas-cli/src/commands/env/exec.ts
@@ -4,7 +4,11 @@ import chalk from 'chalk';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
-import { EASNonInteractiveFlag } from '../../commandUtils/flags';
+import {
+  EASNonInteractiveFlag,
+  extendFlagDescription,
+  validateNonInteractiveRequiredInputs,
+} from '../../commandUtils/flags';
 import { EnvironmentVariablesQuery } from '../../graphql/queries/EnvironmentVariablesQuery';
 import Log from '../../log';
 import { promptVariableEnvironmentAsync } from '../../utils/prompts';
@@ -26,8 +30,14 @@ interface RawFlags {
 }
 
 export default class EnvExec extends EasCommand {
-  static override description =
-    'execute a command with environment variables from the selected environment';
+  static override description = `execute a command with environment variables from the selected environment
+
+In non-interactive mode, provide ENVIRONMENT and bash_command.`;
+
+  static override examples = [
+    "$ eas env:exec development 'echo $EXPO_PUBLIC_API_URL' --non-interactive",
+    "$ eas env:exec production 'npm run build' --non-interactive",
+  ];
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectId,
@@ -35,7 +45,10 @@ export default class EnvExec extends EasCommand {
   };
 
   static override flags = {
-    ...EASNonInteractiveFlag,
+    'non-interactive': extendFlagDescription(
+      EASNonInteractiveFlag['non-interactive'],
+      'Requires ENVIRONMENT and bash_command.'
+    ),
   };
 
   static override args = {
@@ -96,11 +109,14 @@ export default class EnvExec extends EasCommand {
     rawFlags: RawFlags,
     { bash_command, environment }: Record<string, string>
   ): ParsedFlags {
-    if (rawFlags['non-interactive'] && (!bash_command || !environment)) {
-      throw new Error(
-        "You must specify both environment and bash command when running in non-interactive mode. Run command as `eas env:exec ENVIRONMENT 'bash command'`."
-      );
-    }
+    validateNonInteractiveRequiredInputs({
+      nonInteractive: rawFlags['non-interactive'],
+      requiredInputs: [
+        { name: 'ENVIRONMENT', value: environment },
+        { name: 'bash_command', value: bash_command },
+      ],
+      helpCommand: 'eas env:exec --help',
+    });
 
     const firstChar = bash_command[0];
     const lastChar = bash_command[bash_command.length - 1];

--- a/packages/eas-cli/src/commands/env/exec.ts
+++ b/packages/eas-cli/src/commands/env/exec.ts
@@ -45,10 +45,7 @@ In non-interactive mode, provide ENVIRONMENT and bash_command.`;
   };
 
   static override flags = {
-    'non-interactive': extendFlagDescription(
-      EASNonInteractiveFlag['non-interactive'],
-      'Requires ENVIRONMENT and bash_command.'
-    ),
+    ...extendFlagDescription(EASNonInteractiveFlag, 'Requires ENVIRONMENT and bash_command.'),
   };
 
   static override args = {

--- a/packages/eas-cli/src/commands/env/exec.ts
+++ b/packages/eas-cli/src/commands/env/exec.ts
@@ -4,11 +4,7 @@ import chalk from 'chalk';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
-import {
-  EASNonInteractiveFlag,
-  extendFlagDescription,
-  validateNonInteractiveRequiredInputs,
-} from '../../commandUtils/flags';
+import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import { EnvironmentVariablesQuery } from '../../graphql/queries/EnvironmentVariablesQuery';
 import Log from '../../log';
 import { promptVariableEnvironmentAsync } from '../../utils/prompts';
@@ -30,14 +26,10 @@ interface RawFlags {
 }
 
 export default class EnvExec extends EasCommand {
-  static override description = `execute a command with environment variables from the selected environment
+  static override description =
+    'execute a command with environment variables from the selected environment';
 
-In non-interactive mode, provide ENVIRONMENT and bash_command.`;
-
-  static override examples = [
-    "$ eas env:exec development 'echo $EXPO_PUBLIC_API_URL' --non-interactive",
-    "$ eas env:exec production 'npm run build' --non-interactive",
-  ];
+  static override examples = ["$ eas env:exec production 'bun run build'"];
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectId,
@@ -45,7 +37,7 @@ In non-interactive mode, provide ENVIRONMENT and bash_command.`;
   };
 
   static override flags = {
-    ...extendFlagDescription(EASNonInteractiveFlag, 'Requires ENVIRONMENT and bash_command.'),
+    ...EASNonInteractiveFlag,
   };
 
   static override args = {
@@ -106,14 +98,11 @@ In non-interactive mode, provide ENVIRONMENT and bash_command.`;
     rawFlags: RawFlags,
     { bash_command, environment }: Record<string, string>
   ): ParsedFlags {
-    validateNonInteractiveRequiredInputs({
-      nonInteractive: rawFlags['non-interactive'],
-      requiredInputs: [
-        { name: 'ENVIRONMENT', value: environment },
-        { name: 'bash_command', value: bash_command },
-      ],
-      helpCommand: 'eas env:exec --help',
-    });
+    if (rawFlags['non-interactive'] && (!bash_command || !environment)) {
+      throw new Error(
+        "You must specify both environment and bash command when running in non-interactive mode. Run command as `eas env:exec ENVIRONMENT 'bash command'`."
+      );
+    }
 
     const firstChar = bash_command[0];
     const lastChar = bash_command[bash_command.length - 1];

--- a/packages/eas-cli/src/commands/env/get.ts
+++ b/packages/eas-cli/src/commands/env/get.ts
@@ -9,7 +9,6 @@ import {
   EASNonInteractiveFlag,
   EASVariableFormatFlag,
   EasEnvironmentFlagParameters,
-  extendFlagDescription,
   validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
@@ -39,13 +38,11 @@ interface GetFlags {
 }
 
 export default class EnvGet extends EasCommand {
-  static override description = `view an environment variable for the current project or account
-
-In non-interactive mode, provide --variable-name and an environment with ENVIRONMENT or --variable-environment.`;
+  static override description = 'view an environment variable for the current project or account';
 
   static override examples = [
-    '$ eas env:get production --variable-name API_URL --non-interactive',
-    '$ eas env:get --variable-environment production --variable-name API_TOKEN --format long --non-interactive',
+    '$ eas env:get --variable-environment production --variable-name API_URL',
+    '$ eas env:get --variable-environment production --variable-name API_TOKEN --format long',
   ];
 
   static override contextDefinition = {
@@ -63,19 +60,15 @@ In non-interactive mode, provide --variable-name and an environment with ENVIRON
 
   static override flags = {
     'variable-name': Flags.string({
-      description: 'Name of the variable. Required in non-interactive mode.',
+      description: '(required) Name of the variable',
     }),
     'variable-environment': Flags.string({
       ...EasEnvironmentFlagParameters,
-      description:
-        'Current environment of the variable. Required in non-interactive mode unless ENVIRONMENT is provided.',
+      description: '(required) Current environment of the variable',
     }),
     ...EASVariableFormatFlag,
     ...EASEnvironmentVariableScopeFlag,
-    ...extendFlagDescription(
-      EASNonInteractiveFlag,
-      'Requires --variable-name and an environment via ENVIRONMENT or --variable-environment.'
-    ),
+    ...EASNonInteractiveFlag,
   };
 
   async runAsync(): Promise<void> {
@@ -152,7 +145,7 @@ In non-interactive mode, provide --variable-name and an environment with ENVIRON
       requiredInputs: [
         { name: '--variable-name', value: flags['variable-name'] },
         {
-          name: 'ENVIRONMENT or --variable-environment',
+          name: '--variable-environment',
           value: environment ?? flags['variable-environment'],
         },
       ],

--- a/packages/eas-cli/src/commands/env/get.ts
+++ b/packages/eas-cli/src/commands/env/get.ts
@@ -72,8 +72,8 @@ In non-interactive mode, provide --variable-name and an environment with ENVIRON
     }),
     ...EASVariableFormatFlag,
     ...EASEnvironmentVariableScopeFlag,
-    'non-interactive': extendFlagDescription(
-      EASNonInteractiveFlag['non-interactive'],
+    ...extendFlagDescription(
+      EASNonInteractiveFlag,
       'Requires --variable-name and an environment via ENVIRONMENT or --variable-environment.'
     ),
   };

--- a/packages/eas-cli/src/commands/env/get.ts
+++ b/packages/eas-cli/src/commands/env/get.ts
@@ -9,6 +9,8 @@ import {
   EASNonInteractiveFlag,
   EASVariableFormatFlag,
   EasEnvironmentFlagParameters,
+  extendFlagDescription,
+  validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
   EnvironmentVariableFragment,
@@ -37,7 +39,14 @@ interface GetFlags {
 }
 
 export default class EnvGet extends EasCommand {
-  static override description = 'view an environment variable for the current project or account';
+  static override description = `view an environment variable for the current project or account
+
+In non-interactive mode, provide --variable-name and an environment with ENVIRONMENT or --variable-environment.`;
+
+  static override examples = [
+    '$ eas env:get production --variable-name API_URL --non-interactive',
+    '$ eas env:get --variable-environment production --variable-name API_TOKEN --format long --non-interactive',
+  ];
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectId,
@@ -54,15 +63,19 @@ export default class EnvGet extends EasCommand {
 
   static override flags = {
     'variable-name': Flags.string({
-      description: 'Name of the variable',
+      description: 'Name of the variable. Required in non-interactive mode.',
     }),
     'variable-environment': Flags.string({
       ...EasEnvironmentFlagParameters,
-      description: 'Current environment of the variable',
+      description:
+        'Current environment of the variable. Required in non-interactive mode unless ENVIRONMENT is provided.',
     }),
     ...EASVariableFormatFlag,
     ...EASEnvironmentVariableScopeFlag,
-    ...EASNonInteractiveFlag,
+    'non-interactive': extendFlagDescription(
+      EASNonInteractiveFlag['non-interactive'],
+      'Requires --variable-name and an environment via ENVIRONMENT or --variable-environment.'
+    ),
   };
 
   async runAsync(): Promise<void> {
@@ -134,17 +147,17 @@ export default class EnvGet extends EasCommand {
   }
 
   private sanitizeInputs(flags: RawGetFlags, { environment }: { environment?: string }): GetFlags {
-    if (flags['non-interactive']) {
-      if (!flags['variable-name']) {
-        throw new Error('Variable name is required. Run the command with --variable-name flag.');
-      }
-      if (!flags.scope) {
-        throw new Error('Scope is required. Run the command with --scope flag.');
-      }
-      if (!(flags['variable-environment'] ?? environment)) {
-        throw new Error('Environment is required.');
-      }
-    }
+    validateNonInteractiveRequiredInputs({
+      nonInteractive: flags['non-interactive'],
+      requiredInputs: [
+        { name: '--variable-name', value: flags['variable-name'] },
+        {
+          name: 'ENVIRONMENT or --variable-environment',
+          value: environment ?? flags['variable-environment'],
+        },
+      ],
+      helpCommand: 'eas env:get --help',
+    });
     if (environment && flags['variable-environment']) {
       throw new Error(
         "You can't use both --variable-environment flag when environment is passed as an argument. Run `eas env:get --help` for more information."

--- a/packages/eas-cli/src/commands/env/get.ts
+++ b/packages/eas-cli/src/commands/env/get.ts
@@ -10,6 +10,7 @@ import {
   EASVariableFormatFlag,
   EasEnvironmentFlagParameters,
   extendFlagDescription,
+  isFlagProvided,
   validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
@@ -41,11 +42,11 @@ interface GetFlags {
 export default class EnvGet extends EasCommand {
   static override description = `view an environment variable for the current project or account
 
-In non-interactive mode, provide --variable-name and an environment with ENVIRONMENT or --variable-environment.`;
+In non-interactive mode, provide --scope, --variable-name, and an environment with ENVIRONMENT or --variable-environment.`;
 
   static override examples = [
-    '$ eas env:get production --variable-name API_URL --non-interactive',
-    '$ eas env:get --variable-environment production --variable-name API_TOKEN --format long --non-interactive',
+    '$ eas env:get production --scope project --variable-name API_URL --non-interactive',
+    '$ eas env:get --variable-environment production --scope account --variable-name API_TOKEN --format long --non-interactive',
   ];
 
   static override contextDefinition = {
@@ -71,10 +72,13 @@ In non-interactive mode, provide --variable-name and an environment with ENVIRON
         'Current environment of the variable. Required in non-interactive mode unless ENVIRONMENT is provided.',
     }),
     ...EASVariableFormatFlag,
-    ...EASEnvironmentVariableScopeFlag,
+    scope: extendFlagDescription(
+      EASEnvironmentVariableScopeFlag.scope,
+      'Required in non-interactive mode.'
+    ),
     'non-interactive': extendFlagDescription(
       EASNonInteractiveFlag['non-interactive'],
-      'Requires --variable-name and an environment via ENVIRONMENT or --variable-environment.'
+      'Requires --scope, --variable-name, and an environment via ENVIRONMENT or --variable-environment.'
     ),
   };
 
@@ -87,7 +91,9 @@ In non-interactive mode, provide --variable-name and an environment with ENVIRON
       'non-interactive': nonInteractive,
       format,
       scope,
-    } = this.sanitizeInputs(flags, args);
+    } = this.sanitizeInputs(flags, args, {
+      scopeProvided: isFlagProvided(this.argv, '--scope'),
+    });
 
     const {
       projectId,
@@ -146,10 +152,15 @@ In non-interactive mode, provide --variable-name and an environment with ENVIRON
     }
   }
 
-  private sanitizeInputs(flags: RawGetFlags, { environment }: { environment?: string }): GetFlags {
+  private sanitizeInputs(
+    flags: RawGetFlags,
+    { environment }: { environment?: string },
+    { scopeProvided }: { scopeProvided: boolean }
+  ): GetFlags {
     validateNonInteractiveRequiredInputs({
       nonInteractive: flags['non-interactive'],
       requiredInputs: [
+        { name: '--scope', value: scopeProvided ? flags.scope : undefined },
         { name: '--variable-name', value: flags['variable-name'] },
         {
           name: 'ENVIRONMENT or --variable-environment',

--- a/packages/eas-cli/src/commands/env/get.ts
+++ b/packages/eas-cli/src/commands/env/get.ts
@@ -10,7 +10,6 @@ import {
   EASVariableFormatFlag,
   EasEnvironmentFlagParameters,
   extendFlagDescription,
-  isFlagProvided,
   validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
@@ -42,11 +41,11 @@ interface GetFlags {
 export default class EnvGet extends EasCommand {
   static override description = `view an environment variable for the current project or account
 
-In non-interactive mode, provide --scope, --variable-name, and an environment with ENVIRONMENT or --variable-environment.`;
+In non-interactive mode, provide --variable-name and an environment with ENVIRONMENT or --variable-environment.`;
 
   static override examples = [
-    '$ eas env:get production --scope project --variable-name API_URL --non-interactive',
-    '$ eas env:get --variable-environment production --scope account --variable-name API_TOKEN --format long --non-interactive',
+    '$ eas env:get production --variable-name API_URL --non-interactive',
+    '$ eas env:get --variable-environment production --variable-name API_TOKEN --format long --non-interactive',
   ];
 
   static override contextDefinition = {
@@ -72,13 +71,10 @@ In non-interactive mode, provide --scope, --variable-name, and an environment wi
         'Current environment of the variable. Required in non-interactive mode unless ENVIRONMENT is provided.',
     }),
     ...EASVariableFormatFlag,
-    scope: extendFlagDescription(
-      EASEnvironmentVariableScopeFlag.scope,
-      'Required in non-interactive mode.'
-    ),
+    ...EASEnvironmentVariableScopeFlag,
     'non-interactive': extendFlagDescription(
       EASNonInteractiveFlag['non-interactive'],
-      'Requires --scope, --variable-name, and an environment via ENVIRONMENT or --variable-environment.'
+      'Requires --variable-name and an environment via ENVIRONMENT or --variable-environment.'
     ),
   };
 
@@ -91,9 +87,7 @@ In non-interactive mode, provide --scope, --variable-name, and an environment wi
       'non-interactive': nonInteractive,
       format,
       scope,
-    } = this.sanitizeInputs(flags, args, {
-      scopeProvided: isFlagProvided(this.argv, '--scope'),
-    });
+    } = this.sanitizeInputs(flags, args);
 
     const {
       projectId,
@@ -152,15 +146,10 @@ In non-interactive mode, provide --scope, --variable-name, and an environment wi
     }
   }
 
-  private sanitizeInputs(
-    flags: RawGetFlags,
-    { environment }: { environment?: string },
-    { scopeProvided }: { scopeProvided: boolean }
-  ): GetFlags {
+  private sanitizeInputs(flags: RawGetFlags, { environment }: { environment?: string }): GetFlags {
     validateNonInteractiveRequiredInputs({
       nonInteractive: flags['non-interactive'],
       requiredInputs: [
-        { name: '--scope', value: scopeProvided ? flags.scope : undefined },
         { name: '--variable-name', value: flags['variable-name'] },
         {
           name: 'ENVIRONMENT or --variable-environment',

--- a/packages/eas-cli/src/commands/env/get.ts
+++ b/packages/eas-cli/src/commands/env/get.ts
@@ -64,7 +64,7 @@ export default class EnvGet extends EasCommand {
     }),
     'variable-environment': Flags.string({
       ...EasEnvironmentFlagParameters,
-      description: '(required) Current environment of the variable',
+      description: '(required in non-interactive mode) Current environment of the variable',
     }),
     ...EASVariableFormatFlag,
     ...EASEnvironmentVariableScopeFlag,
@@ -153,7 +153,7 @@ export default class EnvGet extends EasCommand {
     });
     if (environment && flags['variable-environment']) {
       throw new Error(
-        "You can't use both --variable-environment flag when environment is passed as an argument. Run `eas env:get --help` for more information."
+        "You can't use the --variable-environment flag when the environment is passed as a positional argument. Run `eas env:get --help` for more information."
       );
     }
 

--- a/packages/eas-cli/src/commands/env/list.ts
+++ b/packages/eas-cli/src/commands/env/list.ts
@@ -111,14 +111,14 @@ In non-interactive mode, provide ENVIRONMENT or --environment.`;
       description: 'Display files content in the output',
       default: false,
     }),
-    environment: extendFlagDescription(
-      EASMultiEnvironmentFlag.environment,
+    ...extendFlagDescription(
+      EASMultiEnvironmentFlag,
       'Required in non-interactive mode unless ENVIRONMENT is provided.'
     ),
     ...EASVariableFormatFlag,
     ...EASEnvironmentVariableScopeFlag,
-    'non-interactive': extendFlagDescription(
-      EASNonInteractiveFlag['non-interactive'],
+    ...extendFlagDescription(
+      EASNonInteractiveFlag,
       'Requires an environment via ENVIRONMENT or --environment.'
     ),
   };

--- a/packages/eas-cli/src/commands/env/list.ts
+++ b/packages/eas-cli/src/commands/env/list.ts
@@ -7,7 +7,10 @@ import {
   EASEnvironmentVariableScopeFlag,
   EASEnvironmentVariableScopeFlagValue,
   EASMultiEnvironmentFlag,
+  EASNonInteractiveFlag,
   EASVariableFormatFlag,
+  extendFlagDescription,
+  validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import { EnvironmentVariableScope } from '../../graphql/generated';
 import {
@@ -72,7 +75,7 @@ interface RawListFlags {
   environment: string[] | undefined;
   'include-sensitive': boolean;
   'include-file-content': boolean;
-  'non-interactive'?: boolean;
+  'non-interactive': boolean;
 }
 
 interface ListFlags {
@@ -85,7 +88,14 @@ interface ListFlags {
 }
 
 export default class EnvList extends EasCommand {
-  static override description = 'list environment variables for the current project or account';
+  static override description = `list environment variables for the current project or account
+
+In non-interactive mode, provide ENVIRONMENT or --environment.`;
+
+  static override examples = [
+    '$ eas env:list production --non-interactive',
+    '$ eas env:list --environment production --environment preview --scope account --format long --non-interactive',
+  ];
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectId,
@@ -101,9 +111,16 @@ export default class EnvList extends EasCommand {
       description: 'Display files content in the output',
       default: false,
     }),
-    ...EASMultiEnvironmentFlag,
+    environment: extendFlagDescription(
+      EASMultiEnvironmentFlag.environment,
+      'Required in non-interactive mode unless ENVIRONMENT is provided.'
+    ),
     ...EASVariableFormatFlag,
     ...EASEnvironmentVariableScopeFlag,
+    'non-interactive': extendFlagDescription(
+      EASNonInteractiveFlag['non-interactive'],
+      'Requires an environment via ENVIRONMENT or --environment.'
+    ),
   };
 
   static override args = {
@@ -125,6 +142,11 @@ export default class EnvList extends EasCommand {
       'include-file-content': includeFileContent,
       'non-interactive': nonInteractive,
     } = this.sanitizeInputs(flags, args);
+    validateNonInteractiveRequiredInputs({
+      nonInteractive,
+      requiredInputs: [{ name: 'ENVIRONMENT or --environment', value: environments }],
+      helpCommand: 'eas env:list --help',
+    });
 
     const {
       projectId,
@@ -186,7 +208,6 @@ export default class EnvList extends EasCommand {
 
     return {
       ...flags,
-      'non-interactive': flags['non-interactive'] ?? false,
       environment: environments,
       scope:
         flags.scope === 'account'

--- a/packages/eas-cli/src/commands/env/list.ts
+++ b/packages/eas-cli/src/commands/env/list.ts
@@ -9,8 +9,7 @@ import {
   EASMultiEnvironmentFlag,
   EASNonInteractiveFlag,
   EASVariableFormatFlag,
-  extendFlagDescription,
-  validateNonInteractiveRequiredInputs,
+  markRequired,
 } from '../../commandUtils/flags';
 import { EnvironmentVariableScope } from '../../graphql/generated';
 import {
@@ -88,14 +87,9 @@ interface ListFlags {
 }
 
 export default class EnvList extends EasCommand {
-  static override description = `list environment variables for the current project or account
+  static override description = 'list environment variables for the current project or account';
 
-In non-interactive mode, provide ENVIRONMENT or --environment.`;
-
-  static override examples = [
-    '$ eas env:list production --non-interactive',
-    '$ eas env:list --environment production --environment preview --scope account --format long --non-interactive',
-  ];
+  static override examples = ['$ eas env:list --environment production'];
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectId,
@@ -111,16 +105,10 @@ In non-interactive mode, provide ENVIRONMENT or --environment.`;
       description: 'Display files content in the output',
       default: false,
     }),
-    ...extendFlagDescription(
-      EASMultiEnvironmentFlag,
-      'Required in non-interactive mode unless ENVIRONMENT is provided.'
-    ),
+    ...markRequired(EASMultiEnvironmentFlag),
     ...EASVariableFormatFlag,
     ...EASEnvironmentVariableScopeFlag,
-    ...extendFlagDescription(
-      EASNonInteractiveFlag,
-      'Requires an environment via ENVIRONMENT or --environment.'
-    ),
+    ...EASNonInteractiveFlag,
   };
 
   static override args = {
@@ -142,11 +130,6 @@ In non-interactive mode, provide ENVIRONMENT or --environment.`;
       'include-file-content': includeFileContent,
       'non-interactive': nonInteractive,
     } = this.sanitizeInputs(flags, args);
-    validateNonInteractiveRequiredInputs({
-      nonInteractive,
-      requiredInputs: [{ name: 'ENVIRONMENT or --environment', value: environments }],
-      helpCommand: 'eas env:list --help',
-    });
 
     const {
       projectId,

--- a/packages/eas-cli/src/commands/env/list.ts
+++ b/packages/eas-cli/src/commands/env/list.ts
@@ -9,7 +9,7 @@ import {
   EASMultiEnvironmentFlag,
   EASNonInteractiveFlag,
   EASVariableFormatFlag,
-  markRequired,
+  markRequiredInNonInteractiveMode,
 } from '../../commandUtils/flags';
 import { EnvironmentVariableScope } from '../../graphql/generated';
 import {
@@ -105,7 +105,7 @@ export default class EnvList extends EasCommand {
       description: 'Display files content in the output',
       default: false,
     }),
-    ...markRequired(EASMultiEnvironmentFlag),
+    ...markRequiredInNonInteractiveMode(EASMultiEnvironmentFlag),
     ...EASVariableFormatFlag,
     ...EASEnvironmentVariableScopeFlag,
     ...EASNonInteractiveFlag,

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -4,12 +4,7 @@ import * as fs from 'fs-extra';
 import path from 'path';
 
 import EasCommand from '../../commandUtils/EasCommand';
-import {
-  EASEnvironmentFlag,
-  EASNonInteractiveFlag,
-  extendFlagDescription,
-  validateNonInteractiveRequiredInputs,
-} from '../../commandUtils/flags';
+import { EASEnvironmentFlag, EASNonInteractiveFlag, markRequired } from '../../commandUtils/flags';
 import { EnvironmentSecretType, EnvironmentVariableVisibility } from '../../graphql/generated';
 import {
   EnvironmentVariableWithFileContent,
@@ -20,13 +15,12 @@ import { confirmAsync } from '../../prompts';
 import { promptVariableEnvironmentAsync } from '../../utils/prompts';
 
 export default class EnvPull extends EasCommand {
-  static override description = `pull environment variables for the selected environment to .env file
-
-In non-interactive mode, provide ENVIRONMENT or --environment.`;
+  static override description =
+    'pull environment variables for the selected environment to .env file';
 
   static override examples = [
-    '$ eas env:pull development --non-interactive',
-    '$ eas env:pull --environment production --path .env.production --non-interactive',
+    '$ eas env:pull --environment development',
+    '$ eas env:pull --environment production --path .env.production',
   ];
 
   static override contextDefinition = {
@@ -44,14 +38,8 @@ In non-interactive mode, provide ENVIRONMENT or --environment.`;
   };
 
   static override flags = {
-    ...extendFlagDescription(
-      EASNonInteractiveFlag,
-      'Requires an environment via ENVIRONMENT or --environment.'
-    ),
-    ...extendFlagDescription(
-      EASEnvironmentFlag,
-      'Required in non-interactive mode unless ENVIRONMENT is provided.'
-    ),
+    ...EASNonInteractiveFlag,
+    ...markRequired(EASEnvironmentFlag),
     path: Flags.string({
       description: 'Path to the result `.env` file',
       default: '.env.local',
@@ -65,11 +53,6 @@ In non-interactive mode, provide ENVIRONMENT or --environment.`;
     } = await this.parse(EnvPull);
 
     let environment = flagEnvironment?.toLowerCase() ?? argEnvironment?.toLowerCase();
-    validateNonInteractiveRequiredInputs({
-      nonInteractive,
-      requiredInputs: [{ name: 'ENVIRONMENT or --environment', value: environment }],
-      helpCommand: 'eas env:pull --help',
-    });
 
     const {
       projectId,

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -44,12 +44,12 @@ In non-interactive mode, provide ENVIRONMENT or --environment.`;
   };
 
   static override flags = {
-    'non-interactive': extendFlagDescription(
-      EASNonInteractiveFlag['non-interactive'],
+    ...extendFlagDescription(
+      EASNonInteractiveFlag,
       'Requires an environment via ENVIRONMENT or --environment.'
     ),
-    environment: extendFlagDescription(
-      EASEnvironmentFlag.environment,
+    ...extendFlagDescription(
+      EASEnvironmentFlag,
       'Required in non-interactive mode unless ENVIRONMENT is provided.'
     ),
     path: Flags.string({

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -4,7 +4,12 @@ import * as fs from 'fs-extra';
 import path from 'path';
 
 import EasCommand from '../../commandUtils/EasCommand';
-import { EASEnvironmentFlag, EASNonInteractiveFlag } from '../../commandUtils/flags';
+import {
+  EASEnvironmentFlag,
+  EASNonInteractiveFlag,
+  extendFlagDescription,
+  validateNonInteractiveRequiredInputs,
+} from '../../commandUtils/flags';
 import { EnvironmentSecretType, EnvironmentVariableVisibility } from '../../graphql/generated';
 import {
   EnvironmentVariableWithFileContent,
@@ -15,8 +20,14 @@ import { confirmAsync } from '../../prompts';
 import { promptVariableEnvironmentAsync } from '../../utils/prompts';
 
 export default class EnvPull extends EasCommand {
-  static override description =
-    'pull environment variables for the selected environment to .env file';
+  static override description = `pull environment variables for the selected environment to .env file
+
+In non-interactive mode, provide ENVIRONMENT or --environment.`;
+
+  static override examples = [
+    '$ eas env:pull development --non-interactive',
+    '$ eas env:pull --environment production --path .env.production --non-interactive',
+  ];
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectId,
@@ -33,8 +44,14 @@ export default class EnvPull extends EasCommand {
   };
 
   static override flags = {
-    ...EASNonInteractiveFlag,
-    ...EASEnvironmentFlag,
+    'non-interactive': extendFlagDescription(
+      EASNonInteractiveFlag['non-interactive'],
+      'Requires an environment via ENVIRONMENT or --environment.'
+    ),
+    environment: extendFlagDescription(
+      EASEnvironmentFlag.environment,
+      'Required in non-interactive mode unless ENVIRONMENT is provided.'
+    ),
     path: Flags.string({
       description: 'Path to the result `.env` file',
       default: '.env.local',
@@ -48,6 +65,11 @@ export default class EnvPull extends EasCommand {
     } = await this.parse(EnvPull);
 
     let environment = flagEnvironment?.toLowerCase() ?? argEnvironment?.toLowerCase();
+    validateNonInteractiveRequiredInputs({
+      nonInteractive,
+      requiredInputs: [{ name: 'ENVIRONMENT or --environment', value: environment }],
+      helpCommand: 'eas env:pull --help',
+    });
 
     const {
       projectId,

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -4,7 +4,11 @@ import * as fs from 'fs-extra';
 import path from 'path';
 
 import EasCommand from '../../commandUtils/EasCommand';
-import { EASEnvironmentFlag, EASNonInteractiveFlag, markRequired } from '../../commandUtils/flags';
+import {
+  EASEnvironmentFlag,
+  EASNonInteractiveFlag,
+  markRequiredInNonInteractiveMode,
+} from '../../commandUtils/flags';
 import { EnvironmentSecretType, EnvironmentVariableVisibility } from '../../graphql/generated';
 import {
   EnvironmentVariableWithFileContent,
@@ -39,7 +43,7 @@ export default class EnvPull extends EasCommand {
 
   static override flags = {
     ...EASNonInteractiveFlag,
-    ...markRequired(EASEnvironmentFlag),
+    ...markRequiredInNonInteractiveMode(EASEnvironmentFlag),
     path: Flags.string({
       description: 'Path to the result `.env` file',
       default: '.env.local',

--- a/packages/eas-cli/src/commands/env/push.ts
+++ b/packages/eas-cli/src/commands/env/push.ts
@@ -4,7 +4,12 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import EasCommand from '../../commandUtils/EasCommand';
-import { EASMultiEnvironmentFlag } from '../../commandUtils/flags';
+import {
+  EASMultiEnvironmentFlag,
+  EASNonInteractiveFlag,
+  extendFlagDescription,
+  validateNonInteractiveRequiredInputs,
+} from '../../commandUtils/flags';
 import {
   CreateEnvironmentVariableInput,
   EnvironmentVariableFragment,
@@ -18,8 +23,14 @@ import { confirmAsync, promptAsync } from '../../prompts';
 import { promptVariableEnvironmentAsync } from '../../utils/prompts';
 
 export default class EnvPush extends EasCommand {
-  static override description =
-    'push environment variables from .env file to the selected environment';
+  static override description = `push environment variables from .env file to the selected environment
+
+In non-interactive mode, provide ENVIRONMENT or --environment. Use --force when overwriting existing variables.`;
+
+  static override examples = [
+    '$ eas env:push development --path .env.local --non-interactive',
+    '$ eas env:push --environment production --path .env.production --force --non-interactive',
+  ];
 
   static override contextDefinition = {
     ...this.ContextOptions.ProjectId,
@@ -27,15 +38,23 @@ export default class EnvPush extends EasCommand {
   };
 
   static override flags = {
-    ...EASMultiEnvironmentFlag,
+    environment: extendFlagDescription(
+      EASMultiEnvironmentFlag.environment,
+      'Required in non-interactive mode unless ENVIRONMENT is provided.'
+    ),
     path: Flags.string({
       description: 'Path to the input `.env` file',
       default: '.env.local',
     }),
     force: Flags.boolean({
-      description: 'Skip confirmation and automatically override existing variables',
+      description:
+        'Skip confirmation and automatically override existing variables. Required in non-interactive mode when overwriting.',
       default: false,
     }),
+    'non-interactive': extendFlagDescription(
+      EASNonInteractiveFlag['non-interactive'],
+      'Requires an environment via ENVIRONMENT or --environment.'
+    ),
   };
 
   static override args = {
@@ -49,18 +68,28 @@ export default class EnvPush extends EasCommand {
   async runAsync(): Promise<void> {
     const { args, flags } = await this.parse(EnvPush);
 
-    let { environment: environments, path: envPath, force } = this.parseFlagsAndArgs(flags, args);
+    let {
+      environment: environments,
+      path: envPath,
+      force,
+      'non-interactive': nonInteractive,
+    } = this.parseFlagsAndArgs(flags, args);
+    validateNonInteractiveRequiredInputs({
+      nonInteractive,
+      requiredInputs: [{ name: 'ENVIRONMENT or --environment', value: environments }],
+      helpCommand: 'eas env:push --help',
+    });
 
     const {
       projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvPush, {
-      nonInteractive: false,
+      nonInteractive,
     });
 
     if (!environments) {
       environments = await promptVariableEnvironmentAsync({
-        nonInteractive: false,
+        nonInteractive,
         multiple: true,
         canEnterCustomEnvironment: true,
         graphqlClient,
@@ -117,6 +146,11 @@ export default class EnvPush extends EasCommand {
       if (existingDifferentVariables.length > 0) {
         Log.warn(`Some variables already exist in the ${displayedEnvironment} environment.`);
         const variableNames = existingDifferentVariables.map(variable => variable.name);
+        validateNonInteractiveRequiredInputs({
+          nonInteractive,
+          requiredInputs: [{ name: '--force', value: force ? true : undefined }],
+          helpCommand: 'eas env:push --help',
+        });
 
         let variablesToOverwrite: string[] = [];
 
@@ -176,6 +210,11 @@ export default class EnvPush extends EasCommand {
       );
 
       if (existingSensitiveVariables.length > 0 && !force) {
+        validateNonInteractiveRequiredInputs({
+          nonInteractive,
+          requiredInputs: [{ name: '--force', value: force ? true : undefined }],
+          helpCommand: 'eas env:push --help',
+        });
         const existingSensitiveVariablesNames = existingSensitiveVariables.map(
           variable => `- ${variable.name}`
         );
@@ -212,9 +251,10 @@ export default class EnvPush extends EasCommand {
       path: string;
       environment: string[] | undefined;
       force: boolean;
+      'non-interactive': boolean;
     },
     { environment }: { environment?: string }
-  ): { environment?: string[]; path: string; force: boolean } {
+  ): { environment?: string[]; path: string; force: boolean; 'non-interactive': boolean } {
     const environments = flags.environment ?? (environment ? [environment] : undefined);
 
     return {

--- a/packages/eas-cli/src/commands/env/push.ts
+++ b/packages/eas-cli/src/commands/env/push.ts
@@ -7,8 +7,7 @@ import EasCommand from '../../commandUtils/EasCommand';
 import {
   EASMultiEnvironmentFlag,
   EASNonInteractiveFlag,
-  extendFlagDescription,
-  validateNonInteractiveRequiredInputs,
+  markRequired,
 } from '../../commandUtils/flags';
 import {
   CreateEnvironmentVariableInput,
@@ -23,13 +22,11 @@ import { confirmAsync, promptAsync } from '../../prompts';
 import { promptVariableEnvironmentAsync } from '../../utils/prompts';
 
 export default class EnvPush extends EasCommand {
-  static override description = `push environment variables from .env file to the selected environment
-
-In non-interactive mode, provide ENVIRONMENT or --environment. Use --force when overwriting existing variables.`;
+  static override description =
+    'push environment variables from .env file to the selected environment';
 
   static override examples = [
-    '$ eas env:push development --path .env.local --non-interactive',
-    '$ eas env:push --environment production --path .env.production --force --non-interactive',
+    '$ eas env:push --environment production --path .env.production --force',
   ];
 
   static override contextDefinition = {
@@ -38,23 +35,16 @@ In non-interactive mode, provide ENVIRONMENT or --environment. Use --force when 
   };
 
   static override flags = {
-    ...extendFlagDescription(
-      EASMultiEnvironmentFlag,
-      'Required in non-interactive mode unless ENVIRONMENT is provided.'
-    ),
+    ...markRequired(EASMultiEnvironmentFlag),
     path: Flags.string({
       description: 'Path to the input `.env` file',
       default: '.env.local',
     }),
     force: Flags.boolean({
-      description:
-        'Skip confirmation and automatically override existing variables. Required in non-interactive mode when overwriting.',
+      description: 'Skip confirmation and automatically override existing variables',
       default: false,
     }),
-    ...extendFlagDescription(
-      EASNonInteractiveFlag,
-      'Requires an environment via ENVIRONMENT or --environment.'
-    ),
+    ...EASNonInteractiveFlag,
   };
 
   static override args = {
@@ -74,11 +64,6 @@ In non-interactive mode, provide ENVIRONMENT or --environment. Use --force when 
       force,
       'non-interactive': nonInteractive,
     } = this.parseFlagsAndArgs(flags, args);
-    validateNonInteractiveRequiredInputs({
-      nonInteractive,
-      requiredInputs: [{ name: 'ENVIRONMENT or --environment', value: environments }],
-      helpCommand: 'eas env:push --help',
-    });
 
     const {
       projectId,
@@ -146,11 +131,6 @@ In non-interactive mode, provide ENVIRONMENT or --environment. Use --force when 
       if (existingDifferentVariables.length > 0) {
         Log.warn(`Some variables already exist in the ${displayedEnvironment} environment.`);
         const variableNames = existingDifferentVariables.map(variable => variable.name);
-        validateNonInteractiveRequiredInputs({
-          nonInteractive,
-          requiredInputs: [{ name: '--force', value: force ? true : undefined }],
-          helpCommand: 'eas env:push --help',
-        });
 
         let variablesToOverwrite: string[] = [];
 
@@ -165,6 +145,12 @@ In non-interactive mode, provide ENVIRONMENT or --environment. Use --force when 
                   ', '
                 )} environment variables already exist in ${displayedEnvironment} environment. Do you want to override them all?`
               : `The ${variableNames[0]} environment variable already exists in ${displayedEnvironment} environment. Do you want to override it?`;
+
+          if (nonInteractive) {
+            throw new Error(
+              'Cannot confirm overwriting existing variables in non-interactive mode. Use --force to overwrite them.'
+            );
+          }
 
           const confirm = await confirmAsync({
             message: confirmationMessage,
@@ -210,14 +196,15 @@ In non-interactive mode, provide ENVIRONMENT or --environment. Use --force when 
       );
 
       if (existingSensitiveVariables.length > 0 && !force) {
-        validateNonInteractiveRequiredInputs({
-          nonInteractive,
-          requiredInputs: [{ name: '--force', value: force ? true : undefined }],
-          helpCommand: 'eas env:push --help',
-        });
         const existingSensitiveVariablesNames = existingSensitiveVariables.map(
           variable => `- ${variable.name}`
         );
+        if (nonInteractive) {
+          throw new Error(
+            'Cannot confirm overwriting sensitive variables in non-interactive mode. Use --force to overwrite them.'
+          );
+        }
+
         const confirm = await confirmAsync({
           message: `You are about to overwrite sensitive variables.\n${existingSensitiveVariablesNames.join(
             '\n'

--- a/packages/eas-cli/src/commands/env/push.ts
+++ b/packages/eas-cli/src/commands/env/push.ts
@@ -38,8 +38,8 @@ In non-interactive mode, provide ENVIRONMENT or --environment. Use --force when 
   };
 
   static override flags = {
-    environment: extendFlagDescription(
-      EASMultiEnvironmentFlag.environment,
+    ...extendFlagDescription(
+      EASMultiEnvironmentFlag,
       'Required in non-interactive mode unless ENVIRONMENT is provided.'
     ),
     path: Flags.string({
@@ -51,8 +51,8 @@ In non-interactive mode, provide ENVIRONMENT or --environment. Use --force when 
         'Skip confirmation and automatically override existing variables. Required in non-interactive mode when overwriting.',
       default: false,
     }),
-    'non-interactive': extendFlagDescription(
-      EASNonInteractiveFlag['non-interactive'],
+    ...extendFlagDescription(
+      EASNonInteractiveFlag,
       'Requires an environment via ENVIRONMENT or --environment.'
     ),
   };

--- a/packages/eas-cli/src/commands/env/push.ts
+++ b/packages/eas-cli/src/commands/env/push.ts
@@ -7,7 +7,7 @@ import EasCommand from '../../commandUtils/EasCommand';
 import {
   EASMultiEnvironmentFlag,
   EASNonInteractiveFlag,
-  markRequired,
+  markRequiredInNonInteractiveMode,
 } from '../../commandUtils/flags';
 import {
   CreateEnvironmentVariableInput,
@@ -35,7 +35,7 @@ export default class EnvPush extends EasCommand {
   };
 
   static override flags = {
-    ...markRequired(EASMultiEnvironmentFlag),
+    ...markRequiredInNonInteractiveMode(EASMultiEnvironmentFlag),
     path: Flags.string({
       description: 'Path to the input `.env` file',
       default: '.env.local',

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -13,7 +13,6 @@ import {
   EASNonInteractiveFlag,
   EASVariableVisibilityFlag,
   EasEnvironmentFlagParameters,
-  extendFlagDescription,
   validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
@@ -67,44 +66,36 @@ interface UpdateFlags {
 export default class EnvUpdate extends EasCommand {
   static override description = `update an environment variable on the current project or account
 
-In non-interactive mode, provide --variable-name and the fields to update. If --type is provided, --value is also required.`;
+If --type is provided, --value is also required.`;
 
   static override examples = [
-    '$ eas env:update production --variable-name API_URL --value https://api.example.com --non-interactive',
-    '$ eas env:update --variable-name GOOGLE_SERVICES_JSON --type file --value ./google-services.json --environment production --non-interactive',
+    '$ eas env:update --variable-environment production --variable-name API_URL --value https://api.example.com',
+    '$ eas env:update --variable-environment development --variable-name GOOGLE_SERVICES_JSON --type file --value ./google-services.json --environment production',
   ];
 
   static override flags = {
     'variable-name': Flags.string({
-      description: 'Current name of the variable. Required in non-interactive mode.',
+      description: '(required) Current name of the variable',
     }),
     'variable-environment': Flags.string({
       ...EasEnvironmentFlagParameters,
-      description: 'Current environment of the variable to update. Helps disambiguate variables.',
+      description: '(required) Current environment of the variable to update',
     }),
     name: Flags.string({
       description: 'New name of the variable',
     }),
     value: Flags.string({
-      description: 'New value for the variable, or a file path when --type=file',
+      description:
+        '(required with --type) New value for the variable, or a file path when --type=file',
     }),
     type: Flags.option({
-      description: 'The type of variable. Requires --value in non-interactive mode.',
+      description: 'The type of variable',
       options: ['string', 'file'] as const,
     })(),
-    ...extendFlagDescription(
-      EASVariableVisibilityFlag,
-      'Used as the new visibility when provided.'
-    ),
+    ...EASVariableVisibilityFlag,
     ...EASEnvironmentVariableScopeFlag,
-    ...extendFlagDescription(
-      EASMultiEnvironmentFlag,
-      'New environment for the variable. May be specified multiple times.'
-    ),
-    ...extendFlagDescription(
-      EASNonInteractiveFlag,
-      'Requires --variable-name. Also requires --value when --type is provided.'
-    ),
+    ...EASMultiEnvironmentFlag,
+    ...EASNonInteractiveFlag,
   };
 
   static override args = {
@@ -232,12 +223,14 @@ In non-interactive mode, provide --variable-name and the fields to update. If --
   ): UpdateFlags {
     validateNonInteractiveRequiredInputs({
       nonInteractive: flags['non-interactive'],
-      requiredInputs: [{ name: '--variable-name', value: flags['variable-name'] }],
-      helpCommand: 'eas env:update --help',
-    });
-    validateNonInteractiveRequiredInputs({
-      nonInteractive: flags['non-interactive'] && !!flags.type,
-      requiredInputs: [{ name: '--value', value: flags.value }],
+      requiredInputs: [
+        { name: '--variable-name', value: flags['variable-name'] },
+        {
+          name: '--variable-environment',
+          value: environment ?? flags['variable-environment'],
+        },
+        { if: !!flags.type, name: '--value', value: flags.value },
+      ],
       helpCommand: 'eas env:update --help',
     });
 

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -13,6 +13,8 @@ import {
   EASNonInteractiveFlag,
   EASVariableVisibilityFlag,
   EasEnvironmentFlagParameters,
+  extendFlagDescription,
+  validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
   EnvironmentSecretType,
@@ -63,30 +65,46 @@ interface UpdateFlags {
 }
 
 export default class EnvUpdate extends EasCommand {
-  static override description = 'update an environment variable on the current project or account';
+  static override description = `update an environment variable on the current project or account
+
+In non-interactive mode, provide --variable-name and the fields to update. If --type is provided, --value is also required.`;
+
+  static override examples = [
+    '$ eas env:update production --variable-name API_URL --value https://api.example.com --non-interactive',
+    '$ eas env:update --variable-name GOOGLE_SERVICES_JSON --type file --value ./google-services.json --environment production --non-interactive',
+  ];
 
   static override flags = {
     'variable-name': Flags.string({
-      description: 'Current name of the variable',
+      description: 'Current name of the variable. Required in non-interactive mode.',
     }),
     'variable-environment': Flags.string({
       ...EasEnvironmentFlagParameters,
-      description: 'Current environment of the variable to update',
+      description: 'Current environment of the variable to update. Helps disambiguate variables.',
     }),
     name: Flags.string({
       description: 'New name of the variable',
     }),
     value: Flags.string({
-      description: 'New value or the variable',
+      description: 'New value for the variable, or a file path when --type=file',
     }),
     type: Flags.option({
-      description: 'The type of variable',
+      description: 'The type of variable. Requires --value in non-interactive mode.',
       options: ['string', 'file'] as const,
     })(),
-    ...EASVariableVisibilityFlag,
+    visibility: extendFlagDescription(
+      EASVariableVisibilityFlag.visibility,
+      'Used as the new visibility when provided.'
+    ),
     ...EASEnvironmentVariableScopeFlag,
-    ...EASMultiEnvironmentFlag,
-    ...EASNonInteractiveFlag,
+    environment: extendFlagDescription(
+      EASMultiEnvironmentFlag.environment,
+      'New environment for the variable. May be specified multiple times.'
+    ),
+    'non-interactive': extendFlagDescription(
+      EASNonInteractiveFlag['non-interactive'],
+      'Requires --variable-name. Also requires --value when --type is provided.'
+    ),
   };
 
   static override args = {
@@ -212,16 +230,16 @@ export default class EnvUpdate extends EasCommand {
     flags: RawUpdateFlags,
     { environment }: { environment?: string }
   ): UpdateFlags {
-    if (flags['non-interactive']) {
-      if (!flags['variable-name']) {
-        throw new Error(
-          'Current name is required in non-interactive mode. Run the command with --variable-name flag.'
-        );
-      }
-      if (flags['type'] && !flags['value']) {
-        throw new Error('Value is required when type is set. Run the command with --value flag.');
-      }
-    }
+    validateNonInteractiveRequiredInputs({
+      nonInteractive: flags['non-interactive'],
+      requiredInputs: [{ name: '--variable-name', value: flags['variable-name'] }],
+      helpCommand: 'eas env:update --help',
+    });
+    validateNonInteractiveRequiredInputs({
+      nonInteractive: flags['non-interactive'] && !!flags.type,
+      requiredInputs: [{ name: '--value', value: flags.value }],
+      helpCommand: 'eas env:update --help',
+    });
 
     const scope =
       flags.scope === 'account'

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -92,17 +92,17 @@ In non-interactive mode, provide --variable-name and the fields to update. If --
       description: 'The type of variable. Requires --value in non-interactive mode.',
       options: ['string', 'file'] as const,
     })(),
-    visibility: extendFlagDescription(
-      EASVariableVisibilityFlag.visibility,
+    ...extendFlagDescription(
+      EASVariableVisibilityFlag,
       'Used as the new visibility when provided.'
     ),
     ...EASEnvironmentVariableScopeFlag,
-    environment: extendFlagDescription(
-      EASMultiEnvironmentFlag.environment,
+    ...extendFlagDescription(
+      EASMultiEnvironmentFlag,
       'New environment for the variable. May be specified multiple times.'
     ),
-    'non-interactive': extendFlagDescription(
-      EASNonInteractiveFlag['non-interactive'],
+    ...extendFlagDescription(
+      EASNonInteractiveFlag,
       'Requires --variable-name. Also requires --value when --type is provided.'
     ),
   };

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -225,10 +225,6 @@ If --type is provided, --value is also required.`;
       nonInteractive: flags['non-interactive'],
       requiredInputs: [
         { name: '--variable-name', value: flags['variable-name'] },
-        {
-          name: '--variable-environment',
-          value: environment ?? flags['variable-environment'],
-        },
         { if: !!flags.type, name: '--value', value: flags.value },
       ],
       helpCommand: 'eas env:update --help',

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -229,6 +229,11 @@ If --type is provided, --value is also required.`;
       ],
       helpCommand: 'eas env:update --help',
     });
+    if (environment && flags['variable-environment']) {
+      throw new Error(
+        "You can't use both --variable-environment flag when environment is passed as an argument. Run `eas env:update --help` for more information."
+      );
+    }
 
     const scope =
       flags.scope === 'account'

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -94,17 +94,17 @@ In non-interactive mode, provide --variable-name and the fields to update. If --
       description: 'The type of variable. Requires --value in non-interactive mode.',
       options: ['string', 'file'] as const,
     })(),
-    visibility: extendFlagDescription(
-      EASVariableVisibilityFlag.visibility,
+    ...extendFlagDescription(
+      EASVariableVisibilityFlag,
       'Used as the new visibility when provided.'
     ),
     ...EASEnvironmentVariableScopeFlag,
-    environment: extendFlagDescription(
-      EASMultiEnvironmentFlag.environment,
+    ...extendFlagDescription(
+      EASMultiEnvironmentFlag,
       'New environment for the variable. May be specified multiple times.'
     ),
-    'non-interactive': extendFlagDescription(
-      EASNonInteractiveFlag['non-interactive'],
+    ...extendFlagDescription(
+      EASNonInteractiveFlag,
       'Requires --variable-name. Also requires --value when --type is provided.'
     ),
   };

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -234,6 +234,11 @@ If --type is provided, --value is also required.`;
       ],
       helpCommand: 'eas env:update --help',
     });
+    if (environment && flags['variable-environment']) {
+      throw new Error(
+        "You can't use both --variable-environment flag when environment is passed as an argument. Run `eas env:update --help` for more information."
+      );
+    }
 
     const scope =
       flags.scope === 'account'

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -13,6 +13,8 @@ import {
   EASNonInteractiveFlag,
   EASVariableVisibilityFlag,
   EasEnvironmentFlagParameters,
+  extendFlagDescription,
+  validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
   EnvironmentSecretType,
@@ -63,32 +65,48 @@ interface UpdateFlags {
 }
 
 export default class EnvUpdate extends EasCommand {
-  static override description =
-    'update an environment variable on the current project or account (deprecated, use eas env:set)';
+  static override description = `update an environment variable on the current project or account (deprecated, use eas env:set)
+
+In non-interactive mode, provide --variable-name and the fields to update. If --type is provided, --value is also required.`;
+
   static override hidden = true;
+
+  static override examples = [
+    '$ eas env:update production --variable-name API_URL --value https://api.example.com --non-interactive',
+    '$ eas env:update --variable-name GOOGLE_SERVICES_JSON --type file --value ./google-services.json --environment production --non-interactive',
+  ];
 
   static override flags = {
     'variable-name': Flags.string({
-      description: 'Current name of the variable',
+      description: 'Current name of the variable. Required in non-interactive mode.',
     }),
     'variable-environment': Flags.string({
       ...EasEnvironmentFlagParameters,
-      description: 'Current environment of the variable to update',
+      description: 'Current environment of the variable to update. Helps disambiguate variables.',
     }),
     name: Flags.string({
       description: 'New name of the variable',
     }),
     value: Flags.string({
-      description: 'New value or the variable',
+      description: 'New value for the variable, or a file path when --type=file',
     }),
     type: Flags.option({
-      description: 'The type of variable',
+      description: 'The type of variable. Requires --value in non-interactive mode.',
       options: ['string', 'file'] as const,
     })(),
-    ...EASVariableVisibilityFlag,
+    visibility: extendFlagDescription(
+      EASVariableVisibilityFlag.visibility,
+      'Used as the new visibility when provided.'
+    ),
     ...EASEnvironmentVariableScopeFlag,
-    ...EASMultiEnvironmentFlag,
-    ...EASNonInteractiveFlag,
+    environment: extendFlagDescription(
+      EASMultiEnvironmentFlag.environment,
+      'New environment for the variable. May be specified multiple times.'
+    ),
+    'non-interactive': extendFlagDescription(
+      EASNonInteractiveFlag['non-interactive'],
+      'Requires --variable-name. Also requires --value when --type is provided.'
+    ),
   };
 
   static override args = {
@@ -217,16 +235,16 @@ export default class EnvUpdate extends EasCommand {
     flags: RawUpdateFlags,
     { environment }: { environment?: string }
   ): UpdateFlags {
-    if (flags['non-interactive']) {
-      if (!flags['variable-name']) {
-        throw new Error(
-          'Current name is required in non-interactive mode. Run the command with --variable-name flag.'
-        );
-      }
-      if (flags['type'] && !flags['value']) {
-        throw new Error('Value is required when type is set. Run the command with --value flag.');
-      }
-    }
+    validateNonInteractiveRequiredInputs({
+      nonInteractive: flags['non-interactive'],
+      requiredInputs: [{ name: '--variable-name', value: flags['variable-name'] }],
+      helpCommand: 'eas env:update --help',
+    });
+    validateNonInteractiveRequiredInputs({
+      nonInteractive: flags['non-interactive'] && !!flags.type,
+      requiredInputs: [{ name: '--value', value: flags.value }],
+      helpCommand: 'eas env:update --help',
+    });
 
     const scope =
       flags.scope === 'account'

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -13,7 +13,6 @@ import {
   EASNonInteractiveFlag,
   EASVariableVisibilityFlag,
   EasEnvironmentFlagParameters,
-  extendFlagDescription,
   validateNonInteractiveRequiredInputs,
 } from '../../commandUtils/flags';
 import {
@@ -67,46 +66,38 @@ interface UpdateFlags {
 export default class EnvUpdate extends EasCommand {
   static override description = `update an environment variable on the current project or account (deprecated, use eas env:set)
 
-In non-interactive mode, provide --variable-name and the fields to update. If --type is provided, --value is also required.`;
+If --type is provided, --value is also required.`;
 
   static override hidden = true;
 
   static override examples = [
-    '$ eas env:update production --variable-name API_URL --value https://api.example.com --non-interactive',
-    '$ eas env:update --variable-name GOOGLE_SERVICES_JSON --type file --value ./google-services.json --environment production --non-interactive',
+    '$ eas env:update --variable-environment production --variable-name API_URL --value https://api.example.com',
+    '$ eas env:update --variable-environment development --variable-name GOOGLE_SERVICES_JSON --type file --value ./google-services.json --environment production',
   ];
 
   static override flags = {
     'variable-name': Flags.string({
-      description: 'Current name of the variable. Required in non-interactive mode.',
+      description: '(required) Current name of the variable',
     }),
     'variable-environment': Flags.string({
       ...EasEnvironmentFlagParameters,
-      description: 'Current environment of the variable to update. Helps disambiguate variables.',
+      description: '(required) Current environment of the variable to update',
     }),
     name: Flags.string({
       description: 'New name of the variable',
     }),
     value: Flags.string({
-      description: 'New value for the variable, or a file path when --type=file',
+      description:
+        '(required with --type) New value for the variable, or a file path when --type=file',
     }),
     type: Flags.option({
-      description: 'The type of variable. Requires --value in non-interactive mode.',
+      description: 'The type of variable',
       options: ['string', 'file'] as const,
     })(),
-    ...extendFlagDescription(
-      EASVariableVisibilityFlag,
-      'Used as the new visibility when provided.'
-    ),
+    ...EASVariableVisibilityFlag,
     ...EASEnvironmentVariableScopeFlag,
-    ...extendFlagDescription(
-      EASMultiEnvironmentFlag,
-      'New environment for the variable. May be specified multiple times.'
-    ),
-    ...extendFlagDescription(
-      EASNonInteractiveFlag,
-      'Requires --variable-name. Also requires --value when --type is provided.'
-    ),
+    ...EASMultiEnvironmentFlag,
+    ...EASNonInteractiveFlag,
   };
 
   static override args = {
@@ -237,12 +228,14 @@ In non-interactive mode, provide --variable-name and the fields to update. If --
   ): UpdateFlags {
     validateNonInteractiveRequiredInputs({
       nonInteractive: flags['non-interactive'],
-      requiredInputs: [{ name: '--variable-name', value: flags['variable-name'] }],
-      helpCommand: 'eas env:update --help',
-    });
-    validateNonInteractiveRequiredInputs({
-      nonInteractive: flags['non-interactive'] && !!flags.type,
-      requiredInputs: [{ name: '--value', value: flags.value }],
+      requiredInputs: [
+        { name: '--variable-name', value: flags['variable-name'] },
+        {
+          name: '--variable-environment',
+          value: environment ?? flags['variable-environment'],
+        },
+        { if: !!flags.type, name: '--value', value: flags.value },
+      ],
       helpCommand: 'eas env:update --help',
     });
 

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -66,7 +66,7 @@ interface UpdateFlags {
 export default class EnvUpdate extends EasCommand {
   static override description = `update an environment variable on the current project or account (deprecated, use eas env:set)
 
-If --type is provided, --value is also required.`;
+In non-interactive mode, if --type is provided, --value is also required.`;
 
   static override hidden = true;
 
@@ -77,18 +77,18 @@ If --type is provided, --value is also required.`;
 
   static override flags = {
     'variable-name': Flags.string({
-      description: '(required) Current name of the variable',
+      description: '(required in non-interactive mode) Current name of the variable',
     }),
     'variable-environment': Flags.string({
       ...EasEnvironmentFlagParameters,
-      description: '(required) Current environment of the variable to update',
+      description: 'Current environment of the variable to update',
     }),
     name: Flags.string({
       description: 'New name of the variable',
     }),
     value: Flags.string({
       description:
-        '(required with --type) New value for the variable, or a file path when --type=file',
+        '(required with --type in non-interactive mode) New value for the variable, or a file path when --type=file',
     }),
     type: Flags.option({
       description: 'The type of variable',
@@ -236,7 +236,7 @@ If --type is provided, --value is also required.`;
     });
     if (environment && flags['variable-environment']) {
       throw new Error(
-        "You can't use both --variable-environment flag when environment is passed as an argument. Run `eas env:update --help` for more information."
+        "You can't use the --variable-environment flag when the environment is passed as a positional argument. Run `eas env:update --help` for more information."
       );
     }
 

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -230,10 +230,6 @@ If --type is provided, --value is also required.`;
       nonInteractive: flags['non-interactive'],
       requiredInputs: [
         { name: '--variable-name', value: flags['variable-name'] },
-        {
-          name: '--variable-environment',
-          value: environment ?? flags['variable-environment'],
-        },
         { if: !!flags.type, name: '--value', value: flags.value },
       ],
       helpCommand: 'eas env:update --help',


### PR DESCRIPTION
# Why

In Expo Agent monitoring (Braintrust) we can see the agent struggles with missing all required flags during envs creation.

From [[link]](https://www.braintrust.dev/app/expo-agent/p/expo-agent/logs) Braintrust's agent: Non-interactive mode confusion (5/15) — the agent keeps hitting "this needs --non-interactive", "this needs --visibility", "this needs --force", "this needs a stdin prompt". A non-interactive cheat-sheet would eliminate most of these.

(Also based on what we have inside of the Expo Agent envs/db [skill](https://github.com/expo/echo-backend/blob/fb37d511c825707244fbb50aed8d5b026f013260/backend/skills/database/SKILL.md))

# How

- add `validateNonInteractiveRequiredInputs` helper which validates all required inputs in the non-interactive mode at once.
- mark all required in non-interactive as required (in interactive mode users are prompted as before)
- add examples with all required flags

# Test Plan

updated existing tests