### PR TITLE
[eas-cli]: warn user on missing primary locale

### DIFF
--- a/packages/eas-cli/src/metadata/__tests__/upload.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/upload.test.ts
@@ -1,9 +1,10 @@
 import { uploadMetadataAsync } from '../upload';
 import { MetadataValidationError } from '../errors';
+import Log from '../../log';
 
 jest.mock('../auth', () => ({
   getAppStoreAuthAsync: jest.fn(() => ({
-    app: { id: '123' },
+    app: { id: '123', attributes: { primaryLocale: 'en-US' } },
     auth: { context: { token: 'mock' } },
   })),
 }));
@@ -15,6 +16,7 @@ jest.mock('../apple/tasks', () => ({
 jest.mock('../config/resolve', () => ({
   createAppleReader: jest.fn(() => ({
     getVersion: jest.fn(() => ({ versionString: '1.0.0' })),
+    getLocales: jest.fn(() => ['en-US']),
   })),
   loadConfigAsync: jest.fn(() => ({ configVersion: 0 })),
 }));
@@ -32,9 +34,6 @@ jest.mock('../../prompts', () => ({
   confirmAsync: jest.fn(),
 }));
 
-const { loadConfigAsync } = require('../config/resolve') as jest.Mocked<
-  typeof import('../config/resolve')
->;
 const { confirmAsync } = require('../../prompts') as jest.Mocked<typeof import('../../prompts')>;
 
 function createArgs(overrides: Record<string, any> = {}) {
@@ -49,6 +48,25 @@ function createArgs(overrides: Record<string, any> = {}) {
     projectId: 'test-project-id',
     ...overrides,
   };
+}
+
+const { getAppStoreAuthAsync } = require('../auth') as jest.Mocked<typeof import('../auth')>;
+const { createAppleReader, loadConfigAsync } = require('../config/resolve') as jest.Mocked<
+  typeof import('../config/resolve')
+>;
+
+function mockApp(primaryLocale?: string) {
+  (getAppStoreAuthAsync as jest.Mock).mockResolvedValueOnce({
+    app: { id: '123', attributes: { primaryLocale } },
+    auth: { context: { token: 'mock' } },
+  });
+}
+
+function mockConfigLocales(locales: string[]) {
+  (createAppleReader as jest.Mock).mockReturnValueOnce({
+    getVersion: jest.fn(() => ({ versionString: '1.0.0' })),
+    getLocales: jest.fn(() => locales),
+  });
 }
 
 describe(uploadMetadataAsync, () => {
@@ -99,5 +117,68 @@ describe(uploadMetadataAsync, () => {
 
     expect(result).toHaveProperty('appleLink');
     expect(result.appleLink).toContain('appstoreconnect.apple.com');
+  });
+
+  describe('locales', () => {
+    it('warns the user when the store config omits the app primary locale', async () => {
+      mockApp('en-GB');
+      mockConfigLocales(['en-US', 'fr-FR']);
+
+      await uploadMetadataAsync(createArgs());
+
+
+      expect(jest.mocked(Log.warn)).toHaveBeenCalledTimes(1);
+      const warn = jest.mocked(Log.warn);
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Your store configuration includes "en-US", "fr-FR", but not the app's primary locale "en-GB".`
+        )
+      );
+      
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(`App Store Connect displays the primary locale by default`)
+      );
+      
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(`Add a "en-GB" entry to your store.config.json.`)
+      );
+    });
+
+    it('does not warn when the primary locale is included in the store config', async () => {
+      mockApp('en-US');
+      mockConfigLocales(['en-US', 'en-GB']);
+
+      await uploadMetadataAsync(createArgs());
+
+      expect(jest.mocked(Log.warn)).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when the primary locale is the only configured locale', async () => {
+      mockApp('en-US');
+      mockConfigLocales(['en-US']);
+
+      await uploadMetadataAsync(createArgs());
+
+      expect(jest.mocked(Log.warn)).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when the store config has no locales', async () => {
+      mockApp('en-GB');
+      mockConfigLocales([]);
+
+      await uploadMetadataAsync(createArgs());
+
+      expect(jest.mocked(Log.warn)).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when the app has no primary locale', async () => {
+      mockApp();
+      mockConfigLocales(['en-US', 'en-GB']);
+
+      await uploadMetadataAsync(createArgs());
+
+      expect(jest.mocked(Log.warn)).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/eas-cli/src/metadata/upload.ts
+++ b/packages/eas-cli/src/metadata/upload.ts
@@ -63,6 +63,31 @@ export async function uploadMetadataAsync({
 
   const errors: Error[] = [];
   const config = createAppleReader(storeConfig);
+
+  /**
+   * Warn the user if the store config doesn't include the app's
+   * primary locale. Pushes that only include non-primary locales
+   * may not appear on the ASC dashboard - due to ASC showing the primary language
+   * by default which could lead to a confusing experience.
+   * @example
+   * en-gb: {}
+   * en-us: { title: "my-app", description: "my-app", keywords: ["cool-app"] }
+   */
+  const locales = config.getLocales();
+  const primaryLocale = app.attributes.primaryLocale;
+
+  if (primaryLocale && locales.length > 0 && !locales.includes(primaryLocale)) {
+    Log.warn(`
+      Your store configuration includes ${locales.map(locale => `"${locale}"`).join(', ')}, but not the app's primary locale "${primaryLocale}".
+      
+      App Store Connect displays the primary locale by default, so changes may not be visible there.
+
+      To fix this, either:
+        • Add a "${primaryLocale}" entry to your store.config.json.
+        • Change the app's primary language in App Store Connect.
+      `);
+  }
+
   const tasks = createAppleTasks({
     // We need to resolve a different version as soon as possible.
     // This version is the parent model of all changes we are going to push.
@@ -93,7 +118,9 @@ export async function uploadMetadataAsync({
     throw new MetadataUploadError(errors, executionId);
   }
 
-  return { appleLink: `https://appstoreconnect.apple.com/apps/${app.id}/appstore` };
+  return {
+    appleLink: `https://appstoreconnect.apple.com/apps/${app.id}/appstore`,
+  };
 }
 
 async function loadConfigWithValidationPromptAsync(
@@ -116,8 +143,16 @@ async function loadConfigWithValidationPromptAsync(
         'Without further updates, the current store configuration can fail to be synchronized with the App Store or pass App Store review.'
       );
 
-      if (await confirmAsync({ message: 'Do you still want to push the store configuration?' })) {
-        return await loadConfigAsync({ projectDir, profile, skipValidation: true });
+      if (
+        await confirmAsync({
+          message: 'Do you still want to push the store configuration?',
+        })
+      ) {
+        return await loadConfigAsync({
+          projectDir,
+          profile,
+          skipValidation: true,
+        });
       }
     }
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why
This PR warns the user if an app's metadata they're attempting to update/add is missing the primary locale (and/or if they have another non-primary locale in their config). Providing a non-primary locale while you are missing primary locale can cause some confusion as it will show up blank in the ASC's dashboard

# How

Log a warning to let the user know they might want to fill out the primary locale and/or change the app's primary language

How did you build this feature or fix this bug and why?

1. Before creating apple tasks, we get the locale `config.getLocales()` and check whether the user has provided an empty object for their primary locale and whether they are using any non-primary locales i.e. 

```
// store.config.json 

en-gb: {}
en-us: { title: "cool app", description: "cool stuff" }
```



# Test Plan

Unit tests - not sure if there is a more automated / interactive way of building the CLI and testing a version so I just went with unit tests for the time being! happy to add more test coverage if there's a better way though

<img width="877" height="293" alt="Screenshot 2026-06-25 at 01 03 15" src="https://github.com/user-attachments/assets/b081165d-e871-4b82-8598-9e9f4c9e3dab" />

