### PR TITLE
Use sjchmiela serve-sim previews without WebRTC

### DIFF
--- a/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
@@ -28,19 +28,18 @@ export function createStartServeSimRemoteSessionBuildFunction(
 
       await selectXcodeDeveloperDirectoryAsync({ env, logger });
 
-      const { previewUrl, streamUrl } = await startServeSimWithTunnelAsync(ctx, {
+      const { previewUrl } = await startServeSimWithTunnelAsync(ctx, {
         baseDomain: ngrokTunnelDomain,
         env,
         logger,
         timeoutMs: STARTUP_TIMEOUT_MS,
       });
       logger.info(`Preview URL: ${previewUrl}`);
-      logger.info(`Stream URL: ${streamUrl}`);
 
       await uploadRemoteSessionConfigAsync({
         ctx,
         deviceRunSessionId,
-        remoteConfig: { previewUrl, streamUrl },
+        remoteConfig: { previewUrl },
         logger,
       });
 

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -38,14 +38,32 @@ function createEnvMock(): BuildStepEnv {
 }
 
 describe(createServeSimTunnelArgs, () => {
-  it('builds ngrok/H264 serve-sim args', () => {
-    expect(createServeSimTunnelArgs({ baseDomain: 'expo-simulator.ngrok.dev' })).toEqual([
+  it('builds ngrok WebRTC/H264 serve-sim args and passes through TURN flags', () => {
+    expect(
+      createServeSimTunnelArgs({
+        baseDomain: 'expo-simulator.ngrok.dev',
+        turnArgs: [
+          '--stun-url',
+          'stun:stun.cloudflare.com:3478',
+          '--turn-url',
+          'turns:turn.cloudflare.com:443?transport=tcp',
+          '--turn-username',
+          'u',
+          '--turn-credential',
+          'c',
+        ],
+      })
+    ).toEqual([
       'serve-sim-sjchmiela@latest',
       '--tunnel',
       '--tunnel-provider',
       'ngrok',
       '--tunnel-domain',
       'expo-simulator.ngrok.dev',
+      '--codec',
+      'webrtc',
+      '--webrtc-codec',
+      'h264',
       '--stream-max-dimension',
       '1280',
       '--stream-quality',
@@ -56,6 +74,14 @@ describe(createServeSimTunnelArgs, () => {
       '3000000',
       '--h264-max-fps',
       '30',
+      '--stun-url',
+      'stun:stun.cloudflare.com:3478',
+      '--turn-url',
+      'turns:turn.cloudflare.com:443?transport=tcp',
+      '--turn-username',
+      'u',
+      '--turn-credential',
+      'c',
     ]);
   });
 });

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -38,7 +38,7 @@ function createEnvMock(): BuildStepEnv {
 }
 
 describe(createServeSimTunnelArgs, () => {
-  it('builds ngrok H264 serve-sim args without forcing WebRTC', () => {
+  it('builds ngrok WebRTC serve-sim args', () => {
     expect(createServeSimTunnelArgs({ baseDomain: 'expo-simulator.ngrok.dev' })).toEqual([
       'serve-sim-sjchmiela@latest',
       '--tunnel',
@@ -52,10 +52,46 @@ describe(createServeSimTunnelArgs, () => {
       '0.55',
       '--stream-fps',
       '10',
+      '--transport',
+      'webrtc',
+      '--webrtc-codec',
+      'h264',
       '--h264-bitrate',
       '3000000',
       '--h264-max-fps',
       '30',
+    ]);
+  });
+
+  it('appends TURN args after the stable serve-sim stream settings', () => {
+    expect(
+      createServeSimTunnelArgs({
+        baseDomain: 'expo-simulator.ngrok.dev',
+        turnArgs: ['--turn-url', 'turns:turn.cloudflare.com:443?transport=tcp'],
+      })
+    ).toEqual([
+      'serve-sim-sjchmiela@latest',
+      '--tunnel',
+      '--tunnel-provider',
+      'ngrok',
+      '--tunnel-domain',
+      'expo-simulator.ngrok.dev',
+      '--stream-max-dimension',
+      '1280',
+      '--stream-quality',
+      '0.55',
+      '--stream-fps',
+      '10',
+      '--transport',
+      'webrtc',
+      '--webrtc-codec',
+      'h264',
+      '--h264-bitrate',
+      '3000000',
+      '--h264-max-fps',
+      '30',
+      '--turn-url',
+      'turns:turn.cloudflare.com:443?transport=tcp',
     ]);
   });
 });

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -5,6 +5,7 @@ import { CustomBuildContext } from '../../../customBuildContext';
 import { Sentry } from '../../../sentry';
 import { turtleFetch } from '../../../utils/turtleFetch';
 import {
+  createServeSimTunnelArgs,
   fetchServeSimTurnArgsAsync,
   turnIceServersToServeSimArgs,
 } from '../remoteDeviceRunSession';
@@ -35,6 +36,51 @@ function createCtxMock(): CustomBuildContext {
 function createEnvMock(): BuildStepEnv {
   return { DEVICE_RUN_SESSION_ID: 'drs-id' } as unknown as BuildStepEnv;
 }
+
+describe(createServeSimTunnelArgs, () => {
+  it('builds ngrok/H264 serve-sim args and passes through TURN flags', () => {
+    expect(
+      createServeSimTunnelArgs({
+        baseDomain: 'expo-simulator.ngrok.dev',
+        turnArgs: [
+          '--stun-url',
+          'stun:stun.cloudflare.com:3478',
+          '--turn-url',
+          'turns:turn.cloudflare.com:443?transport=tcp',
+          '--turn-username',
+          'u',
+          '--turn-credential',
+          'c',
+        ],
+      })
+    ).toEqual([
+      'serve-sim-sjchmiela@latest',
+      '--tunnel',
+      '--tunnel-provider',
+      'ngrok',
+      '--tunnel-domain',
+      'expo-simulator.ngrok.dev',
+      '--stream-max-dimension',
+      '1280',
+      '--stream-quality',
+      '0.55',
+      '--stream-fps',
+      '10',
+      '--h264-bitrate',
+      '3000000',
+      '--h264-max-fps',
+      '30',
+      '--stun-url',
+      'stun:stun.cloudflare.com:3478',
+      '--turn-url',
+      'turns:turn.cloudflare.com:443?transport=tcp',
+      '--turn-username',
+      'u',
+      '--turn-credential',
+      'c',
+    ]);
+  });
+});
 
 describe(turnIceServersToServeSimArgs, () => {
   it('returns no args for an empty ICE server list', () => {

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -38,22 +38,8 @@ function createEnvMock(): BuildStepEnv {
 }
 
 describe(createServeSimTunnelArgs, () => {
-  it('builds ngrok/H264 serve-sim args and passes through TURN flags', () => {
-    expect(
-      createServeSimTunnelArgs({
-        baseDomain: 'expo-simulator.ngrok.dev',
-        turnArgs: [
-          '--stun-url',
-          'stun:stun.cloudflare.com:3478',
-          '--turn-url',
-          'turns:turn.cloudflare.com:443?transport=tcp',
-          '--turn-username',
-          'u',
-          '--turn-credential',
-          'c',
-        ],
-      })
-    ).toEqual([
+  it('builds ngrok/H264 serve-sim args', () => {
+    expect(createServeSimTunnelArgs({ baseDomain: 'expo-simulator.ngrok.dev' })).toEqual([
       'serve-sim-sjchmiela@latest',
       '--tunnel',
       '--tunnel-provider',
@@ -70,14 +56,6 @@ describe(createServeSimTunnelArgs, () => {
       '3000000',
       '--h264-max-fps',
       '30',
-      '--stun-url',
-      'stun:stun.cloudflare.com:3478',
-      '--turn-url',
-      'turns:turn.cloudflare.com:443?transport=tcp',
-      '--turn-username',
-      'u',
-      '--turn-credential',
-      'c',
     ]);
   });
 });

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -38,32 +38,14 @@ function createEnvMock(): BuildStepEnv {
 }
 
 describe(createServeSimTunnelArgs, () => {
-  it('builds ngrok WebRTC/H264 serve-sim args and passes through TURN flags', () => {
-    expect(
-      createServeSimTunnelArgs({
-        baseDomain: 'expo-simulator.ngrok.dev',
-        turnArgs: [
-          '--stun-url',
-          'stun:stun.cloudflare.com:3478',
-          '--turn-url',
-          'turns:turn.cloudflare.com:443?transport=tcp',
-          '--turn-username',
-          'u',
-          '--turn-credential',
-          'c',
-        ],
-      })
-    ).toEqual([
+  it('builds ngrok H264 serve-sim args without forcing WebRTC', () => {
+    expect(createServeSimTunnelArgs({ baseDomain: 'expo-simulator.ngrok.dev' })).toEqual([
       'serve-sim-sjchmiela@latest',
       '--tunnel',
       '--tunnel-provider',
       'ngrok',
       '--tunnel-domain',
       'expo-simulator.ngrok.dev',
-      '--codec',
-      'webrtc',
-      '--webrtc-codec',
-      'h264',
       '--stream-max-dimension',
       '1280',
       '--stream-quality',
@@ -74,14 +56,6 @@ describe(createServeSimTunnelArgs, () => {
       '3000000',
       '--h264-max-fps',
       '30',
-      '--stun-url',
-      'stun:stun.cloudflare.com:3478',
-      '--turn-url',
-      'turns:turn.cloudflare.com:443?transport=tcp',
-      '--turn-username',
-      'u',
-      '--turn-credential',
-      'c',
     ]);
   });
 });

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -253,7 +253,7 @@ export function spawnDetached({
 }
 
 export async function startServeSimWithTunnelAsync(
-  _ctx: CustomBuildContext,
+  ctx: CustomBuildContext,
   {
     baseDomain,
     env,
@@ -267,9 +267,10 @@ export async function startServeSimWithTunnelAsync(
   }
 ): Promise<{ previewUrl: string }> {
   logger.info('Launching serve-sim with tunnel.');
+  const turnArgs = await fetchServeSimTurnArgsAsync(ctx, { env, logger });
   const serveSim = spawnDetached({
     command: 'npx',
-    args: createServeSimTunnelArgs({ baseDomain }),
+    args: createServeSimTunnelArgs({ baseDomain, turnArgs }),
     env,
   });
 
@@ -288,7 +289,13 @@ export async function startServeSimWithTunnelAsync(
   );
 }
 
-export function createServeSimTunnelArgs({ baseDomain }: { baseDomain: string }): string[] {
+export function createServeSimTunnelArgs({
+  baseDomain,
+  turnArgs = [],
+}: {
+  baseDomain: string;
+  turnArgs?: string[];
+}): string[] {
   return [
     SERVE_SIM_PACKAGE_SPEC,
     '--tunnel',
@@ -303,11 +310,17 @@ export function createServeSimTunnelArgs({ baseDomain }: { baseDomain: string })
     SERVE_SIM_MJPEG_FALLBACK_QUALITY,
     '--stream-fps',
     SERVE_SIM_MJPEG_FALLBACK_FPS,
-    // The tunneled helper advertises /stream.avcc, so keep H.264 network usage bounded.
+    // Prefer WebRTC for tunneled live sessions. Keep the HTTP stream tuning below
+    // as bounded fallback settings when the browser/helper drops back to MJPEG/AVCC.
+    '--transport',
+    'webrtc',
+    '--webrtc-codec',
+    'h264',
     '--h264-bitrate',
     SERVE_SIM_H264_BITRATE,
     '--h264-max-fps',
     SERVE_SIM_H264_MAX_FPS,
+    ...turnArgs,
   ];
 }
 

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -267,10 +267,9 @@ export async function startServeSimWithTunnelAsync(
   }
 ): Promise<{ previewUrl: string }> {
   logger.info('Launching serve-sim with tunnel.');
-  const turnArgs = await fetchServeSimTurnArgsAsync(ctx, { env, logger });
   const serveSim = spawnDetached({
     command: 'npx',
-    args: createServeSimTunnelArgs({ baseDomain, turnArgs }),
+    args: createServeSimTunnelArgs({ baseDomain }),
     env,
   });
 
@@ -289,13 +288,7 @@ export async function startServeSimWithTunnelAsync(
   );
 }
 
-export function createServeSimTunnelArgs({
-  baseDomain,
-  turnArgs = [],
-}: {
-  baseDomain: string;
-  turnArgs?: string[];
-}): string[] {
+export function createServeSimTunnelArgs({ baseDomain }: { baseDomain: string }): string[] {
   return [
     SERVE_SIM_PACKAGE_SPEC,
     '--tunnel',
@@ -315,7 +308,6 @@ export function createServeSimTunnelArgs({
     SERVE_SIM_H264_BITRATE,
     '--h264-max-fps',
     SERVE_SIM_H264_MAX_FPS,
-    ...turnArgs,
   ];
 }
 

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -253,7 +253,7 @@ export function spawnDetached({
 }
 
 export async function startServeSimWithTunnelAsync(
-  ctx: CustomBuildContext,
+  _ctx: CustomBuildContext,
   {
     baseDomain,
     env,
@@ -267,10 +267,9 @@ export async function startServeSimWithTunnelAsync(
   }
 ): Promise<{ previewUrl: string }> {
   logger.info('Launching serve-sim with tunnel.');
-  const turnArgs = await fetchServeSimTurnArgsAsync(ctx, { env, logger });
   const serveSim = spawnDetached({
     command: 'npx',
-    args: createServeSimTunnelArgs({ baseDomain, turnArgs }),
+    args: createServeSimTunnelArgs({ baseDomain }),
     env,
   });
 
@@ -289,13 +288,7 @@ export async function startServeSimWithTunnelAsync(
   );
 }
 
-export function createServeSimTunnelArgs({
-  baseDomain,
-  turnArgs = [],
-}: {
-  baseDomain: string;
-  turnArgs?: string[];
-}): string[] {
+export function createServeSimTunnelArgs({ baseDomain }: { baseDomain: string }): string[] {
   return [
     SERVE_SIM_PACKAGE_SPEC,
     '--tunnel',
@@ -303,10 +296,6 @@ export function createServeSimTunnelArgs({
     'ngrok',
     '--tunnel-domain',
     baseDomain,
-    '--codec',
-    'webrtc',
-    '--webrtc-codec',
-    'h264',
     // MJPEG remains the browser fallback when AVCC/H.264 is unavailable.
     '--stream-max-dimension',
     SERVE_SIM_MJPEG_FALLBACK_MAX_DIMENSION,
@@ -319,7 +308,6 @@ export function createServeSimTunnelArgs({
     SERVE_SIM_H264_BITRATE,
     '--h264-max-fps',
     SERVE_SIM_H264_MAX_FPS,
-    ...turnArgs,
   ];
 }
 

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -258,7 +258,7 @@ export async function startServeSimWithTunnelAsync(
     logger: bunyan;
     timeoutMs: number;
   }
-): Promise<{ previewUrl: string; streamUrl: string }> {
+): Promise<{ previewUrl: string }> {
   logger.info('Launching serve-sim with tunnel.');
   const turnArgs = await fetchServeSimTurnArgsAsync(ctx, { env, logger });
   const serveSim = spawnDetached({
@@ -281,19 +281,18 @@ export async function startServeSimWithTunnelAsync(
     env,
   });
 
-  logger.info('Waiting for serve-sim to report tunnel and stream URLs.');
+  logger.info('Waiting for serve-sim to report tunnel URL.');
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const output = serveSim.getOutput();
     const previewUrl = matchLabeledUrl({ output, label: 'Tunnel', baseDomain });
-    const streamUrl = matchLabeledUrl({ output, label: 'Stream', baseDomain });
-    if (previewUrl && streamUrl) {
-      return { previewUrl, streamUrl };
+    if (previewUrl) {
+      return { previewUrl };
     }
     await sleepAsync(1_000);
   }
   throw new SystemError(
-    `Timed out waiting for serve-sim to report Tunnel and Stream URLs. Last output:\n${serveSim.getOutput() || '<empty>'}`
+    `Timed out waiting for serve-sim to report Tunnel URL. Last output:\n${serveSim.getOutput() || '<empty>'}`
   );
 }
 

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -267,9 +267,10 @@ export async function startServeSimWithTunnelAsync(
   }
 ): Promise<{ previewUrl: string }> {
   logger.info('Launching serve-sim with tunnel.');
+  const turnArgs = await fetchServeSimTurnArgsAsync(ctx, { env, logger });
   const serveSim = spawnDetached({
     command: 'npx',
-    args: createServeSimTunnelArgs({ baseDomain }),
+    args: createServeSimTunnelArgs({ baseDomain, turnArgs }),
     env,
   });
 
@@ -288,7 +289,13 @@ export async function startServeSimWithTunnelAsync(
   );
 }
 
-export function createServeSimTunnelArgs({ baseDomain }: { baseDomain: string }): string[] {
+export function createServeSimTunnelArgs({
+  baseDomain,
+  turnArgs = [],
+}: {
+  baseDomain: string;
+  turnArgs?: string[];
+}): string[] {
   return [
     SERVE_SIM_PACKAGE_SPEC,
     '--tunnel',
@@ -296,6 +303,10 @@ export function createServeSimTunnelArgs({ baseDomain }: { baseDomain: string })
     'ngrok',
     '--tunnel-domain',
     baseDomain,
+    '--codec',
+    'webrtc',
+    '--webrtc-codec',
+    'h264',
     // MJPEG remains the browser fallback when AVCC/H.264 is unavailable.
     '--stream-max-dimension',
     SERVE_SIM_MJPEG_FALLBACK_MAX_DIMENSION,
@@ -308,6 +319,7 @@ export function createServeSimTunnelArgs({ baseDomain }: { baseDomain: string })
     SERVE_SIM_H264_BITRATE,
     '--h264-max-fps',
     SERVE_SIM_H264_MAX_FPS,
+    ...turnArgs,
   ];
 }
 

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -16,6 +16,13 @@ import { turtleFetch } from '../../utils/turtleFetch';
 
 const XCODE_DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer';
 
+const SERVE_SIM_PACKAGE_SPEC = 'serve-sim-sjchmiela@latest';
+const SERVE_SIM_MJPEG_FALLBACK_MAX_DIMENSION = '1280';
+const SERVE_SIM_MJPEG_FALLBACK_QUALITY = '0.55';
+const SERVE_SIM_MJPEG_FALLBACK_FPS = '10';
+const SERVE_SIM_H264_BITRATE = '3000000';
+const SERVE_SIM_H264_MAX_FPS = '30';
+
 const START_DEVICE_RUN_SESSION_MUTATION = graphql(`
   mutation StartDeviceRunSession($deviceRunSessionId: ID!, $remoteConfig: JSONObject!) {
     deviceRunSession {
@@ -263,21 +270,7 @@ export async function startServeSimWithTunnelAsync(
   const turnArgs = await fetchServeSimTurnArgsAsync(ctx, { env, logger });
   const serveSim = spawnDetached({
     command: 'npx',
-    args: [
-      'serve-sim-szdziedzic@latest',
-      '--tunnel',
-      '--tunnel-provider',
-      'ngrok',
-      '--tunnel-domain',
-      baseDomain,
-      '--stream-max-dimension',
-      '1280',
-      '--stream-quality',
-      '0.55',
-      '--codec',
-      'webrtc',
-      ...turnArgs,
-    ],
+    args: createServeSimTunnelArgs({ baseDomain, turnArgs }),
     env,
   });
 
@@ -294,6 +287,36 @@ export async function startServeSimWithTunnelAsync(
   throw new SystemError(
     `Timed out waiting for serve-sim to report Tunnel URL. Last output:\n${serveSim.getOutput() || '<empty>'}`
   );
+}
+
+export function createServeSimTunnelArgs({
+  baseDomain,
+  turnArgs = [],
+}: {
+  baseDomain: string;
+  turnArgs?: string[];
+}): string[] {
+  return [
+    SERVE_SIM_PACKAGE_SPEC,
+    '--tunnel',
+    '--tunnel-provider',
+    'ngrok',
+    '--tunnel-domain',
+    baseDomain,
+    // MJPEG remains the browser fallback when AVCC/H.264 is unavailable.
+    '--stream-max-dimension',
+    SERVE_SIM_MJPEG_FALLBACK_MAX_DIMENSION,
+    '--stream-quality',
+    SERVE_SIM_MJPEG_FALLBACK_QUALITY,
+    '--stream-fps',
+    SERVE_SIM_MJPEG_FALLBACK_FPS,
+    // The tunneled helper advertises /stream.avcc, so keep H.264 network usage bounded.
+    '--h264-bitrate',
+    SERVE_SIM_H264_BITRATE,
+    '--h264-max-fps',
+    SERVE_SIM_H264_MAX_FPS,
+    ...turnArgs,
+  ];
 }
 
 function matchLabeledUrl({


### PR DESCRIPTION
## Summary

- switch remote device run sessions to the `serve-sim-sjchmiela` preview helper
- report only the preview URL from serve-sim remote sessions
- avoid forcing WebRTC for tunneled previews for now, keeping the AVCC/H.264 path with MJPEG fallback

## Why

The live WebRTC preview path can get stuck during `/webrtc/offer` while the helper waits for server-side ICE gathering, leaving the browser simulator surface at `connecting`. The AVCC and MJPEG stream endpoints are healthy in that state, so this keeps the new helper while avoiding the broken WebRTC signaling path.

## Test plan

- `yarn oxfmt --write packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts`
- `yarn --cwd packages/build-tools jest-unit src/steps/utils/__tests__/remoteDeviceRunSession.test.ts`
- `git diff --check main..HEAD`