### PR TITLE
[build-tools] Query GQL for build download URL in the downloadBuild function, instead of constructing it manually

### DIFF
--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -61,7 +61,7 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createInstallNodeModulesBuildFunction(),
     createPrebuildBuildFunction(),
     createReadIpaInfoBuildFunction(),
-    createDownloadBuildFunction(),
+    createDownloadBuildFunction(ctx),
     createEasExportBuildFunction(),
     createEasDeployBuildFunction(),
     createRepackBuildFunction(),

--- a/packages/build-tools/src/steps/functions/__tests__/downloadBuild.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/downloadBuild.test.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '@expo/logger';
+import { Client } from '@urql/core';
 import fetch, { Response } from 'node-fetch';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
@@ -17,22 +18,63 @@ const APP_TAR_GZ_BUFFER = Buffer.from(
   'base64'
 );
 
+const APPLICATION_ARCHIVE_URL = `https://expo.dev/artifacts/eas/${randomUUID()}.tar.gz`;
+
+function createMockGraphqlClient({
+  applicationArchiveUrl,
+  error,
+}: {
+  applicationArchiveUrl?: string | null;
+  error?: Error;
+}): Client {
+  const toPromise = jest.fn().mockResolvedValue(
+    error
+      ? { error, data: undefined }
+      : {
+          data: {
+            builds: {
+              byId: {
+                id: randomUUID(),
+                platform: 'IOS',
+                artifacts: {
+                  applicationArchiveUrl: applicationArchiveUrl ?? null,
+                },
+              },
+            },
+          },
+        }
+  );
+
+  return {
+    query: jest.fn().mockReturnValue({ toPromise }),
+  } as unknown as Client;
+}
+
 describe('downloadBuild', () => {
-  it('should handle an archive', async () => {
+  it('downloads from applicationArchiveUrl returned by GraphQL', async () => {
+    const buildId = randomUUID();
+    const graphqlClient = createMockGraphqlClient({
+      applicationArchiveUrl: APPLICATION_ARCHIVE_URL,
+    });
+
     jest.mocked(fetch).mockResolvedValue({
       ok: true,
       body: Readable.from(APP_TAR_GZ_BUFFER),
-      url: `https://storage.googleapis.com/eas-workflows-production/artifacts/${randomUUID()}/${randomUUID()}/application-${randomUUID()}.tar.gz?X-Goog-Algorithm=GOOG4-RSA-SHA256`,
+      url: APPLICATION_ARCHIVE_URL,
     } as unknown as Response);
 
     const { artifactPath } = await downloadBuildAsync({
       logger: createLogger({ name: 'test' }),
-      buildId: randomUUID(),
-      expoApiServerURL: 'http://api.expo.test',
+      buildId,
+      graphqlClient,
       robotAccessToken: null,
       extensions: ['app'],
     });
 
+    expect(jest.mocked(fetch)).toHaveBeenCalledWith(
+      APPLICATION_ARCHIVE_URL,
+      expect.objectContaining({ headers: undefined })
+    );
     expect(artifactPath).toBeDefined();
     expect(await fs.promises.readFile(path.join(artifactPath, 'TestApp'), 'utf8')).toBe(
       'i am executable\n'
@@ -40,16 +82,21 @@ describe('downloadBuild', () => {
   });
 
   it('should handle a straight-up file', async () => {
+    const applicationArchiveUrl = `https://expo.dev/artifacts/eas/${randomUUID()}.apk`;
+    const graphqlClient = createMockGraphqlClient({
+      applicationArchiveUrl,
+    });
+
     jest.mocked(fetch).mockResolvedValue({
       ok: true,
       body: Readable.from(Buffer.from('hello')),
-      url: `https://storage.googleapis.com/eas-workflows-production/artifacts/${randomUUID()}/${randomUUID()}/application-${randomUUID()}.txt?X-Goog-Algorithm=GOOG4-RSA-SHA256`,
+      url: applicationArchiveUrl,
     } as unknown as Response);
 
     const { artifactPath } = await downloadBuildAsync({
       logger: createLogger({ name: 'test' }),
       buildId: randomUUID(),
-      expoApiServerURL: 'http://api.expo.test',
+      graphqlClient,
       robotAccessToken: null,
       extensions: ['app'],
     });
@@ -58,18 +105,57 @@ describe('downloadBuild', () => {
     expect(await fs.promises.readFile(artifactPath, 'utf-8')).toBe('hello');
   });
 
+  it('throws when the build has no application archive url', async () => {
+    const graphqlClient = createMockGraphqlClient({ applicationArchiveUrl: null });
+
+    await expect(
+      downloadBuildAsync({
+        logger: createLogger({ name: 'test' }),
+        buildId: randomUUID(),
+        graphqlClient,
+        robotAccessToken: null,
+        extensions: ['app'],
+      })
+    ).rejects.toThrow('Build does not have an application archive url');
+
+    expect(jest.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('throws when GraphQL request fails', async () => {
+    const buildId = randomUUID();
+    const graphqlClient = createMockGraphqlClient({
+      error: new Error('GraphQL request failed'),
+    });
+
+    await expect(
+      downloadBuildAsync({
+        logger: createLogger({ name: 'test' }),
+        buildId,
+        graphqlClient,
+        robotAccessToken: null,
+        extensions: ['app'],
+      })
+    ).rejects.toThrow(`Could not fetch build ${buildId}: GraphQL request failed`);
+
+    expect(jest.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
   it('should throw an error if no matching files are found', async () => {
+    const graphqlClient = createMockGraphqlClient({
+      applicationArchiveUrl: APPLICATION_ARCHIVE_URL,
+    });
+
     jest.mocked(fetch).mockResolvedValue({
       ok: true,
       body: Readable.from(APP_TAR_GZ_BUFFER),
-      url: `https://storage.googleapis.com/eas-workflows-production/artifacts/${randomUUID()}/${randomUUID()}/application-${randomUUID()}.tar.gz?X-Goog-Algorithm=GOOG4-RSA-SHA256`,
+      url: APPLICATION_ARCHIVE_URL,
     } as unknown as Response);
 
     await expect(
       downloadBuildAsync({
         logger: createLogger({ name: 'test' }),
         buildId: randomUUID(),
-        expoApiServerURL: 'http://api.expo.test',
+        graphqlClient,
         robotAccessToken: null,
         extensions: ['apk'],
       })
@@ -79,7 +165,11 @@ describe('downloadBuild', () => {
 
 describe('createDownloadBuildFunction', () => {
   it('should download a build', async () => {
-    const downloadBuild = createDownloadBuildFunction();
+    const buildId = randomUUID();
+    const graphqlClient = createMockGraphqlClient({
+      applicationArchiveUrl: APPLICATION_ARCHIVE_URL,
+    });
+    const downloadBuild = createDownloadBuildFunction({ graphqlClient } as any);
     const logger = createMockLogger();
 
     const buildStep = downloadBuild.createBuildStepFromFunctionCall(
@@ -92,7 +182,7 @@ describe('createDownloadBuildFunction', () => {
       }),
       {
         callInputs: {
-          build_id: randomUUID(),
+          build_id: buildId,
           extensions: ['app'],
         },
       }
@@ -105,5 +195,9 @@ describe('createDownloadBuildFunction', () => {
     } as unknown as Response);
 
     await expect(buildStep.executeAsync()).rejects.toThrow('Internal Server Error');
+    expect(jest.mocked(fetch)).toHaveBeenCalledWith(
+      APPLICATION_ARCHIVE_URL,
+      expect.objectContaining({ headers: undefined })
+    );
   });
 });

--- a/packages/build-tools/src/steps/functions/__tests__/downloadBuild.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/downloadBuild.test.ts
@@ -1,5 +1,6 @@
+import { SystemError, UserError } from '@expo/eas-build-job';
 import { createLogger } from '@expo/logger';
-import { Client } from '@urql/core';
+import { Client, CombinedError } from '@urql/core';
 import fetch, { Response } from 'node-fetch';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
@@ -105,7 +106,7 @@ describe('downloadBuild', () => {
     expect(await fs.promises.readFile(artifactPath, 'utf-8')).toBe('hello');
   });
 
-  it('throws when the build has no application archive url', async () => {
+  it('throws UserError when the build has no application archive url', async () => {
     const graphqlClient = createMockGraphqlClient({ applicationArchiveUrl: null });
 
     await expect(
@@ -116,26 +117,83 @@ describe('downloadBuild', () => {
         robotAccessToken: null,
         extensions: ['app'],
       })
-    ).rejects.toThrow('Build does not have an application archive url');
+    ).rejects.toMatchObject({
+      errorCode: 'EAS_DOWNLOAD_BUILD_NO_APPLICATION_ARCHIVE',
+      message: 'Build does not have an application archive url',
+    });
 
     expect(jest.mocked(fetch)).not.toHaveBeenCalled();
   });
 
-  it('throws when GraphQL request fails', async () => {
+  it('throws SystemError when GraphQL request fails with a network error', async () => {
     const buildId = randomUUID();
     const graphqlClient = createMockGraphqlClient({
-      error: new Error('GraphQL request failed'),
+      error: new CombinedError({
+        networkError: new Error('Network request failed'),
+      }),
     });
 
-    await expect(
-      downloadBuildAsync({
-        logger: createLogger({ name: 'test' }),
-        buildId,
-        graphqlClient,
-        robotAccessToken: null,
-        extensions: ['app'],
-      })
-    ).rejects.toThrow(`Could not fetch build ${buildId}: GraphQL request failed`);
+    const promise = downloadBuildAsync({
+      logger: createLogger({ name: 'test' }),
+      buildId,
+      graphqlClient,
+      robotAccessToken: null,
+      extensions: ['app'],
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(SystemError);
+    await expect(promise).rejects.toMatchObject({
+      message: `Could not fetch build ${buildId}: [Network] Network request failed`,
+    });
+
+    expect(jest.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('throws SystemError when GraphQL request returns 5xx', async () => {
+    const buildId = randomUUID();
+    const graphqlClient = createMockGraphqlClient({
+      error: Object.assign(new Error('Internal Server Error'), {
+        response: { status: 500 },
+      }),
+    });
+
+    const promise = downloadBuildAsync({
+      logger: createLogger({ name: 'test' }),
+      buildId,
+      graphqlClient,
+      robotAccessToken: null,
+      extensions: ['app'],
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(SystemError);
+    await expect(promise).rejects.toMatchObject({
+      message: `Could not fetch build ${buildId}: Internal Server Error`,
+    });
+
+    expect(jest.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('throws UserError when GraphQL returns a client error', async () => {
+    const buildId = randomUUID();
+    const graphqlClient = createMockGraphqlClient({
+      error: new CombinedError({
+        graphQLErrors: [{ message: 'Build not found' }],
+      }),
+    });
+
+    const promise = downloadBuildAsync({
+      logger: createLogger({ name: 'test' }),
+      buildId,
+      graphqlClient,
+      robotAccessToken: null,
+      extensions: ['app'],
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(UserError);
+    await expect(promise).rejects.toMatchObject({
+      errorCode: 'EAS_DOWNLOAD_BUILD_FETCH_FAILED',
+      message: `Could not fetch build ${buildId}: [GraphQL] Build not found`,
+    });
 
     expect(jest.mocked(fetch)).not.toHaveBeenCalled();
   });

--- a/packages/build-tools/src/steps/functions/downloadBuild.ts
+++ b/packages/build-tools/src/steps/functions/downloadBuild.ts
@@ -7,7 +7,9 @@ import {
   BuildStepInputValueTypeName,
   BuildStepOutput,
 } from '@expo/steps';
+import { Client } from '@urql/core';
 import { glob } from 'fast-glob';
+import { graphql } from 'gql.tada';
 import fetch from 'node-fetch';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -16,6 +18,7 @@ import stream from 'stream';
 import { promisify } from 'util';
 import { z } from 'zod';
 
+import { CustomBuildContext } from '../../customBuildContext';
 import { formatBytes } from '../../utils/artifacts';
 import { decompressTarAsync, isFileTarGzAsync } from '../../utils/files';
 import { retryOnDNSFailure } from '../../utils/retryOnDNSFailure';
@@ -23,7 +26,21 @@ import { pluralize } from '../../utils/strings';
 
 const streamPipeline = promisify(stream.pipeline);
 
-export function createDownloadBuildFunction(): BuildFunction {
+const BUILD_BY_ID_QUERY = graphql(`
+  query DownloadBuildByIdQuery($buildId: ID!) {
+    builds {
+      byId(buildId: $buildId) {
+        id
+        platform
+        artifacts {
+          applicationArchiveUrl
+        }
+      }
+    }
+  }
+`);
+
+export function createDownloadBuildFunction(ctx: CustomBuildContext): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
     id: 'download_build',
@@ -59,7 +76,7 @@ export function createDownloadBuildFunction(): BuildFunction {
       const { artifactPath } = await downloadBuildAsync({
         logger,
         buildId,
-        expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
+        graphqlClient: ctx.graphqlClient,
         robotAccessToken: stepsCtx.global.staticContext.job.secrets?.robotAccessToken ?? null,
         extensions,
       });
@@ -69,16 +86,37 @@ export function createDownloadBuildFunction(): BuildFunction {
   });
 }
 
+async function fetchApplicationArchiveUrlAsync({
+  buildId,
+  graphqlClient,
+}: {
+  buildId: string;
+  graphqlClient: Client;
+}): Promise<string> {
+  const result = await graphqlClient.query(BUILD_BY_ID_QUERY, { buildId }).toPromise();
+
+  if (result.error) {
+    throw new Error(`Could not fetch build ${buildId}: ${result.error.message}`);
+  }
+
+  const applicationArchiveUrl = result.data?.builds.byId?.artifacts?.applicationArchiveUrl;
+  if (!applicationArchiveUrl) {
+    throw new Error('Build does not have an application archive url');
+  }
+
+  return applicationArchiveUrl;
+}
+
 export async function downloadBuildAsync({
   logger,
   buildId,
-  expoApiServerURL,
+  graphqlClient,
   robotAccessToken,
   extensions,
 }: {
   logger: bunyan;
   buildId: string;
-  expoApiServerURL: string;
+  graphqlClient: Client;
   robotAccessToken: string | null;
   extensions: string[];
 }): Promise<{ artifactPath: string }> {
@@ -86,12 +124,11 @@ export async function downloadBuildAsync({
     path.join(os.tmpdir(), 'download_build-downloaded-')
   );
 
-  const response = await retryOnDNSFailure(fetch)(
-    new URL(`/v2/artifacts/eas/${buildId}`, expoApiServerURL),
-    {
-      headers: robotAccessToken ? { Authorization: `Bearer ${robotAccessToken}` } : undefined,
-    }
-  );
+  const downloadUrl = await fetchApplicationArchiveUrlAsync({ buildId, graphqlClient });
+
+  const response = await retryOnDNSFailure(fetch)(downloadUrl, {
+    headers: robotAccessToken ? { Authorization: `Bearer ${robotAccessToken}` } : undefined,
+  });
 
   if (!response.ok) {
     const textResult = await asyncResult(response.text());

--- a/packages/build-tools/src/steps/functions/downloadBuild.ts
+++ b/packages/build-tools/src/steps/functions/downloadBuild.ts
@@ -1,4 +1,4 @@
-import { UserError } from '@expo/eas-build-job';
+import { SystemError, UserError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
 import {
@@ -96,12 +96,20 @@ async function fetchApplicationArchiveUrlAsync({
   const result = await graphqlClient.query(BUILD_BY_ID_QUERY, { buildId }).toPromise();
 
   if (result.error) {
-    throw new Error(`Could not fetch build ${buildId}: ${result.error.message}`);
+    const { error } = result;
+    const message = `Could not fetch build ${buildId}: ${error.message}`;
+
+    throw error.networkError || result.error.response?.status >= 500
+      ? new SystemError(message, { cause: error })
+      : new UserError('EAS_DOWNLOAD_BUILD_FETCH_FAILED', message, { cause: error });
   }
 
   const applicationArchiveUrl = result.data?.builds.byId?.artifacts?.applicationArchiveUrl;
   if (!applicationArchiveUrl) {
-    throw new Error('Build does not have an application archive url');
+    throw new UserError(
+      'EAS_DOWNLOAD_BUILD_NO_APPLICATION_ARCHIVE',
+      'Build does not have an application archive url'
+    );
   }
 
   return applicationArchiveUrl;


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

The `eas/download_build` custom build step was downloading artifacts by constructing a REST URL (`/v2/artifacts/eas/{buildId}`). That path is not the canonical way to resolve build artifacts elsewhere in EAS (e.g. `eas build:run`, `eas build:download`), which use `applicationArchiveUrl` from GraphQL. This change aligns `download_build` with that pattern so it gets the correct signed artifact URL from the API.
# How

- Pass `CustomBuildContext` into `createDownloadBuildFunction` to access the existing GraphQL client.
- Add a `DownloadBuildByIdQuery` that fetches `builds.byId.artifacts.applicationArchiveUrl`.
- Extract `fetchApplicationArchiveUrlAsync` and use its result as the download URL instead of building one from `expoApiServerURL`.

# Test Plan

Added tests.

Ran this script to verify this works:

```js
#!/usr/bin/env node
'use strict';

const { Client, fetchExchange } = require('@urql/core');
const { createLogger } = require('@expo/logger');
const { downloadBuildAsync } = require('../dist/steps/functions/downloadBuild');

function getApiBaseUrl() {
  if (process.env.EXPO_STAGING) {
    return 'https://staging-api.expo.dev';
  }
  if (process.env.EXPO_LOCAL) {
    return 'http://127.0.0.1:3000';
  }
  return 'https://api.expo.dev';
}

function parseExtensionsArg() {
  const extensionsArg = process.argv[3];
  if (!extensionsArg) {
    return ['apk', 'aab', 'ipa', 'app'];
  }
  return extensionsArg.split(',').map(ext => ext.trim()).filter(Boolean);
}

async function main() {
  const buildId = process.argv[2];
  if (!buildId) {
    console.error(
      'Usage: EXPO_TOKEN=... node scripts/manual-test-download-build.js <build-id> [extensions]\n' +
        '\n' +
        '  build-id     UUID of a finished build with an application archive\n' +
        '  extensions   optional comma-separated list (default: apk,aab,ipa,app)\n' +
        '\n' +
        'Example:\n' +
        '  EXPO_TOKEN=$EXPO_TOKEN node scripts/manual-test-download-build.js 01234567-89ab-cdef-0123-456789abcdef\n'
    );
    process.exit(1);
  }

  const token = process.env.EXPO_TOKEN;
  if (!token) {
    console.error('Error: EXPO_TOKEN environment variable is required.');
    console.error('Create a token at https://expo.dev/accounts/[account]/settings/access-tokens');
    process.exit(1);
  }

  const apiBaseUrl = getApiBaseUrl();
  const extensions = parseExtensionsArg();
  const logger = createLogger({
    name: 'manual-test-download-build',
    level: process.env.EXPO_DEBUG ? 'debug' : 'info',
  });

  const graphqlClient = new Client({
    url: new URL('graphql', apiBaseUrl).toString(),
    exchanges: [fetchExchange],
    preferGetMethod: false,
    fetchOptions: {
      headers: {
        Authorization: `Bearer ${token}`,
      },
    },
  });

  console.log(`API: ${apiBaseUrl}`);
  console.log(`Build ID: ${buildId}`);
  console.log(`Extensions: [${extensions.join(', ')}]`);
  console.log('');

  console.log('Downloading artifact...');
  const { artifactPath } = await downloadBuildAsync({
    logger,
    buildId,
    graphqlClient,
    robotAccessToken: token,
    extensions,
  });

  console.log('');
  console.log(`Success. Artifact path: ${artifactPath}`);
}

main().catch(err => {
  console.error('');
  console.error('Failed:', err instanceof Error ? err.message : err);
  process.exit(1);
});
```
