### PR TITLE
[eas-cli] Fix managed tvOS env typecheck

### DIFF
--- a/packages/eas-cli/src/project/ios/target.ts
+++ b/packages/eas-cli/src/project/ios/target.ts
@@ -53,7 +53,7 @@ const AppExtensionsConfigSchema = Joi.array().items(
  * defaulting to IOS.
  */
 export function getManagedTvBuildSettings(
-  env: Record<string, string> | undefined
+  env: Env | undefined
 ): Target['buildSettings'] | undefined {
   const expoTv = (env?.EXPO_TV ?? process.env.EXPO_TV ?? '').toString().toLowerCase();
   if (expoTv === '1' || expoTv === 'true' || expoTv === 'yes') {


### PR DESCRIPTION
## Summary
- fix main typecheck after `Env` was widened to allow undefined values
- align `getManagedTvBuildSettings` with the shared `Env` type instead of requiring `Record<string, string>`

## Test plan

CI should pass.