### PR TITLE
[build-tools] Wait for remote sessions to stop cleanly

### DIFF
--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -54,7 +54,7 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
     ],
-    fn: async ({ logger, global }, { inputs, env }) => {
+    fn: async ({ logger, global }, { inputs, env, signal }) => {
       // Fail fast before any expensive setup if the injected env
       // vars are missing: DEVICE_RUN_SESSION_ID (to report the remote config
       // back to the API server), EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN (base domain
@@ -126,6 +126,7 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
         ctx,
         deviceRunSessionId,
         logger,
+        signal,
       });
     },
   });

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -25,6 +25,7 @@ import {
   startNgrokTunnelAsync,
   startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
+  waitForDeviceRunSessionStoppedAsync,
   waitForFileAsync,
 } from '../utils/remoteDeviceRunSession';
 
@@ -121,10 +122,11 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
         logger,
       });
 
-      logger.info('Remote session is live. Keeping the job alive until the session is stopped.');
-      // Keep the turtle job alive so the daemon and tunnel stay reachable
-      // until stopDeviceRunSession cancels the run.
-      await new Promise<never>(() => {});
+      await waitForDeviceRunSessionStoppedAsync({
+        ctx,
+        deviceRunSessionId,
+        logger,
+      });
     },
   });
 }

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -55,7 +55,7 @@ export function createStartArgentRemoteSessionBuildFunction(
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
     ],
-    fn: async ({ logger, global }, { inputs, env }) => {
+    fn: async ({ logger, global }, { inputs, env, signal }) => {
       // Fail fast before any expensive setup if the injected env
       // vars are missing: DEVICE_RUN_SESSION_ID (to report the remote config
       // back to the API server), EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN (base domain
@@ -123,12 +123,15 @@ export function createStartArgentRemoteSessionBuildFunction(
       }
       logger.info(`Argent tool-server is listening on port ${toolServerPort}.`);
       const artifactPollAbortController = new AbortController();
+      const artifactPollSignal = signal
+        ? AbortSignal.any([signal, artifactPollAbortController.signal])
+        : artifactPollAbortController.signal;
       const artifactPollingPromise = pollArgentArtifactsForUploadAsync(ctx, {
         deviceRunSessionId,
         toolsUrl: `http://127.0.0.1:${toolServerPort}`,
         toolsAuthToken: toolServerToken,
         logger,
-        signal: artifactPollAbortController.signal,
+        signal: artifactPollSignal,
       });
 
       try {
@@ -170,6 +173,7 @@ export function createStartArgentRemoteSessionBuildFunction(
           ctx,
           deviceRunSessionId,
           logger,
+          signal,
         });
       } finally {
         artifactPollAbortController.abort();

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -24,6 +24,7 @@ import {
   startNgrokTunnelAsync,
   startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
+  waitForDeviceRunSessionStoppedAsync,
   waitForFileAsync,
 } from '../utils/remoteDeviceRunSession';
 
@@ -120,51 +121,59 @@ export function createStartArgentRemoteSessionBuildFunction(
         );
       }
       logger.info(`Argent tool-server is listening on port ${toolServerPort}.`);
-      void pollArgentArtifactsForUploadAsync(ctx, {
+      const artifactPollAbortController = new AbortController();
+      const artifactPollingPromise = pollArgentArtifactsForUploadAsync(ctx, {
         deviceRunSessionId,
         toolsUrl: `http://127.0.0.1:${toolServerPort}`,
         toolsAuthToken: toolServerToken,
         logger,
+        signal: artifactPollAbortController.signal,
       });
 
-      const publicToolsUrl = await startNgrokTunnelAsync({
-        port: toolServerPort,
-        subdomainPrefix: 'argent',
-        baseDomain: ngrokTunnelDomain,
-        authtoken: ngrokAuthtoken,
-        rewriteHostHeader: true,
-        logger,
-      });
-      logger.info(`Tunnel is ready at ${publicToolsUrl}.`);
-
-      // serve-sim is iOS-only — Android sessions go without a preview URL.
-      let webPreviewUrl: string | undefined;
-      if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
-        const serveSim = await startServeSimWithTunnelAsync(ctx, {
+      try {
+        const publicToolsUrl = await startNgrokTunnelAsync({
+          port: toolServerPort,
+          subdomainPrefix: 'argent',
           baseDomain: ngrokTunnelDomain,
-          env,
+          authtoken: ngrokAuthtoken,
+          rewriteHostHeader: true,
           logger,
-          timeoutMs: STARTUP_TIMEOUT_MS,
         });
-        webPreviewUrl = serveSim.previewUrl;
-        logger.info(`Web preview URL: ${webPreviewUrl}`);
+        logger.info(`Tunnel is ready at ${publicToolsUrl}.`);
+
+        // serve-sim is iOS-only — Android sessions go without a preview URL.
+        let webPreviewUrl: string | undefined;
+        if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
+          const serveSim = await startServeSimWithTunnelAsync(ctx, {
+            baseDomain: ngrokTunnelDomain,
+            env,
+            logger,
+            timeoutMs: STARTUP_TIMEOUT_MS,
+          });
+          webPreviewUrl = serveSim.previewUrl;
+          logger.info(`Web preview URL: ${webPreviewUrl}`);
+        }
+
+        await uploadRemoteSessionConfigAsync({
+          ctx,
+          deviceRunSessionId,
+          remoteConfig: {
+            toolsUrl: publicToolsUrl,
+            ...(toolServerToken ? { toolsAuthToken: toolServerToken } : {}),
+            ...(webPreviewUrl ? { webPreviewUrl } : {}),
+          },
+          logger,
+        });
+
+        await waitForDeviceRunSessionStoppedAsync({
+          ctx,
+          deviceRunSessionId,
+          logger,
+        });
+      } finally {
+        artifactPollAbortController.abort();
+        await artifactPollingPromise;
       }
-
-      await uploadRemoteSessionConfigAsync({
-        ctx,
-        deviceRunSessionId,
-        remoteConfig: {
-          toolsUrl: publicToolsUrl,
-          ...(toolServerToken ? { toolsAuthToken: toolServerToken } : {}),
-          ...(webPreviewUrl ? { webPreviewUrl } : {}),
-        },
-        logger,
-      });
-
-      logger.info('Remote session is live. Keeping the job alive until the session is stopped.');
-      // Keep the turtle job alive so the tool-server and tunnel stay reachable
-      // until stopDeviceRunSession cancels the run.
-      await new Promise<never>(() => {});
     },
   });
 }

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -14,6 +14,7 @@ import semver from 'semver';
 import { z } from 'zod';
 
 import { CustomBuildContext } from '../../customBuildContext';
+import { Sentry } from '../../sentry';
 import { pollArgentArtifactsForUploadAsync } from '../utils/argentArtifacts';
 import {
   getDeviceRunSessionIdOrThrow,
@@ -172,7 +173,13 @@ export function createStartArgentRemoteSessionBuildFunction(
         });
       } finally {
         artifactPollAbortController.abort();
-        await artifactPollingPromise;
+        try {
+          await artifactPollingPromise;
+        } catch (err) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          Sentry.capture('Could not finish Argent remote session artifact polling', error);
+          logger.warn({ err: error }, 'Could not finish Argent remote session artifact polling.');
+        }
       }
     },
   });

--- a/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
@@ -7,6 +7,7 @@ import {
   selectXcodeDeveloperDirectoryAsync,
   startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
+  waitForDeviceRunSessionStoppedAsync,
 } from '../utils/remoteDeviceRunSession';
 
 const STARTUP_TIMEOUT_MS = 60_000;
@@ -44,10 +45,11 @@ export function createStartServeSimRemoteSessionBuildFunction(
         logger,
       });
 
-      logger.info('Remote session is live. Keeping the job alive until the session is stopped.');
-      // Keep the turtle job alive so the serve-sim tunnel stays reachable
-      // until stopDeviceRunSession cancels the run.
-      await new Promise<never>(() => {});
+      await waitForDeviceRunSessionStoppedAsync({
+        ctx,
+        deviceRunSessionId,
+        logger,
+      });
     },
   });
 }

--- a/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
@@ -21,7 +21,7 @@ export function createStartServeSimRemoteSessionBuildFunction(
     name: 'Start serve-sim remote session',
     __metricsId: 'eas/start_serve_sim_remote_session',
     supportedRuntimePlatforms: [BuildRuntimePlatform.DARWIN],
-    fn: async ({ logger }, { env }) => {
+    fn: async ({ logger }, { env, signal }) => {
       const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
       const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
 
@@ -49,6 +49,7 @@ export function createStartServeSimRemoteSessionBuildFunction(
         ctx,
         deviceRunSessionId,
         logger,
+        signal,
       });
     },
   });

--- a/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
@@ -82,6 +82,7 @@ describe(listArgentArtifactsAsync, () => {
     ]);
     expect(jest.mocked(fetch)).toHaveBeenCalledWith('http://127.0.0.1:1234/artifacts', {
       headers: { Authorization: 'Bearer tools-token' },
+      signal: expect.any(AbortSignal),
     });
   });
 });
@@ -118,6 +119,7 @@ describe(uploadArgentArtifactAsync, () => {
 
     expect(jest.mocked(fetch)).toHaveBeenCalledWith('http://127.0.0.1:1234/artifacts/artifact-id', {
       headers: { Authorization: 'Bearer tools-token' },
+      signal: expect.any(AbortSignal),
     });
     expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenCalledWith(ctx, {
       deviceRunSessionId: 'drs-id',
@@ -273,46 +275,6 @@ describe(pollArgentArtifactsForUploadAsync, () => {
       );
     } finally {
       setTimeoutSpy.mockRestore();
-    }
-  });
-
-  it('removes the abort listener when the polling sleep times out', async () => {
-    jest.useFakeTimers();
-    const logger = createLoggerMock();
-    const ctx = {} as unknown as CustomBuildContext;
-    const abortController = new AbortController();
-    const removeEventListenerSpy = jest.spyOn(abortController.signal, 'removeEventListener');
-
-    try {
-      jest.mocked(fetch).mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            artifacts: [],
-          })
-        )
-      );
-
-      const pollingPromise = pollArgentArtifactsForUploadAsync(ctx, {
-        deviceRunSessionId: 'drs-id',
-        toolsUrl: 'http://127.0.0.1:1234',
-        toolsAuthToken: 'tools-token',
-        logger,
-        signal: abortController.signal,
-      });
-
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(jest.mocked(fetch)).toHaveBeenCalledTimes(1);
-
-      await jest.advanceTimersByTimeAsync(5_000);
-      expect(jest.mocked(fetch)).toHaveBeenCalledTimes(2);
-      expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
-
-      abortController.abort();
-      await pollingPromise;
-    } finally {
-      removeEventListenerSpy.mockRestore();
-      jest.useRealTimers();
     }
   });
 });

--- a/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
@@ -4,9 +4,14 @@ import { Readable } from 'node:stream';
 
 import { CustomBuildContext } from '../../../customBuildContext';
 import { uploadDeviceRunSessionArtifactAsync } from '../deviceRunSessionArtifacts';
-import { listArgentArtifactsAsync, uploadArgentArtifactAsync } from '../argentArtifacts';
+import {
+  listArgentArtifactsAsync,
+  pollArgentArtifactsForUploadAsync,
+  uploadArgentArtifactAsync,
+} from '../argentArtifacts';
 
 jest.mock('../deviceRunSessionArtifacts');
+jest.mock('../../../sentry');
 jest.mock('node-fetch');
 
 const { Response } = jest.requireActual('node-fetch') as typeof import('node-fetch');
@@ -15,6 +20,21 @@ async function readStreamAsync(stream: NodeJS.ReadableStream): Promise<void> {
   for await (const chunk of stream as Readable) {
     void chunk;
   }
+}
+
+async function waitForAssertionAsync(assertion: () => void): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      lastError = err;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+  }
+  throw lastError;
 }
 
 function createLoggerMock(): bunyan {
@@ -105,6 +125,89 @@ describe(uploadArgentArtifactAsync, () => {
       name: 'report.json (artifact-id)',
       filename: 'report.json',
       size: data.length,
+      stream: expect.anything(),
+    });
+  });
+});
+
+describe(pollArgentArtifactsForUploadAsync, () => {
+  beforeEach(() => {
+    jest.mocked(fetch).mockReset();
+    jest.mocked(uploadDeviceRunSessionArtifactAsync).mockReset();
+  });
+
+  it('stops polling when aborted, performs a final drain, and waits for uploads', async () => {
+    const logger = createLoggerMock();
+    const ctx = {} as unknown as CustomBuildContext;
+    const abortController = new AbortController();
+    let listCallCount = 0;
+
+    jest.mocked(fetch).mockImplementation(async url => {
+      const urlString = String(url);
+      if (urlString.endsWith('/artifacts')) {
+        listCallCount += 1;
+        return new Response(
+          JSON.stringify({
+            artifacts:
+              listCallCount === 1
+                ? [
+                    {
+                      id: 'artifact-a',
+                      filename: 'a.json',
+                      mimeType: 'application/json',
+                    },
+                  ]
+                : [
+                    {
+                      id: 'artifact-a',
+                      filename: 'a.json',
+                      mimeType: 'application/json',
+                    },
+                    {
+                      id: 'artifact-b',
+                      filename: 'b.json',
+                      mimeType: 'application/json',
+                    },
+                  ],
+          })
+        );
+      }
+      if (urlString.endsWith('/artifacts/artifact-a')) {
+        return new Response(Readable.from([Buffer.from('artifact-a-data')]));
+      }
+      if (urlString.endsWith('/artifacts/artifact-b')) {
+        return new Response(Readable.from([Buffer.from('artifact-b-data')]));
+      }
+      throw new Error(`Unexpected URL ${urlString}`);
+    });
+    jest
+      .mocked(uploadDeviceRunSessionArtifactAsync)
+      .mockImplementation(async (_ctx, { stream }) => {
+        await readStreamAsync(stream);
+      });
+
+    const pollingPromise = pollArgentArtifactsForUploadAsync(ctx, {
+      deviceRunSessionId: 'drs-id',
+      toolsUrl: 'http://127.0.0.1:1234',
+      toolsAuthToken: 'tools-token',
+      logger,
+      signal: abortController.signal,
+    });
+
+    await waitForAssertionAsync(() => {
+      expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenCalledTimes(1);
+    });
+    abortController.abort();
+    await pollingPromise;
+
+    expect(listCallCount).toBe(2);
+    expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenCalledTimes(2);
+    expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenLastCalledWith(ctx, {
+      deviceRunSessionId: 'drs-id',
+      artifactId: 'artifact-b',
+      name: 'b.json (artifact-b)',
+      filename: 'b.json',
+      size: 'artifact-b-data'.length,
       stream: expect.anything(),
     });
   });

--- a/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
@@ -211,4 +211,68 @@ describe(pollArgentArtifactsForUploadAsync, () => {
       stream: expect.anything(),
     });
   });
+
+  it('throws when pending uploads do not finish before the cleanup timeout', async () => {
+    const logger = createLoggerMock();
+    const ctx = {} as unknown as CustomBuildContext;
+    const abortController = new AbortController();
+    const originalSetTimeout = global.setTimeout;
+    const setTimeoutSpy = jest
+      .spyOn(global, 'setTimeout')
+      .mockImplementation(((
+        callback: Parameters<typeof setTimeout>[0],
+        timeout?: number,
+        ...args: unknown[]
+      ) =>
+        originalSetTimeout(
+          callback,
+          timeout === 30_000 ? 0 : timeout,
+          ...args
+        )) as typeof setTimeout);
+
+    try {
+      jest.mocked(fetch).mockImplementation(async url => {
+        const urlString = String(url);
+        if (urlString.endsWith('/artifacts')) {
+          return new Response(
+            JSON.stringify({
+              artifacts: [
+                {
+                  id: 'artifact-a',
+                  filename: 'a.json',
+                  mimeType: 'application/json',
+                },
+              ],
+            })
+          );
+        }
+        if (urlString.endsWith('/artifacts/artifact-a')) {
+          return new Response(Readable.from([Buffer.from('artifact-a-data')]));
+        }
+        throw new Error(`Unexpected URL ${urlString}`);
+      });
+      jest
+        .mocked(uploadDeviceRunSessionArtifactAsync)
+        .mockImplementation(() => new Promise<void>(() => {}));
+
+      const pollingPromise = pollArgentArtifactsForUploadAsync(ctx, {
+        deviceRunSessionId: 'drs-id',
+        toolsUrl: 'http://127.0.0.1:1234',
+        toolsAuthToken: 'tools-token',
+        logger,
+        signal: abortController.signal,
+      });
+
+      await waitForAssertionAsync(() => {
+        expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenCalledTimes(1);
+      });
+      abortController.abort();
+
+      await expect(pollingPromise).rejects.toThrow(
+        'Timed out after 30s waiting for Argent artifact uploads.'
+      );
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
 });

--- a/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
@@ -275,4 +275,44 @@ describe(pollArgentArtifactsForUploadAsync, () => {
       setTimeoutSpy.mockRestore();
     }
   });
+
+  it('removes the abort listener when the polling sleep times out', async () => {
+    jest.useFakeTimers();
+    const logger = createLoggerMock();
+    const ctx = {} as unknown as CustomBuildContext;
+    const abortController = new AbortController();
+    const removeEventListenerSpy = jest.spyOn(abortController.signal, 'removeEventListener');
+
+    try {
+      jest.mocked(fetch).mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            artifacts: [],
+          })
+        )
+      );
+
+      const pollingPromise = pollArgentArtifactsForUploadAsync(ctx, {
+        deviceRunSessionId: 'drs-id',
+        toolsUrl: 'http://127.0.0.1:1234',
+        toolsAuthToken: 'tools-token',
+        logger,
+        signal: abortController.signal,
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(jest.mocked(fetch)).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(5_000);
+      expect(jest.mocked(fetch)).toHaveBeenCalledTimes(2);
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+
+      abortController.abort();
+      await pollingPromise;
+    } finally {
+      removeEventListenerSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
 });

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -36,7 +36,11 @@ function createCtxMock(): CustomBuildContext {
 }
 
 function createStatusCtxMock(
-  results: ({ status: 'NEW' | 'IN_PROGRESS' | 'STOPPED' | 'ERRORED' } | { error: Error })[]
+  results: (
+    | { status: 'NEW' | 'IN_PROGRESS' | 'STOPPED' | 'ERRORED' }
+    | { error: Error }
+    | { data: unknown }
+  )[]
 ): CustomBuildContext {
   const query = jest.fn(() => {
     const result = results.shift();
@@ -47,6 +51,9 @@ function createStatusCtxMock(
       toPromise: async () => {
         if ('error' in result) {
           throw result.error;
+        }
+        if ('data' in result) {
+          return { data: result.data };
         }
         return {
           data: {
@@ -241,6 +248,33 @@ describe(waitForDeviceRunSessionStoppedAsync, () => {
     expect(jest.mocked(Sentry).capture).toHaveBeenCalledWith(
       'Could not poll device run session status',
       expect.any(Error),
+      { level: 'warning' }
+    );
+  });
+
+  it('logs and retries when the status response is missing', async () => {
+    const ctx = createStatusCtxMock([
+      { data: { deviceRunSessions: { byId: null } } },
+      { status: 'STOPPED' },
+    ]);
+    const logger = createLoggerMock();
+
+    await waitForDeviceRunSessionStoppedAsync({
+      ctx,
+      deviceRunSessionId: 'drs-id',
+      logger,
+    });
+
+    expect(ctx.graphqlClient.query).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ failedStatusPollCount: 1 }),
+      'Could not poll device run session status; will retry.'
+    );
+    expect(jest.mocked(Sentry).capture).toHaveBeenCalledWith(
+      'Could not poll device run session status',
+      expect.objectContaining({
+        message: 'Device run session drs-id status response was missing.',
+      }),
       { level: 'warning' }
     );
   });

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -1,18 +1,18 @@
 import { bunyan } from '@expo/logger';
 import { BuildStepEnv } from '@expo/steps';
+import { setTimeout as setTimeoutAsync } from 'node:timers/promises';
 
 import { CustomBuildContext } from '../../../customBuildContext';
 import { Sentry } from '../../../sentry';
 import { turtleFetch } from '../../../utils/turtleFetch';
-import { sleepAsync } from '../../../utils/retry';
 import {
   fetchServeSimTurnArgsAsync,
   turnIceServersToServeSimArgs,
   waitForDeviceRunSessionStoppedAsync,
 } from '../remoteDeviceRunSession';
 
+jest.mock('node:timers/promises');
 jest.mock('../../../utils/turtleFetch');
-jest.mock('../../../utils/retry');
 jest.mock('../../../sentry');
 
 function createLoggerMock(): bunyan {
@@ -200,8 +200,8 @@ describe(fetchServeSimTurnArgsAsync, () => {
 describe(waitForDeviceRunSessionStoppedAsync, () => {
   beforeEach(() => {
     jest.mocked(Sentry).capture.mockReset();
-    jest.mocked(sleepAsync).mockReset();
-    jest.mocked(sleepAsync).mockResolvedValue(undefined);
+    jest.mocked(setTimeoutAsync).mockReset();
+    jest.mocked(setTimeoutAsync).mockResolvedValue(undefined);
   });
 
   it('continues polling until the device run session is stopped', async () => {

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -4,12 +4,15 @@ import { BuildStepEnv } from '@expo/steps';
 import { CustomBuildContext } from '../../../customBuildContext';
 import { Sentry } from '../../../sentry';
 import { turtleFetch } from '../../../utils/turtleFetch';
+import { sleepAsync } from '../../../utils/retry';
 import {
   fetchServeSimTurnArgsAsync,
   turnIceServersToServeSimArgs,
+  waitForDeviceRunSessionStoppedAsync,
 } from '../remoteDeviceRunSession';
 
 jest.mock('../../../utils/turtleFetch');
+jest.mock('../../../utils/retry');
 jest.mock('../../../sentry');
 
 function createLoggerMock(): bunyan {
@@ -28,6 +31,40 @@ function createCtxMock(): CustomBuildContext {
     },
     job: {
       secrets: { robotAccessToken: 'robot-token' },
+    },
+  } as unknown as CustomBuildContext;
+}
+
+function createStatusCtxMock(
+  results: ({ status: 'NEW' | 'IN_PROGRESS' | 'STOPPED' | 'ERRORED' } | { error: Error })[]
+): CustomBuildContext {
+  const query = jest.fn(() => {
+    const result = results.shift();
+    if (!result) {
+      throw new Error('No mocked status result available');
+    }
+    return {
+      toPromise: async () => {
+        if ('error' in result) {
+          throw result.error;
+        }
+        return {
+          data: {
+            deviceRunSessions: {
+              byId: {
+                id: 'drs-id',
+                status: result.status,
+              },
+            },
+          },
+        };
+      },
+    };
+  });
+
+  return {
+    graphqlClient: {
+      query,
     },
   } as unknown as CustomBuildContext;
 }
@@ -150,5 +187,61 @@ describe(fetchServeSimTurnArgsAsync, () => {
     expect(args).toEqual([]);
     expect(logger.warn).toHaveBeenCalled();
     expect(jest.mocked(Sentry).capture).toHaveBeenCalled();
+  });
+});
+
+describe(waitForDeviceRunSessionStoppedAsync, () => {
+  beforeEach(() => {
+    jest.mocked(Sentry).capture.mockReset();
+    jest.mocked(sleepAsync).mockReset();
+    jest.mocked(sleepAsync).mockResolvedValue(undefined);
+  });
+
+  it('continues polling until the device run session is stopped', async () => {
+    const ctx = createStatusCtxMock([{ status: 'IN_PROGRESS' }, { status: 'STOPPED' }]);
+    const logger = createLoggerMock();
+
+    await waitForDeviceRunSessionStoppedAsync({
+      ctx,
+      deviceRunSessionId: 'drs-id',
+      logger,
+    });
+
+    expect(ctx.graphqlClient.query).toHaveBeenCalledTimes(2);
+    expect(logger.info).toHaveBeenCalledWith('Device run session drs-id was stopped.');
+  });
+
+  it('throws when the device run session errors', async () => {
+    const ctx = createStatusCtxMock([{ status: 'ERRORED' }]);
+
+    await expect(
+      waitForDeviceRunSessionStoppedAsync({
+        ctx,
+        deviceRunSessionId: 'drs-id',
+        logger: createLoggerMock(),
+      })
+    ).rejects.toThrow('Device run session drs-id errored.');
+  });
+
+  it('logs and retries transient polling errors', async () => {
+    const ctx = createStatusCtxMock([{ error: new Error('network down') }, { status: 'STOPPED' }]);
+    const logger = createLoggerMock();
+
+    await waitForDeviceRunSessionStoppedAsync({
+      ctx,
+      deviceRunSessionId: 'drs-id',
+      logger,
+    });
+
+    expect(ctx.graphqlClient.query).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ failedStatusPollCount: 1 }),
+      'Could not poll device run session status; will retry.'
+    );
+    expect(jest.mocked(Sentry).capture).toHaveBeenCalledWith(
+      'Could not poll device run session status',
+      expect.any(Error),
+      { level: 'warning' }
+    );
   });
 });

--- a/packages/build-tools/src/steps/utils/argentArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/argentArtifacts.ts
@@ -83,6 +83,10 @@ export async function pollArgentArtifactsForUploadAsync(
       listArtifactsErrorCount = 0;
       return artifacts;
     } catch (err) {
+      if (signal?.aborted) {
+        return [];
+      }
+
       const error = err instanceof Error ? err : new Error(String(err));
       listArtifactsErrorCount += 1;
       if (listArtifactsErrorCount === 1 || listArtifactsErrorCount % 5 === 0) {
@@ -202,10 +206,6 @@ async function downloadArgentArtifactToFileAsync({
 }): Promise<void> {
   const response = await fetch(new URL(`/artifacts/${artifact.id}`, toolsUrl).toString(), {
     headers: toolsAuthToken ? { Authorization: `Bearer ${toolsAuthToken}` } : {},
-    signal: createTimeoutSignal({
-      signal: undefined,
-      timeoutMs: ARGENT_ARTIFACT_FETCH_TIMEOUT_MS,
-    }),
   });
   if (!response.ok) {
     throw new SystemError(

--- a/packages/build-tools/src/steps/utils/argentArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/argentArtifacts.ts
@@ -71,13 +71,11 @@ export async function pollArgentArtifactsForUploadAsync(
     });
   };
 
-  const listAndQueueArtifactUploadsAsync = async (): Promise<void> => {
+  const listArtifactsForUploadAsync = async (): Promise<ArgentArtifact[]> => {
     try {
       const artifacts = await listArgentArtifactsAsync({ toolsUrl, toolsAuthToken });
       listArtifactsErrorCount = 0;
-      for (const artifact of artifacts) {
-        queueArtifactUpload(artifact);
-      }
+      return artifacts;
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       listArtifactsErrorCount += 1;
@@ -88,6 +86,14 @@ export async function pollArgentArtifactsForUploadAsync(
           'Could not list Argent remote session artifacts.'
         );
       }
+      return [];
+    }
+  };
+
+  const listAndQueueArtifactUploadsAsync = async (): Promise<void> => {
+    const artifacts = await listArtifactsForUploadAsync();
+    for (const artifact of artifacts) {
+      queueArtifactUpload(artifact);
     }
   };
 

--- a/packages/build-tools/src/steps/utils/argentArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/argentArtifacts.ts
@@ -6,6 +6,7 @@ import fetch from 'node-fetch';
 import os from 'node:os';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
+import { setTimeout as setTimeoutAsync } from 'node:timers/promises';
 import { z } from 'zod';
 
 import { CustomBuildContext } from '../../customBuildContext';
@@ -15,6 +16,7 @@ import { uploadDeviceRunSessionArtifactAsync } from './deviceRunSessionArtifacts
 
 const ARGENT_ARTIFACT_UPLOAD_POLL_INTERVAL_MS = 5_000;
 const ARGENT_ARTIFACT_UPLOAD_CLEANUP_TIMEOUT_MS = 30_000;
+const ARGENT_ARTIFACT_FETCH_TIMEOUT_MS = 10_000;
 
 const ArgentArtifactSchema = z.object({
   id: z.string(),
@@ -71,9 +73,13 @@ export async function pollArgentArtifactsForUploadAsync(
     });
   };
 
-  const listArtifactsForUploadAsync = async (): Promise<ArgentArtifact[]> => {
+  const listArtifactsForUploadAsync = async ({
+    signal,
+  }: {
+    signal?: AbortSignal;
+  } = {}): Promise<ArgentArtifact[]> => {
     try {
-      const artifacts = await listArgentArtifactsAsync({ toolsUrl, toolsAuthToken });
+      const artifacts = await listArgentArtifactsAsync({ toolsUrl, toolsAuthToken, signal });
       listArtifactsErrorCount = 0;
       return artifacts;
     } catch (err) {
@@ -90,15 +96,19 @@ export async function pollArgentArtifactsForUploadAsync(
     }
   };
 
-  const listAndQueueArtifactUploadsAsync = async (): Promise<void> => {
-    const artifacts = await listArtifactsForUploadAsync();
+  const listAndQueueArtifactUploadsAsync = async ({
+    signal,
+  }: {
+    signal?: AbortSignal;
+  } = {}): Promise<void> => {
+    const artifacts = await listArtifactsForUploadAsync({ signal });
     for (const artifact of artifacts) {
       queueArtifactUpload(artifact);
     }
   };
 
   while (!signal.aborted) {
-    await listAndQueueArtifactUploadsAsync();
+    await listAndQueueArtifactUploadsAsync({ signal });
     await sleepUntilAbortedAsync(ARGENT_ARTIFACT_UPLOAD_POLL_INTERVAL_MS, signal);
   }
 
@@ -114,12 +124,15 @@ export async function pollArgentArtifactsForUploadAsync(
 export async function listArgentArtifactsAsync({
   toolsUrl,
   toolsAuthToken,
+  signal,
 }: {
   toolsUrl: string;
   toolsAuthToken?: string;
+  signal?: AbortSignal;
 }): Promise<ArgentArtifact[]> {
   const response = await fetch(new URL('/artifacts', toolsUrl).toString(), {
     headers: toolsAuthToken ? { Authorization: `Bearer ${toolsAuthToken}` } : {},
+    signal: createTimeoutSignal({ signal, timeoutMs: ARGENT_ARTIFACT_FETCH_TIMEOUT_MS }),
   });
   if (!response.ok) {
     throw new SystemError(
@@ -189,6 +202,10 @@ async function downloadArgentArtifactToFileAsync({
 }): Promise<void> {
   const response = await fetch(new URL(`/artifacts/${artifact.id}`, toolsUrl).toString(), {
     headers: toolsAuthToken ? { Authorization: `Bearer ${toolsAuthToken}` } : {},
+    signal: createTimeoutSignal({
+      signal: undefined,
+      timeoutMs: ARGENT_ARTIFACT_FETCH_TIMEOUT_MS,
+    }),
   });
   if (!response.ok) {
     throw new SystemError(
@@ -204,30 +221,24 @@ async function downloadArgentArtifactToFileAsync({
 }
 
 async function sleepUntilAbortedAsync(timeoutMs: number, signal: AbortSignal): Promise<void> {
-  if (signal.aborted) {
-    return;
-  }
-  await new Promise<void>(resolve => {
-    let timeout: NodeJS.Timeout | undefined;
-    let settled = false;
-    const finish = (): void => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-      signal.removeEventListener('abort', finish);
-      resolve();
-    };
-    signal.addEventListener('abort', finish, { once: true });
-    if (signal.aborted) {
-      finish();
-      return;
+  try {
+    await setTimeoutAsync(timeoutMs, undefined, { signal });
+  } catch (err) {
+    if (!signal.aborted) {
+      throw err;
     }
-    timeout = setTimeout(finish, timeoutMs);
-  });
+  }
+}
+
+function createTimeoutSignal({
+  signal,
+  timeoutMs,
+}: {
+  signal: AbortSignal | undefined;
+  timeoutMs: number;
+}): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 }
 
 async function waitForPendingUploadsAsync({

--- a/packages/build-tools/src/steps/utils/argentArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/argentArtifacts.ts
@@ -206,6 +206,10 @@ async function downloadArgentArtifactToFileAsync({
 }): Promise<void> {
   const response = await fetch(new URL(`/artifacts/${artifact.id}`, toolsUrl).toString(), {
     headers: toolsAuthToken ? { Authorization: `Bearer ${toolsAuthToken}` } : {},
+    signal: createTimeoutSignal({
+      signal: undefined,
+      timeoutMs: ARGENT_ARTIFACT_FETCH_TIMEOUT_MS,
+    }),
   });
   if (!response.ok) {
     throw new SystemError(

--- a/packages/build-tools/src/steps/utils/argentArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/argentArtifacts.ts
@@ -11,10 +11,10 @@ import { z } from 'zod';
 import { CustomBuildContext } from '../../customBuildContext';
 import { Sentry } from '../../sentry';
 import { formatBytes } from '../../utils/artifacts';
-import { sleepAsync } from '../../utils/retry';
 import { uploadDeviceRunSessionArtifactAsync } from './deviceRunSessionArtifacts';
 
 const ARGENT_ARTIFACT_UPLOAD_POLL_INTERVAL_MS = 5_000;
+const ARGENT_ARTIFACT_UPLOAD_CLEANUP_TIMEOUT_MS = 30_000;
 
 const ArgentArtifactSchema = z.object({
   id: z.string(),
@@ -35,37 +35,48 @@ export async function pollArgentArtifactsForUploadAsync(
     toolsUrl,
     toolsAuthToken,
     logger,
+    signal,
   }: {
     deviceRunSessionId: string;
     toolsUrl: string;
     toolsAuthToken?: string;
     logger: bunyan;
+    signal: AbortSignal;
   }
-): Promise<never> {
+): Promise<void> {
   logger.info('Started polling Argent tool-server for artifacts.');
   const seenArtifactIds = new Set<string>();
+  const pendingUploads = new Set<Promise<void>>();
   let listArtifactsErrorCount = 0;
 
-  for (;;) {
+  const queueArtifactUpload = (artifact: ArgentArtifact): void => {
+    if (seenArtifactIds.has(artifact.id)) {
+      return;
+    }
+    seenArtifactIds.add(artifact.id);
+    const uploadPromise = uploadArgentArtifactAsync(ctx, {
+      deviceRunSessionId,
+      toolsUrl,
+      toolsAuthToken,
+      artifact,
+      logger,
+    }).catch(err => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      Sentry.capture('Could not upload Argent remote session artifact', error);
+      logger.warn({ err: error }, 'Could not upload Argent remote session artifact.');
+    });
+    pendingUploads.add(uploadPromise);
+    void uploadPromise.finally(() => {
+      pendingUploads.delete(uploadPromise);
+    });
+  };
+
+  const listAndQueueArtifactUploadsAsync = async (): Promise<void> => {
     try {
       const artifacts = await listArgentArtifactsAsync({ toolsUrl, toolsAuthToken });
       listArtifactsErrorCount = 0;
       for (const artifact of artifacts) {
-        if (seenArtifactIds.has(artifact.id)) {
-          continue;
-        }
-        seenArtifactIds.add(artifact.id);
-        void uploadArgentArtifactAsync(ctx, {
-          deviceRunSessionId,
-          toolsUrl,
-          toolsAuthToken,
-          artifact,
-          logger,
-        }).catch(err => {
-          const error = err instanceof Error ? err : new Error(String(err));
-          Sentry.capture('Could not upload Argent remote session artifact', error);
-          logger.warn({ err: error }, 'Could not upload Argent remote session artifact.');
-        });
+        queueArtifactUpload(artifact);
       }
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
@@ -78,8 +89,20 @@ export async function pollArgentArtifactsForUploadAsync(
         );
       }
     }
-    await sleepAsync(ARGENT_ARTIFACT_UPLOAD_POLL_INTERVAL_MS);
+  };
+
+  while (!signal.aborted) {
+    await listAndQueueArtifactUploadsAsync();
+    await sleepUntilAbortedAsync(ARGENT_ARTIFACT_UPLOAD_POLL_INTERVAL_MS, signal);
   }
+
+  logger.info('Argent artifact polling stopped; draining remaining artifacts.');
+  await listAndQueueArtifactUploadsAsync();
+  await waitForPendingUploadsAsync({
+    pendingUploads,
+    timeoutMs: ARGENT_ARTIFACT_UPLOAD_CLEANUP_TIMEOUT_MS,
+    logger,
+  });
 }
 
 export async function listArgentArtifactsAsync({
@@ -172,4 +195,52 @@ async function downloadArgentArtifactToFileAsync({
     );
   }
   await pipeline(response.body, createWriteStream(destinationPath));
+}
+
+async function sleepUntilAbortedAsync(timeoutMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return;
+  }
+  await new Promise<void>(resolve => {
+    const timeout = setTimeout(resolve, timeoutMs);
+    signal.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true }
+    );
+  });
+}
+
+async function waitForPendingUploadsAsync({
+  pendingUploads,
+  timeoutMs,
+  logger,
+}: {
+  pendingUploads: Set<Promise<void>>;
+  timeoutMs: number;
+  logger: bunyan;
+}): Promise<void> {
+  if (pendingUploads.size === 0) {
+    return;
+  }
+
+  logger.info(`Waiting for ${pendingUploads.size} Argent artifact upload(s) to finish.`);
+  let timeout: NodeJS.Timeout | undefined;
+  const result = await Promise.race([
+    Promise.allSettled([...pendingUploads]).then(() => 'settled' as const),
+    new Promise<'timeout'>(resolve => {
+      timeout = setTimeout(() => resolve('timeout'), timeoutMs);
+    }),
+  ]);
+  if (timeout) {
+    clearTimeout(timeout);
+  }
+  if (result === 'timeout') {
+    logger.warn(
+      `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for Argent artifact uploads; continuing shutdown.`
+    );
+  }
 }

--- a/packages/build-tools/src/steps/utils/argentArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/argentArtifacts.ts
@@ -71,13 +71,11 @@ export async function pollArgentArtifactsForUploadAsync(
     });
   };
 
-  const listAndQueueArtifactUploadsAsync = async (): Promise<void> => {
+  const listArtifactsForUploadAsync = async (): Promise<ArgentArtifact[]> => {
     try {
       const artifacts = await listArgentArtifactsAsync({ toolsUrl, toolsAuthToken });
       listArtifactsErrorCount = 0;
-      for (const artifact of artifacts) {
-        queueArtifactUpload(artifact);
-      }
+      return artifacts;
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       listArtifactsErrorCount += 1;
@@ -88,6 +86,14 @@ export async function pollArgentArtifactsForUploadAsync(
           'Could not list Argent remote session artifacts.'
         );
       }
+      return [];
+    }
+  };
+
+  const listAndQueueArtifactUploadsAsync = async (): Promise<void> => {
+    const artifacts = await listArtifactsForUploadAsync();
+    for (const artifact of artifacts) {
+      queueArtifactUpload(artifact);
     }
   };
 
@@ -202,15 +208,25 @@ async function sleepUntilAbortedAsync(timeoutMs: number, signal: AbortSignal): P
     return;
   }
   await new Promise<void>(resolve => {
-    const timeout = setTimeout(resolve, timeoutMs);
-    signal.addEventListener(
-      'abort',
-      () => {
+    let timeout: NodeJS.Timeout | undefined;
+    let settled = false;
+    const finish = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeout) {
         clearTimeout(timeout);
-        resolve();
-      },
-      { once: true }
-    );
+      }
+      signal.removeEventListener('abort', finish);
+      resolve();
+    };
+    signal.addEventListener('abort', finish, { once: true });
+    if (signal.aborted) {
+      finish();
+      return;
+    }
+    timeout = setTimeout(finish, timeoutMs);
   });
 }
 

--- a/packages/build-tools/src/steps/utils/argentArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/argentArtifacts.ts
@@ -71,11 +71,13 @@ export async function pollArgentArtifactsForUploadAsync(
     });
   };
 
-  const listArtifactsForUploadAsync = async (): Promise<ArgentArtifact[]> => {
+  const listAndQueueArtifactUploadsAsync = async (): Promise<void> => {
     try {
       const artifacts = await listArgentArtifactsAsync({ toolsUrl, toolsAuthToken });
       listArtifactsErrorCount = 0;
-      return artifacts;
+      for (const artifact of artifacts) {
+        queueArtifactUpload(artifact);
+      }
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       listArtifactsErrorCount += 1;
@@ -86,14 +88,6 @@ export async function pollArgentArtifactsForUploadAsync(
           'Could not list Argent remote session artifacts.'
         );
       }
-      return [];
-    }
-  };
-
-  const listAndQueueArtifactUploadsAsync = async (): Promise<void> => {
-    const artifacts = await listArtifactsForUploadAsync();
-    for (const artifact of artifacts) {
-      queueArtifactUpload(artifact);
     }
   };
 
@@ -242,7 +236,10 @@ async function waitForPendingUploadsAsync({
         timeout = setTimeout(() => {
           reject(
             new SystemError(
-              `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for Argent artifact uploads.`
+              `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for Argent artifact uploads.`,
+              {
+                trackingCode: 'SIMULATOR_ARTIFACT_SLOW_UPLOAD',
+              }
             )
           );
         }, timeoutMs);

--- a/packages/build-tools/src/steps/utils/argentArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/argentArtifacts.ts
@@ -229,18 +229,22 @@ async function waitForPendingUploadsAsync({
 
   logger.info(`Waiting for ${pendingUploads.size} Argent artifact upload(s) to finish.`);
   let timeout: NodeJS.Timeout | undefined;
-  const result = await Promise.race([
-    Promise.allSettled([...pendingUploads]).then(() => 'settled' as const),
-    new Promise<'timeout'>(resolve => {
-      timeout = setTimeout(() => resolve('timeout'), timeoutMs);
-    }),
-  ]);
-  if (timeout) {
-    clearTimeout(timeout);
-  }
-  if (result === 'timeout') {
-    logger.warn(
-      `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for Argent artifact uploads; continuing shutdown.`
-    );
+  try {
+    await Promise.race([
+      Promise.allSettled([...pendingUploads]),
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          reject(
+            new SystemError(
+              `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for Argent artifact uploads.`
+            )
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
   }
 }

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -132,7 +132,10 @@ export async function waitForDeviceRunSessionStoppedAsync({
         throw result.error;
       }
 
-      const status = result.data?.deviceRunSessions.byId.status;
+      const status = result.data?.deviceRunSessions?.byId?.status;
+      if (!status) {
+        throw new Error(`Device run session ${deviceRunSessionId} status response was missing.`);
+      }
       pollErrorCount = 0;
       if (status === 'STOPPED') {
         logger.info(`Device run session ${deviceRunSessionId} was stopped.`);

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -8,6 +8,7 @@ import nullthrows from 'nullthrows';
 import { z } from 'zod';
 import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
+import { setTimeout as setTimeoutAsync } from 'node:timers/promises';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import { Sentry } from '../../sentry';
@@ -113,17 +114,19 @@ export async function waitForDeviceRunSessionStoppedAsync({
   ctx,
   deviceRunSessionId,
   logger,
+  signal,
 }: {
   ctx: CustomBuildContext;
   deviceRunSessionId: string;
   logger: bunyan;
+  signal?: AbortSignal;
 }): Promise<void> {
   logger.info(
     `Remote session is live. Polling device run session ${deviceRunSessionId} until it is stopped.`
   );
   let pollErrorCount = 0;
 
-  for (;;) {
+  while (!signal?.aborted) {
     try {
       const result = await ctx.graphqlClient
         .query(DEVICE_RUN_SESSION_STATUS_QUERY, { deviceRunSessionId })
@@ -159,7 +162,20 @@ export async function waitForDeviceRunSessionStoppedAsync({
         );
       }
     }
-    await sleepAsync(DEVICE_RUN_SESSION_STATUS_POLL_INTERVAL_MS);
+    await sleepUntilAbortedAsync(DEVICE_RUN_SESSION_STATUS_POLL_INTERVAL_MS, signal);
+  }
+}
+
+async function sleepUntilAbortedAsync(
+  timeoutMs: number,
+  signal: AbortSignal | undefined
+): Promise<void> {
+  try {
+    await setTimeoutAsync(timeoutMs, undefined, signal ? { signal } : undefined);
+  } catch (err) {
+    if (!signal?.aborted) {
+      throw err;
+    }
   }
 }
 

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -30,6 +30,19 @@ const START_DEVICE_RUN_SESSION_MUTATION = graphql(`
   }
 `);
 
+const DEVICE_RUN_SESSION_STATUS_QUERY = graphql(`
+  query DeviceRunSessionStatus($deviceRunSessionId: ID!) {
+    deviceRunSessions {
+      byId(deviceRunSessionId: $deviceRunSessionId) {
+        id
+        status
+      }
+    }
+  }
+`);
+
+const DEVICE_RUN_SESSION_STATUS_POLL_INTERVAL_MS = 5_000;
+
 export function getDeviceRunSessionIdOrThrow(env: BuildStepEnv): string {
   const deviceRunSessionId = env.DEVICE_RUN_SESSION_ID;
   if (!deviceRunSessionId) {
@@ -94,6 +107,57 @@ export async function selectXcodeDeveloperDirectoryAsync({
     logger,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+}
+
+export async function waitForDeviceRunSessionStoppedAsync({
+  ctx,
+  deviceRunSessionId,
+  logger,
+}: {
+  ctx: CustomBuildContext;
+  deviceRunSessionId: string;
+  logger: bunyan;
+}): Promise<void> {
+  logger.info(
+    `Remote session is live. Polling device run session ${deviceRunSessionId} until it is stopped.`
+  );
+  let pollErrorCount = 0;
+
+  for (;;) {
+    try {
+      const result = await ctx.graphqlClient
+        .query(DEVICE_RUN_SESSION_STATUS_QUERY, { deviceRunSessionId })
+        .toPromise();
+      if (result.error) {
+        throw result.error;
+      }
+
+      const status = result.data?.deviceRunSessions.byId.status;
+      pollErrorCount = 0;
+      if (status === 'STOPPED') {
+        logger.info(`Device run session ${deviceRunSessionId} was stopped.`);
+        return;
+      }
+      if (status === 'ERRORED') {
+        throw new SystemError(`Device run session ${deviceRunSessionId} errored.`);
+      }
+    } catch (err) {
+      if (err instanceof SystemError) {
+        throw err;
+      }
+
+      const error = err instanceof Error ? err : new Error(String(err));
+      pollErrorCount += 1;
+      if (pollErrorCount === 1 || pollErrorCount % 5 === 0) {
+        Sentry.capture('Could not poll device run session status', error, { level: 'warning' });
+        logger.warn(
+          { err: error, failedStatusPollCount: pollErrorCount },
+          'Could not poll device run session status; will retry.'
+        );
+      }
+    }
+    await sleepAsync(DEVICE_RUN_SESSION_STATUS_POLL_INTERVAL_MS);
+  }
 }
 
 const TurnIceServersResponseSchema = z.object({


### PR DESCRIPTION
## Summary

- replace the remote device session infinite waits with polling for the device run session to become `STOPPED`
- let agent-device, Argent, and serve-sim session steps return normally after the stop signal so the worker can report success and the launcher can close the VM
- make Argent artifact polling stoppable, drain one final artifact list on shutdown, and wait briefly for pending uploads

## Why

Stopping a device run session currently cancels the backing turtle job run, which tears down the VM immediately. That skips graceful shutdown work such as finishing recordings and uploading session artifacts. This change makes the worker observe the session stop state and finish cleanup before exiting.

## Validation

- `yarn oxfmt <modified files>`
- `yarn --cwd packages/build-tools test -- remoteDeviceRunSession`
- `yarn --cwd packages/build-tools test -- argentArtifacts`
- `yarn --cwd packages/build-tools typecheck`
- `git diff --check`

## Note

This relies on the backend/API behavior changing so `ensureDeviceRunSessionStopped` marks the device run session `STOPPED` without canceling the turtle job run, and allows artifact uploads while the stopped session is still cleaning up.