### PR TITLE
[eas-build-job] Allow undefined env values

### DIFF
--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -233,7 +233,7 @@ async function uploadProjectMetadataAsync(
         }
       `),
       {
-        buildId: ctx.env.EAS_BUILD_ID,
+        buildId: nullthrows(ctx.env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set'),
         projectMetadataFile: {
           type: 'GCS',
           bucketKey: uploadSession.bucketKey,

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -63,7 +63,7 @@ export interface BuildContextOptions {
   reportError?: (
     msg: string,
     err?: Error,
-    options?: { tags?: Record<string, string>; extras?: Record<string, string> }
+    options?: { tags?: Record<string, string>; extras?: Record<string, string | undefined> }
   ) => void;
   skipNativeBuild?: boolean;
   metadata?: Metadata;
@@ -80,7 +80,7 @@ export class BuildContext<TJob extends Job = Job> {
   public readonly reportError?: (
     msg: string,
     err?: Error,
-    options?: { tags?: Record<string, string>; extras?: Record<string, string> }
+    options?: { tags?: Record<string, string>; extras?: Record<string, string | undefined> }
   ) => void;
   public readonly skipNativeBuild?: boolean;
   public readonly expoApiV2BaseUrl?: string;

--- a/packages/build-tools/src/ios/fastlane.ts
+++ b/packages/build-tools/src/ios/fastlane.ts
@@ -93,7 +93,7 @@ export async function runFastlane(
     cwd,
   }: {
     logger?: bunyan;
-    env?: Record<string, string>;
+    env?: Env;
     cwd?: string;
   } = {}
 ): Promise<SpawnResult> {

--- a/packages/build-tools/src/steps/functions/createSubmissionEntity.ts
+++ b/packages/build-tools/src/steps/functions/createSubmissionEntity.ts
@@ -1,6 +1,7 @@
 import { asyncResult } from '@expo/results';
 import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
 
+import { Sentry } from '../../sentry';
 import { retryOnDNSFailure } from '../../utils/retryOnDNSFailure';
 
 export function createSubmissionEntityFunction(): BuildFunction {
@@ -54,18 +55,42 @@ export function createSubmissionEntityFunction(): BuildFunction {
       const robotAccessToken = stepsCtx.global.staticContext.job.secrets?.robotAccessToken;
       if (!robotAccessToken) {
         stepsCtx.logger.error('Failed to create submission entity: no robot access token found');
+        Sentry.capture('Failed to create submission entity: missing robot access token');
         return;
       }
 
       const buildId = inputs.build_id.value;
       if (!buildId) {
         stepsCtx.logger.error('Failed to create submission entity: no build ID provided');
+        Sentry.capture('Failed to create submission entity: missing build ID', {
+          extras: {
+            buildId,
+          },
+        });
         return;
       }
 
       const workflowJobId = stepsCtx.global.env.__WORKFLOW_JOB_ID;
       if (!workflowJobId) {
         stepsCtx.logger.error('Failed to create submission entity: no workflow job ID found');
+        Sentry.capture('Failed to create submission entity: missing workflow job ID', {
+          extras: {
+            buildId,
+            workflowJobId,
+          },
+        });
+        return;
+      }
+
+      const expoApiServerURL = stepsCtx.global.staticContext.expoApiServerURL;
+      if (!expoApiServerURL) {
+        stepsCtx.logger.error('Failed to create submission entity: no Expo API server URL found');
+        Sentry.capture('Failed to create submission entity: missing Expo API server URL', {
+          extras: {
+            buildId,
+            workflowJobId,
+          },
+        });
         return;
       }
 
@@ -83,7 +108,7 @@ export function createSubmissionEntityFunction(): BuildFunction {
 
       try {
         const response = await retryOnDNSFailure(fetch)(
-          new URL('/v2/app-store-submissions/', stepsCtx.global.staticContext.expoApiServerURL),
+          new URL('/v2/app-store-submissions/', expoApiServerURL),
           {
             method: 'POST',
             headers: {

--- a/packages/build-tools/src/steps/functions/downloadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/downloadArtifact.ts
@@ -13,6 +13,7 @@ import os from 'node:os';
 import path from 'node:path';
 import stream from 'stream';
 import { promisify } from 'util';
+import nullthrows from 'nullthrows';
 import { z } from 'zod';
 
 import { formatBytes } from '../../utils/artifacts';
@@ -82,7 +83,10 @@ export function createDownloadArtifactFunction(): BuildFunction {
       const { artifactPath } = await downloadArtifactAsync({
         logger,
         workflowRunId,
-        expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
+        expoApiServerURL: nullthrows(
+          stepsCtx.global.staticContext.expoApiServerURL,
+          'expoApiServerURL is not set'
+        ),
         robotAccessToken,
         params,
       });

--- a/packages/build-tools/src/steps/functions/downloadArtifact.ts
+++ b/packages/build-tools/src/steps/functions/downloadArtifact.ts
@@ -1,4 +1,4 @@
-import { UserError } from '@expo/eas-build-job';
+import { SystemError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
 import {
@@ -13,7 +13,6 @@ import os from 'node:os';
 import path from 'node:path';
 import stream from 'stream';
 import { promisify } from 'util';
-import nullthrows from 'nullthrows';
 import { z } from 'zod';
 
 import { formatBytes } from '../../utils/artifacts';
@@ -57,18 +56,23 @@ export function createDownloadArtifactFunction(): BuildFunction {
       const interpolationContext = stepsCtx.global.getInterpolationContext();
 
       if (!('workflow' in interpolationContext)) {
-        throw new UserError(
-          'EAS_DOWNLOAD_ARTIFACT_NO_WORKFLOW',
-          'No workflow found in the interpolation context.'
-        );
+        throw new SystemError('No workflow found in the interpolation context.', {
+          trackingCode: 'EAS_DOWNLOAD_ARTIFACT_NO_WORKFLOW',
+        });
       }
 
       const robotAccessToken = stepsCtx.global.staticContext.job.secrets?.robotAccessToken;
       if (!robotAccessToken) {
-        throw new UserError(
-          'EAS_DOWNLOAD_ARTIFACT_NO_ROBOT_ACCESS_TOKEN',
-          'No robot access token found in the job secrets.'
-        );
+        throw new SystemError('No robot access token found in the job secrets.', {
+          trackingCode: 'EAS_DOWNLOAD_ARTIFACT_NO_ROBOT_ACCESS_TOKEN',
+        });
+      }
+
+      const expoApiServerURL = stepsCtx.global.staticContext.expoApiServerURL;
+      if (!expoApiServerURL) {
+        throw new SystemError('Missing Expo API server URL.', {
+          trackingCode: 'EAS_DOWNLOAD_ARTIFACT_NO_EXPO_API_SERVER_URL',
+        });
       }
 
       const workflowRunId = interpolationContext.workflow.id;
@@ -83,10 +87,7 @@ export function createDownloadArtifactFunction(): BuildFunction {
       const { artifactPath } = await downloadArtifactAsync({
         logger,
         workflowRunId,
-        expoApiServerURL: nullthrows(
-          stepsCtx.global.staticContext.expoApiServerURL,
-          'expoApiServerURL is not set'
-        ),
+        expoApiServerURL,
         robotAccessToken,
         params,
       });

--- a/packages/build-tools/src/steps/functions/restoreCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreCache.ts
@@ -69,6 +69,10 @@ export function createRestoreCacheFunction(): BuildFunction {
           .filter(key => key !== '');
 
         const jobId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
+        const expoApiServerURL = nullthrows(
+          stepsCtx.global.staticContext.expoApiServerURL,
+          'expoApiServerURL is not set'
+        );
         const robotAccessToken = nullthrows(
           stepsCtx.global.staticContext.job.secrets?.robotAccessToken,
           'robotAccessToken is not set'
@@ -77,7 +81,7 @@ export function createRestoreCacheFunction(): BuildFunction {
         const { archivePath, matchedKey } = await downloadCacheAsync({
           logger,
           jobId,
-          expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
+          expoApiServerURL,
           robotAccessToken,
           paths,
           key,

--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -43,6 +43,10 @@ export function createSaveCacheFunction(): BuildFunction {
           .filter(path => path.length > 0);
         const key = z.string().parse(inputs.key.value);
         const jobId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
+        const expoApiServerURL = nullthrows(
+          stepsCtx.global.staticContext.expoApiServerURL,
+          'expoApiServerURL is not set'
+        );
         const robotAccessToken = nullthrows(
           stepsCtx.global.staticContext.job.secrets?.robotAccessToken,
           'robotAccessToken is not set'
@@ -61,7 +65,7 @@ export function createSaveCacheFunction(): BuildFunction {
           await uploadPublicCacheAsync({
             logger,
             jobId,
-            expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
+            expoApiServerURL,
             robotAccessToken,
             archivePath,
             key,
@@ -73,7 +77,7 @@ export function createSaveCacheFunction(): BuildFunction {
           await uploadCacheAsync({
             logger,
             jobId,
-            expoApiServerURL: stepsCtx.global.staticContext.expoApiServerURL,
+            expoApiServerURL,
             robotAccessToken,
             archivePath,
             key,

--- a/packages/build-tools/src/utils/__tests__/expoUpdates.test.ts
+++ b/packages/build-tools/src/utils/__tests__/expoUpdates.test.ts
@@ -104,4 +104,33 @@ describe(expoUpdates.configureExpoUpdatesIfInstalledAsync, () => {
     expect(iosSetChannelNativelyAsync).toBeCalledTimes(1);
     expect(getExpoUpdatesPackageVersionIfInstalledAsync).toBeCalledTimes(1);
   });
+
+  it('does not fail on missing EAS_BUILD_ID when logging fingerprint diffs', async () => {
+    jest.mocked(getExpoUpdatesPackageVersionIfInstalledAsync).mockResolvedValue('0.18.0');
+
+    const warn = jest.fn();
+    const managedCtx: BuildContext<BuildJob> = {
+      appConfig: {},
+      env: {},
+      job: {
+        platform: Platform.IOS,
+      },
+      logger: { warn },
+      metadata: {
+        runtimeVersion: 'runtime-version-from-local-machine',
+      },
+      getReactNativeProjectDirectory: () => '/app',
+    } as any;
+
+    await expect(
+      expoUpdates.configureExpoUpdatesIfInstalledAsync(managedCtx, {
+        resolvedRuntimeVersion: 'runtime-version-from-eas-build',
+        resolvedFingerprintSources: [],
+      })
+    ).rejects.toThrow(
+      'Runtime version calculated on local machine not equal to runtime version calculated during build.'
+    );
+
+    expect(warn).toHaveBeenCalledWith('Skipping fingerprint diff because EAS_BUILD_ID is not set');
+  });
 });

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -6,6 +6,7 @@ import assert from 'assert';
 import fs from 'fs-extra';
 import { graphql } from 'gql.tada';
 import fetch from 'node-fetch';
+import nullthrows from 'nullthrows';
 import os from 'os';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
@@ -257,7 +258,7 @@ async function logDiffFingerprints({
           }
         }
       `),
-      { id: ctx.env.EAS_BUILD_ID }
+      { id: nullthrows(ctx.env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set') }
     )
     .toPromise();
 

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -6,7 +6,6 @@ import assert from 'assert';
 import fs from 'fs-extra';
 import { graphql } from 'gql.tada';
 import fetch from 'node-fetch';
-import nullthrows from 'nullthrows';
 import os from 'os';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
@@ -244,6 +243,12 @@ async function logDiffFingerprints({
   ctx: BuildContext<BuildJob>;
 }): Promise<void> {
   const { resolvedRuntimeVersion, resolvedFingerprintSources } = resolvedRuntime;
+  const buildId = ctx.env.EAS_BUILD_ID;
+
+  if (!buildId) {
+    ctx.logger.warn('Skipping fingerprint diff because EAS_BUILD_ID is not set');
+    return;
+  }
 
   const fingerprintInfo = await ctx.graphqlClient
     .query(
@@ -258,7 +263,7 @@ async function logDiffFingerprints({
           }
         }
       `),
-      { id: nullthrows(ctx.env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set') }
+      { id: buildId }
     )
     .toPromise();
 

--- a/packages/eas-build-job/src/__tests__/common.test.ts
+++ b/packages/eas-build-job/src/__tests__/common.test.ts
@@ -1,4 +1,18 @@
-import { StaticWorkflowInterpolationContextZ } from '../common';
+import { EnvSchema, StaticWorkflowInterpolationContextZ } from '../common';
+
+describe('EnvSchema', () => {
+  it('accepts explicit undefined values', () => {
+    const env = {
+      DEFINED_ENV: 'value',
+      UNDEFINED_ENV: undefined,
+    };
+
+    const { value, error } = EnvSchema.validate(env);
+
+    expect(error).toBeUndefined();
+    expect(value).toEqual(env);
+  });
+});
 
 describe('StaticWorkflowInterpolationContextZ', () => {
   it('accepts app and account context', () => {

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -116,7 +116,7 @@ export const ArchiveSourceSchemaZ = z.discriminatedUnion('type', [
 ]);
 
 export type Env = Record<string, string | undefined>;
-export const EnvSchema = Joi.object().pattern(Joi.string(), Joi.string());
+export const EnvSchema = Joi.object().pattern(Joi.string(), Joi.string().optional());
 
 export type EnvironmentSecret = {
   name: string;

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -115,7 +115,7 @@ export const ArchiveSourceSchemaZ = z.discriminatedUnion('type', [
   }),
 ]);
 
-export type Env = Record<string, string>;
+export type Env = Record<string, string | undefined>;
 export const EnvSchema = Joi.object().pattern(Joi.string(), Joi.string());
 
 export type EnvironmentSecret = {

--- a/packages/eas-build-job/src/context.ts
+++ b/packages/eas-build-job/src/context.ts
@@ -11,7 +11,7 @@ type StaticJobOnlyInterpolationContext = {
       outputs: Record<string, string | undefined>;
     }
   >;
-  expoApiServerURL: string;
+  expoApiServerURL: string | undefined;
 };
 
 export type StaticJobInterpolationContext =

--- a/packages/eas-cli/src/build/context.ts
+++ b/packages/eas-cli/src/build/context.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config';
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Env, Platform, Workflow } from '@expo/eas-build-job';
 import { BuildProfile, EasJson } from '@expo/eas-json';
 import { LoggerLevel } from '@expo/logger';
 import { NodePackageManager } from '@expo/package-manager';
@@ -65,5 +65,5 @@ export interface BuildContext<T extends Platform> {
   loggerLevel?: LoggerLevel;
   isVerboseLoggingEnabled: boolean;
   whatToTest?: string;
-  env: Record<string, string>;
+  env: Env;
 }

--- a/packages/eas-cli/src/build/createContext.ts
+++ b/packages/eas-cli/src/build/createContext.ts
@@ -1,4 +1,4 @@
-import { Platform } from '@expo/eas-build-job';
+import { Env, Platform } from '@expo/eas-build-job';
 import { BuildProfile, EasJson, ResourceClass } from '@expo/eas-json';
 import JsonFile from '@expo/json-file';
 import { LoggerLevel } from '@expo/logger';
@@ -69,7 +69,7 @@ export async function createBuildContextAsync<T extends Platform>({
   refreshAdHocProvisioningProfile?: boolean;
   isVerboseLoggingEnabled: boolean;
   whatToTest?: string;
-  env: Record<string, string>;
+  env: Env;
 }): Promise<BuildContext<T>> {
   const { exp, projectId } = await getDynamicPrivateProjectConfigAsync({
     env,

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -1,4 +1,4 @@
-import { Job, Metadata, version } from '@expo/eas-build-job';
+import { Env, Job, Metadata, version } from '@expo/eas-build-job';
 import spawnAsync from '@expo/spawn-async';
 import { ChildProcess } from 'child_process';
 import semver from 'semver';
@@ -42,7 +42,7 @@ export async function runLocalBuildAsync(
   job: Job,
   metadata: Metadata,
   options: LocalBuildOptions,
-  env: Record<string, string>
+  env: Env
 ): Promise<void> {
   const { command, args } = await getCommandAndArgsAsync(job, metadata);
   let spinner;

--- a/packages/eas-cli/src/fingerprint/utils.ts
+++ b/packages/eas-cli/src/fingerprint/utils.ts
@@ -1,4 +1,4 @@
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Env, Platform, Workflow } from '@expo/eas-build-job';
 
 import { createFingerprintAsync } from './cli';
 import { Fingerprint } from './types';
@@ -16,7 +16,7 @@ export async function getFingerprintInfoFromLocalProjectForPlatformsAsync(
   projectId: string,
   vcsClient: Client,
   platforms: AppPlatform[],
-  { env }: { env?: Record<string, string> } = {}
+  { env }: { env?: Env } = {}
 ): Promise<Fingerprint> {
   const workflows = await resolveWorkflowPerPlatformAsync(projectDir, vcsClient);
   const optionsFromWorkflow = getFingerprintOptionsFromWorkflow(platforms, workflows);

--- a/packages/eas-cli/src/project/ios/entitlements.ts
+++ b/packages/eas-cli/src/project/ios/entitlements.ts
@@ -1,4 +1,5 @@
 import { ExportedConfig, IOSConfig, compileModsAsync } from '@expo/config-plugins';
+import { Env } from '@expo/eas-build-job';
 import { JSONObject } from '@expo/json-file';
 import { getPrebuildConfigAsync } from '@expo/prebuild-config';
 
@@ -17,7 +18,7 @@ interface Target {
 
 export async function getManagedApplicationTargetEntitlementsAsync(
   projectDir: string,
-  env: Record<string, string>,
+  env: Env,
   vcsClient: Client
 ): Promise<JSONObject> {
   let expoConfigError: any;
@@ -95,7 +96,7 @@ export async function getManagedApplicationTargetEntitlementsAsync(
 
 async function resolveManagedApplicationTargetEntitlementsWithBundledConfigAsync(
   projectDir: string,
-  env: Record<string, string>,
+  env: Env,
   vcsClient: Client
 ): Promise<JSONObject> {
   const originalProcessEnv = process.env;

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -1,6 +1,6 @@
 import { ExpoConfig } from '@expo/config';
 import { IOSConfig, XcodeProject } from '@expo/config-plugins';
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Env, Platform, Workflow } from '@expo/eas-build-job';
 import { JSONObject } from '@expo/json-file';
 import Joi from 'joi';
 import type { XCBuildConfiguration } from 'xcode';
@@ -26,7 +26,7 @@ interface UserDefinedTarget {
 interface ResolveTargetOptions {
   projectDir: string;
   exp: ExpoConfig;
-  env?: Record<string, string>;
+  env?: Env;
   xcodeBuildContext: XcodeBuildContext;
   vcsClient: Client;
 }

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig } from '@expo/config';
-import { Platform } from '@expo/eas-build-job';
+import { Env, Platform } from '@expo/eas-build-job';
 import { SubmitProfile } from '@expo/eas-json';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -47,7 +47,7 @@ export interface SubmitArchiveFlags {
 export async function createSubmissionContextAsync<T extends Platform>(params: {
   archiveFlags: SubmitArchiveFlags;
   credentialsCtx?: CredentialsContext;
-  env?: Record<string, string>;
+  env?: Env;
   nonInteractive: boolean;
   isVerboseFastlaneEnabled: boolean;
   groups: string[] | undefined;

--- a/packages/worker/src/displayRuntimeInfo.ts
+++ b/packages/worker/src/displayRuntimeInfo.ts
@@ -76,19 +76,24 @@ function printEnvs(ctx: BuildContext<Job>): void {
   // skip development and testing to avoid leaking local credentials from envs to bucket
   if (config.env !== Environment.DEVELOPMENT && config.env !== Environment.TEST) {
     Object.entries(ctx.env).forEach(([key, value]) => {
-      instanceEnv[key] = value;
+      if (value !== undefined) {
+        instanceEnv[key] = value;
+      }
     });
   }
-  Object.entries(job.builderEnvironment?.env ?? ({} as Record<string, string>)).forEach(
-    ([key, value]) => {
+  Object.entries(job.builderEnvironment?.env ?? {}).forEach(([key, value]) => {
+    if (value !== undefined) {
       publicEnv[key] = value;
       delete instanceEnv[key];
     }
-  );
+  });
 
   job.secrets?.environmentSecrets?.forEach(({ name, type }) => {
     if (type === EnvironmentSecretType.FILE) {
-      secretEnv[name] = ctx.env[name];
+      // File secrets are displayed as the generated file path, which only exists after materialization.
+      if (ctx.env[name] !== undefined) {
+        secretEnv[name] = ctx.env[name];
+      }
     } else {
       secretEnv[name] = '********';
     }

--- a/packages/worker/src/displayRuntimeInfo.ts
+++ b/packages/worker/src/displayRuntimeInfo.ts
@@ -70,7 +70,9 @@ function printImageDescription(ctx: BuildContext<Job>): void {
 function printEnvs(ctx: BuildContext<Job>): void {
   const { logger, job } = ctx;
   const publicEnv: Record<string, string> = {};
-  const secretEnv: Record<string, string> = {};
+  // We don't expect environment secrets to be missing from ctx.env,
+  // but if they do we want to see it in logs as "=undefined".
+  const secretEnv: Record<string, string | undefined> = {};
   const instanceEnv: Record<string, string> = {};
 
   // skip development and testing to avoid leaking local credentials from envs to bucket
@@ -90,10 +92,9 @@ function printEnvs(ctx: BuildContext<Job>): void {
 
   job.secrets?.environmentSecrets?.forEach(({ name, type }) => {
     if (type === EnvironmentSecretType.FILE) {
-      // File secrets are displayed as the generated file path, which only exists after materialization.
-      if (ctx.env[name] !== undefined) {
-        secretEnv[name] = ctx.env[name];
-      }
+      // ctx.env[name] for a FILE-typed environment secret
+      // should be a path to the file.
+      secretEnv[name] = ctx.env[name];
     } else {
       secretEnv[name] = '********';
     }


### PR DESCRIPTION
## Summary

Widens the shared build `Env` type to allow `undefined` values, matching Node/process env semantics where undefined entries can represent absent values.

## Details

- Changes `Env` to `Record<string, string | undefined>` in `@expo/eas-build-job`.
- Allows `ctx.reportError` extras to contain undefined values for diagnostic metadata.
- Updates strict string boundaries to explicitly require values where needed, such as GraphQL IDs and static context API URLs.
- Filters undefined values out of `displayRuntimeInfo` string-only display maps.

## Validation

CI should pass.