### PR TITLE
[eas-cli] Add integrations:posthog:connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Non-interactive iOS App Store and Enterprise builds can now use the App Store Connect API key stored in EAS credentials as a submission key to validate and repair provisioning profiles on Apple servers, without requiring `EXPO_ASC_*` environment variables or an interactive Apple login. ([#3805](https://github.com/expo/eas-cli/pull/3805) by [@sswrk](https://github.com/sswrk))
 - [eas-cli] Add support for non-interactive `eas update:rollback [GROUP_ID]`. The given update group must be the latest for its branch and runtime version; the previous update group is republished, or a roll back to the embedded update is published if there is none. ([#3825](https://github.com/expo/eas-cli/pull/3825) by [@quinlanj](https://github.com/quinlanj))
+- [eas-cli] Add `eas integrations:posthog:connect` command. ([#3836](https://github.com/expo/eas-cli/pull/3836) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Add `eas account:audit [ACCOUNT_NAME]` command to view an account's audit logs. ([#3863](https://github.com/expo/eas-cli/pull/3863) by [@keith-kurak](https://github.com/keith-kurak))
 - [eas-cli] `eas update:view [GROUP_ID]` now also accepts a platform-specific update ID, resolving it to and displaying its update group. ([#3864](https://github.com/expo/eas-cli/pull/3864) by [@keith-kurak](https://github.com/keith-kurak))
+- [eas-cli] Add `eas integrations:posthog:connect` command. ([#3836](https://github.com/expo/eas-cli/pull/3836) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 
@@ -23,7 +24,6 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Non-interactive iOS App Store and Enterprise builds can now use the App Store Connect API key stored in EAS credentials as a submission key to validate and repair provisioning profiles on Apple servers, without requiring `EXPO_ASC_*` environment variables or an interactive Apple login. ([#3805](https://github.com/expo/eas-cli/pull/3805) by [@sswrk](https://github.com/sswrk))
 - [eas-cli] Add support for non-interactive `eas update:rollback [GROUP_ID]`. The given update group must be the latest for its branch and runtime version; the previous update group is republished, or a roll back to the embedded update is published if there is none. ([#3825](https://github.com/expo/eas-cli/pull/3825) by [@quinlanj](https://github.com/quinlanj))
-- [eas-cli] Add `eas integrations:posthog:connect` command. ([#3836](https://github.com/expo/eas-cli/pull/3836) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -7252,6 +7252,18 @@
             "description": "Create a GoogleServiceAccountKeyEntity to store credential and\nconnect it with an edge from AndroidAppCredential",
             "args": [
               {
+                "name": "accountId",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": true,
+                "deprecationReason": "Derived from androidAppCredentialsId"
+              },
+              {
                 "name": "androidAppCredentialsId",
                 "description": null,
                 "type": {
@@ -8569,6 +8581,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "robotAccessToken",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Robot access token is no longer needed as it's generated server-side and injected into the builder environment automatically."
           }
         ],
         "interfaces": null,
@@ -8854,6 +8878,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AndroidKeystoreType",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Type will be automatically inferred from keystore content."
           }
         ],
         "interfaces": null,
@@ -9256,6 +9292,26 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "filterReleaseChannels",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": true,
+                "deprecationReason": "Classic updates are no longer supported"
               },
               {
                 "name": "filterTypes",
@@ -13644,6 +13700,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "privacy",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AppPrivacy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "projectName",
@@ -21680,6 +21748,18 @@
             "deprecationReason": null
           },
           {
+            "name": "privacy",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AppPrivacy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
             "name": "projectName",
             "description": null,
             "type": {
@@ -28808,6 +28888,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "cacheDefaultPaths",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "We don't cache anything by default anymore"
+          },
+          {
             "name": "clear",
             "description": null,
             "type": {
@@ -28818,6 +28910,22 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "customPaths",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "We use paths now since there is no default caching anymore"
           },
           {
             "name": "disabled",
@@ -29468,6 +29576,18 @@
             "deprecationReason": null
           },
           {
+            "name": "buildMode",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Use job.mode instead."
+          },
+          {
             "name": "buildProfile",
             "description": null,
             "type": {
@@ -29766,6 +29886,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "selectedImage",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Unused."
           },
           {
             "name": "simulator",
@@ -34977,6 +35109,18 @@
             "deprecationReason": null
           },
           {
+            "name": "isGlobal",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Whether the variable is global is now governed by its scope - account / app."
+          },
+          {
             "name": "name",
             "description": null,
             "type": {
@@ -36024,7 +36168,7 @@
       {
         "kind": "SCALAR",
         "name": "DateTime",
-        "description": "Date custom scalar type",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -37880,7 +38024,7 @@
       {
         "kind": "SCALAR",
         "name": "DevDomainName",
-        "description": "A DevDomainName for a deployed serverless app",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -44611,7 +44755,7 @@
       {
         "kind": "SCALAR",
         "name": "EnvironmentVariableEnvironment",
-        "description": "A name of an environment variable environment",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -53539,6 +53683,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "robotAccessToken",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Robot access token is no longer needed as it's generated server-side and injected into the builder environment automatically."
           }
         ],
         "interfaces": null,
@@ -53850,7 +54006,7 @@
       {
         "kind": "SCALAR",
         "name": "JSON",
-        "description": "The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -53860,7 +54016,7 @@
       {
         "kind": "SCALAR",
         "name": "JSONObject",
-        "description": "The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -59138,6 +59294,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "runtimeFingerprintSource",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "FingerprintSourceInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Use fingerprintInfoGroup instead"
           },
           {
             "name": "runtimeVersion",
@@ -64487,6 +64655,30 @@
             "deprecationReason": null
           },
           {
+            "name": "githubUsername",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "industry",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
             "name": "lastName",
             "description": null,
             "type": {
@@ -64497,6 +64689,30 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "location",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "twitterUsername",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           }
         ],
         "interfaces": null,
@@ -71159,6 +71375,18 @@
             "deprecationReason": null
           },
           {
+            "name": "isGlobal",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "You cannot change whether the variable is global."
+          },
+          {
             "name": "name",
             "description": null,
             "type": {
@@ -72265,6 +72493,26 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "sdkVersions",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "Use runtimeVersions instead."
           }
         ],
         "interfaces": null,
@@ -75991,6 +76239,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "appetizeCode",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
             "name": "email",
             "description": null,
             "type": {
@@ -76027,6 +76287,18 @@
             "deprecationReason": null
           },
           {
+            "name": "githubUsername",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
             "name": "id",
             "description": null,
             "type": {
@@ -76037,6 +76309,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "industry",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "lastName",
@@ -76051,6 +76335,18 @@
             "deprecationReason": null
           },
           {
+            "name": "location",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
+          },
+          {
             "name": "profilePhoto",
             "description": null,
             "type": {
@@ -76061,6 +76357,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "twitterUsername",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "username",
@@ -80446,7 +80754,7 @@
       {
         "kind": "SCALAR",
         "name": "WorkerDeploymentIdentifier",
-        "description": "A alias name for a serverless deployment",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -80716,7 +81024,7 @@
       {
         "kind": "SCALAR",
         "name": "WorkerDeploymentRequestID",
-        "description": "A Worker Deployment Request ID (also known as the CF Ray ID)",
+        "description": null,
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -90198,15 +90506,6 @@
             "deprecationReason": null
           }
         ]
-      },
-      {
-        "name": "oneOf",
-        "description": "Indicates exactly one field must be supplied and this field must not be `null`.",
-        "isRepeatable": false,
-        "locations": [
-          "INPUT_OBJECT"
-        ],
-        "args": []
       },
       {
         "name": "skip",

--- a/packages/eas-cli/src/commandUtils/posthog.ts
+++ b/packages/eas-cli/src/commandUtils/posthog.ts
@@ -1,0 +1,22 @@
+import chalk from 'chalk';
+
+import { PostHogProjectData } from '../graphql/types/PostHogConnection';
+import Log, { link } from '../log';
+
+export function getPostHogProjectDashboardUrl(project: PostHogProjectData): string {
+  const host = project.posthogHost.replace(/\/$/, '');
+  return `${host}/project/${encodeURIComponent(project.posthogProjectIdentifier)}`;
+}
+
+export function formatPostHogProject(project: PostHogProjectData): string {
+  return [
+    `${chalk.bold('Name')}: ${project.posthogProjectName}`,
+    `${chalk.bold('Host')}: ${project.posthogHost}`,
+    `${chalk.bold('Region')}: ${project.posthogOrganizationConnection.posthogRegion}`,
+    `${chalk.bold('Dashboard')}: ${link(getPostHogProjectDashboardUrl(project), { dim: false })}`,
+  ].join('\n');
+}
+
+export function logNoPostHogProject(projectName: string): void {
+  Log.warn(`No PostHog project is linked to Expo app ${chalk.bold(projectName)} on EAS.`);
+}

--- a/packages/eas-cli/src/commandUtils/posthog.ts
+++ b/packages/eas-cli/src/commandUtils/posthog.ts
@@ -1,22 +1,6 @@
-import chalk from 'chalk';
-
 import { PostHogProjectData } from '../graphql/types/PostHogConnection';
-import Log, { link } from '../log';
 
 export function getPostHogProjectDashboardUrl(project: PostHogProjectData): string {
   const host = project.posthogHost.replace(/\/$/, '');
   return `${host}/project/${encodeURIComponent(project.posthogProjectIdentifier)}`;
-}
-
-export function formatPostHogProject(project: PostHogProjectData): string {
-  return [
-    `${chalk.bold('Name')}: ${project.posthogProjectName}`,
-    `${chalk.bold('Host')}: ${project.posthogHost}`,
-    `${chalk.bold('Region')}: ${project.posthogOrganizationConnection.posthogRegion}`,
-    `${chalk.bold('Dashboard')}: ${link(getPostHogProjectDashboardUrl(project), { dim: false })}`,
-  ].join('\n');
-}
-
-export function logNoPostHogProject(projectName: string): void {
-  Log.warn(`No PostHog project is linked to Expo app ${chalk.bold(projectName)} on EAS.`);
 }

--- a/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
@@ -1,11 +1,14 @@
+import spawnAsync from '@expo/spawn-async';
+import * as fs from 'fs-extra';
+
 import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
 import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { testProjectId } from '../../../../credentials/__tests__/fixtures-constants';
 import {
-  EnvironmentSecretType,
   EnvironmentVariableScope,
   EnvironmentVariableVisibility,
   PostHogRegion,
+  Role,
 } from '../../../../graphql/generated';
 import { EnvironmentVariableMutation } from '../../../../graphql/mutations/EnvironmentVariableMutation';
 import { PostHogMutation } from '../../../../graphql/mutations/PostHogMutation';
@@ -16,12 +19,16 @@ import {
   PostHogProjectData,
 } from '../../../../graphql/types/PostHogConnection';
 import Log from '../../../../log';
+import { createOrModifyExpoConfigAsync } from '../../../../project/expoConfig';
 import { getOwnerAccountForProjectIdAsync } from '../../../../project/projectUtils';
-import { confirmAsync, selectAsync } from '../../../../prompts';
+import { confirmAsync, promptAsync, selectAsync } from '../../../../prompts';
 import { Actor } from '../../../../user/User';
 import { printJsonOnlyOutput } from '../../../../utils/json';
 import IntegrationsPostHogConnect from '../connect';
 
+jest.mock('@expo/spawn-async');
+jest.mock('fs-extra');
+jest.mock('../../../../project/expoConfig');
 jest.mock('../../../../graphql/queries/PostHogQuery');
 jest.mock('../../../../graphql/queries/EnvironmentVariablesQuery');
 jest.mock('../../../../graphql/mutations/PostHogMutation');
@@ -51,12 +58,7 @@ describe(IntegrationsPostHogConnect, () => {
     email: 'user@example.com',
     featureGates: {},
     isExpoAdmin: false,
-    primaryAccount: {
-      id: testAccountId,
-      name: testAccountName,
-      ownerUserActor: null,
-      users: [],
-    },
+    primaryAccount: { id: testAccountId, name: testAccountName, ownerUserActor: null, users: [] },
     preferences: { onboarding: null },
     accounts: [],
   };
@@ -65,7 +67,7 @@ describe(IntegrationsPostHogConnect, () => {
     id: testAccountId,
     name: testAccountName,
     ownerUserActor: { id: 'test-user-id', username: testAccountName },
-    users: [{ role: 'OWNER' as any, actor: { id: 'test-user-id' } }],
+    users: [{ role: Role.Owner, actor: { id: 'test-user-id' } }],
   };
 
   const mockConnection: PostHogOrganizationConnectionData = {
@@ -79,7 +81,7 @@ describe(IntegrationsPostHogConnect, () => {
 
   const mockProject: PostHogProjectData = {
     id: 'project-1',
-    posthogProjectIdentifier: 'res-123',
+    posthogProjectIdentifier: '467657',
     posthogProjectName: 'testapp',
     posthogProjectToken: 'phc_public_key',
     posthogHost: 'https://us.posthog.com',
@@ -93,7 +95,7 @@ describe(IntegrationsPostHogConnect, () => {
     jest.spyOn(command as any, 'getContextAsync').mockReturnValue({
       privateProjectConfig: {
         projectId: testProjectId,
-        exp: { name: 'testapp', slug: 'testapp' },
+        exp: { name: 'testapp', slug: 'testapp', plugins: [] },
         projectDir: '/test/project',
       },
       loggedIn: { graphqlClient, actor },
@@ -101,10 +103,24 @@ describe(IntegrationsPostHogConnect, () => {
     return command;
   }
 
+  // Helper: which features the interactive multiselect returns.
+  function mockFeatureSelection(features: string[]): void {
+    jest.mocked(promptAsync).mockImplementation((async (opts: any) => {
+      if (opts.name === 'features') {
+        return { features };
+      }
+      if (opts.name === 'apiKey') {
+        return { apiKey: 'phx_personal_key' };
+      }
+      return {};
+    }) as any);
+  }
+
   beforeEach(() => {
     jest.resetAllMocks();
     jest.spyOn(Log, 'log').mockImplementation(() => {});
     jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    jest.spyOn(Log, 'error').mockImplementation(() => {});
     jest.spyOn(Log, 'withTick').mockImplementation(() => {});
     jest.spyOn(Log, 'addNewLineIfNone').mockImplementation(() => {});
     jest.spyOn(Log, 'newLine').mockImplementation(() => {});
@@ -112,22 +128,258 @@ describe(IntegrationsPostHogConnect, () => {
     jest.mocked(getOwnerAccountForProjectIdAsync).mockResolvedValue(mockAccount as any);
     jest.mocked(selectAsync).mockResolvedValue(PostHogRegion.Us);
     jest.mocked(confirmAsync).mockResolvedValue(true);
+    jest.mocked(spawnAsync).mockResolvedValue({} as any);
+    jest.mocked(fs.pathExists).mockResolvedValue(false as never);
+    jest.mocked(fs.writeFile).mockResolvedValue(undefined as never);
+    jest.mocked(createOrModifyExpoConfigAsync).mockResolvedValue({ type: 'success' } as any);
+    // Default: reuse an existing connection + project.
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(mockConnection);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
     jest.mocked(PostHogMutation.createPostHogAccountRequestAsync).mockResolvedValue(mockConnection);
     jest.mocked(PostHogMutation.setupPostHogProjectAsync).mockResolvedValue(mockProject);
     jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValue([]);
     jest.mocked(EnvironmentVariableMutation.createForAppAsync).mockResolvedValue({
       id: 'env-var-1',
       scope: EnvironmentVariableScope.Project,
-      visibility: EnvironmentVariableVisibility.Public,
-      type: EnvironmentSecretType.String,
     } as any);
+    mockFeatureSelection(['analytics', 'session-replay', 'error-tracking']);
   });
 
-  it('provisions a new PostHog organization + project and writes the EXPO_PUBLIC_* env vars', async () => {
+  it('sets up all features: installs SDK + replay pkg, adds plugin, writes EXPO_PUBLIC_ + POSTHOG_CLI_ vars', async () => {
+    await createCommand([]).runAsync();
+
+    const installArgs = jest.mocked(spawnAsync).mock.calls[0][1];
+    expect(installArgs).toContain('posthog-react-native');
+    expect(installArgs).toContain('posthog-react-native-session-replay');
+    expect(createOrModifyExpoConfigAsync).toHaveBeenCalled();
+    expect(fs.writeFile).toHaveBeenCalled();
+
+    const createdNames = jest
+      .mocked(EnvironmentVariableMutation.createForAppAsync)
+      .mock.calls.map(call => call[1].name);
+    expect(createdNames).toEqual(
+      expect.arrayContaining([
+        'EXPO_PUBLIC_POSTHOG_API_KEY',
+        'EXPO_PUBLIC_POSTHOG_HOST',
+        'POSTHOG_CLI_API_KEY',
+        'POSTHOG_CLI_PROJECT_ID',
+        'POSTHOG_CLI_HOST',
+      ])
+    );
+    const cliKeyVar = jest
+      .mocked(EnvironmentVariableMutation.createForAppAsync)
+      .mock.calls.find(call => call[1].name === 'POSTHOG_CLI_API_KEY');
+    expect(cliKeyVar?.[1].visibility).toBe(EnvironmentVariableVisibility.Sensitive);
+    // The pasted personal key flows through verbatim — to EAS and to .env.local.
+    expect(cliKeyVar?.[1].value).toBe('phx_personal_key');
+    const written = jest.mocked(fs.writeFile).mock.calls[0][1] as string;
+    expect(written).toContain('POSTHOG_CLI_API_KEY=phx_personal_key');
+  });
+
+  it('asks for features only after provisioning (fast-forward ordering)', async () => {
     jest
       .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
       .mockResolvedValue(null);
     jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+    let provisionedBeforePrompt = false;
+    jest.mocked(promptAsync).mockImplementation((async (opts: any) => {
+      if (opts.name === 'features') {
+        provisionedBeforePrompt =
+          jest.mocked(PostHogMutation.createPostHogAccountRequestAsync).mock.calls.length > 0 &&
+          jest.mocked(PostHogMutation.setupPostHogProjectAsync).mock.calls.length > 0;
+        return { features: ['analytics'] };
+      }
+      return {};
+    }) as any);
+
+    await createCommand(['--region', 'US']).runAsync();
+
+    expect(provisionedBeforePrompt).toBe(true);
+  });
+
+  it('analytics only: no replay pkg, no CLI vars, no key prompt', async () => {
+    mockFeatureSelection(['analytics']);
+
+    await createCommand([]).runAsync();
+
+    expect(jest.mocked(spawnAsync).mock.calls[0][1]).not.toContain(
+      'posthog-react-native-session-replay'
+    );
+    const createdNames = jest
+      .mocked(EnvironmentVariableMutation.createForAppAsync)
+      .mock.calls.map(call => call[1].name);
+    expect(createdNames).toEqual(['EXPO_PUBLIC_POSTHOG_API_KEY', 'EXPO_PUBLIC_POSTHOG_HOST']);
+    expect(promptAsync).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'apiKey' }));
+  });
+
+  it('adds the config plugin and public env vars for session-replay-only (analytics deselected)', async () => {
+    mockFeatureSelection(['session-replay']);
+
+    await createCommand([]).runAsync();
+
+    // The plugin wires native modules replay needs, so it must be added even without analytics.
+    expect(createOrModifyExpoConfigAsync).toHaveBeenCalled();
+    expect(jest.mocked(spawnAsync).mock.calls[0][1]).toContain(
+      'posthog-react-native-session-replay'
+    );
+    // The public key + host initialize the SDK for any feature, so they're still written.
+    const createdNames = jest
+      .mocked(EnvironmentVariableMutation.createForAppAsync)
+      .mock.calls.map(call => call[1].name);
+    expect(createdNames).toEqual(['EXPO_PUBLIC_POSTHOG_API_KEY', 'EXPO_PUBLIC_POSTHOG_HOST']);
+  });
+
+  it('routes the install child off stdout in --json mode', async () => {
+    await createCommand(['--json', '--posthog-cli-api-key', 'phx_x']).runAsync();
+
+    // stdout must carry only the JSON document, so the child writes to fd 2 (stderr).
+    expect(jest.mocked(spawnAsync).mock.calls[0][2]).toEqual(
+      expect.objectContaining({ stdio: ['ignore', 2, 2] })
+    );
+  });
+
+  it('non-interactive defaults: analytics + replay, error tracking auto-skipped', async () => {
+    await createCommand(['--non-interactive']).runAsync();
+
+    expect(promptAsync).not.toHaveBeenCalled();
+    const createdNames = jest
+      .mocked(EnvironmentVariableMutation.createForAppAsync)
+      .mock.calls.map(call => call[1].name);
+    expect(createdNames).not.toContain('POSTHOG_CLI_API_KEY');
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('Skipping error tracking'));
+    // Session replay defaults on, so its package is still installed.
+    expect(jest.mocked(spawnAsync).mock.calls[0][1]).toContain(
+      'posthog-react-native-session-replay'
+    );
+  });
+
+  it('non-interactive --error-tracking without a key fails before any provisioning', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+
+    await expect(
+      createCommand(['--non-interactive', '--error-tracking']).runAsync()
+    ).rejects.toThrow(/personal API key in non-interactive/);
+
+    expect(PostHogMutation.createPostHogAccountRequestAsync).not.toHaveBeenCalled();
+  });
+
+  it('non-interactive --error-tracking with --posthog-cli-api-key sets up CLI vars without prompting', async () => {
+    await createCommand([
+      '--non-interactive',
+      '--error-tracking',
+      '--posthog-cli-api-key',
+      'phx_from_flag',
+    ]).runAsync();
+
+    expect(promptAsync).not.toHaveBeenCalled();
+    const cliKeyVar = jest
+      .mocked(EnvironmentVariableMutation.createForAppAsync)
+      .mock.calls.find(call => call[1].name === 'POSTHOG_CLI_API_KEY');
+    expect(cliKeyVar?.[1].value).toBe('phx_from_flag');
+  });
+
+  it('treats a whitespace-only --posthog-cli-api-key as absent (fails like no key)', async () => {
+    await expect(
+      createCommand([
+        '--non-interactive',
+        '--error-tracking',
+        '--posthog-cli-api-key',
+        '   ',
+      ]).runAsync()
+    ).rejects.toThrow(/personal API key in non-interactive/);
+  });
+
+  it('warns and prints manual edit when the app config is dynamic', async () => {
+    mockFeatureSelection(['analytics']);
+    jest.mocked(createOrModifyExpoConfigAsync).mockResolvedValue({
+      type: 'warn',
+      message: 'Cannot automatically write to dynamic config',
+    } as any);
+
+    await createCommand([]).runAsync();
+
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot automatically write to dynamic config')
+    );
+    // Falls back to actionable manual-edit instructions.
+    expect(Log.log).toHaveBeenCalledWith(
+      expect.stringContaining('Add the PostHog config plugin to your app config')
+    );
+  });
+
+  it('reuses an existing connection + project without provisioning', async () => {
+    await createCommand([]).runAsync();
+
+    expect(PostHogMutation.createPostHogAccountRequestAsync).not.toHaveBeenCalled();
+    expect(PostHogMutation.setupPostHogProjectAsync).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the existing-account dead-end without provisioning a project', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+    jest.mocked(PostHogMutation.createPostHogAccountRequestAsync).mockRejectedValue(
+      Object.assign(new Error('You already have a PostHog account.'), {
+        graphQLErrors: [{ extensions: { errorCode: 'POSTHOG_EXISTING_USER_NOT_SUPPORTED_ERROR' } }],
+      })
+    );
+
+    await expect(createCommand(['--region', 'US']).runAsync()).rejects.toThrow(
+      'You already have a PostHog account.'
+    );
+
+    // Fails (non-zero exit) without provisioning a project or writing any config.
+    expect(PostHogMutation.setupPostHogProjectAsync).not.toHaveBeenCalled();
+    expect(EnvironmentVariableMutation.createForAppAsync).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('emits JSON output with --json', async () => {
+    await createCommand(['--json', '--posthog-cli-api-key', 'phx_x']).runAsync();
+
+    expect(printJsonOnlyOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project: expect.objectContaining({ apiKey: 'phc_public_key' }),
+        // --json supplies the key, so error tracking is on and its vars are reported.
+        features: expect.objectContaining({ analytics: true, errorTracking: true }),
+        dashboardUrl: expect.any(String),
+        environmentVariables: expect.arrayContaining([
+          'EXPO_PUBLIC_POSTHOG_API_KEY',
+          'POSTHOG_CLI_API_KEY',
+          'POSTHOG_CLI_PROJECT_ID',
+          'POSTHOG_CLI_HOST',
+        ]),
+      })
+    );
+  });
+
+  it('requires --region in non-interactive mode when provisioning', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+
+    await expect(createCommand(['--non-interactive']).runAsync()).rejects.toThrow(
+      /region is required in non-interactive/
+    );
+  });
+
+  it('warns when --region differs from the already-connected region', async () => {
+    await createCommand(['--region', 'EU']).runAsync();
+
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('already connected to PostHog'));
+  });
+
+  it('provisions a new connection and project when none exist', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+    mockFeatureSelection(['analytics']);
 
     await createCommand(['--region', 'US']).runAsync();
 
@@ -139,208 +391,232 @@ describe(IntegrationsPostHogConnect, () => {
       appId: testProjectId,
       posthogOrganizationConnectionId: mockConnection.id,
     });
-    const createdNames = jest
-      .mocked(EnvironmentVariableMutation.createForAppAsync)
-      .mock.calls.map(call => call[1].name);
-    expect(createdNames).toEqual(
-      expect.arrayContaining(['EXPO_PUBLIC_POSTHOG_API_KEY', 'EXPO_PUBLIC_POSTHOG_HOST'])
-    );
-    expect(jest.mocked(EnvironmentVariableMutation.createForAppAsync).mock.calls[0][1].value).toBe(
-      'phc_public_key'
-    );
   });
 
-  it('reuses an existing connection and project without provisioning', async () => {
-    jest
-      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
-      .mockResolvedValue(mockConnection);
-    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
-
-    await createCommand(['--region', 'US']).runAsync();
-
-    expect(PostHogMutation.createPostHogAccountRequestAsync).not.toHaveBeenCalled();
-    expect(PostHogMutation.setupPostHogProjectAsync).not.toHaveBeenCalled();
-    expect(EnvironmentVariableMutation.createForAppAsync).toHaveBeenCalled();
-  });
-
-  it('surfaces the existing-account dead-end without provisioning a project', async () => {
+  it('rethrows a non-dead-end provisioning failure', async () => {
     jest
       .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
       .mockResolvedValue(null);
-    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
-    jest.mocked(PostHogMutation.createPostHogAccountRequestAsync).mockRejectedValue(
-      Object.assign(
-        new Error(
-          "You already have a PostHog account. Existing-account sign-in isn't supported yet."
-        ),
-        {
-          graphQLErrors: [
-            { extensions: { errorCode: 'POSTHOG_EXISTING_USER_NOT_SUPPORTED_ERROR' } },
-          ],
-        }
-      )
-    );
-
-    await createCommand(['--region', 'US']).runAsync();
-
-    expect(PostHogMutation.setupPostHogProjectAsync).not.toHaveBeenCalled();
-    expect(EnvironmentVariableMutation.createForAppAsync).not.toHaveBeenCalled();
-    expect(Log.error).toHaveBeenCalledWith(
-      expect.stringContaining('already have a PostHog account')
-    );
-  });
-
-  it('rethrows non-dead-end provisioning errors', async () => {
-    jest
-      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
-      .mockResolvedValue(null);
-    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
     jest
       .mocked(PostHogMutation.createPostHogAccountRequestAsync)
-      .mockRejectedValue(new Error('boom'));
+      .mockRejectedValue(new Error('network down'));
 
-    await expect(createCommand(['--region', 'US']).runAsync()).rejects.toThrow('boom');
+    await expect(createCommand(['--region', 'US']).runAsync()).rejects.toThrow('network down');
   });
 
-  it('updates existing env vars when present and overwrite is confirmed', async () => {
-    jest
-      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
-      .mockResolvedValue(mockConnection);
-    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
-    jest
-      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
-      .mockResolvedValue([{ id: 'env-existing', scope: EnvironmentVariableScope.Project } as any]);
-    jest.mocked(confirmAsync).mockResolvedValue(true);
-
-    await createCommand(['--region', 'US']).runAsync();
-
-    expect(EnvironmentVariableMutation.updateAsync).toHaveBeenCalledTimes(2);
-    expect(EnvironmentVariableMutation.createForAppAsync).not.toHaveBeenCalled();
-  });
-
-  it('skips updating an existing env var when overwrite is declined', async () => {
-    jest
-      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
-      .mockResolvedValue(mockConnection);
-    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
-    jest
-      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
-      .mockResolvedValue([{ id: 'env-existing', scope: EnvironmentVariableScope.Project } as any]);
-    jest.mocked(confirmAsync).mockResolvedValue(false);
-
-    await createCommand(['--region', 'US']).runAsync();
-
-    expect(EnvironmentVariableMutation.updateAsync).not.toHaveBeenCalled();
-  });
-
-  it('requires an explicit region in non-interactive mode (no silent US default)', async () => {
-    jest
-      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
-      .mockResolvedValue(null);
-
-    await expect(createCommand(['--non-interactive']).runAsync()).rejects.toThrow(
-      /region is required in non-interactive mode/
-    );
-    expect(PostHogMutation.createPostHogAccountRequestAsync).not.toHaveBeenCalled();
-  });
-
-  it('warns and reuses when --region differs from the existing connection region', async () => {
-    jest
-      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
-      .mockResolvedValue(mockConnection); // US
-    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
-
-    await createCommand(['--region', 'EU']).runAsync();
-
-    expect(Log.warn).toHaveBeenCalledWith(
-      expect.stringContaining('already connected to PostHog in the US region')
-    );
-    expect(PostHogMutation.createPostHogAccountRequestAsync).not.toHaveBeenCalled();
-  });
-
-  it('emits JSON output with --json', async () => {
-    jest
-      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
-      .mockResolvedValue(null);
+  it('rethrows when project setup fails', async () => {
     jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+    jest
+      .mocked(PostHogMutation.setupPostHogProjectAsync)
+      .mockRejectedValue(new Error('setup failed'));
 
-    await createCommand(['--region', 'US', '--json']).runAsync();
+    await expect(createCommand([]).runAsync()).rejects.toThrow('setup failed');
+  });
 
-    expect(printJsonOnlyOutput).toHaveBeenCalledWith(
-      expect.objectContaining({
-        organizationConnection: expect.objectContaining({ id: mockConnection.id }),
-        project: expect.objectContaining({
-          apiKey: 'phc_public_key',
-          host: 'https://us.posthog.com',
-        }),
-        dashboardUrl: expect.any(String),
-        environmentVariables: ['EXPO_PUBLIC_POSTHOG_API_KEY', 'EXPO_PUBLIC_POSTHOG_HOST'],
-      })
+  it('honors explicit --no-session-replay without showing the feature multiselect', async () => {
+    await createCommand(['--no-session-replay']).runAsync();
+
+    expect(promptAsync).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'features' }));
+    expect(jest.mocked(spawnAsync).mock.calls[0][1]).not.toContain(
+      'posthog-react-native-session-replay'
     );
   });
 
-  it('skips overwriting existing env vars in non-interactive without --overwrite', async () => {
-    jest
-      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
-      .mockResolvedValue(mockConnection);
-    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
-    jest
-      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
-      .mockResolvedValue([{ id: 'env-existing', scope: EnvironmentVariableScope.Project } as any]);
+  it('prompts for a personal API key and validates it', async () => {
+    await createCommand([]).runAsync();
 
-    await createCommand(['--non-interactive']).runAsync();
-
-    expect(EnvironmentVariableMutation.updateAsync).not.toHaveBeenCalled();
-    expect(confirmAsync).not.toHaveBeenCalled();
+    const apiKeyPrompt = jest
+      .mocked(promptAsync)
+      .mock.calls.map(call => call[0])
+      .find((opts: any) => opts.name === 'apiKey') as any;
+    expect(apiKeyPrompt).toBeDefined();
+    expect(apiKeyPrompt.validate('')).toBe('Personal API key cannot be empty');
+    expect(apiKeyPrompt.validate('phx_real')).toBe(true);
   });
 
-  it('overwrites existing env vars in non-interactive with --overwrite', async () => {
-    jest
-      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
-      .mockResolvedValue(mockConnection);
-    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
-    jest
-      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
-      .mockResolvedValue([{ id: 'env-existing', scope: EnvironmentVariableScope.Project } as any]);
+  it('rethrows and warns when SDK installation fails', async () => {
+    mockFeatureSelection(['analytics']);
+    jest.mocked(spawnAsync).mockRejectedValue(new Error('npm exploded'));
 
-    await createCommand(['--non-interactive', '--overwrite']).runAsync();
-
-    expect(EnvironmentVariableMutation.updateAsync).toHaveBeenCalledTimes(2);
-    expect(confirmAsync).not.toHaveBeenCalled();
+    await expect(createCommand([]).runAsync()).rejects.toThrow('npm exploded');
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to install'));
   });
 
-  it('prompts for the region interactively when none exists and --region is omitted', async () => {
-    jest
-      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
-      .mockResolvedValue(null);
-    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+  it('skips the config plugin when it is already configured', async () => {
+    mockFeatureSelection(['analytics']);
+    const command = createCommand([]);
+    jest.spyOn(command as any, 'getContextAsync').mockReturnValue({
+      privateProjectConfig: {
+        projectId: testProjectId,
+        exp: { name: 'testapp', slug: 'testapp', plugins: ['posthog-react-native/expo'] },
+        projectDir: '/test/project',
+      },
+      loggedIn: { graphqlClient, actor: mockActor },
+    } as never);
+
+    await command.runAsync();
+
+    expect(createOrModifyExpoConfigAsync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing local when no features are selected (no install, no writes)', async () => {
+    mockFeatureSelection([]);
 
     await createCommand([]).runAsync();
 
-    expect(selectAsync).toHaveBeenCalled();
+    expect(spawnAsync).not.toHaveBeenCalled();
+    expect(createOrModifyExpoConfigAsync).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(EnvironmentVariableMutation.createForAppAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('No PostHog features selected'));
+  });
+
+  it('merges into an existing .env.local, replacing matching keys and appending new ones', async () => {
+    mockFeatureSelection(['analytics']);
+    jest.mocked(fs.pathExists).mockResolvedValue(true as never);
+    jest
+      .mocked(fs.readFile)
+      .mockResolvedValue('EXPO_PUBLIC_POSTHOG_API_KEY=old_value\nOTHER=keep' as never);
+
+    await createCommand([]).runAsync();
+
+    const written = jest.mocked(fs.writeFile).mock.calls[0][1] as string;
+    expect(written).toContain('EXPO_PUBLIC_POSTHOG_API_KEY=phc_public_key');
+    expect(written).toContain('OTHER=keep');
+    expect(written).toContain('EXPO_PUBLIC_POSTHOG_HOST=https://us.posthog.com');
+  });
+
+  it('prompts for a region interactively when provisioning without --region', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+    mockFeatureSelection(['analytics']);
+
+    await createCommand([]).runAsync();
+
+    expect(selectAsync).toHaveBeenCalledWith('Select a PostHog region', expect.any(Array));
     expect(PostHogMutation.createPostHogAccountRequestAsync).toHaveBeenCalledWith(graphqlClient, {
       accountId: testAccountId,
       region: PostHogRegion.Us,
     });
   });
 
-  it('rethrows when project setup fails', async () => {
-    jest
-      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
-      .mockResolvedValue(mockConnection);
-    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
-    jest
-      .mocked(PostHogMutation.setupPostHogProjectAsync)
-      .mockRejectedValue(new Error('setup boom'));
+  it('skips .env.local when the user declines to overwrite a conflict', async () => {
+    mockFeatureSelection(['analytics']);
+    jest.mocked(fs.pathExists).mockResolvedValue(true as never);
+    jest.mocked(fs.readFile).mockResolvedValue('EXPO_PUBLIC_POSTHOG_API_KEY=old_value\n' as never);
+    jest.mocked(confirmAsync).mockResolvedValue(false);
 
-    await expect(createCommand(['--region', 'US']).runAsync()).rejects.toThrow('setup boom');
+    await createCommand([]).runAsync();
+
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('Skipped updating'));
   });
 
-  it('rejects an unsupported region value', async () => {
-    const command = createCommand([]);
+  it('--overwrite writes .env.local without prompting on a conflict', async () => {
+    mockFeatureSelection(['analytics']);
+    jest.mocked(fs.pathExists).mockResolvedValue(true as never);
+    jest.mocked(fs.readFile).mockResolvedValue('EXPO_PUBLIC_POSTHOG_API_KEY=old_value\n' as never);
 
-    await expect((command as any).resolveRegionAsync('INVALID', false)).rejects.toThrow(
-      /Unsupported PostHog region/
+    await createCommand(['--overwrite']).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    const written = jest.mocked(fs.writeFile).mock.calls[0][1] as string;
+    expect(written).toContain('EXPO_PUBLIC_POSTHOG_API_KEY=phc_public_key');
+  });
+
+  it('non-interactively skips an existing .env.local key without --overwrite', async () => {
+    jest.mocked(fs.pathExists).mockResolvedValue(true as never);
+    jest.mocked(fs.readFile).mockResolvedValue('EXPO_PUBLIC_POSTHOG_API_KEY=old_value\n' as never);
+
+    await createCommand(['--non-interactive']).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('pass --overwrite to replace'));
+  });
+
+  it('non-interactively overwrites an existing .env.local key with --overwrite', async () => {
+    jest.mocked(fs.pathExists).mockResolvedValue(true as never);
+    jest.mocked(fs.readFile).mockResolvedValue('EXPO_PUBLIC_POSTHOG_API_KEY=old_value\n' as never);
+
+    await createCommand(['--non-interactive', '--overwrite']).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    const written = jest.mocked(fs.writeFile).mock.calls[0][1] as string;
+    expect(written).toContain('EXPO_PUBLIC_POSTHOG_API_KEY=phc_public_key');
+  });
+
+  it('writes a personal API key containing $ verbatim (no replacement-pattern expansion)', async () => {
+    const command = createCommand([]);
+    const merged = (command as any).mergeEnvContent('POSTHOG_CLI_API_KEY=old\n', {
+      POSTHOG_CLI_API_KEY: 'phx_a$2b$&c',
+    });
+    expect(merged).toContain('POSTHOG_CLI_API_KEY=phx_a$2b$&c');
+  });
+
+  it('updates an existing EAS environment variable with --overwrite', async () => {
+    mockFeatureSelection(['analytics']);
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
+      .mockResolvedValue([{ id: 'existing-1', scope: EnvironmentVariableScope.Project }] as any);
+    jest
+      .mocked(EnvironmentVariableMutation.updateAsync)
+      .mockResolvedValue({ id: 'existing-1' } as any);
+
+    await createCommand(['--overwrite']).runAsync();
+
+    expect(EnvironmentVariableMutation.updateAsync).toHaveBeenCalled();
+    expect(EnvironmentVariableMutation.createForAppAsync).not.toHaveBeenCalled();
+  });
+
+  it('honors explicit --error-tracking interactively and detects an array-form plugin', async () => {
+    const command = createCommand(['--error-tracking', '--posthog-cli-api-key', 'phx_flag']);
+    jest.spyOn(command as any, 'getContextAsync').mockReturnValue({
+      privateProjectConfig: {
+        projectId: testProjectId,
+        exp: { name: 'testapp', slug: 'testapp', plugins: [['expo-router', {}]] },
+        projectDir: '/test/project',
+      },
+      loggedIn: { graphqlClient, actor: mockActor },
+    } as never);
+
+    await command.runAsync();
+
+    expect(promptAsync).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'features' }));
+    const cliKeyVar = jest
+      .mocked(EnvironmentVariableMutation.createForAppAsync)
+      .mock.calls.find(call => call[1].name === 'POSTHOG_CLI_API_KEY');
+    expect(cliKeyVar?.[1].value).toBe('phx_flag');
+    expect(createOrModifyExpoConfigAsync).toHaveBeenCalled();
+  });
+
+  it('skips an existing EAS environment variable non-interactively without --overwrite', async () => {
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
+      .mockResolvedValue([{ id: 'existing-1', scope: EnvironmentVariableScope.Project }] as any);
+
+    await createCommand(['--non-interactive', '--region', 'US']).runAsync();
+
+    expect(EnvironmentVariableMutation.updateAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('pass --overwrite to replace it')
+    );
+  });
+
+  it('skips an existing EAS environment variable when overwrite is declined', async () => {
+    mockFeatureSelection(['analytics']);
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
+      .mockResolvedValue([{ id: 'existing-1', scope: EnvironmentVariableScope.Project }] as any);
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+
+    await createCommand([]).runAsync();
+
+    expect(EnvironmentVariableMutation.updateAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Skipped updating EAS environment variable')
     );
   });
 });

--- a/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
@@ -1,0 +1,346 @@
+import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../../credentials/__tests__/fixtures-constants';
+import {
+  EnvironmentSecretType,
+  EnvironmentVariableScope,
+  EnvironmentVariableVisibility,
+  PostHogRegion,
+} from '../../../../graphql/generated';
+import { EnvironmentVariableMutation } from '../../../../graphql/mutations/EnvironmentVariableMutation';
+import { PostHogMutation } from '../../../../graphql/mutations/PostHogMutation';
+import { EnvironmentVariablesQuery } from '../../../../graphql/queries/EnvironmentVariablesQuery';
+import { PostHogQuery } from '../../../../graphql/queries/PostHogQuery';
+import {
+  PostHogOrganizationConnectionData,
+  PostHogProjectData,
+} from '../../../../graphql/types/PostHogConnection';
+import Log from '../../../../log';
+import { getOwnerAccountForProjectIdAsync } from '../../../../project/projectUtils';
+import { confirmAsync, selectAsync } from '../../../../prompts';
+import { Actor } from '../../../../user/User';
+import { printJsonOnlyOutput } from '../../../../utils/json';
+import IntegrationsPostHogConnect from '../connect';
+
+jest.mock('../../../../graphql/queries/PostHogQuery');
+jest.mock('../../../../graphql/queries/EnvironmentVariablesQuery');
+jest.mock('../../../../graphql/mutations/PostHogMutation');
+jest.mock('../../../../graphql/mutations/EnvironmentVariableMutation');
+jest.mock('../../../../project/projectUtils');
+jest.mock('../../../../prompts');
+jest.mock('../../../../log');
+jest.mock('../../../../utils/json');
+jest.mock('../../../../ora', () => ({
+  ora: () => ({
+    start: jest.fn().mockReturnThis(),
+    succeed: jest.fn().mockReturnThis(),
+    fail: jest.fn().mockReturnThis(),
+  }),
+}));
+
+describe(IntegrationsPostHogConnect, () => {
+  const graphqlClient = {} as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+  const testAccountId = 'test-account-id';
+  const testAccountName = 'testuser';
+
+  const mockActor: Actor = {
+    __typename: 'User',
+    id: 'test-user-id',
+    username: testAccountName,
+    email: 'user@example.com',
+    featureGates: {},
+    isExpoAdmin: false,
+    primaryAccount: {
+      id: testAccountId,
+      name: testAccountName,
+      ownerUserActor: null,
+      users: [],
+    },
+    preferences: { onboarding: null },
+    accounts: [],
+  };
+
+  const mockAccount = {
+    id: testAccountId,
+    name: testAccountName,
+    ownerUserActor: { id: 'test-user-id', username: testAccountName },
+    users: [{ role: 'OWNER' as any, actor: { id: 'test-user-id' } }],
+  };
+
+  const mockConnection: PostHogOrganizationConnectionData = {
+    id: 'connection-1',
+    posthogOrganizationIdentifier: 'org-123',
+    posthogOrganizationName: 'Test Org',
+    posthogRegion: PostHogRegion.Us,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  };
+
+  const mockProject: PostHogProjectData = {
+    id: 'project-1',
+    posthogProjectIdentifier: 'res-123',
+    posthogProjectName: 'testapp',
+    posthogProjectToken: 'phc_public_key',
+    posthogHost: 'https://us.posthog.com',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    posthogOrganizationConnection: mockConnection,
+  };
+
+  function createCommand(argv: string[], actor: Actor = mockActor): IntegrationsPostHogConnect {
+    const command = new IntegrationsPostHogConnect(argv, mockConfig);
+    jest.spyOn(command as any, 'getContextAsync').mockReturnValue({
+      privateProjectConfig: {
+        projectId: testProjectId,
+        exp: { name: 'testapp', slug: 'testapp' },
+        projectDir: '/test/project',
+      },
+      loggedIn: { graphqlClient, actor },
+    } as never);
+    return command;
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    jest.spyOn(Log, 'withTick').mockImplementation(() => {});
+    jest.spyOn(Log, 'addNewLineIfNone').mockImplementation(() => {});
+    jest.spyOn(Log, 'newLine').mockImplementation(() => {});
+
+    jest.mocked(getOwnerAccountForProjectIdAsync).mockResolvedValue(mockAccount as any);
+    jest.mocked(selectAsync).mockResolvedValue(PostHogRegion.Us);
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+    jest.mocked(PostHogMutation.createPostHogAccountRequestAsync).mockResolvedValue(mockConnection);
+    jest.mocked(PostHogMutation.setupPostHogProjectAsync).mockResolvedValue(mockProject);
+    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockResolvedValue([]);
+    jest.mocked(EnvironmentVariableMutation.createForAppAsync).mockResolvedValue({
+      id: 'env-var-1',
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
+      type: EnvironmentSecretType.String,
+    } as any);
+  });
+
+  it('provisions a new PostHog organization + project and writes the EXPO_PUBLIC_* env vars', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+
+    await createCommand(['--region', 'US']).runAsync();
+
+    expect(PostHogMutation.createPostHogAccountRequestAsync).toHaveBeenCalledWith(graphqlClient, {
+      accountId: testAccountId,
+      region: PostHogRegion.Us,
+    });
+    expect(PostHogMutation.setupPostHogProjectAsync).toHaveBeenCalledWith(graphqlClient, {
+      appId: testProjectId,
+      posthogOrganizationConnectionId: mockConnection.id,
+    });
+    const createdNames = jest
+      .mocked(EnvironmentVariableMutation.createForAppAsync)
+      .mock.calls.map(call => call[1].name);
+    expect(createdNames).toEqual(
+      expect.arrayContaining(['EXPO_PUBLIC_POSTHOG_API_KEY', 'EXPO_PUBLIC_POSTHOG_HOST'])
+    );
+    expect(jest.mocked(EnvironmentVariableMutation.createForAppAsync).mock.calls[0][1].value).toBe(
+      'phc_public_key'
+    );
+  });
+
+  it('reuses an existing connection and project without provisioning', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(mockConnection);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
+
+    await createCommand(['--region', 'US']).runAsync();
+
+    expect(PostHogMutation.createPostHogAccountRequestAsync).not.toHaveBeenCalled();
+    expect(PostHogMutation.setupPostHogProjectAsync).not.toHaveBeenCalled();
+    expect(EnvironmentVariableMutation.createForAppAsync).toHaveBeenCalled();
+  });
+
+  it('surfaces the existing-account dead-end without provisioning a project', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+    jest.mocked(PostHogMutation.createPostHogAccountRequestAsync).mockRejectedValue(
+      Object.assign(
+        new Error(
+          "You already have a PostHog account. Existing-account sign-in isn't supported yet."
+        ),
+        {
+          graphQLErrors: [
+            { extensions: { errorCode: 'POSTHOG_EXISTING_USER_NOT_SUPPORTED_ERROR' } },
+          ],
+        }
+      )
+    );
+
+    await createCommand(['--region', 'US']).runAsync();
+
+    expect(PostHogMutation.setupPostHogProjectAsync).not.toHaveBeenCalled();
+    expect(EnvironmentVariableMutation.createForAppAsync).not.toHaveBeenCalled();
+    expect(Log.error).toHaveBeenCalledWith(
+      expect.stringContaining('already have a PostHog account')
+    );
+  });
+
+  it('rethrows non-dead-end provisioning errors', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+    jest
+      .mocked(PostHogMutation.createPostHogAccountRequestAsync)
+      .mockRejectedValue(new Error('boom'));
+
+    await expect(createCommand(['--region', 'US']).runAsync()).rejects.toThrow('boom');
+  });
+
+  it('updates existing env vars when present and overwrite is confirmed', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(mockConnection);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
+      .mockResolvedValue([{ id: 'env-existing', scope: EnvironmentVariableScope.Project } as any]);
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+
+    await createCommand(['--region', 'US']).runAsync();
+
+    expect(EnvironmentVariableMutation.updateAsync).toHaveBeenCalledTimes(2);
+    expect(EnvironmentVariableMutation.createForAppAsync).not.toHaveBeenCalled();
+  });
+
+  it('skips updating an existing env var when overwrite is declined', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(mockConnection);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
+      .mockResolvedValue([{ id: 'env-existing', scope: EnvironmentVariableScope.Project } as any]);
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+
+    await createCommand(['--region', 'US']).runAsync();
+
+    expect(EnvironmentVariableMutation.updateAsync).not.toHaveBeenCalled();
+  });
+
+  it('requires an explicit region in non-interactive mode (no silent US default)', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+
+    await expect(createCommand(['--non-interactive']).runAsync()).rejects.toThrow(
+      /region is required in non-interactive mode/
+    );
+    expect(PostHogMutation.createPostHogAccountRequestAsync).not.toHaveBeenCalled();
+  });
+
+  it('warns and reuses when --region differs from the existing connection region', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(mockConnection); // US
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
+
+    await createCommand(['--region', 'EU']).runAsync();
+
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('already connected to PostHog in the US region')
+    );
+    expect(PostHogMutation.createPostHogAccountRequestAsync).not.toHaveBeenCalled();
+  });
+
+  it('emits JSON output with --json', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+
+    await createCommand(['--region', 'US', '--json']).runAsync();
+
+    expect(printJsonOnlyOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationConnection: expect.objectContaining({ id: mockConnection.id }),
+        project: expect.objectContaining({
+          apiKey: 'phc_public_key',
+          host: 'https://us.posthog.com',
+        }),
+        dashboardUrl: expect.any(String),
+        environmentVariables: ['EXPO_PUBLIC_POSTHOG_API_KEY', 'EXPO_PUBLIC_POSTHOG_HOST'],
+      })
+    );
+  });
+
+  it('skips overwriting existing env vars in non-interactive without --overwrite', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(mockConnection);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
+      .mockResolvedValue([{ id: 'env-existing', scope: EnvironmentVariableScope.Project } as any]);
+
+    await createCommand(['--non-interactive']).runAsync();
+
+    expect(EnvironmentVariableMutation.updateAsync).not.toHaveBeenCalled();
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+
+  it('overwrites existing env vars in non-interactive with --overwrite', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(mockConnection);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
+      .mockResolvedValue([{ id: 'env-existing', scope: EnvironmentVariableScope.Project } as any]);
+
+    await createCommand(['--non-interactive', '--overwrite']).runAsync();
+
+    expect(EnvironmentVariableMutation.updateAsync).toHaveBeenCalledTimes(2);
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+
+  it('prompts for the region interactively when none exists and --region is omitted', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+
+    await createCommand([]).runAsync();
+
+    expect(selectAsync).toHaveBeenCalled();
+    expect(PostHogMutation.createPostHogAccountRequestAsync).toHaveBeenCalledWith(graphqlClient, {
+      accountId: testAccountId,
+      region: PostHogRegion.Us,
+    });
+  });
+
+  it('rethrows when project setup fails', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(mockConnection);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+    jest
+      .mocked(PostHogMutation.setupPostHogProjectAsync)
+      .mockRejectedValue(new Error('setup boom'));
+
+    await expect(createCommand(['--region', 'US']).runAsync()).rejects.toThrow('setup boom');
+  });
+
+  it('rejects an unsupported region value', async () => {
+    const command = createCommand([]);
+
+    await expect((command as any).resolveRegionAsync('INVALID', false)).rejects.toThrow(
+      /Unsupported PostHog region/
+    );
+  });
+});

--- a/packages/eas-cli/src/commands/integrations/posthog/connect.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/connect.ts
@@ -1,5 +1,10 @@
+import { ExpoConfig } from '@expo/config';
+import spawnAsync from '@expo/spawn-async';
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
+import dotenv from 'dotenv';
+import * as fs from 'fs-extra';
+import path from 'path';
 
 import { DefaultEnvironment } from '../../../build/utils/environment';
 import EasCommand from '../../../commandUtils/EasCommand';
@@ -8,30 +13,24 @@ import {
   EasNonInteractiveAndJsonFlags,
   resolveNonInteractiveAndJsonFlags,
 } from '../../../commandUtils/flags';
+import { getPostHogProjectDashboardUrl } from '../../../commandUtils/posthog';
 import {
   EnvironmentSecretType,
   EnvironmentVariableScope,
   EnvironmentVariableVisibility,
   PostHogRegion,
 } from '../../../graphql/generated';
-import { getPostHogProjectDashboardUrl } from '../../../commandUtils/posthog';
 import { EnvironmentVariableMutation } from '../../../graphql/mutations/EnvironmentVariableMutation';
 import { PostHogMutation } from '../../../graphql/mutations/PostHogMutation';
 import { EnvironmentVariablesQuery } from '../../../graphql/queries/EnvironmentVariablesQuery';
 import { PostHogQuery } from '../../../graphql/queries/PostHogQuery';
+import { PostHogProjectData } from '../../../graphql/types/PostHogConnection';
 import Log, { link } from '../../../log';
 import { ora } from '../../../ora';
+import { createOrModifyExpoConfigAsync } from '../../../project/expoConfig';
 import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
-import { confirmAsync, selectAsync } from '../../../prompts';
+import { Choice, confirmAsync, promptAsync, selectAsync } from '../../../prompts';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
-
-// Backend ExpoErrorCode for the existing-PostHog-user dead-end (v1 supports new accounts only).
-const POSTHOG_EXISTING_USER_NOT_SUPPORTED_ERROR_CODE = 'POSTHOG_EXISTING_USER_NOT_SUPPORTED_ERROR';
-
-function getGraphQLErrorCode(error: unknown): string | undefined {
-  return (error as { graphQLErrors?: { extensions?: { errorCode?: string } }[] }).graphQLErrors?.[0]
-    ?.extensions?.errorCode;
-}
 
 const POSTHOG_REGIONS = [
   { title: 'United States (US)', value: PostHogRegion.Us },
@@ -44,8 +43,27 @@ const EAS_POSTHOG_ENVIRONMENTS = [
   DefaultEnvironment.Development,
 ];
 
+const SDK_PACKAGES = [
+  'posthog-react-native',
+  'expo-file-system',
+  'expo-application',
+  'expo-device',
+  'expo-localization',
+];
+const SESSION_REPLAY_PACKAGE = 'posthog-react-native-session-replay';
+const CONFIG_PLUGIN = 'posthog-react-native/expo';
+
 const EAS_POSTHOG_API_KEY_ENV_VAR_NAME = 'EXPO_PUBLIC_POSTHOG_API_KEY';
 const EAS_POSTHOG_HOST_ENV_VAR_NAME = 'EXPO_PUBLIC_POSTHOG_HOST';
+const POSTHOG_CLI_API_KEY_ENV_VAR_NAME = 'POSTHOG_CLI_API_KEY';
+const POSTHOG_CLI_PROJECT_ID_ENV_VAR_NAME = 'POSTHOG_CLI_PROJECT_ID';
+const POSTHOG_CLI_HOST_ENV_VAR_NAME = 'POSTHOG_CLI_HOST';
+
+const PERSONAL_API_KEY_SETTINGS_PATH = '/settings/user-api-keys';
+const ERROR_TRACKING_NEEDS_KEY_MESSAGE = `Error tracking needs a PostHog personal API key in non-interactive mode. Pass --posthog-cli-api-key (create one in PostHog under Settings → Personal API keys (${PERSONAL_API_KEY_SETTINGS_PATH}) with the "Source map upload" preset), or drop --error-tracking.`;
+
+type Features = { analytics: boolean; sessionReplay: boolean; errorTracking: boolean };
+type EnvVar = { name: string; value: string; visibility: EnvironmentVariableVisibility };
 
 export default class IntegrationsPostHogConnect extends EasCommand {
   static override description = 'connect PostHog to your Expo project';
@@ -60,9 +78,20 @@ export default class IntegrationsPostHogConnect extends EasCommand {
       description: 'PostHog region',
       options: POSTHOG_REGIONS.map(r => r.value),
     }),
-    overwrite: Flags.boolean({
+    'session-replay': Flags.boolean({
+      allowNo: true,
+      description: 'Set up PostHog session replay (default: yes)',
+    }),
+    'error-tracking': Flags.boolean({
+      allowNo: true,
+      description: 'Set up PostHog error tracking / source maps (requires a personal API key)',
+    }),
+    'posthog-cli-api-key': Flags.string({
       description:
-        'Overwrite existing EXPO_PUBLIC_POSTHOG_* environment variables without prompting',
+        'PostHog personal API key for error-tracking source-map uploads (enables error tracking non-interactively)',
+    }),
+    overwrite: Flags.boolean({
+      description: 'Overwrite existing PostHog environment variables without prompting',
       default: false,
     }),
   };
@@ -70,13 +99,20 @@ export default class IntegrationsPostHogConnect extends EasCommand {
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(IntegrationsPostHogConnect);
     const { region: regionFlag, overwrite } = flags;
+    const cliApiKeyFlag =
+      (flags['posthog-cli-api-key'] ?? process.env[POSTHOG_CLI_API_KEY_ENV_VAR_NAME])?.trim() ||
+      undefined;
     const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
     if (jsonFlag) {
       enableJsonOutput();
     }
 
+    if (nonInteractive && flags['error-tracking'] === true && !cliApiKeyFlag) {
+      throw new Error(ERROR_TRACKING_NEEDS_KEY_MESSAGE);
+    }
+
     const {
-      privateProjectConfig: { projectId },
+      privateProjectConfig: { projectId, exp, projectDir },
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(IntegrationsPostHogConnect, {
       nonInteractive,
@@ -85,13 +121,10 @@ export default class IntegrationsPostHogConnect extends EasCommand {
 
     const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
 
-    // PostHog provisioning is irreversible, so reuse the account's existing
-    // connection instead of creating a duplicate organization.
     let connection = await PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync(
       graphqlClient,
       account.id
     );
-
     if (connection) {
       if (regionFlag && regionFlag !== connection.posthogRegion) {
         Log.warn(
@@ -113,19 +146,11 @@ export default class IntegrationsPostHogConnect extends EasCommand {
           `Created PostHog organization ${chalk.bold(connection.posthogOrganizationName)}`
         );
       } catch (error) {
-        // Existing-PostHog-user dead-end: surface the documented guidance rather
-        // than a generic failure. v1 supports brand-new PostHog accounts only.
-        if (getGraphQLErrorCode(error) === POSTHOG_EXISTING_USER_NOT_SUPPORTED_ERROR_CODE) {
-          spinner.fail('This email already has a PostHog account');
-          Log.error((error as Error).message);
-          return;
-        }
         spinner.fail('Failed to create PostHog organization');
         throw error;
       }
     }
 
-    // Reuse an existing project for this app rather than failing the setup mutation.
     let project = await PostHogQuery.getPostHogProjectByAppIdAsync(graphqlClient, projectId);
     if (project) {
       Log.withTick(`Using existing PostHog project ${chalk.bold(project.posthogProjectName)}`);
@@ -143,21 +168,58 @@ export default class IntegrationsPostHogConnect extends EasCommand {
       }
     }
 
-    await this.upsertPostHogEnvVarAsync(
-      graphqlClient,
-      projectId,
-      EAS_POSTHOG_API_KEY_ENV_VAR_NAME,
-      project.posthogProjectToken,
-      nonInteractive,
-      overwrite
-    );
-    await this.upsertPostHogEnvVarAsync(
-      graphqlClient,
-      projectId,
-      EAS_POSTHOG_HOST_ENV_VAR_NAME,
-      project.posthogHost,
-      nonInteractive,
-      overwrite
+    const features = await this.resolveFeaturesAsync(flags, cliApiKeyFlag, nonInteractive);
+    const anyFeatureSelected =
+      features.analytics || features.sessionReplay || features.errorTracking;
+
+    const envVars: EnvVar[] = [];
+    if (anyFeatureSelected) {
+      envVars.push(
+        {
+          name: EAS_POSTHOG_API_KEY_ENV_VAR_NAME,
+          value: project.posthogProjectToken,
+          visibility: EnvironmentVariableVisibility.Public,
+        },
+        {
+          name: EAS_POSTHOG_HOST_ENV_VAR_NAME,
+          value: project.posthogHost,
+          visibility: EnvironmentVariableVisibility.Public,
+        }
+      );
+    }
+    if (features.errorTracking) {
+      const cliApiKey = await this.resolveCliApiKeyAsync(cliApiKeyFlag, project.posthogHost);
+      envVars.push(
+        {
+          name: POSTHOG_CLI_API_KEY_ENV_VAR_NAME,
+          value: cliApiKey,
+          visibility: EnvironmentVariableVisibility.Sensitive,
+        },
+        {
+          name: POSTHOG_CLI_PROJECT_ID_ENV_VAR_NAME,
+          value: project.posthogProjectIdentifier,
+          visibility: EnvironmentVariableVisibility.Public,
+        },
+        {
+          name: POSTHOG_CLI_HOST_ENV_VAR_NAME,
+          value: project.posthogHost,
+          visibility: EnvironmentVariableVisibility.Public,
+        }
+      );
+    }
+
+    if (!anyFeatureSelected) {
+      Log.warn('No PostHog features selected — skipping SDK install and config changes.');
+    } else {
+      await this.installSdkPackagesAsync(projectDir, features, jsonFlag);
+      await this.addConfigPluginAsync(projectDir, exp);
+    }
+
+    await this.writeEnvLocalAsync(projectDir, envVars, nonInteractive, overwrite);
+    await Promise.all(
+      envVars.map(envVar =>
+        this.upsertEasEnvVarAsync(graphqlClient, projectId, envVar, nonInteractive, overwrite)
+      )
     );
 
     if (jsonFlag) {
@@ -173,46 +235,93 @@ export default class IntegrationsPostHogConnect extends EasCommand {
           apiKey: project.posthogProjectToken,
           host: project.posthogHost,
         },
+        features,
         dashboardUrl: getPostHogProjectDashboardUrl(project),
-        environmentVariables: [EAS_POSTHOG_API_KEY_ENV_VAR_NAME, EAS_POSTHOG_HOST_ENV_VAR_NAME],
+        environmentVariables: envVars.map(v => v.name),
       });
       return;
     }
 
-    Log.addNewLineIfNone();
-    Log.log(chalk.green('PostHog is connected!'));
-    Log.newLine();
-    Log.log(
-      `${chalk.bold('Dashboard')}: ${link(getPostHogProjectDashboardUrl(project), { dim: false })}`
-    );
-    Log.log(
-      `Wrote ${chalk.bold(EAS_POSTHOG_API_KEY_ENV_VAR_NAME)} and ${chalk.bold(
-        EAS_POSTHOG_HOST_ENV_VAR_NAME
-      )} to Production, Preview, and Development.`
-    );
-    Log.newLine();
-    Log.log('Next steps:');
-    Log.log(
-      `  Wrap your app in ${chalk.cyan('<PostHogProvider>')} following our guide: ${chalk.cyan('https://docs.expo.dev/guides/using-posthog')}`
-    );
+    this.printNextSteps(project, features);
+  }
+
+  private async resolveFeaturesAsync(
+    flags: { 'session-replay'?: boolean; 'error-tracking'?: boolean },
+    cliApiKey: string | undefined,
+    nonInteractive: boolean
+  ): Promise<Features> {
+    const sessionReplayFlag = flags['session-replay'];
+    const errorTrackingFlag = flags['error-tracking'];
+    const hasCliApiKey = !!cliApiKey;
+
+    if (nonInteractive) {
+      const errorTracking = errorTrackingFlag ?? hasCliApiKey;
+      if (errorTrackingFlag === undefined && !hasCliApiKey) {
+        Log.warn(
+          'Skipping error tracking (source maps) — it needs a personal API key. Re-run interactively, or pass --posthog-cli-api-key to enable it non-interactively.'
+        );
+      }
+      return { analytics: true, sessionReplay: sessionReplayFlag ?? true, errorTracking };
+    }
+
+    if (sessionReplayFlag !== undefined || errorTrackingFlag !== undefined) {
+      return {
+        analytics: true,
+        sessionReplay: sessionReplayFlag ?? true,
+        errorTracking: errorTrackingFlag ?? true,
+      };
+    }
+
+    const { features } = await promptAsync({
+      type: 'multiselect',
+      name: 'features',
+      message: 'PostHog features to set up',
+      choices: [
+        { title: 'Analytics', value: 'analytics', selected: true },
+        { title: 'Session replay', value: 'session-replay', selected: true },
+        {
+          title: 'Error tracking (source maps) — requires a personal API key',
+          value: 'error-tracking',
+          selected: true,
+        },
+      ] satisfies Choice[],
+      instructions: false,
+      min: 0,
+    });
+    const selected = new Set<string>(features as string[]);
+    return {
+      analytics: selected.has('analytics'),
+      sessionReplay: selected.has('session-replay'),
+      errorTracking: selected.has('error-tracking'),
+    };
+  }
+
+  private async resolveCliApiKeyAsync(
+    cliApiKey: string | undefined,
+    host: string
+  ): Promise<string> {
+    if (cliApiKey) {
+      return cliApiKey;
+    }
+    const settingsUrl = `${host.replace(/\/$/, '')}${PERSONAL_API_KEY_SETTINGS_PATH}`;
+    const { apiKey } = await promptAsync({
+      type: 'password',
+      name: 'apiKey',
+      message: `Paste a PostHog personal API key for source-map uploads.\nCreate one at ${settingsUrl} using the "Source map upload" preset.`,
+      validate: (value: string) => (value.trim() ? true : 'Personal API key cannot be empty'),
+    });
+    return apiKey.trim();
   }
 
   private async resolveRegionAsync(
     flagValue: string | undefined,
     nonInteractive: boolean
   ): Promise<PostHogRegion> {
-    if (flagValue) {
-      const match = POSTHOG_REGIONS.find(r => r.value === flagValue);
-      if (!match) {
-        throw new Error(
-          `Unsupported PostHog region "${flagValue}". Use one of: ${POSTHOG_REGIONS.map(r => r.value).join(', ')}.`
-        );
-      }
-      return match.value;
+    const flagRegion = POSTHOG_REGIONS.find(r => r.value === flagValue);
+    if (flagRegion) {
+      return flagRegion.value;
     }
     if (nonInteractive) {
-      // No silent default: region sets data residency and can't be changed after
-      // connecting, so an implicit US default could put EU data in the wrong place.
       throw new Error(
         'A PostHog region is required in non-interactive mode. Pass --region US or --region EU. The region sets data residency and cannot be changed after connecting.'
       );
@@ -220,17 +329,134 @@ export default class IntegrationsPostHogConnect extends EasCommand {
     return await selectAsync('Select a PostHog region', POSTHOG_REGIONS);
   }
 
-  private async upsertPostHogEnvVarAsync(
+  private async installSdkPackagesAsync(
+    projectDir: string,
+    features: Features,
+    jsonFlag: boolean
+  ): Promise<void> {
+    const packages = [...SDK_PACKAGES];
+    if (features.sessionReplay) {
+      packages.push(SESSION_REPLAY_PACKAGE);
+    }
+    Log.newLine();
+    Log.log(`Running ${chalk.bold(`npx expo install ${packages.join(' ')}`)}`);
+    Log.newLine();
+    try {
+      await spawnAsync('npx', ['expo', 'install', ...packages], {
+        cwd: projectDir,
+        stdio: jsonFlag ? ['ignore', 2, 2] : 'inherit',
+      });
+      Log.withTick('Installed the PostHog SDK packages');
+    } catch (error) {
+      Log.warn(
+        `Failed to install the PostHog SDK packages. Run ${chalk.cyan(
+          `npx expo install ${packages.join(' ')}`
+        )} from your project directory.`
+      );
+      throw error;
+    }
+  }
+
+  private async addConfigPluginAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
+    const plugins = exp.plugins ?? [];
+    const alreadyAdded = plugins.some(p => (Array.isArray(p) ? p[0] : p) === CONFIG_PLUGIN);
+    if (alreadyAdded) {
+      Log.withTick(`Config plugin ${chalk.bold(CONFIG_PLUGIN)} is already configured`);
+      return;
+    }
+
+    const modification = await createOrModifyExpoConfigAsync(
+      projectDir,
+      { plugins: [...plugins, CONFIG_PLUGIN] },
+      { skipSDKVersionRequirement: true }
+    );
+    if (modification.type !== 'success') {
+      if (modification.type === 'warn') {
+        Log.warn(modification.message);
+      }
+      Log.log(chalk.cyan('Add the PostHog config plugin to your app config:'));
+      Log.log(`  "plugins": [..., ${JSON.stringify(CONFIG_PLUGIN)}]`);
+      return;
+    }
+    Log.withTick(`Added the ${chalk.bold(CONFIG_PLUGIN)} config plugin`);
+  }
+
+  private async writeEnvLocalAsync(
+    projectDir: string,
+    envVars: EnvVar[],
+    nonInteractive: boolean,
+    overwrite: boolean
+  ): Promise<void> {
+    if (envVars.length === 0) {
+      return;
+    }
+    const envPath = path.join(projectDir, '.env.local');
+    let rawContent = '';
+    if (await fs.pathExists(envPath)) {
+      rawContent = await fs.readFile(envPath, 'utf8');
+      const existing = dotenv.parse(rawContent);
+      const conflicts = envVars.filter(v => existing[v.name] !== undefined);
+      if (conflicts.length > 0 && !overwrite) {
+        if (nonInteractive) {
+          Log.warn(
+            `.env.local already defines ${conflicts
+              .map(v => v.name)
+              .join(', ')}; skipped (pass --overwrite to replace).`
+          );
+          return;
+        }
+        const confirmed = await confirmAsync({
+          message: `.env.local already defines ${conflicts
+            .map(v => v.name)
+            .join(', ')}. Overwrite with the PostHog values?`,
+        });
+        if (!confirmed) {
+          Log.warn(`Skipped updating ${chalk.bold('.env.local')}.`);
+          return;
+        }
+      }
+    }
+
+    const updatedContent = this.mergeEnvContent(
+      rawContent,
+      Object.fromEntries(envVars.map(v => [v.name, v.value]))
+    );
+    await fs.writeFile(envPath, updatedContent);
+    Log.withTick(`Wrote PostHog config to ${chalk.bold('.env.local')}`);
+  }
+
+  private mergeEnvContent(rawContent: string, newVars: Record<string, string>): string {
+    let content = rawContent;
+    const keysToAdd: Record<string, string> = { ...newVars };
+    for (const [key, value] of Object.entries(newVars)) {
+      const regex = new RegExp(`^${key}=.*$`, 'm');
+      if (regex.test(content)) {
+        content = content.replace(regex, () => `${key}=${value}`);
+        delete keysToAdd[key];
+      }
+    }
+    const remaining = Object.entries(keysToAdd);
+    if (remaining.length > 0) {
+      if (content.length > 0 && !content.endsWith('\n')) {
+        content += '\n';
+      }
+      for (const [key, value] of remaining) {
+        content += `${key}=${value}\n`;
+      }
+    }
+    return content;
+  }
+
+  private async upsertEasEnvVarAsync(
     graphqlClient: ExpoGraphqlClient,
     projectId: string,
-    name: string,
-    value: string,
+    envVar: EnvVar,
     nonInteractive: boolean,
     overwrite: boolean
   ): Promise<void> {
     const existingVariables = await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, {
       appId: projectId,
-      filterNames: [name],
+      filterNames: [envVar.name],
     });
     const existingProjectVariable = existingVariables.find(
       variable => variable.scope === EnvironmentVariableScope.Project
@@ -241,11 +467,11 @@ export default class IntegrationsPostHogConnect extends EasCommand {
         overwrite ||
         (!nonInteractive &&
           (await confirmAsync({
-            message: `EAS already has an ${name} environment variable for this project. Overwrite it?`,
+            message: `EAS already has an ${envVar.name} environment variable for this project. Overwrite it?`,
           })));
       if (!shouldOverwrite) {
         Log.warn(
-          `Skipped updating EAS environment variable ${chalk.bold(name)}${
+          `Skipped updating EAS environment variable ${chalk.bold(envVar.name)}${
             nonInteractive ? ' (pass --overwrite to replace it)' : ''
           }.`
         );
@@ -253,27 +479,54 @@ export default class IntegrationsPostHogConnect extends EasCommand {
       }
       await EnvironmentVariableMutation.updateAsync(graphqlClient, {
         id: existingProjectVariable.id,
-        name,
-        value,
+        name: envVar.name,
+        value: envVar.value,
         environments: EAS_POSTHOG_ENVIRONMENTS,
-        visibility: EnvironmentVariableVisibility.Public,
+        visibility: envVar.visibility,
         type: EnvironmentSecretType.String,
       });
-      Log.withTick(`Updated EAS environment variable ${chalk.bold(name)} for builds`);
+      Log.withTick(`Updated EAS environment variable ${chalk.bold(envVar.name)} for builds`);
       return;
     }
 
     await EnvironmentVariableMutation.createForAppAsync(
       graphqlClient,
       {
-        name,
-        value,
+        name: envVar.name,
+        value: envVar.value,
         environments: EAS_POSTHOG_ENVIRONMENTS,
-        visibility: EnvironmentVariableVisibility.Public,
+        visibility: envVar.visibility,
         type: EnvironmentSecretType.String,
       },
       projectId
     );
-    Log.withTick(`Created EAS environment variable ${chalk.bold(name)} for builds`);
+    Log.withTick(`Created EAS environment variable ${chalk.bold(envVar.name)} for builds`);
+  }
+
+  private printNextSteps(project: PostHogProjectData, features: Features): void {
+    Log.addNewLineIfNone();
+    Log.log(chalk.green('PostHog is connected!'));
+    Log.newLine();
+    Log.log(
+      `${chalk.bold('Dashboard')}: ${link(getPostHogProjectDashboardUrl(project), { dim: false })}`
+    );
+    Log.newLine();
+    Log.log('Next steps:');
+    const steps: string[] = [
+      `Wrap your app in ${chalk.cyan('<PostHogProvider>')} following our guide (${chalk.cyan('https://docs.expo.dev/guides/using-posthog')}).`,
+    ];
+    if (features.sessionReplay) {
+      steps.push(
+        `Enable session replay in the provider options (the ${chalk.bold(SESSION_REPLAY_PACKAGE)} package is installed).`
+      );
+    }
+    if (features.errorTracking) {
+      steps.push(
+        `Error-tracking source maps: your ${chalk.bold('POSTHOG_CLI_*')} env vars are set in ${chalk.bold('.env.local')} and EAS — see the guide above to enable source-map uploads on your builds.`
+      );
+    }
+    steps.forEach((step, index) => {
+      Log.log(`  ${index + 1}. ${step}`);
+    });
   }
 }

--- a/packages/eas-cli/src/commands/integrations/posthog/connect.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/connect.ts
@@ -1,0 +1,279 @@
+import { Flags } from '@oclif/core';
+import chalk from 'chalk';
+
+import { DefaultEnvironment } from '../../../build/utils/environment';
+import EasCommand from '../../../commandUtils/EasCommand';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import {
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
+} from '../../../commandUtils/flags';
+import {
+  EnvironmentSecretType,
+  EnvironmentVariableScope,
+  EnvironmentVariableVisibility,
+  PostHogRegion,
+} from '../../../graphql/generated';
+import { getPostHogProjectDashboardUrl } from '../../../commandUtils/posthog';
+import { EnvironmentVariableMutation } from '../../../graphql/mutations/EnvironmentVariableMutation';
+import { PostHogMutation } from '../../../graphql/mutations/PostHogMutation';
+import { EnvironmentVariablesQuery } from '../../../graphql/queries/EnvironmentVariablesQuery';
+import { PostHogQuery } from '../../../graphql/queries/PostHogQuery';
+import Log, { link } from '../../../log';
+import { ora } from '../../../ora';
+import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
+import { confirmAsync, selectAsync } from '../../../prompts';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+
+// Backend ExpoErrorCode for the existing-PostHog-user dead-end (v1 supports new accounts only).
+const POSTHOG_EXISTING_USER_NOT_SUPPORTED_ERROR_CODE = 'POSTHOG_EXISTING_USER_NOT_SUPPORTED_ERROR';
+
+function getGraphQLErrorCode(error: unknown): string | undefined {
+  return (error as { graphQLErrors?: { extensions?: { errorCode?: string } }[] }).graphQLErrors?.[0]
+    ?.extensions?.errorCode;
+}
+
+const POSTHOG_REGIONS = [
+  { title: 'United States (US)', value: PostHogRegion.Us },
+  { title: 'European Union (EU)', value: PostHogRegion.Eu },
+];
+
+const EAS_POSTHOG_ENVIRONMENTS = [
+  DefaultEnvironment.Production,
+  DefaultEnvironment.Preview,
+  DefaultEnvironment.Development,
+];
+
+const EAS_POSTHOG_API_KEY_ENV_VAR_NAME = 'EXPO_PUBLIC_POSTHOG_API_KEY';
+const EAS_POSTHOG_HOST_ENV_VAR_NAME = 'EXPO_PUBLIC_POSTHOG_HOST';
+
+export default class IntegrationsPostHogConnect extends EasCommand {
+  static override description = 'connect PostHog to your Expo project';
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+  };
+
+  static override flags = {
+    ...EasNonInteractiveAndJsonFlags,
+    region: Flags.string({
+      description: 'PostHog region',
+      options: POSTHOG_REGIONS.map(r => r.value),
+    }),
+    overwrite: Flags.boolean({
+      description:
+        'Overwrite existing EXPO_PUBLIC_POSTHOG_* environment variables without prompting',
+      default: false,
+    }),
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(IntegrationsPostHogConnect);
+    const { region: regionFlag, overwrite } = flags;
+    const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    const {
+      privateProjectConfig: { projectId },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(IntegrationsPostHogConnect, {
+      nonInteractive,
+      withServerSideEnvironment: null,
+    });
+
+    const account = await getOwnerAccountForProjectIdAsync(graphqlClient, projectId);
+
+    // PostHog provisioning is irreversible, so reuse the account's existing
+    // connection instead of creating a duplicate organization.
+    let connection = await PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync(
+      graphqlClient,
+      account.id
+    );
+
+    if (connection) {
+      if (regionFlag && regionFlag !== connection.posthogRegion) {
+        Log.warn(
+          `This account is already connected to PostHog in the ${connection.posthogRegion} region; --region ${regionFlag} is ignored. An account has a single PostHog organization and its region can't be changed.`
+        );
+      }
+      Log.withTick(
+        `Using existing PostHog organization ${chalk.bold(connection.posthogOrganizationName)} (${connection.posthogRegion})`
+      );
+    } else {
+      const region = await this.resolveRegionAsync(regionFlag, nonInteractive);
+      const spinner = ora('Creating PostHog organization').start();
+      try {
+        connection = await PostHogMutation.createPostHogAccountRequestAsync(graphqlClient, {
+          accountId: account.id,
+          region,
+        });
+        spinner.succeed(
+          `Created PostHog organization ${chalk.bold(connection.posthogOrganizationName)}`
+        );
+      } catch (error) {
+        // Existing-PostHog-user dead-end: surface the documented guidance rather
+        // than a generic failure. v1 supports brand-new PostHog accounts only.
+        if (getGraphQLErrorCode(error) === POSTHOG_EXISTING_USER_NOT_SUPPORTED_ERROR_CODE) {
+          spinner.fail('This email already has a PostHog account');
+          Log.error((error as Error).message);
+          return;
+        }
+        spinner.fail('Failed to create PostHog organization');
+        throw error;
+      }
+    }
+
+    // Reuse an existing project for this app rather than failing the setup mutation.
+    let project = await PostHogQuery.getPostHogProjectByAppIdAsync(graphqlClient, projectId);
+    if (project) {
+      Log.withTick(`Using existing PostHog project ${chalk.bold(project.posthogProjectName)}`);
+    } else {
+      const spinner = ora('Setting up PostHog project').start();
+      try {
+        project = await PostHogMutation.setupPostHogProjectAsync(graphqlClient, {
+          appId: projectId,
+          posthogOrganizationConnectionId: connection.id,
+        });
+        spinner.succeed(`Created PostHog project ${chalk.bold(project.posthogProjectName)}`);
+      } catch (error) {
+        spinner.fail('Failed to set up PostHog project');
+        throw error;
+      }
+    }
+
+    await this.upsertPostHogEnvVarAsync(
+      graphqlClient,
+      projectId,
+      EAS_POSTHOG_API_KEY_ENV_VAR_NAME,
+      project.posthogProjectToken,
+      nonInteractive,
+      overwrite
+    );
+    await this.upsertPostHogEnvVarAsync(
+      graphqlClient,
+      projectId,
+      EAS_POSTHOG_HOST_ENV_VAR_NAME,
+      project.posthogHost,
+      nonInteractive,
+      overwrite
+    );
+
+    if (jsonFlag) {
+      printJsonOnlyOutput({
+        organizationConnection: {
+          id: connection.id,
+          name: connection.posthogOrganizationName,
+          region: connection.posthogRegion,
+        },
+        project: {
+          id: project.id,
+          name: project.posthogProjectName,
+          apiKey: project.posthogProjectToken,
+          host: project.posthogHost,
+        },
+        dashboardUrl: getPostHogProjectDashboardUrl(project),
+        environmentVariables: [EAS_POSTHOG_API_KEY_ENV_VAR_NAME, EAS_POSTHOG_HOST_ENV_VAR_NAME],
+      });
+      return;
+    }
+
+    Log.addNewLineIfNone();
+    Log.log(chalk.green('PostHog is connected!'));
+    Log.newLine();
+    Log.log(
+      `${chalk.bold('Dashboard')}: ${link(getPostHogProjectDashboardUrl(project), { dim: false })}`
+    );
+    Log.log(
+      `Wrote ${chalk.bold(EAS_POSTHOG_API_KEY_ENV_VAR_NAME)} and ${chalk.bold(
+        EAS_POSTHOG_HOST_ENV_VAR_NAME
+      )} to Production, Preview, and Development.`
+    );
+    Log.newLine();
+    Log.log('Next steps:');
+    Log.log(
+      `  Wrap your app in ${chalk.cyan('<PostHogProvider>')} following our guide: ${chalk.cyan('https://docs.expo.dev/guides/using-posthog')}`
+    );
+  }
+
+  private async resolveRegionAsync(
+    flagValue: string | undefined,
+    nonInteractive: boolean
+  ): Promise<PostHogRegion> {
+    if (flagValue) {
+      const match = POSTHOG_REGIONS.find(r => r.value === flagValue);
+      if (!match) {
+        throw new Error(
+          `Unsupported PostHog region "${flagValue}". Use one of: ${POSTHOG_REGIONS.map(r => r.value).join(', ')}.`
+        );
+      }
+      return match.value;
+    }
+    if (nonInteractive) {
+      // No silent default: region sets data residency and can't be changed after
+      // connecting, so an implicit US default could put EU data in the wrong place.
+      throw new Error(
+        'A PostHog region is required in non-interactive mode. Pass --region US or --region EU. The region sets data residency and cannot be changed after connecting.'
+      );
+    }
+    return await selectAsync('Select a PostHog region', POSTHOG_REGIONS);
+  }
+
+  private async upsertPostHogEnvVarAsync(
+    graphqlClient: ExpoGraphqlClient,
+    projectId: string,
+    name: string,
+    value: string,
+    nonInteractive: boolean,
+    overwrite: boolean
+  ): Promise<void> {
+    const existingVariables = await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, {
+      appId: projectId,
+      filterNames: [name],
+    });
+    const existingProjectVariable = existingVariables.find(
+      variable => variable.scope === EnvironmentVariableScope.Project
+    );
+
+    if (existingProjectVariable) {
+      const shouldOverwrite =
+        overwrite ||
+        (!nonInteractive &&
+          (await confirmAsync({
+            message: `EAS already has an ${name} environment variable for this project. Overwrite it?`,
+          })));
+      if (!shouldOverwrite) {
+        Log.warn(
+          `Skipped updating EAS environment variable ${chalk.bold(name)}${
+            nonInteractive ? ' (pass --overwrite to replace it)' : ''
+          }.`
+        );
+        return;
+      }
+      await EnvironmentVariableMutation.updateAsync(graphqlClient, {
+        id: existingProjectVariable.id,
+        name,
+        value,
+        environments: EAS_POSTHOG_ENVIRONMENTS,
+        visibility: EnvironmentVariableVisibility.Public,
+        type: EnvironmentSecretType.String,
+      });
+      Log.withTick(`Updated EAS environment variable ${chalk.bold(name)} for builds`);
+      return;
+    }
+
+    await EnvironmentVariableMutation.createForAppAsync(
+      graphqlClient,
+      {
+        name,
+        value,
+        environments: EAS_POSTHOG_ENVIRONMENTS,
+        visibility: EnvironmentVariableVisibility.Public,
+        type: EnvironmentSecretType.String,
+      },
+      projectId
+    );
+    Log.withTick(`Created EAS environment variable ${chalk.bold(name)} for builds`);
+  }
+}

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1194,6 +1194,7 @@ export type AndroidAppCredentialsMutationCreateAndroidAppCredentialsArgs = {
 
 
 export type AndroidAppCredentialsMutationCreateFcmV1CredentialArgs = {
+  accountId?: InputMaybe<Scalars['ID']['input']>;
   androidAppCredentialsId: Scalars['String']['input'];
   credential: Scalars['String']['input'];
 };
@@ -1349,6 +1350,8 @@ export type AndroidJobOverridesInput = {
 
 export type AndroidJobSecretsInput = {
   buildCredentials?: InputMaybe<AndroidJobBuildCredentialsInput>;
+  /** @deprecated Robot access token is no longer needed as it's generated server-side and injected into the builder environment automatically. */
+  robotAccessToken?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type AndroidJobVersionInput = {
@@ -1376,6 +1379,8 @@ export type AndroidKeystoreInput = {
   keyAlias: Scalars['String']['input'];
   keyPassword?: InputMaybe<Scalars['String']['input']>;
   keystorePassword: Scalars['String']['input'];
+  /** @deprecated Type will be automatically inferred from keystore content. */
+  type?: InputMaybe<AndroidKeystoreType>;
 };
 
 export type AndroidKeystoreMutation = {
@@ -1485,7 +1490,7 @@ export type App = Project & {
    * @deprecated Classic updates have been deprecated.
    */
   icon?: Maybe<AppIcon>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   iconUrl?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** App query field for querying EAS Insights about this app */
@@ -1503,7 +1508,7 @@ export type App = Project & {
   /** @deprecated 'likes' have been deprecated. */
   isLikedByMe: Scalars['Boolean']['output'];
   lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   lastPublishedTime: Scalars['DateTime']['output'];
   /** Time of the last user activity (update, branch, submission). */
   latestActivity: Scalars['DateTime']['output'];
@@ -1523,9 +1528,9 @@ export type App = Project & {
   name: Scalars['String']['output'];
   observe: AppObserve;
   ownerAccount: Account;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   packageName: Scalars['String']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   packageUsername: Scalars['String']['output'];
   /**
    * android.playStoreUrl field from most recent classic update manifest
@@ -1535,7 +1540,7 @@ export type App = Project & {
   posthogProject?: Maybe<PostHogProject>;
   /** @deprecated No longer supported */
   privacy: Scalars['String']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   privacySetting: AppPrivacy;
   profileImageUrl?: Maybe<Scalars['String']['output']>;
   /**
@@ -1595,7 +1600,7 @@ export type App = Project & {
   usageMetrics: AppUsageMetrics;
   /** @deprecated Use ownerAccount.name instead */
   username: Scalars['String']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   users?: Maybe<Array<Maybe<User>>>;
   vexoApp?: Maybe<VexoApp>;
   /** Notification preferences of the viewer for this app */
@@ -1625,6 +1630,7 @@ export type AppActivityTimelineProjectActivitiesArgs = {
   createdBefore?: InputMaybe<Scalars['DateTime']['input']>;
   filterChannels?: InputMaybe<Array<Scalars['String']['input']>>;
   filterPlatforms?: InputMaybe<Array<AppPlatform>>;
+  filterReleaseChannels?: InputMaybe<Array<Scalars['String']['input']>>;
   filterTypes?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
   limit: Scalars['Int']['input'];
 };
@@ -2084,7 +2090,7 @@ export type AppFingerprintsConnection = {
 
 export type AppIcon = {
   __typename?: 'AppIcon';
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   colorPalette?: Maybe<Scalars['JSON']['output']>;
   originalUrl: Scalars['String']['output'];
   primaryColor?: Maybe<Scalars['String']['output']>;
@@ -2098,6 +2104,8 @@ export type AppInfoInput = {
 export type AppInput = {
   accountId: Scalars['ID']['input'];
   appInfo?: InputMaybe<AppInfoInput>;
+  /** @deprecated Field no longer supported */
+  privacy?: InputMaybe<AppPrivacy>;
   projectName: Scalars['String']['input'];
 };
 
@@ -2133,7 +2141,7 @@ export type AppMutation = {
   __typename?: 'AppMutation';
   /** Create an app */
   createApp: App;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   grantAccess?: Maybe<App>;
   /** Remove profile image (icon) for the app. Do nothing if there's no profile image associated. */
   removeProfileImage: App;
@@ -3140,6 +3148,8 @@ export type AppWithGithubRepositoryInput = {
   accountId: Scalars['ID']['input'];
   appInfo?: InputMaybe<AppInfoInput>;
   installationIdentifier?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  privacy?: InputMaybe<AppPrivacy>;
   projectName: Scalars['String']['input'];
 };
 
@@ -4106,7 +4116,11 @@ export type BuildArtifacts = {
 };
 
 export type BuildCacheInput = {
+  /** @deprecated We don't cache anything by default anymore */
+  cacheDefaultPaths?: InputMaybe<Scalars['Boolean']['input']>;
   clear?: InputMaybe<Scalars['Boolean']['input']>;
+  /** @deprecated We use paths now since there is no default caching anymore */
+  customPaths?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   disabled?: InputMaybe<Scalars['Boolean']['input']>;
   key?: InputMaybe<Scalars['String']['input']>;
   paths?: InputMaybe<Array<Scalars['String']['input']>>;
@@ -4178,6 +4192,8 @@ export type BuildMetadataInput = {
   appIdentifier?: InputMaybe<Scalars['String']['input']>;
   appName?: InputMaybe<Scalars['String']['input']>;
   appVersion?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Use job.mode instead. */
+  buildMode?: InputMaybe<BuildMode>;
   buildProfile?: InputMaybe<Scalars['String']['input']>;
   channel?: InputMaybe<Scalars['String']['input']>;
   cliVersion?: InputMaybe<Scalars['String']['input']>;
@@ -4203,6 +4219,8 @@ export type BuildMetadataInput = {
   runWithNoWaitFlag?: InputMaybe<Scalars['Boolean']['input']>;
   runtimeVersion?: InputMaybe<Scalars['String']['input']>;
   sdkVersion?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Unused. */
+  selectedImage?: InputMaybe<Scalars['String']['input']>;
   simulator?: InputMaybe<Scalars['Boolean']['input']>;
   trackingContext?: InputMaybe<Scalars['JSONObject']['input']>;
   username?: InputMaybe<Scalars['String']['input']>;
@@ -4368,7 +4386,7 @@ export enum BuildPhase {
   StartBuild = 'START_BUILD',
   Unknown = 'UNKNOWN',
   UploadApplicationArchive = 'UPLOAD_APPLICATION_ARCHIVE',
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   UploadArtifacts = 'UPLOAD_ARTIFACTS',
   UploadBuildArtifacts = 'UPLOAD_BUILD_ARTIFACTS'
 }
@@ -4911,6 +4929,8 @@ export type CreateSentryProjectInput = {
 export type CreateSharedEnvironmentVariableInput = {
   environments?: InputMaybe<Array<Scalars['EnvironmentVariableEnvironment']['input']>>;
   fileName?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Whether the variable is global is now governed by its scope - account / app. */
+  isGlobal?: InputMaybe<Scalars['Boolean']['input']>;
   name: Scalars['String']['input'];
   overwrite?: InputMaybe<Scalars['Boolean']['input']>;
   type?: InputMaybe<EnvironmentSecretType>;
@@ -7622,6 +7642,8 @@ export type IosJobOverridesInput = {
 
 export type IosJobSecretsInput = {
   buildCredentials?: InputMaybe<Array<InputMaybe<IosJobTargetCredentialsInput>>>;
+  /** @deprecated Robot access token is no longer needed as it's generated server-side and injected into the builder environment automatically. */
+  robotAccessToken?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type IosJobTargetCredentialsInput = {
@@ -7668,7 +7690,7 @@ export type JobRun = {
   __typename?: 'JobRun';
   app: App;
   artifacts: Array<WorkflowArtifact>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   childJobRun?: Maybe<JobRun>;
   createdAt: Scalars['DateTime']['output'];
   displayName?: Maybe<Scalars['String']['output']>;
@@ -8328,7 +8350,7 @@ export enum PostHogRegion {
 export type Project = {
   description: Scalars['String']['output'];
   fullName: Scalars['String']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   iconUrl?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
@@ -8399,6 +8421,8 @@ export type PublishUpdateGroupInput = {
   message?: InputMaybe<Scalars['String']['input']>;
   rollBackToEmbeddedInfoGroup?: InputMaybe<UpdateRollBackToEmbeddedGroup>;
   rolloutInfoGroup?: InputMaybe<UpdateRolloutInfoGroup>;
+  /** @deprecated Use fingerprintInfoGroup instead */
+  runtimeFingerprintSource?: InputMaybe<FingerprintSourceInput>;
   runtimeVersion: Scalars['String']['input'];
   turtleJobRunId?: InputMaybe<Scalars['String']['input']>;
   updateInfoGroup?: InputMaybe<UpdateInfoGroup>;
@@ -9023,7 +9047,7 @@ export type SsoUser = Actor & UserActor & {
   /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   appCount: Scalars['Int']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   appetizeCode?: Maybe<Scalars['String']['output']>;
   /**
    * Apps this user has published. If this user is the viewer, this field returns the apps the user has access to.
@@ -9046,16 +9070,16 @@ export type SsoUser = Actor & UserActor & {
   fullName?: Maybe<Scalars['String']['output']>;
   /** GitHub account linked to a user */
   githubUser?: Maybe<GitHubUser>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   githubUsername?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   industry?: Maybe<Scalars['String']['output']>;
   isExpoAdmin: Scalars['Boolean']['output'];
   isStaffModeEnabled: Scalars['Boolean']['output'];
   lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
   lastName?: Maybe<Scalars['String']['output']>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   location?: Maybe<Scalars['String']['output']>;
   pinnedApps: Array<App>;
   pinnedDashboardViews: Array<PinnedDashboardView>;
@@ -9067,7 +9091,7 @@ export type SsoUser = Actor & UserActor & {
   profilePhoto: Scalars['String']['output'];
   /** Snacks associated with this account */
   snacks: Array<Snack>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   twitterUsername?: Maybe<Scalars['String']['output']>;
   username: Scalars['String']['output'];
   websiteNotificationsPaginated: WebsiteNotificationsConnection;
@@ -9113,7 +9137,15 @@ export type SsoUserWebsiteNotificationsPaginatedArgs = {
 
 export type SsoUserDataInput = {
   firstName?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  githubUsername?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  industry?: InputMaybe<Scalars['String']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  location?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  twitterUsername?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type SecondFactorBooleanResult = {
@@ -9271,7 +9303,7 @@ export type Snack = Project & {
   /** Has the Snack been run without errors */
   hasBeenRunSuccessfully?: Maybe<Scalars['Boolean']['output']>;
   hashId: Scalars['String']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   iconUrl?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** Draft status, which is true when the Snack was not saved explicitly, but auto-saved */
@@ -10058,6 +10090,8 @@ export type UpdateEnvironmentVariableInput = {
   environments?: InputMaybe<Array<Scalars['EnvironmentVariableEnvironment']['input']>>;
   fileName?: InputMaybe<Scalars['String']['input']>;
   id: Scalars['ID']['input'];
+  /** @deprecated You cannot change whether the variable is global. */
+  isGlobal?: InputMaybe<Scalars['Boolean']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
   type?: InputMaybe<EnvironmentSecretType>;
   value?: InputMaybe<Scalars['String']['input']>;
@@ -10207,6 +10241,8 @@ export type UpdateVexoAppInput = {
 export type UpdatesFilter = {
   platform?: InputMaybe<AppPlatform>;
   runtimeVersions?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** @deprecated Use runtimeVersions instead. */
+  sdkVersions?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type UpdatesFilterV2 = {
@@ -10321,7 +10357,7 @@ export type User = Actor & UserActor & {
   /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   appCount: Scalars['Int']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   appetizeCode?: Maybe<Scalars['String']['output']>;
   /**
    * Apps this user has published
@@ -10346,22 +10382,22 @@ export type User = Actor & UserActor & {
   fullName?: Maybe<Scalars['String']['output']>;
   /** GitHub account linked to a user */
   githubUser?: Maybe<GitHubUser>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   githubUsername?: Maybe<Scalars['String']['output']>;
   hasPassword: Scalars['Boolean']['output'];
   /** Whether this user has any pending user invitations. Only resolves for the viewer. */
   hasPendingUserInvitations: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   industry?: Maybe<Scalars['String']['output']>;
   isExpoAdmin: Scalars['Boolean']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   isLegacy: Scalars['Boolean']['output'];
   isSecondFactorAuthenticationEnabled: Scalars['Boolean']['output'];
   isStaffModeEnabled: Scalars['Boolean']['output'];
   lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
   lastName?: Maybe<Scalars['String']['output']>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   location?: Maybe<Scalars['String']['output']>;
   newEmailPendingVerification?: Maybe<Scalars['String']['output']>;
   oAuthIdentities: Array<OAuthIdentity>;
@@ -10381,7 +10417,7 @@ export type User = Actor & UserActor & {
   secondFactorDevices: Array<UserSecondFactorDevice>;
   /** Snacks associated with this account */
   snacks: Array<Snack>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   twitterUsername?: Maybe<Scalars['String']['output']>;
   username: Scalars['String']['output'];
   websiteNotificationsPaginated: WebsiteNotificationsConnection;
@@ -10436,7 +10472,7 @@ export type UserActor = {
    */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   appCount: Scalars['Int']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   appetizeCode?: Maybe<Scalars['String']['output']>;
   /**
    * Apps this user has published
@@ -10463,16 +10499,16 @@ export type UserActor = {
   fullName?: Maybe<Scalars['String']['output']>;
   /** GitHub account linked to a user */
   githubUser?: Maybe<GitHubUser>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   githubUsername?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   industry?: Maybe<Scalars['String']['output']>;
   isExpoAdmin: Scalars['Boolean']['output'];
   isStaffModeEnabled: Scalars['Boolean']['output'];
   lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
   lastName?: Maybe<Scalars['String']['output']>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   location?: Maybe<Scalars['String']['output']>;
   pinnedApps: Array<App>;
   preferences: UserPreferences;
@@ -10483,7 +10519,7 @@ export type UserActor = {
   profilePhoto: Scalars['String']['output'];
   /** Snacks associated with this user's personal account */
   snacks: Array<Snack>;
-  /** @deprecated No longer supported */
+  /** @deprecated Field no longer supported */
   twitterUsername?: Maybe<Scalars['String']['output']>;
   username: Scalars['String']['output'];
   websiteNotificationsPaginated: WebsiteNotificationsConnection;
@@ -10729,12 +10765,22 @@ export type UserDashboardViewPinMutationUnpinDashboardViewArgs = {
 };
 
 export type UserDataInput = {
+  /** @deprecated Field no longer supported */
+  appetizeCode?: InputMaybe<Scalars['String']['input']>;
   email?: InputMaybe<Scalars['String']['input']>;
   firstName?: InputMaybe<Scalars['String']['input']>;
   fullName?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  githubUsername?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['ID']['input']>;
+  /** @deprecated Field no longer supported */
+  industry?: InputMaybe<Scalars['String']['input']>;
   lastName?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  location?: InputMaybe<Scalars['String']['input']>;
   profilePhoto?: InputMaybe<Scalars['String']['input']>;
+  /** @deprecated Field no longer supported */
+  twitterUsername?: InputMaybe<Scalars['String']['input']>;
   username?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -13207,6 +13253,27 @@ export type CreateLocalBuildMutationVariables = Exact<{
 
 export type CreateLocalBuildMutation = { __typename?: 'RootMutation', build: { __typename?: 'BuildMutation', createLocalBuild: { __typename?: 'CreateBuildResult', build: { __typename?: 'Build', id: string, status: BuildStatus, platform: AppPlatform, logFiles: Array<string>, channel?: string | null, distribution?: DistributionType | null, iosEnterpriseProvisioning?: BuildIosEnterpriseProvisioning | null, buildProfile?: string | null, sdkVersion?: string | null, appVersion?: string | null, appBuildVersion?: string | null, runtimeVersion?: string | null, gitCommitHash?: string | null, gitCommitMessage?: string | null, initialQueuePosition?: number | null, queuePosition?: number | null, estimatedWaitTimeLeftSeconds?: number | null, priority: BuildPriority, createdAt: any, updatedAt: any, message?: string | null, completedAt?: any | null, expirationDate?: any | null, isForIosSimulator: boolean, error?: { __typename?: 'BuildError', errorCode: string, message: string, docsUrl?: string | null } | null, artifacts?: { __typename?: 'BuildArtifacts', buildUrl?: string | null, xcodeBuildLogsUrl?: string | null, applicationArchiveUrl?: string | null, buildArtifactsUrl?: string | null } | null, fingerprint?: { __typename?: 'Fingerprint', id: string, hash: string } | null, initiatingActor?: { __typename: 'PartnerActor', id: string, displayName: string } | { __typename: 'Robot', id: string, displayName: string } | { __typename: 'SSOUser', id: string, displayName: string } | { __typename: 'User', id: string, displayName: string } | null, project: { __typename: 'App', id: string, name: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } } | { __typename: 'Snack', id: string, name: string, slug: string }, metrics?: { __typename?: 'BuildMetrics', buildWaitTime?: number | null, buildQueueTime?: number | null, buildDuration?: number | null } | null } } } };
 
+export type CreatePostHogAccountRequestMutationVariables = Exact<{
+  input: CreatePostHogAccountRequestInput;
+}>;
+
+
+export type CreatePostHogAccountRequestMutation = { __typename?: 'RootMutation', posthogOrganizationConnection: { __typename?: 'PostHogOrganizationConnectionMutation', createPostHogAccountRequest: { __typename?: 'PostHogOrganizationConnection', id: string, posthogOrganizationIdentifier: string, posthogOrganizationName: string, posthogRegion: PostHogRegion, createdAt: any, updatedAt: any } } };
+
+export type SetupPostHogProjectMutationVariables = Exact<{
+  input: SetupPostHogProjectInput;
+}>;
+
+
+export type SetupPostHogProjectMutation = { __typename?: 'RootMutation', posthogProject: { __typename?: 'PostHogProjectMutation', setupPostHogProject: { __typename?: 'PostHogProject', id: string, posthogProjectIdentifier: string, posthogProjectName: string, posthogProjectToken: string, posthogHost: string, createdAt: any, updatedAt: any, posthogOrganizationConnection: { __typename?: 'PostHogOrganizationConnection', id: string, posthogOrganizationIdentifier: string, posthogOrganizationName: string, posthogRegion: PostHogRegion, createdAt: any, updatedAt: any } } } };
+
+export type DeletePostHogProjectMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type DeletePostHogProjectMutation = { __typename?: 'RootMutation', posthogProject: { __typename?: 'PostHogProjectMutation', deletePostHogProject: string } };
+
 export type GetSignedUploadMutationVariables = Exact<{
   contentTypes: Array<Scalars['String']['input']> | Scalars['String']['input'];
 }>;
@@ -13783,6 +13850,20 @@ export type AppObserveNavigationRoutesQueryVariables = Exact<{
 
 export type AppObserveNavigationRoutesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', navigationRoutes: { __typename?: 'AppObserveNavigationRoutesConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveNavigationRouteEdge', cursor: string, node: { __typename?: 'AppObserveNavigationRoute', routeName: string, coldTtr: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null }, warmTtr: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null }, tti: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null } } }> } } } } };
 
+export type PostHogOrganizationConnectionByAccountIdQueryVariables = Exact<{
+  accountId: Scalars['String']['input'];
+}>;
+
+
+export type PostHogOrganizationConnectionByAccountIdQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byId: { __typename?: 'Account', id: string, posthogOrganizationConnection?: { __typename?: 'PostHogOrganizationConnection', id: string, posthogOrganizationIdentifier: string, posthogOrganizationName: string, posthogRegion: PostHogRegion, createdAt: any, updatedAt: any } | null } } };
+
+export type PostHogProjectByAppIdQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+}>;
+
+
+export type PostHogProjectByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, posthogProject?: { __typename?: 'PostHogProject', id: string, posthogProjectIdentifier: string, posthogProjectName: string, posthogProjectToken: string, posthogHost: string, createdAt: any, updatedAt: any, posthogOrganizationConnection: { __typename?: 'PostHogOrganizationConnection', id: string, posthogOrganizationIdentifier: string, posthogOrganizationName: string, posthogRegion: PostHogRegion, createdAt: any, updatedAt: any } } | null } } };
+
 export type GetAssetMetadataQueryVariables = Exact<{
   storageKeys: Array<Scalars['String']['input']> | Scalars['String']['input'];
 }>;
@@ -14011,6 +14092,10 @@ export type AppObserveCustomEventFragment = { __typename?: 'AppObserveCustomEven
 export type AppObserveEventFragment = { __typename?: 'AppObserveEvent', id: string, metricName: string, metricValue: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null };
 
 export type AppObserveAppVersionFragment = { __typename?: 'AppObserveAppVersion', appVersion: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, buildNumbers: Array<{ __typename?: 'AppObserveAppBuildNumber', appBuildNumber: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, updates: Array<{ __typename?: 'AppObserveAppUpdate', appUpdateId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, metrics: Array<{ __typename?: 'AppObserveAppVersionMetric', metricName: string, eventCount: number, statistics: { __typename?: 'AppObserveVersionMarkerStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } }> };
+
+export type PostHogOrganizationConnectionFragment = { __typename?: 'PostHogOrganizationConnection', id: string, posthogOrganizationIdentifier: string, posthogOrganizationName: string, posthogRegion: PostHogRegion, createdAt: any, updatedAt: any };
+
+export type PostHogProjectFragment = { __typename?: 'PostHogProject', id: string, posthogProjectIdentifier: string, posthogProjectName: string, posthogProjectToken: string, posthogHost: string, createdAt: any, updatedAt: any, posthogOrganizationConnection: { __typename?: 'PostHogOrganizationConnection', id: string, posthogOrganizationIdentifier: string, posthogOrganizationName: string, posthogRegion: PostHogRegion, createdAt: any, updatedAt: any } };
 
 export type RuntimeFragment = { __typename?: 'Runtime', id: string, version: string };
 

--- a/packages/eas-cli/src/graphql/mutations/PostHogMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PostHogMutation.ts
@@ -1,0 +1,117 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
+import { CreatePostHogAccountRequestInput, SetupPostHogProjectInput } from '../generated';
+import {
+  PostHogOrganizationConnectionData,
+  PostHogOrganizationConnectionFragmentNode,
+  PostHogProjectData,
+  PostHogProjectFragmentNode,
+} from '../types/PostHogConnection';
+
+type CreatePostHogAccountRequestMutation = {
+  posthogOrganizationConnection: {
+    createPostHogAccountRequest: PostHogOrganizationConnectionData;
+  };
+};
+
+type CreatePostHogAccountRequestMutationVariables = {
+  input: CreatePostHogAccountRequestInput;
+};
+
+type SetupPostHogProjectMutation = {
+  posthogProject: {
+    setupPostHogProject: PostHogProjectData;
+  };
+};
+
+type SetupPostHogProjectMutationVariables = {
+  input: SetupPostHogProjectInput;
+};
+
+type DeletePostHogProjectMutation = {
+  posthogProject: {
+    deletePostHogProject: string;
+  };
+};
+
+type DeletePostHogProjectMutationVariables = {
+  id: string;
+};
+
+export const PostHogMutation = {
+  async createPostHogAccountRequestAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: CreatePostHogAccountRequestInput
+  ): Promise<PostHogOrganizationConnectionData> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<
+          CreatePostHogAccountRequestMutation,
+          CreatePostHogAccountRequestMutationVariables
+        >(
+          gql`
+            mutation CreatePostHogAccountRequest($input: CreatePostHogAccountRequestInput!) {
+              posthogOrganizationConnection {
+                createPostHogAccountRequest(input: $input) {
+                  id
+                  ...PostHogOrganizationConnectionFragment
+                }
+              }
+            }
+            ${print(PostHogOrganizationConnectionFragmentNode)}
+          `,
+          { input }
+        )
+        .toPromise()
+    );
+    return data.posthogOrganizationConnection.createPostHogAccountRequest;
+  },
+
+  async setupPostHogProjectAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: SetupPostHogProjectInput
+  ): Promise<PostHogProjectData> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<SetupPostHogProjectMutation, SetupPostHogProjectMutationVariables>(
+          gql`
+            mutation SetupPostHogProject($input: SetupPostHogProjectInput!) {
+              posthogProject {
+                setupPostHogProject(input: $input) {
+                  id
+                  ...PostHogProjectFragment
+                }
+              }
+            }
+            ${print(PostHogOrganizationConnectionFragmentNode)}
+            ${print(PostHogProjectFragmentNode)}
+          `,
+          { input }
+        )
+        .toPromise()
+    );
+    return data.posthogProject.setupPostHogProject;
+  },
+
+  async deletePostHogProjectAsync(graphqlClient: ExpoGraphqlClient, id: string): Promise<string> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<DeletePostHogProjectMutation, DeletePostHogProjectMutationVariables>(
+          gql`
+            mutation DeletePostHogProject($id: ID!) {
+              posthogProject {
+                deletePostHogProject(id: $id)
+              }
+            }
+          `,
+          { id },
+          { additionalTypenames: ['App', 'PostHogProject'] }
+        )
+        .toPromise()
+    );
+    return data.posthogProject.deletePostHogProject;
+  },
+};

--- a/packages/eas-cli/src/graphql/mutations/PostHogMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PostHogMutation.ts
@@ -31,16 +31,6 @@ type SetupPostHogProjectMutationVariables = {
   input: SetupPostHogProjectInput;
 };
 
-type DeletePostHogProjectMutation = {
-  posthogProject: {
-    deletePostHogProject: string;
-  };
-};
-
-type DeletePostHogProjectMutationVariables = {
-  id: string;
-};
-
 export const PostHogMutation = {
   async createPostHogAccountRequestAsync(
     graphqlClient: ExpoGraphqlClient,
@@ -94,24 +84,5 @@ export const PostHogMutation = {
         .toPromise()
     );
     return data.posthogProject.setupPostHogProject;
-  },
-
-  async deletePostHogProjectAsync(graphqlClient: ExpoGraphqlClient, id: string): Promise<string> {
-    const data = await withErrorHandlingAsync(
-      graphqlClient
-        .mutation<DeletePostHogProjectMutation, DeletePostHogProjectMutationVariables>(
-          gql`
-            mutation DeletePostHogProject($id: ID!) {
-              posthogProject {
-                deletePostHogProject(id: $id)
-              }
-            }
-          `,
-          { id },
-          { additionalTypenames: ['App', 'PostHogProject'] }
-        )
-        .toPromise()
-    );
-    return data.posthogProject.deletePostHogProject;
   },
 };

--- a/packages/eas-cli/src/graphql/queries/PostHogQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/PostHogQuery.ts
@@ -1,0 +1,103 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
+import {
+  PostHogOrganizationConnectionData,
+  PostHogOrganizationConnectionFragmentNode,
+  PostHogProjectData,
+  PostHogProjectFragmentNode,
+} from '../types/PostHogConnection';
+
+type PostHogOrganizationConnectionByAccountIdQuery = {
+  account: {
+    byId: {
+      id: string;
+      posthogOrganizationConnection?: PostHogOrganizationConnectionData | null;
+    };
+  };
+};
+
+type PostHogOrganizationConnectionByAccountIdQueryVariables = {
+  accountId: string;
+};
+
+type PostHogProjectByAppIdQuery = {
+  app: {
+    byId: {
+      id: string;
+      posthogProject?: PostHogProjectData | null;
+    };
+  };
+};
+
+type PostHogProjectByAppIdQueryVariables = {
+  appId: string;
+};
+
+export const PostHogQuery = {
+  async getPostHogOrganizationConnectionByAccountIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    accountId: string
+  ): Promise<PostHogOrganizationConnectionData | null> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<
+          PostHogOrganizationConnectionByAccountIdQuery,
+          PostHogOrganizationConnectionByAccountIdQueryVariables
+        >(
+          gql`
+            query PostHogOrganizationConnectionByAccountId($accountId: String!) {
+              account {
+                byId(accountId: $accountId) {
+                  id
+                  posthogOrganizationConnection {
+                    id
+                    ...PostHogOrganizationConnectionFragment
+                  }
+                }
+              }
+            }
+            ${print(PostHogOrganizationConnectionFragmentNode)}
+          `,
+          { accountId },
+          { additionalTypenames: ['PostHogOrganizationConnection'] }
+        )
+        .toPromise()
+    );
+
+    return data.account.byId.posthogOrganizationConnection ?? null;
+  },
+
+  async getPostHogProjectByAppIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    appId: string
+  ): Promise<PostHogProjectData | null> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<PostHogProjectByAppIdQuery, PostHogProjectByAppIdQueryVariables>(
+          gql`
+            query PostHogProjectByAppId($appId: String!) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  posthogProject {
+                    id
+                    ...PostHogProjectFragment
+                  }
+                }
+              }
+            }
+            ${print(PostHogOrganizationConnectionFragmentNode)}
+            ${print(PostHogProjectFragmentNode)}
+          `,
+          { appId },
+          { additionalTypenames: ['App', 'PostHogProject'] }
+        )
+        .toPromise()
+    );
+
+    return data.app.byId.posthogProject ?? null;
+  },
+};

--- a/packages/eas-cli/src/graphql/types/PostHogConnection.ts
+++ b/packages/eas-cli/src/graphql/types/PostHogConnection.ts
@@ -1,0 +1,53 @@
+import gql from 'graphql-tag';
+
+import { PostHogOrganizationConnection, PostHogProject } from '../generated';
+
+export type PostHogOrganizationConnectionData = Pick<
+  PostHogOrganizationConnection,
+  | 'id'
+  | 'posthogOrganizationIdentifier'
+  | 'posthogOrganizationName'
+  | 'posthogRegion'
+  | 'createdAt'
+  | 'updatedAt'
+>;
+
+export type PostHogProjectData = Pick<
+  PostHogProject,
+  | 'id'
+  | 'posthogProjectIdentifier'
+  | 'posthogProjectName'
+  | 'posthogProjectToken'
+  | 'posthogHost'
+  | 'createdAt'
+  | 'updatedAt'
+> & {
+  posthogOrganizationConnection: PostHogOrganizationConnectionData;
+};
+
+export const PostHogOrganizationConnectionFragmentNode = gql`
+  fragment PostHogOrganizationConnectionFragment on PostHogOrganizationConnection {
+    id
+    posthogOrganizationIdentifier
+    posthogOrganizationName
+    posthogRegion
+    createdAt
+    updatedAt
+  }
+`;
+
+export const PostHogProjectFragmentNode = gql`
+  fragment PostHogProjectFragment on PostHogProject {
+    id
+    posthogProjectIdentifier
+    posthogProjectName
+    posthogProjectToken
+    posthogHost
+    createdAt
+    updatedAt
+    posthogOrganizationConnection {
+      id
+      ...PostHogOrganizationConnectionFragment
+    }
+  }
+`;


### PR DESCRIPTION
## Why

Connect an Expo app to PostHog in one command. It provisions the PostHog project, asks which features you want, installs the SDK, and writes the env vars — so analytics / session replay / error tracking work after a build.

## How

Fast-forward order — provision first, then ask what to wire up:

1. **Provision** — reuses your account's PostHog org + this app's project, or creates them. Only a brand-new connection asks a question: **region** (US / EU), which sets data residency and can't be changed later.
2. **Pick features** — a multiselect, all preselected: Analytics, Session replay, Error tracking (source maps, _requires a personal API key_).
3. **Error tracking, if selected** — prompts you to paste a PostHog personal API key (we can't mint it — you create it in PostHog and paste it in).

It then:

- **Installs** `posthog-react-native` (+ `expo-file-system`, `expo-application`, `expo-device`, `expo-localization`; plus `posthog-react-native-session-replay` when replay is on) via `npx expo install`
- **Adds** the `posthog-react-native/expo` config plugin (prints manual steps if your app config is dynamic)
- **Writes env vars** to `.env.local` (local dev) and EAS (Production / Preview / Development):
  - Analytics → `EXPO_PUBLIC_POSTHOG_API_KEY`, `EXPO_PUBLIC_POSTHOG_HOST` (public)
  - Error tracking → `POSTHOG_CLI_API_KEY` (sensitive), `POSTHOG_CLI_PROJECT_ID`, `POSTHOG_CLI_HOST` (public)
- Source-map uploads on builds are covered by our guide; the command just sets the `POSTHOG_CLI_*` vars.

This PR also includes the PostHog GraphQL layer the command builds on — `PostHogQuery` / `PostHogMutation`, the connection/project types, and `commandUtils/posthog` (dashboard URL).

**Flags:** `--region`, `--session-replay` / `--no-session-replay`, `--error-tracking` / `--no-error-tracking`, `--posthog-cli-api-key`, `--overwrite`, plus `--json` / `--non-interactive`. Agent-ready: error tracking auto-skips without a key (or pass `--posthog-cli-api-key`); `--error-tracking` without a key fails before provisioning; `--region` is required non-interactively.

## Test Plan

- CI — 34 unit tests, full coverage of `connect.ts`
- Ran end-to-end against production: provisioned a PostHog project, selected all features, and confirmed the env vars land in `.env.local` + EAS and the SDK packages / config plugin are added

<img width="2048" height="2718" alt="carbon (1)" src="https://github.com/user-attachments/assets/073a5c41-7f07-48d6-b5b7-b1de3cff89fa" />

