### PR TITLE
[eas-cli] Fix Free plan users being falsely warned they hit their bui…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Fix Free plan users being warned they had reached their build limit while still well below it. Overage warnings are now shown only for paid plans with an actual billable overage cost. ([#3882](https://github.com/expo/eas-cli/pull/3882) by [@sarahlane8](https://github.com/sarahlane8))
 - [eas-cli] Select correct tvOS build target for non-interactive Apple builds when EXPO_TV env variable is set. ([#3907](https://github.com/expo/eas-cli/pull/3907) by [@douglowder](https://github.com/douglowder))
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/utils/usage/__tests__/checkForOverages-test.ts
+++ b/packages/eas-cli/src/utils/usage/__tests__/checkForOverages-test.ts
@@ -242,6 +242,26 @@ describe('maybeWarnAboutUsageOveragesAsync', () => {
     expect(mockWarn).not.toHaveBeenCalled();
   });
 
+  it('does not warn a Free plan below its limit even if the usage API reports an overage', async () => {
+    // Regression: free users with only a handful of builds were told they'd reached
+    // their limit because a nonzero overage row was treated as billable usage.
+    mockGetUsageForOverageWarningAsync.mockResolvedValue(
+      createMockAccountUsage({
+        subscriptionName: 'Free',
+        buildPlanMetrics: [createMockPlanMetric({ value: 6, limit: 30 })],
+        overageMetrics: [{ __typename: 'EstimatedOverageAndCost', id: 'o1', value: 5 }],
+        totalCost: 0,
+      })
+    );
+
+    await maybeWarnAboutUsageOveragesAsync({
+      graphqlClient: mockGraphqlClient,
+      accountId: 'account-id',
+    });
+
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
   it('handles errors gracefully', async () => {
     mockGetUsageForOverageWarningAsync.mockRejectedValue(new Error('Network error'));
 
@@ -267,26 +287,74 @@ describe('maybeWarnAboutUsageOveragesAsync', () => {
 });
 
 describe('classifyUsageTier', () => {
+  const paid = { overageCostCents: 0, hasFreePlan: false };
+
   it('returns null when usage is below threshold', () => {
-    expect(classifyUsageTier({ planValue: 50, limit: 100, overageCount: 0 })).toBeNull();
-    expect(classifyUsageTier({ planValue: 79, limit: 100, overageCount: 0 })).toBeNull();
+    expect(classifyUsageTier({ planValue: 50, limit: 100, overageCount: 0, ...paid })).toBeNull();
+    expect(classifyUsageTier({ planValue: 79, limit: 100, overageCount: 0, ...paid })).toBeNull();
   });
 
   it('returns "approaching" at >= 80% but below limit', () => {
-    expect(classifyUsageTier({ planValue: 80, limit: 100, overageCount: 0 })).toBe('approaching');
-    expect(classifyUsageTier({ planValue: 99, limit: 100, overageCount: 0 })).toBe('approaching');
+    expect(classifyUsageTier({ planValue: 80, limit: 100, overageCount: 0, ...paid })).toBe(
+      'approaching'
+    );
+    expect(classifyUsageTier({ planValue: 99, limit: 100, overageCount: 0, ...paid })).toBe(
+      'approaching'
+    );
   });
 
   it('returns "at" when planValue >= limit and no overage', () => {
-    expect(classifyUsageTier({ planValue: 100, limit: 100, overageCount: 0 })).toBe('at');
+    expect(classifyUsageTier({ planValue: 100, limit: 100, overageCount: 0, ...paid })).toBe('at');
   });
 
-  it('returns "over" when any overage has been counted', () => {
-    expect(classifyUsageTier({ planValue: 105, limit: 100, overageCount: 5 })).toBe('over');
+  it('returns "over" for a paid plan with a counted, billable overage', () => {
+    expect(
+      classifyUsageTier({
+        planValue: 105,
+        limit: 100,
+        overageCount: 5,
+        overageCostCents: 750,
+        hasFreePlan: false,
+      })
+    ).toBe('over');
   });
 
-  it('prefers "over" if overage exists, regardless of planValue', () => {
-    expect(classifyUsageTier({ planValue: 50, limit: 100, overageCount: 1 })).toBe('over');
+  it('prefers "over" if a billable overage exists, regardless of planValue', () => {
+    expect(
+      classifyUsageTier({
+        planValue: 50,
+        limit: 100,
+        overageCount: 1,
+        overageCostCents: 150,
+        hasFreePlan: false,
+      })
+    ).toBe('over');
+  });
+
+  it('never returns "over" for a Free plan, even if an overage is reported', () => {
+    // Regression: free users below their limit were shown the "reached your limit" warning
+    // because a nonzero overage row was treated as billable usage.
+    expect(
+      classifyUsageTier({
+        planValue: 6,
+        limit: 30,
+        overageCount: 5,
+        overageCostCents: 0,
+        hasFreePlan: true,
+      })
+    ).toBeNull();
+  });
+
+  it('does not return "over" for a paid plan when the overage has no billable cost', () => {
+    expect(
+      classifyUsageTier({
+        planValue: 6,
+        limit: 30,
+        overageCount: 5,
+        overageCostCents: 0,
+        hasFreePlan: false,
+      })
+    ).toBeNull();
   });
 });
 

--- a/packages/eas-cli/src/utils/usage/checkForOverages.ts
+++ b/packages/eas-cli/src/utils/usage/checkForOverages.ts
@@ -35,16 +35,18 @@ export async function maybeWarnAboutUsageOveragesAsync({
 
     const overageCount = buildMetrics.overageMetrics.reduce((sum, o) => sum + o.value, 0);
     const overageCostCents = buildMetrics.totalCost;
+    const hasFreePlan = subscription.name === 'Free';
     const tier = classifyUsageTier({
       planValue: planMetric.value,
       limit: planMetric.limit,
       overageCount,
+      overageCostCents,
+      hasFreePlan,
     });
     if (!tier) {
       return;
     }
 
-    const hasFreePlan = subscription.name === 'Free';
     displayOverageWarning({
       tier,
       name,
@@ -64,12 +66,22 @@ export function classifyUsageTier({
   planValue,
   limit,
   overageCount,
+  overageCostCents,
+  hasFreePlan,
 }: {
   planValue: number;
   limit: number;
   overageCount: number;
+  overageCostCents: number;
+  hasFreePlan: boolean;
 }): UsageTier | null {
-  if (overageCount > 0) {
+  // Only paid plans can incur pay-as-you-go overages, and only when there is an
+  // actual billable cost. Free plans are blocked at the limit and are never charged,
+  // so they can never be in an "over" state — a nonzero overage row (e.g. a usage
+  // rollup returned by the API) must not be treated as billable usage. Without this
+  // guard, free users well below their limit were shown a "you've reached your limit,
+  // upgrade to keep building" warning.
+  if (!hasFreePlan && overageCount > 0 && overageCostCents > 0) {
     return 'over';
   }
   if (limit > 0 && planValue >= limit) {


### PR DESCRIPTION
…ld limit

The "over" usage tier fired whenever the summed value of any overageMetrics row was greater than zero, independent of the plan limit or whether a charge was actually incurred. For Free plans that message collapsed into the "you've reached your limit, upgrade to keep building" warning, so free users well below their limit (e.g. 6 builds) were told they were blocked.

Free plans can never be in an "over" state (they are blocked at the limit and never charged pay-as-you-go), and even paid plans now require a real billable overage cost (totalCost > 0) before showing the overage warning.

<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.

# How

How did you build this feature or fix this bug and why?

# Test Plan

Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
