### PR TITLE
[build-tools] Reset Gradle oom score before launch

### DIFF
--- a/packages/build-tools/src/android/gradle.ts
+++ b/packages/build-tools/src/android/gradle.ts
@@ -1,12 +1,10 @@
 import { Android, Env, Job, Platform } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
-import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
-import assert from 'assert';
+import spawn from '@expo/turtle-spawn';
 import fs from 'fs-extra';
 import path from 'path';
 
 import { BuildContext } from '../context';
-import { getParentAndDescendantProcessPidsAsync } from '../utils/processes';
 
 export async function ensureLFLineEndingsInGradlewScript<TJob extends Job>(
   ctx: BuildContext<TJob>
@@ -31,10 +29,19 @@ export async function runGradleCommand(
   logger.info(`Running 'gradlew ${gradleCommand}' in ${androidDir}`);
   await fs.chmod(path.join(androidDir, 'gradlew'), 0o755);
   const verboseFlag = ctx.env['EAS_VERBOSE'] === '1' ? '--info' : '';
+  const shouldResetOOMScore =
+    ctx.env.EAS_BUILD_RUNNER === 'eas-build' && process.platform === 'linux';
 
-  const spawnPromise = spawn(
+  await spawn(
     'bash',
-    ['-c', `./gradlew ${gradleCommand} --profile ${verboseFlag}`],
+    [
+      '-c',
+      getGradleShellCommand({
+        gradleCommand,
+        oomScoreAdj: shouldResetOOMScore ? 0 : undefined,
+        verboseFlag,
+      }),
+    ],
     {
       cwd: androidDir,
       logger,
@@ -53,42 +60,20 @@ export async function runGradleCommand(
       },
     }
   );
-  if (ctx.env.EAS_BUILD_RUNNER === 'eas-build' && process.platform === 'linux') {
-    adjustOOMScore(spawnPromise, logger);
-  }
-
-  await spawnPromise;
 }
 
-/**
- * OOM Killer sometimes kills worker server while build is exceeding memory limits.
- * `oom_score_adj` is a value between -1000 and 1000 and it defaults to 0.
- * It defines which process is more likely to get killed (higher value more likely).
- *
- * This function sets oom_score_adj for Gradle process and all its child processes.
- */
-function adjustOOMScore(spawnPromise: SpawnPromise<SpawnResult>, logger: bunyan): void {
-  setTimeout(
-    async () => {
-      try {
-        assert(spawnPromise.child.pid);
-        const pids = await getParentAndDescendantProcessPidsAsync(spawnPromise.child.pid);
-        await Promise.all(
-          pids.map(async (pid: number) => {
-            // Value 800 is just a guess here. It's probably higher than most other
-            // process. I didn't want to set it any higher, because I'm not sure if OOM Killer
-            // can start killing processes when there is still enough memory left.
-            const oomScoreOverride = 800;
-            await fs.writeFile(`/proc/${pid}/oom_score_adj`, `${oomScoreOverride}\n`);
-          })
-        );
-      } catch (err: any) {
-        logger.debug({ err, stderr: err?.stderr }, 'Failed to override oom_score_adj');
-      }
-    },
-    // Wait 20 seconds to make sure all child processes are started
-    20000
-  );
+export function getGradleShellCommand({
+  gradleCommand,
+  oomScoreAdj,
+  verboseFlag,
+}: {
+  gradleCommand: string;
+  oomScoreAdj?: number;
+  verboseFlag: string;
+}): string {
+  const oomScoreAdjPrefix =
+    oomScoreAdj === undefined ? '' : `echo ${oomScoreAdj} > /proc/$$/oom_score_adj || true; `;
+  return `${oomScoreAdjPrefix}exec ./gradlew ${gradleCommand} --profile ${verboseFlag}`;
 }
 
 // Version envs should be set at the beginning of the build, but when building

--- a/packages/build-tools/src/steps/utils/android/gradle.ts
+++ b/packages/build-tools/src/steps/utils/android/gradle.ts
@@ -1,8 +1,7 @@
 import { Android } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { BuildStepEnv } from '@expo/steps';
-import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
-import assert from 'assert';
+import spawn from '@expo/turtle-spawn';
 import fs from 'fs-extra';
 import path from 'path';
 
@@ -23,10 +22,18 @@ export async function runGradleCommand({
 
   logger.info(`Running 'gradlew ${gradleCommand} ${verboseFlag}' in ${androidDir}`);
   await fs.chmod(path.join(androidDir, 'gradlew'), 0o755);
+  const shouldResetOOMScore = env.EAS_BUILD_RUNNER === 'eas-build' && process.platform === 'linux';
 
-  const spawnPromise = spawn(
+  await spawn(
     'bash',
-    ['-c', `./gradlew ${gradleCommand} --profile ${verboseFlag}`],
+    [
+      '-c',
+      getGradleShellCommand({
+        gradleCommand,
+        oomScoreAdj: shouldResetOOMScore ? 0 : undefined,
+        verboseFlag,
+      }),
+    ],
     {
       cwd: androidDir,
       logger,
@@ -44,73 +51,20 @@ export async function runGradleCommand({
       },
     }
   );
-  if (env.EAS_BUILD_RUNNER === 'eas-build' && process.platform === 'linux') {
-    adjustOOMScore(spawnPromise, logger);
-  }
-
-  await spawnPromise;
 }
 
-/**
- * OOM Killer sometimes kills worker server while build is exceeding memory limits.
- * `oom_score_adj` is a value between -1000 and 1000 and it defaults to 0.
- * It defines which process is more likely to get killed (higher value more likely).
- *
- * This function sets oom_score_adj for Gradle process and all its child processes.
- */
-function adjustOOMScore(spawnPromise: SpawnPromise<SpawnResult>, logger: bunyan): void {
-  setTimeout(
-    async () => {
-      try {
-        assert(spawnPromise.child.pid);
-        const pids = await getParentAndDescendantProcessPidsAsync(spawnPromise.child.pid);
-        await Promise.all(
-          pids.map(async (pid: number) => {
-            // Value 800 is just a guess here. It's probably higher than most other
-            // process. I didn't want to set it any higher, because I'm not sure if OOM Killer
-            // can start killing processes when there is still enough memory left.
-            const oomScoreOverride = 800;
-            await fs.writeFile(`/proc/${pid}/oom_score_adj`, `${oomScoreOverride}\n`);
-          })
-        );
-      } catch (err: any) {
-        logger.debug({ err, stderr: err?.stderr }, 'Failed to override oom_score_adj');
-      }
-    },
-    // Wait 20 seconds to make sure all child processes are started
-    20000
-  );
-}
-
-async function getChildrenPidsAsync(parentPids: number[]): Promise<number[]> {
-  try {
-    const result = await spawn('pgrep', ['-P', parentPids.join(',')], {
-      stdio: 'pipe',
-    });
-    return result.stdout
-      .toString()
-      .split('\n')
-      .map(i => Number(i.trim()))
-      .filter(i => i);
-  } catch {
-    return [];
-  }
-}
-
-async function getParentAndDescendantProcessPidsAsync(ppid: number): Promise<number[]> {
-  const children = new Set<number>([ppid]);
-  let shouldCheckAgain = true;
-  while (shouldCheckAgain) {
-    const pids = await getChildrenPidsAsync([...children]);
-    shouldCheckAgain = false;
-    for (const pid of pids) {
-      if (!children.has(pid)) {
-        shouldCheckAgain = true;
-        children.add(pid);
-      }
-    }
-  }
-  return [...children];
+export function getGradleShellCommand({
+  gradleCommand,
+  oomScoreAdj,
+  verboseFlag,
+}: {
+  gradleCommand: string;
+  oomScoreAdj?: number;
+  verboseFlag: string;
+}): string {
+  const oomScoreAdjPrefix =
+    oomScoreAdj === undefined ? '' : `echo ${oomScoreAdj} > /proc/$$/oom_score_adj || true; `;
+  return `${oomScoreAdjPrefix}exec ./gradlew ${gradleCommand} --profile ${verboseFlag}`;
 }
 
 export function resolveGradleCommand(job: Android.Job, command?: string): string {


### PR DESCRIPTION
## Summary

Replace the delayed Gradle descendant `oom_score_adj` scan with an immediate shell-level reset before launching Gradle.

The worker service is protected with `OOMScoreAdjust=-999`, so Gradle inherits that value unless we reset it. This changes the Gradle launch wrapper to write `0` to `/proc/$$/oom_score_adj` before `exec ./gradlew ...`, which makes Gradle and its child processes inherit the default OOM score instead of the worker's protected score.

## Validation

- `yarn --cwd packages/build-tools typecheck`
- `yarn oxfmt --check packages/build-tools/src/android/gradle.ts packages/build-tools/src/steps/utils/android/gradle.ts`
- `yarn oxlint --type-aware --import-plugin --tsconfig ./tsconfig.oxlint.json packages/build-tools/src/android/gradle.ts packages/build-tools/src/steps/utils/android/gradle.ts`