### PR TITLE
[build-tools] Resolve job environment after metadata update

### DIFF
--- a/packages/build-tools/src/__tests__/context.test.ts
+++ b/packages/build-tools/src/__tests__/context.test.ts
@@ -5,6 +5,7 @@ import {
   Job,
   Metadata,
   Platform,
+  Workflow,
 } from '@expo/eas-build-job';
 import { randomUUID } from 'crypto';
 import fs from 'fs-extra';
@@ -124,6 +125,7 @@ describe('BuildContext', () => {
       {
         env: {
           __API_SERVER_URL: 'http://api.expo.test',
+          EAS_BUILD_ANDROID_VERSION_CODE: 'old-version-code',
         },
         workingdir: '/workingdir',
         logger: createMockLogger(),
@@ -169,6 +171,97 @@ describe('BuildContext', () => {
     expect(ctx.env.EXISTING_ENV).toBe('new-value');
     expect(ctx.env.REMOVED_ENV).toBeUndefined();
     expect(ctx.env.NEW_ENV).toBe('new-env-value');
+  });
+
+  it('updates environment variables from resolved job information', async () => {
+    await vol.promises.mkdir('/workingdir/eas-environment-secrets/', { recursive: true });
+
+    const ctx = new BuildContext(
+      {
+        triggeredBy: BuildTrigger.GIT_BASED_INTEGRATION,
+        secrets: {},
+      } as Job,
+      {
+        env: {
+          __API_SERVER_URL: 'http://api.expo.test',
+        },
+        workingdir: '/workingdir',
+        logger: createMockLogger(),
+        logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+        uploadArtifact: jest.fn(),
+      }
+    );
+
+    ctx.updateJobInformation(
+      {
+        platform: Platform.ANDROID,
+        type: Workflow.MANAGED,
+        username: 'job-username',
+        version: {
+          versionCode: '42',
+          versionName: '1.2.3',
+        },
+      } as Job,
+      {
+        buildProfile: 'production',
+        gitCommitHash: 'abc123',
+      } as Metadata
+    );
+
+    expect(ctx.env).toEqual(
+      expect.objectContaining({
+        EAS_BUILD_PROFILE: 'production',
+        EAS_BUILD_GIT_COMMIT_HASH: 'abc123',
+        EAS_BUILD_USERNAME: 'job-username',
+        EAS_BUILD_ANDROID_VERSION_CODE: '42',
+        EAS_BUILD_ANDROID_VERSION_NAME: '1.2.3',
+      })
+    );
+  });
+
+  it('overwrites stale environment variables from resolved job information', async () => {
+    await vol.promises.mkdir('/workingdir/eas-environment-secrets/', { recursive: true });
+
+    const ctx = new BuildContext(
+      {
+        triggeredBy: BuildTrigger.GIT_BASED_INTEGRATION,
+        platform: Platform.IOS,
+        secrets: {},
+      } as Job,
+      {
+        env: {
+          __API_SERVER_URL: 'http://api.expo.test',
+          EAS_BUILD_PROFILE: 'old-profile',
+          EAS_BUILD_USERNAME: 'old-username',
+          EAS_BUILD_ANDROID_VERSION_CODE: 'old-version-code',
+          EAS_BUILD_IOS_BUILD_NUMBER: 'old-build-number',
+        },
+        workingdir: '/workingdir',
+        logger: createMockLogger(),
+        logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+        uploadArtifact: jest.fn(),
+      }
+    );
+
+    ctx.updateJobInformation(
+      {
+        platform: Platform.ANDROID,
+        type: Workflow.MANAGED,
+        username: 'new-username',
+        version: {
+          versionCode: '42',
+          versionName: '1.2.3',
+        },
+      } as Job,
+      {
+        buildProfile: 'new-profile',
+      } as Metadata
+    );
+
+    expect(ctx.env.EAS_BUILD_PROFILE).toBe('new-profile');
+    expect(ctx.env.EAS_BUILD_USERNAME).toBe('new-username');
+    expect(ctx.env.EAS_BUILD_ANDROID_VERSION_CODE).toBe('42');
+    expect(ctx.env.EAS_BUILD_IOS_BUILD_NUMBER).toBeUndefined();
   });
 
   it('emits build phase duration metrics for successful build phases', async () => {

--- a/packages/build-tools/src/__tests__/context.test.ts
+++ b/packages/build-tools/src/__tests__/context.test.ts
@@ -139,6 +139,38 @@ describe('BuildContext', () => {
     });
   });
 
+  it('overwrites existing environment variables when updating env', async () => {
+    await vol.promises.mkdir('/workingdir/eas-environment-secrets/', { recursive: true });
+
+    const ctx = new BuildContext(
+      {
+        triggeredBy: BuildTrigger.GIT_BASED_INTEGRATION,
+        secrets: {},
+      } as Job,
+      {
+        env: {
+          __API_SERVER_URL: 'http://api.expo.test',
+          EXISTING_ENV: 'old-value',
+          REMOVED_ENV: 'old-value',
+        },
+        workingdir: '/workingdir',
+        logger: createMockLogger(),
+        logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+        uploadArtifact: jest.fn(),
+      }
+    );
+
+    ctx.updateEnv({
+      EXISTING_ENV: 'new-value',
+      REMOVED_ENV: undefined,
+      NEW_ENV: 'new-env-value',
+    });
+
+    expect(ctx.env.EXISTING_ENV).toBe('new-value');
+    expect(ctx.env.REMOVED_ENV).toBeUndefined();
+    expect(ctx.env.NEW_ENV).toBe('new-env-value');
+  });
+
   it('emits build phase duration metrics for successful build phases', async () => {
     const ctx = createTestBuildContext({ platform: Platform.IOS });
 

--- a/packages/build-tools/src/__tests__/customBuildContext.test.ts
+++ b/packages/build-tools/src/__tests__/customBuildContext.test.ts
@@ -40,6 +40,48 @@ describe(CustomBuildContext, () => {
     });
   });
 
+  it('updates environment variables from resolved job information', () => {
+    const ctx = new BuildContext(
+      createTestIosJob({
+        triggeredBy: BuildTrigger.GIT_BASED_INTEGRATION,
+      }),
+      {
+        env: {
+          __API_SERVER_URL: 'http://api.expo.test',
+        },
+        logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+        logger: createMockLogger(),
+        uploadArtifact: jest.fn(),
+        workingdir: '',
+      }
+    );
+    const customContext = new CustomBuildContext(ctx);
+
+    customContext.updateJobInformation(
+      {
+        version: {
+          buildNumber: '123',
+          appVersion: '1.2.3',
+        },
+      } as Ios.Job,
+      {
+        buildProfile: 'preview',
+        gitCommitHash: 'abc123',
+        username: 'metadata-username',
+      } as Metadata
+    );
+
+    expect(customContext.env).toEqual(
+      expect.objectContaining({
+        EAS_BUILD_PROFILE: 'preview',
+        EAS_BUILD_GIT_COMMIT_HASH: 'abc123',
+        EAS_BUILD_USERNAME: 'metadata-username',
+        EAS_BUILD_IOS_BUILD_NUMBER: '123',
+        EAS_BUILD_IOS_APP_VERSION: '1.2.3',
+      })
+    );
+  });
+
   describe('reportStepMetric', () => {
     const expoApiV2BaseUrl = 'http://exp.test/--/api/v2/';
     const workflowJobId = 'test-workflow-job-id';

--- a/packages/build-tools/src/android/gradle.ts
+++ b/packages/build-tools/src/android/gradle.ts
@@ -1,4 +1,4 @@
-import { Android, Env, Job, Platform } from '@expo/eas-build-job';
+import { Android, Env, Job } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
 import assert from 'assert';
@@ -48,7 +48,6 @@ export async function runGradleCommand(
       env: {
         ...ctx.env,
         ...extraEnv,
-        ...resolveVersionOverridesEnvs(ctx),
         LC_ALL: 'C.UTF-8',
       },
     }
@@ -89,27 +88,6 @@ function adjustOOMScore(spawnPromise: SpawnPromise<SpawnResult>, logger: bunyan)
     // Wait 20 seconds to make sure all child processes are started
     20000
   );
-}
-
-// Version envs should be set at the beginning of the build, but when building
-// from github those values are resolved later.
-function resolveVersionOverridesEnvs(ctx: BuildContext<Job>): Env {
-  const extraEnvs: Env = {};
-  if (
-    ctx.job.platform === Platform.ANDROID &&
-    ctx.job.version?.versionCode &&
-    !ctx.env.EAS_BUILD_ANDROID_VERSION_CODE
-  ) {
-    extraEnvs.EAS_BUILD_ANDROID_VERSION_CODE = ctx.job.version.versionCode;
-  }
-  if (
-    ctx.job.platform === Platform.ANDROID &&
-    ctx.job.version?.versionName &&
-    !ctx.env.EAS_BUILD_ANDROID_VERSION_NAME
-  ) {
-    extraEnvs.EAS_BUILD_ANDROID_VERSION_NAME = ctx.job.version.versionName;
-  }
-  return extraEnvs;
 }
 
 export function resolveGradleCommand(job: Android.Job): string {

--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -233,7 +233,7 @@ async function uploadProjectMetadataAsync(
         }
       `),
       {
-        buildId: ctx.env.EAS_BUILD_ID,
+        buildId: nullthrows(ctx.env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set'),
         projectMetadataFile: {
           type: 'GCS',
           bucketKey: uploadSession.bucketKey,

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -248,8 +248,8 @@ export class BuildContext<TJob extends Job = Job> {
       );
     }
     this._env = {
-      ...env,
       ...this._env,
+      ...env,
       __EAS_BUILD_ENVS_DIR: this.buildEnvsDirectory,
     };
     this._env.PATH = this._env.PATH

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -63,7 +63,7 @@ export interface BuildContextOptions {
   reportError?: (
     msg: string,
     err?: Error,
-    options?: { tags?: Record<string, string>; extras?: Record<string, string> }
+    options?: { tags?: Record<string, string>; extras?: Record<string, string | undefined> }
   ) => void;
   skipNativeBuild?: boolean;
   metadata?: Metadata;
@@ -80,7 +80,7 @@ export class BuildContext<TJob extends Job = Job> {
   public readonly reportError?: (
     msg: string,
     err?: Error,
-    options?: { tags?: Record<string, string>; extras?: Record<string, string> }
+    options?: { tags?: Record<string, string>; extras?: Record<string, string | undefined> }
   ) => void;
   public readonly skipNativeBuild?: boolean;
   public readonly expoApiV2BaseUrl?: string;

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -11,6 +11,8 @@ import {
   Metadata,
   errors,
   isGenericArtifact,
+  Platform,
+  Workflow,
 } from '@expo/eas-build-job';
 import { BuildTrigger } from '@expo/eas-build-job/dist/common';
 import { bunyan } from '@expo/logger';
@@ -71,6 +73,33 @@ export interface BuildContextOptions {
 }
 
 export class SkipNativeBuildError extends Error {}
+
+export function getResolvedJobInformationEnv(job: Job, metadata: Metadata): Env {
+  let username = metadata.username;
+  if (!username && 'type' in job && job.type === Workflow.MANAGED) {
+    username = job.username;
+  }
+
+  const env: Env = {
+    EAS_BUILD_PROFILE: metadata.buildProfile,
+    EAS_BUILD_GIT_COMMIT_HASH: metadata.gitCommitHash,
+    EAS_BUILD_USERNAME: username,
+    EAS_BUILD_ANDROID_VERSION_CODE: undefined,
+    EAS_BUILD_ANDROID_VERSION_NAME: undefined,
+    EAS_BUILD_IOS_BUILD_NUMBER: undefined,
+    EAS_BUILD_IOS_APP_VERSION: undefined,
+  };
+
+  if (job.platform === Platform.ANDROID) {
+    env.EAS_BUILD_ANDROID_VERSION_CODE = job.version?.versionCode;
+    env.EAS_BUILD_ANDROID_VERSION_NAME = job.version?.versionName;
+  } else if (job.platform === Platform.IOS) {
+    env.EAS_BUILD_IOS_BUILD_NUMBER = job.version?.buildNumber;
+    env.EAS_BUILD_IOS_APP_VERSION = job.version?.appVersion;
+  }
+
+  return env;
+}
 
 export class BuildContext<TJob extends Job = Job> {
   public readonly workingdir: string;
@@ -282,6 +311,7 @@ export class BuildContext<TJob extends Job = Job> {
       ...(this._job.platform ? { expoBuildUrl: this._job.expoBuildUrl } : null),
     };
     this._metadata = metadata;
+    this.updateEnv(getResolvedJobInformationEnv(this._job, this._metadata));
   }
 
   private async handleBuildPhaseErrorAsync(

--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -14,7 +14,7 @@ import { Client } from '@urql/core';
 import assert from 'assert';
 import path from 'path';
 
-import { ArtifactToUpload, BuildContext } from './context';
+import { ArtifactToUpload, BuildContext, getResolvedJobInformationEnv } from './context';
 import { uploadStepMetricsToWwwAsync } from './utils/stepMetrics';
 
 const platformToBuildRuntimePlatform: Record<Platform, BuildRuntimePlatform> = {
@@ -145,6 +145,10 @@ export class CustomBuildContext<TJob extends Job = Job> implements ExternalBuild
       ...(this.job.platform ? { expoBuildUrl: this.job.expoBuildUrl } : null),
     };
     this.metadata = metadata;
+    this.updateEnv({
+      ...this._env,
+      ...getResolvedJobInformationEnv(this.job, this.metadata),
+    });
   }
 
   public reportStepMetric(metric: StepMetric): void {

--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -10,6 +10,7 @@ export {
   BuildContext,
   BuildContextOptions,
   CacheManager,
+  getResolvedJobInformationEnv,
   LogBuffer,
   SkipNativeBuildError,
 } from './context';

--- a/packages/build-tools/src/ios/fastlane.ts
+++ b/packages/build-tools/src/ios/fastlane.ts
@@ -93,7 +93,7 @@ export async function runFastlane(
     cwd,
   }: {
     logger?: bunyan;
-    env?: Record<string, string>;
+    env?: Env;
     cwd?: string;
   } = {}
 ): Promise<SpawnResult> {

--- a/packages/build-tools/src/steps/functions/createSubmissionEntity.ts
+++ b/packages/build-tools/src/steps/functions/createSubmissionEntity.ts
@@ -1,6 +1,7 @@
 import { asyncResult } from '@expo/results';
 import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
 
+import { Sentry } from '../../sentry';
 import { retryOnDNSFailure } from '../../utils/retryOnDNSFailure';
 
 export function createSubmissionEntityFunction(): BuildFunction {
@@ -54,18 +55,42 @@ export function createSubmissionEntityFunction(): BuildFunction {
       const robotAccessToken = stepsCtx.global.staticContext.job.secrets?.robotAccessToken;
       if (!robotAccessToken) {
         stepsCtx.logger.error('Failed to create submission entity: no robot access token found');
+        Sentry.capture('Failed to create submission entity: missing robot access token');
         return;
       }
 
       const buildId = inputs.build_id.value;
       if (!buildId) {
         stepsCtx.logger.error('Failed to create submission entity: no build ID provided');
+        Sentry.capture('Failed to create submission entity: missing build ID', {
+          extras: {
+            buildId,
+          },
+        });
         return;
       }
 
       const workflowJobId = stepsCtx.global.env.__WORKFLOW_JOB_ID;
       if (!workflowJobId) {
         stepsCtx.logger.error('Failed to create submission entity: no workflow job ID found');
+        Sentry.capture('Failed to create submission entity: missing workflow job ID', {
+          extras: {
+            buildId,
+            workflowJobId,
+          },
+        });
+        return;
+      }
+
+      const expoApiServerURL = stepsCtx.global.staticContext.expoApiServerURL;
+      if (!expoApiServerURL) {
+        stepsCtx.logger.error('Failed to create submission entity: no Expo API server URL found');
+        Sentry.capture('Failed to create submission entity: missing Expo API server URL', {
+          extras: {
+            buildId,
+            workflowJobId,
+          },
+        });
         return;
       }
 
@@ -83,7 +108,7 @@ export function createSubmissionEntityFunction(): BuildFunction {
 
       try {
         const response = await retryOnDNSFailure(fetch)(
-          new URL('/v2/app-store-submissions/', stepsCtx.global.staticContext.expoApiServerURL),
+          new URL('/v2/app-store-submissions/', expoApiServerURL),
           {
             method: 'POST',
             headers: {

--- a/packages/build-tools/src/steps/functions/downloadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/downloadArtifact.ts
@@ -13,6 +13,7 @@ import os from 'node:os';
 import path from 'node:path';
 import stream from 'stream';
 import { promisify } from 'util';
+import nullthrows from 'nullthrows';
 import { z } from 'zod';
 
 import { formatBytes } from '../../utils/artifacts';
@@ -82,7 +83,10 @@ export function createDownloadArtifactFunction(): BuildFunction {
       const { artifactPath } = await downloadArtifactAsync({
         logger,
         workflowRunId,
-        expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
+        expoApiServerURL: nullthrows(
+          stepsCtx.global.staticContext.expoApiServerURL,
+          'expoApiServerURL is not set'
+        ),
         robotAccessToken,
         params,
       });

--- a/packages/build-tools/src/steps/functions/downloadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/downloadArtifact.ts
@@ -1,4 +1,4 @@
-import { UserError } from '@expo/eas-build-job';
+import { SystemError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
 import {
@@ -13,7 +13,6 @@ import os from 'node:os';
 import path from 'node:path';
 import stream from 'stream';
 import { promisify } from 'util';
-import nullthrows from 'nullthrows';
 import { z } from 'zod';
 
 import { formatBytes } from '../../utils/artifacts';
@@ -57,18 +56,23 @@ export function createDownloadArtifactFunction(): BuildFunction {
       const interpolationContext = stepsCtx.global.getInterpolationContext();
 
       if (!('workflow' in interpolationContext)) {
-        throw new UserError(
-          'EAS_DOWNLOAD_ARTIFACT_NO_WORKFLOW',
-          'No workflow found in the interpolation context.'
-        );
+        throw new SystemError('No workflow found in the interpolation context.', {
+          trackingCode: 'EAS_DOWNLOAD_ARTIFACT_NO_WORKFLOW',
+        });
       }
 
       const robotAccessToken = stepsCtx.global.staticContext.job.secrets?.robotAccessToken;
       if (!robotAccessToken) {
-        throw new UserError(
-          'EAS_DOWNLOAD_ARTIFACT_NO_ROBOT_ACCESS_TOKEN',
-          'No robot access token found in the job secrets.'
-        );
+        throw new SystemError('No robot access token found in the job secrets.', {
+          trackingCode: 'EAS_DOWNLOAD_ARTIFACT_NO_ROBOT_ACCESS_TOKEN',
+        });
+      }
+
+      const expoApiServerURL = stepsCtx.global.staticContext.expoApiServerURL;
+      if (!expoApiServerURL) {
+        throw new SystemError('Missing Expo API server URL.', {
+          trackingCode: 'EAS_DOWNLOAD_ARTIFACT_NO_EXPO_API_SERVER_URL',
+        });
       }
 
       const workflowRunId = interpolationContext.workflow.id;
@@ -83,10 +87,7 @@ export function createDownloadArtifactFunction(): BuildFunction {
       const { artifactPath } = await downloadArtifactAsync({
         logger,
         workflowRunId,
-        expoApiServerURL: nullthrows(
-          stepsCtx.global.staticContext.expoApiServerURL,
-          'expoApiServerURL is not set'
-        ),
+        expoApiServerURL,
         robotAccessToken,
         params,
       });

--- a/packages/build-tools/src/steps/functions/restoreCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreCache.ts
@@ -69,6 +69,10 @@ export function createRestoreCacheFunction(): BuildFunction {
           .filter(key => key !== '');
 
         const jobId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
+        const expoApiServerURL = nullthrows(
+          stepsCtx.global.staticContext.expoApiServerURL,
+          'expoApiServerURL is not set'
+        );
         const robotAccessToken = nullthrows(
           stepsCtx.global.staticContext.job.secrets?.robotAccessToken,
           'robotAccessToken is not set'
@@ -77,7 +81,7 @@ export function createRestoreCacheFunction(): BuildFunction {
         const { archivePath, matchedKey } = await downloadCacheAsync({
           logger,
           jobId,
-          expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
+          expoApiServerURL,
           robotAccessToken,
           paths,
           key,

--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -43,6 +43,10 @@ export function createSaveCacheFunction(): BuildFunction {
           .filter(path => path.length > 0);
         const key = z.string().parse(inputs.key.value);
         const jobId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
+        const expoApiServerURL = nullthrows(
+          stepsCtx.global.staticContext.expoApiServerURL,
+          'expoApiServerURL is not set'
+        );
         const robotAccessToken = nullthrows(
           stepsCtx.global.staticContext.job.secrets?.robotAccessToken,
           'robotAccessToken is not set'
@@ -61,7 +65,7 @@ export function createSaveCacheFunction(): BuildFunction {
           await uploadPublicCacheAsync({
             logger,
             jobId,
-            expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
+            expoApiServerURL,
             robotAccessToken,
             archivePath,
             key,
@@ -73,7 +77,7 @@ export function createSaveCacheFunction(): BuildFunction {
           await uploadCacheAsync({
             logger,
             jobId,
-            expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
+            expoApiServerURL,
             robotAccessToken,
             archivePath,
             key,

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -6,6 +6,7 @@ import assert from 'assert';
 import fs from 'fs-extra';
 import { graphql } from 'gql.tada';
 import fetch from 'node-fetch';
+import nullthrows from 'nullthrows';
 import os from 'os';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
@@ -257,7 +258,7 @@ async function logDiffFingerprints({
           }
         }
       `),
-      { id: ctx.env.EAS_BUILD_ID }
+      { id: nullthrows(ctx.env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set') }
     )
     .toPromise();
 

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -115,7 +115,7 @@ export const ArchiveSourceSchemaZ = z.discriminatedUnion('type', [
   }),
 ]);
 
-export type Env = Record<string, string>;
+export type Env = Record<string, string | undefined>;
 export const EnvSchema = Joi.object().pattern(Joi.string(), Joi.string());
 
 export type EnvironmentSecret = {

--- a/packages/eas-build-job/src/context.ts
+++ b/packages/eas-build-job/src/context.ts
@@ -11,7 +11,7 @@ type StaticJobOnlyInterpolationContext = {
       outputs: Record<string, string | undefined>;
     }
   >;
-  expoApiServerURL: string;
+  expoApiServerURL: string | undefined;
 };
 
 export type StaticJobInterpolationContext =

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config';
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Env, Platform, Workflow } from '@expo/eas-build-job';
 import { BuildProfile, EasJson } from '@expo/eas-json';
 import { LoggerLevel } from '@expo/logger';
 import { NodePackageManager } from '@expo/package-manager';
@@ -65,5 +65,5 @@ export interface BuildContext<T extends Platform> {
   loggerLevel?: LoggerLevel;
   isVerboseLoggingEnabled: boolean;
   whatToTest?: string;
-  env: Record<string, string>;
+  env: Env;
 }

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -1,4 +1,4 @@
-import { Platform } from '@expo/eas-build-job';
+import { Env, Platform } from '@expo/eas-build-job';
 import { BuildProfile, EasJson, ResourceClass } from '@expo/eas-json';
 import JsonFile from '@expo/json-file';
 import { LoggerLevel } from '@expo/logger';
@@ -69,7 +69,7 @@ export async function createBuildContextAsync<T extends Platform>({
   refreshAdHocProvisioningProfile?: boolean;
   isVerboseLoggingEnabled: boolean;
   whatToTest?: string;
-  env: Record<string, string>;
+  env: Env;
 }): Promise<BuildContext<T>> {
   const { exp, projectId } = await getDynamicPrivateProjectConfigAsync({
     env,

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -1,4 +1,4 @@
-import { Job, Metadata, version } from '@expo/eas-build-job';
+import { Env, Job, Metadata, version } from '@expo/eas-build-job';
 import spawnAsync from '@expo/spawn-async';
 import { ChildProcess } from 'child_process';
 import semver from 'semver';
@@ -42,7 +42,7 @@ export async function runLocalBuildAsync(
   job: Job,
   metadata: Metadata,
   options: LocalBuildOptions,
-  env: Record<string, string>
+  env: Env
 ): Promise<void> {
   const { command, args } = await getCommandAndArgsAsync(job, metadata);
   let spinner;

--- a/packages/eas-cli/src/fingerprint/utils.ts
+++ b/packages/eas-cli/src/fingerprint/utils.ts
@@ -1,4 +1,4 @@
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Env, Platform, Workflow } from '@expo/eas-build-job';
 
 import { createFingerprintAsync } from './cli';
 import { Fingerprint } from './types';
@@ -16,7 +16,7 @@ export async function getFingerprintInfoFromLocalProjectForPlatformsAsync(
   projectId: string,
   vcsClient: Client,
   platforms: AppPlatform[],
-  { env }: { env?: Record<string, string> } = {}
+  { env }: { env?: Env } = {}
 ): Promise<Fingerprint> {
   const workflows = await resolveWorkflowPerPlatformAsync(projectDir, vcsClient);
   const optionsFromWorkflow = getFingerprintOptionsFromWorkflow(platforms, workflows);

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -1,4 +1,5 @@
 import { ExportedConfig, IOSConfig, compileModsAsync } from '@expo/config-plugins';
+import { Env } from '@expo/eas-build-job';
 import { JSONObject } from '@expo/json-file';
 import { getPrebuildConfigAsync } from '@expo/prebuild-config';
 
@@ -17,7 +18,7 @@ interface Target {
 
 export async function getManagedApplicationTargetEntitlementsAsync(
   projectDir: string,
-  env: Record<string, string>,
+  env: Env,
   vcsClient: Client
 ): Promise<JSONObject> {
   let expoConfigError: any;
@@ -95,7 +96,7 @@ export async function getManagedApplicationTargetEntitlementsAsync(
 
 async function resolveManagedApplicationTargetEntitlementsWithBundledConfigAsync(
   projectDir: string,
-  env: Record<string, string>,
+  env: Env,
   vcsClient: Client
 ): Promise<JSONObject> {
   const originalProcessEnv = process.env;

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { IOSConfig, XcodeProject } from '@expo/config-plugins';
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Env, Platform, Workflow } from '@expo/eas-build-job';
 import { JSONObject } from '@expo/json-file';
 import Joi from 'joi';
 import type { XCBuildConfiguration } from 'xcode';
@@ -26,7 +26,7 @@ interface UserDefinedTarget {
 interface ResolveTargetOptions {
   projectDir: string;
   exp: ExpoConfig;
-  env?: Record<string, string>;
+  env?: Env;
   xcodeBuildContext: XcodeBuildContext;
   vcsClient: Client;
 }

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config';
-import { Platform } from '@expo/eas-build-job';
+import { Env, Platform } from '@expo/eas-build-job';
 import { SubmitProfile } from '@expo/eas-json';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -47,7 +47,7 @@ export interface SubmitArchiveFlags {
 export async function createSubmissionContextAsync<T extends Platform>(params: {
   archiveFlags: SubmitArchiveFlags;
   credentialsCtx?: CredentialsContext;
-  env?: Record<string, string>;
+  env?: Env;
   nonInteractive: boolean;
   isVerboseFastlaneEnabled: boolean;
   groups: string[] | undefined;

--- a/packages/worker/src/displayRuntimeInfo.ts
+++ b/packages/worker/src/displayRuntimeInfo.ts
@@ -76,19 +76,24 @@ function printEnvs(ctx: BuildContext<Job>): void {
   // skip development and testing to avoid leaking local credentials from envs to bucket
   if (config.env !== Environment.DEVELOPMENT && config.env !== Environment.TEST) {
     Object.entries(ctx.env).forEach(([key, value]) => {
-      instanceEnv[key] = value;
+      if (value !== undefined) {
+        instanceEnv[key] = value;
+      }
     });
   }
-  Object.entries(job.builderEnvironment?.env ?? ({} as Record<string, string>)).forEach(
-    ([key, value]) => {
+  Object.entries(job.builderEnvironment?.env ?? {}).forEach(([key, value]) => {
+    if (value !== undefined) {
       publicEnv[key] = value;
       delete instanceEnv[key];
     }
-  );
+  });
 
   job.secrets?.environmentSecrets?.forEach(({ name, type }) => {
     if (type === EnvironmentSecretType.FILE) {
-      secretEnv[name] = ctx.env[name];
+      // File secrets are displayed as the generated file path, which only exists after materialization.
+      if (ctx.env[name] !== undefined) {
+        secretEnv[name] = ctx.env[name];
+      }
     } else {
       secretEnv[name] = '********';
     }

--- a/packages/worker/src/displayRuntimeInfo.ts
+++ b/packages/worker/src/displayRuntimeInfo.ts
@@ -70,7 +70,9 @@ function printImageDescription(ctx: BuildContext<Job>): void {
 function printEnvs(ctx: BuildContext<Job>): void {
   const { logger, job } = ctx;
   const publicEnv: Record<string, string> = {};
-  const secretEnv: Record<string, string> = {};
+  // We don't expect environment secrets to be missing from ctx.env,
+  // but if they do we want to see it in logs as "=undefined".
+  const secretEnv: Record<string, string | undefined> = {};
   const instanceEnv: Record<string, string> = {};
 
   // skip development and testing to avoid leaking local credentials from envs to bucket
@@ -90,10 +92,9 @@ function printEnvs(ctx: BuildContext<Job>): void {
 
   job.secrets?.environmentSecrets?.forEach(({ name, type }) => {
     if (type === EnvironmentSecretType.FILE) {
-      // File secrets are displayed as the generated file path, which only exists after materialization.
-      if (ctx.env[name] !== undefined) {
-        secretEnv[name] = ctx.env[name];
-      }
+      // ctx.env[name] for a FILE-typed environment secret
+      // should be a path to the file.
+      secretEnv[name] = ctx.env[name];
     } else {
       secretEnv[name] = '********';
     }

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -1,5 +1,5 @@
-import { RuntimeSettings } from '@expo/build-tools';
-import { Env, Job, Metadata, Platform, Workflow } from '@expo/eas-build-job';
+import { RuntimeSettings, getResolvedJobInformationEnv } from '@expo/build-tools';
+import { Env, Job, Metadata, Platform } from '@expo/eas-build-job';
 import { spawnSync } from 'child_process';
 import micromatch from 'micromatch';
 import os from 'os';
@@ -45,8 +45,6 @@ export function getBuildEnv({
   setEnv(env, 'NPM_CONFIG_REGISTRY', npmCacheUrl);
   setEnv(env, 'NVM_NODEJS_ORG_MIRROR', nodeJsCacheUrl);
   setEnv(env, 'EAS_BUILD_NPM_CACHE_URL', npmCacheUrl);
-  setEnv(env, 'EAS_BUILD_PROFILE', metadata.buildProfile);
-  setEnv(env, 'EAS_BUILD_GIT_COMMIT_HASH', metadata.gitCommitHash);
   setEnv(env, 'EAS_BUILD_ID', buildId);
   setEnv(env, 'LANG', 'en_US.UTF-8');
   setEnv(env, 'EAS_BUILD_WORKINGDIR', path.join(config.workingdir, 'build'));
@@ -109,27 +107,9 @@ export function getBuildEnv({
     );
   }
 
-  if (job.platform === Platform.ANDROID) {
-    if (job.version?.versionCode) {
-      setEnv(env, 'EAS_BUILD_ANDROID_VERSION_CODE', job.version.versionCode);
-    }
-    if (job.version?.versionName) {
-      setEnv(env, 'EAS_BUILD_ANDROID_VERSION_NAME', job.version.versionName);
-    }
-  } else if (job.platform === Platform.IOS) {
-    if (job.version?.buildNumber) {
-      setEnv(env, 'EAS_BUILD_IOS_BUILD_NUMBER', job.version.buildNumber);
-    }
-    if (job.version?.appVersion) {
-      setEnv(env, 'EAS_BUILD_IOS_APP_VERSION', job.version.appVersion);
-    }
+  for (const [key, value] of Object.entries(getResolvedJobInformationEnv(job, metadata))) {
+    setEnv(env, key, value);
   }
-
-  let username = metadata.username;
-  if (!username && 'type' in job && job.type === Workflow.MANAGED) {
-    username = job.username;
-  }
-  setEnv(env, 'EAS_BUILD_USERNAME', username);
 
   if (config.env === Environment.DEVELOPMENT) {
     setEnv(env, 'EXPO_LOCAL', '1');


### PR DESCRIPTION
## Summary

Stacked on #3900. Refreshes derived EAS build environment variables after GitHub-triggered job information and metadata are resolved, instead of patching Android Gradle execution directly.

I want to unify `runGradleCommand` and I noticed that only one of them polyfills the `EAS_` environment variables for GitHub builds.

## Details

- Adds a shared `getResolvedJobInformationEnv` helper in `@expo/build-tools` for profile, commit hash, username, and platform version env vars.
- Calls that helper from both `BuildContext.updateJobInformation` and `CustomBuildContext.updateJobInformation` so traditional and custom/steps builds see the resolved env.
- Reuses the helper from the worker initial build env construction to keep the mapping consistent.
- Removes the Gradle-only Android version env fallback.

## Validation

CI should pass.