### PR TITLE
[build-tools] Skip embedded bundle upload for dev client builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Skip embedded bundle upload for development client builds instead of warning that the bundle is missing. ([#3940](https://github.com/expo/eas-cli/pull/3940) by [@gwdp](https://github.com/gwdp))
 - [eas-cli] Retry uploading assets that don't finish processing during `eas update`, instead of failing the update. ([#3918](https://github.com/expo/eas-cli/pull/3918) by [@gwdp](https://github.com/gwdp))
 
 ### 🧹 Chores

--- a/packages/build-tools/src/utils/__tests__/expoUpdatesEmbedded.test.ts
+++ b/packages/build-tools/src/utils/__tests__/expoUpdatesEmbedded.test.ts
@@ -32,6 +32,7 @@ function zipEntryMap(entries: Record<string, true>): Record<string, { name: stri
 function makeCtx(overrides: {
   platform: Platform;
   simulator?: boolean;
+  developmentClient?: boolean;
   channel?: string;
   env?: Record<string, string>;
 }): BuildContext<any> {
@@ -40,10 +41,12 @@ function makeCtx(overrides: {
       ? {
           platform: Platform.IOS,
           simulator: overrides.simulator ?? false,
+          developmentClient: overrides.developmentClient ?? false,
           updates: overrides.channel ? { channel: overrides.channel } : undefined,
         }
       : {
           platform: Platform.ANDROID,
+          developmentClient: overrides.developmentClient ?? false,
           updates: overrides.channel ? { channel: overrides.channel } : undefined,
         };
 
@@ -189,6 +192,20 @@ describe('uploadEmbeddedBundleAsync', () => {
     await uploadEmbeddedBundleAsync(ctx);
 
     expect(ctx.markBuildPhaseSkipped).toHaveBeenCalled();
+    expect(artifacts.findArtifacts).not.toHaveBeenCalled();
+  });
+
+  it('skips development client builds', async () => {
+    const ctx = makeCtx({
+      platform: Platform.ANDROID,
+      developmentClient: true,
+      channel: 'development',
+    });
+
+    await uploadEmbeddedBundleAsync(ctx);
+
+    expect(ctx.markBuildPhaseSkipped).toHaveBeenCalled();
+    expect(ctx.markBuildPhaseHasWarnings).not.toHaveBeenCalled();
     expect(artifacts.findArtifacts).not.toHaveBeenCalled();
   });
 

--- a/packages/build-tools/src/utils/expoUpdatesEmbedded.ts
+++ b/packages/build-tools/src/utils/expoUpdatesEmbedded.ts
@@ -18,6 +18,11 @@ export async function uploadEmbeddedBundleAsync(ctx: BuildContext<BuildJob>): Pr
     return;
   }
 
+  if (ctx.job.developmentClient) {
+    ctx.markBuildPhaseSkipped();
+    return;
+  }
+
   const { platform } = ctx.job;
   if (platform === Platform.IOS && (ctx.job as Ios.Job).simulator) {
     ctx.markBuildPhaseSkipped();


### PR DESCRIPTION
## Why

Dev client builds don't embed a bundle. We only skipped the upload for iOS simulators, so other dev builds warned about a missing bundle. This skips all dev client builds.

## Test plan

Added a unit test. CI passes.