### PR TITLE
[eas-cli] Add integrations:posthog:disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] `eas update:view [GROUP_ID]` now also accepts a platform-specific update ID, resolving it to and displaying its update group. ([#3864](https://github.com/expo/eas-cli/pull/3864) by [@keith-kurak](https://github.com/keith-kurak))
 - [eas-cli] Add `eas integrations:posthog:connect` command. ([#3836](https://github.com/expo/eas-cli/pull/3836) by [@gwdp](https://github.com/gwdp))
 - [eas-cli] Add `eas integrations:posthog:dashboard` command. ([#3837](https://github.com/expo/eas-cli/pull/3837) by [@gwdp](https://github.com/gwdp))
+- [eas-cli] Add `eas integrations:posthog:disconnect` command. ([#3838](https://github.com/expo/eas-cli/pull/3838) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commandUtils/posthog.ts
+++ b/packages/eas-cli/src/commandUtils/posthog.ts
@@ -1,11 +1,20 @@
 import chalk from 'chalk';
 
 import { PostHogProjectData } from '../graphql/types/PostHogConnection';
-import Log from '../log';
+import Log, { link } from '../log';
 
 export function getPostHogProjectDashboardUrl(project: PostHogProjectData): string {
   const host = project.posthogHost.replace(/\/$/, '');
   return `${host}/project/${encodeURIComponent(project.posthogProjectIdentifier)}`;
+}
+
+export function formatPostHogProject(project: PostHogProjectData): string {
+  return [
+    `${chalk.bold('Name')}: ${project.posthogProjectName}`,
+    `${chalk.bold('Host')}: ${project.posthogHost}`,
+    `${chalk.bold('Region')}: ${project.posthogOrganizationConnection.posthogRegion}`,
+    `${chalk.bold('Dashboard')}: ${link(getPostHogProjectDashboardUrl(project), { dim: false })}`,
+  ].join('\n');
 }
 
 export function logNoPostHogProject(projectName: string): void {

--- a/packages/eas-cli/src/commands/integrations/posthog/__tests__/disconnect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/__tests__/disconnect.test.ts
@@ -1,0 +1,158 @@
+import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
+import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../../credentials/__tests__/fixtures-constants';
+import { PostHogRegion } from '../../../../graphql/generated';
+import { PostHogMutation } from '../../../../graphql/mutations/PostHogMutation';
+import { PostHogQuery } from '../../../../graphql/queries/PostHogQuery';
+import {
+  PostHogOrganizationConnectionData,
+  PostHogProjectData,
+} from '../../../../graphql/types/PostHogConnection';
+import Log from '../../../../log';
+import { confirmAsync } from '../../../../prompts';
+import { printJsonOnlyOutput } from '../../../../utils/json';
+import IntegrationsPostHogDisconnect from '../disconnect';
+
+jest.mock('../../../../graphql/queries/PostHogQuery');
+jest.mock('../../../../graphql/mutations/PostHogMutation');
+jest.mock('../../../../prompts');
+jest.mock('../../../../log');
+jest.mock('../../../../utils/json');
+jest.mock('../../../../ora', () => ({
+  ora: () => ({
+    start: jest.fn().mockReturnThis(),
+    succeed: jest.fn().mockReturnThis(),
+    fail: jest.fn().mockReturnThis(),
+  }),
+}));
+
+describe(IntegrationsPostHogDisconnect, () => {
+  const graphqlClient = {} as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+
+  const mockConnection: PostHogOrganizationConnectionData = {
+    id: 'connection-1',
+    posthogOrganizationIdentifier: 'org-123',
+    posthogOrganizationName: 'Test Org',
+    posthogRegion: PostHogRegion.Us,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  };
+
+  const mockProject: PostHogProjectData = {
+    id: 'project-1',
+    posthogProjectIdentifier: 'res-123',
+    posthogProjectName: 'Test Project',
+    posthogProjectToken: 'phc_public_key',
+    posthogHost: 'https://us.posthog.com',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    posthogOrganizationConnection: mockConnection,
+  };
+
+  function createCommand(argv: string[]): IntegrationsPostHogDisconnect {
+    const command = new IntegrationsPostHogDisconnect(argv, mockConfig);
+    jest.spyOn(command as any, 'getContextAsync').mockReturnValue({
+      privateProjectConfig: {
+        projectId: testProjectId,
+        exp: { slug: 'testapp' },
+      },
+      loggedIn: { graphqlClient },
+    } as never);
+    return command;
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(Log, 'log').mockImplementation(() => {});
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    jest.spyOn(Log, 'error').mockImplementation(() => {});
+    jest.spyOn(Log, 'addNewLineIfNone').mockImplementation(() => {});
+    jest.spyOn(Log, 'newLine').mockImplementation(() => {});
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
+    jest.mocked(PostHogMutation.deletePostHogProjectAsync).mockResolvedValue(mockProject.id);
+    jest.mocked(confirmAsync).mockResolvedValue(true);
+  });
+
+  it('removes the project link after confirmation', async () => {
+    await createCommand([]).runAsync();
+
+    expect(PostHogMutation.deletePostHogProjectAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      mockProject.id
+    );
+  });
+
+  it('skips the prompt with --yes', async () => {
+    await createCommand(['--yes']).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(PostHogMutation.deletePostHogProjectAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      mockProject.id
+    );
+  });
+
+  it('does nothing when the user declines confirmation', async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+
+    await createCommand([]).runAsync();
+
+    expect(PostHogMutation.deletePostHogProjectAsync).not.toHaveBeenCalled();
+  });
+
+  it('deletes after a warning in non-interactive mode, noting PostHog data is preserved', async () => {
+    await createCommand(['--non-interactive']).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('does not delete the project on PostHog')
+    );
+    expect(PostHogMutation.deletePostHogProjectAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      mockProject.id
+    );
+  });
+
+  it('logs an empty state when no project link exists', async () => {
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+
+    await createCommand([]).runAsync();
+
+    expect(PostHogMutation.deletePostHogProjectAsync).not.toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('No PostHog project is linked to Expo app')
+    );
+  });
+
+  it('emits JSON output with --json and skips the prompt', async () => {
+    await createCommand(['--json']).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(PostHogMutation.deletePostHogProjectAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      mockProject.id
+    );
+    expect(printJsonOnlyOutput).toHaveBeenCalledWith({
+      id: mockProject.id,
+      name: mockProject.posthogProjectName,
+    });
+  });
+
+  it('emits a null id as JSON when no project is linked', async () => {
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+
+    await createCommand(['--json']).runAsync();
+
+    expect(PostHogMutation.deletePostHogProjectAsync).not.toHaveBeenCalled();
+    expect(printJsonOnlyOutput).toHaveBeenCalledWith({ id: null });
+  });
+
+  it('rethrows when the delete mutation fails', async () => {
+    jest
+      .mocked(PostHogMutation.deletePostHogProjectAsync)
+      .mockRejectedValue(new Error('delete boom'));
+
+    await expect(createCommand(['--yes']).runAsync()).rejects.toThrow('delete boom');
+  });
+});

--- a/packages/eas-cli/src/commands/integrations/posthog/disconnect.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/disconnect.ts
@@ -1,0 +1,100 @@
+import { Flags } from '@oclif/core';
+import chalk from 'chalk';
+
+import EasCommand from '../../../commandUtils/EasCommand';
+import {
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
+} from '../../../commandUtils/flags';
+import { formatPostHogProject, logNoPostHogProject } from '../../../commandUtils/posthog';
+import { PostHogMutation } from '../../../graphql/mutations/PostHogMutation';
+import { PostHogQuery } from '../../../graphql/queries/PostHogQuery';
+import Log from '../../../log';
+import { ora } from '../../../ora';
+import { confirmAsync } from '../../../prompts';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+
+export default class IntegrationsPostHogDisconnect extends EasCommand {
+  static override description =
+    'remove the PostHog project link for the current Expo app from EAS servers';
+
+  static override flags = {
+    ...EasNonInteractiveAndJsonFlags,
+    yes: Flags.boolean({
+      char: 'y',
+      description: 'Skip confirmation prompt',
+      default: false,
+    }),
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectConfig,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(IntegrationsPostHogDisconnect);
+    const { yes } = flags;
+    const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    const {
+      privateProjectConfig: { projectId, exp },
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(IntegrationsPostHogDisconnect, {
+      nonInteractive,
+      withServerSideEnvironment: null,
+    });
+
+    const posthogProject = await PostHogQuery.getPostHogProjectByAppIdAsync(
+      graphqlClient,
+      projectId
+    );
+
+    if (!posthogProject) {
+      if (jsonFlag) {
+        printJsonOnlyOutput({ id: null });
+      } else {
+        logNoPostHogProject(exp.slug);
+      }
+      return;
+    }
+
+    if (!jsonFlag) {
+      Log.addNewLineIfNone();
+      Log.log(formatPostHogProject(posthogProject));
+      Log.newLine();
+    }
+
+    if (!nonInteractive && !yes) {
+      const confirmed = await confirmAsync({
+        message:
+          'Remove this PostHog project link from EAS servers? This does not delete the project on PostHog.',
+      });
+      if (!confirmed) {
+        Log.warn('Canceled removal of the PostHog project link.');
+        return;
+      }
+    } else if (!jsonFlag) {
+      Log.warn(
+        'Removing the PostHog project link from EAS servers. This does not delete the project on PostHog.'
+      );
+    }
+
+    const spinner = jsonFlag ? null : ora('Removing PostHog project link').start();
+    try {
+      await PostHogMutation.deletePostHogProjectAsync(graphqlClient, posthogProject.id);
+      spinner?.succeed(
+        `Removed PostHog project ${chalk.bold(posthogProject.posthogProjectName)} from EAS servers`
+      );
+    } catch (error) {
+      spinner?.fail('Failed to remove PostHog project link');
+      throw error;
+    }
+
+    if (jsonFlag) {
+      printJsonOnlyOutput({ id: posthogProject.id, name: posthogProject.posthogProjectName });
+    }
+  }
+}

--- a/packages/eas-cli/src/graphql/mutations/PostHogMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PostHogMutation.ts
@@ -31,6 +31,16 @@ type SetupPostHogProjectMutationVariables = {
   input: SetupPostHogProjectInput;
 };
 
+type DeletePostHogProjectMutation = {
+  posthogProject: {
+    deletePostHogProject: string;
+  };
+};
+
+type DeletePostHogProjectMutationVariables = {
+  id: string;
+};
+
 export const PostHogMutation = {
   async createPostHogAccountRequestAsync(
     graphqlClient: ExpoGraphqlClient,
@@ -84,5 +94,24 @@ export const PostHogMutation = {
         .toPromise()
     );
     return data.posthogProject.setupPostHogProject;
+  },
+
+  async deletePostHogProjectAsync(graphqlClient: ExpoGraphqlClient, id: string): Promise<string> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<DeletePostHogProjectMutation, DeletePostHogProjectMutationVariables>(
+          gql`
+            mutation DeletePostHogProject($id: ID!) {
+              posthogProject {
+                deletePostHogProject(id: $id)
+              }
+            }
+          `,
+          { id },
+          { additionalTypenames: ['App', 'PostHogProject'] }
+        )
+        .toPromise()
+    );
+    return data.posthogProject.deletePostHogProject;
   },
 };


### PR DESCRIPTION
## Why

Unlink your app from PostHog.

## How

- Deletes the project link
- Warns PostHog-side data is preserved; doesn't touch the org connection

## Test Plan

- CI — 8 unit tests
- Ran against production: removed the project link from EAS and confirmed the PostHog project itself is preserved

