### PR TITLE
[build-tools] fix getMaestroVersion parsing error

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
@@ -51,4 +51,40 @@ describe('createInstallMaestroBuildFunction', () => {
 
     expect(Datadog.distribution).not.toHaveBeenCalled();
   });
+
+  it('extracts the version when `maestro --version` prints an analytics notice', async () => {
+    mockedSpawn.mockImplementation((async (command: string) => ({
+      stdout:
+        command === 'maestro'
+          ? 'Anonymous analytics enabled. To opt out, set MAESTRO_CLI_NO_ANALYTICS environment variable to any value before running Maestro.\n2.0.10\n'
+          : '',
+    })) as any);
+
+    const installMaestro = createInstallMaestroBuildFunction();
+    const globalCtx = createGlobalContextMock();
+    globalCtx.updateEnv({ EAS_BUILD_RUNNER: 'eas-build' });
+    const step = installMaestro.createBuildStepFromFunctionCall(globalCtx, { callInputs: {} });
+
+    await step.executeAsync();
+
+    expect(step.getOutputValueByName('maestro_version')).toBe('2.0.10');
+    expect(Datadog.distribution).toHaveBeenCalledWith('eas.maestro.install', 1, {
+      maestro_version: '2.0.10',
+    });
+  });
+
+  it('uses the trailing version when the notice itself contains an earlier version-like string', async () => {
+    mockedSpawn.mockImplementation((async (command: string) => ({
+      stdout: command === 'maestro' ? 'Analytics schema v2.0.0 enabled.\n2.0.10\n' : '',
+    })) as any);
+
+    const installMaestro = createInstallMaestroBuildFunction();
+    const globalCtx = createGlobalContextMock();
+    globalCtx.updateEnv({ EAS_BUILD_RUNNER: 'eas-build' });
+    const step = installMaestro.createBuildStepFromFunctionCall(globalCtx, { callInputs: {} });
+
+    await step.executeAsync();
+
+    expect(step.getOutputValueByName('maestro_version')).toBe('2.0.10');
+  });
 });

--- a/packages/build-tools/src/steps/functions/installMaestro.ts
+++ b/packages/build-tools/src/steps/functions/installMaestro.ts
@@ -134,8 +134,15 @@ export function createInstallMaestroBuildFunction(): BuildFunction {
 }
 
 async function getMaestroVersion({ env }: { env: BuildStepEnv }): Promise<string> {
-  const maestroVersion = await spawn('maestro', ['--version'], { stdio: 'pipe', env });
-  return maestroVersion.stdout.trim();
+  const { stdout } = await spawn('maestro', ['--version'], { stdio: 'pipe', env });
+  // `maestro --version` can print an analytics notice to stdout before the version,
+  // e.g. "Anonymous analytics enabled. To opt out, set MAESTRO_CLI_NO_ANALYTICS...\n2.0.10".
+  // Take the last version-looking token: the real version is printed after the notice, so
+  // this stays correct even if the notice itself contains a version-like string. Keeps the
+  // step output and the eas.maestro.install metric tag clean. Best-effort only: fall back to
+  // the raw output if none is found, so we never fail the build over a version string.
+  const versions = stdout.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/g);
+  return versions?.at(-1) ?? stdout.trim();
 }
 
 async function installMaestro({


### PR DESCRIPTION
# Why

`getMaestroVersion` returned the entire stdout of `maestro --version`, which on some Maestro versions prints an analytics notice before the version number. As a result the `eas.maestro.install` metric recorded polluted `maestro_version` tag values (the whole notice instead of e.g. `2.0.10`); the same value also fed the step output.

ENG-21746 (follow-up to ENG-21682).

# How

Parse the version out of the output instead of using the whole stdout: match all `X.Y.Z` tokens and take the last one, since the real version is printed after the notice (robust even if the notice itself contains a version-like string). Best-effort — falls back to the raw output if none is found, so it never fails the build over a version string.

# Test Plan

Added unit tests in `installMaestro.test.ts`:

- analytics notice + version → reports `2.0.10`
- notice containing an earlier version-like string → still reports `2.0.10`

`yarn test installMaestro` → 4 passing.
