### PR TITLE
[eas-cli] Simplify 2FA now that SMS is no longer supported

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "**/*.code-search": true,
     "**/src/**/build/**": false,
     "**/src/build/**": false,
-  }
+  },
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Simplify 2FA now that SMS is no longer supported. ([#3859](https://github.com/expo/eas-cli/pull/3859) by [@wschurman](https://github.com/wschurman))
+
 ## [20.2.0](https://github.com/expo/eas-cli/releases/tag/v20.2.0) - 2026-06-15
 
 ### 🎉 New features

--- a/packages/eas-cli/src/user/SessionManager.ts
+++ b/packages/eas-cli/src/user/SessionManager.ts
@@ -1,6 +1,5 @@
 import JsonFile from '@expo/json-file';
 import { Errors } from '@oclif/core';
-import assert from 'assert';
 import chalk from 'chalk';
 import nullthrows from 'nullthrows';
 
@@ -13,7 +12,7 @@ import { createGraphqlClient } from '../commandUtils/context/contextUtils/create
 import { CurrentUserQuery } from '../graphql/generated';
 import { UserQuery } from '../graphql/queries/UserQuery';
 import Log, { learnMore } from '../log';
-import { promptAsync, selectAsync } from '../prompts';
+import { promptAsync } from '../prompts';
 import { getStateJsonPath } from '../utils/paths';
 
 type UserSettingsData = {
@@ -27,18 +26,6 @@ type SessionData = {
   userId: string;
   username: string;
   currentConnection: 'Username-Password-Authentication' | 'Browser-Flow-Authentication';
-};
-
-export enum UserSecondFactorDeviceMethod {
-  AUTHENTICATOR = 'authenticator',
-  SMS = 'sms',
-}
-
-type SecondFactorDevice = {
-  id: string;
-  method: UserSecondFactorDeviceMethod;
-  sms_phone_number: string | null;
-  is_primary: boolean;
 };
 
 export type LoggedInAuthenticationInfo =
@@ -205,11 +192,7 @@ export default class SessionManager {
       });
     } catch (e) {
       if (e instanceof ApiV2Error && e.expoApiV2ErrorCode === 'ONE_TIME_PASSWORD_REQUIRED') {
-        await this.retryUsernamePasswordAuthWithOTPAsync(
-          username,
-          password,
-          e.expoApiV2ErrorMetadata as any
-        );
+        await this.retryUsernamePasswordAuthWithOTPAsync(username, password);
       } else {
         throw e;
       }
@@ -245,11 +228,8 @@ export default class SessionManager {
   /**
    * Prompt for an OTP with the option to cancel the question by answering empty (pressing return key).
    */
-  private async promptForOTPAsync(cancelBehavior: 'cancel' | 'menu'): Promise<string | null> {
-    const enterMessage =
-      cancelBehavior === 'cancel'
-        ? `press ${chalk.bold('Enter')} to cancel`
-        : `press ${chalk.bold('Enter')} for more options`;
+  private async promptForOTPAsync(): Promise<string | null> {
+    const enterMessage = `press ${chalk.bold('Enter')} to cancel`;
     const { otp } = await promptAsync({
       type: 'text',
       name: 'otp',
@@ -263,122 +243,14 @@ export default class SessionManager {
   }
 
   /**
-   * Prompt for user to choose a backup OTP method. If selected method is SMS, a request
-   * for a new OTP will be sent to that method. Then, prompt for the OTP, and retry the user login.
-   */
-  private async promptForBackupOTPAsync(
-    username: string,
-    password: string,
-    secondFactorDevices: SecondFactorDevice[]
-  ): Promise<string | null> {
-    const nonPrimarySecondFactorDevices = secondFactorDevices.filter(device => !device.is_primary);
-
-    if (nonPrimarySecondFactorDevices.length === 0) {
-      throw new Error(
-        'No other second-factor devices set up. Ensure you have set up and certified a backup device.'
-      );
-    }
-
-    const hasAuthenticatorSecondFactorDevice = nonPrimarySecondFactorDevices.find(
-      device => device.method === UserSecondFactorDeviceMethod.AUTHENTICATOR
-    );
-
-    const smsNonPrimarySecondFactorDevices = nonPrimarySecondFactorDevices.filter(
-      device => device.method === UserSecondFactorDeviceMethod.SMS
-    );
-
-    const authenticatorChoiceSentinel = -1;
-    const cancelChoiceSentinel = -2;
-
-    const deviceChoices = smsNonPrimarySecondFactorDevices.map((device, idx) => ({
-      title: device.sms_phone_number!,
-      value: idx,
-    }));
-
-    if (hasAuthenticatorSecondFactorDevice) {
-      deviceChoices.push({
-        title: 'Authenticator',
-        value: authenticatorChoiceSentinel,
-      });
-    }
-
-    deviceChoices.push({
-      title: 'Cancel',
-      value: cancelChoiceSentinel,
-    });
-
-    const selectedValue = await selectAsync('Select a second-factor device:', deviceChoices);
-    if (selectedValue === cancelChoiceSentinel) {
-      return null;
-    } else if (selectedValue === authenticatorChoiceSentinel) {
-      return await this.promptForOTPAsync('cancel');
-    }
-
-    const device = smsNonPrimarySecondFactorDevices[selectedValue];
-
-    // this is a logged-out endpoint
-    const apiV2Client = new ApiV2Client({ accessToken: null, sessionSecret: null });
-    await apiV2Client.postAsync('auth/send-sms-otp', {
-      body: {
-        username,
-        password,
-        secondFactorDeviceID: device.id,
-      },
-    });
-
-    return await this.promptForOTPAsync('cancel');
-  }
-
-  /**
-   * Handle the special case error indicating that a second-factor is required for
-   * authentication.
-   *
-   * There are three cases we need to handle:
-   * 1. User's primary second-factor device was SMS, OTP was automatically sent by the server to that
-   *    device already. In this case we should just prompt for the SMS OTP (or backup code), which the
-   *    user should be receiving shortly. We should give the user a way to cancel and the prompt and move
-   *    to case 3 below.
-   * 2. User's primary second-factor device is authenticator. In this case we should prompt for authenticator
-   *    OTP (or backup code) and also give the user a way to cancel and move to case 3 below.
-   * 3. User doesn't have a primary device or doesn't have access to their primary device. In this case
-   *    we should show a picker of the SMS devices that they can have an OTP code sent to, and when
-   *    the user picks one we show a prompt() for the sent OTP.
+   * Handle the special case error indicating that a second-factor is required for authentication.
    */
   private async retryUsernamePasswordAuthWithOTPAsync(
     username: string,
-    password: string,
-    metadata: {
-      secondFactorDevices?: SecondFactorDevice[];
-      smsAutomaticallySent?: boolean;
-    }
+    password: string
   ): Promise<void> {
-    const { secondFactorDevices, smsAutomaticallySent } = metadata;
-    assert(
-      secondFactorDevices !== undefined && smsAutomaticallySent !== undefined,
-      `Malformed OTP error metadata: ${metadata}`
-    );
-
-    const primaryDevice = secondFactorDevices.find(device => device.is_primary);
-    let otp: string | null = null;
-
-    if (smsAutomaticallySent) {
-      assert(primaryDevice, 'OTP should only automatically be sent when there is a primary device');
-      Log.log(
-        `One-time password was sent to the phone number ending in ${primaryDevice.sms_phone_number}.`
-      );
-      otp = await this.promptForOTPAsync('menu');
-    }
-
-    if (primaryDevice?.method === UserSecondFactorDeviceMethod.AUTHENTICATOR) {
-      Log.log('One-time password from authenticator required.');
-      otp = await this.promptForOTPAsync('menu');
-    }
-
-    // user bailed on case 1 or 2, wants to move to case 3
-    if (!otp) {
-      otp = await this.promptForBackupOTPAsync(username, password, secondFactorDevices);
-    }
-
+    Log.log('One-time password from authenticator required.');
+    const otp = await this.promptForOTPAsync();
     if (!otp) {
       throw new Error('Cancelled login');
     }

--- a/packages/eas-cli/src/user/__tests__/SessionManager-test.ts
+++ b/packages/eas-cli/src/user/__tests__/SessionManager-test.ts
@@ -6,9 +6,9 @@ import { ApiV2Error } from '../../ApiV2Error';
 import { AnalyticsWithOrchestration } from '../../analytics/AnalyticsManager';
 import { ApiV2Client } from '../../api';
 import Log from '../../log';
-import { promptAsync, selectAsync } from '../../prompts';
+import { promptAsync } from '../../prompts';
 import { getStateJsonPath } from '../../utils/paths';
-import SessionManager, { UserSecondFactorDeviceMethod } from '../SessionManager';
+import SessionManager from '../SessionManager';
 import { fetchSessionSecretAndUserAsync } from '../fetchSessionSecretAndUser';
 import { fetchSessionSecretAndUserFromBrowserAuthFlowAsync } from '../fetchSessionSecretAndUserFromBrowserAuthFlow';
 
@@ -275,17 +275,6 @@ describe(SessionManager, () => {
           throw new ApiV2Error({
             message: 'An OTP is required',
             code: 'ONE_TIME_PASSWORD_REQUIRED',
-            metadata: {
-              secondFactorDevices: [
-                {
-                  id: 'p0',
-                  is_primary: true,
-                  method: UserSecondFactorDeviceMethod.SMS,
-                  sms_phone_number: 'testphone',
-                },
-              ],
-              smsAutomaticallySent: true,
-            },
           });
         })
         .mockResolvedValueOnce({
@@ -298,18 +287,7 @@ describe(SessionManager, () => {
 
       expect(sessionManagerRetryUsernamePasswordAuthWithOTPAsyncSpy).toHaveBeenCalledWith(
         'hello',
-        'world',
-        {
-          secondFactorDevices: [
-            {
-              id: 'p0',
-              is_primary: true,
-              method: UserSecondFactorDeviceMethod.SMS,
-              sms_phone_number: 'testphone',
-            },
-          ],
-          smsAutomaticallySent: true,
-        }
+        'world'
       );
     });
 
@@ -383,7 +361,7 @@ describe(SessionManager, () => {
   });
 
   describe('retryUsernamePasswordAuthWithOTPAsync', () => {
-    it('shows SMS OTP prompt when SMS is primary and code was automatically sent', async () => {
+    it('shows authenticator OTP prompt', async () => {
       jest
         .mocked(promptAsync)
         .mockImplementationOnce(async () => ({ otp: 'hello' }))
@@ -393,246 +371,24 @@ describe(SessionManager, () => {
       const sessionManager = new SessionManager(analytics);
       const sessionManagerLoginAsyncSpy = jest.spyOn(sessionManager as any, 'loginAsync');
 
-      await sessionManager['retryUsernamePasswordAuthWithOTPAsync']('blah', 'blah', {
-        secondFactorDevices: [
-          {
-            id: 'p0',
-            is_primary: true,
-            method: UserSecondFactorDeviceMethod.SMS,
-            sms_phone_number: 'testphone',
-          },
-        ],
-        smsAutomaticallySent: true,
-      });
-
-      expect(Log.log).toHaveBeenCalledWith(
-        'One-time password was sent to the phone number ending in testphone.'
-      );
-
-      expect(sessionManagerLoginAsyncSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('shows authenticator OTP prompt when authenticator is primary', async () => {
-      jest
-        .mocked(promptAsync)
-        .mockImplementationOnce(async () => ({ otp: 'hello' }))
-        .mockImplementation(() => {
-          throw new Error("shouldn't happen");
-        });
-      const sessionManager = new SessionManager(analytics);
-      const sessionManagerLoginAsyncSpy = jest.spyOn(sessionManager as any, 'loginAsync');
-
-      await sessionManager['retryUsernamePasswordAuthWithOTPAsync']('blah', 'blah', {
-        secondFactorDevices: [
-          {
-            id: 'p0',
-            is_primary: true,
-            method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-            sms_phone_number: null,
-          },
-        ],
-        smsAutomaticallySent: false,
-      });
+      await sessionManager['retryUsernamePasswordAuthWithOTPAsync']('blah', 'blah');
 
       expect(Log.log).toHaveBeenCalledWith('One-time password from authenticator required.');
       expect(sessionManagerLoginAsyncSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('shows menu when user bails on primary', async () => {
-      jest
-        .mocked(promptAsync)
-        .mockImplementationOnce(async () => ({ otp: null }))
-        .mockImplementationOnce(async () => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
-        .mockImplementation(() => {
-          throw new Error("shouldn't happen");
-        });
-
-      jest
-        .mocked(selectAsync)
-        .mockImplementationOnce(async () => -1)
-        .mockImplementation(() => {
-          throw new Error("shouldn't happen");
-        });
-      const sessionManager = new SessionManager(analytics);
-
-      const sessionManagerLoginAsyncSpy = jest.spyOn(sessionManager as any, 'loginAsync');
-
-      await sessionManager['retryUsernamePasswordAuthWithOTPAsync']('blah', 'blah', {
-        secondFactorDevices: [
-          {
-            id: 'p0',
-            is_primary: true,
-            method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-            sms_phone_number: null,
-          },
-          {
-            id: 'p2',
-            is_primary: false,
-            method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-            sms_phone_number: null,
-          },
-        ],
-        smsAutomaticallySent: false,
-      });
-
-      expect(jest.mocked(selectAsync).mock.calls.length).toEqual(1);
-      expect(sessionManagerLoginAsyncSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('shows a warning when when user bails on primary and does not have any secondary set up', async () => {
+    it('exits when user bails', async () => {
       jest
         .mocked(promptAsync)
         .mockImplementationOnce(async () => ({ otp: null }))
         .mockImplementation(() => {
           throw new Error("shouldn't happen");
         });
+
       const sessionManager = new SessionManager(analytics);
 
       await expect(
-        sessionManager['retryUsernamePasswordAuthWithOTPAsync']('blah', 'blah', {
-          secondFactorDevices: [
-            {
-              id: 'p0',
-              is_primary: true,
-              method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-              sms_phone_number: null,
-            },
-          ],
-          smsAutomaticallySent: false,
-        })
-      ).rejects.toThrowError(
-        'No other second-factor devices set up. Ensure you have set up and certified a backup device.'
-      );
-    });
-
-    it('prompts for authenticator OTP when user selects authenticator secondary', async () => {
-      jest
-        .mocked(promptAsync)
-        .mockImplementationOnce(async () => ({ otp: null }))
-        .mockImplementationOnce(async () => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
-        .mockImplementation(() => {
-          throw new Error("shouldn't happen");
-        });
-
-      jest
-        .mocked(selectAsync)
-        .mockImplementationOnce(async () => -1)
-        .mockImplementation(() => {
-          throw new Error("shouldn't happen");
-        });
-      const sessionManager = new SessionManager(analytics);
-
-      await sessionManager['retryUsernamePasswordAuthWithOTPAsync']('blah', 'blah', {
-        secondFactorDevices: [
-          {
-            id: 'p0',
-            is_primary: true,
-            method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-            sms_phone_number: null,
-          },
-          {
-            id: 'p2',
-            is_primary: false,
-            method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-            sms_phone_number: null,
-          },
-        ],
-        smsAutomaticallySent: false,
-      });
-
-      expect(jest.mocked(promptAsync).mock.calls.length).toBe(2); // first OTP, second OTP
-    });
-
-    it('requests SMS OTP and prompts for SMS OTP when user selects SMS secondary', async () => {
-      jest
-        .mocked(promptAsync)
-        .mockImplementationOnce(async () => ({ otp: null }))
-        .mockImplementationOnce(async () => ({ otp: 'hello' })) // second time it is prompted after selecting backup code
-        .mockImplementation(() => {
-          throw new Error("shouldn't happen");
-        });
-
-      jest
-        .mocked(selectAsync)
-        .mockImplementationOnce(async () => 0)
-        .mockImplementation(() => {
-          throw new Error("shouldn't happen");
-        });
-
-      jest.mocked(fetchSessionSecretAndUserAsync).mockResolvedValue({
-        sessionSecret: 'SESSION_SECRET',
-        id: 'USER_ID',
-        username: 'USERNAME',
-      });
-      const apiV2PostSpy = jest.spyOn(ApiV2Client.prototype, 'postAsync');
-
-      const sessionManager = new SessionManager(analytics);
-      await sessionManager['retryUsernamePasswordAuthWithOTPAsync']('blah', 'blah', {
-        secondFactorDevices: [
-          {
-            id: 'p0',
-            is_primary: true,
-            method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-            sms_phone_number: null,
-          },
-          {
-            id: 'p2',
-            is_primary: false,
-            method: UserSecondFactorDeviceMethod.SMS,
-            sms_phone_number: 'wat',
-          },
-        ],
-        smsAutomaticallySent: false,
-      });
-
-      expect(jest.mocked(promptAsync).mock.calls.length).toBe(2); // first OTP, second OTP
-
-      expect(apiV2PostSpy.mock.calls[0]).toEqual([
-        'auth/send-sms-otp',
-        {
-          body: {
-            username: 'blah',
-            password: 'blah',
-            secondFactorDeviceID: 'p2',
-          },
-        },
-      ]);
-    });
-
-    it('exits when user bails on primary and backup', async () => {
-      jest
-        .mocked(promptAsync)
-        .mockImplementationOnce(async () => ({ otp: null }))
-        .mockImplementation(() => {
-          throw new Error("shouldn't happen");
-        });
-
-      jest
-        .mocked(selectAsync)
-        .mockImplementationOnce(async () => -2)
-        .mockImplementation(() => {
-          throw new Error("shouldn't happen");
-        });
-      const sessionManager = new SessionManager(analytics);
-
-      await expect(
-        sessionManager['retryUsernamePasswordAuthWithOTPAsync']('blah', 'blah', {
-          secondFactorDevices: [
-            {
-              id: 'p0',
-              is_primary: true,
-              method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-              sms_phone_number: null,
-            },
-            {
-              id: 'p2',
-              is_primary: false,
-              method: UserSecondFactorDeviceMethod.AUTHENTICATOR,
-              sms_phone_number: null,
-            },
-          ],
-          smsAutomaticallySent: false,
-        })
+        sessionManager['retryUsernamePasswordAuthWithOTPAsync']('blah', 'blah')
       ).rejects.toThrowError('Cancelled login');
     });
   });


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

SMS 2FA is no longer supported, only authenticator (TOTP). Therefore, we can remove parts of the no-browser login flow that supported SMS 2FA.

Equivalent of https://github.com/expo/expo/pull/46879.

# How

Remove the fallback device picker and SMS logic. The flow is now:
1. Try login with username/password
2. Catch `ONE_TIME_PASSWORD_REQUIRED` error, ask for OTP/backup code.
3. User enters it or cancels.
4. Login call with username/password/otp.

# Test Plan

`neas login --no-browser` to an account that has 2fa set up.