### PR TITLE
[eas-cli] Fix channel:pause and channel:resume argument descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Fix `eas channel:pause` and `eas channel:resume` showing the channel argument description as "Name of the channel to edit". ([#PRNUMBER](https://github.com/expo/eas-cli/pull/PRNUMBER) by [@patrickwehbe](https://github.com/patrickwehbe))
+
 ### 🧹 Chores
 
 ## [20.3.0](https://github.com/expo/eas-cli/releases/tag/v20.3.0) - 2026-06-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- [eas-cli] Fix `eas channel:pause` and `eas channel:resume` showing the channel argument description as "Name of the channel to edit". ([#PRNUMBER](https://github.com/expo/eas-cli/pull/PRNUMBER) by [@patrickwehbe](https://github.com/patrickwehbe))
+- [eas-cli] Fix `eas channel:pause` and `eas channel:resume` showing the channel argument description as "Name of the channel to edit". ([#3887](https://github.com/expo/eas-cli/pull/3887) by [@patrickwehbe](https://github.com/patrickwehbe))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -944,7 +944,7 @@ USAGE
   $ eas channel:pause [NAME] [--branch <value>] [--json] [--non-interactive]
 
 ARGUMENTS
-  [NAME]  Name of the channel to edit
+  [NAME]  Name of the channel to pause
 
 FLAGS
   --branch=<value>   Name of the branch to point to
@@ -966,7 +966,7 @@ USAGE
   $ eas channel:resume [NAME] [--branch <value>] [--json] [--non-interactive]
 
 ARGUMENTS
-  [NAME]  Name of the channel to edit
+  [NAME]  Name of the channel to resume
 
 FLAGS
   --branch=<value>   Name of the branch to point to

--- a/packages/eas-cli/src/commands/channel/pause.ts
+++ b/packages/eas-cli/src/commands/channel/pause.ts
@@ -56,7 +56,7 @@ export default class ChannelPause extends EasCommand {
   static override args = {
     name: Args.string({
       required: false,
-      description: 'Name of the channel to edit',
+      description: 'Name of the channel to pause',
     }),
   };
 

--- a/packages/eas-cli/src/commands/channel/resume.ts
+++ b/packages/eas-cli/src/commands/channel/resume.ts
@@ -56,7 +56,7 @@ export default class ChannelResume extends EasCommand {
   static override args = {
     name: Args.string({
       required: false,
-      description: 'Name of the channel to edit',
+      description: 'Name of the channel to resume',
     }),
   };
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->

# Why

The `NAME` argument for `eas channel:pause` and `eas channel:resume` is described as "Name of the channel to edit". That wording was copied over from `channel:edit` and never updated, so `--help` for both commands tells you to pass the channel to "edit" even though neither command edits the channel.

# How

Updated the argument description in `packages/eas-cli/src/commands/channel/pause.ts` to "Name of the channel to pause" and in `packages/eas-cli/src/commands/channel/resume.ts` to "Name of the channel to resume". I also updated the two matching lines in `packages/eas-cli/README.md` by hand to mirror the change, since running the full `yarn oclif readme` regeneration pulls in the whole monorepo install. `channel:edit` keeps its original description.

I added a bug-fix entry to `CHANGELOG.md` under the `main` section.

# Test Plan

This is a string-only change to the command metadata. Help output now reads correctly:

```
$ eas channel:pause --help
...
ARGUMENTS
  [NAME]  Name of the channel to pause

$ eas channel:resume --help
...
ARGUMENTS
  [NAME]  Name of the channel to resume
```
