### PR TITLE
[eas-cli] Fix update:embedded topic description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [expo-cocoapods-proxy] Fix iOS worker tarball build failing on macOS Tahoe due to bundler incompatibility with RubyGems 4. ([#3824](https://github.com/expo/eas-cli/pull/3824) by [@gwdp](https://github.com/gwdp))
+- [eas-cli] Fix `update:embedded` topic showing the `update:embedded:delete` subcommand description in the command listing. ([#3866](https://github.com/expo/eas-cli/pull/3866) by [@jc-expo](https://github.com/jc-expo))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -224,6 +224,9 @@
       "update": {
         "description": "manage individual updates"
       },
+      "update:embedded": {
+        "description": "manage embedded updates registered with EAS Update"
+      },
       "webhook": {
         "description": "manage webhooks"
       },


### PR DESCRIPTION
# Why

The `update:embedded` command group had no explicit topic description, so oclif derived the topic's description from one of its subcommands. As a result, the topic listing rendered:

```
TOPICS
  update:embedded  delete an embedded update registered with EAS Update
```

This is confusing — it describes only the `update:embedded:delete` subcommand rather than the group as a whole.

# How

Added an explicit `update:embedded` topic entry in `packages/eas-cli/package.json` with the description `manage embedded updates registered with EAS Update`, matching the style of the sibling `update` topic (`manage individual updates`).

# Test Plan

Run `eas update --help` and `eas update:embedded --help` and confirm the `update:embedded` group now shows `manage embedded updates registered with EAS Update` instead of the delete-subcommand description.