### PR TITLE
[build-tools] maestro_tests: target booted device via --udid

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -134,6 +134,46 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(args!.join(' ')).toMatch(/--output=.*android-maestro-junit-attempt-0\.xml/);
   });
 
+  it('passes --udid when device_udid is provided', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const step = createStep({
+      flow_path: ['flows/a.yaml'],
+      platform: 'ios',
+      device_udid: 'iphone-15-pro-udid',
+    });
+
+    await step.executeAsync();
+
+    const [, args] = mockedSpawn.mock.calls[0];
+    expect(args).toContain('--udid=iphone-15-pro-udid');
+  });
+
+  it('does not pass --udid when device_udid is empty (multi-device run)', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const step = createStep({
+      flow_path: ['flows/a.yaml'],
+      platform: 'ios',
+      device_udid: '',
+      shards: 2,
+    });
+
+    await step.executeAsync();
+
+    const [, args] = mockedSpawn.mock.calls[0];
+    expect(args?.join(' ')).not.toContain('--udid');
+    expect(args).toContain('--shard-split=2');
+  });
+
+  it('does not pass --udid when device_udid is omitted', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const step = createStep({ flow_path: ['flows/a.yaml'], platform: 'ios' });
+
+    await step.executeAsync();
+
+    const [, args] = mockedSpawn.mock.calls[0];
+    expect(args?.join(' ')).not.toContain('--udid');
+  });
+
   it('throws SystemError when spawn fails with ENOENT (binary missing)', async () => {
     mockedSpawn.mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOENT' }));
     const step = createStep({ flow_path: ['a.yaml'], platform: 'android' });

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -70,6 +70,7 @@ function buildMaestroArgs(args: {
   shards: number | undefined;
   include_tags: string | undefined;
   exclude_tags: string | undefined;
+  device_udid: string | undefined;
 }): string[] {
   const out: string[] = ['test'];
   if (args.output_format) {
@@ -86,6 +87,9 @@ function buildMaestroArgs(args: {
   }
   if (args.exclude_tags) {
     out.push(`--exclude-tags=${args.exclude_tags}`);
+  }
+  if (args.device_udid) {
+    out.push(`--udid=${args.device_udid}`);
   }
   out.push(...args.flow_path);
   return out;
@@ -138,6 +142,11 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       }),
       BuildStepInput.createProvider({
         id: 'platform',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+      BuildStepInput.createProvider({
+        id: 'device_udid',
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
@@ -205,6 +214,7 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
         'shards must be a positive integer.'
       );
       const retryFailedOnly = inputs.retry_failed_only.value as boolean;
+      const deviceUdid = inputs.device_udid.value as string | undefined;
 
       try {
         await fs.mkdir(junitReportDirectory, { recursive: true });
@@ -245,6 +255,7 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
           shards,
           include_tags: includeTags,
           exclude_tags: excludeTags,
+          device_udid: deviceUdid,
         });
         logger.info(
           `Running maestro (attempt ${attempt + 1}/${totalAttempts}): maestro ${maestroArgs.join(' ')}`


### PR DESCRIPTION
# Why

Now that we know which sim we booted (PR below), point `eas/maestro_tests` at it on iOS. This is the step the pre-packaged Maestro job uses.

Picked `device_udid` as behaviour different from `device_identifier` but happy to hear reviewer thoughts :)

# How

New optional `device_udid` input → passes `--udid=<udid>`. Empty/unset → nothing changes, so shard runs keep using `--shard-split`. The value gets wired in from the `start_ios_simulator` output over in universe.

# Test Plan

typecheck + `maestroTests.test.ts` — udid → `--udid`, empty + shards → `--shard-split` only, omitted → nothing.
