### PR TITLE
[worker] Remove legacy upload code, add retries, auto-waive builds

### DIFF
--- a/packages/build-tools/src/steps/functions/findAndUploadBuildArtifacts.ts
+++ b/packages/build-tools/src/steps/functions/findAndUploadBuildArtifacts.ts
@@ -26,14 +26,14 @@ export function createFindAndUploadBuildArtifactsBuildFunction(
       try {
         await uploadApplicationArchivesAsync({ ctx, stepCtx });
       } catch (err: unknown) {
-        stepCtx.logger.error(`Failed to upload application archives.`, err);
+        stepCtx.logger.error({ err }, `Failed to upload application archives.`);
         firstError ||= err;
       }
 
       try {
         await uploadBuildArtifacts({ ctx, stepCtx });
       } catch (err: unknown) {
-        stepCtx.logger.error(`Failed to upload build artifacts.`, err);
+        stepCtx.logger.error({ err }, `Failed to upload build artifacts.`);
         firstError ||= err;
       }
 

--- a/packages/build-tools/src/steps/functions/uploadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/uploadArtifact.ts
@@ -128,7 +128,7 @@ export function createUploadArtifactBuildFunction(ctx: CustomBuildContext): Buil
         }
       } catch (error) {
         if (inputs.ignore_error.value) {
-          logger.error(`Failed to upload ${artifact.type}. Ignoring error.`, error);
+          logger.error({ err: error }, `Failed to upload ${artifact.type}. Ignoring error.`);
           // Ignoring error.
           return;
         }

--- a/packages/worker/src/__unit__/upload.test.ts
+++ b/packages/worker/src/__unit__/upload.test.ts
@@ -164,6 +164,9 @@ describe(uploadApplicationArchiveAsync.name, () => {
         headers: {
           Authorization: `Bearer ${ctx.job.secrets!.robotAccessToken}`,
         },
+        retries: 2,
+        retryIntervalMs: 1000,
+        logger: ctx.logger,
       })
     );
     expect(turtleFetchMock).toHaveBeenNthCalledWith(
@@ -175,6 +178,9 @@ describe(uploadApplicationArchiveAsync.name, () => {
         headers: {
           Authorization: `Bearer ${ctx.job.secrets!.robotAccessToken}`,
         },
+        retries: 2,
+        retryIntervalMs: 1000,
+        logger: ctx.logger,
       })
     );
   });
@@ -369,6 +375,9 @@ describe(uploadBuildArtifactsAsync.name, () => {
         headers: {
           Authorization: `Bearer ${ctx.job.secrets!.robotAccessToken}`,
         },
+        retries: 2,
+        retryIntervalMs: 1000,
+        logger: ctx.logger,
       })
     );
     expect(turtleFetchMock).toHaveBeenNthCalledWith(
@@ -380,6 +389,9 @@ describe(uploadBuildArtifactsAsync.name, () => {
         headers: {
           Authorization: `Bearer ${ctx.job.secrets!.robotAccessToken}`,
         },
+        retries: 2,
+        retryIntervalMs: 1000,
+        logger: ctx.logger,
       })
     );
   });
@@ -538,6 +550,9 @@ describe('with signed upload url provided via www', () => {
         headers: {
           Authorization: `Bearer ${ctx.job.secrets!.robotAccessToken}`,
         },
+        retries: 2,
+        retryIntervalMs: 1000,
+        logger: ctx.logger,
       })
     );
     expect(turtleFetchMock).toHaveBeenNthCalledWith(
@@ -549,6 +564,9 @@ describe('with signed upload url provided via www', () => {
         headers: {
           Authorization: `Bearer ${ctx.job.secrets!.robotAccessToken}`,
         },
+        retries: 2,
+        retryIntervalMs: 1000,
+        logger: ctx.logger,
       })
     );
   });
@@ -627,6 +645,9 @@ describe(uploadWorkflowArtifactAsync.name, () => {
         headers: {
           Authorization: `Bearer ${ctx.job.secrets!.robotAccessToken}`,
         },
+        retries: 2,
+        retryIntervalMs: 1000,
+        logger: ctx.logger,
       })
     );
   });

--- a/packages/worker/src/__unit__/upload.test.ts
+++ b/packages/worker/src/__unit__/upload.test.ts
@@ -1,5 +1,5 @@
 import { BuildContext, GCS } from '@expo/build-tools';
-import { Job } from '@expo/eas-build-job';
+import { Job, errors } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { randomBytes, randomUUID } from 'crypto';
 import { vol } from 'memfs';
@@ -58,7 +58,14 @@ describe(uploadApplicationArchiveAsync.name, () => {
         buildId: 'buildId',
         logger: ctx.logger,
       })
-    ).rejects.toThrow('env variables are not set');
+    ).rejects.toMatchObject({
+      errorCode: errors.ErrorCode.SERVER_ERROR,
+      trackingCode: 'EAS_BUILD_UPLOAD_APPLICATION_ARCHIVE_FAILED',
+      message: 'Failed to upload application archive.',
+      cause: expect.objectContaining({
+        message: expect.stringContaining('env variables are not set'),
+      }),
+    });
 
     ctx.env.__WORKFLOW_JOB_ID = randomUUID();
 
@@ -68,7 +75,14 @@ describe(uploadApplicationArchiveAsync.name, () => {
         buildId: 'buildId',
         logger: ctx.logger,
       })
-    ).rejects.toThrow('robot access token is not set');
+    ).rejects.toMatchObject({
+      errorCode: errors.ErrorCode.SERVER_ERROR,
+      trackingCode: 'EAS_BUILD_UPLOAD_APPLICATION_ARCHIVE_FAILED',
+      message: 'Failed to upload application archive.',
+      cause: expect.objectContaining({
+        message: expect.stringContaining('robot access token is not set'),
+      }),
+    });
   });
 
   it('should upload the application archive', async () => {
@@ -164,6 +178,77 @@ describe(uploadApplicationArchiveAsync.name, () => {
       })
     );
   });
+
+  it('should throw a system error if the application archive upload fails', async () => {
+    vol.fromJSON({
+      './artifact.ipa': JSON.stringify(randomBytes(20)),
+    });
+    const workflowJobId = randomUUID();
+
+    // @ts-expect-error
+    const ctx: BuildContext<Job> = {
+      env: {
+        __WORKFLOW_JOB_ID: workflowJobId,
+      },
+      job: {
+        secrets: {
+          robotAccessToken: 'fake-token',
+        },
+      } as Job,
+      logger: mockLogger,
+    };
+
+    const bucketKey = `test/${randomUUID()}/artifact.ipa`;
+    const uploadUrl = `https://upload.url/${randomUUID()}`;
+    const testSignedUploadAuthorization = randomUUID();
+    const uploadError = new Error('upload failed');
+
+    turtleFetchMock.mockImplementation(async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: {
+            bucketKey,
+            url: uploadUrl,
+            headers: {
+              authorization: testSignedUploadAuthorization,
+            },
+            storageType: 'GCS',
+          },
+        }),
+      } as Response;
+    });
+    jest.mocked(GCS.uploadWithSignedUrl).mockRejectedValueOnce(uploadError);
+
+    let thrownError: unknown;
+    try {
+      await uploadApplicationArchiveAsync(ctx, {
+        artifactPaths: ['./artifact.ipa'],
+        buildId: randomUUID(),
+        logger: ctx.logger,
+      });
+    } catch (err) {
+      thrownError = err;
+    }
+
+    expect(thrownError).toBeInstanceOf(errors.SystemError);
+    expect(thrownError).toMatchObject({
+      errorCode: errors.ErrorCode.SERVER_ERROR,
+      trackingCode: 'EAS_BUILD_UPLOAD_APPLICATION_ARCHIVE_FAILED',
+      message: 'Failed to upload application archive.',
+      buildPhase: undefined,
+      metadata: expect.objectContaining({
+        filename: expect.stringMatching(/^application-.*\.ipa$/),
+        size: expect.any(Number),
+        url: uploadUrl,
+        headers: {
+          authorization: testSignedUploadAuthorization,
+        },
+      }),
+      cause: uploadError,
+    });
+  });
 });
 
 describe(uploadBuildArtifactsAsync.name, () => {
@@ -185,7 +270,14 @@ describe(uploadBuildArtifactsAsync.name, () => {
         buildId: 'buildId',
         logger: ctx.logger,
       })
-    ).rejects.toThrow('env variables are not set');
+    ).rejects.toMatchObject({
+      errorCode: errors.ErrorCode.SERVER_ERROR,
+      trackingCode: 'EAS_BUILD_UPLOAD_BUILD_ARTIFACTS_FAILED',
+      message: 'Failed to upload build artifacts.',
+      cause: expect.objectContaining({
+        message: expect.stringContaining('env variables are not set'),
+      }),
+    });
     ctx.env.__WORKFLOW_JOB_ID = randomUUID();
     await expect(
       uploadBuildArtifactsAsync(ctx, {
@@ -193,7 +285,14 @@ describe(uploadBuildArtifactsAsync.name, () => {
         buildId: 'buildId',
         logger: ctx.logger,
       })
-    ).rejects.toThrow('robot access token is not set');
+    ).rejects.toMatchObject({
+      errorCode: errors.ErrorCode.SERVER_ERROR,
+      trackingCode: 'EAS_BUILD_UPLOAD_BUILD_ARTIFACTS_FAILED',
+      message: 'Failed to upload build artifacts.',
+      cause: expect.objectContaining({
+        message: expect.stringContaining('robot access token is not set'),
+      }),
+    });
   });
 
   it('should upload the build artifacts', async () => {
@@ -283,6 +382,74 @@ describe(uploadBuildArtifactsAsync.name, () => {
         },
       })
     );
+  });
+
+  it('should throw a system error if the build artifacts upload fails', async () => {
+    vol.fromJSON({
+      './video.mp4': JSON.stringify(randomBytes(20)),
+    });
+    const workflowJobId = randomUUID();
+    // @ts-expect-error
+    const ctx: BuildContext<Job> = {
+      env: {
+        __WORKFLOW_JOB_ID: workflowJobId,
+      },
+      job: {
+        secrets: {
+          robotAccessToken: 'fake-token',
+        },
+      } as Job,
+      logger: mockLogger,
+    };
+    const bucketKey = `test/${randomUUID()}/artifact.ipa`;
+    const uploadUrl = `https://upload.url/${randomUUID()}`;
+    const testSignedUploadAuthorization = randomUUID();
+    const uploadError = new Error('upload failed');
+    turtleFetchMock.mockImplementation(async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: {
+            bucketKey,
+            url: uploadUrl,
+            headers: {
+              authorization: testSignedUploadAuthorization,
+            },
+            storageType: 'GCS',
+          },
+        }),
+      } as Response;
+    });
+    jest.mocked(GCS.uploadWithSignedUrl).mockRejectedValueOnce(uploadError);
+
+    let thrownError: unknown;
+    try {
+      await uploadBuildArtifactsAsync(ctx, {
+        artifactPaths: ['./video.mp4'],
+        buildId: randomUUID(),
+        logger: ctx.logger,
+      });
+    } catch (err) {
+      thrownError = err;
+    }
+
+    expect(thrownError).toBeInstanceOf(errors.SystemError);
+    expect(thrownError).toMatchObject({
+      errorCode: errors.ErrorCode.SERVER_ERROR,
+      trackingCode: 'EAS_BUILD_UPLOAD_BUILD_ARTIFACTS_FAILED',
+      message: 'Failed to upload build artifacts.',
+      buildPhase: undefined,
+      metadata: expect.objectContaining({
+        filename: expect.stringMatching(/^artifacts-.*\.mp4$/),
+        size: expect.any(Number),
+        url: uploadUrl,
+        headers: {
+          authorization: testSignedUploadAuthorization,
+        },
+      }),
+      cause: uploadError,
+    });
   });
 });
 

--- a/packages/worker/src/__unit__/upload.test.ts
+++ b/packages/worker/src/__unit__/upload.test.ts
@@ -5,7 +5,6 @@ import { randomBytes, randomUUID } from 'crypto';
 import { vol } from 'memfs';
 import { Response } from 'node-fetch';
 
-import config from '../config';
 import {
   uploadApplicationArchiveAsync,
   uploadBuildArtifactsAsync,
@@ -165,83 +164,6 @@ describe(uploadApplicationArchiveAsync.name, () => {
       })
     );
   });
-
-  describe('with signed upload url provided via config', () => {
-    beforeAll(() => {
-      config.gcsSignedUploadUrlForApplicationArchive = {
-        url: 'https://upload.url/from-config',
-        headers: {
-          authorization: 'test-signed-upload-authorization',
-        },
-      };
-    });
-    afterAll(() => {
-      config.gcsSignedUploadUrlForApplicationArchive = null;
-    });
-
-    it('should fall back to signed upload URL if upload session fails', async () => {
-      vol.fromJSON({
-        './artifact.ipa': JSON.stringify(randomBytes(20)),
-      });
-      const workflowJobId = randomUUID();
-
-      // @ts-expect-error
-      const ctx: BuildContext<Job> = {
-        env: {
-          __WORKFLOW_JOB_ID: workflowJobId,
-        },
-        job: {
-          secrets: {
-            robotAccessToken: 'fake-token',
-          },
-        } as Job,
-        logger: mockLogger,
-      };
-
-      turtleFetchMock.mockImplementation(async () => {
-        return {
-          json: async () => ({
-            data: {
-              bucketKey: 'test/bucketKey',
-              url: 'https://upload.url/from-www',
-              headers: {
-                authorization: 'test-signed-upload-authorization',
-              },
-              storageType: 'GCS',
-            },
-          }),
-          ok: true,
-        } as unknown as Response;
-      });
-
-      // GCS fails to upload to upload session from www.
-      jest.mocked(GCS.uploadWithSignedUrl).mockImplementation(async ({ signedUrl }) => {
-        if (signedUrl.url === 'https://upload.url/from-www') {
-          throw new Error('upload failed');
-        }
-        return signedUrl.url;
-      });
-
-      await uploadApplicationArchiveAsync(ctx, {
-        artifactPaths: ['./artifact.ipa'],
-        buildId: randomUUID(),
-        logger: ctx.logger,
-      });
-
-      expect(GCS.uploadWithSignedUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          signedUrl: {
-            url: 'https://upload.url/from-config',
-            headers: {
-              authorization: 'test-signed-upload-authorization',
-            },
-          },
-        })
-      );
-
-      expect(turtleFetchMock).toHaveBeenCalledTimes(1);
-    });
-  });
 });
 
 describe(uploadBuildArtifactsAsync.name, () => {
@@ -362,93 +284,9 @@ describe(uploadBuildArtifactsAsync.name, () => {
       })
     );
   });
-
-  describe('with signed upload url provided via config', () => {
-    beforeAll(() => {
-      config.gcsSignedUploadUrlForBuildArtifacts = {
-        url: 'https://upload.url/from-config',
-        headers: {
-          authorization: 'test-signed-upload-authorization',
-        },
-      };
-    });
-    afterAll(() => {
-      config.gcsSignedUploadUrlForBuildArtifacts = null;
-    });
-
-    it('should fall back to signed upload URL if upload session fails', async () => {
-      vol.fromJSON({
-        './video.mp4': JSON.stringify(randomBytes(20)),
-      });
-      const workflowJobId = randomUUID();
-
-      // @ts-expect-error
-      const ctx: BuildContext<Job> = {
-        env: {
-          __WORKFLOW_JOB_ID: workflowJobId,
-        },
-        job: {
-          secrets: {
-            robotAccessToken: 'fake-token',
-          },
-        } as Job,
-        logger: mockLogger,
-      };
-
-      turtleFetchMock.mockImplementation(async () => {
-        return {
-          json: async () => ({
-            data: {
-              bucketKey: 'test/bucketKey',
-              url: 'https://upload.url/from-www',
-              headers: {
-                authorization: 'test-signed-upload-authorization',
-              },
-              storageType: 'GCS',
-            },
-          }),
-          ok: true,
-        } as unknown as Response;
-      });
-
-      // GCS fails to upload to upload session from www.
-      jest.mocked(GCS.uploadWithSignedUrl).mockImplementation(async ({ signedUrl }) => {
-        if (signedUrl.url === 'https://upload.url/from-www') {
-          throw new Error('upload failed');
-        }
-        return signedUrl.url;
-      });
-
-      await uploadBuildArtifactsAsync(ctx, {
-        artifactPaths: ['./video.mp4'],
-        buildId: randomUUID(),
-        logger: ctx.logger,
-      });
-
-      expect(GCS.uploadWithSignedUrl).toHaveBeenCalledWith(
-        expect.objectContaining({
-          signedUrl: {
-            url: 'https://upload.url/from-config',
-            headers: {
-              authorization: 'test-signed-upload-authorization',
-            },
-          },
-        })
-      );
-
-      expect(turtleFetchMock).toHaveBeenCalledTimes(1);
-    });
-  });
 });
 
 describe('with signed upload url provided via www', () => {
-  beforeAll(() => {
-    config.gcsSignedUploadUrlForBuildArtifacts = null;
-  });
-  afterAll(() => {
-    config.gcsSignedUploadUrlForBuildArtifacts = null;
-  });
-
   it('should use www signed upload url', async () => {
     vol.fromJSON({
       './video.mp4': JSON.stringify(randomBytes(20)),

--- a/packages/worker/src/__unit__/upload.test.ts
+++ b/packages/worker/src/__unit__/upload.test.ts
@@ -207,9 +207,7 @@ describe(uploadApplicationArchiveAsync.name, () => {
     const bucketKey = `test/${randomUUID()}/artifact.ipa`;
     const uploadUrl = `https://upload.url/${randomUUID()}`;
     const testSignedUploadAuthorization = randomUUID();
-    const uploadError = new Error(
-      'Failed to upload file: status: 403 status text: Forbidden, body: signed-url-secret'
-    );
+    const uploadError = new Error('upload failed');
 
     turtleFetchMock.mockImplementation(async () => {
       return {
@@ -256,14 +254,6 @@ describe(uploadApplicationArchiveAsync.name, () => {
       }),
       cause: uploadError,
     });
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.objectContaining({
-        err: expect.objectContaining({
-          message: 'Failed to upload file: status: 403 status text: Forbidden, body: <redacted>',
-        }),
-      }),
-      'Upload to upload session failed'
-    );
   });
 });
 
@@ -426,9 +416,7 @@ describe(uploadBuildArtifactsAsync.name, () => {
     const bucketKey = `test/${randomUUID()}/artifact.ipa`;
     const uploadUrl = `https://upload.url/${randomUUID()}`;
     const testSignedUploadAuthorization = randomUUID();
-    const uploadError = new Error(
-      'Failed to upload file: status: 403 status text: Forbidden, body: signed-url-secret'
-    );
+    const uploadError = new Error('upload failed');
     turtleFetchMock.mockImplementation(async () => {
       return {
         ok: true,
@@ -474,14 +462,6 @@ describe(uploadBuildArtifactsAsync.name, () => {
       }),
       cause: uploadError,
     });
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.objectContaining({
-        err: expect.objectContaining({
-          message: 'Failed to upload file: status: 403 status text: Forbidden, body: <redacted>',
-        }),
-      }),
-      'Upload to upload session failed'
-    );
   });
 });
 

--- a/packages/worker/src/__unit__/upload.test.ts
+++ b/packages/worker/src/__unit__/upload.test.ts
@@ -207,7 +207,9 @@ describe(uploadApplicationArchiveAsync.name, () => {
     const bucketKey = `test/${randomUUID()}/artifact.ipa`;
     const uploadUrl = `https://upload.url/${randomUUID()}`;
     const testSignedUploadAuthorization = randomUUID();
-    const uploadError = new Error('upload failed');
+    const uploadError = new Error(
+      'Failed to upload file: status: 403 status text: Forbidden, body: signed-url-secret'
+    );
 
     turtleFetchMock.mockImplementation(async () => {
       return {
@@ -254,6 +256,14 @@ describe(uploadApplicationArchiveAsync.name, () => {
       }),
       cause: uploadError,
     });
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.objectContaining({
+          message: 'Failed to upload file: status: 403 status text: Forbidden, body: <redacted>',
+        }),
+      }),
+      'Upload to upload session failed'
+    );
   });
 });
 
@@ -416,7 +426,9 @@ describe(uploadBuildArtifactsAsync.name, () => {
     const bucketKey = `test/${randomUUID()}/artifact.ipa`;
     const uploadUrl = `https://upload.url/${randomUUID()}`;
     const testSignedUploadAuthorization = randomUUID();
-    const uploadError = new Error('upload failed');
+    const uploadError = new Error(
+      'Failed to upload file: status: 403 status text: Forbidden, body: signed-url-secret'
+    );
     turtleFetchMock.mockImplementation(async () => {
       return {
         ok: true,
@@ -462,6 +474,14 @@ describe(uploadBuildArtifactsAsync.name, () => {
       }),
       cause: uploadError,
     });
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.objectContaining({
+          message: 'Failed to upload file: status: 403 status text: Forbidden, body: <redacted>',
+        }),
+      }),
+      'Upload to upload session failed'
+    );
   });
 });
 

--- a/packages/worker/src/config.ts
+++ b/packages/worker/src/config.ts
@@ -63,17 +63,6 @@ export default {
       defaultValue: null,
     }),
   },
-  gcsSignedUploadUrlForApplicationArchive: env<GCS.SignedUrl | null>(
-    'WORKER_RUNTIME_CONFIG_BASE64',
-    {
-      transform: createBase64EnvTransformer('gcsSignedUploadUrlForApplicationArchive'),
-      defaultValue: null,
-    }
-  ),
-  gcsSignedUploadUrlForBuildArtifacts: env<GCS.SignedUrl | null>('WORKER_RUNTIME_CONFIG_BASE64', {
-    transform: createBase64EnvTransformer('gcsSignedUploadUrlForBuildArtifacts'),
-    defaultValue: null,
-  }),
   workingdir: env('WORKINGDIR', { defaultValue: path.join(__dirname, '../workingdir') }),
   sentry: {
     dsn: env('SENTRY_DSN', { defaultValue: '' }),

--- a/packages/worker/src/external/turtle.ts
+++ b/packages/worker/src/external/turtle.ts
@@ -35,8 +35,6 @@ export namespace Worker {
   };
 
   type BuildWorkerRuntimeConfig = {
-    gcsSignedUploadUrlForApplicationArchive: GCS.SignedUrl | null;
-    gcsSignedUploadUrlForBuildArtifacts: GCS.SignedUrl | null;
     gcsSignedUploadUrlForLogs: GCS.SignedUrl;
     gcsSignedUploadUrlForXcodeBuildLogs?: GCS.SignedUrl;
     gcsSignedUploadUrlForBuildCache?: GCS.SignedUrl;

--- a/packages/worker/src/service.ts
+++ b/packages/worker/src/service.ts
@@ -319,8 +319,9 @@ export default class BuildService {
             : new errors.UnknownBuildError();
       const maybeRawError =
         error instanceof errors.ExpoError && error.cause instanceof Error ? error.cause : error;
+      const logError = error instanceof errors.SystemError ? err : maybeRawError;
 
-      logger.error({ err: maybeRawError }, err.message);
+      logger.error({ err: logError }, err.message);
       sentry.capture(err.message, maybeRawError, {
         tags: {
           ...(err.buildPhase ? { buildPhase: err.buildPhase } : {}),

--- a/packages/worker/src/service.ts
+++ b/packages/worker/src/service.ts
@@ -319,9 +319,8 @@ export default class BuildService {
             : new errors.UnknownBuildError();
       const maybeRawError =
         error instanceof errors.ExpoError && error.cause instanceof Error ? error.cause : error;
-      const logError = error instanceof errors.SystemError ? err : maybeRawError;
 
-      logger.error({ err: logError }, err.message);
+      logger.error({ err: maybeRawError }, err.message);
       sentry.capture(err.message, maybeRawError, {
         tags: {
           ...(err.buildPhase ? { buildPhase: err.buildPhase } : {}),

--- a/packages/worker/src/upload.ts
+++ b/packages/worker/src/upload.ts
@@ -27,6 +27,22 @@ class ErrorWithMetadata extends Error {
   }
 }
 
+function sanitizeUploadErrorForLogs(err: unknown): Error {
+  if (!(err instanceof Error)) {
+    return new Error(String(err));
+  }
+
+  const safeMessage = err.message
+    .replace(/^(Unexpected response from server \(\d+\)): [\S\s]*$/u, '$1: <redacted>')
+    .replace(/^(Failed to upload file: status: .*), body: [\S\s]*$/u, '$1, body: <redacted>');
+  const safeError = new Error(safeMessage);
+  safeError.name = err.name;
+  safeError.stack = err.stack
+    ? `${safeError.name}: ${safeMessage}\n${err.stack.split('\n').slice(1).join('\n')}`
+    : undefined;
+  return safeError;
+}
+
 export async function uploadApplicationArchiveAsync(
   ctx: BuildContext,
   {
@@ -69,7 +85,7 @@ export async function uploadApplicationArchiveAsync(
   } catch (err: any) {
     // Otherwise, we log the error and proceed to upload to Launcher's upload URL.
     const msg = 'Upload to upload session failed';
-    logger.error({ err, filename, size }, msg);
+    logger.error({ err: sanitizeUploadErrorForLogs(err), filename, size }, msg);
 
     throw new errors.SystemError('Failed to upload application archive.', {
       trackingCode: 'EAS_BUILD_UPLOAD_APPLICATION_ARCHIVE_FAILED',
@@ -125,7 +141,7 @@ export async function uploadBuildArtifactsAsync(
     return { filename: null };
   } catch (err: any) {
     const msg = 'Upload to upload session failed';
-    logger.error({ err, filename, size }, msg);
+    logger.error({ err: sanitizeUploadErrorForLogs(err), filename, size }, msg);
 
     throw new errors.SystemError('Failed to upload build artifacts.', {
       trackingCode: 'EAS_BUILD_UPLOAD_BUILD_ARTIFACTS_FAILED',

--- a/packages/worker/src/upload.ts
+++ b/packages/worker/src/upload.ts
@@ -1,5 +1,5 @@
 import { BuildContext, GCS } from '@expo/build-tools';
-import { ArchiveSourceType } from '@expo/eas-build-job';
+import { ArchiveSourceType, errors } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
 import fs from 'fs-extra';
@@ -76,7 +76,14 @@ export async function uploadApplicationArchiveAsync(
       },
     });
 
-    throw new Error(`Failed to upload application archive: ${err?.message}\n${err?.stack}`, {
+    throw new errors.SystemError('Failed to upload application archive.', {
+      trackingCode: 'EAS_BUILD_UPLOAD_APPLICATION_ARCHIVE_FAILED',
+      metadata: {
+        filename,
+        size,
+        ...uploadSession,
+        ...(err instanceof ErrorWithMetadata ? err.metadata : {}),
+      },
       cause: err,
     });
   }
@@ -132,7 +139,13 @@ export async function uploadBuildArtifactsAsync(
       },
     });
 
-    throw new Error(`Failed to upload build artifact: ${err?.message}\n${err?.stack}`, {
+    throw new errors.SystemError('Failed to upload build artifacts.', {
+      trackingCode: 'EAS_BUILD_UPLOAD_BUILD_ARTIFACTS_FAILED',
+      metadata: {
+        filename,
+        size,
+        ...uploadSession,
+      },
       cause: err,
     });
   }

--- a/packages/worker/src/upload.ts
+++ b/packages/worker/src/upload.ts
@@ -70,14 +70,6 @@ export async function uploadApplicationArchiveAsync(
     // Otherwise, we log the error and proceed to upload to Launcher's upload URL.
     const msg = 'Upload to upload session failed';
     logger.error({ err, filename, size }, msg);
-    sentry.capture(msg, err, {
-      extras: {
-        filename,
-        size,
-        ...uploadSession,
-        ...(err instanceof ErrorWithMetadata ? err.metadata : {}),
-      },
-    });
 
     throw new errors.SystemError('Failed to upload application archive.', {
       trackingCode: 'EAS_BUILD_UPLOAD_APPLICATION_ARCHIVE_FAILED',
@@ -134,13 +126,6 @@ export async function uploadBuildArtifactsAsync(
   } catch (err: any) {
     const msg = 'Upload to upload session failed';
     logger.error({ err, filename, size }, msg);
-    sentry.capture(msg, err, {
-      extras: {
-        filename,
-        size,
-        ...uploadSession,
-      },
-    });
 
     throw new errors.SystemError('Failed to upload build artifacts.', {
       trackingCode: 'EAS_BUILD_UPLOAD_BUILD_ARTIFACTS_FAILED',

--- a/packages/worker/src/upload.ts
+++ b/packages/worker/src/upload.ts
@@ -46,15 +46,11 @@ export async function uploadApplicationArchiveAsync(
 
   try {
     // Try to upload to the upload session first.
-    const { signedUrl, bucketKey, storageType } = await createUploadSessionAsync(
-      ctx,
-      {
-        filename,
-        name: 'Application Archive',
-        size,
-      },
-      logger
-    );
+    const { signedUrl, bucketKey, storageType } = await createUploadSessionAsync(ctx, {
+      filename,
+      name: 'Application Archive',
+      size,
+    });
 
     uploadSession = signedUrl;
 
@@ -66,7 +62,7 @@ export async function uploadApplicationArchiveAsync(
     });
 
     // If the upload succeeded, we save the artifact to the database.
-    await saveArtifactAsync(ctx, { bucketKey, type: 'applicationArchive', storageType }, logger);
+    await saveArtifactAsync(ctx, { bucketKey, type: 'applicationArchive', storageType });
 
     // The saved artifact has the right filename, we don't need Launcher to rename or store it.
     return { filename: null };
@@ -115,15 +111,11 @@ export async function uploadBuildArtifactsAsync(
 
   try {
     // Try to upload to the upload session first.
-    const { signedUrl, bucketKey, storageType } = await createUploadSessionAsync(
-      ctx,
-      {
-        filename,
-        name: 'Build Artifacts',
-        size,
-      },
-      logger
-    );
+    const { signedUrl, bucketKey, storageType } = await createUploadSessionAsync(ctx, {
+      filename,
+      name: 'Build Artifacts',
+      size,
+    });
 
     uploadSession = signedUrl;
 
@@ -135,7 +127,7 @@ export async function uploadBuildArtifactsAsync(
     });
 
     // If the upload succeeded, we save the artifact to the database.
-    await saveArtifactAsync(ctx, { bucketKey, type: 'buildArtifacts', storageType }, logger);
+    await saveArtifactAsync(ctx, { bucketKey, type: 'buildArtifacts', storageType });
 
     // The saved artifact has the right filename, we don't need Launcher to rename or store it.
     return { filename: null };
@@ -178,15 +170,11 @@ export async function uploadWorkflowArtifactAsync(
   const name = _name || filename;
 
   try {
-    const { signedUrl: uploadSession, artifactId } = await createUploadSessionAsync(
-      ctx,
-      {
-        filename,
-        name,
-        size,
-      },
-      logger
-    );
+    const { signedUrl: uploadSession, artifactId } = await createUploadSessionAsync(ctx, {
+      filename,
+      name,
+      size,
+    });
 
     await GCS.uploadWithSignedUrl({
       signedUrl: uploadSession,
@@ -267,8 +255,7 @@ function getCommonParentDir(path1: string, path2: string): string {
 
 async function createUploadSessionAsync(
   ctx: BuildContext,
-  { filename, name, size }: { filename: string; name: string; size: number },
-  logger: bunyan
+  { filename, name, size }: { filename: string; name: string; size: number }
 ): Promise<{
   bucketKey: string;
   signedUrl: GCS.SignedUrl;
@@ -302,7 +289,7 @@ async function createUploadSessionAsync(
           shouldThrowOnNotOk: false,
           retries: UPLOAD_API_REQUEST_RETRIES,
           retryIntervalMs: UPLOAD_API_REQUEST_RETRY_INTERVAL_MS,
-          logger,
+          logger: ctx.logger,
         }
       )
     );
@@ -319,7 +306,7 @@ async function createUploadSessionAsync(
           shouldThrowOnNotOk: false,
           retries: UPLOAD_API_REQUEST_RETRIES,
           retryIntervalMs: UPLOAD_API_REQUEST_RETRY_INTERVAL_MS,
-          logger,
+          logger: ctx.logger,
         }
       )
     );
@@ -401,8 +388,7 @@ async function saveArtifactAsync(
     bucketKey: string;
     type: 'applicationArchive' | 'buildArtifacts';
     storageType: ArchiveSourceType | null;
-  },
-  logger: bunyan
+  }
 ): Promise<void> {
   nullthrows(storageType, 'Missing storage type for build artifacts');
   const workflowJobId = ctx.env.__WORKFLOW_JOB_ID;
@@ -430,7 +416,7 @@ async function saveArtifactAsync(
           },
           retries: UPLOAD_API_REQUEST_RETRIES,
           retryIntervalMs: UPLOAD_API_REQUEST_RETRY_INTERVAL_MS,
-          logger,
+          logger: ctx.logger,
         }
       )
     );
@@ -446,7 +432,7 @@ async function saveArtifactAsync(
           },
           retries: UPLOAD_API_REQUEST_RETRIES,
           retryIntervalMs: UPLOAD_API_REQUEST_RETRY_INTERVAL_MS,
-          logger,
+          logger: ctx.logger,
         }
       )
     );

--- a/packages/worker/src/upload.ts
+++ b/packages/worker/src/upload.ts
@@ -76,28 +76,10 @@ export async function uploadApplicationArchiveAsync(
       },
     });
 
-    // Lack of `gcsSignedUploadUrlForApplicationArchive` means we're being run by workflow-orchestration.
-    if (!config.gcsSignedUploadUrlForApplicationArchive) {
-      throw new Error(`Failed to upload application archive: ${err?.message}\n${err?.stack}`, {
-        cause: err,
-      });
-    }
-  }
-
-  try {
-    await GCS.uploadWithSignedUrl({
-      signedUrl: config.gcsSignedUploadUrlForApplicationArchive,
-      srcGeneratorAsync: async () => {
-        return fs.createReadStream(localPath);
-      },
-    });
-  } catch (err: any) {
     throw new Error(`Failed to upload application archive: ${err?.message}\n${err?.stack}`, {
       cause: err,
     });
   }
-
-  return { filename };
 }
 
 export async function uploadBuildArtifactsAsync(
@@ -140,14 +122,6 @@ export async function uploadBuildArtifactsAsync(
     // The saved artifact has the right filename, we don't need Launcher to rename or store it.
     return { filename: null };
   } catch (err: any) {
-    // Lack of `gcsSignedUploadUrlForBuildArtifacts` means we're being run by workflow-orchestration.
-    if (!config.gcsSignedUploadUrlForBuildArtifacts) {
-      throw new Error(`Failed to upload build artifact: ${err?.message}\n${err?.stack}`, {
-        cause: err,
-      });
-    }
-
-    // Otherwise, we log the error and proceed to upload to Launcher's upload URL.
     const msg = 'Upload to upload session failed';
     logger.error({ err, filename, size }, msg);
     sentry.capture(msg, err, {
@@ -157,22 +131,11 @@ export async function uploadBuildArtifactsAsync(
         ...uploadSession,
       },
     });
-  }
 
-  try {
-    await GCS.uploadWithSignedUrl({
-      signedUrl: config.gcsSignedUploadUrlForBuildArtifacts,
-      srcGeneratorAsync: async () => {
-        return fs.createReadStream(localPath);
-      },
-    });
-  } catch (err: any) {
     throw new Error(`Failed to upload build artifact: ${err?.message}\n${err?.stack}`, {
       cause: err,
     });
   }
-
-  return { filename };
 }
 
 export async function uploadWorkflowArtifactAsync(

--- a/packages/worker/src/upload.ts
+++ b/packages/worker/src/upload.ts
@@ -68,8 +68,7 @@ export async function uploadApplicationArchiveAsync(
     return { filename: null };
   } catch (err: any) {
     // Otherwise, we log the error and proceed to upload to Launcher's upload URL.
-    const msg = 'Upload to upload session failed';
-    logger.error({ err, filename, size }, msg);
+    logger.error({ err, filename, size }, 'Upload to upload session failed');
 
     throw new errors.SystemError('Failed to upload application archive.', {
       trackingCode: 'EAS_BUILD_UPLOAD_APPLICATION_ARCHIVE_FAILED',
@@ -124,8 +123,7 @@ export async function uploadBuildArtifactsAsync(
     // The saved artifact has the right filename, we don't need Launcher to rename or store it.
     return { filename: null };
   } catch (err: any) {
-    const msg = 'Upload to upload session failed';
-    logger.error({ err, filename, size }, msg);
+    logger.error({ err, filename, size }, 'Upload to upload session failed');
 
     throw new errors.SystemError('Failed to upload build artifacts.', {
       trackingCode: 'EAS_BUILD_UPLOAD_BUILD_ARTIFACTS_FAILED',

--- a/packages/worker/src/upload.ts
+++ b/packages/worker/src/upload.ts
@@ -27,22 +27,6 @@ class ErrorWithMetadata extends Error {
   }
 }
 
-function sanitizeUploadErrorForLogs(err: unknown): Error {
-  if (!(err instanceof Error)) {
-    return new Error(String(err));
-  }
-
-  const safeMessage = err.message
-    .replace(/^(Unexpected response from server \(\d+\)): [\S\s]*$/u, '$1: <redacted>')
-    .replace(/^(Failed to upload file: status: .*), body: [\S\s]*$/u, '$1, body: <redacted>');
-  const safeError = new Error(safeMessage);
-  safeError.name = err.name;
-  safeError.stack = err.stack
-    ? `${safeError.name}: ${safeMessage}\n${err.stack.split('\n').slice(1).join('\n')}`
-    : undefined;
-  return safeError;
-}
-
 export async function uploadApplicationArchiveAsync(
   ctx: BuildContext,
   {
@@ -85,7 +69,7 @@ export async function uploadApplicationArchiveAsync(
   } catch (err: any) {
     // Otherwise, we log the error and proceed to upload to Launcher's upload URL.
     const msg = 'Upload to upload session failed';
-    logger.error({ err: sanitizeUploadErrorForLogs(err), filename, size }, msg);
+    logger.error({ err, filename, size }, msg);
 
     throw new errors.SystemError('Failed to upload application archive.', {
       trackingCode: 'EAS_BUILD_UPLOAD_APPLICATION_ARCHIVE_FAILED',
@@ -141,7 +125,7 @@ export async function uploadBuildArtifactsAsync(
     return { filename: null };
   } catch (err: any) {
     const msg = 'Upload to upload session failed';
-    logger.error({ err: sanitizeUploadErrorForLogs(err), filename, size }, msg);
+    logger.error({ err, filename, size }, msg);
 
     throw new errors.SystemError('Failed to upload build artifacts.', {
       trackingCode: 'EAS_BUILD_UPLOAD_BUILD_ARTIFACTS_FAILED',

--- a/packages/worker/src/upload.ts
+++ b/packages/worker/src/upload.ts
@@ -13,6 +13,9 @@ import { Analytics, Event } from './external/analytics';
 import sentry from './sentry';
 import { TurtleFetchError, turtleFetch } from './utils/turtleFetch';
 
+const UPLOAD_API_REQUEST_RETRIES = 2;
+const UPLOAD_API_REQUEST_RETRY_INTERVAL_MS = 1000;
+
 class ErrorWithMetadata extends Error {
   constructor(
     message: string,
@@ -43,11 +46,15 @@ export async function uploadApplicationArchiveAsync(
 
   try {
     // Try to upload to the upload session first.
-    const { signedUrl, bucketKey, storageType } = await createUploadSessionAsync(ctx, {
-      filename,
-      name: 'Application Archive',
-      size,
-    });
+    const { signedUrl, bucketKey, storageType } = await createUploadSessionAsync(
+      ctx,
+      {
+        filename,
+        name: 'Application Archive',
+        size,
+      },
+      logger
+    );
 
     uploadSession = signedUrl;
 
@@ -59,7 +66,7 @@ export async function uploadApplicationArchiveAsync(
     });
 
     // If the upload succeeded, we save the artifact to the database.
-    await saveArtifactAsync(ctx, { bucketKey, type: 'applicationArchive', storageType });
+    await saveArtifactAsync(ctx, { bucketKey, type: 'applicationArchive', storageType }, logger);
 
     // The saved artifact has the right filename, we don't need Launcher to rename or store it.
     return { filename: null };
@@ -108,11 +115,15 @@ export async function uploadBuildArtifactsAsync(
 
   try {
     // Try to upload to the upload session first.
-    const { signedUrl, bucketKey, storageType } = await createUploadSessionAsync(ctx, {
-      filename,
-      name: 'Build Artifacts',
-      size,
-    });
+    const { signedUrl, bucketKey, storageType } = await createUploadSessionAsync(
+      ctx,
+      {
+        filename,
+        name: 'Build Artifacts',
+        size,
+      },
+      logger
+    );
 
     uploadSession = signedUrl;
 
@@ -124,7 +135,7 @@ export async function uploadBuildArtifactsAsync(
     });
 
     // If the upload succeeded, we save the artifact to the database.
-    await saveArtifactAsync(ctx, { bucketKey, type: 'buildArtifacts', storageType });
+    await saveArtifactAsync(ctx, { bucketKey, type: 'buildArtifacts', storageType }, logger);
 
     // The saved artifact has the right filename, we don't need Launcher to rename or store it.
     return { filename: null };
@@ -167,11 +178,15 @@ export async function uploadWorkflowArtifactAsync(
   const name = _name || filename;
 
   try {
-    const { signedUrl: uploadSession, artifactId } = await createUploadSessionAsync(ctx, {
-      filename,
-      name,
-      size,
-    });
+    const { signedUrl: uploadSession, artifactId } = await createUploadSessionAsync(
+      ctx,
+      {
+        filename,
+        name,
+        size,
+      },
+      logger
+    );
 
     await GCS.uploadWithSignedUrl({
       signedUrl: uploadSession,
@@ -252,7 +267,8 @@ function getCommonParentDir(path1: string, path2: string): string {
 
 async function createUploadSessionAsync(
   ctx: BuildContext,
-  { filename, name, size }: { filename: string; name: string; size: number }
+  { filename, name, size }: { filename: string; name: string; size: number },
+  logger: bunyan
 ): Promise<{
   bucketKey: string;
   signedUrl: GCS.SignedUrl;
@@ -284,6 +300,9 @@ async function createUploadSessionAsync(
             Authorization: `Bearer ${robotAccessToken}`,
           },
           shouldThrowOnNotOk: false,
+          retries: UPLOAD_API_REQUEST_RETRIES,
+          retryIntervalMs: UPLOAD_API_REQUEST_RETRY_INTERVAL_MS,
+          logger,
         }
       )
     );
@@ -298,6 +317,9 @@ async function createUploadSessionAsync(
             Authorization: `Bearer ${robotAccessToken}`,
           },
           shouldThrowOnNotOk: false,
+          retries: UPLOAD_API_REQUEST_RETRIES,
+          retryIntervalMs: UPLOAD_API_REQUEST_RETRY_INTERVAL_MS,
+          logger,
         }
       )
     );
@@ -379,7 +401,8 @@ async function saveArtifactAsync(
     bucketKey: string;
     type: 'applicationArchive' | 'buildArtifacts';
     storageType: ArchiveSourceType | null;
-  }
+  },
+  logger: bunyan
 ): Promise<void> {
   nullthrows(storageType, 'Missing storage type for build artifacts');
   const workflowJobId = ctx.env.__WORKFLOW_JOB_ID;
@@ -405,6 +428,9 @@ async function saveArtifactAsync(
           headers: {
             Authorization: `Bearer ${robotAccessToken}`,
           },
+          retries: UPLOAD_API_REQUEST_RETRIES,
+          retryIntervalMs: UPLOAD_API_REQUEST_RETRY_INTERVAL_MS,
+          logger,
         }
       )
     );
@@ -418,6 +444,9 @@ async function saveArtifactAsync(
           headers: {
             Authorization: `Bearer ${robotAccessToken}`,
           },
+          retries: UPLOAD_API_REQUEST_RETRIES,
+          retryIntervalMs: UPLOAD_API_REQUEST_RETRY_INTERVAL_MS,
+          logger,
         }
       )
     );


### PR DESCRIPTION
## What changed

- Removed `gcsSignedUploadUrlForApplicationArchive` and `gcsSignedUploadUrlForBuildArtifacts` from worker runtime config and runtime config typing.
- Removed launcher signed-upload fallback behavior for managed application archive and build artifacts uploads.
- Classified managed artifact upload failures as `SystemError`s with internal tracking codes while keeping the public error code as `SERVER_ERROR`.
- Added retry options to worker upload API `turtleFetch` calls for upload-session creation and artifact metadata saving.

## Why

These signed upload URL fields are no longer expected, so keeping fallback paths made the worker handle an obsolete runtime contract. Upload failures in these managed paths are infrastructure/API/storage failures rather than user-actionable project issues.

## Validation

- `yarn oxfmt packages/worker/src/config.ts packages/worker/src/upload.ts packages/worker/src/external/turtle.ts packages/worker/src/__unit__/upload.test.ts`
- `yarn workspace @expo/worker test:unit src/__unit__/upload.test.ts --runInBand`
- `yarn workspace @expo/worker typecheck`