### PR TITLE
[eas-cli] Resolve ApplePlatform.TV_OS for managed tvOS targets via EXPO_TV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Select correct tvOS build target for non-interactive Apple builds when EXPO_TV env variable is set. ([#3907](https://github.com/expo/eas-cli/pull/3907) by [@douglowder](https://github.com/douglowder))
+
 ### 🧹 Chores
 
 ## [20.4.0](https://github.com/expo/eas-cli/releases/tag/v20.4.0) - 2026-06-25

--- a/packages/eas-cli/src/project/ios/__tests__/target-test.ts
+++ b/packages/eas-cli/src/project/ios/__tests__/target-test.ts
@@ -1,7 +1,12 @@
 import { testTarget } from '../../../credentials/__tests__/fixtures-ios';
 import { ApplePlatform } from '../../../credentials/ios/appstore/constants';
 import { Target } from '../../../credentials/ios/types';
-import { getApplePlatformFromDeviceFamily, getApplePlatformFromSdkRoot } from '../target';
+import {
+  getApplePlatformFromDeviceFamily,
+  getApplePlatformFromSdkRoot,
+  getApplePlatformFromTarget,
+  getManagedTvBuildSettings,
+} from '../target';
 
 function getApplePlatformWithSdkRoot(sdkRoot: string): ApplePlatform | null {
   const target = {
@@ -54,5 +59,66 @@ describe(getApplePlatformFromDeviceFamily, () => {
     expect(getApplePlatformWithDeviceFamily(3)).toBe(ApplePlatform.TV_OS);
     expect(getApplePlatformWithDeviceFamily(undefined)).toBe(null);
     expect(getApplePlatformWithDeviceFamily('ilovecats')).toBe(null);
+  });
+});
+
+describe(getManagedTvBuildSettings, () => {
+  const originalExpoTv = process.env.EXPO_TV;
+  afterEach(() => {
+    if (originalExpoTv === undefined) {
+      delete process.env.EXPO_TV;
+    } else {
+      process.env.EXPO_TV = originalExpoTv;
+    }
+  });
+
+  test('returns undefined when EXPO_TV is not set in env or process.env', () => {
+    delete process.env.EXPO_TV;
+    expect(getManagedTvBuildSettings(undefined)).toBeUndefined();
+    expect(getManagedTvBuildSettings({})).toBeUndefined();
+    expect(getManagedTvBuildSettings({ EXPO_TV: '' })).toBeUndefined();
+    expect(getManagedTvBuildSettings({ EXPO_TV: '0' })).toBeUndefined();
+    expect(getManagedTvBuildSettings({ EXPO_TV: 'false' })).toBeUndefined();
+    expect(getManagedTvBuildSettings({ EXPO_TV: 'no' })).toBeUndefined();
+  });
+
+  test('returns TARGETED_DEVICE_FAMILY=3 when EXPO_TV is truthy in the env parameter (eas.json case)', () => {
+    delete process.env.EXPO_TV;
+    for (const value of ['1', 'true', 'yes', 'TRUE', 'Yes']) {
+      expect(getManagedTvBuildSettings({ EXPO_TV: value })).toEqual({
+        TARGETED_DEVICE_FAMILY: '3',
+      });
+    }
+  });
+
+  test('falls back to process.env when env is missing EXPO_TV (shell case)', () => {
+    process.env.EXPO_TV = '1';
+    expect(getManagedTvBuildSettings(undefined)).toEqual({ TARGETED_DEVICE_FAMILY: '3' });
+    expect(getManagedTvBuildSettings({})).toEqual({ TARGETED_DEVICE_FAMILY: '3' });
+  });
+
+  test('env-parameter EXPO_TV takes precedence over process.env (eas.json overrides shell)', () => {
+    process.env.EXPO_TV = '0';
+    expect(getManagedTvBuildSettings({ EXPO_TV: '1' })).toEqual({
+      TARGETED_DEVICE_FAMILY: '3',
+    });
+
+    process.env.EXPO_TV = '1';
+    expect(getManagedTvBuildSettings({ EXPO_TV: '0' })).toBeUndefined();
+  });
+
+  test('feeds into getApplePlatformFromTarget so managed tvOS targets resolve to TV_OS', () => {
+    delete process.env.EXPO_TV;
+    const target: Target = {
+      ...testTarget,
+      buildSettings: getManagedTvBuildSettings({ EXPO_TV: '1' }),
+    };
+    expect(getApplePlatformFromTarget(target)).toBe(ApplePlatform.TV_OS);
+
+    const iosTarget: Target = {
+      ...testTarget,
+      buildSettings: getManagedTvBuildSettings({}),
+    };
+    expect(getApplePlatformFromTarget(iosTarget)).toBe(ApplePlatform.IOS);
   });
 });

--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -40,6 +40,28 @@ const AppExtensionsConfigSchema = Joi.array().items(
   })
 );
 
+/**
+ * For managed projects we don't have an Xcode project to read build settings
+ * from, but the @react-native-tvos/config-tv plugin signals a tvOS build via
+ * the EXPO_TV environment variable. That variable can come from the build
+ * profile's `env` in eas.json (the typical case, which flows in via `env`),
+ * or from the shell process when the user runs `EXPO_TV=1 eas build ...`
+ * (which is NOT included in the merged `env` upstream, so we read
+ * `process.env` directly as a fallback). When set, synthesize
+ * TARGETED_DEVICE_FAMILY=3 so getApplePlatformFromTarget (and every
+ * Apple-portal flow downstream) picks TV_OS for these targets instead of
+ * defaulting to IOS.
+ */
+export function getManagedTvBuildSettings(
+  env: Record<string, string> | undefined
+): Target['buildSettings'] | undefined {
+  const expoTv = (env?.EXPO_TV ?? process.env.EXPO_TV ?? '').toString().toLowerCase();
+  if (expoTv === '1' || expoTv === 'true' || expoTv === 'yes') {
+    return { TARGETED_DEVICE_FAMILY: '3' };
+  }
+  return undefined;
+}
+
 export async function resolveManagedProjectTargetsAsync({
   exp,
   projectDir,
@@ -76,12 +98,14 @@ export async function resolveManagedProjectTargetsAsync({
     );
   }
 
+  const managedBuildSettings = getManagedTvBuildSettings(env);
   const extensionsTargets: Target[] = appExtensions.map(extension => ({
     targetName: extension.targetName,
     buildConfiguration,
     bundleIdentifier: extension.bundleIdentifier,
     parentBundleIdentifier: extension.parentBundleIdentifier ?? applicationTargetBundleIdentifier,
     entitlements: extension.entitlements ?? {},
+    ...(managedBuildSettings && { buildSettings: managedBuildSettings }),
   }));
   return [
     {
@@ -89,6 +113,7 @@ export async function resolveManagedProjectTargetsAsync({
       bundleIdentifier: applicationTargetBundleIdentifier,
       buildConfiguration,
       entitlements: applicationTargetEntitlements,
+      ...(managedBuildSettings && { buildSettings: managedBuildSettings }),
     },
     ...extensionsTargets,
   ];


### PR DESCRIPTION
# Why

Non interactive builds were attempting to incorrectly verify tvOS provisioning profiles with settings for the iOS platform.

# How

Recognize when EXPO_TV env variable is set, and in that case, set the target platform to tvOS.

Fixes #3905

# Test Plan

- Tested with a real SDK 56 TV project
- New unit tests added