### PR TITLE
[eas-cli] Add 11 new App Store Connect metadata locales

### DIFF
--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -760,6 +760,7 @@
         "additionalProperties": false,
         "properties": {
           "ar-SA": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Arabic" },
+          "bn-BD": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Bengali" },
           "ca": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Catalan" },
           "zh-Hans": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Chinese (Simplified)" },
           "zh-Hant": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Chinese (Traditional)" },
@@ -776,27 +777,37 @@
           "fr-CA": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "French (Canada)" },
           "de-DE": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "German" },
           "el": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Greek" },
+          "gu-IN": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Gujarati" },
           "he": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Hebrew" },
           "hi": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Hindi" },
           "hu": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Hungarian" },
           "id": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Indonesian" },
           "it": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Italian" },
           "ja": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Japanese" },
+          "kn-IN": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Kannada" },
           "ko": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Korean" },
           "ms": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Malay" },
+          "ml-IN": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Malayalam" },
+          "mr-IN": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Marathi" },
           "no": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Norwegian" },
+          "or-IN": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Oriya" },
           "pl": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Polish" },
           "pt-BR": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Portuguese (Brazil)" },
           "pt-PT": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Portuguese (Portugal)" },
+          "pa-IN": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Punjabi" },
           "ro": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Romanian" },
           "ru": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Russian" },
           "sk": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Slovak" },
+          "sl-SI": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Slovenian" },
           "es-MX": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Spanish (Mexico)" },
           "es-ES": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Spanish (Spain)" },
           "sv": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Swedish" },
+          "ta-IN": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Tamil" },
+          "te-IN": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Telugu" },
           "th": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Thai" },
           "tr": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Turkish" },
           "uk": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Ukrainian" },
+          "ur-PK": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Urdu" },
           "vi": { "$ref": "#/definitions/apple/AppleAppClipLocalizedInfo", "description": "Vietnamese" }
         }
       },
@@ -869,6 +880,10 @@
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Arabic"
             },
+            "bn-BD": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Bengali"
+            },
             "ca": {
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Catalan"
@@ -933,6 +948,10 @@
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Greek"
             },
+            "gu-IN": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Gujarati"
+            },
             "he": {
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Hebrew"
@@ -957,6 +976,10 @@
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Japanese"
             },
+            "kn-IN": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Kannada"
+            },
             "ko": {
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Korean"
@@ -965,9 +988,21 @@
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Malay"
             },
+            "ml-IN": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Malayalam"
+            },
+            "mr-IN": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Marathi"
+            },
             "no": {
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Norwegian"
+            },
+            "or-IN": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Oriya"
             },
             "pl": {
               "$ref": "#/definitions/apple/AppleInfo",
@@ -981,6 +1016,10 @@
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Portuguese (Portugal)"
             },
+            "pa-IN": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Punjabi"
+            },
             "ro": {
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Romanian"
@@ -992,6 +1031,10 @@
             "sk": {
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Slovak"
+            },
+            "sl-SI": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Slovenian"
             },
             "es-MX": {
               "$ref": "#/definitions/apple/AppleInfo",
@@ -1005,6 +1048,14 @@
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Swedish"
             },
+            "ta-IN": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Tamil"
+            },
+            "te-IN": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Telugu"
+            },
             "th": {
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Thai"
@@ -1016,6 +1067,10 @@
             "uk": {
               "$ref": "#/definitions/apple/AppleInfo",
               "description": "Ukrainian"
+            },
+            "ur-PK": {
+              "$ref": "#/definitions/apple/AppleInfo",
+              "description": "Urdu"
             },
             "vi": {
               "$ref": "#/definitions/apple/AppleInfo",

--- a/packages/eas-cli/src/submit/ios/utils/language.ts
+++ b/packages/eas-cli/src/submit/ios/utils/language.ts
@@ -77,6 +77,10 @@ const LANGUAGES: Language[] = [
     itcLocale: 'ar-SA',
   },
   {
+    locale: 'bn-BD',
+    name: 'Bengali',
+  },
+  {
     locale: 'ca-ES',
     name: 'Catalan',
     itcLocale: 'ca',
@@ -148,6 +152,10 @@ const LANGUAGES: Language[] = [
     itcLocale: 'el',
   },
   {
+    locale: 'gu-IN',
+    name: 'Gujarati',
+  },
+  {
     locale: 'he',
     name: 'Hebrew',
     itcLocale: 'he',
@@ -183,6 +191,10 @@ const LANGUAGES: Language[] = [
     itcLocale: 'ja',
   },
   {
+    locale: 'kn-IN',
+    name: 'Kannada',
+  },
+  {
     locale: 'ko-KR',
     name: 'Korean',
     itcLocale: 'ko',
@@ -193,9 +205,21 @@ const LANGUAGES: Language[] = [
     itcLocale: 'ms',
   },
   {
+    locale: 'ml-IN',
+    name: 'Malayalam',
+  },
+  {
+    locale: 'mr-IN',
+    name: 'Marathi',
+  },
+  {
     locale: 'no-NO',
     name: 'Norwegian',
     itcLocale: 'no',
+  },
+  {
+    locale: 'or-IN',
+    name: 'Oriya',
   },
   {
     locale: 'pl-PL',
@@ -209,6 +233,10 @@ const LANGUAGES: Language[] = [
   {
     locale: 'pt-PT',
     name: 'Portuguese',
+  },
+  {
+    locale: 'pa-IN',
+    name: 'Punjabi',
   },
   {
     locale: 'ro-RO',
@@ -235,9 +263,21 @@ const LANGUAGES: Language[] = [
     itcLocale: 'sk',
   },
   {
+    locale: 'sl-SI',
+    name: 'Slovenian',
+  },
+  {
     locale: 'sv-SE',
     name: 'Swedish',
     itcLocale: 'sv',
+  },
+  {
+    locale: 'ta-IN',
+    name: 'Tamil',
+  },
+  {
+    locale: 'te-IN',
+    name: 'Telugu',
   },
   {
     locale: 'th-TH',
@@ -253,6 +293,10 @@ const LANGUAGES: Language[] = [
     locale: 'uk-UA',
     name: 'Ukrainian',
     itcLocale: 'uk',
+  },
+  {
+    locale: 'ur-PK',
+    name: 'Urdu',
   },
   {
     locale: 'vi-VI',


### PR DESCRIPTION
  <!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry
  [breaking-change|new-feature|bug-fix|chore] [message]`. -->
  <!-- You can skip the changelog check by labeling the PR with "no changelog". -->
  
# Why

 Apple [expanded App Store Connect localized metadata support to 50 languages](https://developer.apple.com/news/?id=97t4mt64), adding 11 new locales (with a focus on India): Bengali, Gujarati, Kannada, Malayalam, Marathi, Oriya, Punjabi, Slovenian, Tamil, Telugu, and Urdu. 
  
EAS CLI didn't know about these locales, so configuring metadata for any of them in `store.config.json` was rejected by schema validation, and they weren't selectable when submitting localized metadata. This PR brings EAS CLI in line with the current App Store Connect locale list. 
  
  # How

  Added the 11 new locales using Apple's official shortcodes from [Managing metadata in your app by using locale shortcodes](https://developer.apple.com/documentation/appstoreconnectapi/managing-metadata-in-your-app-by-using-locale-shortcodes):
  
  | Language | Shortcode | Language | Shortcode |
  | --- | --- | --- | --- |
  | Bengali | `bn-BD` | Punjabi | `pa-IN` |
  | Gujarati | `gu-IN` | Slovenian | `sl-SI` |
  | Kannada | `kn-IN` | Tamil | `ta-IN` |
  | Malayalam | `ml-IN` | Telugu | `te-IN` |
  | Marathi | `mr-IN` | Urdu | `ur-PK` |
  | Oriya | `or-IN` | | |
  
  - `packages/eas-cli/schema/metadata-0.json` — added each locale to both the `info` and App Clip (`AppleAppClipInfo`) blocks, inserted in the
  existing alphabetical-by-language ordering. 
  - `packages/eas-cli/src/submit/ios/utils/language.ts` — added each locale to the iOS submit `LANGUAGES` list. These follow the existing convention (e.g. `nl-NL`, `pt-BR`) where the fastlane `locale` already equals the App Store Connect code, so no separate `itcLocale` mapping is needed.
  
  # Test Plan
  
  Before this change, configuring metadata for one of the new locales failed schema validation; after, it validates and is accepted.
    
  **Before** (new locale rejected):
  
<img width="1423" height="888" alt="Screenshot 2026-06-09 at 15 58 02" src="https://github.com/user-attachments/assets/e25ef289-9495-4833-9a9e-0aeda1c2706e" />

  **After** (new locale accepted):
<img width="1397" height="110" alt="Screenshot 2026-06-09 at 15 58 32" src="https://github.com/user-attachments/assets/fb7a68a5-14d4-471c-84e2-60f7cf3d3f74" />

  Also ran:

  - `yarn workspace eas-cli typecheck` — passes
  - `cd packages/eas-cli && yarn test src/submit/ios/utils/__tests__/language-test.ts` — passes
  - `yarn fmt` — applied

  ---