### PR TITLE
[build-tools] Enable simulator accessibility prefs before boot

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
@@ -15,6 +15,7 @@ jest.mock('../../../utils/IosSimulatorUtils', () => ({
     getAvailableDevicesAsync: jest.fn(),
     getDeviceAsync: jest.fn(),
     cloneAsync: jest.fn(),
+    enableAccessibilitySettingsAsync: jest.fn(),
     startAsync: jest.fn(),
     waitForReadyAsync: jest.fn(),
     disableApsdAsync: jest.fn(),
@@ -34,13 +35,57 @@ function createStep(callInputs?: Record<string, unknown>) {
 
 describe(createStartIosSimulatorBuildFunction, () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
     mockedUtils.getAvailableDevicesAsync.mockResolvedValue([]);
     mockedUtils.getDeviceAsync.mockResolvedValue(null);
     mockedUtils.cloneAsync.mockResolvedValue(undefined);
+    mockedUtils.enableAccessibilitySettingsAsync.mockResolvedValue(undefined);
     mockedUtils.startAsync.mockResolvedValue({ udid: 'test-udid' as any });
     mockedUtils.waitForReadyAsync.mockResolvedValue(undefined);
     mockedUtils.disableApsdAsync.mockResolvedValue(undefined);
+  });
+
+  it('does not enable accessibility settings by default', async () => {
+    await createStep({ device_identifier: 'iPhone 15' }).executeAsync();
+
+    expect(mockedUtils.enableAccessibilitySettingsAsync).not.toHaveBeenCalled();
+    expect(mockedUtils.startAsync).toHaveBeenCalledWith({
+      deviceIdentifier: 'iPhone 15',
+      env: expect.any(Object),
+    });
+  });
+
+  it('enables accessibility settings before starting the main device and every clone when requested', async () => {
+    mockedUtils.startAsync
+      .mockResolvedValueOnce({ udid: 'base' as any })
+      .mockResolvedValueOnce({ udid: 'clone-1' as any })
+      .mockResolvedValueOnce({ udid: 'clone-2' as any });
+
+    await createStep({
+      device_identifier: 'iPhone 15',
+      count: 2,
+      enable_accessibility_settings: true,
+    }).executeAsync();
+
+    expect(mockedUtils.enableAccessibilitySettingsAsync).toHaveBeenCalledWith({
+      deviceIdentifier: 'iPhone 15',
+      env: expect.any(Object),
+    });
+    expect(mockedUtils.enableAccessibilitySettingsAsync).toHaveBeenCalledWith({
+      deviceIdentifier: 'eas-simulator-1',
+      env: expect.any(Object),
+    });
+    expect(mockedUtils.enableAccessibilitySettingsAsync).toHaveBeenCalledWith({
+      deviceIdentifier: 'eas-simulator-2',
+      env: expect.any(Object),
+    });
+    for (const [callIndex] of mockedUtils.startAsync.mock.calls.entries()) {
+      const enableCallOrder =
+        mockedUtils.enableAccessibilitySettingsAsync.mock.invocationCallOrder[callIndex];
+      const startCallOrder = mockedUtils.startAsync.mock.invocationCallOrder[callIndex];
+      expect(enableCallOrder).toBeLessThan(startCallOrder);
+    }
   });
 
   it('disables apsd on the main device and every clone', async () => {

--- a/packages/build-tools/src/steps/functions/startIosSimulator.ts
+++ b/packages/build-tools/src/steps/functions/startIosSimulator.ts
@@ -31,6 +31,12 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
         defaultValue: 1,
         allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
       }),
+      BuildStepInput.createProvider({
+        id: 'enable_accessibility_settings',
+        required: false,
+        defaultValue: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+      }),
     ],
     fn: async ({ logger }, { inputs, env }) => {
       try {
@@ -55,11 +61,18 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
         | undefined;
       const originalDeviceIdentifier =
         deviceIdentifierInput ?? (await findMostGenericIphoneUuidAsync({ env }));
+      const enableAccessibilitySettings = Boolean(inputs.enable_accessibility_settings.value);
 
       if (!originalDeviceIdentifier) {
         throw new Error('Could not find an iPhone among available simulator devices.');
       }
 
+      if (enableAccessibilitySettings) {
+        await IosSimulatorUtils.enableAccessibilitySettingsAsync({
+          deviceIdentifier: originalDeviceIdentifier,
+          env,
+        });
+      }
       const { udid } = await IosSimulatorUtils.startAsync({
         deviceIdentifier: originalDeviceIdentifier,
         env,
@@ -97,6 +110,12 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
             env,
           });
 
+          if (enableAccessibilitySettings) {
+            await IosSimulatorUtils.enableAccessibilitySettingsAsync({
+              deviceIdentifier: cloneDeviceName,
+              env,
+            });
+          }
           const { udid: cloneUdid } = await IosSimulatorUtils.startAsync({
             deviceIdentifier: cloneDeviceName,
             env,

--- a/packages/build-tools/src/utils/IosSimulatorUtils.ts
+++ b/packages/build-tools/src/utils/IosSimulatorUtils.ts
@@ -1,3 +1,4 @@
+import { ExpoError, SystemError, UserError } from '@expo/eas-build-job';
 import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -90,6 +91,67 @@ export namespace IosSimulatorUtils {
     await spawn('xcrun', ['simctl', 'clone', sourceDeviceIdentifier, destinationDeviceName], {
       env,
     });
+  }
+
+  export async function enableAccessibilitySettingsAsync({
+    deviceIdentifier,
+    env,
+  }: {
+    deviceIdentifier: IosSimulatorUuid | IosSimulatorName;
+    env: NodeJS.ProcessEnv;
+  }): Promise<void> {
+    try {
+      const devices = await getAvailableDevicesAsync({ env, filter: 'available' });
+      const device = devices.find(
+        device =>
+          device.isAvailable &&
+          (device.udid === deviceIdentifier || device.name === deviceIdentifier)
+      );
+      if (!device) {
+        throw new UserError(
+          'EAS_IOS_SIMULATOR_NOT_FOUND',
+          `Failed to find available iOS Simulator "${deviceIdentifier}" to update accessibility settings.`
+        );
+      }
+      if (device.state !== 'Shutdown') {
+        throw new UserError(
+          'EAS_IOS_SIMULATOR_NOT_SHUTDOWN',
+          `Expected iOS Simulator "${deviceIdentifier}" to be shutdown before updating accessibility settings, but it is ${device.state}.`
+        );
+      }
+
+      const plistPath = path.join(
+        device.dataPath,
+        'Library',
+        'Preferences',
+        'com.apple.Accessibility.plist'
+      );
+      await fs.promises.mkdir(path.dirname(plistPath), { recursive: true });
+
+      const plistExists = await fs.promises
+        .access(plistPath)
+        .then(() => true)
+        .catch(() => false);
+      if (!plistExists) {
+        await spawn('plutil', ['-create', 'binary1', plistPath], { env });
+      }
+
+      for (const key of [
+        'AutomationEnabled',
+        'IgnoreAXServerEntitlements',
+        'AccessibilityEnabled',
+        'ApplicationAccessibilityEnabled',
+      ]) {
+        await spawn('plutil', ['-replace', key, '-bool', 'true', plistPath], { env });
+      }
+    } catch (err) {
+      if (err instanceof ExpoError) {
+        throw err;
+      }
+      throw new SystemError('Failed to update iOS Simulator accessibility settings.', {
+        cause: err,
+      });
+    }
   }
 
   export async function startAsync({

--- a/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
@@ -1,3 +1,4 @@
+import { SystemError, UserError } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 import os from 'node:os';
 import path from 'node:path';
@@ -18,7 +19,141 @@ const mockedSpawn = jest.mocked(spawn);
 
 describe('IosSimulatorUtils', () => {
   beforeEach(() => {
+    mockedSpawn.mockReset();
     mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
+  });
+
+  describe(IosSimulatorUtils.startAsync, () => {
+    it('waits for boot completion without writing accessibility prefs', async () => {
+      mockedSpawn.mockImplementation((async (command: string, args: string[]) => {
+        if (command === 'xcrun' && args.join(' ') === 'simctl bootstatus test-udid -b') {
+          return {
+            stdout: 'Monitoring boot status for iPhone 15 (test-udid).\n',
+            stderr: '',
+          } as any;
+        }
+        return { stdout: '', stderr: '' } as any;
+      }) as any);
+
+      await IosSimulatorUtils.startAsync({
+        deviceIdentifier: 'test-udid' as any,
+        env: process.env,
+      });
+
+      expect(mockedSpawn).not.toHaveBeenCalledWith(
+        'xcrun',
+        ['simctl', 'list', 'devices', '--json', '--no-escape-slashes', 'test-udid'],
+        expect.anything()
+      );
+      expect(mockedSpawn).not.toHaveBeenCalledWith('plutil', expect.anything(), expect.anything());
+    });
+  });
+
+  describe(IosSimulatorUtils.enableAccessibilitySettingsAsync, () => {
+    function device(overrides: Record<string, unknown> = {}) {
+      return {
+        dataPath: '/tmp/eas-test-simulator-data',
+        dataPathSize: 1,
+        logPath: '/tmp/eas-test-simulator-logs',
+        udid: 'test-udid',
+        isAvailable: true,
+        deviceTypeIdentifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-15',
+        state: 'Shutdown',
+        name: 'iPhone 15',
+        ...overrides,
+      };
+    }
+
+    function mockAvailableDevices(devices: Record<string, unknown>[]) {
+      mockedSpawn.mockImplementation((async (command: string, args: string[]) => {
+        if (
+          command === 'xcrun' &&
+          args.join(' ') === 'simctl list devices --json --no-escape-slashes available'
+        ) {
+          return {
+            stdout: JSON.stringify({
+              devices: {
+                'com.apple.CoreSimulator.SimRuntime.iOS-18-0': devices,
+              },
+            }),
+            stderr: '',
+          } as any;
+        }
+        return { stdout: '', stderr: '' } as any;
+      }) as any);
+    }
+
+    it('writes accessibility prefs for an exact shutdown simulator match', async () => {
+      mockAvailableDevices([
+        device({
+          udid: 'test-udid-pro',
+          name: 'iPhone 17 Pro',
+          dataPath: '/tmp/eas-test-simulator-data-pro',
+        }),
+        device({ name: 'iPhone 17' }),
+      ]);
+
+      await expect(
+        IosSimulatorUtils.enableAccessibilitySettingsAsync({
+          deviceIdentifier: 'iPhone 17' as any,
+          env: process.env,
+        })
+      ).resolves.toBeUndefined();
+
+      for (const key of [
+        'AutomationEnabled',
+        'IgnoreAXServerEntitlements',
+        'AccessibilityEnabled',
+        'ApplicationAccessibilityEnabled',
+      ]) {
+        expect(mockedSpawn).toHaveBeenCalledWith(
+          'plutil',
+          [
+            '-replace',
+            key,
+            '-bool',
+            'true',
+            '/tmp/eas-test-simulator-data/Library/Preferences/com.apple.Accessibility.plist',
+          ],
+          { env: process.env }
+        );
+      }
+    });
+
+    it('throws UserError when no available simulator exactly matches the identifier', async () => {
+      mockAvailableDevices([device({ name: 'iPhone 17 Pro' })]);
+
+      await expect(
+        IosSimulatorUtils.enableAccessibilitySettingsAsync({
+          deviceIdentifier: 'iPhone 17' as any,
+          env: process.env,
+        })
+      ).rejects.toThrow(UserError);
+
+      expect(mockedSpawn).not.toHaveBeenCalledWith('plutil', expect.anything(), expect.anything());
+    });
+
+    it('throws UserError when the matched simulator is already booted', async () => {
+      mockAvailableDevices([device({ state: 'Booted' })]);
+
+      await expect(
+        IosSimulatorUtils.enableAccessibilitySettingsAsync({
+          deviceIdentifier: 'test-udid' as any,
+          env: process.env,
+        })
+      ).rejects.toThrow(UserError);
+    });
+
+    it('throws SystemError when pre-boot accessibility setup fails', async () => {
+      mockedSpawn.mockRejectedValue(new Error('Failed to list simulators'));
+
+      await expect(
+        IosSimulatorUtils.enableAccessibilitySettingsAsync({
+          deviceIdentifier: 'test-udid' as any,
+          env: process.env,
+        })
+      ).rejects.toThrow(SystemError);
+    });
   });
 
   describe(IosSimulatorUtils.waitForReadyAsync, () => {


### PR DESCRIPTION
## Summary

- Add an opt-in `enable_accessibility_settings` boolean input to `eas/start_ios_simulator`.
- When enabled, call `IosSimulatorUtils.enableAccessibilitySettingsAsync` inline immediately before each `IosSimulatorUtils.startAsync` call, including cloned simulators.
- Reuse the existing `xcrun simctl list devices --json --no-escape-slashes available` wrapper so the `dataPath` from simctl JSON is used directly, then do an exact UDID/name equality check in JS. This avoids `simctl` search-term substring matches like `iPhone 17` matching `iPhone 17 Pro`.
- Treat invalid requested simulator state as `UserError`; wrap command/filesystem setup failures as `SystemError`.

## Why

These accessibility preferences help Argent and other AX-tree based tools inspect Simulator state more reliably. They can influence app/runtime accessibility behavior, so the setting is explicit and default-off rather than applied to every simulator startup.

## Maestro compatibility

`enable_accessibility_settings` defaults to `false`, so existing Maestro test runs and other `eas/start_ios_simulator` users keep the previous startup behavior unless they opt in. When enabled, the setup only writes preferences for an exact, available, shutdown simulator before `simctl bootstatus -b`. If the requested simulator is not available or not shutdown, the step fails with `UserError`; if the setup command/filesystem work fails, it fails with `SystemError`.

## Notes

- `plutil` is a standard macOS utility (`/usr/bin/plutil` on the local validation machine), so this does not add an external tool installation requirement.

## Validation

CI should pass.