### PR TITLE
[eas-cli] Make integrations:posthog:connect resilient to dynamic app configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] `eas integrations:posthog:connect` no longer aborts when `npx expo install` reports an error (for example, on a dynamic app config); it finishes writing the environment variables and prints any remaining manual steps. ([#3877](https://github.com/expo/eas-cli/pull/3877) by [@gwdp](https://github.com/gwdp))
+
 ### 🧹 Chores
 
 - [eas-cli] Simplify 2FA now that SMS is no longer supported. ([#3859](https://github.com/expo/eas-cli/pull/3859) by [@wschurman](https://github.com/wschurman))

--- a/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
@@ -231,13 +231,10 @@ describe(IntegrationsPostHogConnect, () => {
     expect(createdNames).toEqual(['EXPO_PUBLIC_POSTHOG_API_KEY', 'EXPO_PUBLIC_POSTHOG_HOST']);
   });
 
-  it('routes the install child off stdout in --json mode', async () => {
+  it('captures the install child output so --json stdout stays clean', async () => {
     await createCommand(['--json', '--posthog-cli-api-key', 'phx_x']).runAsync();
 
-    // stdout must carry only the JSON document, so the child writes to fd 2 (stderr).
-    expect(jest.mocked(spawnAsync).mock.calls[0][2]).toEqual(
-      expect.objectContaining({ stdio: ['ignore', 2, 2] })
-    );
+    expect(jest.mocked(spawnAsync).mock.calls[0][2]).not.toHaveProperty('stdio');
   });
 
   it('non-interactive defaults: analytics + replay, error tracking auto-skipped', async () => {
@@ -293,7 +290,7 @@ describe(IntegrationsPostHogConnect, () => {
     ).rejects.toThrow(/personal API key in non-interactive/);
   });
 
-  it('warns and prints manual edit when the app config is dynamic', async () => {
+  it('surfaces a manual plugin step and still writes env vars when the app config is dynamic', async () => {
     mockFeatureSelection(['analytics']);
     jest.mocked(createOrModifyExpoConfigAsync).mockResolvedValue({
       type: 'warn',
@@ -303,12 +300,22 @@ describe(IntegrationsPostHogConnect, () => {
     await createCommand([]).runAsync();
 
     expect(Log.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Cannot automatically write to dynamic config')
+      expect.stringContaining('Add "posthog-react-native/expo" to the "plugins"')
     );
-    // Falls back to actionable manual-edit instructions.
-    expect(Log.log).toHaveBeenCalledWith(
-      expect.stringContaining('Add the PostHog config plugin to your app config')
+    expect(EnvironmentVariableMutation.createForAppAsync).toHaveBeenCalled();
+    expect(fs.writeFile).toHaveBeenCalled();
+  });
+
+  it('surfaces the plugin manual step (without a cause) when the config write fails', async () => {
+    mockFeatureSelection(['analytics']);
+    jest.mocked(createOrModifyExpoConfigAsync).mockResolvedValue({ type: 'fail' } as any);
+
+    await createCommand([]).runAsync();
+
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Add "posthog-react-native/expo" to the "plugins"')
     );
+    expect(EnvironmentVariableMutation.createForAppAsync).toHaveBeenCalled();
   });
 
   it('reuses an existing connection + project without provisioning', async () => {
@@ -434,12 +441,38 @@ describe(IntegrationsPostHogConnect, () => {
     expect(apiKeyPrompt.validate('phx_real')).toBe(true);
   });
 
-  it('rethrows and warns when SDK installation fails', async () => {
+  it('continues (does not abort) and still writes env vars when SDK installation fails', async () => {
     mockFeatureSelection(['analytics']);
     jest.mocked(spawnAsync).mockRejectedValue(new Error('npm exploded'));
 
-    await expect(createCommand([]).runAsync()).rejects.toThrow('npm exploded');
-    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to install'));
+    await createCommand([]).runAsync();
+
+    // Install failure is non-fatal: provisioning + env vars still happen, with a manual follow-up.
+    expect(EnvironmentVariableMutation.createForAppAsync).toHaveBeenCalled();
+    expect(fs.writeFile).toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('npx expo install'));
+  });
+
+  it('on a dynamic config, surfaces only the plugin step (not a reinstall step) when expo install reports the dynamic-config error', async () => {
+    mockFeatureSelection(['analytics']);
+    jest.mocked(spawnAsync).mockRejectedValue(
+      Object.assign(new Error('Process exited with non-zero code: 1'), {
+        stdout: 'Cannot automatically write to dynamic config at: app.config.js\n',
+        stderr: '',
+      })
+    );
+    jest.mocked(createOrModifyExpoConfigAsync).mockResolvedValue({
+      type: 'warn',
+      message: 'Cannot automatically write to dynamic config at: app.config.js',
+    } as any);
+
+    await createCommand([]).runAsync();
+
+    expect(EnvironmentVariableMutation.createForAppAsync).toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Add "posthog-react-native/expo" to the "plugins"')
+    );
+    expect(Log.warn).not.toHaveBeenCalledWith(expect.stringContaining("didn't install"));
   });
 
   it('skips the config plugin when it is already configured', async () => {
@@ -469,6 +502,9 @@ describe(IntegrationsPostHogConnect, () => {
     expect(fs.writeFile).not.toHaveBeenCalled();
     expect(EnvironmentVariableMutation.createForAppAsync).not.toHaveBeenCalled();
     expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('No PostHog features selected'));
+    // Doesn't falsely claim the SDK is wired up when nothing was configured.
+    expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('PostHog is connected!'));
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('Re-run to add'));
   });
 
   it('merges into an existing .env.local, replacing matching keys and appending new ones', async () => {

--- a/packages/eas-cli/src/commands/integrations/posthog/connect.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/connect.ts
@@ -65,6 +65,11 @@ const ERROR_TRACKING_NEEDS_KEY_MESSAGE = `Error tracking needs a PostHog persona
 type Features = { analytics: boolean; sessionReplay: boolean; errorTracking: boolean };
 type EnvVar = { name: string; value: string; visibility: EnvironmentVariableVisibility };
 
+function getSpawnErrorOutput(error: unknown): string {
+  const { stdout, stderr } = (error ?? {}) as { stdout?: string; stderr?: string };
+  return `${stdout ?? ''}${stderr ?? ''}`;
+}
+
 export default class IntegrationsPostHogConnect extends EasCommand {
   static override description = 'connect PostHog to your Expo project';
 
@@ -208,11 +213,22 @@ export default class IntegrationsPostHogConnect extends EasCommand {
       );
     }
 
-    if (!anyFeatureSelected) {
-      Log.warn('No PostHog features selected — skipping SDK install and config changes.');
-    } else {
-      await this.installSdkPackagesAsync(projectDir, features, jsonFlag);
-      await this.addConfigPluginAsync(projectDir, exp);
+    const manualSteps: string[] = [];
+    if (anyFeatureSelected) {
+      const packages = [...SDK_PACKAGES];
+      if (features.sessionReplay) {
+        packages.push(SESSION_REPLAY_PACKAGE);
+      }
+      const installResult = await this.installSdkPackagesAsync(projectDir, packages, jsonFlag);
+      if (installResult === 'failed') {
+        manualSteps.push(
+          `The PostHog SDK packages didn't install. Run npx expo install ${packages.join(' ')} from your project directory.`
+        );
+      }
+      const pluginManualStep = await this.addConfigPluginAsync(projectDir, exp);
+      if (pluginManualStep) {
+        manualSteps.push(pluginManualStep);
+      }
     }
 
     await this.writeEnvLocalAsync(projectDir, envVars, nonInteractive, overwrite);
@@ -238,11 +254,26 @@ export default class IntegrationsPostHogConnect extends EasCommand {
         features,
         dashboardUrl: getPostHogProjectDashboardUrl(project),
         environmentVariables: envVars.map(v => v.name),
+        manualSteps,
       });
       return;
     }
 
-    this.printNextSteps(project, features);
+    if (!anyFeatureSelected) {
+      Log.addNewLineIfNone();
+      Log.log(chalk.green('PostHog project created.'));
+      Log.newLine();
+      Log.log(
+        `${chalk.bold('Dashboard')}: ${link(getPostHogProjectDashboardUrl(project), { dim: false })}`
+      );
+      Log.newLine();
+      Log.warn(
+        'No PostHog features selected, so no SDK, config plugin, or environment variables were set up. Re-run to add analytics, session replay, or error tracking.'
+      );
+      return;
+    }
+
+    this.printNextSteps(project, features, manualSteps);
   }
 
   private async resolveFeaturesAsync(
@@ -331,38 +362,32 @@ export default class IntegrationsPostHogConnect extends EasCommand {
 
   private async installSdkPackagesAsync(
     projectDir: string,
-    features: Features,
+    packages: string[],
     jsonFlag: boolean
-  ): Promise<void> {
-    const packages = [...SDK_PACKAGES];
-    if (features.sessionReplay) {
-      packages.push(SESSION_REPLAY_PACKAGE);
-    }
-    Log.newLine();
-    Log.log(`Running ${chalk.bold(`npx expo install ${packages.join(' ')}`)}`);
-    Log.newLine();
+  ): Promise<'installed' | 'failed'> {
+    const spinner = jsonFlag ? null : ora('Installing the PostHog SDK packages').start();
     try {
-      await spawnAsync('npx', ['expo', 'install', ...packages], {
-        cwd: projectDir,
-        stdio: jsonFlag ? ['ignore', 2, 2] : 'inherit',
-      });
-      Log.withTick('Installed the PostHog SDK packages');
+      await spawnAsync('npx', ['expo', 'install', ...packages], { cwd: projectDir });
+      spinner?.succeed('Installed the PostHog SDK packages');
+      return 'installed';
     } catch (error) {
-      Log.warn(
-        `Failed to install the PostHog SDK packages. Run ${chalk.cyan(
-          `npx expo install ${packages.join(' ')}`
-        )} from your project directory.`
-      );
-      throw error;
+      const output = getSpawnErrorOutput(error);
+      Log.debug(output || error);
+      if (output.includes('Cannot automatically write to dynamic config')) {
+        spinner?.succeed('Installed the PostHog SDK packages');
+        return 'installed';
+      }
+      spinner?.fail('Failed to install the PostHog SDK packages');
+      return 'failed';
     }
   }
 
-  private async addConfigPluginAsync(projectDir: string, exp: ExpoConfig): Promise<void> {
+  private async addConfigPluginAsync(projectDir: string, exp: ExpoConfig): Promise<string | null> {
     const plugins = exp.plugins ?? [];
     const alreadyAdded = plugins.some(p => (Array.isArray(p) ? p[0] : p) === CONFIG_PLUGIN);
     if (alreadyAdded) {
       Log.withTick(`Config plugin ${chalk.bold(CONFIG_PLUGIN)} is already configured`);
-      return;
+      return null;
     }
 
     const modification = await createOrModifyExpoConfigAsync(
@@ -370,15 +395,14 @@ export default class IntegrationsPostHogConnect extends EasCommand {
       { plugins: [...plugins, CONFIG_PLUGIN] },
       { skipSDKVersionRequirement: true }
     );
-    if (modification.type !== 'success') {
-      if (modification.type === 'warn') {
-        Log.warn(modification.message);
-      }
-      Log.log(chalk.cyan('Add the PostHog config plugin to your app config:'));
-      Log.log(`  "plugins": [..., ${JSON.stringify(CONFIG_PLUGIN)}]`);
-      return;
+    if (modification.type === 'success') {
+      Log.withTick(`Added the ${chalk.bold(CONFIG_PLUGIN)} config plugin`);
+      return null;
     }
-    Log.withTick(`Added the ${chalk.bold(CONFIG_PLUGIN)} config plugin`);
+    if (modification.type === 'warn') {
+      return `${modification.message} Add ${JSON.stringify(CONFIG_PLUGIN)} to the "plugins" array in your app config.`;
+    }
+    return `Add ${JSON.stringify(CONFIG_PLUGIN)} to the "plugins" array in your app config.`;
   }
 
   private async writeEnvLocalAsync(
@@ -503,7 +527,11 @@ export default class IntegrationsPostHogConnect extends EasCommand {
     Log.withTick(`Created EAS environment variable ${chalk.bold(envVar.name)} for builds`);
   }
 
-  private printNextSteps(project: PostHogProjectData, features: Features): void {
+  private printNextSteps(
+    project: PostHogProjectData,
+    features: Features,
+    manualSteps: string[]
+  ): void {
     Log.addNewLineIfNone();
     Log.log(chalk.green('PostHog is connected!'));
     Log.newLine();
@@ -522,11 +550,19 @@ export default class IntegrationsPostHogConnect extends EasCommand {
     }
     if (features.errorTracking) {
       steps.push(
-        `Error-tracking source maps: your ${chalk.bold('POSTHOG_CLI_*')} env vars are set in ${chalk.bold('.env.local')} and EAS — see the guide above to enable source-map uploads on your builds.`
+        `Error-tracking source maps: your ${chalk.bold('POSTHOG_CLI_*')} env vars are set. Wrap ${chalk.bold('metro.config.js')} with ${chalk.cyan('getPostHogExpoConfig')} (see ${chalk.cyan('https://docs.expo.dev/guides/using-posthog#source-maps')}); uploads then run automatically on EAS Build, and via ${chalk.cyan('posthog-cli hermes upload')} for EAS Update.`
       );
     }
     steps.forEach((step, index) => {
       Log.log(`  ${index + 1}. ${step}`);
     });
+
+    if (manualSteps.length > 0) {
+      Log.newLine();
+      Log.warn('Finish setup manually:');
+      manualSteps.forEach(step => {
+        Log.warn(`  • ${step}`);
+      });
+    }
   }
 }


### PR DESCRIPTION
## Why

`integrations:posthog:connect` aborted whenever `npx expo install` exited non-zero — which it does on a dynamic `app.config.js` (Expo can't auto-add a config plugin to it), **even though the packages installed**. The throw skipped the env-var writes, so connect left an org/project created but nothing configured, and re-running dead-ended at the same step.

## How

- **SDK install is best-effort** — a non-zero `npx expo install` no longer throws; connect continues and always writes the `.env.local` + EAS env vars.
- **`npx expo install`'s output is captured** behind a spinner, so its npm-audit noise and its own dynamic-config plugin warning (about an unrelated transitive module) no longer clutter the run.
- **Manual follow-ups are collected and shown once at the end** (and in `--json` as `manualSteps`). On a dynamic config that's a single instruction — add `posthog-react-native/expo` to `plugins`. A "packages didn't install" step appears only on a genuine install failure, not when `expo install` merely skipped the plugin write.
- **Tightened the error-tracking next step** to point at the required `metro.config.js` inject + the guide's `#source-maps` section, and to be accurate about EAS Build (automatic) vs EAS Update (manual `posthog-cli hermes upload`).

## Test Plan

- CI
- `easd` (local run)

<img width="2048" height="2160" alt="carbon (3)" src="https://github.com/user-attachments/assets/7495669b-0d29-46c2-a144-b5aa9c6c65bf" />
