### PR TITLE
fix: normalize Windows .gitignore archive paths

### DIFF
--- a/packages/eas-cli/src/vcs/__tests__/local-test.ts
+++ b/packages/eas-cli/src/vcs/__tests__/local-test.ts
@@ -25,6 +25,18 @@ describe(Ignore, () => {
     expect(ignore.ignores('dir/bbb')).toBe(true);
   });
 
+  it('matches nested .gitignore prefixes against Windows-style relative paths', async () => {
+    vol.fromJSON(
+      {
+        'packages/app/.gitignore': 'ignored.txt',
+      },
+      '/root'
+    );
+
+    const ignore = await Ignore.createForCopyingAsync('/root');
+    expect(ignore.ignores(String.raw`packages\app\ignored.txt`)).toBe(true);
+  });
+
   it('ignores .gitignore files if .easignore is present', async () => {
     vol.fromJSON(
       {
@@ -110,5 +122,18 @@ describe(Ignore, () => {
 
     const ignore = await Ignore.createForCopyingAsync('/root');
     expect(() => ignore.ignores('dir/test')).not.toThrowError();
+  });
+
+  it('treats directory rules as directories when checking copy filters', async () => {
+    vol.fromJSON(
+      {
+        '.gitignore': 'dist/\n',
+      },
+      '/root'
+    );
+
+    const ignore = await Ignore.createForCopyingAsync('/root');
+    expect(ignore.ignores('dist', { isDirectory: true })).toBe(true);
+    expect(ignore.ignores('dist/index.js')).toBe(true);
   });
 });

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -83,14 +83,27 @@ node_modules
     });
   }
 
-  public ignores(relativePath: string): boolean {
+  public ignores(relativePath: string, options: { isDirectory?: boolean } = {}): boolean {
+    const normalizedPath = normalizeIgnorePath(relativePath, options);
     for (const [prefix, ignore] of this.ignoreMapping) {
-      if (relativePath.startsWith(prefix) && ignore.ignores(relativePath.slice(prefix.length))) {
+      const normalizedPrefix = normalizeIgnorePath(prefix);
+      if (
+        normalizedPath.startsWith(normalizedPrefix) &&
+        ignore.ignores(normalizedPath.slice(normalizedPrefix.length))
+      ) {
         return true;
       }
     }
     return false;
   }
+}
+
+function normalizeIgnorePath(relativePath: string, options: { isDirectory?: boolean } = {}): string {
+  const normalizedPath = relativePath.replace(/\\/g, '/');
+  if (options.isDirectory && normalizedPath && !normalizedPath.endsWith('/')) {
+    return `${normalizedPath}/`;
+  }
+  return normalizedPath;
 }
 
 export async function makeShallowCopyAsync(_src: string, dst: string): Promise<void> {
@@ -114,8 +127,11 @@ export async function makeShallowCopyAsync(_src: string, dst: string): Promise<v
       if (srcFilePath === src) {
         return true;
       }
+      const stats = fsExtra.lstatSync(srcFilePath);
       const relativePath = path.relative(src, srcFilePath);
-      const shouldCopyTheItem = !ignore.ignores(relativePath);
+      const shouldCopyTheItem = !ignore.ignores(relativePath, {
+        isDirectory: stats.isDirectory(),
+      });
 
       Log.debug(shouldCopyTheItem ? 'copying' : 'skipping', {
         src,


### PR DESCRIPTION
## Summary
- normalize Windows relative paths and nested `.gitignore` prefixes to forward slashes before prefix matching
- treat directory paths as directories during archive copy filtering so rules like `dist/` and `.expo/` match the directory itself
- add regression coverage for Windows-style nested `.gitignore` prefixes and directory rules

## Root cause
`Ignore.ignores()` compared nested `.gitignore` prefixes captured with `/` against `path.relative(...)` results that use `\` on Windows, so nested package ignore rules never matched during `eas build:inspect --stage archive`. Directory-only rules also needed the filter path normalized as a directory.

## Testing
- `corepack yarn workspace eas-cli test src/vcs/__tests__/local-test.ts --runInBand`
- `git diff --check`

Fixes #3733