### PR TITLE
[eas-cli] Use simulator session dashboard URLs

### DIFF
--- a/packages/eas-cli/src/build/utils/url.ts
+++ b/packages/eas-cli/src/build/utils/url.ts
@@ -64,6 +64,19 @@ export function getWorkflowRunUrl(
   ).toString();
 }
 
+export function getDeviceRunSessionUrl(
+  accountName: string,
+  projectName: string,
+  deviceRunSessionId: string
+): string {
+  return new URL(
+    `/accounts/${encodeURIComponent(accountName)}/projects/${encodeURIComponent(
+      projectName
+    )}/simulator-sessions/${encodeURIComponent(deviceRunSessionId)}`,
+    getExpoWebsiteBaseUrl()
+  ).toString();
+}
+
 /**
  * @deprecated Links to the raw job-run page; prefer a higher-level URL (e.g. the workflow run
  * or the feature-specific dashboard) that gives users more context. Use this only for internal

--- a/packages/eas-cli/src/commands/simulator/__tests__/get.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/get.test.ts
@@ -118,7 +118,8 @@ describe(SimulatorGet, () => {
       id: 'session-123',
       type: 'agent-device',
       status: DeviceRunSessionStatus.InProgress,
-      jobRunUrl: 'https://expo.dev/accounts/testuser/projects/testapp/job-runs/job-123',
+      deviceRunSessionUrl:
+        'https://expo.dev/accounts/testuser/projects/testapp/simulator-sessions/session-123',
       remoteConfig: session.remoteConfig,
     });
   });

--- a/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
@@ -135,7 +135,8 @@ describe(SimulatorList, () => {
           createdAt: '2025-01-01T00:00:00.000Z',
           startedAt: '2025-01-01T00:00:05.000Z',
           finishedAt: undefined,
-          jobRunUrl: 'https://expo.dev/accounts/testuser/projects/testapp/job-runs/job-123',
+          deviceRunSessionUrl:
+            'https://expo.dev/accounts/testuser/projects/testapp/simulator-sessions/session-123',
         },
       ],
       pageInfo: {

--- a/packages/eas-cli/src/commands/simulator/__tests__/start.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/start.test.ts
@@ -61,7 +61,8 @@ type DeviceRunSessionById = DeviceRunSessionByIdQuery['deviceRunSessions']['byId
 const graphqlClient = {} as ExpoGraphqlClient;
 const projectDir = '/test/project';
 const simulatorDotenvPath = `${projectDir}/.env.eas-simulator`;
-const jobRunUrl = 'https://expo.dev/accounts/testuser/projects/testapp/job-runs/job-123';
+const deviceRunSessionUrl =
+  'https://expo.dev/accounts/testuser/projects/testapp/simulator-sessions/session-123';
 
 const mockCreateDeviceRunSessionAsync = jest.mocked(
   DeviceRunSessionMutation.createDeviceRunSessionAsync
@@ -185,7 +186,7 @@ describe(SimulatorStart, () => {
     });
     expect(fs.writeFile).not.toHaveBeenCalled();
     expect(mockOra.mock.results[0]?.value.succeed).toHaveBeenCalledWith(
-      `Device run session created (id: session-123) ${jobRunUrl}`
+      `Simulator session created (id: session-123) ${deviceRunSessionUrl}`
     );
     expect(Log.log).toHaveBeenCalledWith(
       expect.stringContaining("export AGENT_DEVICE_DAEMON_BASE_URL='https://agent.example.com'")
@@ -214,7 +215,7 @@ describe(SimulatorStart, () => {
       mockByIdAsync.mock.invocationCallOrder[0]
     );
     expect(mockOra.mock.results[0]?.value.succeed).toHaveBeenCalledWith(
-      `Device run session created (id: session-123, saved to ${SIMULATOR_DOTENV_FILE_NAME}) ${jobRunUrl}`
+      `Simulator session created (id: session-123, saved to ${SIMULATOR_DOTENV_FILE_NAME}) ${deviceRunSessionUrl}`
     );
     expect(Log.withTick).not.toHaveBeenCalled();
     expect(Log.log).toHaveBeenCalledWith(
@@ -298,7 +299,7 @@ describe(SimulatorStart, () => {
 
     const { command } = createCommand(['--platform', 'ios', '--non-interactive', '--no-force']);
     await expect(command.runAsync()).rejects.toThrow(
-      'Existing simulator session in environment. Use --force to create a new device session.'
+      'Existing simulator session in environment. Use --force to create a new simulator session.'
     );
 
     expect(mockCreateDeviceRunSessionAsync).not.toHaveBeenCalled();

--- a/packages/eas-cli/src/commands/simulator/get.ts
+++ b/packages/eas-cli/src/commands/simulator/get.ts
@@ -1,6 +1,6 @@
 import { Flags } from '@oclif/core';
 
-import { getBareJobRunUrl } from '../../build/utils/url';
+import { getDeviceRunSessionUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
 import {
   EasNonInteractiveAndJsonFlags,
@@ -24,11 +24,11 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 export default class SimulatorGet extends EasCommand {
   static override hidden = true;
   static override description =
-    '[EXPERIMENTAL] get info about a remote simulator session on EAS by its device run session ID';
+    '[EXPERIMENTAL] get info about a remote simulator session on EAS by its simulator session ID';
 
   static override flags = {
     id: Flags.string({
-      description: `Device run session ID. Defaults to ${SIMULATOR_DOTENV_FILE_NAME}.`,
+      description: `Simulator session ID. Defaults to ${SIMULATOR_DOTENV_FILE_NAME}.`,
     }),
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -61,26 +61,28 @@ export default class SimulatorGet extends EasCommand {
       );
     }
 
-    const fetchSpinner = ora(`Fetching device run session ${flagId}`).start();
+    const fetchSpinner = ora(`Fetching simulator session ${flagId}`).start();
     let session;
     try {
       session = await DeviceRunSessionQuery.byIdAsync(graphqlClient, flagId);
-      fetchSpinner.succeed(`Fetched device run session ${session.id}`);
+      fetchSpinner.succeed(`Fetched simulator session ${session.id}`);
     } catch (err) {
-      fetchSpinner.fail(`Failed to fetch device run session ${flagId}`);
+      fetchSpinner.fail(`Failed to fetch simulator session ${flagId}`);
       throw err;
     }
 
-    const jobRunUrl = session.turtleJobRun
-      ? getBareJobRunUrl(session.app.ownerAccount.name, session.app.slug, session.turtleJobRun.id)
-      : '';
+    const deviceRunSessionUrl = getDeviceRunSessionUrl(
+      session.app.ownerAccount.name,
+      session.app.slug,
+      session.id
+    );
 
     if (jsonFlag) {
       printJsonOnlyOutput({
         id: session.id,
         type: deviceRunSessionTypeToFlagValue(session.type),
         status: session.status,
-        jobRunUrl: jobRunUrl || undefined,
+        deviceRunSessionUrl,
         remoteConfig: session.remoteConfig,
       });
       return;
@@ -90,7 +92,7 @@ export default class SimulatorGet extends EasCommand {
     Log.log(`ID:       ${session.id}`);
     Log.log(`Type:     ${session.type}`);
     Log.log(`Status:   ${session.status}`);
-    Log.log(`URL:      ${jobRunUrl ? link(jobRunUrl) : ''}`);
+    Log.log(`URL:      ${link(deviceRunSessionUrl)}`);
 
     if (session.status === DeviceRunSessionStatus.InProgress) {
       Log.newLine();

--- a/packages/eas-cli/src/commands/simulator/list.ts
+++ b/packages/eas-cli/src/commands/simulator/list.ts
@@ -1,7 +1,7 @@
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 
-import { getBareJobRunUrl } from '../../build/utils/url';
+import { getDeviceRunSessionUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
 import {
   EasNonInteractiveAndJsonFlags,
@@ -110,7 +110,7 @@ export default class SimulatorList extends EasCommand {
 
     const limit = flags.limit ?? DEFAULT_LIMIT;
 
-    const fetchSpinner = jsonFlag ? null : ora('Fetching device run sessions').start();
+    const fetchSpinner = jsonFlag ? null : ora('Fetching simulator sessions').start();
     let connection;
     try {
       connection = await DeviceRunSessionQuery.listByAppIdAsync(graphqlClient, {
@@ -119,9 +119,9 @@ export default class SimulatorList extends EasCommand {
         after: flags.after,
         filter: Object.keys(filter).length > 0 ? filter : undefined,
       });
-      fetchSpinner?.succeed(`Fetched ${connection.edges.length} device run session(s)`);
+      fetchSpinner?.succeed(`Fetched ${connection.edges.length} simulator session(s)`);
     } catch (err) {
-      fetchSpinner?.fail('Failed to fetch device run sessions');
+      fetchSpinner?.fail('Failed to fetch simulator sessions');
       throw err;
     }
 
@@ -137,13 +137,11 @@ export default class SimulatorList extends EasCommand {
           createdAt: session.createdAt,
           startedAt: session.startedAt ?? undefined,
           finishedAt: session.finishedAt ?? undefined,
-          jobRunUrl: session.turtleJobRun
-            ? getBareJobRunUrl(
-                session.app.ownerAccount.name,
-                session.app.slug,
-                session.turtleJobRun.id
-              )
-            : undefined,
+          deviceRunSessionUrl: getDeviceRunSessionUrl(
+            session.app.ownerAccount.name,
+            session.app.slug,
+            session.id
+          ),
         })),
         pageInfo: connection.pageInfo,
       });
@@ -152,25 +150,25 @@ export default class SimulatorList extends EasCommand {
 
     if (sessions.length === 0) {
       Log.newLine();
-      Log.log('No device run sessions found.');
+      Log.log('No simulator sessions found.');
       return;
     }
 
     Log.newLine();
     const formattedEntries = sessions.map(session => {
-      const jobRunUrl = session.turtleJobRun
-        ? getBareJobRunUrl(session.app.ownerAccount.name, session.app.slug, session.turtleJobRun.id)
-        : null;
+      const deviceRunSessionUrl = getDeviceRunSessionUrl(
+        session.app.ownerAccount.name,
+        session.app.slug,
+        session.id
+      );
       const lines = [
         `ID:       ${session.id}`,
         `Type:     ${session.type}`,
         `Status:   ${session.status}`,
         `Platform: ${session.platform}`,
         `Created:  ${fromNow(new Date(session.createdAt))} ago`,
+        `URL:      ${link(deviceRunSessionUrl)}`,
       ];
-      if (jobRunUrl) {
-        lines.push(`URL:      ${link(jobRunUrl)}`);
-      }
       return lines.join('\n');
     });
     Log.log(formattedEntries.join(`\n\n${chalk.dim('———')}\n\n`));

--- a/packages/eas-cli/src/commands/simulator/start.ts
+++ b/packages/eas-cli/src/commands/simulator/start.ts
@@ -1,7 +1,7 @@
 import { Flags } from '@oclif/core';
 import nullthrows from 'nullthrows';
 
-import { getBareJobRunUrl } from '../../build/utils/url';
+import { getDeviceRunSessionUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import {
@@ -54,22 +54,22 @@ export default class SimulatorStart extends EasCommand {
       required: true,
     })(),
     type: Flags.option({
-      description: 'Type of device run session to create',
+      description: 'Type of simulator session to create',
       options: Object.values(DEVICE_RUN_SESSION_TYPE_FLAG_VALUES),
       default: DEVICE_RUN_SESSION_TYPE_FLAG_VALUES[DeviceRunSessionType.AgentDevice],
     })(),
     'package-version': Flags.string({
       description:
-        'Version of the package backing the device run session (e.g. "0.1.3-alpha.3"). Defaults to "latest" when omitted.',
+        'Version of the package backing the simulator session (e.g. "0.1.3-alpha.3"). Defaults to "latest" when omitted.',
     }),
     'max-duration-minutes': Flags.integer({
       description:
-        'Maximum duration of the device run session in minutes before it is automatically stopped. Only customizable on paid plans. Defaults to a value derived from the job run priority when omitted.',
+        'Maximum duration of the simulator session in minutes before it is automatically stopped. Only customizable on paid plans. Defaults to a value derived from the job run priority when omitted.',
       min: 0,
     }),
     force: Flags.boolean({
       description:
-        '[default: true] Create a new device session even when an existing simulator session is present in the environment.',
+        '[default: true] Create a new simulator session even when an existing simulator session is present in the environment.',
       default: true,
       allowNo: true,
     }),
@@ -107,7 +107,7 @@ export default class SimulatorStart extends EasCommand {
     const existingDeviceRunSessionId = process.env[EAS_SIMULATOR_SESSION_ID];
     if (existingDeviceRunSessionId && !flags.force) {
       throw new Error(
-        `Existing simulator session in environment. Use --force to create a new device session.`
+        `Existing simulator session in environment. Use --force to create a new simulator session.`
       );
     }
     if (existingDeviceRunSessionId) {
@@ -121,9 +121,9 @@ export default class SimulatorStart extends EasCommand {
 
     const platform = flags.platform === 'android' ? AppPlatform.Android : AppPlatform.Ios;
 
-    const createSpinner = ora('🚀 Creating device run session').start();
+    const createSpinner = ora('🚀 Creating simulator session').start();
     let deviceRunSessionId: string;
-    let jobRunUrl: string;
+    let deviceRunSessionUrl: string;
     try {
       const session = await DeviceRunSessionMutation.createDeviceRunSessionAsync(graphqlClient, {
         appId: projectId,
@@ -133,8 +133,12 @@ export default class SimulatorStart extends EasCommand {
         maxRunTimeMinutes: flags['max-duration-minutes'],
       });
       deviceRunSessionId = session.id;
-      const jobRunId = nullthrows(session.turtleJobRun?.id, 'Expected device run session to start');
-      jobRunUrl = getBareJobRunUrl(session.app.ownerAccount.name, session.app.slug, jobRunId);
+      nullthrows(session.turtleJobRun?.id, 'Expected simulator session to start');
+      deviceRunSessionUrl = getDeviceRunSessionUrl(
+        session.app.ownerAccount.name,
+        session.app.slug,
+        deviceRunSessionId
+      );
       const simulatorEnvWritten =
         !jsonFlag && flags['out-config-type'] === OUT_CONFIG_TYPE_VALUES.Dotenv
           ? await writeSimulatorEnvSafelyAsync(projectDir, {
@@ -142,12 +146,12 @@ export default class SimulatorStart extends EasCommand {
             })
           : false;
       createSpinner.succeed(
-        `Device run session created (id: ${deviceRunSessionId}${
+        `Simulator session created (id: ${deviceRunSessionId}${
           simulatorEnvWritten ? `, saved to ${SIMULATOR_DOTENV_FILE_NAME}` : ''
-        }) ${link(jobRunUrl)}`
+        }) ${link(deviceRunSessionUrl)}`
       );
     } catch (err) {
-      createSpinner.fail('Failed to create device run session');
+      createSpinner.fail('Failed to create simulator session');
       throw err;
     }
 
@@ -164,7 +168,7 @@ export default class SimulatorStart extends EasCommand {
           session.status === DeviceRunSessionStatus.Stopped
         ) {
           throw new Error(
-            `Device run session ${deviceRunSessionId} ${session.status.toLowerCase()} before the ${flags.type} session was ready. ${link(jobRunUrl)}`
+            `Simulator session ${deviceRunSessionId} ${session.status.toLowerCase()} before the ${flags.type} session was ready. ${link(deviceRunSessionUrl)}`
           );
         }
 
@@ -175,7 +179,7 @@ export default class SimulatorStart extends EasCommand {
           jobRunStatus === JobRunStatus.Finished
         ) {
           throw new Error(
-            `Turtle job run for device run session ${deviceRunSessionId} ${jobRunStatus.toLowerCase()} before the ${flags.type} session was ready. ${link(jobRunUrl)}`
+            `Turtle job run for simulator session ${deviceRunSessionId} ${jobRunStatus.toLowerCase()} before the ${flags.type} session was ready. ${link(deviceRunSessionUrl)}`
           );
         }
 
@@ -197,7 +201,7 @@ export default class SimulatorStart extends EasCommand {
       pollSpinner.fail(`Timed out waiting for ${flags.type} session to be ready`);
       await ensureDeviceRunSessionStoppedSafelyAsync(graphqlClient, deviceRunSessionId);
       throw new Error(
-        `Timed out after ${Math.round(POLL_TIMEOUT_MS / 1000)}s waiting for ${flags.type} session to be ready. ${link(jobRunUrl)}`
+        `Timed out after ${Math.round(POLL_TIMEOUT_MS / 1000)}s waiting for ${flags.type} session to be ready. ${link(deviceRunSessionUrl)}`
       );
     }
 
@@ -212,7 +216,7 @@ export default class SimulatorStart extends EasCommand {
       printJsonOnlyOutput({
         id: deviceRunSessionId,
         type: flags.type,
-        jobRunUrl,
+        deviceRunSessionUrl,
         remoteConfig,
       });
       return;
@@ -232,7 +236,7 @@ export default class SimulatorStart extends EasCommand {
     await waitForSessionEndOrInterruptAsync({
       graphqlClient,
       deviceRunSessionId,
-      jobRunUrl,
+      deviceRunSessionUrl,
       projectDir,
     });
   }
@@ -258,16 +262,16 @@ async function writeSimulatorEnvSafelyAsync(
 async function waitForSessionEndOrInterruptAsync({
   graphqlClient,
   deviceRunSessionId,
-  jobRunUrl,
+  deviceRunSessionUrl,
   projectDir,
 }: {
   graphqlClient: ExpoGraphqlClient;
   deviceRunSessionId: string;
-  jobRunUrl: string;
+  deviceRunSessionUrl: string;
   projectDir: string;
 }): Promise<void> {
   const spinner = ora(
-    `Device run session active — press Ctrl+C to stop, or run \`eas simulator:stop --id ${deviceRunSessionId}\` from another shell`
+    `Simulator session active — press Ctrl+C to stop, or run \`eas simulator:stop --id ${deviceRunSessionId}\` from another shell`
   ).start();
 
   const abortController = new AbortController();
@@ -286,7 +290,7 @@ async function waitForSessionEndOrInterruptAsync({
       // Force exit on a second Ctrl+C in case cleanup is hanging. The session may still be
       // running on EAS, so tell the user how to make sure it gets terminated.
       spinner.fail(
-        `Aborted before the device run session could be stopped. Run \`eas simulator:stop --id ${deviceRunSessionId}\` to terminate it and avoid unexpected charges.`
+        `Aborted before the simulator session could be stopped. Run \`eas simulator:stop --id ${deviceRunSessionId}\` to terminate it and avoid unexpected charges.`
       );
       process.exit(130);
     }
@@ -301,7 +305,7 @@ async function waitForSessionEndOrInterruptAsync({
         session = await DeviceRunSessionQuery.byIdAsync(graphqlClient, deviceRunSessionId);
       } catch (err) {
         Log.debug(
-          `Failed to poll device run session: ${err instanceof Error ? err.message : String(err)}`
+          `Failed to poll simulator session: ${err instanceof Error ? err.message : String(err)}`
         );
         await Promise.race([sleepAsync(POLL_INTERVAL_MS), abortPromise]);
         continue;
@@ -312,15 +316,15 @@ async function waitForSessionEndOrInterruptAsync({
         session.status === DeviceRunSessionStatus.Errored ||
         jobRunStatus === JobRunStatus.Errored
       ) {
-        spinner.fail(`Device run session errored. ${link(jobRunUrl)}`);
-        throw new Error(`Device run session ${deviceRunSessionId} errored.`);
+        spinner.fail(`Simulator session errored. ${link(deviceRunSessionUrl)}`);
+        throw new Error(`Simulator session ${deviceRunSessionId} errored.`);
       }
       if (
         session.status === DeviceRunSessionStatus.Stopped ||
         jobRunStatus === JobRunStatus.Canceled ||
         jobRunStatus === JobRunStatus.Finished
       ) {
-        spinner.succeed(`Device run session ended. ${link(jobRunUrl)}`);
+        spinner.succeed(`Simulator session ended. ${link(deviceRunSessionUrl)}`);
         await resetSimulatorEnvVerboseAsync(projectDir);
         return;
       }
@@ -328,17 +332,17 @@ async function waitForSessionEndOrInterruptAsync({
       await Promise.race([sleepAsync(POLL_INTERVAL_MS), abortPromise]);
     }
 
-    spinner.text = 'Stopping device run session...';
+    spinner.text = 'Stopping simulator session...';
     const stopped = await ensureDeviceRunSessionStoppedSafelyAsync(
       graphqlClient,
       deviceRunSessionId
     );
     if (stopped) {
-      spinner.succeed('Device run session stopped');
+      spinner.succeed('Simulator session stopped');
       await resetSimulatorEnvVerboseAsync(projectDir);
     } else {
       spinner.fail(
-        `Could not confirm the device run session was stopped. Run \`eas simulator:stop --id ${deviceRunSessionId}\` to terminate it and avoid unexpected charges.`
+        `Could not confirm the simulator session was stopped. Run \`eas simulator:stop --id ${deviceRunSessionId}\` to terminate it and avoid unexpected charges.`
       );
     }
   } finally {
@@ -368,7 +372,7 @@ async function ensureDeviceRunSessionStoppedSafelyAsync(
   } catch (err) {
     // Cleanup is best-effort; surface the failure but don't mask the original error.
     Log.warn(
-      `Failed to stop device run session ${deviceRunSessionId}: ${
+      `Failed to stop simulator session ${deviceRunSessionId}: ${
         err instanceof Error ? err.message : String(err)
       }`
     );

--- a/packages/eas-cli/src/commands/simulator/stop.ts
+++ b/packages/eas-cli/src/commands/simulator/stop.ts
@@ -17,11 +17,11 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 export default class SimulatorStop extends EasCommand {
   static override hidden = true;
   static override description =
-    '[EXPERIMENTAL] stop a remote simulator session on EAS by its device run session ID';
+    '[EXPERIMENTAL] stop a remote simulator session on EAS by its simulator session ID';
 
   static override flags = {
     id: Flags.string({
-      description: `Device run session ID. Defaults to ${SIMULATOR_DOTENV_FILE_NAME}.`,
+      description: `Simulator session ID. Defaults to ${SIMULATOR_DOTENV_FILE_NAME}.`,
     }),
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -54,16 +54,16 @@ export default class SimulatorStop extends EasCommand {
       );
     }
 
-    const stopSpinner = ora(`🛑 Stopping device run session ${flagId}`).start();
+    const stopSpinner = ora(`🛑 Stopping simulator session ${flagId}`).start();
     let session;
     try {
       session = await DeviceRunSessionMutation.ensureDeviceRunSessionStoppedAsync(
         graphqlClient,
         flagId
       );
-      stopSpinner.succeed(`🎉 Device run session ${session.id} is ${session.status.toLowerCase()}`);
+      stopSpinner.succeed(`🎉 Simulator session ${session.id} is ${session.status.toLowerCase()}`);
     } catch (err) {
-      stopSpinner.fail(`Failed to stop device run session ${flagId}`);
+      stopSpinner.fail(`Failed to stop simulator session ${flagId}`);
       throw err;
     }
 


### PR DESCRIPTION
## Why

The Expo dashboard route for device run sessions moved to the simulator sessions surface, so EAS CLI should send users to that page and use the simulator-session terminology in user-facing output.

## How

- Add a dashboard URL helper that points device run sessions at `/simulator-sessions/{id}`.
- Update `eas simulator:{start,get,list}` output and JSON to expose `deviceRunSessionUrl` using the simulator sessions route.
- Update user-facing simulator command copy from "device run session" to "simulator session".

## Test Plan

CI should pass.