### PR TITLE
[worker] Disable Homebrew auto-update in EAS

### DIFF
--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -31,6 +31,7 @@ export function getBuildEnv({
   // https://github.com/mobile-dev-inc/maestro/issues/1257#issuecomment-1654803779
   setEnv(env, 'MAESTRO_DRIVER_STARTUP_TIMEOUT', '120000');
   setEnv(env, 'MAESTRO_CLI_NO_ANALYTICS', '1');
+  setEnv(env, 'HOMEBREW_NO_AUTO_UPDATE', '1');
   setEnv(env, 'EAS_BUILD', 'true');
   setEnv(env, 'EAS_BUILD_RUNNER', 'eas-build');
   setEnv(env, 'EAS_BUILD_PLATFORM', job.platform);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I don't think auto-updating Homebrew in CI makes sense. It creates a harder-to-reproduce / inconsistent environment.

# How

Added `HOMEBREW_NO_AUTO_UPDATE=1` to worker env.

# Test Plan

Next time https://expo.dev/accounts/gwdp/projects/expo-go-maestro/workflows/019f12db-23cd-78af-866b-3af410ccc10f runs I'll confirm `xcodes` does not update other formulas.