### PR TITLE
[ci] Update codemention action pin

### DIFF
--- a/.github/workflows/codemention.yml
+++ b/.github/workflows/codemention.yml
@@ -12,9 +12,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      # Pinned to a commit SHA (not the v1.4.0 tag) because this runs under
-      # pull_request_target with a write-scoped token — a re-pointed tag from
-      # a compromised upstream account would give the attacker repo write access.
-      - uses: tobyhs/codemention@bb6bfb2c3ff1e6fee7ee37006bbee6d114057225 # v1.4.0
+      # Pinned to a commit SHA (not a tag or branch) because this runs under
+      # pull_request_target with a write-scoped token — a re-pointed tag or
+      # moving branch would allow unreviewed upstream code to run here.
+      - uses: tobyhs/codemention@ebac5877393ab8693fd73b42708c8552043e9a3b # post-v1.5.2
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Updates the codemention GitHub Action pin from `v1.4.0` to a reviewed post-`v1.5.2` upstream commit:

- `tobyhs/codemention@ebac5877393ab8693fd73b42708c8552043e9a3b`
- keeps the action pinned to an immutable commit SHA because this workflow runs on `pull_request_target` with `pull-requests: write`
- avoids pinning to moving `main` or a mutable tag

## Security review

I reviewed upstream `tobyhs/codemention` changes from `v1.4.0` through `v1.5.2` and found that `v1.5.2` introduced `handlebars@4.7.8`, which currently has critical/high production dependency advisories. I therefore did not pin to `v1.5.2`.

The selected post-release commit includes follow-up dependency fixes on upstream `main`, including `handlebars@4.7.9`, `js-yaml@4.2.0`, and `undici@6.27.0`. `npm audit --omit=dev` on that upstream commit reported 0 vulnerabilities at review time.

## Validation

- `yarn fmt:check .github/workflows/codemention.yml`
- YAML parse check
- `git diff --check`