### PR TITLE
[build-tools] fetch Cloudflare TURN ICE servers from www and pass to serve-sim

### DIFF
--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -108,7 +108,7 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       // on Darwin. Android sessions go without a preview URL.
       let webPreviewUrl: string | undefined;
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
-        const { previewUrl } = await startServeSimWithTunnelAsync({
+        const { previewUrl } = await startServeSimWithTunnelAsync(ctx, {
           baseDomain: ngrokTunnelDomain,
           env,
           logger,

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -101,7 +101,7 @@ export function createStartArgentRemoteSessionBuildFunction(
       // serve-sim is iOS-only — Android sessions go without a preview URL.
       let webPreviewUrl: string | undefined;
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
-        const serveSim = await startServeSimWithTunnelAsync({
+        const serveSim = await startServeSimWithTunnelAsync(ctx, {
           baseDomain: ngrokTunnelDomain,
           env,
           logger,

--- a/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
@@ -30,7 +30,7 @@ export function createStartServeSimRemoteSessionBuildFunction(
       logger.info(`Selecting Xcode developer directory: ${XCODE_DEVELOPER_DIR}.`);
       await spawn('sudo', ['xcode-select', '-s', XCODE_DEVELOPER_DIR], { env, logger });
 
-      const { previewUrl, streamUrl } = await startServeSimWithTunnelAsync({
+      const { previewUrl, streamUrl } = await startServeSimWithTunnelAsync(ctx, {
         baseDomain: ngrokTunnelDomain,
         env,
         logger,

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -1,0 +1,154 @@
+import { bunyan } from '@expo/logger';
+import { BuildStepEnv } from '@expo/steps';
+
+import { CustomBuildContext } from '../../../customBuildContext';
+import { Sentry } from '../../../sentry';
+import { turtleFetch } from '../../../utils/turtleFetch';
+import {
+  fetchServeSimTurnArgsAsync,
+  turnIceServersToServeSimArgs,
+} from '../remoteDeviceRunSession';
+
+jest.mock('../../../utils/turtleFetch');
+jest.mock('../../../sentry');
+
+function createLoggerMock(): bunyan {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as bunyan;
+}
+
+function createCtxMock(): CustomBuildContext {
+  return {
+    env: {
+      __API_SERVER_URL: 'https://api.expo.test',
+    },
+    job: {
+      secrets: { robotAccessToken: 'robot-token' },
+    },
+  } as unknown as CustomBuildContext;
+}
+
+function createEnvMock(): BuildStepEnv {
+  return { DEVICE_RUN_SESSION_ID: 'drs-id' } as unknown as BuildStepEnv;
+}
+
+describe(turnIceServersToServeSimArgs, () => {
+  it('returns no args for an empty ICE server list', () => {
+    expect(turnIceServersToServeSimArgs([])).toEqual([]);
+  });
+
+  it('builds --stun-url and --turn-url flags from Cloudflare ICE servers', () => {
+    expect(
+      turnIceServersToServeSimArgs([
+        { urls: ['stun:stun.cloudflare.com:3478', 'stun:stun.cloudflare.com:53'] },
+        {
+          urls: [
+            'turn:turn.cloudflare.com:3478?transport=udp',
+            'turns:turn.cloudflare.com:443?transport=tcp',
+          ],
+          username: 'user-123',
+          credential: 'cred-456',
+        },
+      ])
+    ).toEqual([
+      '--stun-url',
+      'stun:stun.cloudflare.com:3478,stun:stun.cloudflare.com:53',
+      '--turn-url',
+      'turn:turn.cloudflare.com:3478?transport=udp,turns:turn.cloudflare.com:443?transport=tcp',
+      '--turn-username',
+      'user-123',
+      '--turn-credential',
+      'cred-456',
+    ]);
+  });
+
+  it('emits only --turn-url flags when no credential-less (STUN) entry is present', () => {
+    expect(
+      turnIceServersToServeSimArgs([
+        {
+          urls: ['turns:turn.cloudflare.com:443?transport=tcp'],
+          username: 'u',
+          credential: 'c',
+        },
+      ])
+    ).toEqual([
+      '--turn-url',
+      'turns:turn.cloudflare.com:443?transport=tcp',
+      '--turn-username',
+      'u',
+      '--turn-credential',
+      'c',
+    ]);
+  });
+
+  it('emits only --stun-url when there is no credentialed TURN entry', () => {
+    expect(turnIceServersToServeSimArgs([{ urls: ['stun:stun.cloudflare.com:3478'] }])).toEqual([
+      '--stun-url',
+      'stun:stun.cloudflare.com:3478',
+    ]);
+  });
+});
+
+describe(fetchServeSimTurnArgsAsync, () => {
+  beforeEach(() => {
+    jest.mocked(turtleFetch).mockReset();
+  });
+
+  it('requests TURN ICE servers from the device run session endpoint and returns serve-sim args', async () => {
+    jest.mocked(turtleFetch).mockResolvedValue({
+      json: async () => ({
+        data: {
+          iceServers: [
+            { urls: ['stun:stun.cloudflare.com:3478'] },
+            {
+              urls: ['turns:turn.cloudflare.com:443?transport=tcp'],
+              username: 'u',
+              credential: 'c',
+            },
+          ],
+        },
+      }),
+    } as unknown as Awaited<ReturnType<typeof turtleFetch>>);
+
+    const args = await fetchServeSimTurnArgsAsync(createCtxMock(), {
+      env: createEnvMock(),
+      logger: createLoggerMock(),
+    });
+
+    expect(args).toEqual([
+      '--stun-url',
+      'stun:stun.cloudflare.com:3478',
+      '--turn-url',
+      'turns:turn.cloudflare.com:443?transport=tcp',
+      '--turn-username',
+      'u',
+      '--turn-credential',
+      'c',
+    ]);
+    expect(jest.mocked(turtleFetch)).toHaveBeenCalledWith(
+      'https://api.expo.test/v2/device-run-sessions/drs-id/turn-ice-servers',
+      'POST',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer robot-token' },
+      })
+    );
+  });
+
+  it('returns [] and warns when the request fails so serve-sim falls back to P2P/STUN', async () => {
+    jest.mocked(turtleFetch).mockRejectedValue(new Error('boom'));
+    const logger = createLoggerMock();
+
+    const args = await fetchServeSimTurnArgsAsync(createCtxMock(), {
+      env: createEnvMock(),
+      logger,
+    });
+
+    expect(args).toEqual([]);
+    expect(logger.warn).toHaveBeenCalled();
+    expect(jest.mocked(Sentry).capture).toHaveBeenCalled();
+  });
+});

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -4,11 +4,15 @@ import { BuildStepEnv } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
 import * as ngrok from '@ngrok/ngrok';
 import { graphql } from 'gql.tada';
+import nullthrows from 'nullthrows';
+import { z } from 'zod';
 import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 
 import { CustomBuildContext } from '../../customBuildContext';
+import { Sentry } from '../../sentry';
 import { sleepAsync } from '../../utils/retry';
+import { turtleFetch } from '../../utils/turtleFetch';
 
 const START_DEVICE_RUN_SESSION_MUTATION = graphql(`
   mutation StartDeviceRunSession($deviceRunSessionId: ID!, $remoteConfig: JSONObject!) {
@@ -58,6 +62,105 @@ export function getNgrokAuthtokenOrThrow(env: BuildStepEnv): string {
     );
   }
   return authtoken;
+}
+
+const TurnIceServersSchema = z.array(
+  z.object({
+    urls: z.array(z.string()),
+    username: z.string().optional(),
+    credential: z.string().optional(),
+  })
+);
+
+export type TurnIceServers = z.infer<typeof TurnIceServersSchema>;
+
+const TurnIceServersResponseSchema = z.object({
+  data: z.object({
+    iceServers: TurnIceServersSchema,
+  }),
+});
+
+/**
+ * Translate Cloudflare ICE servers into serve-sim CLI flags: `--stun-url` (the
+ * credential-less entries) and `--turn-url`/`--turn-username`/`--turn-credential`
+ * (the entry carrying the short-lived credentials).
+ */
+export function turnIceServersToServeSimArgs(iceServers: TurnIceServers): string[] {
+  const stunUrls = iceServers
+    .filter(server => !server.username && !server.credential)
+    .flatMap(server => server.urls);
+  const turnServer = iceServers.find(server => server.username && server.credential);
+
+  const args: string[] = [];
+  if (stunUrls.length > 0) {
+    args.push('--stun-url', stunUrls.join(','));
+  }
+  if (turnServer?.username && turnServer.credential && turnServer.urls.length > 0) {
+    args.push(
+      '--turn-url',
+      turnServer.urls.join(','),
+      '--turn-username',
+      turnServer.username,
+      '--turn-credential',
+      turnServer.credential
+    );
+  }
+  return args;
+}
+
+/**
+ * Fetch short-lived Cloudflare TURN ICE servers for this job run from www
+ * (minted on demand, mirroring how the worker fetches project clone URLs) and
+ * translate them into serve-sim CLI flags.
+ *
+ * Best-effort: on any failure we log and return [] so serve-sim falls back to
+ * its built-in P2P/STUN behavior. The credential is passed to serve-sim as a
+ * process arg and deliberately not logged (turtle-spawn never logs argv and the
+ * worker is single-tenant).
+ */
+export async function fetchServeSimTurnArgsAsync(
+  ctx: CustomBuildContext,
+  { env, logger }: { env: BuildStepEnv; logger: bunyan }
+): Promise<string[]> {
+  try {
+    const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
+    const expoApiServerUrl = nullthrows(ctx.env.__API_SERVER_URL, '__API_SERVER_URL is not set');
+    const robotAccessToken = nullthrows(
+      ctx.job.secrets?.robotAccessToken,
+      'robot access token is not set'
+    );
+
+    const response = await turtleFetch(
+      new URL(
+        `/v2/device-run-sessions/${deviceRunSessionId}/turn-ice-servers`,
+        expoApiServerUrl
+      ).toString(),
+      'POST',
+      {
+        headers: {
+          Authorization: `Bearer ${robotAccessToken}`,
+        },
+        timeout: 5000,
+        retries: 1,
+        logger,
+      }
+    );
+
+    const { data } = TurnIceServersResponseSchema.parse(await response.json());
+    const args = turnIceServersToServeSimArgs(data.iceServers);
+    if (args.length > 0) {
+      logger.info('Configured serve-sim with Cloudflare TURN ICE servers.');
+    }
+    return args;
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    Sentry.capture('Could not fetch Cloudflare TURN ICE servers', error, { level: 'warning' });
+    logger.warn(
+      { err: error },
+      'Could not fetch Cloudflare TURN ICE servers; serve-sim will fall back to P2P/STUN.'
+    );
+    return [];
+  }
 }
 
 export async function uploadRemoteSessionConfigAsync({
@@ -120,18 +223,22 @@ export function spawnDetached({
   return { getOutput: () => output };
 }
 
-export async function startServeSimWithTunnelAsync({
-  baseDomain,
-  env,
-  logger,
-  timeoutMs,
-}: {
-  baseDomain: string;
-  env: BuildStepEnv;
-  logger: bunyan;
-  timeoutMs: number;
-}): Promise<{ previewUrl: string; streamUrl: string }> {
+export async function startServeSimWithTunnelAsync(
+  ctx: CustomBuildContext,
+  {
+    baseDomain,
+    env,
+    logger,
+    timeoutMs,
+  }: {
+    baseDomain: string;
+    env: BuildStepEnv;
+    logger: bunyan;
+    timeoutMs: number;
+  }
+): Promise<{ previewUrl: string; streamUrl: string }> {
   logger.info('Launching serve-sim with tunnel.');
+  const turnArgs = await fetchServeSimTurnArgsAsync(ctx, { env, logger });
   const serveSim = spawnDetached({
     command: 'npx',
     args: [
@@ -147,6 +254,7 @@ export async function startServeSimWithTunnelAsync({
       '0.55',
       '--codec',
       'webrtc',
+      ...turnArgs,
     ],
     env,
   });


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Part of adding a Cloudflare TURN relay so the remote-simulator WebRTC stream works on networks that block UDP or use symmetric NAT (corporate firewalls) — where STUN-only leaves the **video black even though touch/clicks still work**. The companion change in universe (expo/universe#27973) exposes a worker-facing route that mints short-lived TURN credentials on demand; this PR fetches them and feeds them to serve-sim.

# How

When launching serve-sim, the worker fetches short-lived TURN ICE servers from www's `POST /v2/device-run-sessions/:deviceRunSessionId/turn-ice-servers` route via `turtleFetch` — the same robot-token pattern it already uses to fetch the project clone URL (`download-project-archive`) — keyed on the `DEVICE_RUN_SESSION_ID` it already has, and turns them into serve-sim CLI flags:

- `--stun-url` from the credential-less (STUN) entries, and `--turn-url` / `--turn-username` / `--turn-credential` from the entry that carries the short-lived credentials.
- Wired into the shared `startServeSimWithTunnelAsync`, so it covers all three serve-sim launchers (serve-sim, agent-device, and argent web preview).
- **Best-effort:** any failure (mint error, network, unexpected shape) → no flags; serve-sim falls back to its built-in P2P/STUN behavior, so it never blocks a session.
- The credential is passed as a process arg and deliberately **not logged** (turtle-spawn never logs argv, and the worker is single-tenant).

No GraphQL/schema change — this rides the existing `turtle-job-runs` REST router.

> Requires a serve-sim release that accepts a comma-separated `--turn-url` (the worker runs `serve-sim-szdziedzic@latest`), so publish serve-sim first.

# Test Plan

- New unit tests (`remoteDeviceRunSession.test.ts`):
  - `turnIceServersToServeSimArgs` — a valid Cloudflare ICE-servers payload produces the expected `--stun-url` / `--turn-url` / `--turn-username` / `--turn-credential` flags; TURN-only and STUN-only payloads emit the right subset; an empty list produces no flags.
  - `fetchServeSimTurnArgsAsync` — requests the job-run route and returns args on success; returns `[]` and warns on failure (P2P/STUN fallback).
  - **6/6 passing** (`yarn jest-unit remoteDeviceRunSession`).
- `tsc` and `oxlint` clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
