### PR TITLE
[build-tools] start_ios_simulator: output booted device_udid

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
@@ -73,4 +73,25 @@ describe(createStartIosSimulatorBuildFunction, () => {
     // Startup is not aborted: readiness is still awaited for each device.
     expect(mockedUtils.waitForReadyAsync).toHaveBeenCalled();
   });
+
+  it('outputs the booted device udid for a single-device run', async () => {
+    mockedUtils.startAsync.mockResolvedValue({ udid: 'booted-udid' as any });
+
+    const step = createStep({ device_identifier: 'iPhone 15' });
+    await step.executeAsync();
+
+    expect(step.outputById.device_udid.value).toBe('booted-udid');
+  });
+
+  it('does not set device_udid for a multi-device run', async () => {
+    mockedUtils.startAsync
+      .mockResolvedValueOnce({ udid: 'base' as any })
+      .mockResolvedValueOnce({ udid: 'clone-1' as any })
+      .mockResolvedValueOnce({ udid: 'clone-2' as any });
+
+    const step = createStep({ device_identifier: 'iPhone 15', count: 2 });
+    await step.executeAsync();
+
+    expect(step.outputById.device_udid.value).toBeUndefined();
+  });
 });

--- a/packages/build-tools/src/steps/functions/startIosSimulator.ts
+++ b/packages/build-tools/src/steps/functions/startIosSimulator.ts
@@ -3,6 +3,7 @@ import {
   BuildStepEnv,
   BuildStepInput,
   BuildStepInputValueTypeName,
+  BuildStepOutput,
 } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
 import { minBy } from 'lodash';
@@ -32,7 +33,8 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
         allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
       }),
     ],
-    fn: async ({ logger }, { inputs, env }) => {
+    outputProviders: [BuildStepOutput.createProvider({ id: 'device_udid', required: false })],
+    fn: async ({ logger }, { inputs, outputs, env }) => {
       try {
         const availableDevices = await IosSimulatorUtils.getAvailableDevicesAsync({
           env,
@@ -116,6 +118,8 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
           logger.info(`${cloneDeviceName} is ready.`);
           logger.info('');
         }
+      } else {
+        outputs.device_udid.set(udid);
       }
     },
   });


### PR DESCRIPTION
# Why

On iOS, `maestro test` runs without `--udid`, so Maestro just grabs whatever simulator is booted — not necessarily the one you asked for. First step of fixing that (ENG-21966): actually know which sim we booted.

# How

`start_ios_simulator` already has the booted udid, it just threw it away. Now it's a `device_udid` output — set for single-device runs, left unset for multi-device (those get cloned, so `--shard-split` handles them instead).

# Test Plan

typecheck + `startIosSimulator.test.ts` — single-device outputs the udid, multi-device doesn't set it.
