### PR TITLE
[eas-cli] Auto-create branch when channel has no branches mapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Fix `eas update --channel` failing with "Channel has no branches associated with it" when the channel was auto-created by a build. A branch with the channel's name is now created and linked, matching the behavior for a channel that doesn't exist yet. ([#3891](https://github.com/expo/eas-cli/pull/3891) by [@gwdp](https://github.com/gwdp))
+
 ### 🧹 Chores
 
 ## [20.3.0](https://github.com/expo/eas-cli/releases/tag/v20.3.0) - 2026-06-18

--- a/packages/eas-cli/src/update/__tests__/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync-test.ts
+++ b/packages/eas-cli/src/update/__tests__/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync-test.ts
@@ -99,6 +99,21 @@ describe(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync, () => {
     );
   });
 
+  test('rethrows unexpected errors from the channel lookup', async () => {
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
+    jest.mocked(ChannelQuery.viewUpdateChannelAsync).mockImplementationOnce(async () => {
+      throw new Error('Network request failed');
+    });
+
+    await expect(
+      getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
+        graphqlClient,
+        'test-project-id',
+        'test-channel-name'
+      )
+    ).rejects.toThrow('Network request failed');
+  });
+
   test('creates channel and branch when channel does not exist, and returns branch name', async () => {
     const graphqlClient = instance(mock<ExpoGraphqlClient>());
     jest.mocked(ChannelQuery.viewUpdateChannelAsync).mockImplementationOnce(async () => {

--- a/packages/eas-cli/src/update/__tests__/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync-test.ts
+++ b/packages/eas-cli/src/update/__tests__/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync-test.ts
@@ -1,5 +1,8 @@
 import { instance, mock } from 'ts-mockito';
 
+import { ensureBranchExistsAsync } from '../../branch/queries';
+import { ChannelNotFoundError } from '../../channel/errors';
+import { createChannelOnAppAsync } from '../../channel/queries';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import {
   App,
@@ -14,6 +17,8 @@ import { getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync } from '../get
 
 jest.mock('../../graphql/queries/ChannelQuery');
 jest.mock('../../graphql/queries/BranchQuery');
+jest.mock('../../branch/queries');
+jest.mock('../../channel/queries');
 
 describe(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync, () => {
   beforeEach(() => {
@@ -40,7 +45,7 @@ describe(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync, () => {
     expect(result.branchName).toBe('test-branch-name');
   });
 
-  test('errors when no branch is connected to channel', async () => {
+  test('creates and links a branch when channel exists but has no branches (e.g. auto-created by a build)', async () => {
     const graphqlClient = instance(mock<ExpoGraphqlClient>());
     jest.mocked(ChannelQuery.viewUpdateChannelAsync).mockImplementationOnce(
       async () =>
@@ -48,16 +53,29 @@ describe(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync, () => {
           channelName: 'test-channel-name',
         }) as any
     );
+    jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
+      branch: { __typename: 'UpdateBranch', id: 'test-branch-id', name: 'test-channel-name' },
+      createdBranch: true,
+    });
+    jest.mocked(createChannelOnAppAsync).mockResolvedValue({
+      updateChannel: {
+        createUpdateChannelForApp: {
+          id: 'test-channel-id',
+          name: 'test-channel-name',
+          branchMapping:
+            '{"data":[{"branchId":"test-branch-id","branchMappingLogic":"true"}],"version":0}',
+        },
+      },
+    });
 
-    await expect(
-      getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
-        graphqlClient,
-        'test-project-id',
-        'test-channel-name'
-      )
-    ).rejects.toThrow(
-      "Channel has no branches associated with it. Run 'eas channel:edit' to map a branch"
+    const result = await getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
+      graphqlClient,
+      'test-project-id',
+      'test-channel-name'
     );
+
+    expect(result.branchId).toBe('test-branch-id');
+    expect(result.branchName).toBe('test-channel-name');
   });
 
   test('errors when more than one branch is connected to channel', async () => {
@@ -83,13 +101,23 @@ describe(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync, () => {
 
   test('creates channel and branch when channel does not exist, and returns branch name', async () => {
     const graphqlClient = instance(mock<ExpoGraphqlClient>());
-    jest.mocked(ChannelQuery.viewUpdateChannelAsync).mockImplementationOnce(
-      async () =>
-        mockUpdateChannel({
-          channelName: 'test-channel-name',
-          branchNames: ['test-branch-name'],
-        }) as any
-    );
+    jest.mocked(ChannelQuery.viewUpdateChannelAsync).mockImplementationOnce(async () => {
+      throw new ChannelNotFoundError('Could not find channel with the name test-channel-name');
+    });
+    jest.mocked(ensureBranchExistsAsync).mockResolvedValue({
+      branch: { __typename: 'UpdateBranch', id: 'test-branch-id', name: 'test-channel-name' },
+      createdBranch: true,
+    });
+    jest.mocked(createChannelOnAppAsync).mockResolvedValue({
+      updateChannel: {
+        createUpdateChannelForApp: {
+          id: 'test-channel-id',
+          name: 'test-channel-name',
+          branchMapping:
+            '{"data":[{"branchId":"test-branch-id","branchMappingLogic":"true"}],"version":0}',
+        },
+      },
+    });
 
     const result = await getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
       graphqlClient,
@@ -97,7 +125,8 @@ describe(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync, () => {
       'test-channel-name'
     );
 
-    expect(result.branchName).toBe('test-branch-name');
+    expect(result.branchId).toBe('test-branch-id');
+    expect(result.branchName).toBe('test-channel-name');
   });
 });
 

--- a/packages/eas-cli/src/update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync.ts
+++ b/packages/eas-cli/src/update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync.ts
@@ -9,51 +9,55 @@ export async function getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync(
   projectId: string,
   channelName: string
 ): Promise<{ branchName: string; branchId: string }> {
-  let branchInfo: { branchName: string; branchId: string };
-
+  let channel;
   try {
-    const channel = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+    channel = await ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
       appId: projectId,
       channelName,
     });
-
-    if (channel.updateBranches.length === 1) {
-      const branch = channel.updateBranches[0];
-      branchInfo = { branchId: branch.id, branchName: branch.name };
-    } else if (channel.updateBranches.length === 0) {
-      throw new Error(
-        "Channel has no branches associated with it. Run 'eas channel:edit' to map a branch"
-      );
-    } else {
-      throw new Error(
-        `Channel has multiple branches associated with it. Instead, use '--branch' instead of '--channel'`
-      );
-    }
   } catch (error) {
     if (!(error instanceof ChannelNotFoundError)) {
       throw error;
     }
-
-    const { branch } = await ensureBranchExistsAsync(graphqlClient, {
-      appId: projectId,
-      branchName: channelName,
-    });
-    const {
-      updateChannel: { createUpdateChannelForApp: newChannel },
-    } = await createChannelOnAppAsync(graphqlClient, {
-      appId: projectId,
-      channelName,
-      branchId: branch.id,
-    });
-
-    if (!newChannel) {
-      throw new Error(
-        `Could not create channel with name ${channelName} on project with id ${projectId}`
-      );
-    }
-
-    branchInfo = { branchId: branch.id, branchName: channelName };
+    return await createAndLinkBranchToChannelAsync(graphqlClient, projectId, channelName);
   }
 
-  return branchInfo;
+  if (channel.updateBranches.length === 1) {
+    const branch = channel.updateBranches[0];
+    return { branchId: branch.id, branchName: branch.name };
+  }
+
+  if (channel.updateBranches.length === 0) {
+    return await createAndLinkBranchToChannelAsync(graphqlClient, projectId, channelName);
+  }
+
+  throw new Error(
+    `Channel has multiple branches associated with it. Instead, use '--branch' instead of '--channel'`
+  );
+}
+
+async function createAndLinkBranchToChannelAsync(
+  graphqlClient: ExpoGraphqlClient,
+  projectId: string,
+  channelName: string
+): Promise<{ branchName: string; branchId: string }> {
+  const { branch } = await ensureBranchExistsAsync(graphqlClient, {
+    appId: projectId,
+    branchName: channelName,
+  });
+  const {
+    updateChannel: { createUpdateChannelForApp: newChannel },
+  } = await createChannelOnAppAsync(graphqlClient, {
+    appId: projectId,
+    channelName,
+    branchId: branch.id,
+  });
+
+  if (!newChannel) {
+    throw new Error(
+      `Could not create channel with name ${channelName} on project with id ${projectId}`
+    );
+  }
+
+  return { branchId: branch.id, branchName: channelName };
 }

--- a/packages/eas-cli/src/update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync.ts
+++ b/packages/eas-cli/src/update/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync.ts
@@ -45,19 +45,11 @@ async function createAndLinkBranchToChannelAsync(
     appId: projectId,
     branchName: channelName,
   });
-  const {
-    updateChannel: { createUpdateChannelForApp: newChannel },
-  } = await createChannelOnAppAsync(graphqlClient, {
+  await createChannelOnAppAsync(graphqlClient, {
     appId: projectId,
     channelName,
     branchId: branch.id,
   });
-
-  if (!newChannel) {
-    throw new Error(
-      `Could not create channel with name ${channelName} on project with id ${projectId}`
-    );
-  }
 
   return { branchId: branch.id, branchName: channelName };
 }


### PR DESCRIPTION
`eas update --channel <name>` was failing with `Channel has no branches associated with it` when the channel existed but had no branch mapped.

This trips up fresh projects: `eas build` auto-creates the channel without a branch, so by the time you run `eas update` the channel already exists. The CLI only ever auto-created a branch when the channel was *missing* (`ChannelNotFoundError`), so the existing-but-empty channel fell through to the error instead.

Now the empty-channel case does the same thing as the missing-channel case: create a branch with the channel's name and map it.

## Test plan

- Added a unit test for the empty-channel case
- Ran `eas update --channel <empty channel>` against a real project: the old CLI fails with the error above, this build creates the branch and publishes the update
