### PR TITLE
[eas-cli] Support platform-specific update IDs in update:view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- [eas-cli] `eas update:view [GROUP_ID]` now also accepts a platform-specific update ID, resolving it to and displaying its update group. ([#3826](https://github.com/expo/eas-cli/pull/3826) by [@keith-kurak](https://github.com/keith-kurak))
+- [eas-cli] `eas update:view [GROUP_ID]` now also accepts a platform-specific update ID, resolving it to and displaying its update group. ([#3864](https://github.com/expo/eas-cli/pull/3864) by [@keith-kurak](https://github.com/keith-kurak))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] `eas update:view [GROUP_ID]` now also accepts a platform-specific update ID, resolving it to and displaying its update group. ([#3826](https://github.com/expo/eas-cli/pull/3826) by [@keith-kurak](https://github.com/keith-kurak))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -2632,7 +2632,7 @@ USAGE
   $ eas update:view GROUPID [--insights] [--days <value> | --start <value> | --end <value>] [--json]
 
 ARGUMENTS
-  GROUPID  The ID of an update group.
+  GROUPID  The ID of an update group, or the ID of a platform-specific update.
 
 FLAGS
   --days=<value>   Show insights from the last N days (default 7). Only used with --insights.

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -2632,7 +2632,7 @@ USAGE
   $ eas update:view GROUPID [--insights] [--days <value> | --start <value> | --end <value>] [--json]
 
 ARGUMENTS
-  GROUPID  The ID of an update group, or the ID of a platform-specific update.
+  GROUPID  The ID of an update group.
 
 FLAGS
   --days=<value>   Show insights from the last N days (default 7). Only used with --insights.

--- a/packages/eas-cli/src/commands/update/__tests__/view.test.ts
+++ b/packages/eas-cli/src/commands/update/__tests__/view.test.ts
@@ -7,7 +7,7 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
 import UpdateView from '../view';
 
 jest.mock('../../../graphql/queries/UpdateQuery', () => ({
-  UpdateQuery: { viewUpdateGroupAsync: jest.fn() },
+  UpdateQuery: { viewUpdateGroupAsync: jest.fn(), viewByUpdateAsync: jest.fn() },
 }));
 jest.mock('../../../graphql/queries/UpdateInsightsQuery', () => ({
   UpdateInsightsQuery: { viewUpdateGroupInsightsAsync: jest.fn() },
@@ -16,6 +16,7 @@ jest.mock('../../../log');
 jest.mock('../../../utils/json');
 
 const mockViewUpdateGroupAsync = jest.mocked(UpdateQuery.viewUpdateGroupAsync);
+const mockViewByUpdateAsync = jest.mocked(UpdateQuery.viewByUpdateAsync);
 const mockViewUpdateGroupInsightsAsync = jest.mocked(
   UpdateInsightsQuery.viewUpdateGroupInsightsAsync
 );
@@ -154,5 +155,43 @@ describe(UpdateView, () => {
     expect(arg.updates).toBeDefined();
     expect(arg.insights).toBeDefined();
     expect(arg.insights.platforms[0].totals.installs).toBe(990);
+  });
+
+  it('does not look up a single update when the ID resolves as a group', async () => {
+    const command = createCommand(['group-1']);
+    await command.runAsync();
+    expect(mockViewUpdateGroupAsync).toHaveBeenCalledWith(graphqlClient, { groupId: 'group-1' });
+    expect(mockViewByUpdateAsync).not.toHaveBeenCalled();
+  });
+
+  it('resolves a platform-specific update ID to its group', async () => {
+    mockViewUpdateGroupAsync.mockReset();
+    mockViewUpdateGroupAsync
+      .mockRejectedValueOnce(new Error('Could not find any updates with group ID: "u1"'))
+      .mockResolvedValueOnce(updateGroup);
+    mockViewByUpdateAsync.mockResolvedValue({ ...updateGroup[0], group: 'group-1' });
+
+    const command = createCommand(['u1', '--insights']);
+    await command.runAsync();
+
+    expect(mockViewByUpdateAsync).toHaveBeenCalledWith(graphqlClient, { updateId: 'u1' });
+    expect(mockViewUpdateGroupAsync).toHaveBeenLastCalledWith(graphqlClient, {
+      groupId: 'group-1',
+    });
+    expect(mockViewUpdateGroupInsightsAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ groupId: 'group-1' })
+    );
+  });
+
+  it('surfaces the original group lookup error when the ID matches neither a group nor an update', async () => {
+    mockViewUpdateGroupAsync.mockReset();
+    mockViewUpdateGroupAsync.mockRejectedValue(
+      new Error('Could not find any updates with group ID: "bogus"')
+    );
+    mockViewByUpdateAsync.mockRejectedValue(new Error('update not found'));
+
+    const command = createCommand(['bogus']);
+    await expect(command.runAsync()).rejects.toThrow(/Could not find any updates with group ID/);
   });
 });

--- a/packages/eas-cli/src/commands/update/view.ts
+++ b/packages/eas-cli/src/commands/update/view.ts
@@ -3,6 +3,8 @@ import chalk from 'chalk';
 
 import EasCommand from '../../commandUtils/EasCommand';
 import { EasJsonOnlyFlag } from '../../commandUtils/flags';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { UpdateFragment } from '../../graphql/generated';
 import { UpdateInsightsQuery } from '../../graphql/queries/UpdateInsightsQuery';
 import { UpdateQuery } from '../../graphql/queries/UpdateQuery';
 import { resolveInsightsTimeRange } from '../../insights/timeRange';
@@ -26,7 +28,7 @@ export default class UpdateView extends EasCommand {
   static override args = {
     groupId: Args.string({
       required: true,
-      description: 'The ID of an update group.',
+      description: 'The ID of an update group, or the ID of a platform-specific update.',
     }),
   };
 
@@ -58,7 +60,7 @@ export default class UpdateView extends EasCommand {
 
   async runAsync(): Promise<void> {
     const {
-      args: { groupId },
+      args: { groupId: idArg },
       flags: { json: jsonFlag, insights: insightsFlag, days, start, end },
     } = await this.parse(UpdateView);
 
@@ -74,7 +76,10 @@ export default class UpdateView extends EasCommand {
       enableJsonOutput();
     }
 
-    const updatesByGroup = await UpdateQuery.viewUpdateGroupAsync(graphqlClient, { groupId });
+    const { groupId, updatesByGroup } = await UpdateView.resolveUpdateGroupAsync(
+      graphqlClient,
+      idArg
+    );
 
     let insightsSummary: UpdateInsightsSummary | null = null;
     if (insightsFlag) {
@@ -110,6 +115,36 @@ export default class UpdateView extends EasCommand {
         Log.addNewLineIfNone();
         Log.log(buildUpdateInsightsTable(insightsSummary));
       }
+    }
+  }
+
+  /**
+   * Resolves the provided ID into an update group and its updates. The ID may be either an
+   * update group ID or the ID of a single platform-specific update. We first try to look it up
+   * as a group; if no updates are found, we fall back to resolving it as a platform-specific
+   * update and then fetch the group that update belongs to.
+   */
+  private static async resolveUpdateGroupAsync(
+    graphqlClient: ExpoGraphqlClient,
+    id: string
+  ): Promise<{ groupId: string; updatesByGroup: UpdateFragment[] }> {
+    try {
+      const updatesByGroup = await UpdateQuery.viewUpdateGroupAsync(graphqlClient, { groupId: id });
+      return { groupId: id, updatesByGroup };
+    } catch (groupError) {
+      let update: UpdateFragment | undefined;
+      try {
+        update = await UpdateQuery.viewByUpdateAsync(graphqlClient, { updateId: id });
+      } catch {
+        // The ID is neither a valid update group nor a valid platform-specific update; surface
+        // the original group lookup error since the group ID is the primary input.
+        throw groupError;
+      }
+
+      const updatesByGroup = await UpdateQuery.viewUpdateGroupAsync(graphqlClient, {
+        groupId: update.group,
+      });
+      return { groupId: update.group, updatesByGroup };
     }
   }
 }


### PR DESCRIPTION
# Why

User noted that it was difficult to cross reference a platform-specific update ID back to the group ID. It is possible (though not obvious) to put the update ID in this group URL, and it will take you directly to the update: `https://expo.dev/accounts/[account]/projects/[project]/updates/[id]`

Exposing this via the CLI would provide feature parity, but more importantly, open things up to programmatic flows (e.g., you get an update ID from a client bug report and you want to cross reference back to the update group deployment).

# How

Apparently there was already a query available for this, so added a fallback lookup to the existing `eas update:view` command to look for the platform-specific ID.

# Test Plan

<img width="385" height="451" alt="image" src="https://github.com/user-attachments/assets/747cbe99-9387-40df-8a64-351dc73bfe32" />

works with all three ID's, same result:
<img width="924" height="573" alt="image" src="https://github.com/user-attachments/assets/d6c39186-9c5b-44ba-80ba-6a2c0e7d8a96" />
