### PR TITLE
[build-tools] eas/maestro_test: target booted device via --udid

### DIFF
--- a/packages/build-tools/src/steps/functionGroups/__tests__/maestroTest.test.ts
+++ b/packages/build-tools/src/steps/functionGroups/__tests__/maestroTest.test.ts
@@ -1,0 +1,38 @@
+import { BuildJob, Platform } from '@expo/eas-build-job';
+
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import { CustomBuildContext } from '../../../customBuildContext';
+import { createEasMaestroTestFunctionGroup } from '../maestroTest';
+
+function createMockBuildToolsContext(platform: Platform): CustomBuildContext<BuildJob> {
+  return {
+    job: { platform },
+  } as unknown as CustomBuildContext<BuildJob>;
+}
+
+function buildSteps(platform: Platform): { id: string; displayName: string; command?: string }[] {
+  const buildToolsContext = createMockBuildToolsContext(platform);
+  const functionGroup = createEasMaestroTestFunctionGroup(buildToolsContext);
+  const globalCtx = createGlobalContextMock({ logger: createMockLogger() });
+  return functionGroup.createBuildStepsFromFunctionGroupCall(globalCtx, {
+    callInputs: { flow_path: 'flow.yaml' },
+  });
+}
+
+describe(createEasMaestroTestFunctionGroup, () => {
+  it('targets the udid output by start_ios_simulator on iOS', () => {
+    const steps = buildSteps(Platform.IOS);
+    const startStep = steps.find(s => s.displayName === 'Start iOS Simulator');
+    const maestroStep = steps.find(s => s.command?.includes('maestro test'));
+
+    expect(startStep).toBeDefined();
+    expect(maestroStep?.command).toContain(`steps.${startStep!.id}.device_udid`);
+    expect(maestroStep?.command).toContain('${DEVICE_UDID:+--udid="$DEVICE_UDID"');
+  });
+
+  it('does not target a udid on Android', () => {
+    const maestroStep = buildSteps(Platform.ANDROID).find(s => s.command?.includes('maestro test'));
+    expect(maestroStep?.command).toBe('maestro test flow.yaml');
+  });
+});

--- a/packages/build-tools/src/steps/functionGroups/maestroTest.ts
+++ b/packages/build-tools/src/steps/functionGroups/maestroTest.ts
@@ -40,10 +40,11 @@ export function createEasMaestroTestFunctionGroup(
         createInstallMaestroBuildFunction().createBuildStepFromFunctionCall(globalCtx),
       ];
 
+      let startIosSimulatorStep: BuildStep | undefined;
       if (buildToolsContext.job.platform === Platform.IOS) {
-        steps.push(
-          createStartIosSimulatorBuildFunction().createBuildStepFromFunctionCall(globalCtx)
-        );
+        startIosSimulatorStep =
+          createStartIosSimulatorBuildFunction().createBuildStepFromFunctionCall(globalCtx);
+        steps.push(startIosSimulatorStep);
         const searchPath =
           inputs.app_path.getValue({
             interpolationContext: globalCtx.getInterpolationContext(),
@@ -134,7 +135,12 @@ export function createEasMaestroTestFunctionGroup(
             id: BuildStep.getNewId(),
             ifCondition: '${ always() }',
             displayName: `maestro test ${flowPath}`,
-            command: `maestro test ${flowPath}`,
+            command: startIosSimulatorStep
+              ? `
+                    DEVICE_UDID="\${ steps.${startIosSimulatorStep.id}.device_udid }"
+                    maestro test \${DEVICE_UDID:+--udid="$DEVICE_UDID" }${flowPath}
+                  `
+              : `maestro test ${flowPath}`,
           })
         );
       }


### PR DESCRIPTION
# Why

Same fix (ENG-21966) for the `eas/maestro_test` function group — the path custom workflows use. It also ran `maestro test` without `--udid` on iOS.

# How

The iOS `maestro test` command now reads the start step's `device_udid` output and adds `--udid` only when it's set. Android unchanged. No universe dependency here — the group wires its own steps.

# Test Plan

typecheck + `maestroTest.test.ts` (new) — iOS targets the udid, Android stays plain `maestro test <flow>`.
