### PR TITLE
[build-tools] track installed maestro cli version

### DIFF
--- a/packages/build-tools/src/__tests__/datadog.test.ts
+++ b/packages/build-tools/src/__tests__/datadog.test.ts
@@ -51,6 +51,7 @@ describe('Datadog singleton', () => {
                 build_phase: 'install_dependencies',
                 platform: 'ios',
                 result: 'success',
+                target: 'build',
               },
             },
           ],
@@ -70,7 +71,7 @@ describe('Datadog singleton', () => {
       target: { kind: 'jobRun', turtleJobRunId: 'job-run-id' },
     });
 
-    Datadog.distribution('eas.workflow.maestro_cli_version', 1, {
+    Datadog.distribution('eas.maestro.install', 1, {
       maestro_version: '2.1.0',
     });
 
@@ -81,11 +82,12 @@ describe('Datadog singleton', () => {
         json: {
           metrics: [
             {
-              name: 'eas.workflow.maestro_cli_version',
+              name: 'eas.maestro.install',
               type: 'distribution',
               value: 1,
               tags: {
                 maestro_version: '2.1.0',
+                target: 'job_run',
               },
             },
           ],
@@ -120,6 +122,7 @@ describe('Datadog singleton', () => {
           tags: {
             event: 'find_artifacts_absolute_path_dry_run',
             status: 'match',
+            target: 'build',
           },
         },
         headers: { Authorization: 'Bearer token-abc' },
@@ -150,6 +153,7 @@ describe('Datadog singleton', () => {
           message: 'Gradle cache restored (hit)',
           tags: {
             cache_type: 'gradle',
+            target: 'job_run',
           },
         },
         headers: { Authorization: 'Bearer token-abc' },
@@ -184,7 +188,14 @@ describe('Datadog singleton', () => {
       expect.any(Error),
       expect.objectContaining({
         extras: {
-          metrics: [{ name: 'eas.build.phase_duration', type: 'distribution', value: 1, tags: {} }],
+          metrics: [
+            {
+              name: 'eas.build.phase_duration',
+              type: 'distribution',
+              value: 1,
+              tags: { target: 'build' },
+            },
+          ],
         },
       })
     );
@@ -198,7 +209,7 @@ describe('Datadog singleton', () => {
       target: { kind: 'jobRun', turtleJobRunId: 'job-run-id' },
     });
 
-    Datadog.distribution('eas.workflow.maestro_cli_version', 1);
+    Datadog.distribution('eas.maestro.install', 1);
     await flushPromises();
 
     expect(sentryCaptureMock).toHaveBeenCalledWith(
@@ -207,7 +218,12 @@ describe('Datadog singleton', () => {
       expect.objectContaining({
         extras: {
           metrics: [
-            { name: 'eas.workflow.maestro_cli_version', type: 'distribution', value: 1, tags: {} },
+            {
+              name: 'eas.maestro.install',
+              type: 'distribution',
+              value: 1,
+              tags: { target: 'job_run' },
+            },
           ],
         },
       })
@@ -231,7 +247,11 @@ describe('Datadog singleton', () => {
       expect.any(Error),
       expect.objectContaining({
         extras: {
-          log: { buildId: 'build-id', message: 'artifact dry-run matched', tags: {} },
+          log: {
+            buildId: 'build-id',
+            message: 'artifact dry-run matched',
+            tags: { target: 'build' },
+          },
         },
       })
     );
@@ -253,7 +273,11 @@ describe('Datadog singleton', () => {
       expect.any(Error),
       expect.objectContaining({
         extras: {
-          log: { jobRunId: 'job-run-id', message: 'Gradle cache restored (hit)', tags: {} },
+          log: {
+            jobRunId: 'job-run-id',
+            message: 'Gradle cache restored (hit)',
+            tags: { target: 'job_run' },
+          },
         },
       })
     );

--- a/packages/build-tools/src/datadog.ts
+++ b/packages/build-tools/src/datadog.ts
@@ -14,6 +14,13 @@ type DatadogSetupOptions = {
 let setupOptions: DatadogSetupOptions | null = null;
 let pendingUploads: Promise<unknown>[] = [];
 
+function withTargetTag(
+  tags: Record<string, string>,
+  target: MetricsTarget
+): Record<string, string> {
+  return { ...tags, target: target.kind === 'build' ? 'build' : 'job_run' };
+}
+
 export const Datadog = {
   setup(opts: DatadogSetupOptions | null): void {
     setupOptions = opts;
@@ -29,7 +36,7 @@ export const Datadog = {
         name,
         type: 'distribution' as const,
         value,
-        tags,
+        tags: withTargetTag(tags, target),
       },
     ];
 
@@ -58,10 +65,11 @@ export const Datadog = {
       return;
     }
     const { expoApiV2BaseUrl, robotAccessToken, target } = setupOptions;
+    const tagsWithTarget = withTargetTag(tags, target);
     const log =
       target.kind === 'build'
-        ? { buildId: target.turtleBuildId, message, tags }
-        : { jobRunId: target.turtleJobRunId, message, tags };
+        ? { buildId: target.turtleBuildId, message, tags: tagsWithTarget }
+        : { jobRunId: target.turtleJobRunId, message, tags: tagsWithTarget };
     const logsPath = target.kind === 'build' ? 'turtle-builds/logs' : 'turtle-job-runs/logs';
 
     const uploadPromise = turtleFetch(new URL(logsPath, expoApiV2BaseUrl).toString(), 'POST', {

--- a/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
@@ -1,0 +1,54 @@
+import spawn from '@expo/turtle-spawn';
+
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { Datadog } from '../../../datadog';
+import { createInstallMaestroBuildFunction } from '../installMaestro';
+
+jest.mock('@expo/turtle-spawn', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../../datadog', () => ({
+  Datadog: {
+    distribution: jest.fn(),
+  },
+}));
+
+const mockedSpawn = jest.mocked(spawn);
+
+describe('createInstallMaestroBuildFunction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // `maestro --version` reports an installed version; `java -version` succeeds.
+    // With no requested version and Maestro present, the step skips installation.
+    mockedSpawn.mockImplementation((async (command: string) => ({
+      stdout: command === 'maestro' ? '1.41.0\n' : '',
+    })) as any);
+  });
+
+  it('reports the detected Maestro version to Datadog on EAS Build VMs', async () => {
+    const installMaestro = createInstallMaestroBuildFunction();
+    const globalCtx = createGlobalContextMock();
+    globalCtx.updateEnv({ EAS_BUILD_RUNNER: 'eas-build' });
+    const step = installMaestro.createBuildStepFromFunctionCall(globalCtx, { callInputs: {} });
+
+    await step.executeAsync();
+
+    expect(step.getOutputValueByName('maestro_version')).toBe('1.41.0');
+    expect(Datadog.distribution).toHaveBeenCalledWith('eas.maestro.install', 1, {
+      maestro_version: '1.41.0',
+    });
+  });
+
+  it('does not report to Datadog outside EAS Build VMs', async () => {
+    const installMaestro = createInstallMaestroBuildFunction();
+    const step = installMaestro.createBuildStepFromFunctionCall(createGlobalContextMock(), {
+      callInputs: {},
+    });
+
+    await step.executeAsync();
+
+    expect(Datadog.distribution).not.toHaveBeenCalled();
+  });
+});

--- a/packages/build-tools/src/steps/functions/installMaestro.ts
+++ b/packages/build-tools/src/steps/functions/installMaestro.ts
@@ -15,6 +15,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import { Datadog } from '../../datadog';
+
 export function createInstallMaestroBuildFunction(): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
@@ -123,6 +125,10 @@ export function createInstallMaestroBuildFunction(): BuildFunction {
 
       logger.info(`Maestro ${maestroVersionResult.value} is ready.`);
       outputs.maestro_version.set(maestroVersionResult.value);
+
+      Datadog.distribution('eas.maestro.install', 1, {
+        maestro_version: maestroVersionResult.value,
+      });
     },
   });
 }


### PR DESCRIPTION
# Why

[ENG-21441](https://linear.app/expo/issue/ENG-21441/track-maestro-cli-version-in-datadog): track which Maestro CLI versions are used on EAS, to inform migrations to new Maestro features and removal of deprecated ones.

# How

- `eas/install_maestro` now reports the detected version after version detection on EAS Build VMs: `Datadog.distribution('eas.maestro.install', 1, { maestro_version })`. Every EAS-generated Maestro path runs this step (custom builds via the `eas/maestro_test` function group, workflow `maestro` / `maestro_cloud` jobs), so one call site covers them all.
- The `Datadog` module auto-tags every metric/log with `target: build | job_run`, derived from the target it already routes by — so this metric (and existing ones like `eas.build.phase_duration`) can be split by custom build vs workflow job.
- Fire-and-forget: nothing is written to the user's build log; upload failures go to Sentry via the existing `.catch`.

Companion PR expo/universe#27921 allowlists the new metric name on the turtle-builds metrics endpoint and **must be deployed before this PR is released** (the turtle-job-runs endpoint is free-form and needs no change).

# Test Plan

- New `installMaestro.test.ts` unit test: emits with the detected version on the EAS Build VM path; does not emit on the local-runner path.
- `datadog.test.ts` updated for the automatic `target` tag on all metric/log payloads.
- `yarn test` (build-tools unit suite): 559/559 passing.
- After both PRs are live: verify `expo.www.eas.maestro.install` in Datadog, grouped by `maestro_version` and `target`.
