### PR TITLE
[build-tools] read JUnit new file attribute for Maestro 2.6+

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
@@ -4,10 +4,14 @@ import { vol } from 'memfs';
 
 import {
   copyLatestAttemptXml,
+  isFileAttrRun,
+  junitFileHasFileAttrs,
   mergeJUnitReports,
+  parseFailedFlowsFromFileAttrs,
   parseFailedFlowsFromJUnit,
   parseJUnitTestCases,
   parseMaestroResults,
+  parseMaestroResultsFromFileAttrs,
 } from '../maestroResultParser';
 
 describe(parseMaestroResults, () => {
@@ -298,7 +302,169 @@ describe(parseMaestroResults, () => {
   });
 });
 
+describe(parseMaestroResultsFromFileAttrs, () => {
+  it('uses file= as the path', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="login" file=".maestro/login.yaml" status="SUCCESS" time="1.0"/>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    const results = await parseMaestroResultsFromFileAttrs('/junit');
+    expect(results[0]).toEqual(
+      expect.objectContaining({ name: 'login', path: '.maestro/login.yaml' })
+    );
+  });
+
+  it('keeps two same-named flows separate by their file= path', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="login" file="a/login.yaml" status="SUCCESS" time="1.0"/>',
+        '  <testcase name="login" file="b/login.yaml" status="ERROR" time="1.0"><failure>x</failure></testcase>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    const results = await parseMaestroResultsFromFileAttrs('/junit');
+    expect(results.map(r => r.path).sort()).toEqual(['a/login.yaml', 'b/login.yaml']);
+  });
+
+  it('returns per-attempt results keyed by file= across attempt files', async () => {
+    vol.fromJSON({
+      '/junit/android-maestro-junit-attempt-0.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="login" file="flows/login.yaml" time="1.0"><failure>x</failure></testcase>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+      '/junit/android-maestro-junit-attempt-1.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="login" file="flows/login.yaml" status="SUCCESS" time="1.0"/>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    const results = await parseMaestroResultsFromFileAttrs('/junit');
+    expect(results).toEqual([
+      expect.objectContaining({ path: 'flows/login.yaml', status: 'failed', retryCount: 0 }),
+      expect.objectContaining({ path: 'flows/login.yaml', status: 'passed', retryCount: 1 }),
+    ]);
+  });
+
+  it('returns empty array when the directory does not exist', async () => {
+    const results = await parseMaestroResultsFromFileAttrs('/nope');
+    expect(results).toEqual([]);
+  });
+
+  it('skips testcases without file= instead of emitting an undefined path (contract guard)', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="a" file="a.yaml" status="SUCCESS" time="1.0"/>',
+        '  <testcase name="b" status="SUCCESS" time="1.0"/>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    const results = await parseMaestroResultsFromFileAttrs('/junit');
+    expect(results).toEqual([expect.objectContaining({ name: 'a', path: 'a.yaml' })]);
+  });
+});
+
+describe('junitFileHasFileAttrs', () => {
+  it('returns true when every testcase has a non-empty file= attribute', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="a" file="a.yaml" status="SUCCESS" time="1.0"/>',
+        '  <testcase name="b" file="b.yaml" status="SUCCESS" time="1.0"/>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    expect(await junitFileHasFileAttrs('/junit/report.xml')).toBe(true);
+  });
+
+  it('returns false when any testcase lacks file= (mixed report)', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="a" file="a.yaml" status="SUCCESS" time="1.0"/>',
+        '  <testcase name="b" status="SUCCESS" time="1.0"/>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    expect(await junitFileHasFileAttrs('/junit/report.xml')).toBe(false);
+  });
+
+  it('returns false when file= is an empty string', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="a" file="" status="SUCCESS" time="1.0"/>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    expect(await junitFileHasFileAttrs('/junit/report.xml')).toBe(false);
+  });
+
+  it('returns false for a legacy report with no file= attributes', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="a" status="SUCCESS" time="1.0"/>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    expect(await junitFileHasFileAttrs('/junit/report.xml')).toBe(false);
+  });
+
+  it('returns false when the file cannot be read', async () => {
+    expect(await junitFileHasFileAttrs('/missing.xml')).toBe(false);
+  });
+});
+
+describe('isFileAttrRun', () => {
+  it('returns false for an empty list (an empty report is not a file-attr run)', () => {
+    expect(isFileAttrRun([])).toBe(false);
+  });
+});
+
 describe(parseJUnitTestCases, () => {
+  it('extracts the file= attribute when present', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="login" file=".maestro/login.yaml" status="SUCCESS" time="1.0"/>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    const results = await parseJUnitTestCases('/junit');
+    expect(results[0].file).toBe('.maestro/login.yaml');
+  });
+
+  it('treats a missing or empty file= attribute as undefined', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="a" status="SUCCESS" time="1.0"/>',
+        '  <testcase name="b" file="" status="SUCCESS" time="1.0"/>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    const results = await parseJUnitTestCases('/junit');
+    expect(results.find(r => r.name === 'a')!.file).toBeUndefined();
+    expect(results.find(r => r.name === 'b')!.file).toBeUndefined();
+  });
+
   it('parses a single testcase with SUCCESS status', async () => {
     vol.fromJSON({
       '/junit/report.xml': [
@@ -582,6 +748,100 @@ describe(parseJUnitTestCases, () => {
   });
 });
 
+describe(parseFailedFlowsFromFileAttrs, () => {
+  it('returns the failing flows by file= (duplicate names retry correctly)', async () => {
+    vol.fromJSON({
+      '/tmp/jr/attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="login" file="a/login.yaml" status="SUCCESS" time="1.0"/>
+  <testcase name="login" file="b/login.yaml" time="1.0"><failure>x</failure></testcase>
+</testsuite></testsuites>`,
+      '/proj/b/login.yaml': '',
+    });
+    const result = await parseFailedFlowsFromFileAttrs({
+      junitFile: '/tmp/jr/attempt-0.xml',
+      workingDirectory: '/proj',
+    });
+    expect(result).toEqual(['b/login.yaml']);
+  });
+
+  it('returns null when a file= path does not exist on disk (dumb retry, never legacy)', async () => {
+    vol.fromJSON({
+      '/tmp/jr/attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="gone" file="missing/flow.yaml" time="1.0"><failure>x</failure></testcase>
+</testsuite></testsuites>`,
+    });
+    const result = await parseFailedFlowsFromFileAttrs({
+      junitFile: '/tmp/jr/attempt-0.xml',
+      workingDirectory: '/proj',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the report lacks file= attributes (callers must pre-check)', async () => {
+    vol.fromJSON({
+      '/tmp/jr/attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="A" file="a.yaml" time="1.0"><failure>x</failure></testcase>
+  <testcase name="B" time="1.0"><failure>y</failure></testcase>
+</testsuite></testsuites>`,
+      '/proj/a.yaml': '',
+    });
+    const result = await parseFailedFlowsFromFileAttrs({
+      junitFile: '/tmp/jr/attempt-0.xml',
+      workingDirectory: '/proj',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('dedupes repeated failing file= paths (same flow failed twice in one attempt)', async () => {
+    vol.fromJSON({
+      '/tmp/jr/attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="login" file="flows/login.yaml" time="1.0"><failure>x</failure></testcase>
+  <testcase name="login" file="flows/login.yaml" time="1.0"><failure>y</failure></testcase>
+</testsuite></testsuites>`,
+      '/proj/flows/login.yaml': '',
+    });
+    const result = await parseFailedFlowsFromFileAttrs({
+      junitFile: '/tmp/jr/attempt-0.xml',
+      workingDirectory: '/proj',
+    });
+    expect(result).toEqual(['flows/login.yaml']);
+  });
+
+  it('resolves and existence-checks an absolute file= path', async () => {
+    vol.fromJSON({
+      '/tmp/jr/attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="ext" file="/outside/flow.yaml" time="1.0"><failure>x</failure></testcase>
+</testsuite></testsuites>`,
+      '/outside/flow.yaml': '',
+    });
+    const result = await parseFailedFlowsFromFileAttrs({
+      junitFile: '/tmp/jr/attempt-0.xml',
+      workingDirectory: '/proj',
+    });
+    expect(result).toEqual(['/outside/flow.yaml']);
+  });
+
+  it('returns null when junit XML is truncated mid-tag (partial parse risk)', async () => {
+    vol.fromJSON({
+      '/tmp/jr/attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="A" file="a.yaml" time="1.0"><failure>x</failure></testcase>
+  <testcase name="B" file="b.yaml"`, // intentionally truncated mid-tag
+      '/proj/a.yaml': '',
+    });
+    const result = await parseFailedFlowsFromFileAttrs({
+      junitFile: '/tmp/jr/attempt-0.xml',
+      workingDirectory: '/proj',
+    });
+    expect(result).toBeNull();
+  });
+});
+
 describe('parseFailedFlowsFromJUnit', () => {
   it('returns the subset of input flow paths whose testcases failed', async () => {
     vol.fromJSON({
@@ -763,6 +1023,28 @@ describe('mergeJUnitReports', () => {
     expect(a['@_status']).toBe('SUCCESS'); // from attempt 0
     expect(b['@_status']).toBe('SUCCESS'); // from attempt 1 (latest)
     expect(b.failure).toBeUndefined();
+  });
+
+  it('keeps a same-named flow from an earlier attempt when keyed by file=', async () => {
+    vol.fromJSON({
+      '/tmp/r/android-maestro-junit-attempt-0.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="login" file="a/login.yaml" status="SUCCESS" time="1.0"/>
+  <testcase name="login" file="b/login.yaml" time="1.0"><failure>x</failure></testcase>
+</testsuite></testsuites>`,
+      '/tmp/r/android-maestro-junit-attempt-1.xml': `<?xml version="1.0"?>
+<testsuites><testsuite>
+  <testcase name="login" file="b/login.yaml" status="SUCCESS" time="1.0"/>
+</testsuite></testsuites>`,
+    });
+
+    await mergeJUnitReports({ sourceDir: '/tmp/r', outputPath: '/tmp/final.xml' });
+
+    const out = await fs.readFile('/tmp/final.xml', 'utf-8');
+    const parsed = new XMLParser({ ignoreAttributes: false }).parse(out);
+    const testcases = parsed.testsuites.testsuite.testcase;
+    const files = testcases.map((t: any) => t['@_file']).sort();
+    expect(files).toEqual(['a/login.yaml', 'b/login.yaml']);
   });
 
   it('throws when source directory contains no *.xml files', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -273,6 +273,33 @@ describe('createMaestroTestsBuildFunction', () => {
     );
   });
 
+  it('uses the file= path on reports that carry it, without scanning flow files', async () => {
+    mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
+    jest.spyOn(parser, 'junitFileHasFileAttrs').mockResolvedValue(true);
+    const discoverySpy = jest.spyOn(discovery, 'buildFlowNameToPathMap');
+    const legacyParseSpy = jest.spyOn(parser, 'parseFailedFlowsFromJUnit');
+    const newParseSpy = jest
+      .spyOn(parser, 'parseFailedFlowsFromFileAttrs')
+      .mockResolvedValue(['flows/b.yaml']);
+
+    const step = createStep({
+      flow_path: ['flows/a.yaml', 'flows/b.yaml'],
+      retries: 1,
+      output_format: 'junit',
+      retry_failed_only: true,
+      platform: 'android',
+    });
+    await step.executeAsync();
+
+    expect(newParseSpy).toHaveBeenCalledTimes(1);
+    // The new branch needs no name→path map: no scan, no legacy parser.
+    expect(discoverySpy).not.toHaveBeenCalled();
+    expect(legacyParseSpy).not.toHaveBeenCalled();
+    const a1 = mockedSpawn.mock.calls[1][1]!;
+    expect(a1).toContain('flows/b.yaml');
+    expect(a1).not.toContain('flows/a.yaml');
+  });
+
   it('falls back to all-flows retry when nameToPath is null (duplicate flow names)', async () => {
     mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
     jest.spyOn(discovery, 'buildFlowNameToPathMap').mockResolvedValue(null);
@@ -291,6 +318,44 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(mockedSpawn.mock.calls[1][1]).toEqual(
       expect.arrayContaining(['flows/a.yaml', 'flows/b.yaml'])
     );
+  });
+
+  it('never scans flow files when all attempts succeed', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const discoverySpy = jest.spyOn(discovery, 'buildFlowNameToPathMap');
+
+    const step = createStep({ flow_path: ['flows/a.yaml'], platform: 'android' });
+    await step.executeAsync();
+
+    expect(discoverySpy).not.toHaveBeenCalled();
+  });
+
+  it('memoizes the flow scan across retries (legacy reports)', async () => {
+    // Routing note: the step lands in the legacy arm because the real
+    // junitFileHasFileAttrs returns false — the attempt XML does not exist on
+    // the mock fs. Creating that file with file= attrs would flip the branch.
+    mockedSpawn
+      .mockRejectedValueOnce(rejectExit1())
+      .mockRejectedValueOnce(rejectExit1())
+      .mockResolvedValueOnce(SPAWN_SUCCESS);
+    const discoverySpy = jest
+      .spyOn(discovery, 'buildFlowNameToPathMap')
+      .mockResolvedValue(new Map([['a', 'flows/a.yaml']]));
+    const parseSpy = jest
+      .spyOn(parser, 'parseFailedFlowsFromJUnit')
+      .mockResolvedValue(['flows/a.yaml']);
+
+    const step = createStep({
+      flow_path: ['flows/a.yaml'],
+      retries: 2,
+      output_format: 'junit',
+      platform: 'android',
+    });
+    await step.executeAsync();
+
+    // Two failed attempts hit the legacy branch twice; the scan runs once.
+    expect(parseSpy).toHaveBeenCalledTimes(2);
+    expect(discoverySpy).toHaveBeenCalledTimes(1);
   });
 
   it('defaults retry_failed_only to true when omitted from inputs', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/reportMaestroTestResults.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/reportMaestroTestResults.test.ts
@@ -3,6 +3,7 @@ import { vol } from 'memfs';
 
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createMockLogger } from '../../../__tests__/utils/logger';
+import * as discovery from '../maestroFlowDiscovery';
 import { createReportMaestroTestResultsFunction } from '../reportMaestroTestResults';
 
 const JUNIT_PASS = [
@@ -43,15 +44,24 @@ describe(createReportMaestroTestResultsFunction, () => {
     } as unknown as Client;
   });
 
+  // Returns a mock logger whose child() is itself, so step-level log calls can
+  // be asserted on the returned object.
+  function createSelfChildedLogger(): ReturnType<typeof createMockLogger> {
+    const logger = createMockLogger();
+    (logger.child as jest.Mock).mockReturnValue(logger);
+    return logger;
+  }
+
   function createStep(overrides?: {
     callInputs?: Record<string, unknown>;
     staticContextContent?: Record<string, unknown>;
     env?: Record<string, string>;
+    logger?: ReturnType<typeof createMockLogger>;
   }) {
     const ctx = { graphqlClient: mockGraphqlClient };
     const fn = createReportMaestroTestResultsFunction(ctx as any);
     const globalCtx = createGlobalContextMock({
-      logger: createMockLogger(),
+      logger: overrides?.logger ?? createMockLogger(),
       projectTargetDirectory: '/root/project',
       staticContextContent: {
         expoApiServerURL: 'https://api.expo.test',
@@ -103,6 +113,54 @@ describe(createReportMaestroTestResultsFunction, () => {
         properties: {},
       }),
     ]);
+  });
+
+  it('reports both flows when two share a name but have distinct file= paths', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="login" file="a/login.yaml" status="SUCCESS" time="1.0"/>',
+        '  <testcase name="login" file="b/login.yaml" status="SUCCESS" time="1.0"/>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    mockMutationFn.mockResolvedValue({
+      data: {
+        workflowDeviceTestCaseResult: {
+          createWorkflowDeviceTestCaseResults: [{ id: '1' }, { id: '2' }],
+        },
+      },
+    });
+    await createStep().executeAsync();
+    expect(mockGraphqlClient.mutation).toHaveBeenCalledTimes(1);
+    const [, variables] = (mockGraphqlClient.mutation as jest.Mock).mock.calls[0];
+    expect(variables.input.testCaseResults.map((r: any) => r.path).sort()).toEqual([
+      'a/login.yaml',
+      'b/login.yaml',
+    ]);
+  });
+
+  it('never scans flow files for a file= report, even when flow_path is provided', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="login" file="flows/login.yaml" status="SUCCESS" time="1.0"/>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    const discoverySpy = jest.spyOn(discovery, 'buildFlowNameToPathMap');
+    mockMutationFn.mockResolvedValue({
+      data: {
+        workflowDeviceTestCaseResult: { createWorkflowDeviceTestCaseResults: [{ id: '1' }] },
+      },
+    });
+
+    await createStep({ callInputs: { flow_path: ['flows/login.yaml'] } }).executeAsync();
+
+    expect(mockGraphqlClient.mutation).toHaveBeenCalledTimes(1);
+    expect(discoverySpy).not.toHaveBeenCalled();
   });
 
   it('sends tags and properties from JUnit XML', async () => {
@@ -221,7 +279,7 @@ describe(createReportMaestroTestResultsFunction, () => {
     await createStep().executeAsync();
   });
 
-  it('skips report when duplicate testcase names found', async () => {
+  it('skips report when duplicate testcase names found (legacy), advising unique names', async () => {
     vol.fromJSON({
       '/junit/report.xml': [
         '<?xml version="1.0"?>',
@@ -238,8 +296,27 @@ describe(createReportMaestroTestResultsFunction, () => {
       }),
     });
 
-    await createStep().executeAsync();
+    const logger = createSelfChildedLogger();
+    await createStep({ logger }).executeAsync();
     expect(mockGraphqlClient.mutation).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('unique name'));
+  });
+
+  it('skips report when the same flow file appears twice in one attempt, advising flow_path check', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="login" file="flows/login.yaml" status="SUCCESS" time="1.0"/>',
+        '  <testcase name="login" file="flows/login.yaml" status="SUCCESS" time="2.0"/>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+
+    const logger = createSelfChildedLogger();
+    await createStep({ logger }).executeAsync();
+    expect(mockGraphqlClient.mutation).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('flow_path entries'));
   });
 
   it('sends per-attempt results with same name but different retryCount', async () => {

--- a/packages/build-tools/src/steps/functions/maestroResultParser.ts
+++ b/packages/build-tools/src/steps/functions/maestroResultParser.ts
@@ -1,3 +1,4 @@
+import { asyncResult } from '@expo/results';
 import { XMLBuilder, XMLParser, XMLValidator } from 'fast-xml-parser';
 import fs from 'fs/promises';
 import path from 'path';
@@ -18,6 +19,7 @@ const ATTEMPT_PATTERN = /attempt-(\d+)/;
 
 export interface JUnitTestCaseResult {
   name: string;
+  file: string | undefined;
   status: 'passed' | 'failed';
   duration: number; // milliseconds
   errorMessage: string | null;
@@ -31,6 +33,12 @@ const xmlParser = new XMLParser({
   // Ensure single-element arrays are always arrays
   isArray: name => ['testsuite', 'testcase', 'property'].includes(name),
 });
+
+// A `file=` attribute counts as present only when it is a non-empty string.
+function fileAttrOf(tc: any): string | undefined {
+  const f = tc?.['@_file'];
+  return typeof f === 'string' && f.length > 0 ? f : undefined;
+}
 
 function parseJUnitContent(content: string): JUnitTestCaseResult[] {
   const results: JUnitTestCaseResult[] = [];
@@ -53,6 +61,8 @@ function parseJUnitContent(content: string): JUnitTestCaseResult[] {
         if (!name) {
           continue;
         }
+
+        const file = fileAttrOf(tc);
 
         const timeStr = tc['@_time'];
         const timeSeconds = timeStr ? parseFloat(timeStr) : 0;
@@ -94,7 +104,7 @@ function parseJUnitContent(content: string): JUnitTestCaseResult[] {
           : [];
         delete properties['tags'];
 
-        results.push({ name, status, duration, errorMessage, tags, properties });
+        results.push({ name, file, status, duration, errorMessage, tags, properties });
       }
     }
   } catch {
@@ -129,6 +139,142 @@ export async function parseJUnitTestCases(junitDirectory: string): Promise<JUnit
     xmlFiles.map(f => parseJUnitFile(path.join(junitDirectory, f)))
   );
   return perFile.flat();
+}
+
+// ---------------------------------------------------------------------------
+// Maestro >= 2.6.0 code path: every <testcase> carries a `file=` attribute with
+// its flow's own path (all-or-none per run). Callers check the report first
+// (isFileAttrRun / junitFileHasFileAttrs) and route here; the legacy name→path
+// scan is then never consulted.
+// ---------------------------------------------------------------------------
+
+export function isFileAttrRun(
+  testcases: JUnitTestCaseResult[]
+): testcases is (JUnitTestCaseResult & { file: string })[] {
+  return testcases.length > 0 && testcases.every(tc => tc.file !== undefined);
+}
+
+// Unreadable or attribute-less reports ⇒ false: the caller then takes the
+// legacy path, whose own guards degrade safely.
+export async function junitFileHasFileAttrs(junitFile: string): Promise<boolean> {
+  return isFileAttrRun(await parseJUnitFile(junitFile));
+}
+
+async function fileExists(absPath: string): Promise<boolean> {
+  return (await asyncResult(fs.stat(absPath))).ok;
+}
+
+// Group by `file=` so two same-named flows in different files stay separate.
+export async function parseMaestroResultsFromFileAttrs(
+  junitDirectory: string
+): Promise<MaestroFlowResult[]> {
+  interface JUnitEntry {
+    result: JUnitTestCaseResult;
+    sourceFile: string;
+  }
+
+  let junitEntries: string[];
+  try {
+    junitEntries = await fs.readdir(junitDirectory);
+  } catch {
+    return [];
+  }
+  const xmlFiles = junitEntries.filter(f => f.endsWith('.xml')).sort();
+
+  const entries: JUnitEntry[] = [];
+  for (const xmlFile of xmlFiles) {
+    const fileResults = await parseJUnitFile(path.join(junitDirectory, xmlFile));
+    for (const result of fileResults) {
+      entries.push({ result, sourceFile: xmlFile });
+    }
+  }
+
+  const byPath = new Map<string, JUnitEntry[]>();
+  for (const entry of entries) {
+    // Callers verify the report with isFileAttrRun/junitFileHasFileAttrs first;
+    // skip (rather than emit an undefined path) if that contract is violated.
+    const flowPath = entry.result.file;
+    if (flowPath === undefined) {
+      continue;
+    }
+    const group = byPath.get(flowPath) ?? [];
+    group.push(entry);
+    byPath.set(flowPath, group);
+  }
+
+  const results: MaestroFlowResult[] = [];
+  for (const [flowPath, group] of byPath) {
+    // retryCount is derived from each entry's source filename (`attempt-N`);
+    // a single entry from `report.xml` (no marker) collapses to attempt 0.
+    const sorted = group
+      .map(entry => {
+        const match = entry.sourceFile.match(ATTEMPT_PATTERN);
+        const attemptIndex = match ? parseInt(match[1], 10) : 0;
+        return { ...entry, attemptIndex };
+      })
+      .sort((a, b) => a.attemptIndex - b.attemptIndex);
+
+    for (const { result, attemptIndex } of sorted) {
+      results.push({
+        name: result.name,
+        path: flowPath,
+        status: result.status,
+        errorMessage: result.errorMessage,
+        duration: result.duration,
+        retryCount: attemptIndex,
+        tags: result.tags,
+        properties: result.properties,
+      });
+    }
+  }
+  return results;
+}
+
+/**
+ * Returns the `file=` paths of the failing testcases in the given attempt's
+ * JUnit file, or `null` when the result cannot be trusted (caller then falls
+ * back to dumb retry — re-run everything; never the legacy scan).
+ *
+ * Callers verify the report carries `file=` attributes first
+ * (junitFileHasFileAttrs).
+ */
+export async function parseFailedFlowsFromFileAttrs(args: {
+  junitFile: string;
+  workingDirectory: string;
+}): Promise<string[] | null> {
+  // Same hardening as the legacy parser: fast-xml-parser is lenient — a
+  // truncated XML could drop testcases, and trusting that partial failing set
+  // would skip retries for cut-off flows.
+  let content: string;
+  try {
+    content = await fs.readFile(args.junitFile, 'utf-8');
+  } catch {
+    return null;
+  }
+  if (XMLValidator.validate(content) !== true) {
+    return null;
+  }
+
+  const testcases = parseJUnitContent(content);
+  if (!isFileAttrRun(testcases)) {
+    return null;
+  }
+
+  const failing = testcases.filter(tc => tc.status === 'failed');
+  if (failing.length === 0) {
+    return [];
+  }
+
+  // Each failing testcase is self-identifying via `file=`, so duplicate flow
+  // names retry correctly. path.resolve (not join): `file=` may be absolute
+  // when the flow lives outside the working directory.
+  const paths = [...new Set(failing.map(tc => tc.file))];
+  for (const p of paths) {
+    if (!(await fileExists(path.resolve(args.workingDirectory, p)))) {
+      return null;
+    }
+  }
+  return paths;
 }
 
 export async function parseMaestroResults(
@@ -313,6 +459,13 @@ export async function mergeJUnitReports(args: {
     }
     const match = filename.match(ATTEMPT_PATTERN);
     const attemptIndex = match ? parseInt(match[1], 10) : 0;
+    // Maestro >= 2.6.0 reports: key by `file=` so two same-named flows in
+    // different files merge separately. Legacy reports keep name keying.
+    const allCases = testsuites.flatMap((suite: any) =>
+      Array.isArray(suite?.testcase) ? suite.testcase : []
+    );
+    const useFileKeys =
+      allCases.length > 0 && allCases.every((tc: any) => fileAttrOf(tc) !== undefined);
     const testcasesByName = new Map<string, unknown[]>();
     for (const suite of testsuites) {
       const cases = suite?.testcase;
@@ -324,9 +477,10 @@ export async function mergeJUnitReports(args: {
         if (typeof name !== 'string') {
           continue;
         }
-        const group = testcasesByName.get(name) ?? [];
+        const key = useFileKeys ? fileAttrOf(tc)! : name;
+        const group = testcasesByName.get(key) ?? [];
         group.push(tc);
-        testcasesByName.set(name, group);
+        testcasesByName.set(key, group);
       }
     }
     if (testcasesByName.size === 0) {

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -14,7 +14,9 @@ import { z } from 'zod';
 import { buildFlowNameToPathMap } from './maestroFlowDiscovery';
 import {
   copyLatestAttemptXml,
+  junitFileHasFileAttrs,
   mergeJUnitReports,
+  parseFailedFlowsFromFileAttrs,
   parseFailedFlowsFromJUnit,
 } from './maestroResultParser';
 import { sleepAsync } from '../../utils/retry';
@@ -200,13 +202,10 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
         throw new SystemError('Failed to create JUnit report directory', { cause: err });
       }
 
-      // null → duplicate flow names; retry-failed-only disabled, fall through to
-      // dumb retry (re-run everything) on failure.
-      const nameToPath = await buildFlowNameToPathMap({
-        inputFlowPaths: flowPaths,
-        projectRoot: stepCtx.workingDirectory,
-        logger,
-      });
+      // Legacy-only (Maestro < 2.6.0 reports carry no `file=` attribute): the
+      // flow scan is built lazily in the retry branch below and memoized so
+      // retries share one scan. Never runs when the report has `file=`.
+      let nameToPathPromise: Promise<Map<string, string> | null> | undefined;
 
       // Retry loop. spawn-async error shapes:
       //   ENOENT/EACCES → infra (binary missing/not executable) → SystemError.
@@ -214,7 +213,7 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
       //   else (signal-only, OOM kill, unknown) → infra → SystemError, never
       //     downgraded to "tests failed".
       // Retry-failed-only (junit mode): after a failed attempt, subset to the failing
-      // flows. parseFailedFlowsFromJUnit returns null when the JUnit cannot be
+      // flows. The failed-flow parsers return null when the JUnit cannot be
       // trusted; we then fall through to dumb retry (re-run everything).
       let flowsToRun: string[] = flowPaths;
       let lastAttemptExitCode: number | null = null;
@@ -263,11 +262,26 @@ export function createMaestroTestsBuildFunction(): BuildFunction {
           break;
         }
 
-        if (retryFailedOnly && outputFormat === 'junit' && outputPath && nameToPath) {
-          const failed = await parseFailedFlowsFromJUnit({
-            junitFile: outputPath,
-            nameToPath,
-          });
+        if (retryFailedOnly && outputFormat === 'junit' && outputPath) {
+          let failed: string[] | null;
+          if (await junitFileHasFileAttrs(outputPath)) {
+            failed = await parseFailedFlowsFromFileAttrs({
+              junitFile: outputPath,
+              workingDirectory: stepCtx.workingDirectory,
+            });
+          } else {
+            // Legacy (Maestro < 2.6.0): map failed testcase names back to flow
+            // paths via the flow-file scan. DELETE this arm once the fleet is
+            // on >= 2.6.0.
+            const nameToPath = await (nameToPathPromise ??= buildFlowNameToPathMap({
+              inputFlowPaths: flowPaths,
+              projectRoot: stepCtx.workingDirectory,
+              logger,
+            }));
+            failed = nameToPath
+              ? await parseFailedFlowsFromJUnit({ junitFile: outputPath, nameToPath })
+              : null;
+          }
           if (failed !== null && failed.length > 0) {
             flowsToRun = failed;
             logger.info(

--- a/packages/build-tools/src/steps/functions/reportMaestroTestResults.ts
+++ b/packages/build-tools/src/steps/functions/reportMaestroTestResults.ts
@@ -3,7 +3,13 @@ import { graphql } from 'gql.tada';
 import { z } from 'zod';
 
 import { buildFlowNameToPathMap } from './maestroFlowDiscovery';
-import { MaestroFlowResult, parseMaestroResults } from './maestroResultParser';
+import {
+  MaestroFlowResult,
+  isFileAttrRun,
+  parseJUnitTestCases,
+  parseMaestroResults,
+  parseMaestroResultsFromFileAttrs,
+} from './maestroResultParser';
 import { CustomBuildContext } from '../../customBuildContext';
 
 const FlowPathSchema = z.array(z.string().min(1)).min(1);
@@ -61,47 +67,64 @@ export function createReportMaestroTestResultsFunction(ctx: CustomBuildContext):
         return;
       }
 
-      const flowPathRaw = inputs.flow_path.value;
-      let nameToPath: Map<string, string> | null = null;
-      if (flowPathRaw !== undefined) {
-        const parsed = FlowPathSchema.safeParse(flowPathRaw);
-        if (parsed.success) {
-          nameToPath = await buildFlowNameToPathMap({
-            inputFlowPaths: parsed.data,
-            projectRoot: stepsCtx.workingDirectory,
-            logger,
-          });
-        } else {
-          logger.warn(
-            'Ignoring malformed flow_path input (expected a non-empty array of non-empty strings).'
-          );
-        }
-      }
-
       try {
-        const flowResults = await parseMaestroResults(junitDirectory, nameToPath);
+        // Maestro >= 2.6.0 stamps every <testcase> with its flow's path in a
+        // `file=` attribute; older reports need the legacy flow-file scan to
+        // map testcase names back to paths.
+        const usedFileAttrs = isFileAttrRun(await parseJUnitTestCases(junitDirectory));
+
+        let flowResults: MaestroFlowResult[];
+        if (usedFileAttrs) {
+          flowResults = await parseMaestroResultsFromFileAttrs(junitDirectory);
+        } else {
+          // Legacy (Maestro < 2.6.0) — DELETE this arm once the fleet is on >= 2.6.0.
+          const flowPathRaw = inputs.flow_path.value;
+          let nameToPath: Map<string, string> | null = null;
+          if (flowPathRaw !== undefined) {
+            const parsed = FlowPathSchema.safeParse(flowPathRaw);
+            if (parsed.success) {
+              nameToPath = await buildFlowNameToPathMap({
+                inputFlowPaths: parsed.data,
+                projectRoot: stepsCtx.workingDirectory,
+                logger,
+              });
+            } else {
+              logger.warn(
+                'Ignoring malformed flow_path input (expected a non-empty array of non-empty strings).'
+              );
+            }
+          }
+          flowResults = await parseMaestroResults(junitDirectory, nameToPath);
+        }
+
         if (flowResults.length === 0) {
           logger.info('No maestro test results found, skipping report');
           return;
         }
 
-        // Detect truly conflicting results: same (name, retryCount) pair means different flow files
-        // share the same name (Maestro config override), which we can't disambiguate.
-        // Same name with different retryCount is expected (per-attempt results from retries).
+        // Detect truly conflicting results: the same (path, retryCount) twice means two
+        // flow files resolved to the same path, which we can't disambiguate and the API
+        // rejects as a duplicate. Same path with different retryCount is expected
+        // (per-attempt results from retries).
         const seen = new Set<string>();
         const conflicting = new Set<string>();
         for (const r of flowResults) {
-          const key = `${r.name}:${r.retryCount}`;
+          const key = `${r.path}:${r.retryCount}`;
           if (seen.has(key)) {
-            conflicting.add(r.name);
+            conflicting.add(r.path);
           }
           seen.add(key);
         }
         if (conflicting.size > 0) {
+          const conflictList = [...conflicting].join(', ');
           logger.error(
-            `Duplicate test case names found in JUnit output: ${[...conflicting].join(
-              ', '
-            )}. Skipping report. Ensure each Maestro flow has a unique name.`
+            usedFileAttrs
+              ? `The same flow file was reported more than once in a single attempt: ` +
+                  `${conflictList}. Skipping report. Check for duplicate flow_path entries ` +
+                  `or leftover XML files in the JUnit report directory.`
+              : `Duplicate Maestro flow names found: ${conflictList}. Skipping report. ` +
+                  `Give each flow a unique name, or upgrade Maestro to >= 2.6.0 (flows are ` +
+                  `then identified by file path, so duplicate names are fine).`
           );
           return;
         }


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Maestro 2.6.0 stamps every JUnit `<testcase>` with a `file=` attribute carrying the flow's own path ([mobile-dev-inc/Maestro#3266](https://github.com/mobile-dev-inc/Maestro/pull/3266)). We can now read flow paths directly from the report instead of recovering them with the filesystem scan + YAML `name:` heuristic, which breaks on duplicate flow names (retry-failed-only gets disabled and result reporting is skipped entirely).

Linear: ENG-21194

# How

Callers check whether the JUnit report carries `file=` attributes (`junitFileHasFileAttrs` / `isFileAttrRun`) and branch:

- **New path (Maestro >= 2.6.0)**: `parseMaestroResultsFromFileAttrs` / `parseFailedFlowsFromFileAttrs` read paths straight from the report — no filesystem scan. Duplicate flow names now work end to end: retry-failed-only re-runs the right file, and results are reported as distinct rows (the API already keys results on `(path, retryCount)`).
- **Legacy path (< 2.6.0)**: the existing parser functions are kept byte-identical (signatures included), and the flow scan now runs lazily — only when a legacy report actually needs it (never on green runs or >= 2.6.0). Removing the legacy path later is a wholesale deletion: the legacy functions, the `else` arms in the two steps, and `maestroFlowDiscovery.ts`.
- `mergeJUnitReports` keys testcases by `file=` when present, fixing a merged-artifact bug where a same-named flow that wasn't re-run in the latest attempt vanished from `final_report_path`.
- Safety: any problem inside the new retry path (e.g. a `file=` path missing on disk) falls back to re-running all flows — never into the legacy logic. A report without `file=` (or a hypothetical mixed one) takes the legacy path, i.e. today's behavior.

# Test Plan

- Unit tests for both paths: the branching checks, `file=`-based retry subset/dedupe/existence guard (incl. absolute paths and truncated XML), same-named flows kept separate in reporting and in the merged artifact, mode-specific conflict messages, lazy + memoized scan (no scan on green or `file=` runs), and the legacy suites restored to their original form to pin unchanged `< 2.6.0` behavior.
- Manual e2e (local runs):
  - **Maestro 2.4.0 (legacy path)**: full run passes; subset retry re-runs only the failing flows — behavior unchanged from production.
  - **Maestro 2.6.0 (new path)**: full run passes; subset retry re-runs only the failing flows via their `file=` paths. Verified the produced JUnit report: every `<testcase>` carries a cwd-relative `file=` attribute, and the multi-attempt merged `final_report_path` artifact preserves `file=` attributes, tags, and properties through the merge.
  - **Server-side results verified for both runs**: per-attempt rows recorded correctly (retried flows get one row per attempt; only the failing subset appears in attempt 1, including a real flaky case that failed then passed), durations/tags/properties intact, and the stored `path` values are byte-identical between the 2.4 and 2.6 runs — no identity discontinuity for existing test-case history.

