### PR TITLE
[eas-cli] Fix fingerprint commands corrupting --json output with --environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Fix `eas fingerprint:generate` and `eas fingerprint:compare` corrupting `--json` output when `--environment` is set, by enabling JSON output before loading server-side environment variables. ([#3870](https://github.com/expo/eas-cli/pull/3870) by [@nossila](https://github.com/nossila))
+
 ### 🧹 Chores
 
 - [eas-cli] Simplify 2FA now that SMS is no longer supported. ([#3859](https://github.com/expo/eas-cli/pull/3859) by [@wschurman](https://github.com/wschurman))

--- a/packages/eas-cli/src/commands/fingerprint/compare.ts
+++ b/packages/eas-cli/src/commands/fingerprint/compare.ts
@@ -119,6 +119,13 @@ export default class FingerprintCompare extends EasCommand {
     const [buildId1, buildId2] = buildIds ?? [];
     const [updateId1, updateId2] = updateIds ?? [];
 
+    // Enable JSON output before resolving context so that any logs emitted while
+    // loading server-side environment variables are redirected to stderr instead
+    // of polluting the JSON written to stdout.
+    if (json) {
+      enableJsonOutput();
+    }
+
     const {
       projectId,
       privateProjectConfig: { projectDir },
@@ -129,9 +136,6 @@ export default class FingerprintCompare extends EasCommand {
       nonInteractive,
       withServerSideEnvironment: environment ?? null,
     });
-    if (json) {
-      enableJsonOutput();
-    }
 
     const firstFingerprintInfo = await getFingerprintInfoAsync(
       graphqlClient,

--- a/packages/eas-cli/src/commands/fingerprint/generate.ts
+++ b/packages/eas-cli/src/commands/fingerprint/generate.ts
@@ -66,6 +66,13 @@ export default class FingerprintGenerate extends EasCommand {
     const { json, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
     const { platform: platformStringFlag, environment, 'build-profile': buildProfileName } = flags;
 
+    // Enable JSON output before resolving context so that any logs emitted while
+    // loading server-side environment variables are redirected to stderr instead
+    // of polluting the JSON written to stdout.
+    if (json) {
+      enableJsonOutput();
+    }
+
     const {
       projectId,
       privateProjectConfig: { projectDir },
@@ -77,9 +84,6 @@ export default class FingerprintGenerate extends EasCommand {
       nonInteractive,
       withServerSideEnvironment: environment ?? null,
     });
-    if (json) {
-      enableJsonOutput();
-    }
 
     let platform: AppPlatform;
     if (platformStringFlag) {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Running `eas fingerprint:generate --platform ios --environment preview --json --non-interactive` (or `fingerprint:compare` with `--environment`) emits an `eas-cli` log line to **stdout** before the JSON, so the output is not valid JSON and tools like `jq` fail to parse it:

```
Environment variables with visibility "Plain text" and "Sensitive" loaded from the "preview" environment on EAS: APP_ANDROID_PACKAGE, ...

{
  "sources": [ ... ]
}
```

## What's going on

In `--json` mode, [`src/utils/json.ts`](https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/utils/json.ts) redirects `process.stdout.write → process.stderr.write` so progress logs don't pollute the final JSON, and only `printJsonOnlyOutput()` writes to the real stdout.

But in both `fingerprint:generate` and `fingerprint:compare`, `enableJsonOutput()` was called **after** `getContextAsync()`. When `--environment` is set, the `ProjectConfig` context (`PrivateProjectConfigContextField`) **eagerly** loads the server-side environment variables during context resolution, and `loadServerSideEnvironmentVariablesAsync()` logs the `Environment variables with visibility ...` line via `Log.log` → `console.log` → `process.stdout.write`. Because that happens before the redirect is installed, the line lands on the real stdout and corrupts the JSON. (The value is cached, so the later `getServerSideEnvironmentVariablesAsync()` call doesn't re-log it — the context load is the only emitter.)

This is a separate, in-process cause from the subprocess-output corruption fixed in #3659; that PR set `silent: true` for `@expo/fingerprint` subprocesses and does not touch this ordering.

# How

Move the `if (json) { enableJsonOutput(); }` block to **before** `getContextAsync()` in both commands, so the stdout→stderr redirect is active while the context loads (and logs) the server-side environment variables. The `json` flag is already resolved earlier, so this is safe. Added a CHANGELOG bug-fix entry.

# Test Plan

- `yarn typecheck` — passes.
- `yarn lint` / `yarn fmt:check` — pass (0 errors in touched files).
- Manual reproduction:

  ```bash
  # Before: leading "Environment variables with visibility ..." line breaks parsing
  eas fingerprint:generate -p ios --environment preview --json --non-interactive | jq -r '.hash'

  # After: stdout is clean JSON, jq extracts the hash directly
  ```

  With the fix, the env-var log is written to stderr and stdout contains only the JSON, so `jq -r '.hash'` succeeds. Redirecting stderr to `/dev/null` (`2>/dev/null`) leaves valid JSON.