### PR TITLE
[build-tools] Apply npm cache registry only to the dependency install

### DIFF
--- a/packages/build-tools/src/common/__tests__/installDependencies.test.ts
+++ b/packages/build-tools/src/common/__tests__/installDependencies.test.ts
@@ -40,7 +40,7 @@ describe(installDependenciesWithNpmCacheFallbackAsync, () => {
       env: {
         EAS_VERBOSE: '1',
         EAS_USE_NPM_CACHE: '1',
-        NPM_CONFIG_REGISTRY: npmCacheUrl,
+        EAS_BUILD_NPM_CACHE_URL: npmCacheUrl,
       },
       logger,
       cwd: '/tmp/build',
@@ -56,6 +56,7 @@ describe(installDependenciesWithNpmCacheFallbackAsync, () => {
       env: {
         EAS_VERBOSE: '1',
         EAS_USE_NPM_CACHE: '1',
+        EAS_BUILD_NPM_CACHE_URL: npmCacheUrl,
         NPM_CONFIG_REGISTRY: npmCacheUrl,
       },
     });
@@ -66,6 +67,7 @@ describe(installDependenciesWithNpmCacheFallbackAsync, () => {
       env: {
         EAS_VERBOSE: '1',
         EAS_USE_NPM_CACHE: '1',
+        EAS_BUILD_NPM_CACHE_URL: npmCacheUrl,
       },
     });
     expect(logger.warn).toHaveBeenCalledWith(
@@ -110,7 +112,7 @@ describe(installDependenciesWithNpmCacheFallbackAsync, () => {
       packageManager: PackageManager.NPM,
       env: {
         EAS_USE_NPM_CACHE: '1',
-        NPM_CONFIG_REGISTRY: npmCacheUrl,
+        EAS_BUILD_NPM_CACHE_URL: npmCacheUrl,
       },
       logger,
       cwd: '/tmp/build',
@@ -158,7 +160,7 @@ describe(installDependenciesWithNpmCacheFallbackAsync, () => {
         packageManager: PackageManager.NPM,
         env: {
           EAS_USE_NPM_CACHE: '1',
-          NPM_CONFIG_REGISTRY: 'http://npm.staging.caches.eas-build.internal',
+          EAS_BUILD_NPM_CACHE_URL: 'http://npm.staging.caches.eas-build.internal',
         },
         logger,
         cwd: '/tmp/build',
@@ -189,7 +191,7 @@ describe(installDependenciesWithNpmCacheFallbackAsync, () => {
       installDependenciesWithNpmCacheFallbackAsync({
         packageManager: PackageManager.NPM,
         env: {
-          NPM_CONFIG_REGISTRY: npmCacheUrl,
+          EAS_BUILD_NPM_CACHE_URL: npmCacheUrl,
         },
         logger,
         cwd: '/tmp/build',

--- a/packages/build-tools/src/common/__tests__/installDependencies.test.ts
+++ b/packages/build-tools/src/common/__tests__/installDependencies.test.ts
@@ -172,7 +172,7 @@ describe(installDependenciesWithNpmCacheFallbackAsync, () => {
     expect(Sentry.capture).not.toHaveBeenCalled();
   });
 
-  it('does not retry when EAS_USE_NPM_CACHE is not enabled', async () => {
+  it('does not retry when the npm cache is not enabled', async () => {
     const logger = createMockLogger();
     const npmCacheUrl = 'http://npm.staging.caches.eas-build.internal';
     const error = Object.assign(
@@ -190,9 +190,7 @@ describe(installDependenciesWithNpmCacheFallbackAsync, () => {
     await expect(
       installDependenciesWithNpmCacheFallbackAsync({
         packageManager: PackageManager.NPM,
-        env: {
-          EAS_BUILD_NPM_CACHE_URL: npmCacheUrl,
-        },
+        env: {},
         logger,
         cwd: '/tmp/build',
         useFrozenLockfile: false,

--- a/packages/build-tools/src/common/__tests__/installDependencies.test.ts
+++ b/packages/build-tools/src/common/__tests__/installDependencies.test.ts
@@ -202,6 +202,40 @@ describe(installDependenciesWithNpmCacheFallbackAsync, () => {
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(Sentry.capture).not.toHaveBeenCalled();
   });
+
+  it('installs through the npm cache registry without retrying when the cache install succeeds', async () => {
+    const logger = createMockLogger();
+    const npmCacheUrl = 'http://npm.staging.caches.eas-build.internal';
+
+    jest
+      .mocked(spawn)
+      .mockReturnValueOnce(createSpawnPromise(Promise.resolve(createSpawnResult())));
+
+    await installDependenciesWithNpmCacheFallbackAsync({
+      packageManager: PackageManager.NPM,
+      env: {
+        EAS_USE_NPM_CACHE: '1',
+        EAS_BUILD_NPM_CACHE_URL: npmCacheUrl,
+      },
+      logger,
+      cwd: '/tmp/build',
+      useFrozenLockfile: false,
+    });
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith('npm', ['install', '--include=dev'], {
+      cwd: '/tmp/build',
+      logger,
+      infoCallbackFn: undefined,
+      lineTransformer: expect.any(Function),
+      env: {
+        EAS_USE_NPM_CACHE: '1',
+        EAS_BUILD_NPM_CACHE_URL: npmCacheUrl,
+        NPM_CONFIG_REGISTRY: npmCacheUrl,
+      },
+    });
+    expect(Sentry.capture).not.toHaveBeenCalled();
+  });
 });
 
 function createSpawnPromise(result: Promise<SpawnResult>): SpawnPromise<SpawnResult> {

--- a/packages/build-tools/src/common/installDependencies.ts
+++ b/packages/build-tools/src/common/installDependencies.ts
@@ -109,7 +109,6 @@ export async function installDependenciesWithNpmCacheFallbackAsync({
     return;
   }
 
-  const cacheEnv = { ...env, NPM_CONFIG_REGISTRY: npmCacheUrl };
   let firstErrorLine: string | undefined;
   let errorLineCount = 0;
 
@@ -117,7 +116,7 @@ export async function installDependenciesWithNpmCacheFallbackAsync({
     await (
       await installDependenciesAsync({
         packageManager,
-        env: cacheEnv,
+        env: { ...env, NPM_CONFIG_REGISTRY: npmCacheUrl },
         logger,
         infoCallbackFn,
         lineTransformer: (line: string) => {

--- a/packages/build-tools/src/common/installDependencies.ts
+++ b/packages/build-tools/src/common/installDependencies.ts
@@ -93,7 +93,7 @@ export async function installDependenciesWithNpmCacheFallbackAsync({
   infoCallbackFn?: SpawnOptions['infoCallbackFn'];
   useFrozenLockfile: boolean;
 }): Promise<void> {
-  const npmCacheUrl = env.EAS_USE_NPM_CACHE === '1' ? env.EAS_BUILD_NPM_CACHE_URL : undefined;
+  const npmCacheUrl = env.EAS_BUILD_NPM_CACHE_URL;
 
   if (!npmCacheUrl) {
     await (
@@ -108,6 +108,8 @@ export async function installDependenciesWithNpmCacheFallbackAsync({
     ).spawnPromise;
     return;
   }
+
+  logger.info(`Installing dependencies using the npm cache registry (${npmCacheUrl}).`);
 
   let firstErrorLine: string | undefined;
   let errorLineCount = 0;

--- a/packages/build-tools/src/common/installDependencies.ts
+++ b/packages/build-tools/src/common/installDependencies.ts
@@ -93,7 +93,23 @@ export async function installDependenciesWithNpmCacheFallbackAsync({
   infoCallbackFn?: SpawnOptions['infoCallbackFn'];
   useFrozenLockfile: boolean;
 }): Promise<void> {
-  const npmCacheUrl = env.NPM_CONFIG_REGISTRY;
+  const npmCacheUrl = env.EAS_USE_NPM_CACHE === '1' ? env.EAS_BUILD_NPM_CACHE_URL : undefined;
+
+  if (!npmCacheUrl) {
+    await (
+      await installDependenciesAsync({
+        packageManager,
+        env,
+        logger,
+        infoCallbackFn,
+        cwd,
+        useFrozenLockfile,
+      })
+    ).spawnPromise;
+    return;
+  }
+
+  const cacheEnv = { ...env, NPM_CONFIG_REGISTRY: npmCacheUrl };
   let firstErrorLine: string | undefined;
   let errorLineCount = 0;
 
@@ -101,11 +117,11 @@ export async function installDependenciesWithNpmCacheFallbackAsync({
     await (
       await installDependenciesAsync({
         packageManager,
-        env,
+        env: cacheEnv,
         logger,
         infoCallbackFn,
         lineTransformer: (line: string) => {
-          if (isNpmCacheRegistryErrorLine(line, { env, npmCacheUrl })) {
+          if (isNpmCacheRegistryErrorLine(line, npmCacheUrl)) {
             firstErrorLine ??= line;
             errorLineCount += 1;
           }
@@ -124,7 +140,7 @@ export async function installDependenciesWithNpmCacheFallbackAsync({
       });
     }
   } catch (err: unknown) {
-    if (!isNpmCacheInstallFailure(err, { env, npmCacheUrl })) {
+    if (!isNpmCacheInstallFailure(err, npmCacheUrl)) {
       throw err;
     }
 
@@ -144,11 +160,10 @@ export async function installDependenciesWithNpmCacheFallbackAsync({
       },
     });
 
-    const { NPM_CONFIG_REGISTRY: _NPM_CONFIG_REGISTRY, ...fallbackEnv } = env;
     await (
       await installDependenciesAsync({
         packageManager,
-        env: fallbackEnv,
+        env,
         logger,
         infoCallbackFn,
         cwd,
@@ -172,33 +187,15 @@ export function resolvePackagerDir(ctx: BuildContext<Job>): string {
   return packagerRunDir;
 }
 
-function isNpmCacheInstallFailure(
-  err: unknown,
-  { env, npmCacheUrl }: { env: Record<string, string | undefined>; npmCacheUrl: string | undefined }
-): boolean {
-  if (!isNpmCacheRegistryEnabled(env, npmCacheUrl)) {
-    return false;
-  }
-  const errorOutput = getErrorOutput(err);
-  return errorOutput.includes(npmCacheUrl);
+function isNpmCacheInstallFailure(err: unknown, npmCacheUrl: string): boolean {
+  return getErrorOutput(err).includes(npmCacheUrl);
 }
 
-function isNpmCacheRegistryErrorLine(
-  line: string,
-  { env, npmCacheUrl }: { env: Record<string, string | undefined>; npmCacheUrl: string | undefined }
-): boolean {
+function isNpmCacheRegistryErrorLine(line: string, npmCacheUrl: string): boolean {
   return (
-    isNpmCacheRegistryEnabled(env, npmCacheUrl) &&
     line.includes(npmCacheUrl) &&
     /(?:error|failed|ENOTFOUND|ECONN|ETIMEDOUT|EAI_AGAIN|FetchError)/i.test(line)
   );
-}
-
-function isNpmCacheRegistryEnabled(
-  env: Record<string, string | undefined>,
-  npmCacheUrl: string | undefined
-): npmCacheUrl is string {
-  return env.EAS_USE_NPM_CACHE === '1' && !!npmCacheUrl;
 }
 
 function getErrorOutput(err: unknown): string {

--- a/packages/worker/src/__unit__/env.test.ts
+++ b/packages/worker/src/__unit__/env.test.ts
@@ -269,7 +269,7 @@ describe(getBuildEnv.name, () => {
     });
 
     expect(env.NPM_CACHE_URL).toBe('https://npm.example');
-    expect(env.NPM_CONFIG_REGISTRY).toBe('https://npm.example');
+    expect(env.NPM_CONFIG_REGISTRY).toBeUndefined();
     expect(env.EAS_BUILD_NPM_CACHE_URL).toBe('https://npm.example');
     expect(env.NVM_NODEJS_ORG_MIRROR).toBe('https://node.example');
     expect(env.EAS_BUILD_MAVEN_CACHE_URL).toBe('https://maven.example');

--- a/packages/worker/src/__unit__/env.test.ts
+++ b/packages/worker/src/__unit__/env.test.ts
@@ -268,7 +268,7 @@ describe(getBuildEnv.name, () => {
       buildId: 'build-id',
     });
 
-    expect(env.NPM_CACHE_URL).toBe('https://npm.example');
+    expect(env.NPM_CACHE_URL).toBeUndefined();
     expect(env.NPM_CONFIG_REGISTRY).toBeUndefined();
     expect(env.EAS_BUILD_NPM_CACHE_URL).toBe('https://npm.example');
     expect(env.NVM_NODEJS_ORG_MIRROR).toBe('https://node.example');

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -43,7 +43,6 @@ export function getBuildEnv({
   const cocoapodsCacheUrl = RuntimeSettings.getCocoapodsCacheUrl();
 
   setEnv(env, 'NPM_CACHE_URL', npmCacheUrl);
-  setEnv(env, 'NPM_CONFIG_REGISTRY', npmCacheUrl);
   setEnv(env, 'NVM_NODEJS_ORG_MIRROR', nodeJsCacheUrl);
   setEnv(env, 'EAS_BUILD_NPM_CACHE_URL', npmCacheUrl);
   setEnv(env, 'EAS_BUILD_PROFILE', metadata.buildProfile);

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -36,13 +36,11 @@ export function getBuildEnv({
   setEnv(env, 'EAS_BUILD_RUNNER', 'eas-build');
   setEnv(env, 'EAS_BUILD_PLATFORM', job.platform);
   setEnv(env, 'EAS_CLI_SENTRY_DSN', config.sentry.dsn);
-  // NPM_CACHE_URL is deprecated
   const npmCacheUrl = RuntimeSettings.getNpmCacheUrl();
   const nodeJsCacheUrl = RuntimeSettings.getNodeJsCacheUrl();
   const mavenCacheUrl = RuntimeSettings.getMavenCacheUrl();
   const cocoapodsCacheUrl = RuntimeSettings.getCocoapodsCacheUrl();
 
-  setEnv(env, 'NPM_CACHE_URL', npmCacheUrl);
   setEnv(env, 'NVM_NODEJS_ORG_MIRROR', nodeJsCacheUrl);
   setEnv(env, 'EAS_BUILD_NPM_CACHE_URL', npmCacheUrl);
   setEnv(env, 'EAS_BUILD_PROFILE', metadata.buildProfile);


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

#3855 started exporting NPM_CONFIG_REGISTRY into the global build env so installs would resolve packages through our internal npm cache. Because it was a global env var, every npm invocation in a build (workflow job steps, custom steps, and internal npm -g install … calls during environment setup) routed through the cache, but only the managed prebuild install had a fallback. When the killswitch was disabled (expo/universe#28199), this unguarded load overwhelmed the Verdaccio instance and impacted jobs.

# How

- Removed the global NPM_CONFIG_REGISTRY export from worker/src/env.ts (the line added in #3855)
   - EAS_BUILD_NPM_CACHE_URL remains as the signal carrying the resolved cache URL into the build.
- `installDependenciesWithNpmCacheFallbackAsync` now reads the URL from EAS_BUILD_NPM_CACHE_URL (gated on EAS_USE_NPM_CACHE=1) and injects NPM_CONFIG_REGISTRY only into that install's spawn env. On a cache-related failure it retries with the base env (default registry)
- After this change, unrelated npm invocations no longer hit the cache; only the guarded install does, and it still falls back if the cache is unavailable.


# Test Plan

- Unit tests in installDependencies.test.ts cover: registry applied per-spawn on the first attempt, retry without the registry on a cache failure, non-fatal cache-registry error reporting, no retry on unrelated failures, and no cache use when EAS_USE_NPM_CACHE is not enabled.
- worker/src/__unit__/env.test.ts asserts NPM_CONFIG_REGISTRY is no longer present in the global build env while EAS_BUILD_NPM_CACHE_URL still is — the regression guard proving the leak is closed.
