### PR TITLE
[eas-cli] Refresh README

### DIFF
--- a/.github/resources/eas.svg
+++ b/.github/resources/eas.svg
@@ -1,0 +1,31 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1887_635)">
+<rect width="128" height="128" rx="64" fill="#18191B"/>
+<path d="M99.6237 27.9758C119.134 47.4859 119.024 79.2583 99.3412 98.9413C79.6583 118.624 47.8858 118.734 28.3758 99.2237C8.86596 79.7136 8.976 47.9418 28.6589 28.2589C48.3418 8.57602 80.1136 8.46598 99.6237 27.9758Z" stroke="url(#paint0_linear_1887_635)" stroke-width="3.24"/>
+<path d="M114.38 64C114.38 72.6638 109.008 80.7192 99.8828 86.6855C90.7722 92.6425 78.0904 96.3799 64 96.3799C49.9096 96.3799 37.2278 92.6425 28.1172 86.6855C18.9922 80.7192 13.6201 72.6638 13.6201 64C13.6201 55.3362 18.9922 47.2808 28.1172 41.3144C37.2278 35.3575 49.9096 31.6201 64 31.6201C78.0904 31.6201 90.7722 35.3575 99.8828 41.3145C109.008 47.2808 114.38 55.3362 114.38 64Z" stroke="url(#paint1_linear_1887_635)" stroke-width="3.24"/>
+<path d="M64 13.6201C72.6638 13.6201 80.7192 18.9922 86.6855 28.1172C92.6425 37.2278 96.3799 49.9096 96.3799 64C96.3799 78.0904 92.6425 90.7722 86.6855 99.8828C80.7192 109.008 72.6638 114.38 64 114.38C55.3362 114.38 47.2808 109.008 41.3145 99.8828C35.3575 90.7722 31.6201 78.0904 31.6201 64C31.6201 49.9096 35.3575 37.2278 41.3145 28.1172C47.2808 18.9922 55.3362 13.6201 64 13.6201Z" stroke="url(#paint2_linear_1887_635)" stroke-width="3.24"/>
+<path d="M66.0082 42.48H61.9918C60.1376 42.48 58.4378 43.4711 57.5835 45.0503L40.5592 76.5206C40.164 77.2512 40.1343 78.1142 40.4784 78.8683L41.8881 81.9568C42.7652 83.8787 45.527 84.0723 46.6859 82.2932L62.8238 57.5187C63.0773 57.1295 63.5218 56.8932 64 56.8932C64.4782 56.8932 64.9227 57.1295 65.1761 57.5187L81.3141 82.2932C82.473 84.0723 85.2348 83.8787 86.1119 81.9568L87.5215 78.8683C87.8657 78.1142 87.836 77.2512 87.4408 76.5206L70.4165 45.0503C69.5622 43.4711 67.8624 42.48 66.0082 42.48Z" fill="url(#paint3_linear_1887_635)"/>
+</g>
+<rect x="1" y="1" width="126" height="126" rx="63" stroke="white" stroke-opacity="0.3" stroke-width="2"/>
+<defs>
+<linearGradient id="paint0_linear_1887_635" x1="112.4" y1="20.4" x2="138.422" y2="-10.3513" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<linearGradient id="paint1_linear_1887_635" x1="130" y1="88" x2="233.2" y2="134.8" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<linearGradient id="paint2_linear_1887_635" x1="86" y1="30.4" x2="130.8" y2="-75.2" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<linearGradient id="paint3_linear_1887_635" x1="64" y1="84" x2="64" y2="210.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="white" stop-opacity="0"/>
+</linearGradient>
+<clipPath id="clip0_1887_635">
+<rect width="128" height="128" rx="64" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Refresh README as an EAS product landing page. ([#3844](https://github.com/expo/eas-cli/pull/3844) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [21.3.0](https://github.com/expo/eas-cli/releases/tag/v21.3.0) - 2026-07-27
 
 ### 🎉 New features

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -28,7 +28,7 @@
   <a aria-label="npm version" href="https://www.npmjs.com/package/eas-cli" target="_blank">
     <img alt="npm version" src="https://img.shields.io/npm/v/eas-cli.svg?style=for-the-badge&label=npm&labelColor=000000&color=4630EB" />
   </a>
-  <a aria-label="npm downloads" href="https://www.npmtrends.com/eas-cli" target="_blank">
+  <a aria-label="npm downloads" href="https://npm-stat.com/charts.html?package=eas-cli" target="_blank">
     <img alt="downloads" src="https://img.shields.io/npm/dm/eas-cli.svg?style=for-the-badge&labelColor=000000&color=33CC12&label=downloads" />
   </a>
   <a aria-label="License: MIT" href="https://github.com/expo/eas-cli/blob/main/LICENSE" target="_blank">

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -39,27 +39,6 @@
   </a>
 </p>
 
-<p align="center">
-  <a aria-label="Follow Expo on X" href="https://x.com/intent/follow?screen_name=expo" target="_blank">
-    <img alt="Expo on X" src="https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white" />
-  </a>&nbsp;
-  <a aria-label="Follow Expo on GitHub" href="https://github.com/expo" target="_blank">
-    <img alt="Expo on GitHub" src="https://img.shields.io/badge/GitHub-222222?style=for-the-badge&logo=github&logoColor=white" />
-  </a>&nbsp;
-  <a aria-label="Follow Expo on Reddit" href="https://www.reddit.com/r/expo/" target="_blank">
-    <img alt="Expo on Reddit" src="https://img.shields.io/badge/Reddit-FF4500?style=for-the-badge&logo=reddit&logoColor=white" />
-  </a>&nbsp;
-  <a aria-label="Follow Expo on Bluesky" href="https://bsky.app/profile/expo.dev" target="_blank">
-    <img alt="Expo on Bluesky" src="https://img.shields.io/badge/Bluesky-1DA1F2?style=for-the-badge&logo=bluesky&logoColor=white" />
-  </a>&nbsp;
-  <a aria-label="Follow Expo on LinkedIn" href="https://www.linkedin.com/company/expo-dev" target="_blank">
-    <img alt="Expo on LinkedIn" src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=LinkedIn&logoColor=white" />
-  </a>&nbsp;
-  <a aria-label="Subscribe to Expo on YouTube" href="https://www.youtube.com/channel/UCx_YiR733cfqVPRsQ1n8Fag" target="_blank">
-    <img alt="Expo on YouTube" src="https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=YouTube&logoColor=white" />
-  </a>
-</p>
-
 ---
 
 EAS CLI is the command-line interface for [Expo Application Services (EAS)](https://expo.dev/eas) — deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -1,29 +1,117 @@
-# eas-cli
+<!-- Title -->
 
-EAS command line tool
+<p align="center">
+  <a href="https://expo.dev/eas">
+    <img alt="EAS" height="96" src="../../.github/resources/eas.svg">
+  </a>
+</p>
 
-[![oclif](https://img.shields.io/badge/cli-oclif-brightgreen.svg)](https://oclif.io)
-[![Version](https://img.shields.io/npm/v/eas-cli.svg)](https://npmjs.org/package/eas-cli)
-[![Downloads/week](https://img.shields.io/npm/dw/eas-cli.svg)](https://npmjs.org/package/eas-cli)
-[![License](https://img.shields.io/npm/l/eas-cli.svg)](https://github.com/expo/eas-cli/blob/main/package.json)
+<h1 align="center">EAS CLI</h1>
 
-- [Installation](#installation)
-- [Usage](#usage)
-- [Commands](#commands)
+<p align="center">Ship Expo and React Native apps from your terminal — build, submit, update, deploy, and automate with EAS.</p>
 
-# Installation
+<p align="center">
+  <a aria-label="eas documentation" href="https://docs.expo.dev/eas/">📚 Documentation</a>
+  &ensp;•&ensp;
+  <a aria-label="eas cli reference" href="https://docs.expo.dev/eas/cli/">📖 CLI Reference</a>
+  &ensp;•&ensp;
+  <a aria-label="eas" href="https://expo.dev/eas">🚀 EAS</a>
+  &ensp;•&ensp;
+  <a aria-label="expo blog" href="https://expo.dev/blog">📝 Blog</a>
+  &ensp;•&ensp;
+  <a aria-label="expo changelog" href="https://expo.dev/changelog">📰 Changelog</a>
+  &ensp;•&ensp;
+  <a aria-label="contribute to eas cli" href="https://github.com/expo/eas-cli/blob/main/CONTRIBUTING.md">👏 Contribute</a>
+</p>
+
+<p align="center">
+  <a aria-label="npm version" href="https://www.npmjs.com/package/eas-cli" target="_blank">
+    <img alt="npm version" src="https://img.shields.io/npm/v/eas-cli.svg?style=for-the-badge&label=npm&labelColor=000000&color=4630EB" />
+  </a>
+  <a aria-label="npm downloads" href="https://www.npmtrends.com/eas-cli" target="_blank">
+    <img alt="downloads" src="https://img.shields.io/npm/dm/eas-cli.svg?style=for-the-badge&labelColor=000000&color=33CC12&label=downloads" />
+  </a>
+  <a aria-label="License: MIT" href="https://github.com/expo/eas-cli/blob/main/LICENSE" target="_blank">
+    <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-success.svg?style=for-the-badge&labelColor=000000&color=33CC12" />
+  </a>
+  <a aria-label="Join the Expo Discord" href="https://chat.expo.dev" target="_blank">
+    <img alt="Discord" src="https://img.shields.io/discord/695411232856997968.svg?style=for-the-badge&color=5865F2&logo=discord&logoColor=FFFFFF" />
+  </a>
+</p>
+
+<p align="center">
+  <a aria-label="Follow Expo on X" href="https://x.com/intent/follow?screen_name=expo" target="_blank">
+    <img alt="Expo on X" src="https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white" />
+  </a>&nbsp;
+  <a aria-label="Follow Expo on GitHub" href="https://github.com/expo" target="_blank">
+    <img alt="Expo on GitHub" src="https://img.shields.io/badge/GitHub-222222?style=for-the-badge&logo=github&logoColor=white" />
+  </a>&nbsp;
+  <a aria-label="Follow Expo on Reddit" href="https://www.reddit.com/r/expo/" target="_blank">
+    <img alt="Expo on Reddit" src="https://img.shields.io/badge/Reddit-FF4500?style=for-the-badge&logo=reddit&logoColor=white" />
+  </a>&nbsp;
+  <a aria-label="Follow Expo on Bluesky" href="https://bsky.app/profile/expo.dev" target="_blank">
+    <img alt="Expo on Bluesky" src="https://img.shields.io/badge/Bluesky-1DA1F2?style=for-the-badge&logo=bluesky&logoColor=white" />
+  </a>&nbsp;
+  <a aria-label="Follow Expo on LinkedIn" href="https://www.linkedin.com/company/expo-dev" target="_blank">
+    <img alt="Expo on LinkedIn" src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=LinkedIn&logoColor=white" />
+  </a>&nbsp;
+  <a aria-label="Subscribe to Expo on YouTube" href="https://www.youtube.com/channel/UCx_YiR733cfqVPRsQ1n8Fag" target="_blank">
+    <img alt="Expo on YouTube" src="https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=YouTube&logoColor=white" />
+  </a>
+</p>
+
+---
+
+EAS CLI is the command-line interface for [Expo Application Services (EAS)](https://expo.dev/eas) — deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.
+
+It gives you a terminal-native path from source code to production: compile signed Android and iOS binaries in the cloud, submit them to the app stores, push over-the-air updates, deploy web apps and API routes, and automate the entire release process — from your machine or from CI.
+
+## Quick start
+
+Install the CLI, log in to your Expo account, and link your project:
 
 ```sh
-npm install -g eas-cli
-# or
-yarn global add eas-cli
+npm install --global eas-cli
+eas login
+eas init
 ```
 
-## Enforcing eas-cli version for your project
+Then ship:
 
-If you want to enforce the `eas-cli` version for your project, use the `"cli.version"` field in **eas.json**. Installing `eas-cli` to your project dependencies is strongly discouraged because it may cause dependency conflicts that are difficult to debug.
+```sh
+# Compile installable Android and iOS binaries in the cloud
+eas build --platform all
 
-An example of **eas.json** that enforces `eas-cli` in version `1.0.0` or newer:
+# Submit the latest builds to Google Play and the App Store
+eas submit --platform all
+
+# Push an over-the-air update to your users
+eas update --branch production --message "Fix checkout crash"
+```
+
+Prefer not to install globally? Every command also works with `npx eas-cli@latest`:
+
+```sh
+npx eas-cli@latest build --platform ios
+```
+
+New to EAS? Follow [Create your first build](https://docs.expo.dev/build/setup/) for a complete walkthrough.
+
+## What you can do
+
+- **[EAS Build](https://docs.expo.dev/build/introduction/)** (`eas build`) — compile and sign Android and iOS apps with custom native code in the cloud, manage app credentials, and share internal distribution builds.
+- **[EAS Submit](https://docs.expo.dev/submit/introduction/)** (`eas submit`) — upload your app to Google Play and App Store Connect with one command.
+- **[EAS Update](https://docs.expo.dev/eas-update/introduction/)** (`eas update`) — push JavaScript and asset fixes directly to users, with branches, channels, runtime versions, rollouts, and rollbacks.
+- **[EAS Workflows](https://docs.expo.dev/eas/workflows/get-started/)** (`eas workflow`) — automate development and release with CI/CD jobs that build, test, submit, update, and deploy your app from `.eas/workflows`.
+- **[EAS Hosting](https://docs.expo.dev/eas/hosting/introduction/)** (`eas deploy`) — deploy Expo Router and React Native web apps and API routes.
+- **[EAS Metadata](https://docs.expo.dev/eas/metadata/)** (`eas metadata:push`) — maintain your app store presence from the command line (in preview).
+- **Project operations** (`eas env`, `eas credentials`, `eas device`, `eas channel`, …) — manage environment variables, signing credentials, Apple devices, update channels, webhooks, and project settings.
+
+## Version policy
+
+EAS CLI is designed to be installed globally or run with `npx`. Installing `eas-cli` into project dependencies is strongly discouraged because it can cause dependency conflicts that are difficult to debug.
+
+If you want to enforce the `eas-cli` version for your project, use the `"cli.version"` field in [eas.json](https://docs.expo.dev/eas/json/):
 
 ```json
 {
@@ -39,18 +127,13 @@ An example of **eas.json** that enforces `eas-cli` in version `1.0.0` or newer:
 }
 ```
 
-Learn more: https://docs.expo.dev/build/eas-json/
+## Learn more
 
-# Usage
-
-```sh
-eas COMMAND
-# runs the command
-eas (-v|--version|version)
-# prints the version
-eas --help COMMAND
-# outputs help for specific command
-```
+- [EAS documentation](https://docs.expo.dev/eas/) for the full service overview.
+- [EAS CLI reference](https://docs.expo.dev/eas/cli/) for command usage, flags, and arguments.
+- [Expo dashboard](https://expo.dev/accounts) to view projects, builds, submissions, updates, and workflows.
+- [Expo changelog](https://expo.dev/changelog) and [blog](https://expo.dev/blog) for product updates.
+- [Discord and Forums](https://chat.expo.dev) for community support.
 
 # Commands
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -1,21 +1,21 @@
-<!-- Title -->
+<!-- Everything above the "# Commands" section is generated from packages/eas-cli/scripts/readme-header.md. Edit that file, not README.md; `yarn version` regenerates README.md and overwrites this content. -->
 
 <p align="center">
-  <a href="https://expo.dev/eas">
+  <a href="https://expo.dev/services">
     <img alt="EAS" height="96" src="../../.github/resources/eas.svg">
   </a>
 </p>
 
 <h1 align="center">EAS CLI</h1>
 
-<p align="center">Ship Expo and React Native apps from your terminal — build, submit, update, deploy, and automate with EAS.</p>
+<p align="center">Ship Expo and React Native apps from your terminal: build, submit, update, deploy, and automate with EAS.</p>
 
 <p align="center">
   <a aria-label="eas documentation" href="https://docs.expo.dev/eas/">📚 Documentation</a>
   &ensp;•&ensp;
   <a aria-label="eas cli reference" href="https://docs.expo.dev/eas/cli/">📖 CLI Reference</a>
   &ensp;•&ensp;
-  <a aria-label="eas" href="https://expo.dev/eas">🚀 EAS</a>
+  <a aria-label="eas" href="https://expo.dev/services">🚀 EAS</a>
   &ensp;•&ensp;
   <a aria-label="expo blog" href="https://expo.dev/blog">📝 Blog</a>
   &ensp;•&ensp;
@@ -41,9 +41,9 @@
 
 ---
 
-EAS CLI is the command-line interface for [Expo Application Services (EAS)](https://expo.dev/eas) — deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.
+EAS CLI is the command-line interface for [Expo Application Services (EAS)](https://expo.dev/services): deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.
 
-It gives you a terminal-native path from source code to production: compile signed Android and iOS binaries in the cloud, submit them to the app stores, push over-the-air updates, deploy web apps and API routes, and automate the entire release process — from your machine or from CI.
+It gives you a terminal-native path from source code to production: compile signed Android and iOS binaries in the cloud, submit them to the app stores, push over-the-air updates, deploy web apps and API routes, and automate the entire release process, from your machine or from CI.
 
 ## Quick start
 
@@ -78,13 +78,13 @@ New to EAS? Follow [Create your first build](https://docs.expo.dev/build/setup/)
 
 ## What you can do
 
-- **[EAS Build](https://docs.expo.dev/build/introduction/)** (`eas build`) — compile and sign Android and iOS apps with custom native code in the cloud, manage app credentials, and share internal distribution builds.
-- **[EAS Submit](https://docs.expo.dev/submit/introduction/)** (`eas submit`) — upload your app to Google Play and App Store Connect with one command.
-- **[EAS Update](https://docs.expo.dev/eas-update/introduction/)** (`eas update`) — push JavaScript and asset fixes directly to users, with branches, channels, runtime versions, rollouts, and rollbacks.
-- **[EAS Workflows](https://docs.expo.dev/eas/workflows/get-started/)** (`eas workflow`) — automate development and release with CI/CD jobs that build, test, submit, update, and deploy your app from `.eas/workflows`.
-- **[EAS Hosting](https://docs.expo.dev/eas/hosting/introduction/)** (`eas deploy`) — deploy Expo Router and React Native web apps and API routes.
-- **[EAS Metadata](https://docs.expo.dev/eas/metadata/)** (`eas metadata:push`) — maintain your app store presence from the command line (in preview).
-- **Project operations** (`eas env`, `eas credentials`, `eas device`, `eas channel`, …) — manage environment variables, signing credentials, Apple devices, update channels, webhooks, and project settings.
+- **[EAS Build](https://docs.expo.dev/build/introduction/)** (`eas build`): compile and sign Android and iOS apps with custom native code in the cloud, manage app credentials, and share internal distribution builds.
+- **[EAS Submit](https://docs.expo.dev/deploy/submit-to-app-stores/)** (`eas submit`): upload your app to Google Play and App Store Connect with one command.
+- **[EAS Update](https://docs.expo.dev/eas-update/introduction/)** (`eas update`): push JavaScript and asset fixes directly to users, with branches, channels, runtime versions, rollouts, and rollbacks.
+- **[EAS Workflows](https://docs.expo.dev/eas/workflows/get-started/)** (`eas workflow`): automate development and release with CI/CD jobs that build, test, submit, update, and deploy your app from `.eas/workflows`.
+- **[EAS Hosting](https://docs.expo.dev/eas/hosting/introduction/)** (`eas deploy`): deploy Expo Router and React Native web apps and API routes.
+- **[EAS Metadata](https://docs.expo.dev/eas/metadata/)** (`eas metadata:push`): maintain your app store presence from the command line (in preview).
+- **Project operations** (`eas env`, `eas credentials`, `eas device`, `eas channel`, …): manage environment variables, signing credentials, Apple devices, update channels, webhooks, and project settings.
 
 ## Version policy
 
@@ -95,7 +95,7 @@ If you want to enforce the `eas-cli` version for your project, use the `"cli.ver
 ```json
 {
   "cli": {
-    "version": ">=1.0.0"
+    "version": ">=21.0.0"
   },
   "build": {
     // build profiles
@@ -110,9 +110,9 @@ If you want to enforce the `eas-cli` version for your project, use the `"cli.ver
 
 - [EAS documentation](https://docs.expo.dev/eas/) for the full service overview.
 - [EAS CLI reference](https://docs.expo.dev/eas/cli/) for command usage, flags, and arguments.
-- [Expo dashboard](https://expo.dev/accounts) to view projects, builds, submissions, updates, and workflows.
+- [Expo dashboard](https://expo.dev/) to view projects, builds, submissions, updates, and workflows.
 - [Expo changelog](https://expo.dev/changelog) and [blog](https://expo.dev/blog) for product updates.
-- [Discord and Forums](https://chat.expo.dev) for community support.
+- [Discord](https://chat.expo.dev) for community support.
 
 # Commands
 

--- a/packages/eas-cli/scripts/patch-readme.js
+++ b/packages/eas-cli/scripts/patch-readme.js
@@ -1,11 +1,35 @@
 const fs = require('fs/promises');
+const path = require('path');
+
+const packageRoot = path.join(__dirname, '..');
+const readmePath = path.join(packageRoot, 'README.md');
+const readmeHeaderPath = path.join(__dirname, 'readme-header.md');
 
 (async () => {
   // Patch `oclif readme` path and link generation
-  let readmeContent = await fs.readFile('README.md', 'utf8');
-  readmeContent = readmeContent.replace(/src\/commands/g, 'packages/eas-cli/src/commands');
-  await fs.writeFile('README.md', readmeContent);
+  let readmeContent = await fs.readFile(readmePath, 'utf8');
+  readmeContent = readmeContent
+    .replace(/\[src\/commands/g, '[packages/eas-cli/src/commands')
+    .replace(
+      /https:\/\/github\.com\/expo\/eas-cli\/blob\/v([^/]+)\/src\/commands/g,
+      'https://github.com/expo/eas-cli/blob/v$1/packages/eas-cli/src/commands'
+    )
+    .replace(
+      /packages\/eas-cli\/(?:packages\/eas-cli\/)+src\/commands/g,
+      'packages/eas-cli/src/commands'
+    );
+
+  const commandReferenceMarker = '# Commands\n\n<!-- commands -->';
+  const commandReferenceStart = readmeContent.indexOf(commandReferenceMarker);
+  if (commandReferenceStart === -1) {
+    throw new Error(`Could not find generated command reference marker in ${readmePath}`);
+  }
+
+  const readmeHeader = await fs.readFile(readmeHeaderPath, 'utf8');
+  readmeContent = `${readmeHeader.trimEnd()}\n\n${readmeContent.slice(commandReferenceStart)}`;
+
+  await fs.writeFile(readmePath, readmeContent);
 
   // eslint-disable-next-line no-console
-  console.log('Patched README path generation');
+  console.log('Patched README path generation and header');
 })();

--- a/packages/eas-cli/scripts/readme-header.md
+++ b/packages/eas-cli/scripts/readme-header.md
@@ -28,7 +28,7 @@
   <a aria-label="npm version" href="https://www.npmjs.com/package/eas-cli" target="_blank">
     <img alt="npm version" src="https://img.shields.io/npm/v/eas-cli.svg?style=for-the-badge&label=npm&labelColor=000000&color=4630EB" />
   </a>
-  <a aria-label="npm downloads" href="https://www.npmtrends.com/eas-cli" target="_blank">
+  <a aria-label="npm downloads" href="https://npm-stat.com/charts.html?package=eas-cli" target="_blank">
     <img alt="downloads" src="https://img.shields.io/npm/dm/eas-cli.svg?style=for-the-badge&labelColor=000000&color=33CC12&label=downloads" />
   </a>
   <a aria-label="License: MIT" href="https://github.com/expo/eas-cli/blob/main/LICENSE" target="_blank">

--- a/packages/eas-cli/scripts/readme-header.md
+++ b/packages/eas-cli/scripts/readme-header.md
@@ -39,27 +39,6 @@
   </a>
 </p>
 
-<p align="center">
-  <a aria-label="Follow Expo on X" href="https://x.com/intent/follow?screen_name=expo" target="_blank">
-    <img alt="Expo on X" src="https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white" />
-  </a>&nbsp;
-  <a aria-label="Follow Expo on GitHub" href="https://github.com/expo" target="_blank">
-    <img alt="Expo on GitHub" src="https://img.shields.io/badge/GitHub-222222?style=for-the-badge&logo=github&logoColor=white" />
-  </a>&nbsp;
-  <a aria-label="Follow Expo on Reddit" href="https://www.reddit.com/r/expo/" target="_blank">
-    <img alt="Expo on Reddit" src="https://img.shields.io/badge/Reddit-FF4500?style=for-the-badge&logo=reddit&logoColor=white" />
-  </a>&nbsp;
-  <a aria-label="Follow Expo on Bluesky" href="https://bsky.app/profile/expo.dev" target="_blank">
-    <img alt="Expo on Bluesky" src="https://img.shields.io/badge/Bluesky-1DA1F2?style=for-the-badge&logo=bluesky&logoColor=white" />
-  </a>&nbsp;
-  <a aria-label="Follow Expo on LinkedIn" href="https://www.linkedin.com/company/expo-dev" target="_blank">
-    <img alt="Expo on LinkedIn" src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=LinkedIn&logoColor=white" />
-  </a>&nbsp;
-  <a aria-label="Subscribe to Expo on YouTube" href="https://www.youtube.com/channel/UCx_YiR733cfqVPRsQ1n8Fag" target="_blank">
-    <img alt="Expo on YouTube" src="https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=YouTube&logoColor=white" />
-  </a>
-</p>
-
 ---
 
 EAS CLI is the command-line interface for [Expo Application Services (EAS)](https://expo.dev/eas) — deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.

--- a/packages/eas-cli/scripts/readme-header.md
+++ b/packages/eas-cli/scripts/readme-header.md
@@ -1,0 +1,136 @@
+<!-- Title -->
+
+<p align="center">
+  <a href="https://expo.dev/eas">
+    <img alt="EAS" height="96" src="../../.github/resources/eas.svg">
+  </a>
+</p>
+
+<h1 align="center">EAS CLI</h1>
+
+<p align="center">Ship Expo and React Native apps from your terminal — build, submit, update, deploy, and automate with EAS.</p>
+
+<p align="center">
+  <a aria-label="eas documentation" href="https://docs.expo.dev/eas/">📚 Documentation</a>
+  &ensp;•&ensp;
+  <a aria-label="eas cli reference" href="https://docs.expo.dev/eas/cli/">📖 CLI Reference</a>
+  &ensp;•&ensp;
+  <a aria-label="eas" href="https://expo.dev/eas">🚀 EAS</a>
+  &ensp;•&ensp;
+  <a aria-label="expo blog" href="https://expo.dev/blog">📝 Blog</a>
+  &ensp;•&ensp;
+  <a aria-label="expo changelog" href="https://expo.dev/changelog">📰 Changelog</a>
+  &ensp;•&ensp;
+  <a aria-label="contribute to eas cli" href="https://github.com/expo/eas-cli/blob/main/CONTRIBUTING.md">👏 Contribute</a>
+</p>
+
+<p align="center">
+  <a aria-label="npm version" href="https://www.npmjs.com/package/eas-cli" target="_blank">
+    <img alt="npm version" src="https://img.shields.io/npm/v/eas-cli.svg?style=for-the-badge&label=npm&labelColor=000000&color=4630EB" />
+  </a>
+  <a aria-label="npm downloads" href="https://www.npmtrends.com/eas-cli" target="_blank">
+    <img alt="downloads" src="https://img.shields.io/npm/dm/eas-cli.svg?style=for-the-badge&labelColor=000000&color=33CC12&label=downloads" />
+  </a>
+  <a aria-label="License: MIT" href="https://github.com/expo/eas-cli/blob/main/LICENSE" target="_blank">
+    <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-success.svg?style=for-the-badge&labelColor=000000&color=33CC12" />
+  </a>
+  <a aria-label="Join the Expo Discord" href="https://chat.expo.dev" target="_blank">
+    <img alt="Discord" src="https://img.shields.io/discord/695411232856997968.svg?style=for-the-badge&color=5865F2&logo=discord&logoColor=FFFFFF" />
+  </a>
+</p>
+
+<p align="center">
+  <a aria-label="Follow Expo on X" href="https://x.com/intent/follow?screen_name=expo" target="_blank">
+    <img alt="Expo on X" src="https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white" />
+  </a>&nbsp;
+  <a aria-label="Follow Expo on GitHub" href="https://github.com/expo" target="_blank">
+    <img alt="Expo on GitHub" src="https://img.shields.io/badge/GitHub-222222?style=for-the-badge&logo=github&logoColor=white" />
+  </a>&nbsp;
+  <a aria-label="Follow Expo on Reddit" href="https://www.reddit.com/r/expo/" target="_blank">
+    <img alt="Expo on Reddit" src="https://img.shields.io/badge/Reddit-FF4500?style=for-the-badge&logo=reddit&logoColor=white" />
+  </a>&nbsp;
+  <a aria-label="Follow Expo on Bluesky" href="https://bsky.app/profile/expo.dev" target="_blank">
+    <img alt="Expo on Bluesky" src="https://img.shields.io/badge/Bluesky-1DA1F2?style=for-the-badge&logo=bluesky&logoColor=white" />
+  </a>&nbsp;
+  <a aria-label="Follow Expo on LinkedIn" href="https://www.linkedin.com/company/expo-dev" target="_blank">
+    <img alt="Expo on LinkedIn" src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=LinkedIn&logoColor=white" />
+  </a>&nbsp;
+  <a aria-label="Subscribe to Expo on YouTube" href="https://www.youtube.com/channel/UCx_YiR733cfqVPRsQ1n8Fag" target="_blank">
+    <img alt="Expo on YouTube" src="https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=YouTube&logoColor=white" />
+  </a>
+</p>
+
+---
+
+EAS CLI is the command-line interface for [Expo Application Services (EAS)](https://expo.dev/eas) — deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.
+
+It gives you a terminal-native path from source code to production: compile signed Android and iOS binaries in the cloud, submit them to the app stores, push over-the-air updates, deploy web apps and API routes, and automate the entire release process — from your machine or from CI.
+
+## Quick start
+
+Install the CLI, log in to your Expo account, and link your project:
+
+```sh
+npm install --global eas-cli
+eas login
+eas init
+```
+
+Then ship:
+
+```sh
+# Compile installable Android and iOS binaries in the cloud
+eas build --platform all
+
+# Submit the latest builds to Google Play and the App Store
+eas submit --platform all
+
+# Push an over-the-air update to your users
+eas update --branch production --message "Fix checkout crash"
+```
+
+Prefer not to install globally? Every command also works with `npx eas-cli@latest`:
+
+```sh
+npx eas-cli@latest build --platform ios
+```
+
+New to EAS? Follow [Create your first build](https://docs.expo.dev/build/setup/) for a complete walkthrough.
+
+## What you can do
+
+- **[EAS Build](https://docs.expo.dev/build/introduction/)** (`eas build`) — compile and sign Android and iOS apps with custom native code in the cloud, manage app credentials, and share internal distribution builds.
+- **[EAS Submit](https://docs.expo.dev/submit/introduction/)** (`eas submit`) — upload your app to Google Play and App Store Connect with one command.
+- **[EAS Update](https://docs.expo.dev/eas-update/introduction/)** (`eas update`) — push JavaScript and asset fixes directly to users, with branches, channels, runtime versions, rollouts, and rollbacks.
+- **[EAS Workflows](https://docs.expo.dev/eas/workflows/get-started/)** (`eas workflow`) — automate development and release with CI/CD jobs that build, test, submit, update, and deploy your app from `.eas/workflows`.
+- **[EAS Hosting](https://docs.expo.dev/eas/hosting/introduction/)** (`eas deploy`) — deploy Expo Router and React Native web apps and API routes.
+- **[EAS Metadata](https://docs.expo.dev/eas/metadata/)** (`eas metadata:push`) — maintain your app store presence from the command line (in preview).
+- **Project operations** (`eas env`, `eas credentials`, `eas device`, `eas channel`, …) — manage environment variables, signing credentials, Apple devices, update channels, webhooks, and project settings.
+
+## Version policy
+
+EAS CLI is designed to be installed globally or run with `npx`. Installing `eas-cli` into project dependencies is strongly discouraged because it can cause dependency conflicts that are difficult to debug.
+
+If you want to enforce the `eas-cli` version for your project, use the `"cli.version"` field in [eas.json](https://docs.expo.dev/eas/json/):
+
+```json
+{
+  "cli": {
+    "version": ">=1.0.0"
+  },
+  "build": {
+    // build profiles
+  },
+  "submit": {
+    // submit profiles
+  }
+}
+```
+
+## Learn more
+
+- [EAS documentation](https://docs.expo.dev/eas/) for the full service overview.
+- [EAS CLI reference](https://docs.expo.dev/eas/cli/) for command usage, flags, and arguments.
+- [Expo dashboard](https://expo.dev/accounts) to view projects, builds, submissions, updates, and workflows.
+- [Expo changelog](https://expo.dev/changelog) and [blog](https://expo.dev/blog) for product updates.
+- [Discord and Forums](https://chat.expo.dev) for community support.

--- a/packages/eas-cli/scripts/readme-header.md
+++ b/packages/eas-cli/scripts/readme-header.md
@@ -1,21 +1,21 @@
-<!-- Title -->
+<!-- Everything above the "# Commands" section is generated from packages/eas-cli/scripts/readme-header.md. Edit that file, not README.md; `yarn version` regenerates README.md and overwrites this content. -->
 
 <p align="center">
-  <a href="https://expo.dev/eas">
+  <a href="https://expo.dev/services">
     <img alt="EAS" height="96" src="../../.github/resources/eas.svg">
   </a>
 </p>
 
 <h1 align="center">EAS CLI</h1>
 
-<p align="center">Ship Expo and React Native apps from your terminal — build, submit, update, deploy, and automate with EAS.</p>
+<p align="center">Ship Expo and React Native apps from your terminal: build, submit, update, deploy, and automate with EAS.</p>
 
 <p align="center">
   <a aria-label="eas documentation" href="https://docs.expo.dev/eas/">📚 Documentation</a>
   &ensp;•&ensp;
   <a aria-label="eas cli reference" href="https://docs.expo.dev/eas/cli/">📖 CLI Reference</a>
   &ensp;•&ensp;
-  <a aria-label="eas" href="https://expo.dev/eas">🚀 EAS</a>
+  <a aria-label="eas" href="https://expo.dev/services">🚀 EAS</a>
   &ensp;•&ensp;
   <a aria-label="expo blog" href="https://expo.dev/blog">📝 Blog</a>
   &ensp;•&ensp;
@@ -41,9 +41,9 @@
 
 ---
 
-EAS CLI is the command-line interface for [Expo Application Services (EAS)](https://expo.dev/eas) — deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.
+EAS CLI is the command-line interface for [Expo Application Services (EAS)](https://expo.dev/services): deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.
 
-It gives you a terminal-native path from source code to production: compile signed Android and iOS binaries in the cloud, submit them to the app stores, push over-the-air updates, deploy web apps and API routes, and automate the entire release process — from your machine or from CI.
+It gives you a terminal-native path from source code to production: compile signed Android and iOS binaries in the cloud, submit them to the app stores, push over-the-air updates, deploy web apps and API routes, and automate the entire release process, from your machine or from CI.
 
 ## Quick start
 
@@ -78,13 +78,13 @@ New to EAS? Follow [Create your first build](https://docs.expo.dev/build/setup/)
 
 ## What you can do
 
-- **[EAS Build](https://docs.expo.dev/build/introduction/)** (`eas build`) — compile and sign Android and iOS apps with custom native code in the cloud, manage app credentials, and share internal distribution builds.
-- **[EAS Submit](https://docs.expo.dev/submit/introduction/)** (`eas submit`) — upload your app to Google Play and App Store Connect with one command.
-- **[EAS Update](https://docs.expo.dev/eas-update/introduction/)** (`eas update`) — push JavaScript and asset fixes directly to users, with branches, channels, runtime versions, rollouts, and rollbacks.
-- **[EAS Workflows](https://docs.expo.dev/eas/workflows/get-started/)** (`eas workflow`) — automate development and release with CI/CD jobs that build, test, submit, update, and deploy your app from `.eas/workflows`.
-- **[EAS Hosting](https://docs.expo.dev/eas/hosting/introduction/)** (`eas deploy`) — deploy Expo Router and React Native web apps and API routes.
-- **[EAS Metadata](https://docs.expo.dev/eas/metadata/)** (`eas metadata:push`) — maintain your app store presence from the command line (in preview).
-- **Project operations** (`eas env`, `eas credentials`, `eas device`, `eas channel`, …) — manage environment variables, signing credentials, Apple devices, update channels, webhooks, and project settings.
+- **[EAS Build](https://docs.expo.dev/build/introduction/)** (`eas build`): compile and sign Android and iOS apps with custom native code in the cloud, manage app credentials, and share internal distribution builds.
+- **[EAS Submit](https://docs.expo.dev/deploy/submit-to-app-stores/)** (`eas submit`): upload your app to Google Play and App Store Connect with one command.
+- **[EAS Update](https://docs.expo.dev/eas-update/introduction/)** (`eas update`): push JavaScript and asset fixes directly to users, with branches, channels, runtime versions, rollouts, and rollbacks.
+- **[EAS Workflows](https://docs.expo.dev/eas/workflows/get-started/)** (`eas workflow`): automate development and release with CI/CD jobs that build, test, submit, update, and deploy your app from `.eas/workflows`.
+- **[EAS Hosting](https://docs.expo.dev/eas/hosting/introduction/)** (`eas deploy`): deploy Expo Router and React Native web apps and API routes.
+- **[EAS Metadata](https://docs.expo.dev/eas/metadata/)** (`eas metadata:push`): maintain your app store presence from the command line (in preview).
+- **Project operations** (`eas env`, `eas credentials`, `eas device`, `eas channel`, …): manage environment variables, signing credentials, Apple devices, update channels, webhooks, and project settings.
 
 ## Version policy
 
@@ -95,7 +95,7 @@ If you want to enforce the `eas-cli` version for your project, use the `"cli.ver
 ```json
 {
   "cli": {
-    "version": ">=1.0.0"
+    "version": ">=21.0.0"
   },
   "build": {
     // build profiles
@@ -110,6 +110,6 @@ If you want to enforce the `eas-cli` version for your project, use the `"cli.ver
 
 - [EAS documentation](https://docs.expo.dev/eas/) for the full service overview.
 - [EAS CLI reference](https://docs.expo.dev/eas/cli/) for command usage, flags, and arguments.
-- [Expo dashboard](https://expo.dev/accounts) to view projects, builds, submissions, updates, and workflows.
+- [Expo dashboard](https://expo.dev/) to view projects, builds, submissions, updates, and workflows.
 - [Expo changelog](https://expo.dev/changelog) and [blog](https://expo.dev/blog) for product updates.
-- [Discord and Forums](https://chat.expo.dev) for community support.
+- [Discord](https://chat.expo.dev) for community support.


### PR DESCRIPTION
# Why

The `eas-cli` README is the landing page for the package on npm and for this repo, but it opened with a bare "EAS command line tool" note. This gives it the same treatment as the `expo` package README (https://github.com/expo/expo/pull/46088): a product-focused landing page that explains what EAS is, what the CLI can do, and where to go next.

**👉 [Read the rendered README](https://github.com/expo/eas-cli/blob/szdziedzic-codex/eas-cli-readme/packages/eas-cli/README.md)**

# How

- Rewrote the README top section as a landing page: EAS logo, tagline, doc/social links, badges, quick start, service overview, and version policy — following the structure and visual style of the `expo` package README.
- Added the EAS logo as an SVG at `.github/resources/eas.svg` (same location/pattern as `expo.svg` in expo/expo), with a subtle outline ring so the dark mark stays visible on GitHub dark mode. The README references it via a relative path that resolves both on GitHub and on npm, so no image needs to ship in the npm tarball.
- Aligned wording and links with current docs: the official EAS one-liner ("deeply integrated cloud services for Expo and React Native apps, from the team behind Expo"), install/login/init flow from the docs, and the current service lineup (Build, Submit, Update, Workflows, Hosting, Metadata). All doc URLs verified against docs.expo.dev.
- Kept the generated command reference intact: the custom header lives in `scripts/readme-header.md`, and `scripts/patch-readme.js` (already run from the `version` lifecycle script) re-applies it after every `oclif readme` regeneration.

# Test Plan

- `node scripts/patch-readme.js` regenerates the README with the header applied and the command reference untouched.
- Verified the rendered README on this branch: the logo `<img>` resolves to `/expo/eas-cli/raw/<branch>/.github/resources/eas.svg` (HTTP 200) on GitHub.
- Checked every documentation link in the header returns HTTP 200 (including `docs.expo.dev/eas/workflows/get-started/` — note the `/eas-workflows/...` variant used in the expo README is now a 404).
- `oxfmt` on changed files, `git diff --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
