### PR TITLE
[eas-cli] add support for non-interactive update:rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [eas-cli] Non-interactive iOS App Store and Enterprise builds can now use the App Store Connect API key stored in EAS credentials as a submission key to validate and repair provisioning profiles on Apple servers, without requiring `EXPO_ASC_*` environment variables or an interactive Apple login. ([#3805](https://github.com/expo/eas-cli/pull/3805) by [@sswrk](https://github.com/sswrk))
+- [eas-cli] Add support for non-interactive `eas update:rollback [GROUP_ID]`. The given update group must be the latest for its branch and runtime version; the previous update group is republished, or a roll back to the embedded update is published if there is none. ([#3825](https://github.com/expo/eas-cli/pull/3825) by [@quinlanj](https://github.com/quinlanj))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -158,7 +158,7 @@ eas --help COMMAND
 * [`eas update:republish`](#eas-updaterepublish)
 * [`eas update:revert-update-rollout`](#eas-updaterevert-update-rollout)
 * [`eas update:roll-back-to-embedded`](#eas-updateroll-back-to-embedded)
-* [`eas update:rollback`](#eas-updaterollback)
+* [`eas update:rollback [GROUPID]`](#eas-updaterollback-groupid)
 * [`eas update:view GROUPID`](#eas-updateview-groupid)
 * [`eas upload`](#eas-upload)
 * [`eas webhook:create`](#eas-webhookcreate)
@@ -2391,6 +2391,53 @@ DESCRIPTION
 
 _See code: [packages/eas-cli/src/commands/update/embedded/list.ts](https://github.com/expo/eas-cli/blob/v20.1.0/packages/eas-cli/src/commands/update/embedded/list.ts)_
 
+## `eas update:embedded:delete ID`
+
+delete an embedded update registered with EAS Update
+
+```
+USAGE
+  $ eas update:embedded:delete ID [--json] [--non-interactive]
+
+ARGUMENTS
+  ID  The ID of the embedded update (manifest UUID from app.manifest).
+
+FLAGS
+  --json             Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.
+  --non-interactive  Run the command in non-interactive mode.
+
+DESCRIPTION
+  delete an embedded update registered with EAS Update
+```
+
+_See code: [packages/eas-cli/src/commands/update/embedded/delete.ts](https://github.com/expo/eas-cli/blob/v20.0.0/packages/eas-cli/src/commands/update/embedded/delete.ts)_
+
+## `eas update:embedded:list`
+
+list embedded updates registered with EAS Update for this project
+
+```
+USAGE
+  $ eas update:embedded:list [-p ios|android] [--runtime-version <value>] [--channel <value>] [--limit <value>]
+    [--after-cursor <value>] [--json] [--non-interactive]
+
+FLAGS
+  -p, --platform=<option>        Filter by platform
+                                 <options: ios|android>
+      --after-cursor=<value>     Return items after this cursor (for pagination)
+      --channel=<value>          Filter by channel name (pass "all" to skip the channel prompt)
+      --json                     Enable JSON output, non-JSON messages will be printed to stderr. Implies
+                                 --non-interactive.
+      --limit=<value>            The number of items to fetch each query. Defaults to 25 and is capped at 50.
+      --non-interactive          Run the command in non-interactive mode.
+      --runtime-version=<value>  Filter by runtime version
+
+DESCRIPTION
+  list embedded updates registered with EAS Update for this project
+```
+
+_See code: [packages/eas-cli/src/commands/update/embedded/list.ts](https://github.com/expo/eas-cli/blob/v20.0.0/packages/eas-cli/src/commands/update/embedded/list.ts)_
+
 ## `eas update:embedded:upload`
 
 upload the JS bundle embedded in a native build so EAS Update can generate bsdiff patches against it
@@ -2440,6 +2487,26 @@ DESCRIPTION
 ```
 
 _See code: [packages/eas-cli/src/commands/update/embedded/view.ts](https://github.com/expo/eas-cli/blob/v20.1.0/packages/eas-cli/src/commands/update/embedded/view.ts)_
+
+## `eas update:embedded:view ID`
+
+view details of an embedded update registered with EAS Update
+
+```
+USAGE
+  $ eas update:embedded:view ID [--json]
+
+ARGUMENTS
+  ID  The ID of the embedded update (manifest UUID from app.manifest).
+
+FLAGS
+  --json  Enable JSON output, non-JSON messages will be printed to stderr.
+
+DESCRIPTION
+  view details of an embedded update registered with EAS Update
+```
+
+_See code: [packages/eas-cli/src/commands/update/embedded/view.ts](https://github.com/expo/eas-cli/blob/v20.0.0/packages/eas-cli/src/commands/update/embedded/view.ts)_
 
 ## `eas update:insights GROUPID`
 
@@ -2591,23 +2658,34 @@ DESCRIPTION
 
 _See code: [packages/eas-cli/src/commands/update/roll-back-to-embedded.ts](https://github.com/expo/eas-cli/blob/v20.1.0/packages/eas-cli/src/commands/update/roll-back-to-embedded.ts)_
 
-## `eas update:rollback`
+## `eas update:rollback [GROUPID]`
 
-Roll back to an embedded update or an existing update. Users wishing to run this command non-interactively should instead execute "eas update:republish" or "eas update:roll-back-to-embedded".
+roll back to an embedded update or an existing update
 
 ```
 USAGE
-  $ eas update:rollback [--private-key-path <value>]
+  $ eas update:rollback [GROUPID] [-m <value>] [-p android|ios|all] [--private-key-path <value>] [--json]
+    [--non-interactive]
+
+ARGUMENTS
+  [GROUPID]  The ID of the update group to roll back. Must be the latest update for its branch and runtime version. The
+             update group published before it is republished; if there is none, a roll back to the embedded update is
+             published. Required in non-interactive mode.
 
 FLAGS
-  --private-key-path=<value>  File containing the PEM-encoded private key corresponding to the certificate in
-                              expo-updates' configuration. Defaults to a file named "private-key.pem" in the
-                              certificate's directory. Only relevant if you are using code signing:
-                              https://docs.expo.dev/eas-update/code-signing/
+  -m, --message=<value>           Short message describing the rollback update
+  -p, --platform=<option>         [default: all]
+                                  <options: android|ios|all>
+      --json                      Enable JSON output, non-JSON messages will be printed to stderr. Implies
+                                  --non-interactive.
+      --non-interactive           Run the command in non-interactive mode.
+      --private-key-path=<value>  File containing the PEM-encoded private key corresponding to the certificate in
+                                  expo-updates' configuration. Defaults to a file named "private-key.pem" in the
+                                  certificate's directory. Only relevant if you are using code signing:
+                                  https://docs.expo.dev/eas-update/code-signing/
 
 DESCRIPTION
-  Roll back to an embedded update or an existing update. Users wishing to run this command non-interactively should
-  instead execute "eas update:republish" or "eas update:roll-back-to-embedded".
+  roll back to an embedded update or an existing update
 ```
 
 _See code: [packages/eas-cli/src/commands/update/rollback.ts](https://github.com/expo/eas-cli/blob/v20.1.0/packages/eas-cli/src/commands/update/rollback.ts)_

--- a/packages/eas-cli/src/commands/update/__tests__/rollback.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/rollback.test.ts
@@ -1,0 +1,314 @@
+import { AppJSONConfig, ExpoConfig, PackageJSONConfig, getConfig } from '@expo/config';
+import { DirectoryJSON, vol } from 'memfs';
+import { instance, mock } from 'ts-mockito';
+
+import { getMockOclifConfig } from '../../../__tests__/commands/utils';
+import LoggedInContextField from '../../../commandUtils/context/LoggedInContextField';
+import { PrivateProjectConfigContextField } from '../../../commandUtils/context/PrivateProjectConfigContextField';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import FeatureGateEnvOverrides from '../../../commandUtils/gating/FeatureGateEnvOverrides';
+import FeatureGating from '../../../commandUtils/gating/FeatureGating';
+import { jester } from '../../../credentials/__tests__/fixtures-constants';
+import { UpdateFragment } from '../../../graphql/generated';
+import { AppQuery } from '../../../graphql/queries/AppQuery';
+import { UpdateQuery } from '../../../graphql/queries/UpdateQuery';
+import UpdateRepublish from '../republish';
+import UpdateRollBackToEmbedded from '../roll-back-to-embedded';
+import UpdateRollback from '../rollback';
+
+const projectRoot = '/test-project';
+const commandOptions = getMockOclifConfig({ root: projectRoot });
+
+const updateStub: UpdateFragment = {
+  id: 'update-1234',
+  group: 'group-source',
+  branch: { id: 'branch-1234', name: 'main' },
+  message: 'source message',
+  runtimeVersion: 'exposdk:47.0.0',
+  platform: 'ios',
+  gitCommitHash: 'commit',
+  isGitWorkingTreeDirty: false,
+  manifestFragment: JSON.stringify({ fake: 'manifest' }),
+  isRollBackToEmbedded: false,
+  manifestPermalink: 'https://expo.dev/fake/manifest/link',
+  codeSigningInfo: null,
+  createdAt: '2022-01-01T12:00:00Z',
+};
+
+jest.mock('fs');
+jest.mock('@expo/config');
+jest.mock('../../../commandUtils/context/contextUtils/getProjectIdAsync');
+jest.mock('../../../graphql/queries/AppQuery');
+jest.mock('../../../graphql/queries/UpdateQuery');
+
+describe(UpdateRollback.name, () => {
+  beforeEach(() => {
+    jest.spyOn(UpdateRepublish, 'run').mockResolvedValue(undefined as any);
+    jest.spyOn(UpdateRollBackToEmbedded, 'run').mockResolvedValue(undefined as any);
+  });
+
+  afterEach(() => {
+    vol.reset();
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it('errors in non-interactive mode when no group ID is provided', async () => {
+    const flags = ['--non-interactive'];
+    mockTestProject();
+
+    await expect(new UpdateRollback(flags, commandOptions).run()).rejects.toThrow(
+      'The update group ID argument is required in non-interactive mode.'
+    );
+
+    expect(UpdateRepublish.run).not.toHaveBeenCalled();
+    expect(UpdateRollBackToEmbedded.run).not.toHaveBeenCalled();
+  });
+
+  it('republishes the previous update group when the source group is the latest', async () => {
+    const flags = ['group-source', '--non-interactive'];
+    mockTestProject();
+
+    jest
+      .mocked(UpdateQuery.viewUpdateGroupAsync)
+      .mockResolvedValue([{ ...updateStub, group: 'group-source' }]);
+
+    // Most-recent-first: the source group is the latest, the previous group follows.
+    jest
+      .mocked(UpdateQuery.viewUpdateGroupsPaginatedOnBranchAsync)
+      .mockResolvedValue([
+        [{ ...updateStub, group: 'group-source', message: 'source message' }],
+        [{ ...updateStub, group: 'group-previous', message: 'previous message' }],
+      ]);
+
+    await new UpdateRollback(flags, commandOptions).run();
+
+    expect(UpdateRollBackToEmbedded.run).not.toHaveBeenCalled();
+    expect(UpdateRepublish.run).toHaveBeenCalledWith([
+      '--group',
+      'group-previous',
+      '--message',
+      'Roll back to "previous message" (group: group-previous)',
+      '--non-interactive',
+      '--platform',
+      'all',
+    ]);
+  });
+
+  it('rolls back to embedded when the source group is the only update for its runtime version', async () => {
+    const flags = ['group-source', '--non-interactive'];
+    mockTestProject();
+
+    jest
+      .mocked(UpdateQuery.viewUpdateGroupAsync)
+      .mockResolvedValue([{ ...updateStub, group: 'group-source' }]);
+
+    // Only the source group exists for this runtime version -> no previous group.
+    jest
+      .mocked(UpdateQuery.viewUpdateGroupsPaginatedOnBranchAsync)
+      .mockResolvedValue([[{ ...updateStub, group: 'group-source', message: 'source message' }]]);
+
+    await new UpdateRollback(flags, commandOptions).run();
+
+    expect(UpdateRepublish.run).not.toHaveBeenCalled();
+    expect(UpdateRollBackToEmbedded.run).toHaveBeenCalledWith([
+      '--branch',
+      'main',
+      '--runtime-version',
+      'exposdk:47.0.0',
+      '--message',
+      'Roll back to embedded',
+      '--non-interactive',
+      '--platform',
+      'all',
+    ]);
+  });
+
+  it('forwards --message, --platform, and --private-key-path to the republish path', async () => {
+    const flags = [
+      'group-source',
+      '--non-interactive',
+      '--message',
+      'custom rollback message',
+      '--platform',
+      'ios',
+      '--private-key-path',
+      './keys/private-key.pem',
+    ];
+    mockTestProject();
+
+    jest
+      .mocked(UpdateQuery.viewUpdateGroupAsync)
+      .mockResolvedValue([{ ...updateStub, group: 'group-source' }]);
+
+    jest
+      .mocked(UpdateQuery.viewUpdateGroupsPaginatedOnBranchAsync)
+      .mockResolvedValue([
+        [{ ...updateStub, group: 'group-source', message: 'source message' }],
+        [{ ...updateStub, group: 'group-previous', message: 'previous message' }],
+      ]);
+
+    await new UpdateRollback(flags, commandOptions).run();
+
+    expect(UpdateRepublish.run).toHaveBeenCalledWith([
+      '--group',
+      'group-previous',
+      '--message',
+      'custom rollback message',
+      '--non-interactive',
+      '--platform',
+      'ios',
+      '--private-key-path',
+      './keys/private-key.pem',
+    ]);
+  });
+
+  it('forwards --json to the republish path', async () => {
+    const flags = ['group-source', '--json', '--non-interactive'];
+    mockTestProject();
+
+    jest
+      .mocked(UpdateQuery.viewUpdateGroupAsync)
+      .mockResolvedValue([{ ...updateStub, group: 'group-source' }]);
+
+    jest
+      .mocked(UpdateQuery.viewUpdateGroupsPaginatedOnBranchAsync)
+      .mockResolvedValue([
+        [{ ...updateStub, group: 'group-source', message: 'source message' }],
+        [{ ...updateStub, group: 'group-previous', message: 'previous message' }],
+      ]);
+
+    await new UpdateRollback(flags, commandOptions).run();
+
+    expect(UpdateRepublish.run).toHaveBeenCalledWith(expect.arrayContaining(['--json']));
+  });
+
+  it('forwards --platform and --private-key-path to the embedded rollback path', async () => {
+    const flags = [
+      'group-source',
+      '--non-interactive',
+      '--platform',
+      'ios',
+      '--private-key-path',
+      './keys/private-key.pem',
+    ];
+    mockTestProject();
+
+    jest
+      .mocked(UpdateQuery.viewUpdateGroupAsync)
+      .mockResolvedValue([{ ...updateStub, group: 'group-source' }]);
+
+    // No previous group -> roll back to embedded.
+    jest
+      .mocked(UpdateQuery.viewUpdateGroupsPaginatedOnBranchAsync)
+      .mockResolvedValue([[{ ...updateStub, group: 'group-source', message: 'source message' }]]);
+
+    await new UpdateRollback(flags, commandOptions).run();
+
+    expect(UpdateRepublish.run).not.toHaveBeenCalled();
+    expect(UpdateRollBackToEmbedded.run).toHaveBeenCalledWith([
+      '--branch',
+      'main',
+      '--runtime-version',
+      'exposdk:47.0.0',
+      '--message',
+      'Roll back to embedded',
+      '--non-interactive',
+      '--platform',
+      'ios',
+      '--private-key-path',
+      './keys/private-key.pem',
+    ]);
+  });
+
+  it('errors when the source group is not the latest update for its runtime version', async () => {
+    const flags = ['group-source', '--non-interactive'];
+    mockTestProject();
+
+    jest
+      .mocked(UpdateQuery.viewUpdateGroupAsync)
+      .mockResolvedValue([{ ...updateStub, group: 'group-source' }]);
+
+    // A newer group is the latest for this runtime version, so the source group is stale.
+    jest
+      .mocked(UpdateQuery.viewUpdateGroupsPaginatedOnBranchAsync)
+      .mockResolvedValue([
+        [{ ...updateStub, group: 'group-newer', message: 'newer message' }],
+        [{ ...updateStub, group: 'group-source', message: 'source message' }],
+      ]);
+
+    await expect(new UpdateRollback(flags, commandOptions).run()).rejects.toThrow(
+      'Update group "group-source" is not the latest update on branch "main" for runtime version "exposdk:47.0.0" (the latest is "group-newer"). Only the latest update can be rolled back.'
+    );
+
+    expect(UpdateRepublish.run).not.toHaveBeenCalled();
+    expect(UpdateRollBackToEmbedded.run).not.toHaveBeenCalled();
+  });
+});
+
+function mockTestProject({
+  configuredProjectId = '1234',
+  extraManifest,
+  extraVol,
+}: {
+  configuredProjectId?: string;
+  extraManifest?: Partial<ExpoConfig>;
+  extraVol?: DirectoryJSON;
+} = {}): void {
+  const packageJSON: PackageJSONConfig = {
+    name: 'testing123',
+    version: '0.1.0',
+    description: 'fake description',
+    main: 'index.js',
+  };
+
+  const appJSON: AppJSONConfig = {
+    expo: {
+      name: 'testing 123',
+      version: '0.1.0',
+      slug: 'testing-123',
+      sdkVersion: '33.0.0',
+      owner: jester.accounts[0].name,
+      extra: {
+        eas: {
+          projectId: configuredProjectId,
+        },
+      },
+      ...extraManifest,
+    },
+  };
+
+  vol.fromJSON(
+    {
+      'package.json': JSON.stringify(packageJSON),
+      'app.json': JSON.stringify(appJSON),
+      ...extraVol,
+    },
+    projectRoot
+  );
+
+  const mockManifest = { exp: appJSON.expo };
+  const graphqlClient = instance(mock<ExpoGraphqlClient>({}));
+
+  jest.mocked(getConfig).mockReturnValue(mockManifest as any);
+  jest.spyOn(PrivateProjectConfigContextField.prototype, 'getValueAsync').mockResolvedValue({
+    exp: mockManifest.exp,
+    projectDir: projectRoot,
+    projectId: configuredProjectId,
+  });
+
+  jest.spyOn(LoggedInContextField.prototype, 'getValueAsync').mockResolvedValue({
+    actor: jester,
+    featureGating: new FeatureGating({}, new FeatureGateEnvOverrides()),
+    graphqlClient,
+    authenticationInfo: { accessToken: null, sessionSecret: '1234' },
+  });
+
+  jest.mocked(AppQuery.byIdAsync).mockResolvedValue({
+    id: '1234',
+    slug: 'testing-123',
+    name: 'testing-123',
+    fullName: '@jester/testing-123',
+    ownerAccount: jester.accounts[0],
+  });
+}

--- a/packages/eas-cli/src/commands/update/rollback.ts
+++ b/packages/eas-cli/src/commands/update/rollback.ts
@@ -1,41 +1,188 @@
-import { Flags } from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 
 import UpdateRepublish from './republish';
 import UpdateRollBackToEmbedded from './roll-back-to-embedded';
 import EasCommand from '../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import {
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
+} from '../../commandUtils/flags';
+import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
 import { promptAsync } from '../../prompts';
 
-export default class UpdateRollback extends EasCommand {
-  static override description =
-    'Roll back to an embedded update or an existing update. Users wishing to run this command non-interactively should instead execute "eas update:republish" or "eas update:roll-back-to-embedded".';
+const defaultRollbackPlatforms = ['android', 'ios'] as const;
 
-  static override flags = {
-    'private-key-path': Flags.string({
-      description: `File containing the PEM-encoded private key corresponding to the certificate in expo-updates' configuration. Defaults to a file named "private-key.pem" in the certificate's directory. Only relevant if you are using code signing: https://docs.expo.dev/eas-update/code-signing/`,
+type SourceUpdateGroup = {
+  groupId: string;
+  branchName: string;
+  runtimeVersion: string;
+};
+
+type PreviousUpdateGroup = {
+  groupId: string;
+  message: string | null;
+};
+
+export default class UpdateRollback extends EasCommand {
+  static override description = 'roll back to an embedded update or an existing update';
+
+  static override args = {
+    groupId: Args.string({
+      description:
+        'The ID of the update group to roll back. Must be the latest update for its branch and runtime version. The update group published before it is republished; if there is none, a roll back to the embedded update is published. Required in non-interactive mode.',
       required: false,
     }),
   };
 
+  static override flags = {
+    message: Flags.string({
+      char: 'm',
+      description: 'Short message describing the rollback update',
+      required: false,
+    }),
+    platform: Flags.option({
+      char: 'p',
+      options: [...defaultRollbackPlatforms, 'all'] as const,
+      default: 'all',
+      required: false,
+    })(),
+    'private-key-path': Flags.string({
+      description: `File containing the PEM-encoded private key corresponding to the certificate in expo-updates' configuration. Defaults to a file named "private-key.pem" in the certificate's directory. Only relevant if you are using code signing: https://docs.expo.dev/eas-update/code-signing/`,
+      required: false,
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+    ...this.ContextOptions.LoggedIn,
+  };
+
   async runAsync(): Promise<void> {
-    const { flags } = await this.parse(UpdateRollback);
-
-    const { choice } = await promptAsync({
-      type: 'select',
-      message: 'Which type of update would you like to roll back to?',
-      name: 'choice',
-      choices: [
-        { title: 'Published Update', value: 'published' },
-        { title: 'Embedded Update', value: 'embedded' },
-      ],
-    });
-
+    const { args, flags } = await this.parse(UpdateRollback);
+    const { json, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+    const groupId = args.groupId;
+    const platform = flags.platform;
+    const messageArg = flags.message;
     const privateKeyPathArg = flags['private-key-path']
       ? ['--private-key-path', flags['private-key-path']]
       : [];
-    if (choice === 'published') {
-      await UpdateRepublish.run(privateKeyPathArg);
+
+    if (!groupId) {
+      if (nonInteractive) {
+        throw new Error('The update group ID argument is required in non-interactive mode.');
+      }
+
+      const { choice } = await promptAsync({
+        type: 'select',
+        message: 'Which type of update would you like to roll back to?',
+        name: 'choice',
+        choices: [
+          { title: 'Published Update', value: 'published' },
+          { title: 'Embedded Update', value: 'embedded' },
+        ],
+      });
+
+      if (choice === 'published') {
+        await UpdateRepublish.run(privateKeyPathArg);
+      } else {
+        await UpdateRollBackToEmbedded.run(privateKeyPathArg);
+      }
+      return;
+    }
+
+    const {
+      loggedIn: { graphqlClient },
+      privateProjectConfig: { projectId },
+    } = await this.getContextAsync(UpdateRollback, {
+      nonInteractive,
+      withServerSideEnvironment: null,
+    });
+
+    const sourceGroup = await getSourceUpdateGroupAsync(graphqlClient, groupId);
+    const previousGroup = await getPreviousUpdateGroupAsync(graphqlClient, projectId, sourceGroup);
+
+    const commonArgs = [
+      '--non-interactive',
+      '--platform',
+      platform,
+      ...privateKeyPathArg,
+      ...(json ? ['--json'] : []),
+    ];
+
+    if (previousGroup) {
+      const message =
+        messageArg ??
+        `Roll back to "${previousGroup.message ?? ''}" (group: ${previousGroup.groupId})`;
+      await UpdateRepublish.run([
+        '--group',
+        previousGroup.groupId,
+        '--message',
+        message,
+        ...commonArgs,
+      ]);
     } else {
-      await UpdateRollBackToEmbedded.run(privateKeyPathArg);
+      const message = messageArg ?? 'Roll back to embedded';
+      await UpdateRollBackToEmbedded.run([
+        '--branch',
+        sourceGroup.branchName,
+        '--runtime-version',
+        sourceGroup.runtimeVersion,
+        '--message',
+        message,
+        ...commonArgs,
+      ]);
     }
   }
+}
+
+async function getSourceUpdateGroupAsync(
+  graphqlClient: ExpoGraphqlClient,
+  groupId: string
+): Promise<SourceUpdateGroup> {
+  // viewUpdateGroupAsync throws if no updates are found for the group ID.
+  const updateGroup = await UpdateQuery.viewUpdateGroupAsync(graphqlClient, { groupId });
+  const arbitraryUpdate = updateGroup[0];
+  return {
+    groupId,
+    branchName: arbitraryUpdate.branch.name,
+    runtimeVersion: arbitraryUpdate.runtimeVersion,
+  };
+}
+
+async function getPreviousUpdateGroupAsync(
+  graphqlClient: ExpoGraphqlClient,
+  projectId: string,
+  sourceGroup: SourceUpdateGroup
+): Promise<PreviousUpdateGroup | null> {
+  // Clients on a given runtime version are served the latest update group on the branch,
+  // so a rollback is only meaningful when the source group is that latest group. Fetch the
+  // two most recent groups for the runtime version (returned most-recent-first): the first
+  // must be the source group, and the second (if any) is the update to roll back to.
+  const latestGroups = await UpdateQuery.viewUpdateGroupsPaginatedOnBranchAsync(graphqlClient, {
+    appId: projectId,
+    branchName: sourceGroup.branchName,
+    first: 2,
+    filter: { runtimeVersions: [sourceGroup.runtimeVersion] },
+  });
+
+  const latestGroup = latestGroups[0];
+  if (!latestGroup?.length || latestGroup[0].group !== sourceGroup.groupId) {
+    throw new Error(
+      `Update group "${sourceGroup.groupId}" is not the latest update on branch "${
+        sourceGroup.branchName
+      }" for runtime version "${sourceGroup.runtimeVersion}"${
+        latestGroup?.length ? ` (the latest is "${latestGroup[0].group}")` : ''
+      }. Only the latest update can be rolled back.`
+    );
+  }
+
+  // Source group is the only update for this runtime version: roll back to embedded.
+  const previousGroup = latestGroups[1];
+  if (!previousGroup?.length) {
+    return null;
+  }
+
+  return { groupId: previousGroup[0].group, message: previousGroup[0].message ?? null };
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -13589,6 +13589,19 @@ export type ViewUpdateGroupsOnBranchQueryVariables = Exact<{
 
 export type ViewUpdateGroupsOnBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, isGitWorkingTreeDirty: boolean, environment?: any | null, rolloutPercentage?: number | null, manifestHostOverride?: string | null, assetHostOverride?: string | null, actor?: { __typename: 'PartnerActor', username: string, id: string } | { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string, group: string } | null, fingerprint?: { __typename?: 'Fingerprint', id: string, hash: string, debugInfoUrl?: string | null, source?: { __typename?: 'FingerprintSource', type: FingerprintSourceType, bucketKey: string, isDebugFingerprint?: boolean | null } | null } | null }>> } | null } } };
 
+export type ViewUpdateGroupsPaginatedOnBranchQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+  branchName: Scalars['String']['input'];
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<UpdatesFilterV2>;
+}>;
+
+
+export type ViewUpdateGroupsPaginatedOnBranchQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateBranchByName?: { __typename?: 'UpdateBranch', id: string, updateGroupsPaginated: { __typename?: 'UpdateGroupsConnection', edges: Array<{ __typename?: 'UpdateGroupEdge', node: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, isGitWorkingTreeDirty: boolean, environment?: any | null, rolloutPercentage?: number | null, manifestHostOverride?: string | null, assetHostOverride?: string | null, actor?: { __typename: 'PartnerActor', username: string, id: string } | { __typename: 'Robot', firstName?: string | null, id: string } | { __typename: 'SSOUser', username: string, id: string } | { __typename: 'User', username: string, id: string } | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string, group: string } | null, fingerprint?: { __typename?: 'Fingerprint', id: string, hash: string, debugInfoUrl?: string | null, source?: { __typename?: 'FingerprintSource', type: FingerprintSourceType, bucketKey: string, isDebugFingerprint?: boolean | null } | null } | null }> }> } } | null } } };
+
 export type ViewUpdateGroupsOnAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];
   limit: Scalars['Int']['input'];

--- a/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/UpdateQuery.ts
@@ -11,6 +11,8 @@ import {
   ViewUpdateGroupsOnAppQueryVariables,
   ViewUpdateGroupsOnBranchQuery,
   ViewUpdateGroupsOnBranchQueryVariables,
+  ViewUpdateGroupsPaginatedOnBranchQuery,
+  ViewUpdateGroupsPaginatedOnBranchQueryVariables,
   ViewUpdatesByGroupQuery,
   ViewUpdatesByGroupQueryVariables,
 } from '../generated';
@@ -95,6 +97,80 @@ export const UpdateQuery = {
     }
 
     return branch.updateGroups;
+  },
+  async viewUpdateGroupsPaginatedOnBranchAsync(
+    graphqlClient: ExpoGraphqlClient,
+    {
+      appId,
+      branchName,
+      first,
+      last,
+      after,
+      before,
+      filter,
+    }: ViewUpdateGroupsPaginatedOnBranchQueryVariables
+  ): Promise<UpdateFragment[][]> {
+    const response = await withErrorHandlingAsync(
+      graphqlClient
+        .query<
+          ViewUpdateGroupsPaginatedOnBranchQuery,
+          ViewUpdateGroupsPaginatedOnBranchQueryVariables
+        >(
+          gql`
+            query ViewUpdateGroupsPaginatedOnBranch(
+              $appId: String!
+              $branchName: String!
+              $first: Int
+              $last: Int
+              $after: String
+              $before: String
+              $filter: UpdatesFilterV2
+            ) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  updateBranchByName(name: $branchName) {
+                    id
+                    updateGroupsPaginated(
+                      first: $first
+                      last: $last
+                      after: $after
+                      before: $before
+                      filter: $filter
+                    ) {
+                      edges {
+                        node {
+                          id
+                          ...UpdateFragment
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            ${print(UpdateFragmentNode)}
+          `,
+          {
+            appId,
+            branchName,
+            first,
+            last,
+            after,
+            before,
+            filter,
+          },
+          { additionalTypenames: ['Update'] }
+        )
+        .toPromise()
+    );
+    const branch = response.app.byId.updateBranchByName;
+
+    if (!branch) {
+      throw new Error(`Could not find branch "${branchName}"`);
+    }
+
+    return branch.updateGroupsPaginated.edges.map(edge => edge.node);
   },
   async viewUpdateGroupsOnAppAsync(
     graphqlClient: ExpoGraphqlClient,


### PR DESCRIPTION
# Why
Slack context: https://exponent-internal.slack.com/archives/C083Q88U4M8/p1780603389422949

`eas update:rollback` used to be interactive only: it prompts whether to republish a previous update or roll back to the embedded bundle, then delegates to `eas update:republish` / `eas update:roll-back-to-embedded`. Teams building rollback pipelines (e.g. with access controls around who can change prod) want a single non-interactive command that "just rolls back the specified update" without having to know which of the two underlying commands to run. Motivated by a customer request.

# Manual testing
### Published regular update (`eas update --branch main`)
<img width="622" height="224" alt="Screenshot 2026-06-05 at 10 16 34 PM" src="https://github.com/user-attachments/assets/66bfa38f-d5aa-4d9a-929d-df83cb09fac3" />

### Rollback with only 1 update group published for runtime/branch pair
<img width="937" height="328" alt="Screenshot 2026-06-05 at 10 17 27 PM" src="https://github.com/user-attachments/assets/bca6bc13-409a-450a-85c6-632c74018ac7" />

### Rollback when update group is not latest for runtime/branch pair
<img width="1226" height="165" alt="Screenshot 2026-06-05 at 10 17 36 PM" src="https://github.com/user-attachments/assets/90198ea5-aae8-4c58-a557-9e9509174af6" />

### Rollback with multiple update groups published for runtime/branch pair
<img width="1216" height="340" alt="Screenshot 2026-06-05 at 10 18 15 PM" src="https://github.com/user-attachments/assets/a2f54e07-c636-4d23-a95f-7d4143e6da44" />

### Rollback with invalid group id
<img width="959" height="145" alt="Screenshot 2026-06-05 at 10 18 22 PM" src="https://github.com/user-attachments/assets/1f9c28de-bd9b-4b32-8490-681d76dd4daa" />

# How

Adds an optional positional `GROUP_ID` argument to `eas update:rollback`:

- Looks up the group and derives its branch + runtime version.
- Requires the group to be the **latest (live) update** for that branch + runtime version. Clients on a given runtime version are served the most recent update group, so a rollback only makes sense for the live one. If the passed group is not the latest, the command errors and names the actual latest group — a stale/wrong ID, or a newer update published in between, halts the pipeline rather than silently reverting the wrong thing.
- Republishes the update group published immediately before it; if there is none, publishes a roll back to the embedded update.
- Delegates to the existing `eas update:republish` / `eas update:roll-back-to-embedded` commands, reusing all of their validation and publish logic. `--message` (with sensible defaults), `--platform`, `--private-key-path`, and `--json` are forwarded.

With no `GROUP_ID`, the existing interactive behavior is unchanged; in `--non-interactive` mode the argument is required.

The latest/previous lookup uses the modern `updateGroupsPaginated` Relay connection (`UpdatesFilterV2`), fetching just the top two groups for the runtime version.

# Test Plan

- New unit tests in `rollback.test.ts` (7 cases): republish previous group, roll back to embedded when there is no previous group, not-latest → error, missing group ID in `--non-interactive` → error, and `--message` / `--platform` / `--private-key-path` / `--json` forwarding on both delegated paths.
- `yarn test src/commands/update` — all update-command suites pass.
- `yarn typecheck`, `yarn lint`, and `yarn fmt:check` are clean.
- `yarn verify-graphql-code` confirms the generated GraphQL is in sync.
