### PR TITLE
[eas-cli] Add `account:audit` command to view account audit logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add `eas account:audit [ACCOUNT_NAME]` command to view an account's audit logs. ([#3863](https://github.com/expo/eas-cli/pull/3863) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/account/audit.ts
+++ b/packages/eas-cli/src/commands/account/audit.ts
@@ -1,0 +1,141 @@
+import { Args } from '@oclif/core';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import { EASNonInteractiveFlag, EasJsonOnlyFlag } from '../../commandUtils/flags';
+import { getLimitFlagWithCustomValues } from '../../commandUtils/pagination';
+import { AuditLogFragment } from '../../graphql/generated';
+import { AuditLogQuery } from '../../graphql/queries/AuditLogQuery';
+import Log from '../../log';
+import { ora } from '../../ora';
+import { confirmAsync, selectAsync } from '../../prompts';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+import renderTextTable from '../../utils/renderTextTable';
+
+const AUDIT_LOGS_LIMIT = 50;
+
+export default class AccountAudit extends EasCommand {
+  static override description = 'view the audit logs for an account';
+
+  static override args = {
+    ACCOUNT_NAME: Args.string({
+      description:
+        'Account name to view audit logs for. If not provided, the account will be selected interactively (or defaults to the only account if there is just one)',
+    }),
+  };
+
+  static override flags = {
+    limit: getLimitFlagWithCustomValues({ defaultTo: AUDIT_LOGS_LIMIT, limit: 100 }),
+    ...EasJsonOnlyFlag,
+    ...EASNonInteractiveFlag,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const {
+      args: { ACCOUNT_NAME: accountName },
+      flags: { limit, json: jsonFlag, 'non-interactive': nonInteractive },
+    } = await this.parse(AccountAudit);
+
+    const json = jsonFlag || nonInteractive;
+    if (json) {
+      enableJsonOutput();
+    }
+
+    const {
+      loggedIn: { graphqlClient, actor },
+    } = await this.getContextAsync(AccountAudit, { nonInteractive });
+
+    const pageSize = limit ?? AUDIT_LOGS_LIMIT;
+
+    let targetAccount: { id: string; name: string };
+    const availableAccounts = actor.accounts.map(a => a.name).join(', ');
+    if (accountName) {
+      const found = actor.accounts.find(a => a.name === accountName);
+      if (!found) {
+        throw new Error(
+          `Account "${accountName}" not found or you don't have access. Available accounts: ${availableAccounts}`
+        );
+      }
+      targetAccount = found;
+    } else if (nonInteractive) {
+      throw new Error(
+        'ACCOUNT_NAME argument must be provided when running in `--non-interactive` mode.'
+      );
+    } else if (actor.accounts.length === 1) {
+      targetAccount = actor.accounts[0];
+    } else {
+      targetAccount = await selectAsync(
+        'Select account to view audit logs for:',
+        actor.accounts.map(account => ({
+          title: account.name,
+          value: account,
+        }))
+      );
+    }
+
+    if (json) {
+      const spinner = ora(`Fetching audit logs for account ${targetAccount.name}`).start();
+      try {
+        const connection = await AuditLogQuery.getAllForAccountAsync(
+          graphqlClient,
+          targetAccount.id,
+          {
+            first: pageSize,
+          }
+        );
+        spinner.stop();
+        printJsonOnlyOutput(connection.edges.map(edge => edge.node));
+      } catch (error) {
+        spinner.fail(`Failed to fetch audit logs for account ${targetAccount.name}`);
+        throw error;
+      }
+      return;
+    }
+
+    let after: string | undefined;
+    do {
+      const spinner = ora(`Fetching audit logs for account ${targetAccount.name}`).start();
+      const connection = await AuditLogQuery.getAllForAccountAsync(
+        graphqlClient,
+        targetAccount.id,
+        {
+          first: pageSize,
+          after,
+        }
+      );
+      spinner.stop();
+
+      const logs = connection.edges.map(edge => edge.node);
+      renderPageOfAuditLogs(logs);
+
+      if (!connection.pageInfo.hasNextPage) {
+        break;
+      }
+      after = connection.pageInfo.endCursor ?? undefined;
+    } while (after && (await confirmAsync({ message: 'Load more audit logs?' })));
+  }
+}
+
+function renderPageOfAuditLogs(logs: AuditLogFragment[]): void {
+  if (logs.length === 0) {
+    Log.log('No audit logs found.');
+    return;
+  }
+
+  Log.log(
+    renderTextTable(
+      ['Date', 'Actor', 'Action', 'Entity', 'Message'],
+      logs.map(log => [
+        new Date(log.createdAt).toLocaleString(),
+        log.actor?.displayName ?? 'Unknown',
+        log.targetEntityMutationType,
+        log.targetEntityTypePublicName,
+        log.websiteMessage,
+      ])
+    )
+  );
+  Log.addNewLineIfNone();
+}

--- a/packages/eas-cli/src/commands/account/audit.ts
+++ b/packages/eas-cli/src/commands/account/audit.ts
@@ -1,4 +1,4 @@
-import { Args } from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { EASNonInteractiveFlag, EasJsonOnlyFlag } from '../../commandUtils/flags';
@@ -25,6 +25,10 @@ export default class AccountAudit extends EasCommand {
 
   static override flags = {
     limit: getLimitFlagWithCustomValues({ defaultTo: AUDIT_LOGS_LIMIT, limit: 100 }),
+    after: Flags.string({
+      description:
+        'Cursor for pagination. Use the endCursor from a previous query to fetch the next page.',
+    }),
     ...EasJsonOnlyFlag,
     ...EASNonInteractiveFlag,
   };
@@ -36,7 +40,7 @@ export default class AccountAudit extends EasCommand {
   async runAsync(): Promise<void> {
     const {
       args: { ACCOUNT_NAME: accountName },
-      flags: { limit, json: jsonFlag, 'non-interactive': nonInteractive },
+      flags: { limit, after, json: jsonFlag, 'non-interactive': nonInteractive },
     } = await this.parse(AccountAudit);
 
     const json = jsonFlag || nonInteractive;
@@ -84,10 +88,14 @@ export default class AccountAudit extends EasCommand {
           targetAccount.id,
           {
             first: pageSize,
+            after,
           }
         );
         spinner.stop();
-        printJsonOnlyOutput(connection.edges.map(edge => edge.node));
+        printJsonOnlyOutput({
+          auditLogs: connection.edges.map(edge => edge.node),
+          pageInfo: connection.pageInfo,
+        });
       } catch (error) {
         spinner.fail(`Failed to fetch audit logs for account ${targetAccount.name}`);
         throw error;
@@ -95,7 +103,7 @@ export default class AccountAudit extends EasCommand {
       return;
     }
 
-    let after: string | undefined;
+    let cursor = after;
     do {
       const spinner = ora(`Fetching audit logs for account ${targetAccount.name}`).start();
       const connection = await AuditLogQuery.getAllForAccountAsync(
@@ -103,7 +111,7 @@ export default class AccountAudit extends EasCommand {
         targetAccount.id,
         {
           first: pageSize,
-          after,
+          after: cursor,
         }
       );
       spinner.stop();
@@ -114,8 +122,8 @@ export default class AccountAudit extends EasCommand {
       if (!connection.pageInfo.hasNextPage) {
         break;
       }
-      after = connection.pageInfo.endCursor ?? undefined;
-    } while (after && (await confirmAsync({ message: 'Load more audit logs?' })));
+      cursor = connection.pageInfo.endCursor ?? undefined;
+    } while (cursor && (await confirmAsync({ message: 'Load more audit logs?' })));
   }
 }
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -13195,6 +13195,17 @@ export type GetAssetSignedUrlsQueryVariables = Exact<{
 
 export type GetAssetSignedUrlsQuery = { __typename?: 'RootQuery', asset: { __typename?: 'AssetQuery', signedUrls: Array<{ __typename?: 'AssetSignedUrlResult', storageKey: string, url: string, headers?: any | null }> } };
 
+export type AuditLogsByAccountQueryVariables = Exact<{
+  accountId: Scalars['String']['input'];
+  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type AuditLogsByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byId: { __typename?: 'Account', id: string, auditLogsPaginated: { __typename?: 'AuditLogConnection', edges: Array<{ __typename?: 'AuditLogEdge', cursor: string, node: { __typename?: 'AuditLog', id: string, createdAt: any, websiteMessage: string, targetEntityTypePublicName: string, targetEntityMutationType: TargetEntityMutationType, actor?: { __typename?: 'PartnerActor', id: string, displayName: string } | { __typename?: 'Robot', id: string, displayName: string } | { __typename?: 'SSOUser', id: string, displayName: string } | { __typename?: 'User', id: string, displayName: string } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
+
 export type BackgroundJobReceiptByIdQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
@@ -13707,6 +13718,8 @@ export type UsageMetricTotalFragment = { __typename?: 'UsageMetricTotal', id: st
 export type AccountUsageMetricFragment = { __typename?: 'AccountUsageMetric', id: string, serviceMetric: EasServiceMetric, metricType: UsageMetricType, value: number };
 
 export type AppFragment = { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string } | { __typename?: 'User', id: string, username: string } | null, users: Array<{ __typename?: 'UserPermission', role: Role, actor: { __typename?: 'PartnerActor', id: string } | { __typename?: 'Robot', id: string } | { __typename?: 'SSOUser', id: string } | { __typename?: 'User', id: string } }> }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null };
+
+export type AuditLogFragment = { __typename?: 'AuditLog', id: string, createdAt: any, websiteMessage: string, targetEntityTypePublicName: string, targetEntityMutationType: TargetEntityMutationType, actor?: { __typename?: 'PartnerActor', id: string, displayName: string } | { __typename?: 'Robot', id: string, displayName: string } | { __typename?: 'SSOUser', id: string, displayName: string } | { __typename?: 'User', id: string, displayName: string } | null };
 
 export type BackgroundJobReceiptDataFragment = { __typename?: 'BackgroundJobReceipt', id: string, state: BackgroundJobState, tries: number, willRetry: boolean, resultId?: string | null, resultType: BackgroundJobResultType, resultData?: any | null, errorCode?: string | null, errorMessage?: string | null, createdAt: any, updatedAt: any };
 

--- a/packages/eas-cli/src/graphql/queries/AuditLogQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/AuditLogQuery.ts
@@ -40,7 +40,6 @@ export const AuditLogQuery = {
                     edges {
                       cursor
                       node {
-                        id
                         ...AuditLogFragment
                       }
                     }

--- a/packages/eas-cli/src/graphql/queries/AuditLogQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/AuditLogQuery.ts
@@ -40,6 +40,7 @@ export const AuditLogQuery = {
                     edges {
                       cursor
                       node {
+                        id
                         ...AuditLogFragment
                       }
                     }

--- a/packages/eas-cli/src/graphql/queries/AuditLogQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/AuditLogQuery.ts
@@ -1,0 +1,73 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { Connection, QueryParams } from '../../utils/relay';
+import { withErrorHandlingAsync } from '../client';
+import {
+  AuditLogFragment,
+  AuditLogsByAccountQuery,
+  AuditLogsByAccountQueryVariables,
+} from '../generated';
+import { AuditLogFragmentNode } from '../types/AuditLog';
+
+export const AuditLogQuery = {
+  async getAllForAccountAsync(
+    graphqlClient: ExpoGraphqlClient,
+    accountId: string,
+    queryParams: QueryParams
+  ): Promise<Connection<AuditLogFragment>> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<AuditLogsByAccountQuery, AuditLogsByAccountQueryVariables>(
+          gql`
+            query AuditLogsByAccount(
+              $accountId: String!
+              $first: Int
+              $after: String
+              $last: Int
+              $before: String
+            ) {
+              account {
+                byId(accountId: $accountId) {
+                  id
+                  auditLogsPaginated(
+                    first: $first
+                    after: $after
+                    last: $last
+                    before: $before
+                  ) {
+                    edges {
+                      cursor
+                      node {
+                        id
+                        ...AuditLogFragment
+                      }
+                    }
+                    pageInfo {
+                      hasNextPage
+                      hasPreviousPage
+                      startCursor
+                      endCursor
+                    }
+                  }
+                }
+              }
+            }
+            ${print(AuditLogFragmentNode)}
+          `,
+          {
+            accountId,
+            first: queryParams.first,
+            after: queryParams.after,
+            last: queryParams.last,
+            before: queryParams.before,
+          },
+          { additionalTypenames: ['AuditLog'] }
+        )
+        .toPromise()
+    );
+
+    return data.account.byId.auditLogsPaginated;
+  },
+};

--- a/packages/eas-cli/src/graphql/queries/__tests__/AuditLogQuery-test.ts
+++ b/packages/eas-cli/src/graphql/queries/__tests__/AuditLogQuery-test.ts
@@ -1,0 +1,47 @@
+import { anything, capture, instance, mock, when } from 'ts-mockito';
+
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { AuditLogQuery } from '../AuditLogQuery';
+
+describe(AuditLogQuery.getAllForAccountAsync.name, () => {
+  it('returns the audit log connection for an account and forwards pagination params', async () => {
+    const connection = {
+      edges: [
+        {
+          cursor: 'cursor-1',
+          node: {
+            id: 'audit-log-id',
+            createdAt: '2026-05-21T17:43:32.433Z',
+            websiteMessage: 'Created a new Project',
+            targetEntityTypePublicName: 'Project',
+            targetEntityMutationType: 'CREATE',
+            actor: { id: 'actor-id', displayName: 'tester' },
+          },
+        },
+      ],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: 'cursor-1',
+        endCursor: 'cursor-1',
+      },
+    };
+
+    const graphqlClientMock = mock<ExpoGraphqlClient>();
+    when(graphqlClientMock.query(anything(), anything(), anything())).thenReturn({
+      toPromise: () =>
+        Promise.resolve({ data: { account: { byId: { auditLogsPaginated: connection } } } }),
+    } as any);
+    const graphqlClient = instance(graphqlClientMock);
+
+    const result = await AuditLogQuery.getAllForAccountAsync(graphqlClient, 'account-id', {
+      first: 10,
+      after: 'cursor-0',
+    });
+
+    expect(result).toBe(connection);
+
+    const [, variables] = capture<any, any, any>(graphqlClientMock.query as any).first();
+    expect(variables).toMatchObject({ accountId: 'account-id', first: 10, after: 'cursor-0' });
+  });
+});

--- a/packages/eas-cli/src/graphql/types/AuditLog.ts
+++ b/packages/eas-cli/src/graphql/types/AuditLog.ts
@@ -1,0 +1,15 @@
+import gql from 'graphql-tag';
+
+export const AuditLogFragmentNode = gql`
+  fragment AuditLogFragment on AuditLog {
+    id
+    createdAt
+    websiteMessage
+    targetEntityTypePublicName
+    targetEntityMutationType
+    actor {
+      id
+      displayName
+    }
+  }
+`;


### PR DESCRIPTION
# Why

A common request is for a programmatic way to ingest audit logs. This exposes that same data as `eas account:audit [ACCOUNT_NAME]`.

# How

Added a new command patterned after other `account` query commands.

# Test Plan

## Falls back to API error when user doesn't have access:
<img width="426" height="53" alt="image" src="https://github.com/user-attachments/assets/680ed93f-d3b9-4631-ac73-f6d1f8ec6573" />

(enterprise plans only, but all enterprise plan users have access)

## Shows account picker with no team
<img width="694" height="162" alt="image" src="https://github.com/user-attachments/assets/b79dabeb-ecc7-4e44-8d98-fe13db7023fb" />

## Displays directly with team specified
<img width="781" height="173" alt="image" src="https://github.com/user-attachments/assets/49b7f06a-db7a-4686-94d1-c6f1158e398f" />

## Display table
<img width="728" height="230" alt="image" src="https://github.com/user-attachments/assets/46dd1f09-abf6-46ed-beb6-925882765437" />

## JSON output with `--json`
<img width="274" height="190" alt="image" src="https://github.com/user-attachments/assets/c33a3cd7-e5b0-456e-bbfe-b4ef6120cbde" />
