### PR TITLE
[eas-cli] Quote env:pull values containing # or whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Quote `eas env:pull` values that contain `#`, whitespace or newlines so they are no longer truncated when the generated `.env` file is read back by dotenv. ([#3911](https://github.com/expo/eas-cli/pull/3911) by [@ryanda9910](https://github.com/ryanda9910))
+
 ### 🧹 Chores
 
 ## [20.4.0](https://github.com/expo/eas-cli/releases/tag/v20.4.0) - 2026-06-25

--- a/packages/eas-cli/src/commands/env/__tests__/EnvPull.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvPull.test.ts
@@ -1,3 +1,4 @@
+import dotenv from 'dotenv';
 import * as fs from 'fs-extra';
 import path from 'path';
 
@@ -16,7 +17,7 @@ import {
 } from '../../../graphql/queries/EnvironmentVariablesQuery';
 import Log from '../../../log';
 import { confirmAsync } from '../../../prompts';
-import EnvPull from '../pull';
+import EnvPull, { serializeDotenvValue } from '../pull';
 
 jest.mock('../../../graphql/queries/EnvironmentVariablesQuery');
 jest.mock('../../../prompts');
@@ -384,5 +385,88 @@ describe(EnvPull, () => {
         expect.stringContaining('Reused local values for following secrets: SECRET_KEY')
       );
     });
+  });
+
+  describe('values with special characters', () => {
+    it('quotes values that would otherwise be misparsed by dotenv', async () => {
+      jest.mocked(EnvironmentVariablesQuery.byAppIdWithSensitiveAsync).mockResolvedValue([
+        {
+          id: 'var1',
+          name: 'HEX_COLOR',
+          value: '#ffffff',
+          environments: [DefaultEnvironment.Development],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          scope: EnvironmentVariableScope.Project,
+          visibility: EnvironmentVariableVisibility.Public,
+          type: EnvironmentSecretType.String,
+        },
+        {
+          id: 'var2',
+          name: 'CALLBACK_URL',
+          value: 'https://example.com/page#section',
+          environments: [DefaultEnvironment.Development],
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          scope: EnvironmentVariableScope.Project,
+          visibility: EnvironmentVariableVisibility.Public,
+          type: EnvironmentSecretType.String,
+        },
+      ]);
+
+      const command = new EnvPull(['development'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      const writeFileCalls = jest.mocked(fs.writeFile).mock.calls;
+      const envFileCall = writeFileCalls.find(call => call[0] === testTargetPath);
+      expect(envFileCall).toBeDefined();
+      const fileContent = envFileCall![1] as string;
+
+      // The raw line must be quoted so the `#` is not read as an inline comment ...
+      expect(fileContent).toContain("HEX_COLOR='#ffffff'");
+      expect(fileContent).toContain("CALLBACK_URL='https://example.com/page#section'");
+
+      // ... and the written file must round-trip back to the original values.
+      const parsed = dotenv.parse(fileContent);
+      expect(parsed.HEX_COLOR).toBe('#ffffff');
+      expect(parsed.CALLBACK_URL).toBe('https://example.com/page#section');
+    });
+  });
+});
+
+describe(serializeDotenvValue, () => {
+  it('leaves values without special characters unquoted', () => {
+    expect(serializeDotenvValue('https://api.example.com')).toBe('https://api.example.com');
+    expect(serializeDotenvValue('postgres://localhost:5432/mydb')).toBe(
+      'postgres://localhost:5432/mydb'
+    );
+  });
+
+  it('round-trips values with special characters through dotenv', () => {
+    const values = [
+      '#ffffff',
+      'https://example.com/page#section',
+      'value with spaces',
+      'has#hash and space',
+      "it's a #test",
+      'line1\nline2',
+      'has"quote',
+      'C:\\Users\\me\\with space',
+      '  leading and trailing  ',
+      '',
+    ];
+
+    for (const value of values) {
+      const parsed = dotenv.parse(`K=${serializeDotenvValue(value)}`);
+      expect(parsed.K).toBe(value);
+    }
   });
 });

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -14,6 +14,34 @@ import Log from '../../log';
 import { confirmAsync } from '../../prompts';
 import { promptVariableEnvironmentAsync } from '../../utils/prompts';
 
+/**
+ * Serialize a value so that it round-trips through a dotenv parser.
+ *
+ * Without quoting, dotenv treats an unquoted `#` as the start of an inline comment, trims
+ * surrounding whitespace and splits on newlines, so values like a `#ffffff` hex color or a URL
+ * with a fragment would be silently truncated when the `.env` file is read back. See
+ * https://github.com/motdotla/dotenv#comments.
+ *
+ * Single quotes are preferred because dotenv treats single-quoted values as literal, preserving
+ * `#`, whitespace, backslashes and double quotes as-is. Double quotes (with `\n`/`\r` escaping) are
+ * only used when the value contains a single quote or a newline.
+ */
+export function serializeDotenvValue(value: string): string {
+  // Values made up of "safe" characters can be written verbatim.
+  if (value !== '' && !/[\s#'"`\\]/.test(value)) {
+    return value;
+  }
+  if (!value.includes("'") && !/[\r\n]/.test(value)) {
+    return `'${value}'`;
+  }
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
+  return `"${escaped}"`;
+}
+
 export default class EnvPull extends EasCommand {
   static override description =
     'pull environment variables for the selected environment to .env file';
@@ -111,7 +139,7 @@ export default class EnvPull extends EasCommand {
         if (variable.visibility === EnvironmentVariableVisibility.Secret) {
           if (currentEnvLocal[variable.name]) {
             overridenSecretVariables.push(variable.name);
-            return `${variable.name}=${currentEnvLocal[variable.name]}`;
+            return `${variable.name}=${serializeDotenvValue(currentEnvLocal[variable.name])}`;
           }
           skippedSecretVariables.push(variable.name);
           return `# ${variable.name}=***** (secret)`;
@@ -119,9 +147,9 @@ export default class EnvPull extends EasCommand {
         if (variable.type === EnvironmentSecretType.FileBase64 && variable.valueWithFileContent) {
           const filePath = path.join(envDir, variable.name);
           await fs.writeFile(filePath, variable.valueWithFileContent, 'base64');
-          return `${variable.name}=${filePath}`;
+          return `${variable.name}=${serializeDotenvValue(filePath)}`;
         }
-        return `${variable.name}=${variable.value}`;
+        return `${variable.name}=${serializeDotenvValue(variable.value ?? '')}`;
       })
     );
 


### PR DESCRIPTION
# Why

Fixes #2813.

`eas env:pull` writes the generated `.env` file by interpolating each value directly: `${name}=${value}`. When a value contains a `#` (a hex color like `#ffffff`, or a URL with a fragment), dotenv reads the `#` as the start of an inline comment and drops everything after it, so the variable loads with a truncated or empty value. The same happens for values with surrounding whitespace (trimmed) or newlines (split across lines). The dotenv docs call this out and recommend wrapping such values in quotes: https://github.com/motdotla/dotenv#comments

Repro:

```
eas env:create --name TEST --value '#ffffff' --type string --visibility plaintext --environment development
eas env:pull --environment development
# .env.local now contains:  TEST=#ffffff
# dotenv parses TEST as ""  (everything after # is treated as a comment)
```

# How

Added a small `serializeDotenvValue` helper in `pull.ts` and routed the three places that write a value through it (plain values, reused local secret values, and generated file paths).

The helper quotes only when needed and is built to round-trip through the dotenv version this package ships (`16.3.1`), whose parser un-escapes `\n`/`\r` inside double quotes but does not un-escape `\"` or `\\`:

- values made of safe characters are written verbatim (no churn for existing files),
- otherwise single quotes are preferred, since dotenv treats single-quoted values as literal and preserves `#`, whitespace, backslashes and double quotes as-is (this also avoids accidental `dotenv-expand` `$` interpolation),
- double quotes (with `\n`/`\r` escaping) are used only when the value contains a single quote or a newline.

The one case dotenv 16.3.1 genuinely cannot represent is a value containing both a single and a double quote; that is a limitation of the bundled parser, not of the encoding.

# Test Plan

Added to `EnvPull.test.ts`:

- an integration test asserting a `#`-containing value is quoted in the written file and that the file round-trips back to the original value via `dotenv.parse`,
- a focused `serializeDotenvValue` test that round-trips a table of tricky values (`#ffffff`, URL with fragment, spaces, embedded `#`, single quote, newline, Windows path, leading/trailing whitespace, empty string) through the real dotenv parser, and confirms plain values stay unquoted.

```
$ yarn test src/commands/env/__tests__/EnvPull.test.ts
PASS src/commands/env/__tests__/EnvPull.test.ts
  ...
  values with special characters
    ✓ quotes values that would otherwise be misparsed by dotenv
  serializeDotenvValue
    ✓ leaves values without special characters unquoted
    ✓ round-trips values with special characters through dotenv
Tests:       16 passed, 16 total

$ yarn test src/commands/env/__tests__/   # whole env suite, no regressions
Tests:       57 passed, 57 total

$ yarn typecheck   # clean
$ yarn oxlint ... pull.ts EnvPull.test.ts   # Found 0 warnings and 0 errors.
$ yarn oxfmt --check ... # All matched files use the correct format.
```

This is a draft pending maintainer review.
