### PR TITLE
[build-tools] Skip xcode-select and use local argent when EXPO_LOCAL

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession.test.ts
@@ -1,10 +1,19 @@
 import { SystemError } from '@expo/eas-build-job';
 import { type bunyan } from '@expo/logger';
+import { spawnSync } from 'node:child_process';
 
 import {
   MIN_ARGENT_REMOTE_SESSION_VERSION,
+  resolveArgentInvocation,
+  resolveLocalArgentBin,
   warnIfArgentPackageVersionCannotBeVerified,
 } from '../startArgentRemoteSession';
+
+jest.mock('node:child_process', () => ({
+  spawnSync: jest.fn(),
+}));
+
+const mockedSpawnSync = jest.mocked(spawnSync);
 
 describe(warnIfArgentPackageVersionCannotBeVerified, () => {
   const warn = jest.fn();
@@ -68,5 +77,34 @@ describe(warnIfArgentPackageVersionCannotBeVerified, () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('Continuing and letting bunx resolve it.')
     );
+  });
+});
+
+describe(resolveArgentInvocation, () => {
+  it('runs the local binary directly when one is provided', () => {
+    expect(
+      resolveArgentInvocation({ localArgentBin: '/usr/local/bin/argent', versionSpec: '1.2.3' })
+    ).toEqual({ command: '/usr/local/bin/argent', packageArgs: [] });
+  });
+
+  it('fetches the pinned package via bunx when there is no local binary', () => {
+    expect(resolveArgentInvocation({ localArgentBin: null, versionSpec: '1.2.3' })).toEqual({
+      command: 'bunx',
+      packageArgs: ['@swmansion/argent@1.2.3'],
+    });
+  });
+});
+
+describe(resolveLocalArgentBin, () => {
+  it('returns the resolved path when argent is on PATH', () => {
+    mockedSpawnSync.mockReturnValue({ status: 0, stdout: '/usr/local/bin/argent\n' } as ReturnType<
+      typeof spawnSync
+    >);
+    expect(resolveLocalArgentBin()).toBe('/usr/local/bin/argent');
+  });
+
+  it('returns null when argent is not on PATH', () => {
+    mockedSpawnSync.mockReturnValue({ status: 1, stdout: '' } as ReturnType<typeof spawnSync>);
+    expect(resolveLocalArgentBin()).toBeNull();
   });
 });

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -7,6 +7,7 @@ import {
   BuildStepInputValueTypeName,
 } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -70,6 +71,13 @@ export function createStartArgentRemoteSessionBuildFunction(
         `Starting argent remote session (version: ${versionSpec}, runtime: ${runtimePlatform}).`
       );
 
+      // In local dev, run the argent already on PATH instead of fetching it via bunx.
+      const localArgentBin = env.EXPO_LOCAL === '1' ? resolveLocalArgentBin() : null;
+      const { command: argentCommand, packageArgs: argentPackageArgs } = resolveArgentInvocation({
+        localArgentBin,
+        versionSpec,
+      });
+
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
         await selectXcodeDeveloperDirectoryAsync({ env, logger });
       }
@@ -78,16 +86,23 @@ export function createStartArgentRemoteSessionBuildFunction(
       await fs.promises.rm(ARGENT_STATE_FILE, { force: true });
       logger.info('Enabling the Argent artifacts list endpoint flag.');
       await spawn(
-        'bunx',
-        [`${ARGENT_PACKAGE_NAME}@${versionSpec}`, 'enable', ARGENT_ARTIFACTS_LIST_ENDPOINT_FLAG],
-        { env, logger }
+        argentCommand,
+        [...argentPackageArgs, 'enable', ARGENT_ARTIFACTS_LIST_ENDPOINT_FLAG],
+        {
+          env,
+          logger,
+        }
       );
 
-      logger.info(`Launching ${ARGENT_PACKAGE_NAME}@${versionSpec} tool-server via bunx.`);
+      logger.info(
+        localArgentBin
+          ? `Launching local argent tool-server (${localArgentBin}).`
+          : `Launching ${ARGENT_PACKAGE_NAME}@${versionSpec} tool-server via bunx.`
+      );
       const argentServer = spawnDetached({
-        command: 'bunx',
+        command: argentCommand,
         args: [
-          `${ARGENT_PACKAGE_NAME}@${versionSpec}`,
+          ...argentPackageArgs,
           'server',
           'start',
           '--port',
@@ -197,6 +212,23 @@ export function warnIfArgentPackageVersionCannotBeVerified({
         `Use "latest" or pass an exact version >= ${MIN_ARGENT_REMOTE_SESSION_VERSION}.`
     );
   }
+}
+
+export function resolveLocalArgentBin(): string | null {
+  const result = spawnSync('which', ['argent'], { encoding: 'utf8' });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+export function resolveArgentInvocation({
+  localArgentBin,
+  versionSpec,
+}: {
+  localArgentBin: string | null;
+  versionSpec: string;
+}): { command: string; packageArgs: string[] } {
+  return localArgentBin
+    ? { command: localArgentBin, packageArgs: [] }
+    : { command: 'bunx', packageArgs: [`${ARGENT_PACKAGE_NAME}@${versionSpec}`] };
 }
 
 function parseArgentToolServerState(raw: string): { port: number; token?: string } {


### PR DESCRIPTION
### Why

Local dev shortcut for argent remote sessions: skip the `sudo xcode-select` that hangs in non-interactive shells, and use the locally installed `argent` CLI instead of fetching via bunx.

### How

When `EXPO_LOCAL=1` and `argent` is on PATH, both the `enable` flag step and the `server start` launch use the local binary. `xcode-select` is skipped entirely in local dev.

### Test plan

CI passes.