### PR TITLE
[eas-cli] Upload agent-device session artifacts

### DIFF
--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -14,6 +14,7 @@ import path from 'node:path';
 
 import { type CustomBuildContext } from '../../customBuildContext';
 import { Sentry } from '../../sentry';
+import { pollAgentDeviceArtifactsForUploadAsync } from '../utils/agentDeviceArtifacts';
 import {
   type DetachedProcessHandle,
   getDeviceRunSessionIdOrThrow,
@@ -28,7 +29,7 @@ import {
 } from '../utils/remoteDeviceRunSession';
 
 const AGENT_DEVICE_PACKAGE_NAME = 'agent-device';
-const AGENT_DEVICE_REPO_URL = 'https://github.com/callstackincubator/agent-device.git';
+const AGENT_DEVICE_REPO_URL = 'https://github.com/callstack/agent-device.git';
 const SRC_DIR = '/tmp/agent-device-src';
 const DAEMON_JSON_PATH = path.join(os.homedir(), '.agent-device', 'daemon.json');
 const STARTUP_TIMEOUT_MS = 60_000;
@@ -111,6 +112,12 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
           agentDeviceRemoteSessionToken: daemonToken,
           ...(webPreviewUrl ? { webPreviewUrl } : {}),
         },
+        logger,
+      });
+      void pollAgentDeviceArtifactsForUploadAsync(ctx, {
+        deviceRunSessionId,
+        daemonUrl: `http://127.0.0.1:${daemonPort}`,
+        daemonToken,
         logger,
       });
 

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -32,6 +32,10 @@ const AGENT_DEVICE_REPO_URL = 'https://github.com/callstackincubator/agent-devic
 const SRC_DIR = '/tmp/agent-device-src';
 const DAEMON_JSON_PATH = path.join(os.homedir(), '.agent-device', 'daemon.json');
 const STARTUP_TIMEOUT_MS = 60_000;
+const AGENT_DEVICE_DAEMON_ENV = {
+  AGENT_DEVICE_DAEMON_SERVER_MODE: 'http',
+  AGENT_DEVICE_RETAIN_ARTIFACTS: '1',
+};
 
 export function createStartAgentDeviceRemoteSessionBuildFunction(
   ctx: CustomBuildContext
@@ -144,7 +148,7 @@ async function startAgentDeviceDaemonAsync({
     return spawnDetached({
       command: 'node',
       args: [daemonPath],
-      env: { ...env, AGENT_DEVICE_DAEMON_SERVER_MODE: 'http' },
+      env: { ...env, ...AGENT_DEVICE_DAEMON_ENV },
     });
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
@@ -201,7 +205,7 @@ async function startAgentDeviceDaemonFromGitAsync({
     command: 'bun',
     args: ['run', 'src/daemon.ts'],
     cwd: SRC_DIR,
-    env: { ...env, AGENT_DEVICE_DAEMON_SERVER_MODE: 'http' },
+    env: { ...env, ...AGENT_DEVICE_DAEMON_ENV },
   });
 }
 

--- a/packages/build-tools/src/steps/utils/__tests__/agentDeviceArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/agentDeviceArtifacts.test.ts
@@ -1,0 +1,205 @@
+import { bunyan } from '@expo/logger';
+import fetch from 'node-fetch';
+import { Readable } from 'node:stream';
+
+import { CustomBuildContext } from '../../../customBuildContext';
+import { uploadDeviceRunSessionArtifactAsync } from '../deviceRunSessionArtifacts';
+import {
+  listAgentDeviceArtifactsAsync,
+  pollAgentDeviceArtifactsForUploadAsync,
+  uploadAgentDeviceArtifactAsync,
+} from '../agentDeviceArtifacts';
+
+jest.mock('../deviceRunSessionArtifacts');
+jest.mock('node-fetch');
+
+const { Response } = jest.requireActual('node-fetch') as typeof import('node-fetch');
+
+async function readStreamAsync(stream: NodeJS.ReadableStream): Promise<void> {
+  for await (const chunk of stream as Readable) {
+    void chunk;
+  }
+}
+
+async function flushPromisesAsync(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await jest.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+  }
+}
+
+function createLoggerMock(): bunyan {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as bunyan;
+}
+
+describe(listAgentDeviceArtifactsAsync, () => {
+  beforeEach(() => {
+    jest.mocked(fetch).mockReset();
+  });
+
+  it('lists agent-device artifacts with bearer auth', async () => {
+    jest.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          artifacts: [
+            {
+              id: 'artifact-id',
+              filename: 'report.json',
+              mimeType: 'application/json',
+              sizeBytes: 123,
+              createdAt: '2026-07-02T12:00:00.000Z',
+              expiresAt: '2026-07-02T12:15:00.000Z',
+            },
+          ],
+        })
+      )
+    );
+
+    const artifacts = await listAgentDeviceArtifactsAsync({
+      daemonUrl: 'http://127.0.0.1:1234',
+      daemonToken: 'daemon-token',
+    });
+
+    expect(artifacts).toEqual([
+      {
+        id: 'artifact-id',
+        filename: 'report.json',
+      },
+    ]);
+    expect(jest.mocked(fetch)).toHaveBeenCalledWith('http://127.0.0.1:1234/artifacts', {
+      headers: { Authorization: 'Bearer daemon-token' },
+    });
+  });
+
+  it('reports artifact inventory as unsupported when the daemon does not expose the endpoint', async () => {
+    jest.mocked(fetch).mockResolvedValue(new Response('Not found', { status: 404 }));
+
+    await expect(
+      listAgentDeviceArtifactsAsync({
+        daemonUrl: 'http://127.0.0.1:1234',
+        daemonToken: 'daemon-token',
+      })
+    ).rejects.toThrow('agent-device daemon does not expose artifact inventory.');
+  });
+});
+
+describe(uploadAgentDeviceArtifactAsync, () => {
+  beforeEach(() => {
+    jest.mocked(fetch).mockReset();
+    jest.mocked(uploadDeviceRunSessionArtifactAsync).mockReset();
+  });
+
+  it('downloads an agent-device artifact and uploads it as a device run session artifact', async () => {
+    const data = Buffer.from('artifact-data');
+    const logger = createLoggerMock();
+    const ctx = {} as unknown as CustomBuildContext;
+
+    jest.mocked(fetch).mockResolvedValueOnce(new Response(Readable.from([data])));
+    jest
+      .mocked(uploadDeviceRunSessionArtifactAsync)
+      .mockImplementationOnce(async (_ctx, { stream }) => {
+        await readStreamAsync(stream);
+      });
+
+    await uploadAgentDeviceArtifactAsync(ctx, {
+      deviceRunSessionId: 'drs-id',
+      daemonUrl: 'http://127.0.0.1:1234',
+      daemonToken: 'daemon-token',
+      logger,
+      artifact: {
+        id: 'artifact-id',
+        filename: 'report.json',
+      },
+    });
+
+    expect(jest.mocked(fetch)).toHaveBeenCalledWith('http://127.0.0.1:1234/artifacts/artifact-id', {
+      headers: { Authorization: 'Bearer daemon-token' },
+    });
+    expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenCalledWith(ctx, {
+      deviceRunSessionId: 'drs-id',
+      artifactId: 'artifact-id',
+      name: 'report.json (artifact-id)',
+      filename: 'report.json',
+      size: data.length,
+      stream: expect.anything(),
+    });
+  });
+});
+
+describe(pollAgentDeviceArtifactsForUploadAsync, () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.mocked(fetch).mockReset();
+    jest.mocked(uploadDeviceRunSessionArtifactAsync).mockReset();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('retries an artifact after a failed upload', async () => {
+    const data = Buffer.from('artifact-data');
+    const logger = createLoggerMock();
+    const ctx = {} as unknown as CustomBuildContext;
+    const artifact = {
+      id: 'artifact-id',
+      filename: 'report.json',
+    };
+    const listResponse = () => new Response(JSON.stringify({ artifacts: [artifact] }));
+
+    jest
+      .mocked(fetch)
+      .mockResolvedValueOnce(listResponse())
+      .mockResolvedValueOnce(new Response(Readable.from([data])))
+      .mockResolvedValueOnce(listResponse())
+      .mockResolvedValueOnce(new Response(Readable.from([data])));
+    jest
+      .mocked(uploadDeviceRunSessionArtifactAsync)
+      .mockRejectedValueOnce(new Error('upload failed'))
+      .mockImplementationOnce(async (_ctx, { stream }) => {
+        await readStreamAsync(stream);
+      });
+
+    void pollAgentDeviceArtifactsForUploadAsync(ctx, {
+      deviceRunSessionId: 'drs-id',
+      daemonUrl: 'http://127.0.0.1:1234',
+      daemonToken: 'daemon-token',
+      logger,
+    });
+
+    await flushPromisesAsync();
+    expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(5_000);
+    await flushPromisesAsync();
+
+    expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops polling when the daemon does not expose artifact inventory', async () => {
+    const logger = createLoggerMock();
+    const ctx = {} as unknown as CustomBuildContext;
+
+    jest.mocked(fetch).mockResolvedValueOnce(new Response('Not found', { status: 404 }));
+
+    await expect(
+      pollAgentDeviceArtifactsForUploadAsync(ctx, {
+        deviceRunSessionId: 'drs-id',
+        daemonUrl: 'http://127.0.0.1:1234',
+        daemonToken: 'daemon-token',
+        logger,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(jest.mocked(fetch)).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'agent-device daemon does not expose artifact inventory; remote session artifact uploads are disabled.'
+    );
+  });
+});

--- a/packages/build-tools/src/steps/utils/agentDeviceArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/agentDeviceArtifacts.ts
@@ -1,0 +1,191 @@
+import { SystemError } from '@expo/eas-build-job';
+import { type bunyan } from '@expo/logger';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { mkdtemp, rm, stat } from 'node:fs/promises';
+import fetch from 'node-fetch';
+import os from 'node:os';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { z } from 'zod';
+
+import { CustomBuildContext } from '../../customBuildContext';
+import { Sentry } from '../../sentry';
+import { formatBytes } from '../../utils/artifacts';
+import { sleepAsync } from '../../utils/retry';
+import { uploadDeviceRunSessionArtifactAsync } from './deviceRunSessionArtifacts';
+
+const AGENT_DEVICE_ARTIFACT_UPLOAD_POLL_INTERVAL_MS = 5_000;
+
+const AgentDeviceArtifactSchema = z.object({
+  id: z.string(),
+  filename: z.string(),
+});
+const AgentDeviceArtifactsListResponseSchema = z.object({
+  artifacts: z.array(AgentDeviceArtifactSchema),
+});
+
+export type AgentDeviceArtifact = z.infer<typeof AgentDeviceArtifactSchema>;
+
+class AgentDeviceArtifactsUnsupportedError extends SystemError {
+  constructor() {
+    super('agent-device daemon does not expose artifact inventory.');
+  }
+}
+
+export async function pollAgentDeviceArtifactsForUploadAsync(
+  ctx: CustomBuildContext,
+  {
+    deviceRunSessionId,
+    daemonUrl,
+    daemonToken,
+    logger,
+  }: {
+    deviceRunSessionId: string;
+    daemonUrl: string;
+    daemonToken: string;
+    logger: bunyan;
+  }
+): Promise<void> {
+  logger.info('Started polling agent-device daemon for artifacts.');
+  const uploadedArtifactIds = new Set<string>();
+  let listArtifactsErrorCount = 0;
+
+  for (;;) {
+    try {
+      const artifacts = await listAgentDeviceArtifactsAsync({ daemonUrl, daemonToken });
+      listArtifactsErrorCount = 0;
+      for (const artifact of artifacts) {
+        if (uploadedArtifactIds.has(artifact.id)) {
+          continue;
+        }
+        try {
+          await uploadAgentDeviceArtifactAsync(ctx, {
+            deviceRunSessionId,
+            daemonUrl,
+            daemonToken,
+            artifact,
+            logger,
+          });
+          uploadedArtifactIds.add(artifact.id);
+        } catch (err) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          Sentry.capture('Could not upload agent-device remote session artifact', error);
+          logger.warn({ err: error }, 'Could not upload agent-device remote session artifact.');
+        }
+      }
+    } catch (err) {
+      if (err instanceof AgentDeviceArtifactsUnsupportedError) {
+        logger.warn(
+          'agent-device daemon does not expose artifact inventory; remote session artifact uploads are disabled.'
+        );
+        return;
+      }
+      const error = err instanceof Error ? err : new Error(String(err));
+      listArtifactsErrorCount += 1;
+      if (listArtifactsErrorCount === 1 || listArtifactsErrorCount % 5 === 0) {
+        Sentry.capture('Could not list agent-device remote session artifacts', error);
+        logger.warn(
+          { err: error, failedArtifactListCount: listArtifactsErrorCount },
+          'Could not list agent-device remote session artifacts.'
+        );
+      }
+    }
+    await sleepAsync(AGENT_DEVICE_ARTIFACT_UPLOAD_POLL_INTERVAL_MS);
+  }
+}
+
+export async function listAgentDeviceArtifactsAsync({
+  daemonUrl,
+  daemonToken,
+}: {
+  daemonUrl: string;
+  daemonToken: string;
+}): Promise<AgentDeviceArtifact[]> {
+  const response = await fetch(new URL('/artifacts', daemonUrl).toString(), {
+    headers: { Authorization: `Bearer ${daemonToken}` },
+  });
+  if (response.status === 404) {
+    throw new AgentDeviceArtifactsUnsupportedError();
+  }
+  if (!response.ok) {
+    throw new SystemError(
+      `Failed to list agent-device artifacts: ${response.status} ${response.statusText}`
+    );
+  }
+  const result = AgentDeviceArtifactsListResponseSchema.safeParse(await response.json());
+  if (!result.success) {
+    throw new SystemError(`Invalid agent-device artifacts response: ${result.error.message}`);
+  }
+  return result.data.artifacts;
+}
+
+export async function uploadAgentDeviceArtifactAsync(
+  ctx: CustomBuildContext,
+  {
+    deviceRunSessionId,
+    daemonUrl,
+    daemonToken,
+    artifact,
+    logger,
+  }: {
+    deviceRunSessionId: string;
+    daemonUrl: string;
+    daemonToken: string;
+    artifact: AgentDeviceArtifact;
+    logger: bunyan;
+  }
+): Promise<void> {
+  logger.info(`Downloading artifact ${artifact.filename}.`);
+  const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), 'agent-device-artifact-'));
+  try {
+    const temporaryArtifactPath = path.join(temporaryDirectory, path.basename(artifact.filename));
+    await downloadAgentDeviceArtifactToFileAsync({
+      artifact,
+      daemonUrl,
+      daemonToken,
+      destinationPath: temporaryArtifactPath,
+    });
+    const { size } = await stat(temporaryArtifactPath);
+    logger.info(`Uploading artifact ${artifact.filename} (${formatBytes(size)}).`);
+    await uploadDeviceRunSessionArtifactAsync(ctx, {
+      deviceRunSessionId,
+      artifactId: artifact.id,
+      name: `${artifact.filename} (${artifact.id})`,
+      filename: artifact.filename,
+      size,
+      stream: createReadStream(temporaryArtifactPath),
+    });
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+async function downloadAgentDeviceArtifactToFileAsync({
+  artifact,
+  daemonUrl,
+  daemonToken,
+  destinationPath,
+}: {
+  artifact: AgentDeviceArtifact;
+  daemonUrl: string;
+  daemonToken: string;
+  destinationPath: string;
+}): Promise<void> {
+  const response = await fetch(
+    new URL(`/artifacts/${encodeURIComponent(artifact.id)}`, daemonUrl).toString(),
+    {
+      headers: { Authorization: `Bearer ${daemonToken}` },
+    }
+  );
+  if (!response.ok) {
+    throw new SystemError(
+      `Failed to download agent-device artifact ${artifact.id}: ${response.status} ${response.statusText}`
+    );
+  }
+  if (!response.body) {
+    throw new SystemError(
+      `Agent-device artifact ${artifact.id} response did not include a readable body.`
+    );
+  }
+  await pipeline(response.body, createWriteStream(destinationPath));
+}


### PR DESCRIPTION
# Why

Agent-device now exposes daemon artifact inventory and download endpoints, and EAS remote sessions should upload those artifacts to DeviceRunSession artifacts the same way Argent sessions do. This lets artifacts produced during an agent-device remote session become available through the existing EAS artifact download UI/API instead of staying only on the VM.

Release constraint: the EAS VM installs `agent-device@latest` unless `package_version` is provided. npm `agent-device@latest` is currently `0.18.2`, which predates the landed artifact endpoint changes in callstack/agent-device#1020 and callstack/agent-device#1027. This PR wires EAS CLI support, but a real run needs an agent-device release that contains those endpoints, or the step must be run with such a package version once available. If the installed daemon does not expose `/artifacts`, EAS logs once and disables artifact uploads for that session.

# How

- Start agent-device daemon with `AGENT_DEVICE_RETAIN_ARTIFACTS=1` so the local remote client and the VM uploader can both download the same artifacts.
- After the remote config is reported and the DeviceRunSession is in progress, poll the local daemon over `http://127.0.0.1:<daemonPort>/artifacts` using the daemon token, independent of the public ngrok tunnel.
- Download each new artifact by ID and upload it through the existing DeviceRunSession artifact upload helper.
- Upload artifacts sequentially per poll cycle so the poller cannot spawn unbounded simultaneous disk/network work. Successfully uploaded IDs are tracked so failed uploads can retry on the next poll.
- Update the git fallback clone URL to `https://github.com/callstack/agent-device.git`.
- Add focused tests for listing, unsupported inventory, uploading, and upload retry behavior.

# Test Plan

- `corepack yarn workspace @expo/build-tools jest-unit packages/build-tools/src/steps/utils/__tests__/agentDeviceArtifacts.test.ts packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts packages/build-tools/src/steps/utils/__tests__/deviceRunSessionArtifacts.test.ts`
- `corepack yarn oxfmt --check packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts packages/build-tools/src/steps/utils/agentDeviceArtifacts.ts packages/build-tools/src/steps/utils/__tests__/agentDeviceArtifacts.test.ts`
- `corepack yarn oxlint --type-aware --import-plugin --tsconfig ./tsconfig.oxlint.json packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts packages/build-tools/src/steps/utils/agentDeviceArtifacts.ts packages/build-tools/src/steps/utils/__tests__/agentDeviceArtifacts.test.ts`
- `corepack yarn workspace eas-cli typecheck`
- `corepack yarn workspace @expo/build-tools typecheck`
- `corepack yarn typecheck`