### PR TITLE
[eas-cli] Fix update:republish command description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Fix `eas update:republish` showing the `update:rollback` description ("roll back to an existing update") in its help output. ([#3888](https://github.com/expo/eas-cli/pull/3888) by [@patrickwehbe](https://github.com/patrickwehbe))
+
 ### 🧹 Chores
 
 ## [20.3.0](https://github.com/expo/eas-cli/releases/tag/v20.3.0) - 2026-06-18

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -2589,7 +2589,7 @@ _See code: [packages/eas-cli/src/commands/update/list.ts](https://github.com/exp
 
 ## `eas update:republish`
 
-roll back to an existing update
+republish an existing update to a branch
 
 ```
 USAGE
@@ -2620,7 +2620,7 @@ FLAGS
                                      1 and 100. When not specified, this defaults to 100.
 
 DESCRIPTION
-  roll back to an existing update
+  republish an existing update to a branch
 ```
 
 _See code: [packages/eas-cli/src/commands/update/republish.ts](https://github.com/expo/eas-cli/blob/v20.3.0/packages/eas-cli/src/commands/update/republish.ts)_

--- a/packages/eas-cli/src/commands/update/republish.ts
+++ b/packages/eas-cli/src/commands/update/republish.ts
@@ -50,7 +50,7 @@ type UpdateRepublishFlags = {
 };
 
 export default class UpdateRepublish extends EasCommand {
-  static override description = 'roll back to an existing update';
+  static override description = 'republish an existing update to a branch';
 
   static override flags = {
     channel: Flags.string({


### PR DESCRIPTION
# Why

`eas update:republish --help` shows the description "roll back to an existing update", which belongs to the separate `eas update:rollback` command. It looks like that string was copied over when the command was set up. Everything else about `update:republish` is about republishing an update group to a branch: its flags (`--branch`, `--group`, `--destination-branch`, ...), its log output ("The republished update group will appear..."), and the `republishAsync` call it runs. So the description is just wrong and is confusing in the help output and the generated CLI reference.

For comparison, `update/rollback.ts` keeps its own correct description, "roll back to an embedded update or an existing update".

# How

Changed the `static description` on the `UpdateRepublish` command from "roll back to an existing update" to "republish an existing update to a branch", then updated the matching lines in `packages/eas-cli/README.md` so the generated reference stays in sync. The README change mirrors exactly what `oclif readme` produces for this command (verified by regenerating and diffing); I applied just the two republish lines by hand to keep this PR scoped to the fix and avoid pulling in unrelated regenerated sections.

Also added a bug-fix entry to `CHANGELOG.md`.

# Test Plan

- `yarn build` for the monorepo succeeds with the change.
- After building, `eas update:republish --help` now prints "republish an existing update to a branch" in both the summary line and the DESCRIPTION block, and `eas update:rollback --help` is unaffected.
