### PR TITLE
[build-tools] Add eas/posthog_capture_event workflow function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Improve `eas workflow:create`: add a `--template` flag, generate a placeholder workflow when a file name is passed, use shorter default file names (`build.yml`, `update.yml`, `deploy.yml`), configure EAS Build and EAS Update automatically when the chosen template requires them, set default app identifiers without prompting for the development build and deploy templates, install `expo-dev-client` during development build setup, and tighten the generated comments and next steps. ([#3943](https://github.com/expo/eas-cli/pull/3943) by [@jonsamp](https://github.com/jonsamp))
 - [eas-cli] `eas integrations:posthog:dashboard` now opens PostHog via a signed-in link, skipping the login prompt. ([#3975](https://github.com/expo/eas-cli/pull/3975) by [@gwdp](https://github.com/gwdp))
+- [build-tools] Add `eas/posthog_capture_event` workflow function to send PostHog events from workflow runs. ([#3934](https://github.com/expo/eas-cli/pull/3934) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -1,6 +1,7 @@
 import { BuildFunction } from '@expo/steps';
 
 import { calculateEASUpdateRuntimeVersionFunction } from './functions/calculateEASUpdateRuntimeVersion';
+import { createCapturePosthogEventFunction } from './functions/capturePosthogEvent';
 import { createCheckoutBuildFunction } from './functions/checkout';
 import { configureAndroidVersionFunction } from './functions/configureAndroidVersion';
 import { configureEASUpdateIfInstalledFunction } from './functions/configureEASUpdateIfInstalled';
@@ -91,6 +92,7 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
 
     createInstallPodsBuildFunction(),
     createSendSlackMessageFunction(),
+    createCapturePosthogEventFunction(),
 
     calculateEASUpdateRuntimeVersionFunction(),
 

--- a/packages/build-tools/src/steps/functions/__tests__/capturePosthogEvent.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/capturePosthogEvent.test.ts
@@ -1,0 +1,176 @@
+import fetch, { Response } from 'node-fetch';
+
+import { createGlobalContextMock } from '../../../__tests__/utils/context';
+import { createCapturePosthogEventFunction } from '../capturePosthogEvent';
+
+jest.mock('@expo/logger');
+jest.mock('node-fetch');
+
+describe(createCapturePosthogEventFunction, () => {
+  const fetchMock = jest.mocked(fetch);
+  const captureEvent = createCapturePosthogEventFunction();
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  function createStep(
+    callInputs: Record<string, unknown>,
+    env: Record<string, string>
+  ): ReturnType<typeof captureEvent.createBuildStepFromFunctionCall> {
+    return captureEvent.createBuildStepFromFunctionCall(createGlobalContextMock({}), {
+      callInputs,
+      env,
+      id: captureEvent.id,
+    });
+  }
+
+  it('sends the event to the ingestion endpoint using the env key', async () => {
+    fetchMock.mockResolvedValue({ status: 200, ok: true } as Response);
+    const step = createStep(
+      { event: 'workflow_finished', distinct_id: 'account-1' },
+      {
+        EXPO_PUBLIC_POSTHOG_API_KEY: 'phc_test',
+        EXPO_PUBLIC_POSTHOG_HOST: 'https://us.posthog.com',
+      }
+    );
+
+    await step.executeAsync();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://us.posthog.com/i/v0/e/');
+    const body = JSON.parse(init?.body as string);
+    expect(body).toMatchObject({
+      api_key: 'phc_test',
+      event: 'workflow_finished',
+      distinct_id: 'account-1',
+    });
+    expect(body.properties?.$process_person_profile).toBeUndefined();
+  });
+
+  it('sends an anonymous system event when no distinct_id is given', async () => {
+    fetchMock.mockResolvedValue({ status: 200, ok: true } as Response);
+    const step = createStep(
+      { event: 'workflow_finished' },
+      { EXPO_PUBLIC_POSTHOG_API_KEY: 'phc_test' }
+    );
+
+    await step.executeAsync();
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(body.distinct_id).toBe('eas-workflow');
+    expect(body.properties.$process_person_profile).toBe(false);
+  });
+
+  it('skips when no api key is available and ignore_error is set', async () => {
+    const step = createStep(
+      { event: 'workflow_finished', distinct_id: 'account-1', ignore_error: true },
+      {}
+    );
+    const warnMock = jest.spyOn(step.ctx.logger, 'warn');
+
+    await step.executeAsync();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warnMock).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      expect.stringMatching(/Ignoring error\.$/)
+    );
+  });
+
+  it('logs and does not throw on a non-2xx response when ignore_error is set', async () => {
+    fetchMock.mockResolvedValue({
+      status: 400,
+      ok: false,
+      text: async () => '',
+    } as unknown as Response);
+    const step = createStep(
+      { event: 'workflow_finished', distinct_id: 'account-1', ignore_error: true },
+      { EXPO_PUBLIC_POSTHOG_API_KEY: 'phc_test' }
+    );
+    const warnMock = jest.spyOn(step.ctx.logger, 'warn');
+
+    await expect(step.executeAsync()).resolves.not.toThrow();
+    expect(warnMock).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Sending PostHog event "workflow_finished" failed with status 400. Ignoring error.'
+    );
+  });
+
+  it('does not let properties override the anonymous marker', async () => {
+    fetchMock.mockResolvedValue({ status: 200, ok: true } as Response);
+    const step = createStep(
+      { event: 'workflow_finished', properties: { $process_person_profile: true, foo: 'bar' } },
+      { EXPO_PUBLIC_POSTHOG_API_KEY: 'phc_test' }
+    );
+
+    await step.executeAsync();
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(body.properties.$process_person_profile).toBe(false);
+    expect(body.properties.foo).toBe('bar');
+  });
+
+  it('throws on a network error by default', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNRESET'));
+    const step = createStep(
+      { event: 'workflow_finished' },
+      { EXPO_PUBLIC_POSTHOG_API_KEY: 'phc_test' }
+    );
+
+    await expect(step.executeAsync()).rejects.toThrow(
+      'Sending PostHog event "workflow_finished" failed.'
+    );
+  });
+
+  it('logs and does not throw on a network error when ignore_error is set', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNRESET'));
+    const step = createStep(
+      { event: 'workflow_finished', ignore_error: true },
+      { EXPO_PUBLIC_POSTHOG_API_KEY: 'phc_test' }
+    );
+    const warnMock = jest.spyOn(step.ctx.logger, 'warn');
+
+    await expect(step.executeAsync()).resolves.not.toThrow();
+    expect(warnMock).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Sending PostHog event "workflow_finished" failed. Ignoring error.'
+    );
+  });
+
+  it('throws with the PostHog error detail on failure by default', async () => {
+    fetchMock.mockResolvedValue({
+      status: 400,
+      ok: false,
+      text: async () => JSON.stringify({ detail: 'Invalid event name' }),
+    } as unknown as Response);
+    const step = createStep(
+      { event: 'workflow_finished' },
+      { EXPO_PUBLIC_POSTHOG_API_KEY: 'phc_test' }
+    );
+
+    await expect(step.executeAsync()).rejects.toThrow(/failed with status 400: Invalid event name/);
+  });
+
+  it('falls back to the raw error body when PostHog omits a detail', async () => {
+    fetchMock.mockResolvedValue({
+      status: 400,
+      ok: false,
+      text: async () => JSON.stringify({ error: 'nope' }),
+    } as unknown as Response);
+    const step = createStep(
+      { event: 'workflow_finished' },
+      { EXPO_PUBLIC_POSTHOG_API_KEY: 'phc_test' }
+    );
+
+    await expect(step.executeAsync()).rejects.toThrow(/failed with status 400: {"error":"nope"}/);
+  });
+
+  it('throws on missing key by default', async () => {
+    const step = createStep({ event: 'workflow_finished' }, {});
+
+    await expect(step.executeAsync()).rejects.toThrow(/PostHog API key not provided/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/build-tools/src/steps/functions/capturePosthogEvent.ts
+++ b/packages/build-tools/src/steps/functions/capturePosthogEvent.ts
@@ -2,7 +2,7 @@ import { UserError } from '@expo/eas-build-job';
 import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
 
 import { PosthogClient } from '../utils/PosthogClient';
-import { failOrLogError } from '../utils/PosthogUtils';
+import { PosthogUtils } from '../utils/PosthogUtils';
 
 export function createCapturePosthogEventFunction(): BuildFunction {
   return new BuildFunction({
@@ -53,7 +53,7 @@ export function createCapturePosthogEventFunction(): BuildFunction {
         env,
       });
       if (!client) {
-        failOrLogError({
+        PosthogUtils.failOrLogError({
           logger,
           ignoreError,
           error: new UserError(
@@ -72,7 +72,7 @@ export function createCapturePosthogEventFunction(): BuildFunction {
           properties: inputs.properties.value as Record<string, unknown> | undefined,
         });
       } catch (error) {
-        failOrLogError({ logger, ignoreError, error });
+        PosthogUtils.failOrLogError({ logger, ignoreError, error });
         return;
       }
       logger.info(`Sent PostHog event "${event}"`);

--- a/packages/build-tools/src/steps/functions/capturePosthogEvent.ts
+++ b/packages/build-tools/src/steps/functions/capturePosthogEvent.ts
@@ -1,0 +1,81 @@
+import { UserError } from '@expo/eas-build-job';
+import { BuildFunction, BuildStepInput, BuildStepInputValueTypeName } from '@expo/steps';
+
+import { PosthogClient } from '../utils/PosthogClient';
+import { failOrLogError } from '../utils/PosthogUtils';
+
+export function createCapturePosthogEventFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'posthog_capture_event',
+    name: 'Capture PostHog event',
+    __metricsId: 'eas/posthog_capture_event',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'event',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        required: true,
+      }),
+      BuildStepInput.createProvider({
+        id: 'distinct_id',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'properties',
+        allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'api_key',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'host',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        required: false,
+      }),
+      BuildStepInput.createProvider({
+        id: 'ignore_error',
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+        required: false,
+      }),
+    ],
+    fn: async (stepCtx, { inputs, env }) => {
+      const { logger } = stepCtx;
+      const ignoreError = Boolean(inputs.ignore_error.value);
+      const event = inputs.event.value as string;
+
+      const client = PosthogClient.forIngestion({
+        apiKeyOverride: inputs.api_key.value as string | undefined,
+        hostOverride: inputs.host.value as string | undefined,
+        env,
+      });
+      if (!client) {
+        failOrLogError({
+          logger,
+          ignoreError,
+          error: new UserError(
+            'EAS_POSTHOG_MISSING_API_KEY',
+            'PostHog API key not provided. Set the "api_key" input or the EXPO_PUBLIC_POSTHOG_API_KEY environment variable.'
+          ),
+        });
+        return;
+      }
+
+      logger.info(`Sending PostHog event "${event}"`);
+      try {
+        await client.captureEventAsync({
+          event,
+          distinctId: inputs.distinct_id.value as string | undefined,
+          properties: inputs.properties.value as Record<string, unknown> | undefined,
+        });
+      } catch (error) {
+        failOrLogError({ logger, ignoreError, error });
+        return;
+      }
+      logger.info(`Sent PostHog event "${event}"`);
+    },
+  });
+}

--- a/packages/build-tools/src/steps/functions/capturePosthogEvent.ts
+++ b/packages/build-tools/src/steps/functions/capturePosthogEvent.ts
@@ -42,7 +42,7 @@ export function createCapturePosthogEventFunction(): BuildFunction {
         required: false,
       }),
     ],
-    fn: async (stepCtx, { inputs, env }) => {
+    fn: async (stepCtx, { inputs, env, signal }) => {
       const { logger } = stepCtx;
       const ignoreError = Boolean(inputs.ignore_error.value);
       const event = inputs.event.value as string;
@@ -70,6 +70,7 @@ export function createCapturePosthogEventFunction(): BuildFunction {
           event,
           distinctId: inputs.distinct_id.value as string | undefined,
           properties: inputs.properties.value as Record<string, unknown> | undefined,
+          signal,
         });
       } catch (error) {
         PosthogUtils.failOrLogError({ logger, ignoreError, error });

--- a/packages/build-tools/src/steps/utils/PosthogClient.ts
+++ b/packages/build-tools/src/steps/utils/PosthogClient.ts
@@ -22,11 +22,18 @@ const POSTHOG_API_CREDENTIALS = {
   projectId: { label: 'project id', envVar: 'POSTHOG_CLI_PROJECT_ID', input: 'project_id' },
 } satisfies Record<string, PosthogCredential>;
 
-export function missingPosthogCredentialsMessage(missing: PosthogCredential[]): string {
+function missingPosthogCredentialsMessage(missing: PosthogCredential[]): string {
   const labels = missing.map(credential => credential.label).join(', ');
   const envVars = missing.map(credential => credential.envVar).join(', ');
   const inputs = missing.map(credential => credential.input).join(', ');
   return `Missing PostHog credentials: ${labels}. Set the environment variables (${envVars}) or step inputs (${inputs}) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.`;
+}
+
+export function missingPosthogCredentialsError(missing: PosthogCredential[]): UserError {
+  return new UserError(
+    'EAS_POSTHOG_MISSING_CREDENTIALS',
+    missingPosthogCredentialsMessage(missing)
+  );
 }
 
 export class PosthogRetryableError extends Error {}
@@ -159,15 +166,23 @@ export class PosthogClient {
     return response;
   }
 
-  async runQueryAsync(query: string, logger: bunyan): Promise<unknown> {
+  async runQueryAsync(
+    query: string,
+    logger: bunyan,
+    signal: AbortSignal | undefined
+  ): Promise<unknown> {
     let response: Response;
     try {
       response = await fetch(this.apiUrl('/query/'), {
         method: 'POST',
         headers: this.authHeaders(),
         body: JSON.stringify({ query: { kind: 'HogQLQuery', query }, refresh: 'blocking' }),
+        signal,
       });
     } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
       logger.debug(error);
       logger.warn(
         'Running the PostHog query failed with a network error; will retry on the next poll.'

--- a/packages/build-tools/src/steps/utils/PosthogClient.ts
+++ b/packages/build-tools/src/steps/utils/PosthogClient.ts
@@ -11,31 +11,6 @@ const SYSTEM_DISTINCT_ID = 'eas-workflow';
 
 const QueryResponseSchema = z.object({ results: z.array(z.array(z.unknown())) });
 
-interface PosthogCredential {
-  label: string;
-  envVar: string;
-  input: string;
-}
-
-const POSTHOG_API_CREDENTIALS = {
-  apiKey: { label: 'personal API key', envVar: 'POSTHOG_CLI_API_KEY', input: 'api_key' },
-  projectId: { label: 'project id', envVar: 'POSTHOG_CLI_PROJECT_ID', input: 'project_id' },
-} satisfies Record<string, PosthogCredential>;
-
-function missingPosthogCredentialsMessage(missing: PosthogCredential[]): string {
-  const labels = missing.map(credential => credential.label).join(', ');
-  const envVars = missing.map(credential => credential.envVar).join(', ');
-  const inputs = missing.map(credential => credential.input).join(', ');
-  return `Missing PostHog credentials: ${labels}. Set the environment variables (${envVars}) or step inputs (${inputs}) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.`;
-}
-
-export function missingPosthogCredentialsError(missing: PosthogCredential[]): UserError {
-  return new UserError(
-    'EAS_POSTHOG_MISSING_CREDENTIALS',
-    missingPosthogCredentialsMessage(missing)
-  );
-}
-
 export class PosthogRetryableError extends Error {}
 
 export class PosthogClient {
@@ -53,15 +28,15 @@ export class PosthogClient {
     apiKeyOverride: string | undefined;
     projectIdOverride: string | undefined;
     env: BuildStepEnv;
-  }): { client: PosthogClient } | { client: undefined; missing: PosthogCredential[] } {
+  }): { client: PosthogClient } | { client: undefined; missing: PosthogUtils.Credential[] } {
     const apiKey = apiKeyOverride || env.POSTHOG_CLI_API_KEY;
     const projectId = projectIdOverride || env.POSTHOG_CLI_PROJECT_ID;
     if (!apiKey || !projectId) {
       return {
         client: undefined,
         missing: [
-          ...(apiKey ? [] : [POSTHOG_API_CREDENTIALS.apiKey]),
-          ...(projectId ? [] : [POSTHOG_API_CREDENTIALS.projectId]),
+          ...(apiKey ? [] : [PosthogUtils.API_CREDENTIALS.apiKey]),
+          ...(projectId ? [] : [PosthogUtils.API_CREDENTIALS.projectId]),
         ],
       };
     }

--- a/packages/build-tools/src/steps/utils/PosthogClient.ts
+++ b/packages/build-tools/src/steps/utils/PosthogClient.ts
@@ -4,7 +4,7 @@ import { type BuildStepEnv } from '@expo/steps';
 import fetch, { Response } from 'node-fetch';
 import { z } from 'zod';
 
-import { readErrorAsync } from './PosthogUtils';
+import { PosthogUtils } from './PosthogUtils';
 
 const POSTHOG_DEFAULT_HOST = 'https://us.posthog.com';
 const SYSTEM_DISTINCT_ID = 'eas-workflow';
@@ -32,13 +32,13 @@ export class PosthogClient {
     projectIdOverride: string | undefined;
     env: BuildStepEnv;
   }): PosthogClient | undefined {
-    const apiKey = apiKeyOverride ?? env.POSTHOG_CLI_API_KEY;
-    const projectId = projectIdOverride ?? env.POSTHOG_CLI_PROJECT_ID;
+    const apiKey = apiKeyOverride || env.POSTHOG_CLI_API_KEY;
+    const projectId = projectIdOverride || env.POSTHOG_CLI_PROJECT_ID;
     if (!apiKey || !projectId) {
       return undefined;
     }
     return new PosthogClient(
-      (env.POSTHOG_CLI_HOST ?? POSTHOG_DEFAULT_HOST).replace(/\/+$/, ''),
+      (env.POSTHOG_CLI_HOST || POSTHOG_DEFAULT_HOST).replace(/\/+$/, ''),
       apiKey,
       projectId
     );
@@ -53,12 +53,12 @@ export class PosthogClient {
     hostOverride: string | undefined;
     env: BuildStepEnv;
   }): PosthogClient | undefined {
-    const apiKey = apiKeyOverride ?? env.EXPO_PUBLIC_POSTHOG_API_KEY ?? env.POSTHOG_API_KEY;
+    const apiKey = apiKeyOverride || env.EXPO_PUBLIC_POSTHOG_API_KEY || env.POSTHOG_API_KEY;
     if (!apiKey) {
       return undefined;
     }
     return new PosthogClient(
-      (hostOverride ?? env.EXPO_PUBLIC_POSTHOG_HOST ?? POSTHOG_DEFAULT_HOST).replace(/\/+$/, ''),
+      (hostOverride || env.EXPO_PUBLIC_POSTHOG_HOST || POSTHOG_DEFAULT_HOST).replace(/\/+$/, ''),
       apiKey,
       ''
     );
@@ -101,7 +101,7 @@ export class PosthogClient {
     if (!response.ok) {
       throw new UserError(
         'EAS_POSTHOG_CAPTURE_FAILED',
-        `Sending PostHog event "${event}" failed with ${await readErrorAsync(response)}.`
+        `Sending PostHog event "${event}" failed with ${await PosthogUtils.readErrorAsync(response)}.`
       );
     }
   }
@@ -130,7 +130,7 @@ export class PosthogClient {
     if (!response.ok) {
       throw new UserError(
         'EAS_POSTHOG_REQUEST_FAILED',
-        `${action} failed with ${await readErrorAsync(response)}.`
+        `${action} failed with ${await PosthogUtils.readErrorAsync(response)}.`
       );
     }
     return response;
@@ -166,7 +166,7 @@ export class PosthogClient {
     if (!response.ok) {
       throw new UserError(
         'EAS_POSTHOG_REQUEST_FAILED',
-        `Running the PostHog query failed with ${await readErrorAsync(response)}.`
+        `Running the PostHog query failed with ${await PosthogUtils.readErrorAsync(response)}.`
       );
     }
     let body: unknown;

--- a/packages/build-tools/src/steps/utils/PosthogClient.ts
+++ b/packages/build-tools/src/steps/utils/PosthogClient.ts
@@ -1,0 +1,198 @@
+import { UserError } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
+import { type BuildStepEnv } from '@expo/steps';
+import fetch, { Response } from 'node-fetch';
+import { z } from 'zod';
+
+import { readErrorAsync } from './PosthogUtils';
+
+const POSTHOG_DEFAULT_HOST = 'https://us.posthog.com';
+const SYSTEM_DISTINCT_ID = 'eas-workflow';
+
+const QueryResponseSchema = z.object({ results: z.array(z.array(z.unknown())) });
+
+export const MISSING_POSTHOG_API_TARGET_MESSAGE =
+  'PostHog personal API key or project id is missing. Re-run "eas integrations:posthog:connect" with error tracking enabled, set the POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID environment variables on EAS, or pass the "api_key" and "project_id" inputs to this step.';
+
+export class PosthogRetryableError extends Error {}
+
+export class PosthogClient {
+  private constructor(
+    private readonly host: string,
+    private readonly apiKey: string,
+    private readonly projectId: string
+  ) {}
+
+  static fromEnv({
+    apiKeyOverride,
+    projectIdOverride,
+    env,
+  }: {
+    apiKeyOverride: string | undefined;
+    projectIdOverride: string | undefined;
+    env: BuildStepEnv;
+  }): PosthogClient | undefined {
+    const apiKey = apiKeyOverride ?? env.POSTHOG_CLI_API_KEY;
+    const projectId = projectIdOverride ?? env.POSTHOG_CLI_PROJECT_ID;
+    if (!apiKey || !projectId) {
+      return undefined;
+    }
+    return new PosthogClient(
+      (env.POSTHOG_CLI_HOST ?? POSTHOG_DEFAULT_HOST).replace(/\/+$/, ''),
+      apiKey,
+      projectId
+    );
+  }
+
+  static forIngestion({
+    apiKeyOverride,
+    hostOverride,
+    env,
+  }: {
+    apiKeyOverride: string | undefined;
+    hostOverride: string | undefined;
+    env: BuildStepEnv;
+  }): PosthogClient | undefined {
+    const apiKey = apiKeyOverride ?? env.EXPO_PUBLIC_POSTHOG_API_KEY ?? env.POSTHOG_API_KEY;
+    if (!apiKey) {
+      return undefined;
+    }
+    return new PosthogClient(
+      (hostOverride ?? env.EXPO_PUBLIC_POSTHOG_HOST ?? POSTHOG_DEFAULT_HOST).replace(/\/+$/, ''),
+      apiKey,
+      ''
+    );
+  }
+
+  async captureEventAsync({
+    event,
+    distinctId,
+    properties,
+  }: {
+    event: string;
+    distinctId: string | undefined;
+    properties: Record<string, unknown> | undefined;
+  }): Promise<void> {
+    let response: Response;
+    try {
+      response = await fetch(`${this.host}/i/v0/e/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          api_key: this.apiKey,
+          event,
+          distinct_id: distinctId ?? SYSTEM_DISTINCT_ID,
+          properties:
+            distinctId !== undefined
+              ? properties
+              : { ...properties, $process_person_profile: false },
+          timestamp: new Date().toISOString(),
+        }),
+      });
+    } catch (error) {
+      throw new UserError(
+        'EAS_POSTHOG_CAPTURE_FAILED',
+        `Sending PostHog event "${event}" failed.`,
+        {
+          cause: error,
+        }
+      );
+    }
+    if (!response.ok) {
+      throw new UserError(
+        'EAS_POSTHOG_CAPTURE_FAILED',
+        `Sending PostHog event "${event}" failed with ${await readErrorAsync(response)}.`
+      );
+    }
+  }
+
+  async requestAsync(
+    method: 'GET' | 'POST' | 'PATCH',
+    path: string,
+    { action, forbiddenScope, body }: { action: string; forbiddenScope: string; body?: unknown }
+  ): Promise<Response> {
+    let response: Response;
+    try {
+      response = await fetch(this.apiUrl(path), {
+        method,
+        headers: this.authHeaders(),
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+    } catch (error) {
+      throw new UserError('EAS_POSTHOG_REQUEST_FAILED', `${action} failed.`, { cause: error });
+    }
+    if (response.status === 403) {
+      throw new UserError(
+        'EAS_POSTHOG_FORBIDDEN',
+        `${action} was forbidden (403). The personal API key likely lacks the "${forbiddenScope}" scope.`
+      );
+    }
+    if (!response.ok) {
+      throw new UserError(
+        'EAS_POSTHOG_REQUEST_FAILED',
+        `${action} failed with ${await readErrorAsync(response)}.`
+      );
+    }
+    return response;
+  }
+
+  async runQueryAsync(query: string, logger: bunyan): Promise<unknown> {
+    let response: Response;
+    try {
+      response = await fetch(this.apiUrl('/query/'), {
+        method: 'POST',
+        headers: this.authHeaders(),
+        body: JSON.stringify({ query: { kind: 'HogQLQuery', query }, refresh: 'blocking' }),
+      });
+    } catch (error) {
+      logger.debug(error);
+      logger.warn(
+        'Running the PostHog query failed with a network error; will retry on the next poll.'
+      );
+      throw new PosthogRetryableError();
+    }
+    if (response.status === 403) {
+      throw new UserError(
+        'EAS_POSTHOG_FORBIDDEN',
+        'Running the PostHog query was forbidden (403). The personal API key likely lacks the "query:read" scope.'
+      );
+    }
+    if (response.status >= 500 || response.status === 429) {
+      logger.warn(
+        `Running the PostHog query failed with status ${response.status}; will retry on the next poll.`
+      );
+      throw new PosthogRetryableError();
+    }
+    if (!response.ok) {
+      throw new UserError(
+        'EAS_POSTHOG_REQUEST_FAILED',
+        `Running the PostHog query failed with ${await readErrorAsync(response)}.`
+      );
+    }
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch (error) {
+      logger.debug(error);
+      logger.warn('The PostHog query response was not valid JSON; will retry on the next poll.');
+      throw new PosthogRetryableError();
+    }
+    const parsed = QueryResponseSchema.safeParse(body);
+    return parsed.success ? parsed.data.results[0]?.[0] : undefined;
+  }
+
+  cliConfig(): { host: string; env: Record<string, string> } {
+    return {
+      host: this.host,
+      env: { POSTHOG_CLI_API_KEY: this.apiKey, POSTHOG_CLI_PROJECT_ID: this.projectId },
+    };
+  }
+
+  private apiUrl(path: string): string {
+    return `${this.host}/api/projects/${encodeURIComponent(this.projectId)}${path}`;
+  }
+
+  private authHeaders(): Record<string, string> {
+    return { Authorization: `Bearer ${this.apiKey}`, 'Content-Type': 'application/json' };
+  }
+}

--- a/packages/build-tools/src/steps/utils/PosthogClient.ts
+++ b/packages/build-tools/src/steps/utils/PosthogClient.ts
@@ -11,8 +11,23 @@ const SYSTEM_DISTINCT_ID = 'eas-workflow';
 
 const QueryResponseSchema = z.object({ results: z.array(z.array(z.unknown())) });
 
-export const MISSING_POSTHOG_API_TARGET_MESSAGE =
-  'PostHog personal API key or project id is missing. Re-run "eas integrations:posthog:connect" with error tracking enabled, set the POSTHOG_CLI_API_KEY and POSTHOG_CLI_PROJECT_ID environment variables on EAS, or pass the "api_key" and "project_id" inputs to this step.';
+interface PosthogCredential {
+  label: string;
+  envVar: string;
+  input: string;
+}
+
+const POSTHOG_API_CREDENTIALS = {
+  apiKey: { label: 'personal API key', envVar: 'POSTHOG_CLI_API_KEY', input: 'api_key' },
+  projectId: { label: 'project id', envVar: 'POSTHOG_CLI_PROJECT_ID', input: 'project_id' },
+} satisfies Record<string, PosthogCredential>;
+
+export function missingPosthogCredentialsMessage(missing: PosthogCredential[]): string {
+  const labels = missing.map(credential => credential.label).join(', ');
+  const envVars = missing.map(credential => credential.envVar).join(', ');
+  const inputs = missing.map(credential => credential.input).join(', ');
+  return `Missing PostHog credentials: ${labels}. Set the environment variables (${envVars}) or step inputs (${inputs}) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.`;
+}
 
 export class PosthogRetryableError extends Error {}
 
@@ -31,17 +46,25 @@ export class PosthogClient {
     apiKeyOverride: string | undefined;
     projectIdOverride: string | undefined;
     env: BuildStepEnv;
-  }): PosthogClient | undefined {
+  }): { client: PosthogClient } | { client: undefined; missing: PosthogCredential[] } {
     const apiKey = apiKeyOverride || env.POSTHOG_CLI_API_KEY;
     const projectId = projectIdOverride || env.POSTHOG_CLI_PROJECT_ID;
     if (!apiKey || !projectId) {
-      return undefined;
+      return {
+        client: undefined,
+        missing: [
+          ...(apiKey ? [] : [POSTHOG_API_CREDENTIALS.apiKey]),
+          ...(projectId ? [] : [POSTHOG_API_CREDENTIALS.projectId]),
+        ],
+      };
     }
-    return new PosthogClient(
-      (env.POSTHOG_CLI_HOST || POSTHOG_DEFAULT_HOST).replace(/\/+$/, ''),
-      apiKey,
-      projectId
-    );
+    return {
+      client: new PosthogClient(
+        (env.POSTHOG_CLI_HOST || POSTHOG_DEFAULT_HOST).replace(/\/+$/, ''),
+        apiKey,
+        projectId
+      ),
+    };
   }
 
   static forIngestion({

--- a/packages/build-tools/src/steps/utils/PosthogClient.ts
+++ b/packages/build-tools/src/steps/utils/PosthogClient.ts
@@ -73,10 +73,12 @@ export class PosthogClient {
     event,
     distinctId,
     properties,
+    signal,
   }: {
     event: string;
     distinctId: string | undefined;
     properties: Record<string, unknown> | undefined;
+    signal: AbortSignal | undefined;
   }): Promise<void> {
     let response: Response;
     try {
@@ -93,8 +95,12 @@ export class PosthogClient {
               : { ...properties, $process_person_profile: false },
           timestamp: new Date().toISOString(),
         }),
+        signal,
       });
     } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
       throw new UserError(
         'EAS_POSTHOG_CAPTURE_FAILED',
         `Sending PostHog event "${event}" failed.`,
@@ -114,7 +120,12 @@ export class PosthogClient {
   async requestAsync(
     method: 'GET' | 'POST' | 'PATCH',
     path: string,
-    { action, forbiddenScope, body }: { action: string; forbiddenScope: string; body?: unknown }
+    {
+      action,
+      forbiddenScope,
+      body,
+      signal,
+    }: { action: string; forbiddenScope: string; body?: unknown; signal: AbortSignal | undefined }
   ): Promise<Response> {
     let response: Response;
     try {
@@ -122,8 +133,12 @@ export class PosthogClient {
         method,
         headers: this.authHeaders(),
         body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal,
       });
     } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
       throw new UserError('EAS_POSTHOG_REQUEST_FAILED', `${action} failed.`, { cause: error });
     }
     if (response.status === 403) {

--- a/packages/build-tools/src/steps/utils/PosthogUtils.ts
+++ b/packages/build-tools/src/steps/utils/PosthogUtils.ts
@@ -1,8 +1,47 @@
+import { setTimeout as setTimeoutAsync } from 'node:timers/promises';
+
 import { UserError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { Response } from 'node-fetch';
 
 export namespace PosthogUtils {
+  export const DEFAULT_POLL_TIMEOUT_SECONDS = 600;
+  export const DEFAULT_POLL_INTERVAL_SECONDS = 30;
+
+  export function assertPollBoundsPositive({
+    timeoutSeconds,
+    intervalSeconds,
+    errorCode,
+  }: {
+    timeoutSeconds: number;
+    intervalSeconds: number;
+    errorCode: string;
+  }): void {
+    if (timeoutSeconds <= 0 || intervalSeconds <= 0) {
+      throw new UserError(
+        errorCode,
+        '"timeout_seconds" and "interval_seconds" must be greater than 0.'
+      );
+    }
+  }
+
+  export async function waitForNextPollAsync({
+    intervalSeconds,
+    deadline,
+    signal,
+  }: {
+    intervalSeconds: number;
+    deadline: number;
+    signal: AbortSignal | undefined;
+  }): Promise<boolean> {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return false;
+    }
+    await setTimeoutAsync(Math.min(intervalSeconds * 1000, remainingMs), undefined, { signal });
+    return true;
+  }
+
   export function failOrLogError({
     logger,
     ignoreError,

--- a/packages/build-tools/src/steps/utils/PosthogUtils.ts
+++ b/packages/build-tools/src/steps/utils/PosthogUtils.ts
@@ -1,0 +1,38 @@
+import { UserError } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
+import { Response } from 'node-fetch';
+
+export function failOrLogError({
+  logger,
+  ignoreError,
+  error,
+}: {
+  logger: bunyan;
+  ignoreError: boolean;
+  error: unknown;
+}): void {
+  if (!ignoreError || (error instanceof UserError && error.errorCode === 'EAS_POSTHOG_FORBIDDEN')) {
+    throw error;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  logger.warn({ err: error }, `${message} Ignoring error.`);
+}
+
+export async function readErrorAsync(response: Response): Promise<string> {
+  const text = await response.text().catch(() => '');
+  if (text) {
+    try {
+      const body = JSON.parse(text) as unknown;
+      if (typeof body === 'object' && body !== null) {
+        const { detail } = body as Record<string, unknown>;
+        if (typeof detail === 'string' && detail !== '') {
+          return `status ${response.status}: ${detail} (${text})`;
+        }
+      }
+    } catch {
+      return `status ${response.status}: ${text}`;
+    }
+    return `status ${response.status}: ${text}`;
+  }
+  return `status ${response.status}`;
+}

--- a/packages/build-tools/src/steps/utils/PosthogUtils.ts
+++ b/packages/build-tools/src/steps/utils/PosthogUtils.ts
@@ -5,6 +5,27 @@ import { bunyan } from '@expo/logger';
 import { Response } from 'node-fetch';
 
 export namespace PosthogUtils {
+  export interface Credential {
+    label: string;
+    envVar: string;
+    input: string;
+  }
+
+  export const API_CREDENTIALS = {
+    apiKey: { label: 'personal API key', envVar: 'POSTHOG_CLI_API_KEY', input: 'api_key' },
+    projectId: { label: 'project id', envVar: 'POSTHOG_CLI_PROJECT_ID', input: 'project_id' },
+  } satisfies Record<string, Credential>;
+
+  export function missingCredentialsError(missing: Credential[]): UserError {
+    const labels = missing.map(credential => credential.label).join(', ');
+    const envVars = missing.map(credential => credential.envVar).join(', ');
+    const inputs = missing.map(credential => credential.input).join(', ');
+    return new UserError(
+      'EAS_POSTHOG_MISSING_CREDENTIALS',
+      `Missing PostHog credentials: ${labels}. Set the environment variables (${envVars}) or step inputs (${inputs}) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.`
+    );
+  }
+
   export const DEFAULT_POLL_TIMEOUT_SECONDS = 600;
   export const DEFAULT_POLL_INTERVAL_SECONDS = 30;
 

--- a/packages/build-tools/src/steps/utils/PosthogUtils.ts
+++ b/packages/build-tools/src/steps/utils/PosthogUtils.ts
@@ -2,37 +2,42 @@ import { UserError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { Response } from 'node-fetch';
 
-export function failOrLogError({
-  logger,
-  ignoreError,
-  error,
-}: {
-  logger: bunyan;
-  ignoreError: boolean;
-  error: unknown;
-}): void {
-  if (!ignoreError || (error instanceof UserError && error.errorCode === 'EAS_POSTHOG_FORBIDDEN')) {
-    throw error;
+export namespace PosthogUtils {
+  export function failOrLogError({
+    logger,
+    ignoreError,
+    error,
+  }: {
+    logger: bunyan;
+    ignoreError: boolean;
+    error: unknown;
+  }): void {
+    if (
+      !ignoreError ||
+      (error instanceof UserError && error.errorCode === 'EAS_POSTHOG_FORBIDDEN')
+    ) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn({ err: error }, `${message} Ignoring error.`);
   }
-  const message = error instanceof Error ? error.message : String(error);
-  logger.warn({ err: error }, `${message} Ignoring error.`);
-}
 
-export async function readErrorAsync(response: Response): Promise<string> {
-  const text = await response.text().catch(() => '');
-  if (text) {
-    try {
-      const body = JSON.parse(text) as unknown;
-      if (typeof body === 'object' && body !== null) {
-        const { detail } = body as Record<string, unknown>;
-        if (typeof detail === 'string' && detail !== '') {
-          return `status ${response.status}: ${detail} (${text})`;
+  export async function readErrorAsync(response: Response): Promise<string> {
+    const text = await response.text().catch(() => '');
+    if (text) {
+      try {
+        const body = JSON.parse(text) as unknown;
+        if (typeof body === 'object' && body !== null) {
+          const { detail } = body as Record<string, unknown>;
+          if (typeof detail === 'string' && detail !== '') {
+            return `status ${response.status}: ${detail} (${text})`;
+          }
         }
+      } catch {
+        return `status ${response.status}: ${text}`;
       }
-    } catch {
       return `status ${response.status}: ${text}`;
     }
-    return `status ${response.status}: ${text}`;
+    return `status ${response.status}`;
   }
-  return `status ${response.status}`;
 }

--- a/packages/build-tools/src/steps/utils/__tests__/PosthogClient.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/PosthogClient.test.ts
@@ -125,7 +125,12 @@ describe('PosthogClient.forIngestion', () => {
       hostOverride: 'https://eu.posthog.com//',
       env: {},
     });
-    await client?.captureEventAsync({ event: 'e', distinctId: 'u', properties: undefined });
+    await client?.captureEventAsync({
+      event: 'e',
+      distinctId: 'u',
+      properties: undefined,
+      signal: undefined,
+    });
     expect(fetchMock.mock.calls[0][0]).toBe('https://eu.posthog.com/i/v0/e/');
   });
 
@@ -155,7 +160,12 @@ describe('captureEventAsync', () => {
 
   it('sends an anonymous system event when no distinct_id is given', async () => {
     fetchMock.mockResolvedValue(res({ ok: true, status: 200 }));
-    await client?.captureEventAsync({ event: 'e', distinctId: undefined, properties: { a: 1 } });
+    await client?.captureEventAsync({
+      event: 'e',
+      distinctId: undefined,
+      properties: { a: 1 },
+      signal: undefined,
+    });
     const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
     expect(body.distinct_id).toBe('eas-workflow');
     expect(body.properties).toEqual({ a: 1, $process_person_profile: false });
@@ -164,15 +174,40 @@ describe('captureEventAsync', () => {
   it('throws a UserError on a non-2xx response', async () => {
     fetchMock.mockResolvedValue(res({ ok: false, status: 400, text: 'bad' }));
     await expect(
-      client?.captureEventAsync({ event: 'e', distinctId: 'u', properties: undefined })
+      client?.captureEventAsync({
+        event: 'e',
+        distinctId: 'u',
+        properties: undefined,
+        signal: undefined,
+      })
     ).rejects.toThrow(/failed with status 400: bad/);
   });
 
   it('throws a UserError on a network error', async () => {
     fetchMock.mockRejectedValue(new Error('ECONNRESET'));
     await expect(
-      client?.captureEventAsync({ event: 'e', distinctId: 'u', properties: undefined })
+      client?.captureEventAsync({
+        event: 'e',
+        distinctId: 'u',
+        properties: undefined,
+        signal: undefined,
+      })
     ).rejects.toThrow(/Sending PostHog event "e" failed\.$/);
+  });
+
+  it('passes the signal and propagates without wrapping when aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    fetchMock.mockRejectedValue(new Error('The operation was aborted'));
+    await expect(
+      client?.captureEventAsync({
+        event: 'e',
+        distinctId: 'u',
+        properties: undefined,
+        signal: controller.signal,
+      })
+    ).rejects.toThrow('The operation was aborted');
+    expect(fetchMock.mock.calls[0][1]?.signal).toBe(controller.signal);
   });
 });
 
@@ -189,6 +224,7 @@ describe('requestAsync', () => {
       action: 'Updating flag',
       forbiddenScope: 'feature_flag:write',
       body: { active: true },
+      signal: undefined,
     });
     expect(response?.ok).toBe(true);
     const [url, init] = fetchMock.mock.calls[0];
@@ -203,6 +239,7 @@ describe('requestAsync', () => {
       client?.requestAsync('GET', '/feature_flags/', {
         action: 'Looking up flag',
         forbiddenScope: 'feature_flag:read',
+        signal: undefined,
       })
     ).rejects.toMatchObject({
       errorCode: 'EAS_POSTHOG_FORBIDDEN',
@@ -216,6 +253,7 @@ describe('requestAsync', () => {
       client?.requestAsync('GET', '/feature_flags/', {
         action: 'Looking up flag',
         forbiddenScope: 'feature_flag:read',
+        signal: undefined,
       })
     ).rejects.toThrow(/Looking up flag failed with status 400: nope/);
   });
@@ -226,8 +264,23 @@ describe('requestAsync', () => {
       client?.requestAsync('GET', '/feature_flags/', {
         action: 'Looking up flag',
         forbiddenScope: 'feature_flag:read',
+        signal: undefined,
       })
     ).rejects.toThrow(/Looking up flag failed\.$/);
+  });
+
+  it('passes the signal and propagates without wrapping when aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    fetchMock.mockRejectedValue(new Error('The operation was aborted'));
+    await expect(
+      client?.requestAsync('GET', '/feature_flags/', {
+        action: 'Looking up flag',
+        forbiddenScope: 'feature_flag:read',
+        signal: controller.signal,
+      })
+    ).rejects.toThrow('The operation was aborted');
+    expect(fetchMock.mock.calls[0][1]?.signal).toBe(controller.signal);
   });
 });
 

--- a/packages/build-tools/src/steps/utils/__tests__/PosthogClient.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/PosthogClient.test.ts
@@ -2,7 +2,11 @@ import { UserError } from '@expo/eas-build-job';
 import { createLogger } from '@expo/logger';
 import fetch, { Response } from 'node-fetch';
 
-import { PosthogClient, PosthogRetryableError } from '../PosthogClient';
+import {
+  PosthogClient,
+  PosthogRetryableError,
+  missingPosthogCredentialsMessage,
+} from '../PosthogClient';
 
 jest.mock('@expo/logger');
 jest.mock('node-fetch');
@@ -44,13 +48,13 @@ describe('PosthogClient.fromEnv', () => {
         apiKeyOverride: undefined,
         projectIdOverride: undefined,
         env: API_ENV,
-      })
+      }).client
     ).toBeInstanceOf(PosthogClient);
   });
 
   it('prefers overrides over env', async () => {
     fetchMock.mockResolvedValue(res({ json: { results: [[1]] } }));
-    const client = PosthogClient.fromEnv({
+    const { client } = PosthogClient.fromEnv({
       apiKeyOverride: 'phx_override',
       projectIdOverride: '999',
       env: {},
@@ -62,7 +66,7 @@ describe('PosthogClient.fromEnv', () => {
   });
 
   it('exposes host and CLI env for subprocess uploads', () => {
-    const client = PosthogClient.fromEnv({
+    const { client } = PosthogClient.fromEnv({
       apiKeyOverride: 'phx_k',
       projectIdOverride: '55',
       env: { POSTHOG_CLI_HOST: 'https://eu.posthog.com' },
@@ -73,28 +77,72 @@ describe('PosthogClient.fromEnv', () => {
     });
   });
 
-  it('returns undefined when the key or project id is missing', () => {
-    expect(
-      PosthogClient.fromEnv({ apiKeyOverride: undefined, projectIdOverride: undefined, env: {} })
-    ).toBeUndefined();
-    expect(
-      PosthogClient.fromEnv({
-        apiKeyOverride: 'phx',
-        projectIdOverride: undefined,
-        env: {},
-      })
-    ).toBeUndefined();
+  it('reports both missing credentials when neither is provided', () => {
+    const result = PosthogClient.fromEnv({
+      apiKeyOverride: undefined,
+      projectIdOverride: undefined,
+      env: {},
+    });
+    expect(result.client).toBeUndefined();
+    expect(result).toMatchObject({
+      missing: [{ label: 'personal API key' }, { label: 'project id' }],
+    });
+  });
+
+  it('reports only the missing project id when the key is present', () => {
+    const result = PosthogClient.fromEnv({
+      apiKeyOverride: 'phx',
+      projectIdOverride: undefined,
+      env: {},
+    });
+    expect(result.client).toBeUndefined();
+    expect(result).toMatchObject({ missing: [{ label: 'project id' }] });
+  });
+
+  it('reports only the missing api key when the project id is present', () => {
+    const result = PosthogClient.fromEnv({
+      apiKeyOverride: undefined,
+      projectIdOverride: '1',
+      env: {},
+    });
+    expect(result.client).toBeUndefined();
+    expect(result).toMatchObject({ missing: [{ label: 'personal API key' }] });
   });
 
   it('falls back to the default host', async () => {
     fetchMock.mockResolvedValue(res({ json: { results: [[1]] } }));
-    const client = PosthogClient.fromEnv({
+    const { client } = PosthogClient.fromEnv({
       apiKeyOverride: 'phx',
       projectIdOverride: '1',
       env: {},
     });
     await client?.runQueryAsync('select 1', logger);
     expect(fetchMock.mock.calls[0][0]).toBe('https://us.posthog.com/api/projects/1/query/');
+  });
+});
+
+describe(missingPosthogCredentialsMessage, () => {
+  function missingFrom(
+    env: Record<string, string>
+  ): Parameters<typeof missingPosthogCredentialsMessage>[0] {
+    const result = PosthogClient.fromEnv({
+      apiKeyOverride: undefined,
+      projectIdOverride: undefined,
+      env,
+    });
+    return result.client ? [] : result.missing;
+  }
+
+  it('names both missing credentials with their env vars and inputs', () => {
+    expect(missingPosthogCredentialsMessage(missingFrom({}))).toBe(
+      'Missing PostHog credentials: personal API key, project id. Set the environment variables (POSTHOG_CLI_API_KEY, POSTHOG_CLI_PROJECT_ID) or step inputs (api_key, project_id) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.'
+    );
+  });
+
+  it('names only the missing credential', () => {
+    expect(missingPosthogCredentialsMessage(missingFrom({ POSTHOG_CLI_API_KEY: 'phx' }))).toBe(
+      'Missing PostHog credentials: project id. Set the environment variables (POSTHOG_CLI_PROJECT_ID) or step inputs (project_id) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.'
+    );
   });
 });
 
@@ -158,7 +206,7 @@ describe('captureEventAsync', () => {
 });
 
 describe('requestAsync', () => {
-  const client = PosthogClient.fromEnv({
+  const { client } = PosthogClient.fromEnv({
     apiKeyOverride: undefined,
     projectIdOverride: undefined,
     env: API_ENV,
@@ -213,7 +261,7 @@ describe('requestAsync', () => {
 });
 
 describe('runQueryAsync', () => {
-  const client = PosthogClient.fromEnv({
+  const { client } = PosthogClient.fromEnv({
     apiKeyOverride: undefined,
     projectIdOverride: undefined,
     env: API_ENV,
@@ -269,7 +317,7 @@ describe('runQueryAsync', () => {
 });
 
 it('is a UserError subclass so the step surfaces it to the user', async () => {
-  const client = PosthogClient.fromEnv({
+  const { client } = PosthogClient.fromEnv({
     apiKeyOverride: undefined,
     projectIdOverride: undefined,
     env: API_ENV,

--- a/packages/build-tools/src/steps/utils/__tests__/PosthogClient.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/PosthogClient.test.ts
@@ -1,0 +1,279 @@
+import { UserError } from '@expo/eas-build-job';
+import { createLogger } from '@expo/logger';
+import fetch, { Response } from 'node-fetch';
+
+import { PosthogClient, PosthogRetryableError } from '../PosthogClient';
+
+jest.mock('@expo/logger');
+jest.mock('node-fetch');
+
+const fetchMock = jest.mocked(fetch);
+const logger = createLogger({ name: 'test' });
+
+function res({
+  ok = true,
+  status = 200,
+  json,
+  text,
+}: {
+  ok?: boolean;
+  status?: number;
+  json?: unknown;
+  text?: string;
+}): Response {
+  return {
+    ok,
+    status,
+    json: async () => json,
+    text: async () => text ?? (json !== undefined ? JSON.stringify(json) : ''),
+  } as unknown as Response;
+}
+
+const API_ENV = {
+  POSTHOG_CLI_API_KEY: 'phx_test',
+  POSTHOG_CLI_PROJECT_ID: '123',
+  POSTHOG_CLI_HOST: 'https://us.posthog.com',
+};
+
+afterEach(() => jest.resetAllMocks());
+
+describe('PosthogClient.fromEnv', () => {
+  it('builds a client from env vars', () => {
+    expect(
+      PosthogClient.fromEnv({
+        apiKeyOverride: undefined,
+        projectIdOverride: undefined,
+        env: API_ENV,
+      })
+    ).toBeInstanceOf(PosthogClient);
+  });
+
+  it('prefers overrides over env', async () => {
+    fetchMock.mockResolvedValue(res({ json: { results: [[1]] } }));
+    const client = PosthogClient.fromEnv({
+      apiKeyOverride: 'phx_override',
+      projectIdOverride: '999',
+      env: {},
+    });
+    await client?.runQueryAsync('select 1', logger);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://us.posthog.com/api/projects/999/query/');
+    expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer phx_override');
+  });
+
+  it('exposes host and CLI env for subprocess uploads', () => {
+    const client = PosthogClient.fromEnv({
+      apiKeyOverride: 'phx_k',
+      projectIdOverride: '55',
+      env: { POSTHOG_CLI_HOST: 'https://eu.posthog.com' },
+    });
+    expect(client?.cliConfig()).toEqual({
+      host: 'https://eu.posthog.com',
+      env: { POSTHOG_CLI_API_KEY: 'phx_k', POSTHOG_CLI_PROJECT_ID: '55' },
+    });
+  });
+
+  it('returns undefined when the key or project id is missing', () => {
+    expect(
+      PosthogClient.fromEnv({ apiKeyOverride: undefined, projectIdOverride: undefined, env: {} })
+    ).toBeUndefined();
+    expect(
+      PosthogClient.fromEnv({
+        apiKeyOverride: 'phx',
+        projectIdOverride: undefined,
+        env: {},
+      })
+    ).toBeUndefined();
+  });
+
+  it('falls back to the default host', async () => {
+    fetchMock.mockResolvedValue(res({ json: { results: [[1]] } }));
+    const client = PosthogClient.fromEnv({
+      apiKeyOverride: 'phx',
+      projectIdOverride: '1',
+      env: {},
+    });
+    await client?.runQueryAsync('select 1', logger);
+    expect(fetchMock.mock.calls[0][0]).toBe('https://us.posthog.com/api/projects/1/query/');
+  });
+});
+
+describe('PosthogClient.forIngestion', () => {
+  it('builds a client and normalizes a trailing-slash host', async () => {
+    fetchMock.mockResolvedValue(res({ ok: true, status: 200 }));
+    const client = PosthogClient.forIngestion({
+      apiKeyOverride: 'phc_x',
+      hostOverride: 'https://eu.posthog.com//',
+      env: {},
+    });
+    await client?.captureEventAsync({ event: 'e', distinctId: 'u', properties: undefined });
+    expect(fetchMock.mock.calls[0][0]).toBe('https://eu.posthog.com/i/v0/e/');
+  });
+
+  it('falls back to a non-public POSTHOG_API_KEY', () => {
+    expect(
+      PosthogClient.forIngestion({
+        apiKeyOverride: undefined,
+        hostOverride: undefined,
+        env: { POSTHOG_API_KEY: 'phc_secret' },
+      })
+    ).toBeInstanceOf(PosthogClient);
+  });
+
+  it('returns undefined when no key is available', () => {
+    expect(
+      PosthogClient.forIngestion({ apiKeyOverride: undefined, hostOverride: undefined, env: {} })
+    ).toBeUndefined();
+  });
+});
+
+describe('captureEventAsync', () => {
+  const client = PosthogClient.forIngestion({
+    apiKeyOverride: 'phc_x',
+    hostOverride: undefined,
+    env: {},
+  });
+
+  it('sends an anonymous system event when no distinct_id is given', async () => {
+    fetchMock.mockResolvedValue(res({ ok: true, status: 200 }));
+    await client?.captureEventAsync({ event: 'e', distinctId: undefined, properties: { a: 1 } });
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(body.distinct_id).toBe('eas-workflow');
+    expect(body.properties).toEqual({ a: 1, $process_person_profile: false });
+  });
+
+  it('throws a UserError on a non-2xx response', async () => {
+    fetchMock.mockResolvedValue(res({ ok: false, status: 400, text: 'bad' }));
+    await expect(
+      client?.captureEventAsync({ event: 'e', distinctId: 'u', properties: undefined })
+    ).rejects.toThrow(/failed with status 400: bad/);
+  });
+
+  it('throws a UserError on a network error', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNRESET'));
+    await expect(
+      client?.captureEventAsync({ event: 'e', distinctId: 'u', properties: undefined })
+    ).rejects.toThrow(/Sending PostHog event "e" failed\.$/);
+  });
+});
+
+describe('requestAsync', () => {
+  const client = PosthogClient.fromEnv({
+    apiKeyOverride: undefined,
+    projectIdOverride: undefined,
+    env: API_ENV,
+  });
+
+  it('sends an authenticated request and returns the response', async () => {
+    fetchMock.mockResolvedValue(res({ ok: true, status: 200, json: { id: 1 } }));
+    const response = await client?.requestAsync('PATCH', '/feature_flags/1/', {
+      action: 'Updating flag',
+      forbiddenScope: 'feature_flag:write',
+      body: { active: true },
+    });
+    expect(response?.ok).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://us.posthog.com/api/projects/123/feature_flags/1/');
+    expect(init?.method).toBe('PATCH');
+    expect(JSON.parse(init?.body as string)).toEqual({ active: true });
+  });
+
+  it('throws a forbidden UserError with the named scope on 403', async () => {
+    fetchMock.mockResolvedValue(res({ ok: false, status: 403 }));
+    await expect(
+      client?.requestAsync('GET', '/feature_flags/', {
+        action: 'Looking up flag',
+        forbiddenScope: 'feature_flag:read',
+      })
+    ).rejects.toMatchObject({
+      errorCode: 'EAS_POSTHOG_FORBIDDEN',
+      message: expect.stringContaining('"feature_flag:read"'),
+    });
+  });
+
+  it('throws with the error detail on a non-2xx response', async () => {
+    fetchMock.mockResolvedValue(res({ ok: false, status: 400, json: { detail: 'nope' } }));
+    await expect(
+      client?.requestAsync('GET', '/feature_flags/', {
+        action: 'Looking up flag',
+        forbiddenScope: 'feature_flag:read',
+      })
+    ).rejects.toThrow(/Looking up flag failed with status 400: nope/);
+  });
+
+  it('throws on a network error', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNRESET'));
+    await expect(
+      client?.requestAsync('GET', '/feature_flags/', {
+        action: 'Looking up flag',
+        forbiddenScope: 'feature_flag:read',
+      })
+    ).rejects.toThrow(/Looking up flag failed\.$/);
+  });
+});
+
+describe('runQueryAsync', () => {
+  const client = PosthogClient.fromEnv({
+    apiKeyOverride: undefined,
+    projectIdOverride: undefined,
+    env: API_ENV,
+  });
+
+  it('returns the top-left cell', async () => {
+    fetchMock.mockResolvedValue(res({ json: { results: [[42]] } }));
+    await expect(client?.runQueryAsync('select 1', logger)).resolves.toBe(42);
+  });
+
+  it('throws a retryable error on a network error', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNRESET'));
+    await expect(client?.runQueryAsync('q', logger)).rejects.toBeInstanceOf(PosthogRetryableError);
+  });
+
+  it('throws a retryable error on 5xx and 429', async () => {
+    fetchMock.mockResolvedValueOnce(res({ ok: false, status: 500 }));
+    await expect(client?.runQueryAsync('q', logger)).rejects.toBeInstanceOf(PosthogRetryableError);
+    fetchMock.mockResolvedValueOnce(res({ ok: false, status: 429 }));
+    await expect(client?.runQueryAsync('q', logger)).rejects.toBeInstanceOf(PosthogRetryableError);
+  });
+
+  it('throws a retryable error on an invalid JSON body', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error('bad json');
+      },
+    } as unknown as Response);
+    await expect(client?.runQueryAsync('q', logger)).rejects.toBeInstanceOf(PosthogRetryableError);
+  });
+
+  it('returns undefined for a malformed result shape', async () => {
+    fetchMock.mockResolvedValue(res({ json: { results: 'nope' } }));
+    await expect(client?.runQueryAsync('q', logger)).resolves.toBeUndefined();
+  });
+
+  it('throws a forbidden UserError on 403', async () => {
+    fetchMock.mockResolvedValue(res({ ok: false, status: 403 }));
+    await expect(client?.runQueryAsync('q', logger)).rejects.toMatchObject({
+      errorCode: 'EAS_POSTHOG_FORBIDDEN',
+      message: expect.stringContaining('"query:read"'),
+    });
+  });
+
+  it('throws with the error detail on a non-2xx response', async () => {
+    fetchMock.mockResolvedValue(res({ ok: false, status: 400, text: 'Malformed HogQL' }));
+    await expect(client?.runQueryAsync('q', logger)).rejects.toThrow(
+      /failed with status 400: Malformed HogQL/
+    );
+  });
+});
+
+it('is a UserError subclass so the step surfaces it to the user', async () => {
+  const client = PosthogClient.fromEnv({
+    apiKeyOverride: undefined,
+    projectIdOverride: undefined,
+    env: API_ENV,
+  });
+  fetchMock.mockResolvedValue(res({ ok: false, status: 403 }));
+  await expect(client?.runQueryAsync('q', logger)).rejects.toBeInstanceOf(UserError);
+});

--- a/packages/build-tools/src/steps/utils/__tests__/PosthogClient.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/PosthogClient.test.ts
@@ -5,7 +5,7 @@ import fetch, { Response } from 'node-fetch';
 import {
   PosthogClient,
   PosthogRetryableError,
-  missingPosthogCredentialsMessage,
+  missingPosthogCredentialsError,
 } from '../PosthogClient';
 
 jest.mock('@expo/logger');
@@ -59,7 +59,7 @@ describe('PosthogClient.fromEnv', () => {
       projectIdOverride: '999',
       env: {},
     });
-    await client?.runQueryAsync('select 1', logger);
+    await client?.runQueryAsync('select 1', logger, undefined);
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe('https://us.posthog.com/api/projects/999/query/');
     expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer phx_override');
@@ -116,15 +116,15 @@ describe('PosthogClient.fromEnv', () => {
       projectIdOverride: '1',
       env: {},
     });
-    await client?.runQueryAsync('select 1', logger);
+    await client?.runQueryAsync('select 1', logger, undefined);
     expect(fetchMock.mock.calls[0][0]).toBe('https://us.posthog.com/api/projects/1/query/');
   });
 });
 
-describe(missingPosthogCredentialsMessage, () => {
+describe(missingPosthogCredentialsError, () => {
   function missingFrom(
     env: Record<string, string>
-  ): Parameters<typeof missingPosthogCredentialsMessage>[0] {
+  ): Parameters<typeof missingPosthogCredentialsError>[0] {
     const result = PosthogClient.fromEnv({
       apiKeyOverride: undefined,
       projectIdOverride: undefined,
@@ -134,13 +134,17 @@ describe(missingPosthogCredentialsMessage, () => {
   }
 
   it('names both missing credentials with their env vars and inputs', () => {
-    expect(missingPosthogCredentialsMessage(missingFrom({}))).toBe(
-      'Missing PostHog credentials: personal API key, project id. Set the environment variables (POSTHOG_CLI_API_KEY, POSTHOG_CLI_PROJECT_ID) or step inputs (api_key, project_id) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.'
-    );
+    expect(missingPosthogCredentialsError(missingFrom({}))).toMatchObject({
+      errorCode: 'EAS_POSTHOG_MISSING_CREDENTIALS',
+      message:
+        'Missing PostHog credentials: personal API key, project id. Set the environment variables (POSTHOG_CLI_API_KEY, POSTHOG_CLI_PROJECT_ID) or step inputs (api_key, project_id) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.',
+    });
   });
 
   it('names only the missing credential', () => {
-    expect(missingPosthogCredentialsMessage(missingFrom({ POSTHOG_CLI_API_KEY: 'phx' }))).toBe(
+    expect(
+      missingPosthogCredentialsError(missingFrom({ POSTHOG_CLI_API_KEY: 'phx' })).message
+    ).toBe(
       'Missing PostHog credentials: project id. Set the environment variables (POSTHOG_CLI_PROJECT_ID) or step inputs (project_id) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.'
     );
   });
@@ -269,19 +273,35 @@ describe('runQueryAsync', () => {
 
   it('returns the top-left cell', async () => {
     fetchMock.mockResolvedValue(res({ json: { results: [[42]] } }));
-    await expect(client?.runQueryAsync('select 1', logger)).resolves.toBe(42);
+    await expect(client?.runQueryAsync('select 1', logger, undefined)).resolves.toBe(42);
   });
 
   it('throws a retryable error on a network error', async () => {
     fetchMock.mockRejectedValue(new Error('ECONNRESET'));
-    await expect(client?.runQueryAsync('q', logger)).rejects.toBeInstanceOf(PosthogRetryableError);
+    await expect(client?.runQueryAsync('q', logger, undefined)).rejects.toBeInstanceOf(
+      PosthogRetryableError
+    );
+  });
+
+  it('passes the signal to fetch and propagates without retrying when aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    fetchMock.mockRejectedValue(new Error('The operation was aborted'));
+    await expect(client?.runQueryAsync('q', logger, controller.signal)).rejects.toThrow(
+      'The operation was aborted'
+    );
+    expect(fetchMock.mock.calls[0][1]?.signal).toBe(controller.signal);
   });
 
   it('throws a retryable error on 5xx and 429', async () => {
     fetchMock.mockResolvedValueOnce(res({ ok: false, status: 500 }));
-    await expect(client?.runQueryAsync('q', logger)).rejects.toBeInstanceOf(PosthogRetryableError);
+    await expect(client?.runQueryAsync('q', logger, undefined)).rejects.toBeInstanceOf(
+      PosthogRetryableError
+    );
     fetchMock.mockResolvedValueOnce(res({ ok: false, status: 429 }));
-    await expect(client?.runQueryAsync('q', logger)).rejects.toBeInstanceOf(PosthogRetryableError);
+    await expect(client?.runQueryAsync('q', logger, undefined)).rejects.toBeInstanceOf(
+      PosthogRetryableError
+    );
   });
 
   it('throws a retryable error on an invalid JSON body', async () => {
@@ -292,17 +312,19 @@ describe('runQueryAsync', () => {
         throw new Error('bad json');
       },
     } as unknown as Response);
-    await expect(client?.runQueryAsync('q', logger)).rejects.toBeInstanceOf(PosthogRetryableError);
+    await expect(client?.runQueryAsync('q', logger, undefined)).rejects.toBeInstanceOf(
+      PosthogRetryableError
+    );
   });
 
   it('returns undefined for a malformed result shape', async () => {
     fetchMock.mockResolvedValue(res({ json: { results: 'nope' } }));
-    await expect(client?.runQueryAsync('q', logger)).resolves.toBeUndefined();
+    await expect(client?.runQueryAsync('q', logger, undefined)).resolves.toBeUndefined();
   });
 
   it('throws a forbidden UserError on 403', async () => {
     fetchMock.mockResolvedValue(res({ ok: false, status: 403 }));
-    await expect(client?.runQueryAsync('q', logger)).rejects.toMatchObject({
+    await expect(client?.runQueryAsync('q', logger, undefined)).rejects.toMatchObject({
       errorCode: 'EAS_POSTHOG_FORBIDDEN',
       message: expect.stringContaining('"query:read"'),
     });
@@ -310,7 +332,7 @@ describe('runQueryAsync', () => {
 
   it('throws with the error detail on a non-2xx response', async () => {
     fetchMock.mockResolvedValue(res({ ok: false, status: 400, text: 'Malformed HogQL' }));
-    await expect(client?.runQueryAsync('q', logger)).rejects.toThrow(
+    await expect(client?.runQueryAsync('q', logger, undefined)).rejects.toThrow(
       /failed with status 400: Malformed HogQL/
     );
   });
@@ -323,5 +345,5 @@ it('is a UserError subclass so the step surfaces it to the user', async () => {
     env: API_ENV,
   });
   fetchMock.mockResolvedValue(res({ ok: false, status: 403 }));
-  await expect(client?.runQueryAsync('q', logger)).rejects.toBeInstanceOf(UserError);
+  await expect(client?.runQueryAsync('q', logger, undefined)).rejects.toBeInstanceOf(UserError);
 });

--- a/packages/build-tools/src/steps/utils/__tests__/PosthogClient.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/PosthogClient.test.ts
@@ -2,11 +2,7 @@ import { UserError } from '@expo/eas-build-job';
 import { createLogger } from '@expo/logger';
 import fetch, { Response } from 'node-fetch';
 
-import {
-  PosthogClient,
-  PosthogRetryableError,
-  missingPosthogCredentialsError,
-} from '../PosthogClient';
+import { PosthogClient, PosthogRetryableError } from '../PosthogClient';
 
 jest.mock('@expo/logger');
 jest.mock('node-fetch');
@@ -118,35 +114,6 @@ describe('PosthogClient.fromEnv', () => {
     });
     await client?.runQueryAsync('select 1', logger, undefined);
     expect(fetchMock.mock.calls[0][0]).toBe('https://us.posthog.com/api/projects/1/query/');
-  });
-});
-
-describe(missingPosthogCredentialsError, () => {
-  function missingFrom(
-    env: Record<string, string>
-  ): Parameters<typeof missingPosthogCredentialsError>[0] {
-    const result = PosthogClient.fromEnv({
-      apiKeyOverride: undefined,
-      projectIdOverride: undefined,
-      env,
-    });
-    return result.client ? [] : result.missing;
-  }
-
-  it('names both missing credentials with their env vars and inputs', () => {
-    expect(missingPosthogCredentialsError(missingFrom({}))).toMatchObject({
-      errorCode: 'EAS_POSTHOG_MISSING_CREDENTIALS',
-      message:
-        'Missing PostHog credentials: personal API key, project id. Set the environment variables (POSTHOG_CLI_API_KEY, POSTHOG_CLI_PROJECT_ID) or step inputs (api_key, project_id) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.',
-    });
-  });
-
-  it('names only the missing credential', () => {
-    expect(
-      missingPosthogCredentialsError(missingFrom({ POSTHOG_CLI_API_KEY: 'phx' })).message
-    ).toBe(
-      'Missing PostHog credentials: project id. Set the environment variables (POSTHOG_CLI_PROJECT_ID) or step inputs (project_id) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.'
-    );
   });
 });
 

--- a/packages/build-tools/src/steps/utils/__tests__/PosthogUtils.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/PosthogUtils.test.ts
@@ -54,6 +54,68 @@ describe(PosthogUtils.readErrorAsync, () => {
   });
 });
 
+describe(PosthogUtils.assertPollBoundsPositive, () => {
+  it('throws with the given error code when a bound is not positive', () => {
+    expect(() =>
+      PosthogUtils.assertPollBoundsPositive({
+        timeoutSeconds: 0,
+        intervalSeconds: 30,
+        errorCode: 'EAS_POSTHOG_TEST_INTERVAL',
+      })
+    ).toThrow(/greater than 0/);
+    expect(() =>
+      PosthogUtils.assertPollBoundsPositive({
+        timeoutSeconds: 600,
+        intervalSeconds: -1,
+        errorCode: 'EAS_POSTHOG_TEST_INTERVAL',
+      })
+    ).toThrow(/greater than 0/);
+  });
+
+  it('does nothing when both bounds are positive', () => {
+    expect(() =>
+      PosthogUtils.assertPollBoundsPositive({
+        timeoutSeconds: 600,
+        intervalSeconds: 30,
+        errorCode: 'EAS_POSTHOG_TEST_INTERVAL',
+      })
+    ).not.toThrow();
+  });
+});
+
+describe(PosthogUtils.waitForNextPollAsync, () => {
+  it('returns false without sleeping when the deadline has passed', async () => {
+    await expect(
+      PosthogUtils.waitForNextPollAsync({
+        intervalSeconds: 30,
+        deadline: Date.now() - 1,
+        signal: undefined,
+      })
+    ).resolves.toBe(false);
+  });
+
+  it('sleeps for the clamped interval and returns true when time remains', async () => {
+    await expect(
+      PosthogUtils.waitForNextPollAsync({
+        intervalSeconds: 0.01,
+        deadline: Date.now() + 1000,
+        signal: undefined,
+      })
+    ).resolves.toBe(true);
+  });
+
+  it('rejects when the signal aborts during the sleep', async () => {
+    const controller = new AbortController();
+    const promise = PosthogUtils.waitForNextPollAsync({
+      intervalSeconds: 30,
+      deadline: Date.now() + 60_000,
+      signal: controller.signal,
+    });
+    controller.abort();
+    await expect(promise).rejects.toThrow();
+  });
+});
+
 describe(PosthogUtils.failOrLogError, () => {
   it('throws the error when ignoreError is false', () => {
     const error = new Error('boom');

--- a/packages/build-tools/src/steps/utils/__tests__/PosthogUtils.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/PosthogUtils.test.ts
@@ -1,0 +1,84 @@
+import { UserError } from '@expo/eas-build-job';
+import { bunyan, createLogger } from '@expo/logger';
+import { Response } from 'node-fetch';
+
+import { failOrLogError, readErrorAsync } from '../PosthogUtils';
+
+jest.mock('@expo/logger');
+
+const logger = createLogger({ name: 'test' }) as bunyan;
+
+function errorResponse({ status, text }: { status: number; text?: string }): Response {
+  return { status, text: async () => text ?? '' } as unknown as Response;
+}
+
+describe(readErrorAsync, () => {
+  it('surfaces a JSON detail followed by the raw body', async () => {
+    await expect(
+      readErrorAsync(errorResponse({ status: 400, text: '{"detail":"boom"}' }))
+    ).resolves.toBe('status 400: boom ({"detail":"boom"})');
+  });
+
+  it('falls back to the raw body for detail-less JSON', async () => {
+    await expect(readErrorAsync(errorResponse({ status: 400, text: '{"other":1}' }))).resolves.toBe(
+      'status 400: {"other":1}'
+    );
+  });
+
+  it('ignores an empty-string detail', async () => {
+    await expect(
+      readErrorAsync(errorResponse({ status: 400, text: '{"detail":""}' }))
+    ).resolves.toBe('status 400: {"detail":""}');
+  });
+
+  it('falls back to the raw text for a non-JSON body', async () => {
+    await expect(readErrorAsync(errorResponse({ status: 502, text: 'Bad Gateway' }))).resolves.toBe(
+      'status 502: Bad Gateway'
+    );
+  });
+
+  it('uses just the status when the body is empty', async () => {
+    await expect(readErrorAsync(errorResponse({ status: 500, text: '' }))).resolves.toBe(
+      'status 500'
+    );
+  });
+
+  it('uses just the status when reading the body throws', async () => {
+    const response = {
+      status: 500,
+      text: async () => {
+        throw new Error('read fail');
+      },
+    } as unknown as Response;
+    await expect(readErrorAsync(response)).resolves.toBe('status 500');
+  });
+});
+
+describe(failOrLogError, () => {
+  it('throws the error when ignoreError is false', () => {
+    const error = new Error('boom');
+    expect(() => failOrLogError({ logger, ignoreError: false, error })).toThrow('boom');
+  });
+
+  it('warns and swallows the error when ignoreError is true', () => {
+    const warnMock = jest.spyOn(logger, 'warn');
+    const error = new Error('boom');
+
+    failOrLogError({ logger, ignoreError: true, error });
+
+    expect(warnMock).toHaveBeenCalledWith({ err: error }, 'boom Ignoring error.');
+  });
+
+  it('rethrows a forbidden error even when ignoreError is true', () => {
+    const error = new UserError('EAS_POSTHOG_FORBIDDEN', 'no scope');
+    expect(() => failOrLogError({ logger, ignoreError: true, error })).toThrow('no scope');
+  });
+
+  it('stringifies a non-Error value when swallowing', () => {
+    const warnMock = jest.spyOn(logger, 'warn');
+
+    failOrLogError({ logger, ignoreError: true, error: 'plain string' });
+
+    expect(warnMock).toHaveBeenCalledWith({ err: 'plain string' }, 'plain string Ignoring error.');
+  });
+});

--- a/packages/build-tools/src/steps/utils/__tests__/PosthogUtils.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/PosthogUtils.test.ts
@@ -54,6 +54,29 @@ describe(PosthogUtils.readErrorAsync, () => {
   });
 });
 
+describe(PosthogUtils.missingCredentialsError, () => {
+  it('names both missing credentials with their env vars and inputs', () => {
+    expect(
+      PosthogUtils.missingCredentialsError([
+        PosthogUtils.API_CREDENTIALS.apiKey,
+        PosthogUtils.API_CREDENTIALS.projectId,
+      ])
+    ).toMatchObject({
+      errorCode: 'EAS_POSTHOG_MISSING_CREDENTIALS',
+      message:
+        'Missing PostHog credentials: personal API key, project id. Set the environment variables (POSTHOG_CLI_API_KEY, POSTHOG_CLI_PROJECT_ID) or step inputs (api_key, project_id) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.',
+    });
+  });
+
+  it('names only the missing credential', () => {
+    expect(
+      PosthogUtils.missingCredentialsError([PosthogUtils.API_CREDENTIALS.projectId]).message
+    ).toBe(
+      'Missing PostHog credentials: project id. Set the environment variables (POSTHOG_CLI_PROJECT_ID) or step inputs (project_id) on EAS, or re-run "eas integrations:posthog:connect" with error tracking enabled.'
+    );
+  });
+});
+
 describe(PosthogUtils.assertPollBoundsPositive, () => {
   it('throws with the given error code when a bound is not positive', () => {
     expect(() =>

--- a/packages/build-tools/src/steps/utils/__tests__/PosthogUtils.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/PosthogUtils.test.ts
@@ -2,7 +2,7 @@ import { UserError } from '@expo/eas-build-job';
 import { bunyan, createLogger } from '@expo/logger';
 import { Response } from 'node-fetch';
 
-import { failOrLogError, readErrorAsync } from '../PosthogUtils';
+import { PosthogUtils } from '../PosthogUtils';
 
 jest.mock('@expo/logger');
 
@@ -12,35 +12,35 @@ function errorResponse({ status, text }: { status: number; text?: string }): Res
   return { status, text: async () => text ?? '' } as unknown as Response;
 }
 
-describe(readErrorAsync, () => {
+describe(PosthogUtils.readErrorAsync, () => {
   it('surfaces a JSON detail followed by the raw body', async () => {
     await expect(
-      readErrorAsync(errorResponse({ status: 400, text: '{"detail":"boom"}' }))
+      PosthogUtils.readErrorAsync(errorResponse({ status: 400, text: '{"detail":"boom"}' }))
     ).resolves.toBe('status 400: boom ({"detail":"boom"})');
   });
 
   it('falls back to the raw body for detail-less JSON', async () => {
-    await expect(readErrorAsync(errorResponse({ status: 400, text: '{"other":1}' }))).resolves.toBe(
-      'status 400: {"other":1}'
-    );
+    await expect(
+      PosthogUtils.readErrorAsync(errorResponse({ status: 400, text: '{"other":1}' }))
+    ).resolves.toBe('status 400: {"other":1}');
   });
 
   it('ignores an empty-string detail', async () => {
     await expect(
-      readErrorAsync(errorResponse({ status: 400, text: '{"detail":""}' }))
+      PosthogUtils.readErrorAsync(errorResponse({ status: 400, text: '{"detail":""}' }))
     ).resolves.toBe('status 400: {"detail":""}');
   });
 
   it('falls back to the raw text for a non-JSON body', async () => {
-    await expect(readErrorAsync(errorResponse({ status: 502, text: 'Bad Gateway' }))).resolves.toBe(
-      'status 502: Bad Gateway'
-    );
+    await expect(
+      PosthogUtils.readErrorAsync(errorResponse({ status: 502, text: 'Bad Gateway' }))
+    ).resolves.toBe('status 502: Bad Gateway');
   });
 
   it('uses just the status when the body is empty', async () => {
-    await expect(readErrorAsync(errorResponse({ status: 500, text: '' }))).resolves.toBe(
-      'status 500'
-    );
+    await expect(
+      PosthogUtils.readErrorAsync(errorResponse({ status: 500, text: '' }))
+    ).resolves.toBe('status 500');
   });
 
   it('uses just the status when reading the body throws', async () => {
@@ -50,34 +50,38 @@ describe(readErrorAsync, () => {
         throw new Error('read fail');
       },
     } as unknown as Response;
-    await expect(readErrorAsync(response)).resolves.toBe('status 500');
+    await expect(PosthogUtils.readErrorAsync(response)).resolves.toBe('status 500');
   });
 });
 
-describe(failOrLogError, () => {
+describe(PosthogUtils.failOrLogError, () => {
   it('throws the error when ignoreError is false', () => {
     const error = new Error('boom');
-    expect(() => failOrLogError({ logger, ignoreError: false, error })).toThrow('boom');
+    expect(() => PosthogUtils.failOrLogError({ logger, ignoreError: false, error })).toThrow(
+      'boom'
+    );
   });
 
   it('warns and swallows the error when ignoreError is true', () => {
     const warnMock = jest.spyOn(logger, 'warn');
     const error = new Error('boom');
 
-    failOrLogError({ logger, ignoreError: true, error });
+    PosthogUtils.failOrLogError({ logger, ignoreError: true, error });
 
     expect(warnMock).toHaveBeenCalledWith({ err: error }, 'boom Ignoring error.');
   });
 
   it('rethrows a forbidden error even when ignoreError is true', () => {
     const error = new UserError('EAS_POSTHOG_FORBIDDEN', 'no scope');
-    expect(() => failOrLogError({ logger, ignoreError: true, error })).toThrow('no scope');
+    expect(() => PosthogUtils.failOrLogError({ logger, ignoreError: true, error })).toThrow(
+      'no scope'
+    );
   });
 
   it('stringifies a non-Error value when swallowing', () => {
     const warnMock = jest.spyOn(logger, 'warn');
 
-    failOrLogError({ logger, ignoreError: true, error: 'plain string' });
+    PosthogUtils.failOrLogError({ logger, ignoreError: true, error: 'plain string' });
 
     expect(warnMock).toHaveBeenCalledWith({ err: 'plain string' }, 'plain string Ignoring error.');
   });


### PR DESCRIPTION
# Why

First PostHog workflow step: send an event from a workflow (e.g. mark a deploy).

# How

add `eas/posthog_capture_event` function; Uses the env vars `integrations:posthog:connect` already sets, or `api_key`/`host` inputs.

No `distinct_id` = anonymous event, so CI runs don't create person profiles. Failures fail the step; set `ignore_error: true` to log a warning and continue instead (same as `upload_artifact`).

# Test Plan

CI passes. Ran this workflow against a local — all three jobs green, both events visible in the project's PostHog activity (anonymous one under the `eas-workflow` person), and the ignored failure logs a warning without failing the step:

```yaml
name: PostHog capture test

jobs:
  anonymous_event:
    steps:
      - uses: eas/posthog_capture_event
        with:
          event: eas_workflow_test
          properties:
            source: coin-flip-workflow-test

  identified_event:
    steps:
      - uses: eas/posthog_capture_event
        with:
          event: eas_workflow_test_identified
          distinct_id: gwdp-local-test
          properties:
            source: coin-flip-workflow-test
            variant: identified

  ignored_failure:
    steps:
      - uses: eas/posthog_capture_event
        with:
          event: eas_workflow_test_ignored
          host: https://example.com
          ignore_error: true
```

### Workflow succeeds 
<img width="1304" height="568" alt="Screenshot 2026-07-02 at 4 51 42 PM" src="https://github.com/user-attachments/assets/9db1a478-8753-415f-b844-c0fa30c29c73" />

### Data appears on my posthog organization
<img width="2954" height="532" alt="Screenshot 2026-07-02 at 4 52 57 PM" src="https://github.com/user-attachments/assets/004beef1-2560-4121-bcb1-405b00cec299" />


