### PR TITLE
[build-tools] Use environment variable to enable Gradle cache instead of `gradle.properties`

### DIFF
--- a/packages/build-tools/src/builders/__tests__/android.test.ts
+++ b/packages/build-tools/src/builders/__tests__/android.test.ts
@@ -137,7 +137,6 @@ describe(androidBuilder, () => {
       logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
       logger: createMockLogger(),
       env: {
-        EAS_BUILD_RUNNER: 'eas-build',
         __API_SERVER_URL: 'http://api.expo.test',
       },
       uploadArtifact: jest.fn(),

--- a/packages/build-tools/src/builders/__tests__/android.test.ts
+++ b/packages/build-tools/src/builders/__tests__/android.test.ts
@@ -13,6 +13,10 @@ import {
   injectConfigureVersionGradleConfig,
   injectCredentialsGradleConfig,
 } from '../../steps/utils/android/gradleConfig';
+import {
+  logGradleCacheEnv,
+  restoreGradleCacheAsync,
+} from '../../steps/functions/restoreBuildCache';
 
 jest.mock('../common', () => ({
   runBuilderWithHooksAsync: jest.fn(async (ctx, buildFn) => {
@@ -41,10 +45,13 @@ jest.mock('../../common/setup', () => ({
 }));
 jest.mock('../../steps/functions/restoreBuildCache', () => ({
   cacheStatsAsync: jest.fn(),
+  logGradleCacheEnv: jest.fn(),
   restoreCcacheAsync: jest.fn(),
+  restoreGradleCacheAsync: jest.fn(async () => ({ env: {} })),
 }));
 jest.mock('../../steps/functions/saveBuildCache', () => ({
   saveCcacheAsync: jest.fn(),
+  saveGradleCacheAsync: jest.fn(),
 }));
 jest.mock('../../steps/utils/android/gradleConfig', () => ({
   ...jest.requireActual('../../steps/utils/android/gradleConfig'),
@@ -130,6 +137,7 @@ describe(androidBuilder, () => {
       logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
       logger: createMockLogger(),
       env: {
+        EAS_BUILD_RUNNER: 'eas-build',
         __API_SERVER_URL: 'http://api.expo.test',
       },
       uploadArtifact: jest.fn(),
@@ -143,6 +151,30 @@ describe(androidBuilder, () => {
     );
     expect(restoreCredentials).toHaveBeenCalledWith(ctx);
     expect(injectConfigureVersionGradleConfig).not.toHaveBeenCalled();
+  });
+
+  it('logs Gradle cache environment variables returned by restoreGradleCacheAsync', async () => {
+    jest.mocked(restoreGradleCacheAsync).mockResolvedValueOnce({
+      env: {
+        'ORG_GRADLE_PROJECT_org.gradle.caching': 'true',
+      },
+    });
+    const ctx = new BuildContext(createTestAndroidJob(), {
+      workingdir: '/workingdir',
+      logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+      logger: createMockLogger(),
+      env: {
+        EAS_BUILD_RUNNER: 'eas-build',
+        __API_SERVER_URL: 'http://api.expo.test',
+      },
+      uploadArtifact: jest.fn(),
+    });
+
+    await androidBuilder(ctx);
+
+    expect(logGradleCacheEnv).toHaveBeenCalledWith(expect.anything(), {
+      'ORG_GRADLE_PROJECT_org.gradle.caching': 'true',
+    });
   });
 
   it('marks the configure Android version phase as warning for legacy eas-build.gradle', async () => {

--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -1,4 +1,4 @@
-import { Android, BuildMode, BuildPhase, BuildTrigger, Workflow } from '@expo/eas-build-job';
+import { Android, BuildMode, BuildPhase, Workflow } from '@expo/eas-build-job';
 import nullthrows from 'nullthrows';
 import path from 'path';
 
@@ -96,9 +96,7 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
       secrets: ctx.job.secrets,
     });
     if (Object.keys(env).length > 0) {
-      if (ctx.job.triggeredBy === BuildTrigger.GIT_BASED_INTEGRATION) {
-        ctx.updateEnv(env);
-      }
+      Object.assign(ctx.env, env);
       logGradleCacheEnv(ctx.logger, env);
     }
   });

--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -1,4 +1,4 @@
-import { Android, BuildMode, BuildPhase, Workflow } from '@expo/eas-build-job';
+import { Android, BuildMode, BuildPhase, BuildTrigger, Workflow } from '@expo/eas-build-job';
 import nullthrows from 'nullthrows';
 import path from 'path';
 
@@ -18,6 +18,7 @@ import { setupAsync } from '../common/setup';
 import { Artifacts, BuildContext, SkipNativeBuildError } from '../context';
 import {
   cacheStatsAsync,
+  logGradleCacheEnv,
   restoreCcacheAsync,
   restoreGradleCacheAsync,
 } from '../steps/functions/restoreBuildCache';
@@ -88,12 +89,18 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
       env: ctx.env,
       secrets: ctx.job.secrets,
     });
-    await restoreGradleCacheAsync({
+    const { env } = await restoreGradleCacheAsync({
       logger: ctx.logger,
       workingDirectory,
       env: ctx.env,
       secrets: ctx.job.secrets,
     });
+    if (Object.keys(env).length > 0) {
+      if (ctx.job.triggeredBy === BuildTrigger.GIT_BASED_INTEGRATION) {
+        ctx.updateEnv(env);
+      }
+      logGradleCacheEnv(ctx.logger, env);
+    }
   });
 
   await ctx.runBuildPhase(BuildPhase.POST_INSTALL_HOOK, async () => {

--- a/packages/build-tools/src/steps/functions/restoreBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreBuildCache.ts
@@ -57,12 +57,19 @@ export function createRestoreBuildCacheFunction(): BuildFunction {
       });
 
       if (platform === Platform.ANDROID) {
-        await restoreGradleCacheAsync({
+        const { env: gradleCacheEnv } = await restoreGradleCacheAsync({
           logger,
           workingDirectory,
           env,
           secrets: stepCtx.global.staticContext.job.secrets,
         });
+        if (Object.keys(gradleCacheEnv).length > 0) {
+          stepCtx.global.updateEnv({
+            ...stepCtx.global.env,
+            ...gradleCacheEnv,
+          });
+          logGradleCacheEnv(logger, gradleCacheEnv);
+        }
       }
     },
   });
@@ -200,19 +207,16 @@ export async function restoreGradleCacheAsync({
   workingDirectory: string;
   env: Record<string, string | undefined>;
   secrets?: { robotAccessToken?: string };
-}): Promise<void> {
+}): Promise<{ env: Record<string, string> }> {
   if (env.EAS_GRADLE_CACHE !== '1') {
-    return;
+    return { env: {} };
   }
 
-  try {
-    const gradlePropertiesPath = path.join(workingDirectory, 'android', 'gradle.properties');
-    const gradlePropertiesContent = await fs.promises.readFile(gradlePropertiesPath, 'utf-8');
-    await fs.promises.writeFile(
-      gradlePropertiesPath,
-      `${gradlePropertiesContent}\n\norg.gradle.caching=true\n`
-    );
+  const gradleCacheEnv = {
+    'ORG_GRADLE_PROJECT_org.gradle.caching': 'true',
+  };
 
+  try {
     // Configure cache cleanup via init script (works with both Gradle 8 and 9,
     // org.gradle.cache.cleanup property was removed in Gradle 9)
     const initScriptDir = path.join(os.homedir(), '.gradle', 'init.d');
@@ -294,6 +298,18 @@ export async function restoreGradleCacheAsync({
       logger.warn('Failed to restore Gradle cache: ', err);
     }
   }
+
+  return { env: gradleCacheEnv };
+}
+
+export function logGradleCacheEnv(logger: bunyan, env: Record<string, string>): void {
+  logger.info(
+    `Enabling Gradle cache. Running Gradle with additional environment variables.\n${Object.entries(
+      env
+    )
+      .map(([key, value]) => `${key}=${value}`)
+      .join('\n')}`
+  );
 }
 
 export async function cacheStatsAsync({


### PR DESCRIPTION
Instead of mutating `gradle.properties` which can influence fingerprint we can use environment variable to enable caching.

See https://docs.gradle.org/current/userguide/build_environment.html#setting_a_project_property and https://exponent-internal.slack.com/archives/C1QP38NQ5/p1781167813244859?thread_ts=1781160178.382929&cid=C1QP38NQ5.