### PR TITLE
[build-tools] Enable Gradle cache via machine-level gradle.properties to avoid fingerprint mutation

### DIFF
--- a/packages/build-tools/src/steps/functions/restoreBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreBuildCache.ts
@@ -206,16 +206,16 @@ export async function restoreGradleCacheAsync({
   }
 
   try {
-    const gradlePropertiesPath = path.join(workingDirectory, 'android', 'gradle.properties');
-    const gradlePropertiesContent = await fs.promises.readFile(gradlePropertiesPath, 'utf-8');
-    await fs.promises.writeFile(
-      gradlePropertiesPath,
-      `${gradlePropertiesContent}\n\norg.gradle.caching=true\n`
-    );
+    // Enable build cache via user-level gradle.properties.
+    // This avoids mutating android/gradle.properties which affects fingerprinting.
+    const gradleUserHome = path.join(os.homedir(), '.gradle');
+    await fs.promises.mkdir(gradleUserHome, { recursive: true });
+    const userGradlePropertiesPath = path.join(gradleUserHome, 'gradle.properties');
+    await fs.promises.appendFile(userGradlePropertiesPath, '\norg.gradle.caching=true\n');
 
-    // Configure cache cleanup via init script (works with both Gradle 8 and 9,
-    // org.gradle.cache.cleanup property was removed in Gradle 9)
-    const initScriptDir = path.join(os.homedir(), '.gradle', 'init.d');
+    // Configure cache cleanup via init script.
+    // Works with both Gradle 8 and 9 (org.gradle.cache.cleanup property was removed in Gradle 9).
+    const initScriptDir = path.join(gradleUserHome, 'init.d');
     await fs.promises.mkdir(initScriptDir, { recursive: true });
     await fs.promises.writeFile(
       path.join(initScriptDir, 'eas-cache-cleanup.gradle'),


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Writing `org.gradle.caching=true` to `android/gradle.properties` mutates a project file, which affects Expo fingerprinting. This can cause unnecessary cache invalidation and incorrect fingerprint changes. We explored enabling via environment variable https://github.com/expo/eas-cli/pull/3849 which is still not supported https://github.com/gradle/gradle/issues/18087


# How

Enable Gradle build cache by writing to `~/.gradle/gradle.properties` (machine-level) instead of `android/gradle.properties` (project-level). This is functionally equivalent but doesn't touch any project files.

# Test Plan

Validated locally and confirmed Gradle cache hits (`FROM-CACHE`) in the build output, matching the behavior of the current approach.

<img width="878" height="555" alt="Screenshot 2026-06-11 at 11 44 38 AM" src="https://github.com/user-attachments/assets/525814fc-14cf-4be9-9b69-b487f34e553c" />

