### PR TITLE
[eas-build-job] remove unused field

### DIFF
--- a/packages/build-tools/src/steps/utils/expoUpdates.ts
+++ b/packages/build-tools/src/steps/utils/expoUpdates.ts
@@ -32,8 +32,7 @@ export async function configureEASUpdateAsync({
   appConfig: ExpoConfig;
   metadata: Metadata | null;
 }): Promise<void> {
-  const runtimeVersion =
-    inputs.runtimeVersion ?? job.version?.runtimeVersion ?? inputs.resolvedRuntimeVersion;
+  const runtimeVersion = inputs.runtimeVersion ?? inputs.resolvedRuntimeVersion;
 
   if (metadata?.runtimeVersion && metadata.runtimeVersion !== runtimeVersion) {
     logger.warn(

--- a/packages/build-tools/src/utils/expoUpdates.ts
+++ b/packages/build-tools/src/utils/expoUpdates.ts
@@ -97,15 +97,14 @@ export async function configureExpoUpdatesIfInstalledAsync(
     return;
   }
 
-  const appConfigRuntimeVersion =
-    ctx.job.version?.runtimeVersion ?? resolvedRuntime.resolvedRuntimeVersion;
+  const resolvedRuntimeVersion = resolvedRuntime.resolvedRuntimeVersion;
 
-  if (ctx.metadata?.runtimeVersion && ctx.metadata.runtimeVersion !== appConfigRuntimeVersion) {
+  if (ctx.metadata?.runtimeVersion && ctx.metadata.runtimeVersion !== resolvedRuntimeVersion) {
     ctx.logger.warn(
       `
 Runtime version mismatch:
 - Runtime version calculated on local machine: ${ctx.metadata.runtimeVersion}
-- Runtime version calculated on EAS: ${appConfigRuntimeVersion}
+- Runtime version calculated on EAS: ${resolvedRuntimeVersion}
 
 This may be due to one or more factors:
 - Differing result of conditional app config (app.config.js) evaluation for runtime version resolution.
@@ -149,11 +148,6 @@ This would cause any updates published on the local machine to not be compatible
         ctx.markBuildPhaseHasWarnings();
       }
     }
-  }
-
-  if (ctx.job.version?.runtimeVersion) {
-    ctx.logger.info('Updating runtimeVersion in Expo.plist');
-    await setRuntimeVersionNativelyAsync(ctx, ctx.job.version.runtimeVersion);
   }
 }
 

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -94,10 +94,6 @@ export interface Job {
      * support for this field is implemented, but specifying it is disabled on schema level
      */
     versionName?: string;
-    /**
-     * support for this field is implemented, but specifying it is disabled on schema level
-     */
-    runtimeVersion?: string;
   };
   buildArtifactPaths?: string[];
 

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -108,10 +108,6 @@ export interface Job {
      * support for this field is implemented, but specifying it is disabled on schema level
      */
     appVersion?: string;
-    /**
-     * support for this field is implemented, but specifying it is disabled on schema level
-     */
-    runtimeVersion?: string;
   };
   buildArtifactPaths?: string[];
 


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

As far as I can tell, this field isn't set anywhere. 

It was added in https://github.com/expo/eas-build/pull/114.

Found this while trying to investigate fingerprint rtv policy issues with @AbbanMustafa. Trying to narrow investigation surface area.

# For reviewers

If you know of any other way this could be set outside of this repo or www, let me know. As far as I can tell, graphql doesn't even accept other fields (`AndroidJobVersionInput`, for example).

# How

Remove field from types. Propagate built types to server and run tsc to ensure they're not set there. Grep in org for `version.runtimeVersion`/`version?.runtimeVersion` and search for anywhere any sub-field of `version` is set. Only places I can find only set versionCode or buildNumber:
- https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/build/ios/prepareJob.ts#L96-L98
- https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/build/android/prepareJob.ts#L101-L103

# Test Plan

tsc
