### PR TITLE
[build-tools] - bubble validation error for when caches exceed max size

### DIFF
--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -141,6 +141,10 @@ export async function uploadCacheAsync({
       return;
     }
     const textResult = await asyncResult(response.text());
+    const errorMessage = extractValidationErrorMessage(textResult.value);
+    if (errorMessage) {
+      throw new Error(errorMessage);
+    }
     throw new Error(`Unexpected response from server (${response.status}): ${textResult.value}`);
   }
 
@@ -229,6 +233,16 @@ export async function uploadPublicCacheAsync({
     );
   }
   logger.info(`Uploaded cache archive to ${archivePath} (${formatBytes(size)}).`);
+}
+
+function extractValidationErrorMessage(body: string): string | undefined {
+  try {
+    const { errors } = JSON.parse(body);
+    if (errors?.[0]?.code === 'VALIDATION_ERROR') {
+      return errors[0].message;
+    }
+  } catch {}
+  return undefined;
 }
 
 export async function compressCacheAsync({

--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -236,6 +236,9 @@ export async function uploadPublicCacheAsync({
 }
 
 function extractValidationErrorMessage(body: string | undefined): string | undefined {
+  if (!body) {
+    return undefined;
+  }
   try {
     const { errors } = JSON.parse(body);
     if (errors?.[0]?.code === 'VALIDATION_ERROR') {

--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -235,7 +235,7 @@ export async function uploadPublicCacheAsync({
   logger.info(`Uploaded cache archive to ${archivePath} (${formatBytes(size)}).`);
 }
 
-function extractValidationErrorMessage(body: string): string | undefined {
+function extractValidationErrorMessage(body: string | undefined): string | undefined {
   try {
     const { errors } = JSON.parse(body);
     if (errors?.[0]?.code === 'VALIDATION_ERROR') {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why




# How

https://github.com/expo/universe/pull/28086


# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
