### PR TITLE
[eas-cli] Show Organization label and drop "Limited" prefix in new project account picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Drop confusing `Limited` prefix and add `(Organization)` label in the account picker shown by `eas new`. ([#3829](https://github.com/expo/eas-cli/pull/3829) by [@davidmokos](https://github.com/davidmokos))
+
 ## [20.1.0](https://github.com/expo/eas-cli/releases/tag/v20.1.0) - 2026-06-05
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commandUtils/new/__tests__/configs.test.ts
+++ b/packages/eas-cli/src/commandUtils/new/__tests__/configs.test.ts
@@ -159,14 +159,14 @@ describe('configs', () => {
 
       expect(result).toEqual([
         {
-          title: 'other',
+          title: 'other (Organization)',
           value: { name: 'other' },
           disabled: true,
           description:
             'You do not have the required permissions to create projects on this account.',
         },
         {
-          title: 'jester',
+          title: 'jester (Organization)',
           value: { name: 'jester' },
         },
       ]);

--- a/packages/eas-cli/src/commandUtils/new/configs.ts
+++ b/packages/eas-cli/src/commandUtils/new/configs.ts
@@ -120,14 +120,14 @@ export function getAccountChoices(actor: Actor, permissionsMap?: Map<string, boo
   const sortedAccounts = [...actor.accounts].sort((a, _b) => (a.ownerUserActor ? 1 : -1));
 
   return sortedAccounts.map(account => {
-    const isPersonalAccount = !!account.ownerUserActor && account.ownerUserActor.id === actor.id;
-    const isTeamAccount = !!account.ownerUserActor && account.ownerUserActor.id !== actor.id;
-
-    const accountDisplayName = isPersonalAccount
-      ? `${account.name} (Limited - Personal Account)`
-      : isTeamAccount
-        ? `${account.name} (Limited - Team Account)`
-        : account.name;
+    // Team accounts are a legacy setup - a personal (user-owned) account with
+    // additional collaborators. New multi-user setups use Organizations instead.
+    const accountKindSuffix = !account.ownerUserActor
+      ? '(Organization)'
+      : account.ownerUserActor.id === actor.id
+        ? '(Personal)'
+        : '(Team)';
+    const accountDisplayName = `${account.name} ${accountKindSuffix}`;
 
     const disabled = !permissions.get(account.name);
 


### PR DESCRIPTION
# Why

The account picker shown by `eas new` (when choosing which account to own a new project) currently labels accounts as:

- `(Limited - Personal Account)` for your own personal account
- `(Limited - Team Account)` for accounts owned by another user that you've been added to
- *(no label)* for Organization accounts

<img width="646" height="101" alt="Screenshot 2026-06-08 at 14 05 28" src="https://github.com/user-attachments/assets/2427bc7d-e1ca-462b-a222-68a0b6bc8d98" />

The "Limited" prefix is confusing - it reads as if some restriction applies to the user, when it's really just describing the kind of account. Organizations are also unlabeled, which makes it hard to tell at a glance what kind of account each row represents (especially when an org and a personal account share a similar name).

The result would look something like this:
<img width="560" height="138" alt="Screenshot 2026-06-08 at 16 30 51" src="https://github.com/user-attachments/assets/6495811d-7003-4ad6-b1cd-f0ffbf04d80f" />

# How

- Drops the `Limited - ` prefix.
- Adds a `(Organization)` label for Organization-owned accounts (detected via `!account.ownerUserActor`, matching the existing check in `commands/project/init.ts`).
- Adds a short comment noting that `(Team)` is the legacy setup (a user-owned account with extra collaborators) — new multi-user setups use Organizations.
- Collapses the three boolean flags + nested ternary into a single suffix derived directly from `ownerUserActor`, removing an unreachable fallback branch.

Resulting labels:

- `my-personal (Personal)` — your own personal account
- `some-team (Team)` — legacy user-owned account you were added to
- `some-org (Organization)` — Organization account

# Test Plan

- Ran `eas new` against an account with a mix of personal / team / organization memberships and confirmed each row renders the new label.
- `yarn typecheck` and `yarn lint` pass for `eas-cli`.