### PR TITLE
[eas-cli] Add --skip-screenshots and --skip-previews flags to metadata commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add `--skip-screenshots` and `--skip-previews` flags to `eas metadata:pull` and `eas metadata:push` to skip downloading or uploading screenshots and video previews. ([#3843](https://github.com/expo/eas-cli/pull/3843) by [@TimBroddin](https://github.com/TimBroddin))
+
 ### 🐛 Bug fixes
 
 - [expo-cocoapods-proxy] Fix iOS worker tarball build failing on macOS Tahoe due to bundler incompatibility with RubyGems 4. ([#3824](https://github.com/expo/eas-cli/pull/3824) by [@gwdp](https://github.com/gwdp))

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -1875,11 +1875,13 @@ generate the local store configuration from the app stores
 
 ```
 USAGE
-  $ eas metadata:pull [-e <value>] [--non-interactive]
+  $ eas metadata:pull [-e <value>] [--skip-screenshots] [--skip-previews] [--non-interactive]
 
 FLAGS
-  -e, --profile=<value>  Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.
-      --non-interactive  Run the command in non-interactive mode.
+  -e, --profile=<value>   Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.
+      --non-interactive   Run the command in non-interactive mode.
+      --skip-previews     Skip downloading video previews from the app stores
+      --skip-screenshots  Skip downloading screenshots from the app stores
 
 DESCRIPTION
   generate the local store configuration from the app stores
@@ -1893,11 +1895,14 @@ sync the local store configuration to the app stores
 
 ```
 USAGE
-  $ eas metadata:push [-e <value>] [--non-interactive]
+  $ eas metadata:push [-e <value>] [--skip-screenshots] [--skip-previews] [--non-interactive]
 
 FLAGS
-  -e, --profile=<value>  Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.
-      --non-interactive  Run the command in non-interactive mode.
+  -e, --profile=<value>   Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.
+      --non-interactive   Run the command in non-interactive mode.
+      --skip-previews     Skip uploading video previews to the app stores. Video previews missing from the store config
+                          are not deleted from the app stores.
+      --skip-screenshots  Skip uploading screenshots to the app stores
 
 DESCRIPTION
   sync the local store configuration to the app stores

--- a/packages/eas-cli/src/commands/metadata/pull.ts
+++ b/packages/eas-cli/src/commands/metadata/pull.ts
@@ -22,6 +22,14 @@ export default class MetadataPull extends EasCommand {
       description:
         'Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.',
     }),
+    'skip-screenshots': Flags.boolean({
+      description: 'Skip downloading screenshots from the app stores',
+      default: false,
+    }),
+    'skip-previews': Flags.boolean({
+      description: 'Skip downloading video previews from the app stores',
+      default: false,
+    }),
     ...EASNonInteractiveFlag,
   };
 
@@ -46,6 +54,14 @@ export default class MetadataPull extends EasCommand {
       nonInteractive,
       withServerSideEnvironment: null,
     });
+
+    if (flags['skip-previews']) {
+      Log.warn(
+        `Skipping video previews. Pushing the generated store config without ${chalk.bold(
+          '--skip-previews'
+        )} will delete existing video previews from the app stores.`
+      );
+    }
 
     await ensureProjectConfiguredAsync({ projectDir, nonInteractive, vcsClient });
 
@@ -82,6 +98,8 @@ export default class MetadataPull extends EasCommand {
         nonInteractive,
         graphqlClient,
         projectId,
+        skipScreenshots: flags['skip-screenshots'],
+        skipPreviews: flags['skip-previews'],
       });
       const relativePath = path.relative(process.cwd(), filePath);
 

--- a/packages/eas-cli/src/commands/metadata/push.ts
+++ b/packages/eas-cli/src/commands/metadata/push.ts
@@ -20,6 +20,15 @@ export default class MetadataPush extends EasCommand {
       description:
         'Name of the submit profile from eas.json. Defaults to "production" if defined in eas.json.',
     }),
+    'skip-screenshots': Flags.boolean({
+      description: 'Skip uploading screenshots to the app stores',
+      default: false,
+    }),
+    'skip-previews': Flags.boolean({
+      description:
+        'Skip uploading video previews to the app stores. Video previews missing from the store config are not deleted from the app stores.',
+      default: false,
+    }),
     ...EASNonInteractiveFlag,
   };
 
@@ -80,6 +89,8 @@ export default class MetadataPush extends EasCommand {
         nonInteractive,
         graphqlClient,
         projectId,
+        skipScreenshots: flags['skip-screenshots'],
+        skipPreviews: flags['skip-previews'],
       });
 
       Log.addNewLineIfNone();

--- a/packages/eas-cli/src/metadata/__tests__/download.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/download.test.ts
@@ -40,6 +40,9 @@ jest.mock('../../prompts', () => ({
 }));
 
 const { confirmAsync } = require('../../prompts') as jest.Mocked<typeof import('../../prompts')>;
+const { createAppleTasks } = require('../apple/tasks') as jest.Mocked<
+  typeof import('../apple/tasks')
+>;
 
 function createArgs(overrides: Record<string, any> = {}) {
   return {
@@ -96,5 +99,27 @@ describe(downloadMetadataAsync, () => {
     await downloadMetadataAsync(createArgs({ nonInteractive: false }));
 
     expect(confirmAsync).not.toHaveBeenCalled();
+  });
+
+  it('does not skip screenshots or previews by default', async () => {
+    await downloadMetadataAsync(createArgs());
+
+    expect(createAppleTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ skipScreenshots: false, skipPreviews: false })
+    );
+  });
+
+  it('skips screenshots when skipScreenshots is enabled', async () => {
+    await downloadMetadataAsync(createArgs({ skipScreenshots: true }));
+
+    expect(createAppleTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ skipScreenshots: true })
+    );
+  });
+
+  it('skips previews when skipPreviews is enabled', async () => {
+    await downloadMetadataAsync(createArgs({ skipPreviews: true }));
+
+    expect(createAppleTasks).toHaveBeenCalledWith(expect.objectContaining({ skipPreviews: true }));
   });
 });

--- a/packages/eas-cli/src/metadata/__tests__/upload.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/upload.test.ts
@@ -36,6 +36,9 @@ const { loadConfigAsync } = require('../config/resolve') as jest.Mocked<
   typeof import('../config/resolve')
 >;
 const { confirmAsync } = require('../../prompts') as jest.Mocked<typeof import('../../prompts')>;
+const { createAppleTasks } = require('../apple/tasks') as jest.Mocked<
+  typeof import('../apple/tasks')
+>;
 
 function createArgs(overrides: Record<string, any> = {}) {
   return {
@@ -99,5 +102,27 @@ describe(uploadMetadataAsync, () => {
 
     expect(result).toHaveProperty('appleLink');
     expect(result.appleLink).toContain('appstoreconnect.apple.com');
+  });
+
+  it('does not skip screenshots or previews by default', async () => {
+    await uploadMetadataAsync(createArgs());
+
+    expect(createAppleTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ skipScreenshots: false, skipPreviews: false })
+    );
+  });
+
+  it('skips screenshots when skipScreenshots is enabled', async () => {
+    await uploadMetadataAsync(createArgs({ skipScreenshots: true }));
+
+    expect(createAppleTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ skipScreenshots: true })
+    );
+  });
+
+  it('skips previews when skipPreviews is enabled', async () => {
+    await uploadMetadataAsync(createArgs({ skipPreviews: true }));
+
+    expect(createAppleTasks).toHaveBeenCalledWith(expect.objectContaining({ skipPreviews: true }));
   });
 });

--- a/packages/eas-cli/src/metadata/apple/tasks/__tests__/index.test.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/__tests__/index.test.ts
@@ -1,0 +1,39 @@
+import { createAppleTasks } from '../index';
+import { PreviewsTask } from '../previews';
+import { ScreenshotsTask } from '../screenshots';
+
+describe(createAppleTasks, () => {
+  it('includes the screenshots and previews tasks by default', () => {
+    const tasks = createAppleTasks();
+
+    expect(tasks.some(task => task instanceof ScreenshotsTask)).toBe(true);
+    expect(tasks.some(task => task instanceof PreviewsTask)).toBe(true);
+  });
+
+  it('omits the screenshots task when skipScreenshots is enabled', () => {
+    const defaultTasks = createAppleTasks();
+    const tasks = createAppleTasks({ skipScreenshots: true });
+
+    expect(tasks.some(task => task instanceof ScreenshotsTask)).toBe(false);
+    expect(tasks.some(task => task instanceof PreviewsTask)).toBe(true);
+    expect(tasks).toHaveLength(defaultTasks.length - 1);
+  });
+
+  it('omits the previews task when skipPreviews is enabled', () => {
+    const defaultTasks = createAppleTasks();
+    const tasks = createAppleTasks({ skipPreviews: true });
+
+    expect(tasks.some(task => task instanceof PreviewsTask)).toBe(false);
+    expect(tasks.some(task => task instanceof ScreenshotsTask)).toBe(true);
+    expect(tasks).toHaveLength(defaultTasks.length - 1);
+  });
+
+  it('omits both tasks when skipScreenshots and skipPreviews are enabled', () => {
+    const defaultTasks = createAppleTasks();
+    const tasks = createAppleTasks({ skipScreenshots: true, skipPreviews: true });
+
+    expect(tasks.some(task => task instanceof ScreenshotsTask)).toBe(false);
+    expect(tasks.some(task => task instanceof PreviewsTask)).toBe(false);
+    expect(tasks).toHaveLength(defaultTasks.length - 2);
+  });
+});

--- a/packages/eas-cli/src/metadata/apple/tasks/index.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/index.ts
@@ -9,13 +9,21 @@ import { AppleTask } from '../task';
 
 type AppleTaskOptions = {
   version?: AppVersionOptions['version'];
+  /** If enabled, screenshots are not downloaded or uploaded */
+  skipScreenshots?: boolean;
+  /** If enabled, video previews are not downloaded or uploaded */
+  skipPreviews?: boolean;
 };
 
 /**
  * List of all eligible tasks to sync local store configuration to the App store.
  */
-export function createAppleTasks({ version }: AppleTaskOptions = {}): AppleTask[] {
-  return [
+export function createAppleTasks({
+  version,
+  skipScreenshots,
+  skipPreviews,
+}: AppleTaskOptions = {}): AppleTask[] {
+  const tasks = [
     new AppVersionTask({ version }),
     new AppInfoTask(),
     new AgeRatingTask(),
@@ -24,4 +32,14 @@ export function createAppleTasks({ version }: AppleTaskOptions = {}): AppleTask[
     new PreviewsTask(),
     new AppClipTask(),
   ];
+
+  return tasks.filter(task => {
+    if (skipScreenshots && task instanceof ScreenshotsTask) {
+      return false;
+    }
+    if (skipPreviews && task instanceof PreviewsTask) {
+      return false;
+    }
+    return true;
+  });
 }

--- a/packages/eas-cli/src/metadata/download.ts
+++ b/packages/eas-cli/src/metadata/download.ts
@@ -28,6 +28,8 @@ export async function downloadMetadataAsync({
   nonInteractive,
   graphqlClient,
   projectId,
+  skipScreenshots = false,
+  skipPreviews = false,
 }: {
   projectDir: string;
   profile: SubmitProfile;
@@ -37,6 +39,8 @@ export async function downloadMetadataAsync({
   nonInteractive: boolean;
   graphqlClient: ExpoGraphqlClient;
   projectId: string;
+  skipScreenshots?: boolean;
+  skipPreviews?: boolean;
 }): Promise<string> {
   const filePath = getStaticConfigFilePath({ projectDir, profile });
 
@@ -76,7 +80,7 @@ export async function downloadMetadataAsync({
 
   const errors: Error[] = [];
   const config = createAppleWriter();
-  const tasks = createAppleTasks();
+  const tasks = createAppleTasks({ skipScreenshots, skipPreviews });
   const taskCtx = { app, projectDir };
 
   for (const task of tasks) {

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -27,6 +27,8 @@ export async function uploadMetadataAsync({
   nonInteractive,
   graphqlClient,
   projectId,
+  skipScreenshots = false,
+  skipPreviews = false,
 }: {
   projectDir: string;
   profile: SubmitProfile;
@@ -36,6 +38,8 @@ export async function uploadMetadataAsync({
   nonInteractive: boolean;
   graphqlClient: ExpoGraphqlClient;
   projectId: string;
+  skipScreenshots?: boolean;
+  skipPreviews?: boolean;
 }): Promise<{ appleLink: string }> {
   const storeConfig = await loadConfigWithValidationPromptAsync(
     projectDir,
@@ -67,6 +71,8 @@ export async function uploadMetadataAsync({
     // We need to resolve a different version as soon as possible.
     // This version is the parent model of all changes we are going to push.
     version: config.getVersion()?.versionString,
+    skipScreenshots,
+    skipPreviews,
   });
 
   const taskCtx = { app, projectDir };


### PR DESCRIPTION
# Why

`eas metadata:pull` downloads every screenshot and video preview from App Store Connect, and `eas metadata:push` syncs them back. When you only want to manage textual metadata (descriptions, keywords, review info, etc.), downloading/uploading all media assets is slow and unnecessary. This PR adds opt-out flags for both asset types.

# How

- Added a `--skip-screenshots` and a `--skip-previews` flag to both `eas metadata:pull` and `eas metadata:push`.
- The flags are threaded through `downloadMetadataAsync` / `uploadMetadataAsync` to `createAppleTasks()`, which now filters out the `ScreenshotsTask` and/or `PreviewsTask`. Skipping the task entirely also avoids the per-locale screenshot/preview set fetches in `prepareAsync`.
- Because push deletes remote video previews whose types are missing from the store config, `metadata:pull --skip-previews` logs a warning that pushing the generated config without `--skip-previews` would delete remote previews. (Screenshots have no such cleanup pass, so mixing the screenshot flag between pull and push is safe.)
- Regenerated the oclif README and added a changelog entry.

# Test Plan

- New unit tests for `createAppleTasks` filtering (`packages/eas-cli/src/metadata/apple/tasks/__tests__/index.test.ts`) and for flag pass-through in `download.test.ts` / `upload.test.ts`.
- Full metadata suite passes: 16 suites, 197 tests.
- Verified `bin/run metadata:pull --help` and `bin/run metadata:push --help` show the new flags.
- `yarn typecheck`, `yarn lint`, and `yarn fmt:check` pass.