### PR TITLE
[build-tools] Fix runtime version mismatch from premature fingerprint in eas build:internal

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -31,6 +31,7 @@ import { uploadApplicationArchive } from '../utils/artifacts';
 import {
   configureExpoUpdatesIfInstalledAsync,
   resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync,
+  updateBuildRuntimeVersionInDatabaseAsync,
 } from '../utils/expoUpdates';
 import { uploadEmbeddedBundleAsync } from '../utils/expoUpdatesEmbedded';
 import { Hook, runHookIfPresent } from '../utils/hooks';
@@ -103,7 +104,7 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
   const resolvedExpoUpdatesRuntimeVersion = await ctx.runBuildPhase(
     BuildPhase.CALCULATE_EXPO_UPDATES_RUNTIME_VERSION,
     async () => {
-      return await resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
+      const resolved = await resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
         cwd: ctx.getReactNativeProjectDirectory(),
         logger: ctx.logger,
         appConfig: await ctx.appConfig,
@@ -111,6 +112,10 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
         workflow: ctx.job.type,
         env: ctx.env,
       });
+      if (resolved?.runtimeVersion) {
+        await updateBuildRuntimeVersionInDatabaseAsync(ctx, resolved.runtimeVersion, resolved.fingerprintSources);
+      }
+      return resolved;
     }
   );
 

--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -113,7 +113,11 @@ async function buildAsync(ctx: BuildContext<Android.Job>): Promise<void> {
         env: ctx.env,
       });
       if (resolved?.runtimeVersion) {
-        await updateBuildRuntimeVersionInDatabaseAsync(ctx, resolved.runtimeVersion, resolved.fingerprintSources);
+        await updateBuildRuntimeVersionInDatabaseAsync(
+          ctx,
+          resolved.runtimeVersion,
+          resolved.fingerprintSources
+        );
       }
       return resolved;
     }

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -24,6 +24,7 @@ import { uploadApplicationArchive } from '../utils/artifacts';
 import {
   configureExpoUpdatesIfInstalledAsync,
   resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync,
+  updateBuildRuntimeVersionInDatabaseAsync,
 } from '../utils/expoUpdates';
 import { uploadEmbeddedBundleAsync } from '../utils/expoUpdatesEmbedded';
 import { Hook, runHookIfPresent } from '../utils/hooks';
@@ -104,7 +105,7 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
     const resolvedExpoUpdatesRuntimeVersion = await ctx.runBuildPhase(
       BuildPhase.CALCULATE_EXPO_UPDATES_RUNTIME_VERSION,
       async () => {
-        return await resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
+        const resolved = await resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
           cwd: ctx.getReactNativeProjectDirectory(),
           logger: ctx.logger,
           appConfig: await ctx.appConfig,
@@ -112,6 +113,10 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
           workflow: ctx.job.type,
           env: ctx.env,
         });
+        if (resolved?.runtimeVersion) {
+          await updateBuildRuntimeVersionInDatabaseAsync(ctx, resolved.runtimeVersion, resolved.fingerprintSources);
+        }
+        return resolved;
       }
     );
 

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -114,7 +114,11 @@ async function buildAsync(ctx: BuildContext<Ios.Job>): Promise<void> {
           env: ctx.env,
         });
         if (resolved?.runtimeVersion) {
-          await updateBuildRuntimeVersionInDatabaseAsync(ctx, resolved.runtimeVersion, resolved.fingerprintSources);
+          await updateBuildRuntimeVersionInDatabaseAsync(
+            ctx,
+            resolved.runtimeVersion,
+            resolved.fingerprintSources
+          );
         }
         return resolved;
       }

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config';
-import { BuildJob, Job, Platform, Workflow } from '@expo/eas-build-job';
+import { BuildJob, BuildTrigger, Job, Platform, Workflow } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { BuildStepEnv } from '@expo/steps';
 import assert from 'assert';
@@ -192,6 +192,42 @@ export async function resolveRuntimeVersionForExpoUpdatesIfConfiguredAsync({
 
   logger.info(`Resolved runtime version: ${resolvedRuntimeVersion?.runtimeVersion}`);
   return resolvedRuntimeVersion;
+}
+
+export async function updateBuildRuntimeVersionInDatabaseAsync(
+  ctx: BuildContext<BuildJob>,
+  runtimeVersion: string,
+  fingerprintSources: object[] | null
+): Promise<void> {
+  const buildId = ctx.env.EAS_BUILD_ID;
+  if (!buildId || ctx.job.triggeredBy !== BuildTrigger.GIT_BASED_INTEGRATION) {
+    return;
+  }
+  const fingerprintHash = fingerprintSources ? runtimeVersion : undefined;
+  const result = await ctx.graphqlClient
+    .mutation(
+      graphql(`
+        mutation UpdateBuildRuntimeVersionMutation(
+          $buildId: ID!
+          $runtimeVersion: String!
+          $fingerprintHash: String
+        ) {
+          build {
+            updateBuildMetadata(
+              buildId: $buildId
+              metadata: { runtimeVersion: $runtimeVersion, fingerprintHash: $fingerprintHash }
+            ) {
+              id
+            }
+          }
+        }
+      `),
+      { buildId, runtimeVersion, fingerprintHash }
+    )
+    .toPromise();
+  if (result.error) {
+    throw result.error;
+  }
 }
 
 export async function getChannelAsync(ctx: BuildContext<Job>): Promise<string | null> {

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -178,8 +178,13 @@ export async function prepareBuildRequestForPlatformAsync<
   }
   assert(projectArchive);
 
+  // In INTERNAL mode the fingerprint is computed before prebuild runs, so native directories
+  // don't exist yet. The post-prebuild fingerprint is written to the DB by the
+  // CALCULATE_EXPO_UPDATES_RUNTIME_VERSION build phase instead.
   const runtimeAndFingerprintMetadata =
-    await computeAndMaybeUploadRuntimeAndFingerprintMetadataAsync(ctx);
+    ctx.localBuildOptions.localBuildMode === LocalBuildMode.INTERNAL
+      ? {}
+      : await computeAndMaybeUploadRuntimeAndFingerprintMetadataAsync(ctx);
   const metadata = await collectMetadataAsync(ctx, runtimeAndFingerprintMetadata);
   const buildParams = resolveBuildParamsInput(ctx, metadata);
   const job = await builder.prepareJobAsync(ctx, {


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Workflow builds were failing with a false-positive "Runtime version mismatch" error for jobs using calculate expo updates.

Root cause: workflow builds have an extra internal phase `build:internal` that runs on the worker to resolve job config. The problem is the order of operations:

  1. eas build:internal runs → computes fingerprint before PREBUILD → stores hash A in `ctx.metadata.runtimeVersion`
  2. PREBUILD runs → creates`ios/` or `android/` directory, native code is generated
  3. CALCULATE_EXPO_UPDATES_RUNTIME_VERSION runs → computes fingerprint after PREBUILD → gets hash B
  4. CONFIGURE_EXPO_UPDATES compares A vs B → mismatch → throws error

For some projects the fingerprint legitimately differs pre vs post prebuild because the react-native autolinking config changes once native directories exist. The fingerprint should reflect the post-prebuild state eas build:internal is just computing it too early.

# How

  Two changes:

  1. Skip fingerprint computation in eas build:internal (build.ts). In INTERNAL mode, return {} instead of computing the fingerprint. This means `ctx.metadata.runtimeVersion` is never set from a stale pre-prebuild
  fingerprint, so the mismatch check in CONFIGURE_EXPO_UPDATES short-circuits and no error is thrown.
  2. Write the correct post-prebuild fingerprint to the DB (expoUpdates.ts, android.ts, ios.ts). Since part 1 stops writing runtimeVersion to the DB from eas build:internal, we now write it from the CALCULATE_EXPO_UPDATES_RUNTIME_VERSION phase instead — after PREBUILD has run and native directories exist. This is gated on BuildTrigger.GIT_BASED_INTEGRATION since non-workflow builds still go through the normal build.ts path.

  # Test Plan

Trigger a workflow build on a project using runtimeVersion: { policy: 'fingerprint' } with a managed workflow (no pre-existing ios/ or android/ directories). Before this fix the build would fail in CONFIGURE_EXPO_UPDATES with "Runtime version calculated on local machine not equal to runtime version calculated during build."

<img width="1133" height="686" alt="Screenshot 2026-06-24 at 12 29 25 AM" src="https://github.com/user-attachments/assets/4792d7bf-874d-42db-b5d7-be6a22c39033" />

