### PR TITLE
Fix repack AAB output path

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/repack.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/repack.test.ts
@@ -48,6 +48,47 @@ describe(createRepackBuildFunction, () => {
     expect(repackStep.outputById['output_path'].value).toBe('/path/to/output_app');
   });
 
+  it('should rename explicit aab output path to apk', async () => {
+    const repack = createRepackBuildFunction();
+    const repackStep = repack.createBuildStepFromFunctionCall(
+      createGlobalContextMock({
+        staticContextContent: {
+          job: createTestAndroidJob(),
+        },
+      }),
+      {
+        callInputs: {
+          platform: 'android',
+          source_app_path: '/path/to/source_app.aab',
+          output_path: '/path/to/output_app.aab',
+        },
+      }
+    );
+
+    await repackStep.executeAsync();
+    expect(repackStep.outputById['output_path'].value).toBe('/path/to/output_app.apk');
+  });
+
+  it('should rename generated aab output path to apk', async () => {
+    const repack = createRepackBuildFunction();
+    const repackStep = repack.createBuildStepFromFunctionCall(
+      createGlobalContextMock({
+        staticContextContent: {
+          job: createTestAndroidJob(),
+        },
+      }),
+      {
+        callInputs: {
+          platform: 'android',
+          source_app_path: '/path/to/source_app.aab',
+        },
+      }
+    );
+
+    await repackStep.executeAsync();
+    expect(repackStep.outputById['output_path'].value).toMatch(/repacked-.*\.apk$/);
+  });
+
   it('should throw for unsupported platforms', async () => {
     const repack = createRepackBuildFunction();
     const repackStep = repack.createBuildStepFromFunctionCall(

--- a/packages/build-tools/src/steps/functions/__tests__/repack.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/repack.test.ts
@@ -27,7 +27,7 @@ describe(createRepackBuildFunction, () => {
     vol.reset();
   });
 
-  it('should set the output path for successful repack', async () => {
+  it('should set generated output path for successful repack', async () => {
     const repack = createRepackBuildFunction();
     const repackStep = repack.createBuildStepFromFunctionCall(
       createGlobalContextMock({
@@ -38,35 +38,13 @@ describe(createRepackBuildFunction, () => {
       {
         callInputs: {
           platform: 'ios',
-          source_app_path: '/path/to/source_app',
-          output_path: '/path/to/output_app',
+          source_app_path: '/path/to/source_app.ipa',
         },
       }
     );
 
     await repackStep.executeAsync();
-    expect(repackStep.outputById['output_path'].value).toBe('/path/to/output_app');
-  });
-
-  it('should preserve explicit aab output path', async () => {
-    const repack = createRepackBuildFunction();
-    const repackStep = repack.createBuildStepFromFunctionCall(
-      createGlobalContextMock({
-        staticContextContent: {
-          job: createTestAndroidJob(),
-        },
-      }),
-      {
-        callInputs: {
-          platform: 'android',
-          source_app_path: '/path/to/source_app.aab',
-          output_path: '/path/to/output_app.aab',
-        },
-      }
-    );
-
-    await repackStep.executeAsync();
-    expect(repackStep.outputById['output_path'].value).toBe('/path/to/output_app.aab');
+    expect(repackStep.outputById['output_path'].value).toMatch(/repacked-.*\.ipa$/);
   });
 
   it('should rename generated aab output path to apk', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/repack.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/repack.test.ts
@@ -48,7 +48,7 @@ describe(createRepackBuildFunction, () => {
     expect(repackStep.outputById['output_path'].value).toBe('/path/to/output_app');
   });
 
-  it('should rename explicit aab output path to apk', async () => {
+  it('should preserve explicit aab output path', async () => {
     const repack = createRepackBuildFunction();
     const repackStep = repack.createBuildStepFromFunctionCall(
       createGlobalContextMock({
@@ -66,7 +66,7 @@ describe(createRepackBuildFunction, () => {
     );
 
     await repackStep.executeAsync();
-    expect(repackStep.outputById['output_path'].value).toBe('/path/to/output_app.apk');
+    expect(repackStep.outputById['output_path'].value).toBe('/path/to/output_app.aab');
   });
 
   it('should rename generated aab output path to apk', async () => {

--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -43,11 +43,6 @@ export function createRepackBuildFunction(): BuildFunction {
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
       BuildStepInput.createProvider({
-        id: 'output_path',
-        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
-        required: false,
-      }),
-      BuildStepInput.createProvider({
         id: 'embed_bundle_assets',
         allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
         required: false,
@@ -110,7 +105,6 @@ export function createRepackBuildFunction(): BuildFunction {
 
       const sourceAppPath = inputs.source_app_path.value as string;
       const outputPath = createOutputPath({
-        requestedOutputPath: inputs.output_path.value as string | undefined,
         sourceAppPath,
         tmpDir,
       });
@@ -205,18 +199,12 @@ export function createRepackBuildFunction(): BuildFunction {
 }
 
 function createOutputPath({
-  requestedOutputPath,
   sourceAppPath,
   tmpDir,
 }: {
-  requestedOutputPath?: string;
   sourceAppPath: string;
   tmpDir: string;
 }): string {
-  if (requestedOutputPath) {
-    return requestedOutputPath;
-  }
-
   const outputPath = path.join(tmpDir, `repacked-${randomUUID()}${path.extname(sourceAppPath)}`);
   const extension = path.extname(outputPath);
   if (extension.toLowerCase() !== '.aab') {

--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -213,9 +213,11 @@ function createOutputPath({
   sourceAppPath: string;
   tmpDir: string;
 }): string {
-  const outputPath =
-    requestedOutputPath ??
-    path.join(tmpDir, `repacked-${randomUUID()}${path.extname(sourceAppPath)}`);
+  if (requestedOutputPath) {
+    return requestedOutputPath;
+  }
+
+  const outputPath = path.join(tmpDir, `repacked-${randomUUID()}${path.extname(sourceAppPath)}`);
   const extension = path.extname(outputPath);
   if (extension.toLowerCase() !== '.aab') {
     return outputPath;

--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -109,9 +109,11 @@ export function createRepackBuildFunction(): BuildFunction {
       stepsCtx.logger.info(`Created temporary working directory: ${workingDirectory}`);
 
       const sourceAppPath = inputs.source_app_path.value as string;
-      const outputPath =
-        (inputs.output_path.value as string) ??
-        path.join(tmpDir, `repacked-${randomUUID()}${path.extname(sourceAppPath)}`);
+      const outputPath = createOutputPath({
+        requestedOutputPath: inputs.output_path.value as string | undefined,
+        sourceAppPath,
+        tmpDir,
+      });
       const exportEmbedOptions = inputs.embed_bundle_assets.value
         ? {
             sourcemapOutput: undefined,
@@ -200,6 +202,25 @@ export function createRepackBuildFunction(): BuildFunction {
       outputs.output_path.set(outputPath);
     },
   });
+}
+
+function createOutputPath({
+  requestedOutputPath,
+  sourceAppPath,
+  tmpDir,
+}: {
+  requestedOutputPath?: string;
+  sourceAppPath: string;
+  tmpDir: string;
+}): string {
+  const outputPath =
+    requestedOutputPath ??
+    path.join(tmpDir, `repacked-${randomUUID()}${path.extname(sourceAppPath)}`);
+  const extension = path.extname(outputPath);
+  if (extension.toLowerCase() !== '.aab') {
+    return outputPath;
+  }
+  return `${outputPath.slice(0, -extension.length)}.apk`;
 }
 
 /**


### PR DESCRIPTION
# Why

Repacked Android builds should produce an APK output path when the source app path ends in `.aab`.

# How

Removed the unused `output_path` input and generate the repacked output path internally. Generated `.aab` paths are rewritten to `.apk`.

# Test Plan

- `yarn run -T oxfmt packages/build-tools/src/steps/functions/repack.ts packages/build-tools/src/steps/functions/__tests__/repack.test.ts`
- `yarn --cwd packages/build-tools jest-unit repack.test.ts --watchman=false`
