### PR TITLE
[eas-cli] Add PostHog GraphQL layer and command utils

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -2129,6 +2129,18 @@
             "deprecationReason": null
           },
           {
+            "name": "posthogOrganizationConnection",
+            "description": "PostHog organization connection for this account",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PostHogOrganizationConnection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "profileImageUrl",
             "description": null,
             "args": [],
@@ -7240,6 +7252,18 @@
             "description": "Create a GoogleServiceAccountKeyEntity to store credential and\nconnect it with an edge from AndroidAppCredential",
             "args": [
               {
+                "name": "accountId",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": true,
+                "deprecationReason": "Derived from androidAppCredentialsId"
+              },
+              {
                 "name": "androidAppCredentialsId",
                 "description": null,
                 "type": {
@@ -8557,6 +8581,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "robotAccessToken",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Robot access token is no longer needed as it's generated server-side and injected into the builder environment automatically."
           }
         ],
         "interfaces": null,
@@ -8842,6 +8878,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AndroidKeystoreType",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Type will be automatically inferred from keystore content."
           }
         ],
         "interfaces": null,
@@ -9244,6 +9292,26 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "filterReleaseChannels",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": true,
+                "deprecationReason": "Classic updates are no longer supported"
               },
               {
                 "name": "filterTypes",
@@ -10898,6 +10966,18 @@
             },
             "isDeprecated": true,
             "deprecationReason": "Classic updates have been deprecated."
+          },
+          {
+            "name": "posthogProject",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "PostHogProject",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           },
           {
             "name": "privacy",
@@ -13620,6 +13700,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "privacy",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AppPrivacy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "projectName",
@@ -21656,6 +21748,18 @@
             "deprecationReason": null
           },
           {
+            "name": "privacy",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AppPrivacy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
             "name": "projectName",
             "description": null,
             "type": {
@@ -28772,6 +28876,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "cacheDefaultPaths",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "We don't cache anything by default anymore"
+          },
+          {
             "name": "clear",
             "description": null,
             "type": {
@@ -28782,6 +28898,22 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "customPaths",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "We use paths now since there is no default caching anymore"
           },
           {
             "name": "disabled",
@@ -29432,6 +29564,18 @@
             "deprecationReason": null
           },
           {
+            "name": "buildMode",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Use job.mode instead."
+          },
+          {
             "name": "buildProfile",
             "description": null,
             "type": {
@@ -29730,6 +29874,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "selectedImage",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Unused."
           },
           {
             "name": "simulator",
@@ -34802,6 +34958,49 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "CreatePostHogAccountRequestInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "accountId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "region",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "PostHogRegion",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "CreateSentryProjectInput",
         "description": null,
         "fields": null,
@@ -34896,6 +35095,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "isGlobal",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Whether the variable is global is now governed by its scope - account / app."
           },
           {
             "name": "name",
@@ -35945,7 +36156,7 @@
       {
         "kind": "SCALAR",
         "name": "DateTime",
-        "description": "Date custom scalar type",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -37801,7 +38012,7 @@
       {
         "kind": "SCALAR",
         "name": "DevDomainName",
-        "description": "A DevDomainName for a deployed serverless app",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -43942,6 +44153,18 @@
             "deprecationReason": null
           },
           {
+            "name": "PostHogOrganizationConnectionEntity",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PostHogProjectEntity",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "UserInvitationEntity",
             "description": null,
             "isDeprecated": false,
@@ -44520,7 +44743,7 @@
       {
         "kind": "SCALAR",
         "name": "EnvironmentVariableEnvironment",
-        "description": "A name of an environment variable environment",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -52852,6 +53075,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "robotAccessToken",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Robot access token is no longer needed as it's generated server-side and injected into the builder environment automatically."
           }
         ],
         "interfaces": null,
@@ -53163,7 +53398,7 @@
       {
         "kind": "SCALAR",
         "name": "JSON",
-        "description": "The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -53173,7 +53408,7 @@
       {
         "kind": "SCALAR",
         "name": "JSONObject",
-        "description": "The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -57280,6 +57515,512 @@
         ]
       },
       {
+        "kind": "OBJECT",
+        "name": "PostHogIntegrationQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "clientIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PostHogOrganizationConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "account",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogOrganizationIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogOrganizationName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogProjects",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PostHogProject",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogRegion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "PostHogRegion",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PostHogOrganizationConnectionMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "createPostHogAccountRequest",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreatePostHogAccountRequestInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PostHogOrganizationConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deletePostHogOrganizationConnection",
+            "description": "Removes the Expo-side connection only; the PostHog organization is preserved.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PostHogProject",
+        "description": null,
+        "fields": [
+          {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogHost",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogOrganizationConnection",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PostHogOrganizationConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogProjectIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogProjectName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogProjectToken",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PostHogProjectMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "deletePostHogProject",
+            "description": "Removes the Expo-side project link only; the PostHog project is preserved.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "setupPostHogProject",
+            "description": "Provisions a PostHog project for the app; the project name is derived from the app.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SetupPostHogProjectInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PostHogProject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "PostHogRegion",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "EU",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "US",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "INTERFACE",
         "name": "Project",
         "description": null,
@@ -57945,6 +58686,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "runtimeFingerprintSource",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "FingerprintSourceInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Use fingerprintInfoGroup instead"
           },
           {
             "name": "runtimeVersion",
@@ -60127,6 +60880,38 @@
             "deprecationReason": null
           },
           {
+            "name": "posthogOrganizationConnection",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PostHogOrganizationConnectionMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogProject",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PostHogProjectMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "robot",
             "description": "Mutations that create, update, and delete Robots",
             "args": [],
@@ -60184,6 +60969,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "SubmissionMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tunnels",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "TunnelsMutation",
                 "ofType": null
               }
             },
@@ -61187,6 +61988,22 @@
               "kind": "INTERFACE",
               "name": "UserActor",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogIntegration",
+            "description": "Top-level query object for querying PostHog Integration information.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PostHogIntegrationQuery",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -63214,6 +64031,30 @@
             "deprecationReason": null
           },
           {
+            "name": "githubUsername",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "industry",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
             "name": "lastName",
             "description": null,
             "type": {
@@ -63224,6 +64065,30 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "location",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "twitterUsername",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           }
         ],
         "interfaces": null,
@@ -64151,6 +65016,49 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SetupPostHogProjectInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogOrganizationConnectionId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -66655,6 +67563,93 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "TunnelSignedUrlResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "label",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "TunnelsMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "createSignedTunnelUrl",
+            "description": "Create a signed tunnel URL for an account",
+            "args": [
+              {
+                "name": "accountId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "TunnelSignedUrlResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -69768,6 +70763,18 @@
             "deprecationReason": null
           },
           {
+            "name": "isGlobal",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "You cannot change whether the variable is global."
+          },
+          {
             "name": "name",
             "description": null,
             "type": {
@@ -70874,6 +71881,26 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "sdkVersions",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Use runtimeVersions instead."
           }
         ],
         "interfaces": null,
@@ -74576,6 +75603,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "appetizeCode",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
             "name": "email",
             "description": null,
             "type": {
@@ -74612,6 +75651,18 @@
             "deprecationReason": null
           },
           {
+            "name": "githubUsername",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
             "name": "id",
             "description": null,
             "type": {
@@ -74622,6 +75673,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "industry",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "lastName",
@@ -74636,6 +75699,18 @@
             "deprecationReason": null
           },
           {
+            "name": "location",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
             "name": "profilePhoto",
             "description": null,
             "type": {
@@ -74646,6 +75721,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "twitterUsername",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "username",
@@ -78926,7 +80013,7 @@
       {
         "kind": "SCALAR",
         "name": "WorkerDeploymentIdentifier",
-        "description": "A alias name for a serverless deployment",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -79196,7 +80283,7 @@
       {
         "kind": "SCALAR",
         "name": "WorkerDeploymentRequestID",
-        "description": "A Worker Deployment Request ID (also known as the CF Ray ID)",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -88636,15 +89723,6 @@
             "deprecationReason": null
           }
         ]
-      },
-      {
-        "name": "oneOf",
-        "description": "Indicates exactly one field must be supplied and this field must not be `null`.",
-        "isRepeatable": false,
-        "locations": [
-          "INPUT_OBJECT"
-        ],
-        "args": []
       },
       {
         "name": "skip",

--- a/packages/eas-cli/src/commandUtils/posthog.ts
+++ b/packages/eas-cli/src/commandUtils/posthog.ts
@@ -1,0 +1,22 @@
+import chalk from 'chalk';
+
+import { PostHogProjectData } from '../graphql/types/PostHogConnection';
+import Log, { link } from '../log';
+
+export function getPostHogProjectDashboardUrl(project: PostHogProjectData): string {
+  const host = project.posthogHost.replace(/\/$/, '');
+  return `${host}/project/${encodeURIComponent(project.posthogProjectIdentifier)}`;
+}
+
+export function formatPostHogProject(project: PostHogProjectData): string {
+  return [
+    `${chalk.bold('Name')}: ${project.posthogProjectName}`,
+    `${chalk.bold('Host')}: ${project.posthogHost}`,
+    `${chalk.bold('Region')}: ${project.posthogOrganizationConnection.posthogRegion}`,
+    `${chalk.bold('Dashboard')}: ${link(getPostHogProjectDashboardUrl(project), { dim: false })}`,
+  ].join('\n');
+}
+
+export function logNoPostHogProject(projectName: string): void {
+  Log.warn(`No PostHog project is linked to Expo app ${chalk.bold(projectName)} on EAS.`);
+}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -168,6 +168,8 @@ export type Account = {
   /** Owning UserActor of this account if personal account */
   ownerUserActor?: Maybe<UserActor>;
   pendingSentryInstallation?: Maybe<PendingSentryInstallation>;
+  /** PostHog organization connection for this account */
+  posthogOrganizationConnection?: Maybe<PostHogOrganizationConnection>;
   profileImageUrl: Scalars['String']['output'];
   pushSecurityEnabled: Scalars['Boolean']['output'];
   requireTwoFactor: Scalars['Boolean']['output'];
@@ -1192,6 +1194,7 @@ export type AndroidAppCredentialsMutationCreateAndroidAppCredentialsArgs = {
 
 
 export type AndroidAppCredentialsMutationCreateFcmV1CredentialArgs = {
+  accountId?: InputMaybe<Scalars['ID']['input']>;
   androidAppCredentialsId: Scalars['String']['input'];
   credential: Scalars['String']['input'];
 };
@@ -1347,6 +1350,8 @@ export type AndroidJobOverridesInput = {
 
 export type AndroidJobSecretsInput = {
   buildCredentials?: InputMaybe<AndroidJobBuildCredentialsInput>;
+  /** @deprecated Robot access token is no longer needed as it's generated server-side and injected into the builder environment automatically. */
+  robotAccessToken?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type AndroidJobVersionInput = {
@@ -1374,6 +1379,8 @@ export type AndroidKeystoreInput = {
   keyAlias: Scalars['String']['input'];
   keyPassword?: InputMaybe<Scalars['String']['input']>;
   keystorePassword: Scalars['String']['input'];
+  /** @deprecated Type will be automatically inferred from keystore content. */
+  type?: InputMaybe<AndroidKeystoreType>;
 };
 
 export type AndroidKeystoreMutation = {
@@ -1483,7 +1490,7 @@ export type App = Project & {
    * @deprecated Classic updates have been deprecated.
    */
   icon?: Maybe<AppIcon>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   iconUrl?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** App query field for querying EAS Insights about this app */
@@ -1501,7 +1508,7 @@ export type App = Project & {
   /** @deprecated 'likes' have been deprecated. */
   isLikedByMe: Scalars['Boolean']['output'];
   lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   lastPublishedTime: Scalars['DateTime']['output'];
   /** Time of the last user activity (update, branch, submission). */
   latestActivity: Scalars['DateTime']['output'];
@@ -1521,18 +1528,19 @@ export type App = Project & {
   name: Scalars['String']['output'];
   observe: AppObserve;
   ownerAccount: Account;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   packageName: Scalars['String']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   packageUsername: Scalars['String']['output'];
   /**
    * android.playStoreUrl field from most recent classic update manifest
    * @deprecated Classic updates have been deprecated.
    */
   playStoreUrl?: Maybe<Scalars['String']['output']>;
-  /** @deprecated No longer supported */
+  posthogProject?: Maybe<PostHogProject>;
+  /** @deprecated Field no longer supported */
   privacy: Scalars['String']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   privacySetting: AppPrivacy;
   profileImageUrl?: Maybe<Scalars['String']['output']>;
   /**
@@ -1592,7 +1600,7 @@ export type App = Project & {
   usageMetrics: AppUsageMetrics;
   /** @deprecated Use ownerAccount.name instead */
   username: Scalars['String']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   users?: Maybe<Array<Maybe<User>>>;
   vexoApp?: Maybe<VexoApp>;
   /** Notification preferences of the viewer for this app */
@@ -1622,6 +1630,7 @@ export type AppActivityTimelineProjectActivitiesArgs = {
   createdBefore?: InputMaybe<Scalars['DateTime']['input']>;
   filterChannels?: InputMaybe<Array<Scalars['String']['input']>>;
   filterPlatforms?: InputMaybe<Array<AppPlatform>>;
+  filterReleaseChannels?: InputMaybe<Array<Scalars['String']['input']>>;
   filterTypes?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
   limit: Scalars['Int']['input'];
 };
@@ -2081,7 +2090,7 @@ export type AppFingerprintsConnection = {
 
 export type AppIcon = {
   __typename?: 'AppIcon';
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   colorPalette?: Maybe<Scalars['JSON']['output']>;
   originalUrl: Scalars['String']['output'];
   primaryColor?: Maybe<Scalars['String']['output']>;
@@ -2095,6 +2104,8 @@ export type AppInfoInput = {
 export type AppInput = {
   accountId: Scalars['ID']['input'];
   appInfo?: InputMaybe<AppInfoInput>;
+  /** @deprecated Field no longer supported */
+  privacy?: InputMaybe<AppPrivacy>;
   projectName: Scalars['String']['input'];
 };
 
@@ -2130,7 +2141,7 @@ export type AppMutation = {
   __typename?: 'AppMutation';
   /** Create an app */
   createApp: App;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   grantAccess?: Maybe<App>;
   /** Remove profile image (icon) for the app. Do nothing if there's no profile image associated. */
   removeProfileImage: App;
@@ -3137,6 +3148,8 @@ export type AppWithGithubRepositoryInput = {
   accountId: Scalars['ID']['input'];
   appInfo?: InputMaybe<AppInfoInput>;
   installationIdentifier?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  privacy?: InputMaybe<AppPrivacy>;
   projectName: Scalars['String']['input'];
 };
 
@@ -4102,7 +4115,11 @@ export type BuildArtifacts = {
 };
 
 export type BuildCacheInput = {
+  /** @deprecated We don't cache anything by default anymore */
+  cacheDefaultPaths?: InputMaybe<Scalars['Boolean']['input']>;
   clear?: InputMaybe<Scalars['Boolean']['input']>;
+  /** @deprecated We use paths now since there is no default caching anymore */
+  customPaths?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   disabled?: InputMaybe<Scalars['Boolean']['input']>;
   key?: InputMaybe<Scalars['String']['input']>;
   paths?: InputMaybe<Array<Scalars['String']['input']>>;
@@ -4174,6 +4191,8 @@ export type BuildMetadataInput = {
   appIdentifier?: InputMaybe<Scalars['String']['input']>;
   appName?: InputMaybe<Scalars['String']['input']>;
   appVersion?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Use job.mode instead. */
+  buildMode?: InputMaybe<BuildMode>;
   buildProfile?: InputMaybe<Scalars['String']['input']>;
   channel?: InputMaybe<Scalars['String']['input']>;
   cliVersion?: InputMaybe<Scalars['String']['input']>;
@@ -4199,6 +4218,8 @@ export type BuildMetadataInput = {
   runWithNoWaitFlag?: InputMaybe<Scalars['Boolean']['input']>;
   runtimeVersion?: InputMaybe<Scalars['String']['input']>;
   sdkVersion?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Unused. */
+  selectedImage?: InputMaybe<Scalars['String']['input']>;
   simulator?: InputMaybe<Scalars['Boolean']['input']>;
   trackingContext?: InputMaybe<Scalars['JSONObject']['input']>;
   username?: InputMaybe<Scalars['String']['input']>;
@@ -4364,7 +4385,7 @@ export enum BuildPhase {
   StartBuild = 'START_BUILD',
   Unknown = 'UNKNOWN',
   UploadApplicationArchive = 'UPLOAD_APPLICATION_ARCHIVE',
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   UploadArtifacts = 'UPLOAD_ARTIFACTS',
   UploadBuildArtifacts = 'UPLOAD_BUILD_ARTIFACTS'
 }
@@ -4893,6 +4914,11 @@ export type CreateIosSubmissionInput = {
   submittedBuildId?: InputMaybe<Scalars['ID']['input']>;
 };
 
+export type CreatePostHogAccountRequestInput = {
+  accountId: Scalars['ID']['input'];
+  region: PostHogRegion;
+};
+
 export type CreateSentryProjectInput = {
   appId: Scalars['ID']['input'];
   sentryProjectId: Scalars['String']['input'];
@@ -4902,6 +4928,8 @@ export type CreateSentryProjectInput = {
 export type CreateSharedEnvironmentVariableInput = {
   environments?: InputMaybe<Array<Scalars['EnvironmentVariableEnvironment']['input']>>;
   fileName?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Whether the variable is global is now governed by its scope - account / app. */
+  isGlobal?: InputMaybe<Scalars['Boolean']['input']>;
   name: Scalars['String']['input'];
   overwrite?: InputMaybe<Scalars['Boolean']['input']>;
   type?: InputMaybe<EnvironmentSecretType>;
@@ -6295,6 +6323,8 @@ export enum EntityTypeName {
   IosAppCredentialsEntity = 'IosAppCredentialsEntity',
   LogRocketOrganizationEntity = 'LogRocketOrganizationEntity',
   LogRocketProjectEntity = 'LogRocketProjectEntity',
+  PostHogOrganizationConnectionEntity = 'PostHogOrganizationConnectionEntity',
+  PostHogProjectEntity = 'PostHogProjectEntity',
   UserInvitationEntity = 'UserInvitationEntity',
   UserPermissionEntity = 'UserPermissionEntity',
   VexoAccountConnectionEntity = 'VexoAccountConnectionEntity',
@@ -7494,6 +7524,8 @@ export type IosJobOverridesInput = {
 
 export type IosJobSecretsInput = {
   buildCredentials?: InputMaybe<Array<InputMaybe<IosJobTargetCredentialsInput>>>;
+  /** @deprecated Robot access token is no longer needed as it's generated server-side and injected into the builder environment automatically. */
+  robotAccessToken?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type IosJobTargetCredentialsInput = {
@@ -7540,7 +7572,7 @@ export type JobRun = {
   __typename?: 'JobRun';
   app: App;
   artifacts: Array<WorkflowArtifact>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   childJobRun?: Maybe<JobRun>;
   createdAt: Scalars['DateTime']['output'];
   displayName?: Maybe<Scalars['String']['output']>;
@@ -8127,10 +8159,80 @@ export type PinnedDashboardView = {
 
 export type PlanEnablement = Concurrencies | EasTotalPlanEnablement;
 
+export type PostHogIntegrationQuery = {
+  __typename?: 'PostHogIntegrationQuery';
+  clientIdentifier: Scalars['String']['output'];
+};
+
+export type PostHogOrganizationConnection = {
+  __typename?: 'PostHogOrganizationConnection';
+  account: Account;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['ID']['output'];
+  posthogOrganizationIdentifier: Scalars['String']['output'];
+  posthogOrganizationName: Scalars['String']['output'];
+  posthogProjects: Array<PostHogProject>;
+  posthogRegion: PostHogRegion;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+export type PostHogOrganizationConnectionMutation = {
+  __typename?: 'PostHogOrganizationConnectionMutation';
+  createPostHogAccountRequest: PostHogOrganizationConnection;
+  /** Removes the Expo-side connection only; the PostHog organization is preserved. */
+  deletePostHogOrganizationConnection: Scalars['ID']['output'];
+};
+
+
+export type PostHogOrganizationConnectionMutationCreatePostHogAccountRequestArgs = {
+  input: CreatePostHogAccountRequestInput;
+};
+
+
+export type PostHogOrganizationConnectionMutationDeletePostHogOrganizationConnectionArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type PostHogProject = {
+  __typename?: 'PostHogProject';
+  app: App;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['ID']['output'];
+  posthogHost: Scalars['String']['output'];
+  posthogOrganizationConnection: PostHogOrganizationConnection;
+  posthogProjectIdentifier: Scalars['String']['output'];
+  posthogProjectName: Scalars['String']['output'];
+  posthogProjectToken: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+export type PostHogProjectMutation = {
+  __typename?: 'PostHogProjectMutation';
+  /** Removes the Expo-side project link only; the PostHog project is preserved. */
+  deletePostHogProject: Scalars['ID']['output'];
+  /** Provisions a PostHog project for the app; the project name is derived from the app. */
+  setupPostHogProject: PostHogProject;
+};
+
+
+export type PostHogProjectMutationDeletePostHogProjectArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type PostHogProjectMutationSetupPostHogProjectArgs = {
+  input: SetupPostHogProjectInput;
+};
+
+export enum PostHogRegion {
+  Eu = 'EU',
+  Us = 'US'
+}
+
 export type Project = {
   description: Scalars['String']['output'];
   fullName: Scalars['String']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   iconUrl?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
@@ -8201,6 +8303,8 @@ export type PublishUpdateGroupInput = {
   message?: InputMaybe<Scalars['String']['input']>;
   rollBackToEmbeddedInfoGroup?: InputMaybe<UpdateRollBackToEmbeddedGroup>;
   rolloutInfoGroup?: InputMaybe<UpdateRolloutInfoGroup>;
+  /** @deprecated Use fingerprintInfoGroup instead */
+  runtimeFingerprintSource?: InputMaybe<FingerprintSourceInput>;
   runtimeVersion: Scalars['String']['input'];
   turtleJobRunId?: InputMaybe<Scalars['String']['input']>;
   updateInfoGroup?: InputMaybe<UpdateInfoGroup>;
@@ -8480,6 +8584,8 @@ export type RootMutation = {
   me: MeMutation;
   /** Notification preference management */
   notificationPreference: NotificationPreferenceMutation;
+  posthogOrganizationConnection: PostHogOrganizationConnectionMutation;
+  posthogProject: PostHogProjectMutation;
   /** Mutations that create, update, and delete Robots */
   robot: RobotMutation;
   /** Mutations for Sentry installations */
@@ -8488,6 +8594,7 @@ export type RootMutation = {
   sentryProject: SentryProjectMutation;
   /** Mutations that modify an EAS Submit submission */
   submission: SubmissionMutation;
+  tunnels: TunnelsMutation;
   turtleBrownfieldArtifacts: TurtleBrownfieldArtifactMutation;
   update: UpdateMutation;
   updateBranch: UpdateBranchMutation;
@@ -8626,6 +8733,8 @@ export type RootQuery = {
    * this is the appropriate top-level query object
    */
   meUserActor?: Maybe<UserActor>;
+  /** Top-level query object for querying PostHog Integration information. */
+  posthogIntegration: PostHogIntegrationQuery;
   /** @deprecated Snacks and apps should be queried separately */
   project: ProjectQuery;
   /** Top-level query object for querying Runtimes. */
@@ -8818,7 +8927,7 @@ export type SsoUser = Actor & UserActor & {
   /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   appCount: Scalars['Int']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   appetizeCode?: Maybe<Scalars['String']['output']>;
   /**
    * Apps this user has published. If this user is the viewer, this field returns the apps the user has access to.
@@ -8841,16 +8950,16 @@ export type SsoUser = Actor & UserActor & {
   fullName?: Maybe<Scalars['String']['output']>;
   /** GitHub account linked to a user */
   githubUser?: Maybe<GitHubUser>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   githubUsername?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   industry?: Maybe<Scalars['String']['output']>;
   isExpoAdmin: Scalars['Boolean']['output'];
   isStaffModeEnabled: Scalars['Boolean']['output'];
   lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
   lastName?: Maybe<Scalars['String']['output']>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   location?: Maybe<Scalars['String']['output']>;
   pinnedApps: Array<App>;
   pinnedDashboardViews: Array<PinnedDashboardView>;
@@ -8862,7 +8971,7 @@ export type SsoUser = Actor & UserActor & {
   profilePhoto: Scalars['String']['output'];
   /** Snacks associated with this account */
   snacks: Array<Snack>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   twitterUsername?: Maybe<Scalars['String']['output']>;
   username: Scalars['String']['output'];
   websiteNotificationsPaginated: WebsiteNotificationsConnection;
@@ -8908,7 +9017,15 @@ export type SsoUserWebsiteNotificationsPaginatedArgs = {
 
 export type SsoUserDataInput = {
   firstName?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  githubUsername?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  industry?: InputMaybe<Scalars['String']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  location?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  twitterUsername?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type SecondFactorBooleanResult = {
@@ -9043,6 +9160,11 @@ export type SetupConvexProjectResult = {
   deployKey: Scalars['String']['output'];
 };
 
+export type SetupPostHogProjectInput = {
+  appId: Scalars['ID']['input'];
+  posthogOrganizationConnectionId: Scalars['ID']['input'];
+};
+
 export type SizeBreakdownCategory = {
   __typename?: 'SizeBreakdownCategory';
   assetCount: Scalars['Int']['output'];
@@ -9059,7 +9181,7 @@ export type Snack = Project & {
   /** Has the Snack been run without errors */
   hasBeenRunSuccessfully?: Maybe<Scalars['Boolean']['output']>;
   hashId: Scalars['String']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   iconUrl?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** Draft status, which is true when the Snack was not saved explicitly, but auto-saved */
@@ -9408,6 +9530,23 @@ export type TimelineActivityFilterInput = {
   platforms?: InputMaybe<Array<AppPlatform>>;
   releaseChannels?: InputMaybe<Array<Scalars['String']['input']>>;
   types?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
+};
+
+export type TunnelSignedUrlResult = {
+  __typename?: 'TunnelSignedUrlResult';
+  label: Scalars['ID']['output'];
+  url: Scalars['String']['output'];
+};
+
+export type TunnelsMutation = {
+  __typename?: 'TunnelsMutation';
+  /** Create a signed tunnel URL for an account */
+  createSignedTunnelUrl: TunnelSignedUrlResult;
+};
+
+
+export type TunnelsMutationCreateSignedTunnelUrlArgs = {
+  accountId: Scalars['ID']['input'];
 };
 
 export type TurtleBrownfieldArtifactMutation = {
@@ -9829,6 +9968,8 @@ export type UpdateEnvironmentVariableInput = {
   environments?: InputMaybe<Array<Scalars['EnvironmentVariableEnvironment']['input']>>;
   fileName?: InputMaybe<Scalars['String']['input']>;
   id: Scalars['ID']['input'];
+  /** @deprecated You cannot change whether the variable is global. */
+  isGlobal?: InputMaybe<Scalars['Boolean']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
   type?: InputMaybe<EnvironmentSecretType>;
   value?: InputMaybe<Scalars['String']['input']>;
@@ -9978,6 +10119,8 @@ export type UpdateVexoAppInput = {
 export type UpdatesFilter = {
   platform?: InputMaybe<AppPlatform>;
   runtimeVersions?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** @deprecated Use runtimeVersions instead. */
+  sdkVersions?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type UpdatesFilterV2 = {
@@ -10092,7 +10235,7 @@ export type User = Actor & UserActor & {
   /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   appCount: Scalars['Int']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   appetizeCode?: Maybe<Scalars['String']['output']>;
   /**
    * Apps this user has published
@@ -10117,22 +10260,22 @@ export type User = Actor & UserActor & {
   fullName?: Maybe<Scalars['String']['output']>;
   /** GitHub account linked to a user */
   githubUser?: Maybe<GitHubUser>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   githubUsername?: Maybe<Scalars['String']['output']>;
   hasPassword: Scalars['Boolean']['output'];
   /** Whether this user has any pending user invitations. Only resolves for the viewer. */
   hasPendingUserInvitations: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   industry?: Maybe<Scalars['String']['output']>;
   isExpoAdmin: Scalars['Boolean']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   isLegacy: Scalars['Boolean']['output'];
   isSecondFactorAuthenticationEnabled: Scalars['Boolean']['output'];
   isStaffModeEnabled: Scalars['Boolean']['output'];
   lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
   lastName?: Maybe<Scalars['String']['output']>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   location?: Maybe<Scalars['String']['output']>;
   newEmailPendingVerification?: Maybe<Scalars['String']['output']>;
   oAuthIdentities: Array<OAuthIdentity>;
@@ -10150,7 +10293,7 @@ export type User = Actor & UserActor & {
   secondFactorDevices: Array<UserSecondFactorDevice>;
   /** Snacks associated with this account */
   snacks: Array<Snack>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   twitterUsername?: Maybe<Scalars['String']['output']>;
   username: Scalars['String']['output'];
   websiteNotificationsPaginated: WebsiteNotificationsConnection;
@@ -10205,7 +10348,7 @@ export type UserActor = {
    */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   appCount: Scalars['Int']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   appetizeCode?: Maybe<Scalars['String']['output']>;
   /**
    * Apps this user has published
@@ -10232,16 +10375,16 @@ export type UserActor = {
   fullName?: Maybe<Scalars['String']['output']>;
   /** GitHub account linked to a user */
   githubUser?: Maybe<GitHubUser>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   githubUsername?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   industry?: Maybe<Scalars['String']['output']>;
   isExpoAdmin: Scalars['Boolean']['output'];
   isStaffModeEnabled: Scalars['Boolean']['output'];
   lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
   lastName?: Maybe<Scalars['String']['output']>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   location?: Maybe<Scalars['String']['output']>;
   pinnedApps: Array<App>;
   preferences: UserPreferences;
@@ -10252,7 +10395,7 @@ export type UserActor = {
   profilePhoto: Scalars['String']['output'];
   /** Snacks associated with this user's personal account */
   snacks: Array<Snack>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   twitterUsername?: Maybe<Scalars['String']['output']>;
   username: Scalars['String']['output'];
   websiteNotificationsPaginated: WebsiteNotificationsConnection;
@@ -10498,12 +10641,22 @@ export type UserDashboardViewPinMutationUnpinDashboardViewArgs = {
 };
 
 export type UserDataInput = {
+  /** @deprecated Field no longer supported */
+  appetizeCode?: InputMaybe<Scalars['String']['input']>;
   email?: InputMaybe<Scalars['String']['input']>;
   firstName?: InputMaybe<Scalars['String']['input']>;
   fullName?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  githubUsername?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['ID']['input']>;
+  /** @deprecated Field no longer supported */
+  industry?: InputMaybe<Scalars['String']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  location?: InputMaybe<Scalars['String']['input']>;
   profilePhoto?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  twitterUsername?: InputMaybe<Scalars['String']['input']>;
   username?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -12946,6 +13099,27 @@ export type CreateLocalBuildMutationVariables = Exact<{
 
 export type CreateLocalBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createLocalBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, logFiles: Array<string>, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, fingerprint?: { __typename?: 'Fingerprint', id: string, hash: string } | null, initiatingActor?: { __typename: 'PartnerActor', id: string, displayName: string } | { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string }, metrics?: { __typename?: 'BuildMetrics', buildWaitTime?: number | null, buildQueueTime?: number | null, buildDuration?: number | null } | null } } } };
 
+export type CreatePostHogAccountRequestMutationVariables = Exact<{
+  input: CreatePostHogAccountRequestInput;
+}>;
+
+
+export type CreatePostHogAccountRequestMutation = { __typename?: 'RootMutation', posthogOrganizationConnection: { __typename?: 'PostHogOrganizationConnectionMutation', createPostHogAccountRequest: { __typename?: 'PostHogOrganizationConnection', id: string, posthogOrganizationIdentifier: string, posthogOrganizationName: string, posthogRegion: PostHogRegion, createdAt: any, updatedAt: any } } };
+
+export type SetupPostHogProjectMutationVariables = Exact<{
+  input: SetupPostHogProjectInput;
+}>;
+
+
+export type SetupPostHogProjectMutation = { __typename?: 'RootMutation', posthogProject: { __typename?: 'PostHogProjectMutation', setupPostHogProject: { __typename?: 'PostHogProject', id: string, posthogProjectIdentifier: string, posthogProjectName: string, posthogProjectToken: string, posthogHost: string, createdAt: any, updatedAt: any, posthogOrganizationConnection: { __typename?: 'PostHogOrganizationConnection', id: string, posthogOrganizationIdentifier: string, posthogOrganizationName: string, posthogRegion: PostHogRegion, createdAt: any, updatedAt: any } } } };
+
+export type DeletePostHogProjectMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type DeletePostHogProjectMutation = { __typename?: 'RootMutation', posthogProject: { __typename?: 'PostHogProjectMutation', deletePostHogProject: string } };
+
 export type GetSignedUploadMutationVariables = Exact<{
   contentTypes: Array<Scalars['String']['input']> | Scalars['String']['input'];
 }>;
@@ -13511,6 +13685,20 @@ export type AppObserveNavigationRoutesQueryVariables = Exact<{
 
 export type AppObserveNavigationRoutesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', navigationRoutes: { __typename?: 'AppObserveNavigationRoutesConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveNavigationRouteEdge', cursor: string, node: { __typename?: 'AppObserveNavigationRoute', routeName: string, coldTtr: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null }, warmTtr: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null }, tti: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null } } }> } } } } };
 
+export type PostHogOrganizationConnectionByAccountIdQueryVariables = Exact<{
+  accountId: Scalars['String']['input'];
+}>;
+
+
+export type PostHogOrganizationConnectionByAccountIdQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byId: { __typename?: 'Account', id: string, posthogOrganizationConnection?: { __typename?: 'PostHogOrganizationConnection', id: string, posthogOrganizationIdentifier: string, posthogOrganizationName: string, posthogRegion: PostHogRegion, createdAt: any, updatedAt: any } | null } } };
+
+export type PostHogProjectByAppIdQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+}>;
+
+
+export type PostHogProjectByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, posthogProject?: { __typename?: 'PostHogProject', id: string, posthogProjectIdentifier: string, posthogProjectName: string, posthogProjectToken: string, posthogHost: string, createdAt: any, updatedAt: any, posthogOrganizationConnection: { __typename?: 'PostHogOrganizationConnection', id: string, posthogOrganizationIdentifier: string, posthogOrganizationName: string, posthogRegion: PostHogRegion, createdAt: any, updatedAt: any } } | null } } };
+
 export type GetAssetMetadataQueryVariables = Exact<{
   storageKeys: Array<Scalars['String']['input']> | Scalars['String']['input'];
 }>;
@@ -13724,6 +13912,10 @@ export type AppObserveCustomEventFragment = { __typename?: 'AppObserveCustomEven
 export type AppObserveEventFragment = { __typename?: 'AppObserveEvent', id: string, metricName: string, metricValue: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null };
 
 export type AppObserveAppVersionFragment = { __typename?: 'AppObserveAppVersion', appVersion: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, buildNumbers: Array<{ __typename?: 'AppObserveAppBuildNumber', appBuildNumber: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, updates: Array<{ __typename?: 'AppObserveAppUpdate', appUpdateId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, metrics: Array<{ __typename?: 'AppObserveAppVersionMetric', metricName: string, eventCount: number, statistics: { __typename?: 'AppObserveVersionMarkerStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } }> };
+
+export type PostHogOrganizationConnectionFragment = { __typename?: 'PostHogOrganizationConnection', id: string, posthogOrganizationIdentifier: string, posthogOrganizationName: string, posthogRegion: PostHogRegion, createdAt: any, updatedAt: any };
+
+export type PostHogProjectFragment = { __typename?: 'PostHogProject', id: string, posthogProjectIdentifier: string, posthogProjectName: string, posthogProjectToken: string, posthogHost: string, createdAt: any, updatedAt: any, posthogOrganizationConnection: { __typename?: 'PostHogOrganizationConnection', id: string, posthogOrganizationIdentifier: string, posthogOrganizationName: string, posthogRegion: PostHogRegion, createdAt: any, updatedAt: any } };
 
 export type RuntimeFragment = { __typename?: 'Runtime', id: string, version: string };
 

--- a/packages/eas-cli/src/graphql/mutations/PostHogMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PostHogMutation.ts
@@ -1,0 +1,117 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
+import { CreatePostHogAccountRequestInput, SetupPostHogProjectInput } from '../generated';
+import {
+  PostHogOrganizationConnectionData,
+  PostHogOrganizationConnectionFragmentNode,
+  PostHogProjectData,
+  PostHogProjectFragmentNode,
+} from '../types/PostHogConnection';
+
+type CreatePostHogAccountRequestMutation = {
+  posthogOrganizationConnection: {
+    createPostHogAccountRequest: PostHogOrganizationConnectionData;
+  };
+};
+
+type CreatePostHogAccountRequestMutationVariables = {
+  input: CreatePostHogAccountRequestInput;
+};
+
+type SetupPostHogProjectMutation = {
+  posthogProject: {
+    setupPostHogProject: PostHogProjectData;
+  };
+};
+
+type SetupPostHogProjectMutationVariables = {
+  input: SetupPostHogProjectInput;
+};
+
+type DeletePostHogProjectMutation = {
+  posthogProject: {
+    deletePostHogProject: string;
+  };
+};
+
+type DeletePostHogProjectMutationVariables = {
+  id: string;
+};
+
+export const PostHogMutation = {
+  async createPostHogAccountRequestAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: CreatePostHogAccountRequestInput
+  ): Promise<PostHogOrganizationConnectionData> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<
+          CreatePostHogAccountRequestMutation,
+          CreatePostHogAccountRequestMutationVariables
+        >(
+          gql`
+            mutation CreatePostHogAccountRequest($input: CreatePostHogAccountRequestInput!) {
+              posthogOrganizationConnection {
+                createPostHogAccountRequest(input: $input) {
+                  id
+                  ...PostHogOrganizationConnectionFragment
+                }
+              }
+            }
+            ${print(PostHogOrganizationConnectionFragmentNode)}
+          `,
+          { input }
+        )
+        .toPromise()
+    );
+    return data.posthogOrganizationConnection.createPostHogAccountRequest;
+  },
+
+  async setupPostHogProjectAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: SetupPostHogProjectInput
+  ): Promise<PostHogProjectData> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<SetupPostHogProjectMutation, SetupPostHogProjectMutationVariables>(
+          gql`
+            mutation SetupPostHogProject($input: SetupPostHogProjectInput!) {
+              posthogProject {
+                setupPostHogProject(input: $input) {
+                  id
+                  ...PostHogProjectFragment
+                }
+              }
+            }
+            ${print(PostHogOrganizationConnectionFragmentNode)}
+            ${print(PostHogProjectFragmentNode)}
+          `,
+          { input }
+        )
+        .toPromise()
+    );
+    return data.posthogProject.setupPostHogProject;
+  },
+
+  async deletePostHogProjectAsync(graphqlClient: ExpoGraphqlClient, id: string): Promise<string> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<DeletePostHogProjectMutation, DeletePostHogProjectMutationVariables>(
+          gql`
+            mutation DeletePostHogProject($id: ID!) {
+              posthogProject {
+                deletePostHogProject(id: $id)
+              }
+            }
+          `,
+          { id },
+          { additionalTypenames: ['App', 'PostHogProject'] }
+        )
+        .toPromise()
+    );
+    return data.posthogProject.deletePostHogProject;
+  },
+};

--- a/packages/eas-cli/src/graphql/queries/PostHogQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/PostHogQuery.ts
@@ -1,0 +1,103 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
+import {
+  PostHogOrganizationConnectionData,
+  PostHogOrganizationConnectionFragmentNode,
+  PostHogProjectData,
+  PostHogProjectFragmentNode,
+} from '../types/PostHogConnection';
+
+type PostHogOrganizationConnectionByAccountIdQuery = {
+  account: {
+    byId: {
+      id: string;
+      posthogOrganizationConnection?: PostHogOrganizationConnectionData | null;
+    };
+  };
+};
+
+type PostHogOrganizationConnectionByAccountIdQueryVariables = {
+  accountId: string;
+};
+
+type PostHogProjectByAppIdQuery = {
+  app: {
+    byId: {
+      id: string;
+      posthogProject?: PostHogProjectData | null;
+    };
+  };
+};
+
+type PostHogProjectByAppIdQueryVariables = {
+  appId: string;
+};
+
+export const PostHogQuery = {
+  async getPostHogOrganizationConnectionByAccountIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    accountId: string
+  ): Promise<PostHogOrganizationConnectionData | null> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<
+          PostHogOrganizationConnectionByAccountIdQuery,
+          PostHogOrganizationConnectionByAccountIdQueryVariables
+        >(
+          gql`
+            query PostHogOrganizationConnectionByAccountId($accountId: String!) {
+              account {
+                byId(accountId: $accountId) {
+                  id
+                  posthogOrganizationConnection {
+                    id
+                    ...PostHogOrganizationConnectionFragment
+                  }
+                }
+              }
+            }
+            ${print(PostHogOrganizationConnectionFragmentNode)}
+          `,
+          { accountId },
+          { additionalTypenames: ['PostHogOrganizationConnection'] }
+        )
+        .toPromise()
+    );
+
+    return data.account.byId.posthogOrganizationConnection ?? null;
+  },
+
+  async getPostHogProjectByAppIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    appId: string
+  ): Promise<PostHogProjectData | null> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<PostHogProjectByAppIdQuery, PostHogProjectByAppIdQueryVariables>(
+          gql`
+            query PostHogProjectByAppId($appId: String!) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  posthogProject {
+                    id
+                    ...PostHogProjectFragment
+                  }
+                }
+              }
+            }
+            ${print(PostHogOrganizationConnectionFragmentNode)}
+            ${print(PostHogProjectFragmentNode)}
+          `,
+          { appId },
+          { additionalTypenames: ['App', 'PostHogProject'] }
+        )
+        .toPromise()
+    );
+
+    return data.app.byId.posthogProject ?? null;
+  },
+};

--- a/packages/eas-cli/src/graphql/types/PostHogConnection.ts
+++ b/packages/eas-cli/src/graphql/types/PostHogConnection.ts
@@ -1,0 +1,53 @@
+import gql from 'graphql-tag';
+
+import { PostHogOrganizationConnection, PostHogProject } from '../generated';
+
+export type PostHogOrganizationConnectionData = Pick<
+  PostHogOrganizationConnection,
+  | 'id'
+  | 'posthogOrganizationIdentifier'
+  | 'posthogOrganizationName'
+  | 'posthogRegion'
+  | 'createdAt'
+  | 'updatedAt'
+>;
+
+export type PostHogProjectData = Pick<
+  PostHogProject,
+  | 'id'
+  | 'posthogProjectIdentifier'
+  | 'posthogProjectName'
+  | 'posthogProjectToken'
+  | 'posthogHost'
+  | 'createdAt'
+  | 'updatedAt'
+> & {
+  posthogOrganizationConnection: PostHogOrganizationConnectionData;
+};
+
+export const PostHogOrganizationConnectionFragmentNode = gql`
+  fragment PostHogOrganizationConnectionFragment on PostHogOrganizationConnection {
+    id
+    posthogOrganizationIdentifier
+    posthogOrganizationName
+    posthogRegion
+    createdAt
+    updatedAt
+  }
+`;
+
+export const PostHogProjectFragmentNode = gql`
+  fragment PostHogProjectFragment on PostHogProject {
+    id
+    posthogProjectIdentifier
+    posthogProjectName
+    posthogProjectToken
+    posthogHost
+    createdAt
+    updatedAt
+    posthogOrganizationConnection {
+      id
+      ...PostHogOrganizationConnectionFragment
+    }
+  }
+`;


### PR DESCRIPTION
## Why

Plumbing for the `posthog` commands — GraphQL layer + shared utils.

## How

- `PostHogQuery` + `PostHogMutation` + fragments/types
- `commandUtils/posthog.ts` (dashboard URL, formatter)
- `generated.ts` from the universe schema

## Test Plan

- CI
- Live integration needs the universe PostHog backend deployed
