### PR TITLE
[eas-cli] Show accurate build overage count in pre-build usage warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [eas-cli] Fix Free plan users being warned they had reached their build limit while still well below it. Overage warnings are now shown only for paid plans with an actual billable overage cost. ([#3882](https://github.com/expo/eas-cli/pull/3882) by [@sarahlane8](https://github.com/sarahlane8))
-- [eas-cli] Count only genuine per-worker build overages in the pre-build usage warning, so the reported number of builds beyond included credits is accurate. ([#3882](https://github.com/expo/eas-cli/pull/3882) by [@sarahlane8](https://github.com/sarahlane8))
+- [eas-cli] Count only genuine per-worker build overages in the pre-build usage warning, so the reported number of builds beyond included credits is accurate. ([#3932](https://github.com/expo/eas-cli/pull/3932) by [@sarahlane8](https://github.com/sarahlane8))
 - [eas-cli] Select correct tvOS build target for non-interactive Apple builds when EXPO_TV env variable is set. ([#3907](https://github.com/expo/eas-cli/pull/3907) by [@douglowder](https://github.com/douglowder))
 
 ### 🧹 Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [eas-cli] Fix Free plan users being warned they had reached their build limit while still well below it. Overage warnings are now shown only for paid plans with an actual billable overage cost. ([#3882](https://github.com/expo/eas-cli/pull/3882) by [@sarahlane8](https://github.com/sarahlane8))
+- [eas-cli] Count only genuine per-worker build overages in the pre-build usage warning, so the reported number of builds beyond included credits is accurate. ([#3882](https://github.com/expo/eas-cli/pull/3882) by [@sarahlane8](https://github.com/sarahlane8))
 - [eas-cli] Select correct tvOS build target for non-interactive Apple builds when EXPO_TV env variable is set. ([#3907](https://github.com/expo/eas-cli/pull/3907) by [@douglowder](https://github.com/douglowder))
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -14042,7 +14042,7 @@ export type AccountUsageForOverageWarningQueryVariables = Exact<{
 }>;
 
 
-export type AccountUsageForOverageWarningQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byId: { __typename?: 'Account', id: string, name: string, subscription?: { __typename?: 'SubscriptionDetails', id: string, name?: string | null } | null, usageMetrics: { __typename?: 'AccountUsageMetrics', EAS_BUILD: { __typename?: 'UsageMetricTotal', id: string, totalCost: number, planMetrics: Array<{ __typename?: 'EstimatedUsage', id: string, serviceMetric: EasServiceMetric, value: number, limit: number }>, overageMetrics: Array<{ __typename?: 'EstimatedOverageAndCost', id: string, value: number }> } } } } };
+export type AccountUsageForOverageWarningQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byId: { __typename?: 'Account', id: string, name: string, subscription?: { __typename?: 'SubscriptionDetails', id: string, name?: string | null } | null, usageMetrics: { __typename?: 'AccountUsageMetrics', EAS_BUILD: { __typename?: 'UsageMetricTotal', id: string, totalCost: number, planMetrics: Array<{ __typename?: 'EstimatedUsage', id: string, serviceMetric: EasServiceMetric, value: number, limit: number }>, overageMetrics: Array<{ __typename?: 'EstimatedOverageAndCost', id: string, value: number, metadata?: { __typename?: 'AccountUsageEASBuildMetadata', billingResourceClass?: EasBuildBillingResourceClass | null, platform?: AppPlatform | null } | null }> } } } } };
 
 export type AccountBillingPeriodQueryVariables = Exact<{
   accountId: Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/queries/AccountQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/AccountQuery.ts
@@ -201,6 +201,12 @@ export const AccountQuery = {
                       overageMetrics {
                         id
                         value
+                        metadata {
+                          ... on AccountUsageEASBuildMetadata {
+                            billingResourceClass
+                            platform
+                          }
+                        }
                       }
                       totalCost
                     }

--- a/packages/eas-cli/src/utils/usage/__tests__/checkForOverages-test.ts
+++ b/packages/eas-cli/src/utils/usage/__tests__/checkForOverages-test.ts
@@ -1,6 +1,8 @@
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import {
   AccountUsageForOverageWarningQuery,
+  AppPlatform,
+  EasBuildBillingResourceClass,
   EasService,
   EasServiceMetric,
   EstimatedUsage,
@@ -40,6 +42,30 @@ function createMockPlanMetric({
   };
 }
 
+type MockOverageMetric =
+  AccountUsageForOverageWarningQuery['account']['byId']['usageMetrics']['EAS_BUILD']['overageMetrics'][number];
+
+// A genuine per-worker build overage row, i.e. one carrying build metadata. Only rows
+// shaped like this should be counted toward the "N builds beyond your credits" total.
+function createMockBuildOverage({
+  id = 'overage-id',
+  value = 1,
+  platform = AppPlatform.Ios,
+  billingResourceClass = EasBuildBillingResourceClass.Medium,
+}: {
+  id?: string;
+  value?: number;
+  platform?: AppPlatform;
+  billingResourceClass?: EasBuildBillingResourceClass;
+} = {}): MockOverageMetric {
+  return {
+    __typename: 'EstimatedOverageAndCost',
+    id,
+    value,
+    metadata: { __typename: 'AccountUsageEASBuildMetadata', billingResourceClass, platform },
+  };
+}
+
 function createMockAccountUsage({
   id = 'account-id',
   name = 'test-account',
@@ -52,7 +78,7 @@ function createMockAccountUsage({
   name?: string;
   subscriptionName?: string;
   buildPlanMetrics?: EstimatedUsage[];
-  overageMetrics?: { __typename: 'EstimatedOverageAndCost'; id: string; value: number }[];
+  overageMetrics?: MockOverageMetric[];
   totalCost?: number;
 } = {}): AccountUsageForOverageWarningQuery['account']['byId'] {
   return {
@@ -184,7 +210,7 @@ describe('maybeWarnAboutUsageOveragesAsync', () => {
     mockGetUsageForOverageWarningAsync.mockResolvedValue(
       createMockAccountUsage({
         buildPlanMetrics: [createMockPlanMetric({ value: 105 })],
-        overageMetrics: [{ __typename: 'EstimatedOverageAndCost', id: 'o1', value: 5 }],
+        overageMetrics: [createMockBuildOverage({ id: 'o1', value: 5 })],
         totalCost: 0,
       })
     );
@@ -207,7 +233,7 @@ describe('maybeWarnAboutUsageOveragesAsync', () => {
       createMockAccountUsage({
         subscriptionName: 'Starter',
         buildPlanMetrics: [createMockPlanMetric({ value: 110 })],
-        overageMetrics: [{ __typename: 'EstimatedOverageAndCost', id: 'o1', value: 10 }],
+        overageMetrics: [createMockBuildOverage({ id: 'o1', value: 10 })],
         totalCost: 1500,
       })
     );
@@ -242,6 +268,32 @@ describe('maybeWarnAboutUsageOveragesAsync', () => {
     expect(mockWarn).not.toHaveBeenCalled();
   });
 
+  it('counts only per-worker build overage rows, ignoring rows without build metadata', async () => {
+    mockGetUsageForOverageWarningAsync.mockResolvedValue(
+      createMockAccountUsage({
+        subscriptionName: 'Starter',
+        buildPlanMetrics: [createMockPlanMetric({ value: 103 })],
+        overageMetrics: [
+          createMockBuildOverage({ id: 'real', value: 3 }),
+          // A rollup/summary row with no build metadata - must not be summed in.
+          { __typename: 'EstimatedOverageAndCost', id: 'rollup', value: 50 },
+        ],
+        totalCost: 450,
+      })
+    );
+
+    await maybeWarnAboutUsageOveragesAsync({
+      graphqlClient: mockGraphqlClient,
+      accountId: 'account-id',
+    });
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "You've used 3 builds beyond your included credits this billing period ($4.50 in overages so far)."
+      )
+    );
+  });
+
   it('does not warn a Free plan below its limit even if the usage API reports an overage', async () => {
     // Regression: free users with only a handful of builds were told they'd reached
     // their limit because a nonzero overage row was treated as billable usage.
@@ -249,7 +301,7 @@ describe('maybeWarnAboutUsageOveragesAsync', () => {
       createMockAccountUsage({
         subscriptionName: 'Free',
         buildPlanMetrics: [createMockPlanMetric({ value: 6, limit: 30 })],
-        overageMetrics: [{ __typename: 'EstimatedOverageAndCost', id: 'o1', value: 5 }],
+        overageMetrics: [createMockBuildOverage({ id: 'o1', value: 5 })],
         totalCost: 0,
       })
     );

--- a/packages/eas-cli/src/utils/usage/checkForOverages.ts
+++ b/packages/eas-cli/src/utils/usage/checkForOverages.ts
@@ -33,7 +33,12 @@ export async function maybeWarnAboutUsageOveragesAsync({
       return;
     }
 
-    const overageCount = buildMetrics.overageMetrics.reduce((sum, o) => sum + o.value, 0);
+    // Count only genuine per-worker build overage rows. `overageMetrics` can also
+    // contain rows without build metadata (e.g. rollups), which must not be summed
+    // in — otherwise the displayed "N builds beyond your credits" count is inflated.
+    const overageCount = buildMetrics.overageMetrics
+      .filter(o => o.metadata?.billingResourceClass && o.metadata?.platform)
+      .reduce((sum, o) => sum + o.value, 0);
     const overageCostCents = buildMetrics.totalCost;
     const hasFreePlan = subscription.name === 'Free';
     const tier = classifyUsageTier({


### PR DESCRIPTION
The overage count shown to paid users ("N builds beyond your included credits") summed the value of every overageMetrics row, including rows without build metadata (e.g. rollup/summary rows), which could inflate the number. Filter to genuine per-worker build overage rows (those carrying billingResourceClass + platform metadata) before summing.

Fetch that metadata on overageMetrics in the warning query so the rows can be distinguished.

<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->