### PR TITLE
[build-tools] Add iOS Simulator recorder

### DIFF
--- a/packages/build-tools/.gitignore
+++ b/packages/build-tools/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+bin/record-sim
 
 .secrets*
 !.secrets.example

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -23,6 +23,7 @@
     "watch": "tsc --watch --preserveWatchOutput",
     "prebuild": "yarn gql",
     "build": "tsc",
+    "build:record-sim": "mkdir -p bin && swift build -c release --package-path resources/record-sim --build-path resources/record-sim/.build && cp resources/record-sim/.build/release/record-sim bin/record-sim && chmod +x bin/record-sim",
     "typecheck": "tsc",
     "prepack": "rimraf dist \"*.tsbuildinfo\" && yarn gql && tsc -p tsconfig.build.json",
     "jest-unit": "jest --config jest/unit-config.ts",

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -23,7 +23,7 @@
     "watch": "tsc --watch --preserveWatchOutput",
     "prebuild": "yarn gql",
     "build": "tsc",
-    "build:record-sim": "mkdir -p bin && swift build -c release --package-path resources/record-sim --build-path resources/record-sim/.build && cp resources/record-sim/.build/release/record-sim bin/record-sim && chmod +x bin/record-sim",
+    "build:record-sim": "mkdir -p bin && record_sim_bin_path=$(swift build -c release --package-path resources/record-sim --build-path resources/record-sim/.build --show-bin-path) && swift build -c release --package-path resources/record-sim --build-path resources/record-sim/.build && cp \"$record_sim_bin_path/record-sim\" bin/record-sim && chmod +x bin/record-sim",
     "typecheck": "tsc",
     "prepack": "rimraf dist \"*.tsbuildinfo\" && yarn gql && tsc -p tsconfig.build.json",
     "jest-unit": "jest --config jest/unit-config.ts",

--- a/packages/build-tools/resources/record-sim/.gitignore
+++ b/packages/build-tools/resources/record-sim/.gitignore
@@ -1,0 +1,4 @@
+.build/
+.swiftpm/
+DerivedData/
+.DS_Store

--- a/packages/build-tools/resources/record-sim/Package.swift
+++ b/packages/build-tools/resources/record-sim/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "record-sim",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(name: "RecordSim", targets: ["RecordSim"]),
+        .executable(name: "record-sim", targets: ["record-sim"]),
+    ],
+    targets: [
+        .target(
+            name: "RecordSim",
+            linkerSettings: [
+                .linkedFramework("AVFoundation"),
+                .linkedFramework("CoreGraphics"),
+                .linkedFramework("CoreMedia"),
+                .linkedFramework("CoreVideo"),
+                .linkedFramework("IOSurface"),
+                .linkedFramework("UniformTypeIdentifiers"),
+            ]
+        ),
+        .executableTarget(name: "record-sim", dependencies: ["RecordSim"]),
+    ]
+)

--- a/packages/build-tools/resources/record-sim/README.md
+++ b/packages/build-tools/resources/record-sim/README.md
@@ -1,0 +1,79 @@
+# RecordSim
+
+Small Swift library for non-exclusive iOS Simulator screen recording.
+
+It implements one recording path:
+
+1. Listen to SimRenderServer framebuffer callbacks.
+2. Copy the live `IOSurface` immediately into an owned `CVPixelBuffer`.
+3. Feed one continuous `AVAssetWriter`.
+4. Emit Apple HLS/CMAF-style fragmented MP4 segments.
+
+The output is suitable for uploading while recording. `session.json` contains
+the ordered segment metadata needed to build a playlist later.
+
+## Output
+
+```text
+session/
+  init.mp4
+  session.json
+  segments/
+    segment-000000.m4s
+    segment-000001.m4s
+```
+
+`init.mp4` is the fMP4 initialization segment. Individual `.m4s` files are not
+standalone MP4 files. `session.json` stores the wall-clock timestamp for the
+first video frame plus the metadata needed to build a playlist: HLS version,
+target duration, media sequence, `initSegment`, and the ordered `segments` array
+with file path and duration for each media segment.
+
+## CLI
+
+```bash
+swift run record-sim \
+  --udid <BOOTED_SIMULATOR_UDID> \
+  --output /tmp/sim-recording \
+  --segment-duration 120 \
+  --fps 30 \
+  --bitrate 30000000 \
+  --codec h264
+```
+
+For sparse 2h sessions, `--segment-duration 120` is a reasonable default: about
+60 media objects plus the init segment. The recorder appends a single duplicate
+hold frame near each segment boundary when the simulator is idle, so long idle
+periods still produce uploadable segments without encoding idle frames at 60fps.
+Use `--segment-duration 0` to write one continuous `recording.mp4` instead of
+`init.mp4` plus media segments.
+
+Frame timestamps use monotonic host time, not wall-clock time. The recorder also
+probes the framebuffer seed once per second; if the surface changes without
+callbacks for 5 seconds, it captures that frame and rewires the private callback
+registration.
+
+## Library
+
+```swift
+let recorder = SimulatorRecorder(
+  configuration: SimulatorRecordingConfiguration(
+    deviceUDID: udid,
+    outputDirectory: sessionDirectory,
+    segmentDuration: 120
+  )
+)
+
+recorder.onSegment = { segment in
+  // Enqueue upload of segment.url.
+}
+
+try recorder.start()
+try recorder.waitUntilFirstFrame()
+// ...
+let manifest = try recorder.stop()
+```
+
+`session.json` contains the precise wall-clock time for video PTS zero. In
+segmented mode it also contains the init segment and ordered media segment
+file/duration entries; in single-file mode it points at `recording.mp4`.

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/FramebufferDisplaySource.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/FramebufferDisplaySource.swift
@@ -92,8 +92,15 @@ final class FramebufferDisplaySource {
         unregisterCallbacks()
         descriptors = nextDescriptors
         retainedBlocks.removeAll()
-        for descriptor in descriptors {
-            try registerCallbacks(descriptor: descriptor)
+        do {
+            for descriptor in descriptors {
+                try registerCallbacks(descriptor: descriptor)
+            }
+        } catch {
+            unregisterCallbacks()
+            descriptors.removeAll()
+            retainedBlocks.removeAll()
+            throw error
         }
     }
 

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/FramebufferDisplaySource.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/FramebufferDisplaySource.swift
@@ -1,0 +1,175 @@
+import Foundation
+import IOSurface
+import ObjectiveC
+
+final class FramebufferDisplaySource {
+    struct SurfaceSnapshot {
+        let surface: IOSurface
+        let width: Int
+        let height: Int
+        let seed: UInt32
+    }
+
+    private let deviceUDID: String
+    private let callbackQueue: DispatchQueue
+    private let onFrame: () -> Void
+    private let onSurfaceChange: () -> Void
+    private var descriptors: [NSObject] = []
+    private var callbackUUIDs: [ObjectIdentifier: NSUUID] = [:]
+    private var retainedBlocks: [AnyObject] = []
+    private var ioClient: NSObject?
+
+    init(
+        deviceUDID: String,
+        callbackQueue: DispatchQueue,
+        onFrame: @escaping () -> Void,
+        onSurfaceChange: @escaping () -> Void
+    ) {
+        self.deviceUDID = deviceUDID
+        self.callbackQueue = callbackQueue
+        self.onFrame = onFrame
+        self.onSurfaceChange = onSurfaceChange
+    }
+
+    func start() throws {
+        PrivateSimulatorFrameworks.load()
+        guard let device = SimulatorDeviceLookup.find(udid: deviceUDID) else {
+            throw RecorderError.make(1, "Simulator \(deviceUDID) not found")
+        }
+        let state = device.value(forKey: "stateString") as? String ?? "unknown"
+        guard state == "Booted" else {
+            throw RecorderError.make(2, "Simulator \(deviceUDID) is not booted (state: \(state))")
+        }
+        guard let io = device.perform(NSSelectorFromString("io"))?.takeUnretainedValue() as? NSObject else {
+            throw RecorderError.make(3, "Failed to get simulator IO client")
+        }
+        ioClient = io
+        try wireUpFramebuffer()
+    }
+
+    func stop() {
+        unregisterCallbacks()
+        descriptors.removeAll()
+        retainedBlocks.removeAll()
+        ioClient = nil
+    }
+
+    func surfaceSnapshot() -> SurfaceSnapshot? {
+        let surfaceSelector = NSSelectorFromString("framebufferSurface")
+        var bestSnapshot: SurfaceSnapshot?
+        var bestArea = 0
+        for descriptor in descriptors {
+            guard let surfaceObject = descriptor.perform(surfaceSelector)?.takeUnretainedValue() else {
+                continue
+            }
+            let surface = unsafeBitCast(surfaceObject, to: IOSurface.self)
+            let width = IOSurfaceGetWidth(surface)
+            let height = IOSurfaceGetHeight(surface)
+            let area = width * height
+            if area > bestArea {
+                bestSnapshot = SurfaceSnapshot(
+                    surface: surface,
+                    width: width,
+                    height: height,
+                    seed: IOSurfaceGetSeed(surface)
+                )
+                bestArea = area
+            }
+        }
+        return bestSnapshot
+    }
+
+    func rewireFramebuffer() throws {
+        try wireUpFramebuffer()
+    }
+
+    private func wireUpFramebuffer() throws {
+        guard let io = ioClient else {
+            throw RecorderError.make(3, "No simulator IO client")
+        }
+        io.perform(NSSelectorFromString("updateIOPorts"))
+        let nextDescriptors = try findFramebufferDescriptors(io: io)
+        unregisterCallbacks()
+        descriptors = nextDescriptors
+        retainedBlocks.removeAll()
+        for descriptor in descriptors {
+            try registerCallbacks(descriptor: descriptor)
+        }
+    }
+
+    private func findFramebufferDescriptors(io: NSObject) throws -> [NSObject] {
+        guard let ports = io.value(forKey: "deviceIOPorts") as? [NSObject] else {
+            throw RecorderError.make(4, "Failed to read simulator IO ports")
+        }
+        let portIdentifierSelector = NSSelectorFromString("portIdentifier")
+        let descriptorSelector = NSSelectorFromString("descriptor")
+        let surfaceSelector = NSSelectorFromString("framebufferSurface")
+
+        var candidates: [NSObject] = []
+        for port in ports {
+            guard port.responds(to: portIdentifierSelector),
+                  let portIdentifier = port.perform(portIdentifierSelector)?.takeUnretainedValue(),
+                  "\(portIdentifier)" == "com.apple.framebuffer.display",
+                  port.responds(to: descriptorSelector),
+                  let descriptor = port.perform(descriptorSelector)?.takeUnretainedValue() as? NSObject,
+                  descriptor.responds(to: surfaceSelector)
+            else {
+                continue
+            }
+            candidates.append(descriptor)
+        }
+        if candidates.isEmpty {
+            throw RecorderError.make(5, "No framebuffer display descriptor found")
+        }
+        return candidates
+    }
+
+    private func registerCallbacks(descriptor: NSObject) throws {
+        let selector = NSSelectorFromString("registerScreenCallbacksWithUUID:callbackQueue:frameCallback:surfacesChangedCallback:propertiesChangedCallback:")
+        guard descriptor.responds(to: selector) else {
+            throw RecorderError.make(6, "Framebuffer descriptor does not support screen callbacks")
+        }
+        guard let msgSendPointer = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "objc_msgSend") else {
+            throw RecorderError.make(7, "objc_msgSend not found")
+        }
+        typealias MsgSend = @convention(c) (
+            AnyObject, Selector, AnyObject, AnyObject, AnyObject, AnyObject, AnyObject
+        ) -> Void
+        let msgSend = unsafeBitCast(msgSendPointer, to: MsgSend.self)
+
+        let uuid = NSUUID()
+        callbackUUIDs[ObjectIdentifier(descriptor)] = uuid
+
+        let frameCallback: @convention(block) () -> Void = { [weak self] in
+            self?.onFrame()
+        }
+        let surfacesCallback: @convention(block) (AnyObject?, AnyObject?) -> Void = { [weak self] _, _ in
+            self?.onSurfaceChange()
+        }
+        let propertiesCallback: @convention(block) () -> Void = {}
+        retainedBlocks.append(frameCallback as AnyObject)
+        retainedBlocks.append(surfacesCallback as AnyObject)
+        retainedBlocks.append(propertiesCallback as AnyObject)
+
+        msgSend(
+            descriptor,
+            selector,
+            uuid,
+            callbackQueue as AnyObject,
+            frameCallback as AnyObject,
+            surfacesCallback as AnyObject,
+            propertiesCallback as AnyObject
+        )
+    }
+
+    private func unregisterCallbacks() {
+        let selector = NSSelectorFromString("unregisterScreenCallbacksWithUUID:")
+        for descriptor in descriptors {
+            if let uuid = callbackUUIDs[ObjectIdentifier(descriptor)],
+               descriptor.responds(to: selector) {
+                descriptor.perform(selector, with: uuid)
+            }
+        }
+        callbackUUIDs.removeAll()
+    }
+}

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/FramebufferDisplaySource.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/FramebufferDisplaySource.swift
@@ -32,7 +32,7 @@ final class FramebufferDisplaySource {
     }
 
     func start() throws {
-        PrivateSimulatorFrameworks.load()
+        try PrivateSimulatorFrameworks.load()
         guard let device = SimulatorDeviceLookup.find(udid: deviceUDID) else {
             throw RecorderError.make(1, "Simulator \(deviceUDID) not found")
         }
@@ -40,7 +40,9 @@ final class FramebufferDisplaySource {
         guard state == "Booted" else {
             throw RecorderError.make(2, "Simulator \(deviceUDID) is not booted (state: \(state))")
         }
-        guard let io = device.perform(NSSelectorFromString("io"))?.takeUnretainedValue() as? NSObject else {
+        guard
+            let io = device.perform(NSSelectorFromString("io"))?.takeUnretainedValue() as? NSObject
+        else {
             throw RecorderError.make(3, "Failed to get simulator IO client")
         }
         ioClient = io
@@ -59,7 +61,8 @@ final class FramebufferDisplaySource {
         var bestSnapshot: SurfaceSnapshot?
         var bestArea = 0
         for descriptor in descriptors {
-            guard let surfaceObject = descriptor.perform(surfaceSelector)?.takeUnretainedValue() else {
+            guard let surfaceObject = descriptor.perform(surfaceSelector)?.takeUnretainedValue()
+            else {
                 continue
             }
             let surface = unsafeBitCast(surfaceObject, to: IOSurface.self)
@@ -115,11 +118,12 @@ final class FramebufferDisplaySource {
         var candidates: [NSObject] = []
         for port in ports {
             guard port.responds(to: portIdentifierSelector),
-                  let portIdentifier = port.perform(portIdentifierSelector)?.takeUnretainedValue(),
-                  "\(portIdentifier)" == "com.apple.framebuffer.display",
-                  port.responds(to: descriptorSelector),
-                  let descriptor = port.perform(descriptorSelector)?.takeUnretainedValue() as? NSObject,
-                  descriptor.responds(to: surfaceSelector)
+                let portIdentifier = port.perform(portIdentifierSelector)?.takeUnretainedValue(),
+                "\(portIdentifier)" == "com.apple.framebuffer.display",
+                port.responds(to: descriptorSelector),
+                let descriptor = port.perform(descriptorSelector)?.takeUnretainedValue()
+                    as? NSObject,
+                descriptor.responds(to: surfaceSelector)
             else {
                 continue
             }
@@ -132,16 +136,20 @@ final class FramebufferDisplaySource {
     }
 
     private func registerCallbacks(descriptor: NSObject) throws {
-        let selector = NSSelectorFromString("registerScreenCallbacksWithUUID:callbackQueue:frameCallback:surfacesChangedCallback:propertiesChangedCallback:")
+        let selector = NSSelectorFromString(
+            "registerScreenCallbacksWithUUID:callbackQueue:frameCallback:surfacesChangedCallback:propertiesChangedCallback:"
+        )
         guard descriptor.responds(to: selector) else {
             throw RecorderError.make(6, "Framebuffer descriptor does not support screen callbacks")
         }
-        guard let msgSendPointer = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "objc_msgSend") else {
+        guard let msgSendPointer = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "objc_msgSend")
+        else {
             throw RecorderError.make(7, "objc_msgSend not found")
         }
-        typealias MsgSend = @convention(c) (
-            AnyObject, Selector, AnyObject, AnyObject, AnyObject, AnyObject, AnyObject
-        ) -> Void
+        typealias MsgSend =
+            @convention(c) (
+                AnyObject, Selector, AnyObject, AnyObject, AnyObject, AnyObject, AnyObject
+            ) -> Void
         let msgSend = unsafeBitCast(msgSendPointer, to: MsgSend.self)
 
         let uuid = NSUUID()
@@ -150,7 +158,8 @@ final class FramebufferDisplaySource {
         let frameCallback: @convention(block) () -> Void = { [weak self] in
             self?.onFrame()
         }
-        let surfacesCallback: @convention(block) (AnyObject?, AnyObject?) -> Void = { [weak self] _, _ in
+        let surfacesCallback: @convention(block) (AnyObject?, AnyObject?) -> Void = {
+            [weak self] _, _ in
             self?.onSurfaceChange()
         }
         let propertiesCallback: @convention(block) () -> Void = {}
@@ -173,7 +182,8 @@ final class FramebufferDisplaySource {
         let selector = NSSelectorFromString("unregisterScreenCallbacksWithUUID:")
         for descriptor in descriptors {
             if let uuid = callbackUUIDs[ObjectIdentifier(descriptor)],
-               descriptor.responds(to: selector) {
+                descriptor.responds(to: selector)
+            {
                 descriptor.perform(selector, with: uuid)
             }
         }

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/PrivateSimulatorServices.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/PrivateSimulatorServices.swift
@@ -2,8 +2,10 @@ import Foundation
 import ObjectiveC
 
 enum XcodeDeveloperDirectory {
-    static func current() -> String {
-        if let developerDir = ProcessInfo.processInfo.environment["DEVELOPER_DIR"], !developerDir.isEmpty {
+    static let current: String = {
+        if let developerDir = ProcessInfo.processInfo.environment["DEVELOPER_DIR"],
+            !developerDir.isEmpty
+        {
             return developerDir
         }
 
@@ -21,38 +23,62 @@ enum XcodeDeveloperDirectory {
         process.waitUntilExit()
         return String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? fallback
-    }
+    }()
 }
 
 enum PrivateSimulatorFrameworks {
-    static func load() {
-        let developerDir = XcodeDeveloperDirectory.current()
+    static func load() throws {
+        try loadResult.get()
+    }
+
+    private static let loadResult: Result<Void, Error> = {
+        let developerDir = XcodeDeveloperDirectory.current
         let candidates = [
             "/Library/Developer/PrivateFrameworks/CoreSimulator.framework/CoreSimulator",
             "\(developerDir)/Library/PrivateFrameworks/CoreSimulator.framework/CoreSimulator",
             "\(developerDir)/../SharedFrameworks/SimulatorKit.framework/SimulatorKit",
             "\(developerDir)/Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit",
         ]
+        var failures: [String] = []
         for path in candidates {
-            _ = dlopen(path, RTLD_NOW)
+            if dlopen(path, RTLD_NOW) == nil {
+                let message = dlerror().map { String(cString: $0) } ?? "unknown error"
+                failures.append("\(path): \(message)")
+            }
         }
-    }
+        guard NSClassFromString("SimServiceContext") != nil else {
+            let tried = candidates.joined(separator: ", ")
+            let errors = failures.isEmpty ? "no dlopen errors" : failures.joined(separator: "; ")
+            return .failure(
+                RecorderError.make(
+                    8,
+                    "Failed to load CoreSimulator/SimulatorKit (tried: \(tried); errors: \(errors))"
+                )
+            )
+        }
+        return .success(())
+    }()
 }
 
 enum SimulatorDeviceLookup {
-    static func find(udid: String) -> NSObject? {
+    private static let context: NSObject? = {
         guard let contextClass = NSClassFromString("SimServiceContext") as? NSObject.Type else {
             return nil
         }
         let sharedSelector = NSSelectorFromString("sharedServiceContextForDeveloperDir:error:")
-        guard let context = contextClass.perform(sharedSelector, with: XcodeDeveloperDirectory.current(), with: nil)?
+        return contextClass.perform(
+            sharedSelector, with: XcodeDeveloperDirectory.current, with: nil)?
             .takeUnretainedValue() as? NSObject
-        else {
+    }()
+
+    static func find(udid: String) -> NSObject? {
+        guard let context else {
             return nil
         }
         let deviceSetSelector = NSSelectorFromString("defaultDeviceSetWithError:")
-        guard let deviceSet = context.perform(deviceSetSelector, with: nil)?
-            .takeUnretainedValue() as? NSObject
+        guard
+            let deviceSet = context.perform(deviceSetSelector, with: nil)?
+                .takeUnretainedValue() as? NSObject
         else {
             return nil
         }

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/PrivateSimulatorServices.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/PrivateSimulatorServices.swift
@@ -1,0 +1,66 @@
+import Foundation
+import ObjectiveC
+
+enum XcodeDeveloperDirectory {
+    static func current() -> String {
+        let fallback = "/Applications/Xcode.app/Contents/Developer"
+        let pipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcode-select")
+        process.arguments = ["-p"]
+        process.standardOutput = pipe
+        do {
+            try process.run()
+        } catch {
+            return fallback
+        }
+        process.waitUntilExit()
+        return String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? fallback
+    }
+}
+
+enum PrivateSimulatorFrameworks {
+    static func load() {
+        let developerDir = XcodeDeveloperDirectory.current()
+        let candidates = [
+            "/Library/Developer/PrivateFrameworks/CoreSimulator.framework/CoreSimulator",
+            "\(developerDir)/Library/PrivateFrameworks/CoreSimulator.framework/CoreSimulator",
+            "\(developerDir)/../SharedFrameworks/SimulatorKit.framework/SimulatorKit",
+            "\(developerDir)/Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit",
+        ]
+        for path in candidates {
+            _ = dlopen(path, RTLD_NOW)
+        }
+    }
+}
+
+enum SimulatorDeviceLookup {
+    static func find(udid: String) -> NSObject? {
+        guard let contextClass = NSClassFromString("SimServiceContext") as? NSObject.Type else {
+            return nil
+        }
+        let sharedSelector = NSSelectorFromString("sharedServiceContextForDeveloperDir:error:")
+        guard let context = contextClass.perform(sharedSelector, with: XcodeDeveloperDirectory.current(), with: nil)?
+            .takeUnretainedValue() as? NSObject
+        else {
+            return nil
+        }
+        let deviceSetSelector = NSSelectorFromString("defaultDeviceSetWithError:")
+        guard let deviceSet = context.perform(deviceSetSelector, with: nil)?
+            .takeUnretainedValue() as? NSObject
+        else {
+            return nil
+        }
+        guard let devices = deviceSet.value(forKey: "devices") as? [NSObject] else {
+            return nil
+        }
+        return devices.first {
+            ($0.value(forKey: "UDID") as? NSUUID)?.uuidString == udid
+        }
+    }
+
+    static func stateString(udid: String) -> String? {
+        find(udid: udid)?.value(forKey: "stateString") as? String
+    }
+}

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/PrivateSimulatorServices.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/PrivateSimulatorServices.swift
@@ -3,6 +3,10 @@ import ObjectiveC
 
 enum XcodeDeveloperDirectory {
     static func current() -> String {
+        if let developerDir = ProcessInfo.processInfo.environment["DEVELOPER_DIR"], !developerDir.isEmpty {
+            return developerDir
+        }
+
         let fallback = "/Applications/Xcode.app/Contents/Developer"
         let pipe = Pipe()
         let process = Process()

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/RecordingModels.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/RecordingModels.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public enum RecorderCodec: String, Codable, Sendable {
+    case h264
+    case hevc
+}
+
+public struct SimulatorRecordingConfiguration: Sendable {
+    public var deviceUDID: String
+    public var outputDirectory: URL
+    public var fps: Int
+    public var bitrate: Int
+    public var codec: RecorderCodec
+    public var segmentDuration: TimeInterval
+    public var maxPendingFrames: Int
+    public var overwrite: Bool
+
+    public init(
+        deviceUDID: String,
+        outputDirectory: URL,
+        fps: Int = 30,
+        bitrate: Int = 30_000_000,
+        codec: RecorderCodec = .h264,
+        segmentDuration: TimeInterval = 120,
+        maxPendingFrames: Int = 8,
+        overwrite: Bool = true
+    ) {
+        self.deviceUDID = deviceUDID
+        self.outputDirectory = outputDirectory
+        self.fps = fps
+        self.bitrate = bitrate
+        self.codec = codec
+        self.segmentDuration = segmentDuration
+        self.maxPendingFrames = maxPendingFrames
+        self.overwrite = overwrite
+    }
+}
+
+public enum SegmentKind: String, Codable, Sendable {
+    case initialization
+    case media
+}
+
+public struct SegmentOutput: Sendable {
+    public let kind: SegmentKind
+    public let relativePath: String
+    public let url: URL
+    public let byteCount: Int
+    public let durationSeconds: Double?
+}
+
+public struct MediaSegmentRecord: Codable, Sendable {
+    public let file: String
+    public let durationSeconds: Double
+}
+
+public struct FirstFrameWallClock: Codable, Sendable {
+    public let unixMs: Int64
+    public let iso8601: String
+}
+
+public struct RecordingManifest: Codable, Sendable {
+    public let firstFrameWallClock: FirstFrameWallClock
+    public let hlsVersion: Int?
+    public let hlsTargetDurationSeconds: Int?
+    public let hlsMediaSequence: Int?
+    public let recording: String?
+    public let initSegment: String?
+    public let segments: [MediaSegmentRecord]
+}

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/RecordingOutputWriter.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/RecordingOutputWriter.swift
@@ -48,8 +48,8 @@ final class RecordingOutputWriter: NSObject, AVAssetWriterDelegate {
                 return
             }
             do {
-                switch segmentType.rawValue {
-                case 1:
+                switch segmentType {
+                case .initialization:
                     let relativePath = "init.mp4"
                     let url = rootDirectory.appendingPathComponent(relativePath)
                     try segmentData.write(to: url, options: .atomic)
@@ -61,7 +61,7 @@ final class RecordingOutputWriter: NSObject, AVAssetWriterDelegate {
                         byteCount: segmentData.count,
                         durationSeconds: nil
                     )
-                case 2:
+                case .separable:
                     let index = nextMediaSegmentIndex
                     let relativePath = String(format: "segments/segment-%06d.m4s", index)
                     let url = rootDirectory.appendingPathComponent(relativePath)

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/RecordingOutputWriter.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/RecordingOutputWriter.swift
@@ -107,6 +107,12 @@ final class RecordingOutputWriter: NSObject, AVAssetWriterDelegate {
                 throw firstError
             }
             let segmented = configuration.segmentDuration > 0
+            if segmented, initSegmentPath == nil {
+                throw RecorderError.make(50, "Missing initialization segment")
+            }
+            if segmented, segments.isEmpty {
+                throw RecorderError.make(51, "No media segments were written")
+            }
             let targetDuration = segmented
                 ? max(1, Int(ceil(segments.map(\.durationSeconds).max() ?? configuration.segmentDuration)))
                 : nil

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/RecordingOutputWriter.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/RecordingOutputWriter.swift
@@ -1,0 +1,130 @@
+import AVFoundation
+import Foundation
+
+final class RecordingOutputWriter: NSObject, AVAssetWriterDelegate {
+    private let rootDirectory: URL
+    private let segmentsDirectory: URL
+    let singleRecordingURL: URL
+    private let stateQueue = DispatchQueue(label: "record-sim.segment-writer")
+    private let notificationQueue = DispatchQueue(label: "record-sim.segment-notifications")
+    private let onSegment: ((SegmentOutput) -> Void)?
+    private var initSegmentPath: String?
+    private var segments: [MediaSegmentRecord] = []
+    private var nextMediaSegmentIndex = 0
+    private var firstError: Error?
+
+    init(rootDirectory: URL, onSegment: ((SegmentOutput) -> Void)?) {
+        self.rootDirectory = rootDirectory
+        self.segmentsDirectory = rootDirectory.appendingPathComponent("segments", isDirectory: true)
+        self.singleRecordingURL = rootDirectory.appendingPathComponent("recording.mp4")
+        self.onSegment = onSegment
+        super.init()
+    }
+
+    func prepare(overwrite: Bool, segmented: Bool) throws {
+        if overwrite {
+            try? FileManager.default.removeItem(at: rootDirectory)
+        }
+        try FileManager.default.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
+        if segmented {
+            try FileManager.default.createDirectory(at: segmentsDirectory, withIntermediateDirectories: true)
+        }
+    }
+
+    var error: Error? {
+        stateQueue.sync { firstError }
+    }
+
+    func assetWriter(
+        _ writer: AVAssetWriter,
+        didOutputSegmentData segmentData: Data,
+        segmentType: AVAssetSegmentType,
+        segmentReport: AVAssetSegmentReport?
+    ) {
+        var notification: SegmentOutput?
+
+        stateQueue.sync {
+            if firstError != nil {
+                return
+            }
+            do {
+                switch segmentType.rawValue {
+                case 1:
+                    let relativePath = "init.mp4"
+                    let url = rootDirectory.appendingPathComponent(relativePath)
+                    try segmentData.write(to: url, options: .atomic)
+                    initSegmentPath = relativePath
+                    notification = SegmentOutput(
+                        kind: .initialization,
+                        relativePath: relativePath,
+                        url: url,
+                        byteCount: segmentData.count,
+                        durationSeconds: nil
+                    )
+                case 2:
+                    let index = nextMediaSegmentIndex
+                    let relativePath = String(format: "segments/segment-%06d.m4s", index)
+                    let url = rootDirectory.appendingPathComponent(relativePath)
+                    try segmentData.write(to: url, options: .atomic)
+
+                    let videoReport = segmentReport?.trackReports.first(where: { $0.mediaType == .video })
+                    let duration = videoReport.flatMap { timeSeconds($0.duration) } ?? 0
+                    let record = MediaSegmentRecord(
+                        file: relativePath,
+                        durationSeconds: duration
+                    )
+                    nextMediaSegmentIndex += 1
+                    segments.append(record)
+                    notification = SegmentOutput(
+                        kind: .media,
+                        relativePath: relativePath,
+                        url: url,
+                        byteCount: segmentData.count,
+                        durationSeconds: duration
+                    )
+                default:
+                    break
+                }
+            } catch {
+                firstError = error
+            }
+        }
+
+        if let notification, let onSegment {
+            notificationQueue.async {
+                onSegment(notification)
+            }
+        }
+    }
+
+    @discardableResult
+    func writeManifest(
+        configuration: SimulatorRecordingConfiguration,
+        firstFrameWallClock: Date
+    ) throws -> RecordingManifest {
+        try stateQueue.sync {
+            if let firstError {
+                throw firstError
+            }
+            let segmented = configuration.segmentDuration > 0
+            let targetDuration = segmented
+                ? max(1, Int(ceil(segments.map(\.durationSeconds).max() ?? configuration.segmentDuration)))
+                : nil
+            let manifest = RecordingManifest(
+                firstFrameWallClock: FirstFrameWallClock(
+                    unixMs: unixMs(firstFrameWallClock),
+                    iso8601: iso8601(firstFrameWallClock)
+                ),
+                hlsVersion: segmented ? 7 : nil,
+                hlsTargetDurationSeconds: targetDuration,
+                hlsMediaSequence: segmented ? 0 : nil,
+                recording: segmented ? nil : "recording.mp4",
+                initSegment: segmented ? initSegmentPath : nil,
+                segments: segments
+            )
+            let data = try JSONEncoder.prettySorted.encode(manifest)
+            try data.write(to: rootDirectory.appendingPathComponent("session.json"), options: .atomic)
+            return manifest
+        }
+    }
+}

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
@@ -8,6 +8,7 @@ public final class SimulatorRecorder {
     public var onSimulatorStopped: ((String) -> Void)?
 
     private static let callbackStalenessTimeout: TimeInterval = 5
+    private static let firstFrameRewireInterval: TimeInterval = 1
     private let configuration: SimulatorRecordingConfiguration
     private let callbackQueue = DispatchQueue(label: "record-sim.frame-callbacks", qos: .userInteractive)
     private let writerQueue = DispatchQueue(label: "record-sim.asset-writer", qos: .userInitiated)
@@ -25,6 +26,7 @@ public final class SimulatorRecorder {
     private var lastPTS: CMTime?
     private var lastSeed: UInt32?
     private var lastFrameCallbackElapsed: TimeInterval?
+    private var lastFirstFrameRewireElapsed: TimeInterval = 0
     private var lastAppendedPixelBuffer: CVPixelBuffer?
     private var nextBoundaryElapsed: TimeInterval = 0
     private var simulatorStoppedReason: String?
@@ -48,6 +50,7 @@ public final class SimulatorRecorder {
 
         monotonicClock = MonotonicClock()
         nextBoundaryElapsed = configuration.segmentDuration
+        lastFirstFrameRewireElapsed = 0
         stopped = false
 
         let source = FramebufferDisplaySource(
@@ -256,6 +259,15 @@ public final class SimulatorRecorder {
         guard !stopped, let displaySource else {
             return
         }
+        let elapsed = monotonicClock.elapsedSeconds()
+        if !isFirstFrameReady(),
+           elapsed - lastFirstFrameRewireElapsed >= Self.firstFrameRewireInterval {
+            lastFirstFrameRewireElapsed = elapsed
+            rewireFramebuffer(reason: "waiting for first frame")
+            captureFrame(force: true, reason: .healthProbe)
+            return
+        }
+
         guard let snapshot = displaySource.surfaceSnapshot(),
               snapshot.width > 0,
               snapshot.height > 0
@@ -269,7 +281,6 @@ public final class SimulatorRecorder {
             return
         }
 
-        let elapsed = monotonicClock.elapsedSeconds()
         let lastCallback = lastFrameCallbackElapsed ?? 0
         if elapsed - lastCallback >= Self.callbackStalenessTimeout {
             captureFrame(force: false, reason: .healthProbe)
@@ -524,5 +535,11 @@ public final class SimulatorRecorder {
         }
         firstFrameReady = true
         firstFrameSemaphore.signal()
+    }
+
+    private func isFirstFrameReady() -> Bool {
+        writerQueue.sync {
+            firstFrameReady
+        }
     }
 }

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
@@ -11,7 +11,8 @@ public final class SimulatorRecorder {
     private static let callbackStalenessTimeout: TimeInterval = 5
     private static let firstFrameRewireInterval: TimeInterval = 1
     private let configuration: SimulatorRecordingConfiguration
-    private let callbackQueue = DispatchQueue(label: "record-sim.frame-callbacks", qos: .userInteractive)
+    private let callbackQueue = DispatchQueue(
+        label: "record-sim.frame-callbacks", qos: .userInteractive)
     private let writerQueue = DispatchQueue(label: "record-sim.asset-writer", qos: .userInitiated)
     private let eventQueue = DispatchQueue(label: "record-sim.events", qos: .utility)
     private let pendingLock = NSLock()
@@ -44,10 +45,13 @@ public final class SimulatorRecorder {
     public func start() throws {
         try validateConfiguration()
 
-        let outputWriter = RecordingOutputWriter(rootDirectory: configuration.outputDirectory, onSegment: { [weak self] segment in
-            self?.onSegment?(segment)
-        })
-        try outputWriter.prepare(overwrite: configuration.overwrite, segmented: configuration.segmentDuration > 0)
+        let outputWriter = RecordingOutputWriter(
+            rootDirectory: configuration.outputDirectory,
+            onSegment: { [weak self] segment in
+                self?.onSegment?(segment)
+            })
+        try outputWriter.prepare(
+            overwrite: configuration.overwrite, segmented: configuration.segmentDuration > 0)
         self.outputWriter = outputWriter
 
         monotonicClock = MonotonicClock()
@@ -189,37 +193,32 @@ public final class SimulatorRecorder {
         guard configuration.segmentDuration > 0 else {
             return
         }
-        let currentPTSSeconds = writerQueue.sync { () -> TimeInterval? in
+        writerQueue.sync {
             guard firstAcceptedCaptureTime != nil else {
-                return nil
+                return
             }
-            return CMTimeGetSeconds(normalizedPresentationTime(for: monotonicClock.elapsedTime()))
-        }
-        guard let currentPTSSeconds, currentPTSSeconds >= nextBoundaryElapsed else {
-            return
-        }
-
-        let boundary = nextBoundaryElapsed
-
-        let didAppendBoundaryFrame = writerQueue.sync { () -> Bool in
+            let currentPTSSeconds = CMTimeGetSeconds(
+                normalizedPresentationTime(for: monotonicClock.elapsedTime()))
+            guard currentPTSSeconds >= nextBoundaryElapsed else {
+                return
+            }
+            let boundary = nextBoundaryElapsed
             guard let lastPTS else {
-                return false
-            }
-            if CMTimeGetSeconds(lastPTS) >= boundary {
-                return true
+                return
             }
 
             do {
-                let boundaryPTS = CMTime(seconds: boundary, preferredTimescale: 1_000_000_000)
-                return try appendHeldFrame(at: boundaryPTS)
+                if CMTimeGetSeconds(lastPTS) < boundary {
+                    let boundaryPTS = CMTime(seconds: boundary, preferredTimescale: 1_000_000_000)
+                    guard try appendHeldFrame(at: boundaryPTS) else {
+                        return
+                    }
+                }
+                nextBoundaryElapsed = boundary + configuration.segmentDuration
             } catch {
                 firstError = error
                 signalFirstFrameReadyIfNeeded()
-                return false
             }
-        }
-        if didAppendBoundaryFrame {
-            nextBoundaryElapsed = boundary + configuration.segmentDuration
         }
     }
 
@@ -241,7 +240,8 @@ public final class SimulatorRecorder {
         }
 
         let seed = snapshot.seed
-        if !force, let lastSeed, lastSeed == seed {
+        let matchesLastAppendedSeed = writerQueue.sync { lastSeed == seed }
+        if !force, matchesLastAppendedSeed {
             return
         }
 
@@ -257,9 +257,9 @@ public final class SimulatorRecorder {
                 width: surfaceWidth,
                 height: surfaceHeight
             )
-            lastSeed = seed
             appendOwned(
                 pixelBuffer: pixelBuffer,
+                seed: seed,
                 capturedAt: capturedAt,
                 capturedAtWallClock: capturedAtWallClock
             )
@@ -278,7 +278,8 @@ public final class SimulatorRecorder {
         }
         let elapsed = monotonicClock.elapsedSeconds()
         if !isFirstFrameReady(),
-           elapsed - lastFirstFrameRewireElapsed >= Self.firstFrameRewireInterval {
+            elapsed - lastFirstFrameRewireElapsed >= Self.firstFrameRewireInterval
+        {
             lastFirstFrameRewireElapsed = elapsed
             rewireFramebuffer()
             captureFrame(force: true, reason: .healthProbe)
@@ -286,15 +287,16 @@ public final class SimulatorRecorder {
         }
 
         guard let snapshot = displaySource.surfaceSnapshot(),
-              snapshot.width > 0,
-              snapshot.height > 0
+            snapshot.width > 0,
+            snapshot.height > 0
         else {
             rewireFramebuffer()
             return
         }
 
         let observedSeed = snapshot.seed
-        guard let lastSeed, observedSeed != lastSeed else {
+        let lastAppendedSeed = writerQueue.sync { lastSeed }
+        guard let lastAppendedSeed, observedSeed != lastAppendedSeed else {
             return
         }
 
@@ -381,8 +383,15 @@ public final class SimulatorRecorder {
             throw RecorderError.make(41, "Failed to allocate pixel buffer from pool: \(status)")
         }
 
-        CVPixelBufferLockBaseAddress(destination, [])
-        IOSurfaceLock(surface, .readOnly, nil)
+        let destinationLockStatus = CVPixelBufferLockBaseAddress(destination, [])
+        guard destinationLockStatus == kCVReturnSuccess else {
+            throw RecorderError.make(50, "Failed to lock pixel buffer: \(destinationLockStatus)")
+        }
+        let surfaceLockStatus = IOSurfaceLock(surface, .readOnly, nil)
+        guard surfaceLockStatus == KERN_SUCCESS else {
+            CVPixelBufferUnlockBaseAddress(destination, [])
+            throw RecorderError.make(49, "Failed to lock IOSurface: \(surfaceLockStatus)")
+        }
         defer {
             IOSurfaceUnlock(surface, .readOnly, nil)
             CVPixelBufferUnlockBaseAddress(destination, [])
@@ -394,8 +403,11 @@ public final class SimulatorRecorder {
         let sourceAddress = IOSurfaceGetBaseAddress(surface)
         let sourceStride = IOSurfaceGetBytesPerRow(surface)
         let destinationStride = CVPixelBufferGetBytesPerRow(destination)
-        let copyBytes = min(width * 4, sourceStride, destinationStride)
-        for row in 0..<height {
+        let copyWidth = min(width, IOSurfaceGetWidth(surface), CVPixelBufferGetWidth(destination))
+        let copyHeight = min(
+            height, IOSurfaceGetHeight(surface), CVPixelBufferGetHeight(destination))
+        let copyBytes = min(copyWidth * 4, sourceStride, destinationStride)
+        for row in 0..<copyHeight {
             memcpy(
                 destinationAddress.advanced(by: row * destinationStride),
                 sourceAddress.advanced(by: row * sourceStride),
@@ -407,6 +419,7 @@ public final class SimulatorRecorder {
 
     private func appendOwned(
         pixelBuffer: CVPixelBuffer,
+        seed: UInt32,
         capturedAt: CMTime,
         capturedAtWallClock: Date
     ) {
@@ -418,6 +431,7 @@ public final class SimulatorRecorder {
             do {
                 try self.appendOnWriterQueue(
                     pixelBuffer: pixelBuffer,
+                    seed: seed,
                     capturedAt: capturedAt,
                     capturedAtWallClock: capturedAtWallClock
                 )
@@ -430,6 +444,7 @@ public final class SimulatorRecorder {
 
     private func appendOnWriterQueue(
         pixelBuffer: CVPixelBuffer,
+        seed: UInt32,
         capturedAt: CMTime,
         capturedAtWallClock: Date
     ) throws {
@@ -455,6 +470,7 @@ public final class SimulatorRecorder {
             firstAcceptedWallClock = capturedAtWallClock
         }
         lastPTS = pts
+        lastSeed = seed
         lastAppendedPixelBuffer = pixelBuffer
         signalFirstFrameReadyIfNeeded()
     }
@@ -479,7 +495,7 @@ public final class SimulatorRecorder {
 
     private func appendPendingBoundaryFrames(before pts: CMTime) throws -> Bool {
         guard configuration.segmentDuration > 0,
-              firstAcceptedCaptureTime != nil
+            firstAcceptedCaptureTime != nil
         else {
             return true
         }
@@ -490,7 +506,8 @@ public final class SimulatorRecorder {
                 continue
             }
 
-            let boundaryPTS = CMTime(seconds: nextBoundaryElapsed, preferredTimescale: 1_000_000_000)
+            let boundaryPTS = CMTime(
+                seconds: nextBoundaryElapsed, preferredTimescale: 1_000_000_000)
             guard try appendHeldFrame(at: boundaryPTS) else {
                 return false
             }
@@ -501,9 +518,9 @@ public final class SimulatorRecorder {
 
     private func appendHeldFrame(at pts: CMTime) throws -> Bool {
         guard let input,
-              let adaptor,
-              let lastPTS,
-              let lastAppendedPixelBuffer
+            let adaptor,
+            let lastPTS,
+            let lastAppendedPixelBuffer
         else {
             return true
         }

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
@@ -441,6 +441,9 @@ public final class SimulatorRecorder {
         if let lastPTS, CMTimeCompare(pts, lastPTS) <= 0 {
             return
         }
+        guard try appendPendingBoundaryFrames(before: pts) else {
+            return
+        }
         guard input.isReadyForMoreMediaData else {
             return
         }
@@ -472,6 +475,28 @@ public final class SimulatorRecorder {
     private func appendTailFrame(finalPTS: CMTime) throws -> Bool {
         let pts = normalizedPresentationTime(for: finalPTS)
         return try appendHeldFrame(at: pts)
+    }
+
+    private func appendPendingBoundaryFrames(before pts: CMTime) throws -> Bool {
+        guard configuration.segmentDuration > 0,
+              firstAcceptedCaptureTime != nil
+        else {
+            return true
+        }
+
+        while CMTimeGetSeconds(pts) > nextBoundaryElapsed {
+            if let lastPTS, CMTimeGetSeconds(lastPTS) >= nextBoundaryElapsed {
+                nextBoundaryElapsed += configuration.segmentDuration
+                continue
+            }
+
+            let boundaryPTS = CMTime(seconds: nextBoundaryElapsed, preferredTimescale: 1_000_000_000)
+            guard try appendHeldFrame(at: boundaryPTS) else {
+                return false
+            }
+            nextBoundaryElapsed += configuration.segmentDuration
+        }
+        return true
     }
 
     private func appendHeldFrame(at pts: CMTime) throws -> Bool {

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import CoreVideo
 import Foundation
 import IOSurface
+import UniformTypeIdentifiers
 
 public final class SimulatorRecorder {
     public var onSegment: ((SegmentOutput) -> Void)?
@@ -114,7 +115,10 @@ public final class SimulatorRecorder {
                 throw firstError
             }
             guard let writer, let input, let outputWriter else {
-                throw RecorderError.make(22, "No frames were captured")
+                let error = RecorderError.make(22, "No frames were captured")
+                firstError = error
+                signalFirstFrameReadyIfNeeded()
+                throw error
             }
             try appendTailFrameIfNeeded(finalPTS: monotonicClock.elapsedTime())
             input.markAsFinished()

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
@@ -189,28 +189,38 @@ public final class SimulatorRecorder {
         guard configuration.segmentDuration > 0 else {
             return
         }
-        let elapsed = monotonicClock.elapsedSeconds()
-        guard elapsed >= nextBoundaryElapsed else {
+        let currentPTSSeconds = writerQueue.sync { () -> TimeInterval? in
+            guard firstAcceptedCaptureTime != nil else {
+                return nil
+            }
+            return CMTimeGetSeconds(normalizedPresentationTime(for: monotonicClock.elapsedTime()))
+        }
+        guard let currentPTSSeconds, currentPTSSeconds >= nextBoundaryElapsed else {
             return
         }
 
-        var boundary = nextBoundaryElapsed
-        while boundary + configuration.segmentDuration <= elapsed {
-            boundary += configuration.segmentDuration
-        }
+        let boundary = nextBoundaryElapsed
 
-        let alreadyCrossedBoundary = writerQueue.sync { () -> Bool in
+        let didAppendBoundaryFrame = writerQueue.sync { () -> Bool in
             guard let lastPTS else {
                 return false
             }
-            return CMTimeGetSeconds(lastPTS) >= boundary
-        }
-        if alreadyCrossedBoundary {
-            nextBoundaryElapsed = boundary + configuration.segmentDuration
-            return
-        }
+            if CMTimeGetSeconds(lastPTS) >= boundary {
+                return true
+            }
 
-        captureFrame(force: true, reason: .boundary)
+            do {
+                let boundaryPTS = CMTime(seconds: boundary, preferredTimescale: 1_000_000_000)
+                return try appendHeldFrame(at: boundaryPTS)
+            } catch {
+                firstError = error
+                signalFirstFrameReadyIfNeeded()
+                return false
+            }
+        }
+        if didAppendBoundaryFrame {
+            nextBoundaryElapsed = boundary + configuration.segmentDuration
+        }
     }
 
     private func captureFrame(force: Bool, reason: CaptureReason) {
@@ -460,6 +470,11 @@ public final class SimulatorRecorder {
     }
 
     private func appendTailFrame(finalPTS: CMTime) throws -> Bool {
+        let pts = normalizedPresentationTime(for: finalPTS)
+        return try appendHeldFrame(at: pts)
+    }
+
+    private func appendHeldFrame(at pts: CMTime) throws -> Bool {
         guard let input,
               let adaptor,
               let lastPTS,
@@ -467,7 +482,6 @@ public final class SimulatorRecorder {
         else {
             return true
         }
-        let pts = normalizedPresentationTime(for: finalPTS)
         if CMTimeCompare(pts, lastPTS) <= 0 {
             return true
         }
@@ -475,7 +489,7 @@ public final class SimulatorRecorder {
             return false
         }
         if !adaptor.append(lastAppendedPixelBuffer, withPresentationTime: pts) {
-            throw writer?.error ?? RecorderError.make(45, "Failed to append tail frame")
+            throw writer?.error ?? RecorderError.make(45, "Failed to append held frame")
         }
         self.lastPTS = pts
         return true

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
@@ -65,8 +65,8 @@ public final class SimulatorRecorder {
                 self?.captureFrame(force: true, reason: .surfaceChange)
             }
         )
-        displaySource = source
         try source.start()
+        displaySource = source
 
         startBoundaryTimer()
     }
@@ -198,7 +198,6 @@ public final class SimulatorRecorder {
         while boundary + configuration.segmentDuration <= elapsed {
             boundary += configuration.segmentDuration
         }
-        nextBoundaryElapsed = boundary + configuration.segmentDuration
 
         let alreadyCrossedBoundary = writerQueue.sync { () -> Bool in
             guard let lastPTS else {
@@ -206,9 +205,12 @@ public final class SimulatorRecorder {
             }
             return CMTimeGetSeconds(lastPTS) >= boundary
         }
-        if !alreadyCrossedBoundary {
-            captureFrame(force: true, reason: .boundary)
+        if alreadyCrossedBoundary {
+            nextBoundaryElapsed = boundary + configuration.segmentDuration
+            return
         }
+
+        captureFrame(force: true, reason: .boundary)
     }
 
     private func captureFrame(force: Bool, reason: CaptureReason) {
@@ -302,6 +304,13 @@ public final class SimulatorRecorder {
             return
         }
         simulatorStoppedReason = state
+        let error = RecorderError.make(26, "Simulator stopped before first frame (state: \(state))")
+        writerQueue.async {
+            if self.firstError == nil, !self.firstFrameReady {
+                self.firstError = error
+                self.signalFirstFrameReadyIfNeeded()
+            }
+        }
         let onSimulatorStopped = onSimulatorStopped
         eventQueue.async {
             onSimulatorStopped?(state)
@@ -438,24 +447,38 @@ public final class SimulatorRecorder {
     }
 
     private func appendTailFrameIfNeeded(finalPTS: CMTime) throws {
+        let deadline = Date().addingTimeInterval(5)
+        while true {
+            if try appendTailFrame(finalPTS: finalPTS) {
+                return
+            }
+            if Date() >= deadline {
+                throw RecorderError.make(45, "Timed out waiting to append tail frame")
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+    }
+
+    private func appendTailFrame(finalPTS: CMTime) throws -> Bool {
         guard let input,
               let adaptor,
               let lastPTS,
               let lastAppendedPixelBuffer
         else {
-            return
+            return true
         }
         let pts = normalizedPresentationTime(for: finalPTS)
         if CMTimeCompare(pts, lastPTS) <= 0 {
-            return
+            return true
         }
         guard input.isReadyForMoreMediaData else {
-            return
+            return false
         }
         if !adaptor.append(lastAppendedPixelBuffer, withPresentationTime: pts) {
             throw writer?.error ?? RecorderError.make(45, "Failed to append tail frame")
         }
         self.lastPTS = pts
+        return true
     }
 
     private func normalizedPresentationTime(for capturedAt: CMTime) -> CMTime {

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
@@ -280,7 +280,7 @@ public final class SimulatorRecorder {
         if !isFirstFrameReady(),
            elapsed - lastFirstFrameRewireElapsed >= Self.firstFrameRewireInterval {
             lastFirstFrameRewireElapsed = elapsed
-            rewireFramebuffer(reason: "waiting for first frame")
+            rewireFramebuffer()
             captureFrame(force: true, reason: .healthProbe)
             return
         }
@@ -289,7 +289,7 @@ public final class SimulatorRecorder {
               snapshot.width > 0,
               snapshot.height > 0
         else {
-            rewireFramebuffer(reason: "missing framebuffer surface")
+            rewireFramebuffer()
             return
         }
 
@@ -301,7 +301,7 @@ public final class SimulatorRecorder {
         let lastCallback = lastFrameCallbackElapsed ?? 0
         if elapsed - lastCallback >= Self.callbackStalenessTimeout {
             captureFrame(force: false, reason: .healthProbe)
-            rewireFramebuffer(reason: "framebuffer changed without callbacks")
+            rewireFramebuffer()
         }
     }
 
@@ -327,7 +327,7 @@ public final class SimulatorRecorder {
         }
     }
 
-    private func rewireFramebuffer(reason: String) {
+    private func rewireFramebuffer() {
         guard let displaySource else {
             return
         }

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
@@ -1,0 +1,528 @@
+import AVFoundation
+import CoreVideo
+import Foundation
+import IOSurface
+
+public final class SimulatorRecorder {
+    public var onSegment: ((SegmentOutput) -> Void)?
+    public var onSimulatorStopped: ((String) -> Void)?
+
+    private static let callbackStalenessTimeout: TimeInterval = 5
+    private let configuration: SimulatorRecordingConfiguration
+    private let callbackQueue = DispatchQueue(label: "record-sim.frame-callbacks", qos: .userInteractive)
+    private let writerQueue = DispatchQueue(label: "record-sim.asset-writer", qos: .userInitiated)
+    private let pendingLock = NSLock()
+    private var pendingFrames = 0
+    private var displaySource: FramebufferDisplaySource?
+    private var outputWriter: RecordingOutputWriter?
+    private var writer: AVAssetWriter?
+    private var input: AVAssetWriterInput?
+    private var adaptor: AVAssetWriterInputPixelBufferAdaptor?
+    private var boundaryTimer: DispatchSourceTimer?
+    private var monotonicClock = MonotonicClock()
+    private var firstAcceptedCaptureTime: CMTime?
+    private var firstAcceptedWallClock: Date?
+    private var lastPTS: CMTime?
+    private var lastSeed: UInt32?
+    private var lastFrameCallbackElapsed: TimeInterval?
+    private var lastAppendedPixelBuffer: CVPixelBuffer?
+    private var nextBoundaryElapsed: TimeInterval = 0
+    private var simulatorStoppedReason: String?
+    private var stopped = false
+    private var firstFrameReady = false
+    private let firstFrameSemaphore = DispatchSemaphore(value: 0)
+    private var firstError: Error?
+
+    public init(configuration: SimulatorRecordingConfiguration) {
+        self.configuration = configuration
+    }
+
+    public func start() throws {
+        try validateConfiguration()
+
+        let outputWriter = RecordingOutputWriter(rootDirectory: configuration.outputDirectory, onSegment: { [weak self] segment in
+            self?.onSegment?(segment)
+        })
+        try outputWriter.prepare(overwrite: configuration.overwrite, segmented: configuration.segmentDuration > 0)
+        self.outputWriter = outputWriter
+
+        monotonicClock = MonotonicClock()
+        nextBoundaryElapsed = configuration.segmentDuration
+        stopped = false
+
+        let source = FramebufferDisplaySource(
+            deviceUDID: configuration.deviceUDID,
+            callbackQueue: callbackQueue,
+            onFrame: { [weak self] in
+                self?.captureFrame(force: false, reason: .callback)
+            },
+            onSurfaceChange: { [weak self] in
+                self?.captureFrame(force: true, reason: .surfaceChange)
+            }
+        )
+        displaySource = source
+        try source.start()
+
+        startBoundaryTimer()
+    }
+
+    public func waitUntilFirstFrame(timeoutSeconds: TimeInterval = 15) throws {
+        let alreadyReady = try writerQueue.sync {
+            if let firstError {
+                throw firstError
+            }
+            return firstFrameReady
+        }
+        if alreadyReady {
+            return
+        }
+        if firstFrameSemaphore.wait(timeout: .now() + timeoutSeconds) == .timedOut {
+            throw RecorderError.make(20, "Timed out waiting for first frame")
+        }
+        try writerQueue.sync {
+            if let firstError {
+                throw firstError
+            }
+            if !firstFrameReady {
+                throw RecorderError.make(21, "Recorder stopped before first frame")
+            }
+        }
+    }
+
+    public func simulatorStopReason() -> String? {
+        callbackQueue.sync {
+            simulatorStoppedReason
+        }
+    }
+
+    @discardableResult
+    public func stop() throws -> RecordingManifest {
+        callbackQueue.sync {
+            stopped = true
+            boundaryTimer?.cancel()
+            boundaryTimer = nil
+            displaySource?.stop()
+            displaySource = nil
+        }
+
+        return try writerQueue.sync {
+            if let firstError {
+                throw firstError
+            }
+            guard let writer, let input, let outputWriter else {
+                throw RecorderError.make(22, "No frames were captured")
+            }
+            try appendTailFrameIfNeeded(finalPTS: monotonicClock.elapsedTime())
+            input.markAsFinished()
+            let semaphore = DispatchSemaphore(value: 0)
+            writer.finishWriting {
+                semaphore.signal()
+            }
+            if semaphore.wait(timeout: .now() + 60) == .timedOut {
+                throw RecorderError.make(23, "Timed out finishing AVAssetWriter")
+            }
+            if writer.status == .failed {
+                throw writer.error ?? RecorderError.make(24, "AVAssetWriter failed")
+            }
+            if let error = outputWriter.error {
+                throw error
+            }
+            guard let firstAcceptedWallClock else {
+                throw RecorderError.make(25, "Missing first frame wall-clock timestamp")
+            }
+            return try outputWriter.writeManifest(
+                configuration: configuration,
+                firstFrameWallClock: firstAcceptedWallClock
+            )
+        }
+    }
+
+    private enum CaptureReason {
+        case callback
+        case surfaceChange
+        case boundary
+        case healthProbe
+    }
+
+    private func validateConfiguration() throws {
+        guard !configuration.deviceUDID.isEmpty else {
+            throw RecorderError.make(30, "deviceUDID must not be empty")
+        }
+        guard configuration.fps > 0, configuration.fps <= 120 else {
+            throw RecorderError.make(31, "fps must be between 1 and 120")
+        }
+        guard configuration.bitrate > 0 else {
+            throw RecorderError.make(32, "bitrate must be positive")
+        }
+        guard configuration.segmentDuration >= 0 else {
+            throw RecorderError.make(33, "segmentDuration must be non-negative")
+        }
+        guard configuration.maxPendingFrames > 0 else {
+            throw RecorderError.make(34, "maxPendingFrames must be positive")
+        }
+    }
+
+    private func startBoundaryTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: callbackQueue)
+        timer.schedule(deadline: .now() + 1, repeating: 1, leeway: .milliseconds(100))
+        timer.setEventHandler { [weak self] in
+            self?.probeSimulatorState()
+            self?.probeFramebufferHealth()
+            self?.appendBoundaryFrameIfNeeded()
+        }
+        timer.resume()
+        boundaryTimer = timer
+    }
+
+    private func appendBoundaryFrameIfNeeded() {
+        if stopped {
+            return
+        }
+        guard configuration.segmentDuration > 0 else {
+            return
+        }
+        let elapsed = monotonicClock.elapsedSeconds()
+        guard elapsed >= nextBoundaryElapsed else {
+            return
+        }
+
+        var boundary = nextBoundaryElapsed
+        while boundary + configuration.segmentDuration <= elapsed {
+            boundary += configuration.segmentDuration
+        }
+        nextBoundaryElapsed = boundary + configuration.segmentDuration
+
+        let alreadyCrossedBoundary = writerQueue.sync { () -> Bool in
+            guard let lastPTS else {
+                return false
+            }
+            return CMTimeGetSeconds(lastPTS) >= boundary
+        }
+        if !alreadyCrossedBoundary {
+            captureFrame(force: true, reason: .boundary)
+        }
+    }
+
+    private func captureFrame(force: Bool, reason: CaptureReason) {
+        if stopped {
+            return
+        }
+        if reason == .callback {
+            lastFrameCallbackElapsed = monotonicClock.elapsedSeconds()
+        }
+        guard let snapshot = displaySource?.surfaceSnapshot() else {
+            return
+        }
+        let surface = snapshot.surface
+        let surfaceWidth = snapshot.width
+        let surfaceHeight = snapshot.height
+        guard surfaceWidth > 0, surfaceHeight > 0 else {
+            return
+        }
+
+        let seed = snapshot.seed
+        if !force, let lastSeed, lastSeed == seed {
+            return
+        }
+
+        guard reservePendingFrame() else {
+            return
+        }
+
+        let capturedAt = monotonicClock.elapsedTime()
+        let capturedAtWallClock = Date()
+        do {
+            let pixelBuffer = try copySurfaceToOwnedPixelBuffer(
+                surface,
+                width: surfaceWidth,
+                height: surfaceHeight
+            )
+            lastSeed = seed
+            appendOwned(
+                pixelBuffer: pixelBuffer,
+                capturedAt: capturedAt,
+                capturedAtWallClock: capturedAtWallClock
+            )
+        } catch {
+            releasePendingFrame()
+            writerQueue.async {
+                self.firstError = error
+                self.signalFirstFrameReadyIfNeeded()
+            }
+        }
+    }
+
+    private func probeFramebufferHealth() {
+        guard !stopped, let displaySource else {
+            return
+        }
+        guard let snapshot = displaySource.surfaceSnapshot(),
+              snapshot.width > 0,
+              snapshot.height > 0
+        else {
+            rewireFramebuffer(reason: "missing framebuffer surface")
+            return
+        }
+
+        let observedSeed = snapshot.seed
+        guard let lastSeed, observedSeed != lastSeed else {
+            return
+        }
+
+        let elapsed = monotonicClock.elapsedSeconds()
+        let lastCallback = lastFrameCallbackElapsed ?? 0
+        if elapsed - lastCallback >= Self.callbackStalenessTimeout {
+            captureFrame(force: false, reason: .healthProbe)
+            rewireFramebuffer(reason: "framebuffer changed without callbacks")
+        }
+    }
+
+    private func probeSimulatorState() {
+        guard !stopped, simulatorStoppedReason == nil else {
+            return
+        }
+        let state = SimulatorDeviceLookup.stateString(udid: configuration.deviceUDID) ?? "missing"
+        guard state != "Booted" else {
+            return
+        }
+        simulatorStoppedReason = state
+        onSimulatorStopped?(state)
+    }
+
+    private func rewireFramebuffer(reason: String) {
+        guard let displaySource else {
+            return
+        }
+        do {
+            try displaySource.rewireFramebuffer()
+        } catch {
+            writerQueue.async {
+                self.firstError = error
+                self.signalFirstFrameReadyIfNeeded()
+            }
+        }
+    }
+
+    private func reservePendingFrame() -> Bool {
+        pendingLock.lock()
+        defer { pendingLock.unlock() }
+        if pendingFrames >= configuration.maxPendingFrames {
+            return false
+        }
+        pendingFrames += 1
+        return true
+    }
+
+    private func releasePendingFrame() {
+        pendingLock.lock()
+        pendingFrames = max(0, pendingFrames - 1)
+        pendingLock.unlock()
+    }
+
+    private func copySurfaceToOwnedPixelBuffer(
+        _ surface: IOSurface,
+        width: Int,
+        height: Int
+    ) throws -> CVPixelBuffer {
+        let pool = try writerQueue.sync {
+            if let firstError {
+                throw firstError
+            }
+            if writer == nil {
+                try startWriter(width: width, height: height)
+            }
+            guard let pool = adaptor?.pixelBufferPool else {
+                throw RecorderError.make(40, "AVAssetWriter pixel buffer pool is unavailable")
+            }
+            return pool
+        }
+
+        var output: CVPixelBuffer?
+        let status = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &output)
+        guard status == kCVReturnSuccess, let destination = output else {
+            throw RecorderError.make(41, "Failed to allocate pixel buffer from pool: \(status)")
+        }
+
+        CVPixelBufferLockBaseAddress(destination, [])
+        IOSurfaceLock(surface, .readOnly, nil)
+        defer {
+            IOSurfaceUnlock(surface, .readOnly, nil)
+            CVPixelBufferUnlockBaseAddress(destination, [])
+        }
+
+        guard let destinationAddress = CVPixelBufferGetBaseAddress(destination) else {
+            throw RecorderError.make(42, "Pixel buffer has no base address")
+        }
+        let sourceAddress = IOSurfaceGetBaseAddress(surface)
+        let sourceStride = IOSurfaceGetBytesPerRow(surface)
+        let destinationStride = CVPixelBufferGetBytesPerRow(destination)
+        let copyBytes = min(width * 4, sourceStride, destinationStride)
+        for row in 0..<height {
+            memcpy(
+                destinationAddress.advanced(by: row * destinationStride),
+                sourceAddress.advanced(by: row * sourceStride),
+                copyBytes
+            )
+        }
+        return destination
+    }
+
+    private func appendOwned(
+        pixelBuffer: CVPixelBuffer,
+        capturedAt: CMTime,
+        capturedAtWallClock: Date
+    ) {
+        writerQueue.async {
+            defer { self.releasePendingFrame() }
+            if self.firstError != nil {
+                return
+            }
+            do {
+                try self.appendOnWriterQueue(
+                    pixelBuffer: pixelBuffer,
+                    capturedAt: capturedAt,
+                    capturedAtWallClock: capturedAtWallClock
+                )
+            } catch {
+                self.firstError = error
+                self.signalFirstFrameReadyIfNeeded()
+            }
+        }
+    }
+
+    private func appendOnWriterQueue(
+        pixelBuffer: CVPixelBuffer,
+        capturedAt: CMTime,
+        capturedAtWallClock: Date
+    ) throws {
+        guard let writer, let input, let adaptor else {
+            throw RecorderError.make(43, "AVAssetWriter is not initialized")
+        }
+        let isFirstFrame = firstAcceptedCaptureTime == nil
+        let pts = isFirstFrame ? .zero : normalizedPresentationTime(for: capturedAt)
+        if let lastPTS, CMTimeCompare(pts, lastPTS) <= 0 {
+            return
+        }
+        guard input.isReadyForMoreMediaData else {
+            return
+        }
+        if !adaptor.append(pixelBuffer, withPresentationTime: pts) {
+            throw writer.error ?? RecorderError.make(44, "Failed to append pixel buffer")
+        }
+        if isFirstFrame {
+            firstAcceptedCaptureTime = capturedAt
+            firstAcceptedWallClock = capturedAtWallClock
+        }
+        lastPTS = pts
+        lastAppendedPixelBuffer = pixelBuffer
+        signalFirstFrameReadyIfNeeded()
+    }
+
+    private func appendTailFrameIfNeeded(finalPTS: CMTime) throws {
+        guard let input,
+              let adaptor,
+              let lastPTS,
+              let lastAppendedPixelBuffer
+        else {
+            return
+        }
+        let pts = normalizedPresentationTime(for: finalPTS)
+        if CMTimeCompare(pts, lastPTS) <= 0 {
+            return
+        }
+        guard input.isReadyForMoreMediaData else {
+            return
+        }
+        if !adaptor.append(lastAppendedPixelBuffer, withPresentationTime: pts) {
+            throw writer?.error ?? RecorderError.make(45, "Failed to append tail frame")
+        }
+        self.lastPTS = pts
+    }
+
+    private func normalizedPresentationTime(for capturedAt: CMTime) -> CMTime {
+        let start = firstAcceptedCaptureTime ?? capturedAt
+        return CMTimeSubtract(capturedAt, start)
+    }
+
+    private func startWriter(width: Int, height: Int) throws {
+        guard let outputWriter else {
+            throw RecorderError.make(46, "Missing output writer")
+        }
+
+        let writer: AVAssetWriter
+        if configuration.segmentDuration > 0 {
+            writer = AVAssetWriter(contentType: .mpeg4Movie)
+            writer.delegate = outputWriter
+            writer.outputFileTypeProfile = .mpeg4AppleHLS
+            writer.preferredOutputSegmentInterval = CMTime(
+                seconds: configuration.segmentDuration,
+                preferredTimescale: 600
+            )
+        } else {
+            writer = try AVAssetWriter(outputURL: outputWriter.singleRecordingURL, fileType: .mp4)
+        }
+        writer.initialSegmentStartTime = .zero
+
+        let input = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: assetWriterSettings(width: width, height: height)
+        )
+        input.expectsMediaDataInRealTime = true
+
+        let attributes: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            kCVPixelBufferWidthKey as String: width,
+            kCVPixelBufferHeightKey as String: height,
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+        ]
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: attributes
+        )
+
+        guard writer.canAdd(input) else {
+            throw RecorderError.make(47, "AVAssetWriter cannot add video input")
+        }
+        writer.add(input)
+        guard writer.startWriting() else {
+            throw writer.error ?? RecorderError.make(48, "AVAssetWriter failed to start")
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        self.writer = writer
+        self.input = input
+        self.adaptor = adaptor
+    }
+
+    private func assetWriterSettings(width: Int, height: Int) -> [String: Any] {
+        let codecType: AVVideoCodecType = configuration.codec == .hevc ? .hevc : .h264
+        var compression: [String: Any] = [
+            AVVideoAverageBitRateKey: configuration.bitrate,
+            AVVideoExpectedSourceFrameRateKey: configuration.fps,
+            AVVideoAllowFrameReorderingKey: true,
+        ]
+        if configuration.segmentDuration > 0 {
+            compression[AVVideoMaxKeyFrameIntervalKey] = max(
+                1,
+                Int((configuration.segmentDuration * Double(configuration.fps)).rounded())
+            )
+        }
+        if configuration.codec == .h264 {
+            compression[AVVideoProfileLevelKey] = AVVideoProfileLevelH264HighAutoLevel
+        }
+        return [
+            AVVideoCodecKey: codecType,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height,
+            AVVideoCompressionPropertiesKey: compression,
+        ]
+    }
+
+    private func signalFirstFrameReadyIfNeeded() {
+        if firstFrameReady {
+            return
+        }
+        firstFrameReady = true
+        firstFrameSemaphore.signal()
+    }
+}

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
@@ -12,6 +12,7 @@ public final class SimulatorRecorder {
     private let configuration: SimulatorRecordingConfiguration
     private let callbackQueue = DispatchQueue(label: "record-sim.frame-callbacks", qos: .userInteractive)
     private let writerQueue = DispatchQueue(label: "record-sim.asset-writer", qos: .userInitiated)
+    private let eventQueue = DispatchQueue(label: "record-sim.events", qos: .utility)
     private let pendingLock = NSLock()
     private var pendingFrames = 0
     private var displaySource: FramebufferDisplaySource?
@@ -297,7 +298,10 @@ public final class SimulatorRecorder {
             return
         }
         simulatorStoppedReason = state
-        onSimulatorStopped?(state)
+        let onSimulatorStopped = onSimulatorStopped
+        eventQueue.async {
+            onSimulatorStopped?(state)
+        }
     }
 
     private func rewireFramebuffer(reason: String) {

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/Utilities.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/Utilities.swift
@@ -1,0 +1,60 @@
+import CoreMedia
+import Foundation
+
+enum RecorderError {
+    static func make(_ code: Int, _ message: String) -> NSError {
+        NSError(
+            domain: "RecordSim",
+            code: code,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+}
+
+extension JSONEncoder {
+    static var prettySorted: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }
+}
+
+func timeSeconds(_ time: CMTime) -> Double? {
+    guard time.isValid, !time.isIndefinite, !time.isNegativeInfinity, !time.isPositiveInfinity else {
+        return nil
+    }
+    return CMTimeGetSeconds(time)
+}
+
+func iso8601(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    return formatter.string(from: date)
+}
+
+func unixMs(_ date: Date) -> Int64 {
+    Int64((date.timeIntervalSince1970 * 1000).rounded())
+}
+
+struct MonotonicClock {
+    private static let timescale: CMTimeScale = 1_000_000_000
+
+    let startedAtUptimeNanoseconds: UInt64
+
+    init() {
+        startedAtUptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
+    }
+
+    func elapsedSeconds() -> TimeInterval {
+        TimeInterval(elapsedNanoseconds()) / TimeInterval(Self.timescale)
+    }
+
+    func elapsedTime() -> CMTime {
+        CMTime(value: CMTimeValue(elapsedNanoseconds()), timescale: Self.timescale)
+    }
+
+    private func elapsedNanoseconds() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds - startedAtUptimeNanoseconds
+    }
+}

--- a/packages/build-tools/resources/record-sim/Sources/record-sim/main.swift
+++ b/packages/build-tools/resources/record-sim/Sources/record-sim/main.swift
@@ -1,0 +1,143 @@
+import Foundation
+import RecordSim
+
+struct CLIOptions {
+    var udid: String?
+    var output: String?
+    var segmentDuration: TimeInterval = 120
+    var fps = 30
+    var bitrate = 30_000_000
+    var codec: RecorderCodec = .h264
+}
+
+private var stopRequested: CInt = 0
+private var simulatorStopped: CInt = 0
+
+private func handleStopSignal(_ signal: CInt) {
+    stopRequested = 1
+}
+
+private func isStopRequested() -> Bool {
+    stopRequested != 0 || simulatorStopped != 0
+}
+
+func usage() -> String {
+    """
+    Usage:
+      record-sim --udid <UDID> --output <session-dir> [options]
+
+    Options:
+      --segment-duration <seconds>  Target fMP4 media segment duration. Use 0 for one MP4. Default: 120
+      --fps <fps>                   Expected source frame rate. Default: 30
+      --bitrate <bits/sec>          AVAssetWriter average bitrate. Default: 30000000
+      --codec <h264|hevc>           Video codec. Default: h264
+      -h, --help                    Show this help
+    """
+}
+
+func parseOptions(_ args: [String]) throws -> CLIOptions {
+    var options = CLIOptions()
+    var i = 0
+
+    func next(_ flag: String) throws -> String {
+        i += 1
+        guard i < args.count else {
+            throw NSError(domain: "record-sim", code: 2, userInfo: [NSLocalizedDescriptionKey: "Missing value for \(flag)"])
+        }
+        return args[i]
+    }
+
+    while i < args.count {
+        let arg = args[i]
+        switch arg {
+        case "--udid", "-u":
+            options.udid = try next(arg)
+        case "--output", "--output-dir", "--out", "-o":
+            options.output = try next(arg)
+        case "--segment-duration":
+            options.segmentDuration = Double(try next(arg)) ?? -1
+        case "--fps":
+            options.fps = Int(try next(arg)) ?? 0
+        case "--bitrate":
+            options.bitrate = Int(try next(arg)) ?? 0
+        case "--codec":
+            let raw = try next(arg)
+            guard let codec = RecorderCodec(rawValue: raw) else {
+                throw NSError(domain: "record-sim", code: 2, userInfo: [NSLocalizedDescriptionKey: "--codec must be h264 or hevc"])
+            }
+            options.codec = codec
+        case "--help", "-h":
+            print(usage())
+            exit(0)
+        default:
+            throw NSError(domain: "record-sim", code: 2, userInfo: [NSLocalizedDescriptionKey: "Unknown argument: \(arg)"])
+        }
+        i += 1
+    }
+
+    guard options.udid != nil else {
+        throw NSError(domain: "record-sim", code: 2, userInfo: [NSLocalizedDescriptionKey: "Missing required --udid"])
+    }
+    guard options.output != nil else {
+        throw NSError(domain: "record-sim", code: 2, userInfo: [NSLocalizedDescriptionKey: "Missing required --output"])
+    }
+    guard options.segmentDuration >= 0 else {
+        throw NSError(domain: "record-sim", code: 2, userInfo: [NSLocalizedDescriptionKey: "--segment-duration must be non-negative"])
+    }
+    guard options.fps > 0, options.fps <= 120 else {
+        throw NSError(domain: "record-sim", code: 2, userInfo: [NSLocalizedDescriptionKey: "--fps must be between 1 and 120"])
+    }
+    guard options.bitrate > 0 else {
+        throw NSError(domain: "record-sim", code: 2, userInfo: [NSLocalizedDescriptionKey: "--bitrate must be positive"])
+    }
+    return options
+}
+
+do {
+    signal(SIGINT, handleStopSignal)
+    signal(SIGTERM, handleStopSignal)
+
+    let options = try parseOptions(Array(CommandLine.arguments.dropFirst()))
+    let configuration = SimulatorRecordingConfiguration(
+        deviceUDID: options.udid!,
+        outputDirectory: URL(fileURLWithPath: options.output!),
+        fps: options.fps,
+        bitrate: options.bitrate,
+        codec: options.codec,
+        segmentDuration: options.segmentDuration
+    )
+
+    let recorder = SimulatorRecorder(configuration: configuration)
+    recorder.onSimulatorStopped = { state in
+        simulatorStopped = 1
+        fputs("[record-sim] simulator stopped state=\(state); finalizing recording\n", stderr)
+    }
+    recorder.onSegment = { segment in
+        switch segment.kind {
+        case .initialization:
+            fputs("[record-sim] init \(segment.relativePath) bytes=\(segment.byteCount)\n", stderr)
+        case .media:
+            let duration = segment.durationSeconds ?? 0
+            fputs(String(format: "[record-sim] segment %@ duration=%.3fs bytes=%d\n", segment.relativePath, duration, segment.byteCount), stderr)
+        }
+    }
+
+    try recorder.start()
+    try recorder.waitUntilFirstFrame()
+    fputs("[record-sim] recording -> \(options.output!)\n", stderr)
+
+    while !isStopRequested() {
+        Thread.sleep(forTimeInterval: 0.1)
+    }
+
+    let manifest = try recorder.stop()
+    if let recording = manifest.recording {
+        fputs("[record-sim] done recording=\(recording)\n", stderr)
+    } else {
+        fputs("[record-sim] done segments=\(manifest.segments.count)\n", stderr)
+    }
+    fputs("[record-sim] manifest \(URL(fileURLWithPath: options.output!).appendingPathComponent("session.json").path)\n", stderr)
+} catch {
+    fputs("error: \(error.localizedDescription)\n", stderr)
+    exit(1)
+}

--- a/packages/build-tools/resources/record-sim/Sources/record-sim/main.swift
+++ b/packages/build-tools/resources/record-sim/Sources/record-sim/main.swift
@@ -13,7 +13,7 @@ struct CLIOptions {
 private var stopRequested: CInt = 0
 private var simulatorStopped: CInt = 0
 
-private func handleStopSignal(_ signal: CInt) {
+private func handleStopSignal(_: CInt) {
     stopRequested = 1
 }
 

--- a/packages/worker/package.sh
+++ b/packages/worker/package.sh
@@ -25,6 +25,7 @@ echo "Building $OUTPUT_FILE"
 tmp_dir=$(mktemp -d)
 target_root_dir="$tmp_dir"
 target_worker_dir="$tmp_dir/packages/worker"
+record_sim_build_dir=$(mktemp -d)
 
 mkdir -p "$target_worker_dir"
 
@@ -84,7 +85,21 @@ yarn workspaces focus @expo/worker --production
 rm -rf tsconfig.json tsconfig.build.json
 popd >/dev/null 2>&1
 
+if [[ "$PLATFORM" != "ios" ]]; then
+  rm -f "$target_root_dir/packages/build-tools/bin/record-sim"
+fi
+
 if [[ "$PLATFORM" == "ios" ]]; then
+  record_sim_package_dir="$ROOT_DIR/packages/build-tools/resources/record-sim"
+  record_sim_bin_dir="$target_root_dir/packages/build-tools/bin"
+  mkdir -p "$record_sim_bin_dir"
+  swift build \
+    -c release \
+    --package-path "$record_sim_package_dir" \
+    --build-path "$record_sim_build_dir"
+  cp "$record_sim_build_dir/release/record-sim" "$record_sim_bin_dir/record-sim"
+  chmod +x "$record_sim_bin_dir/record-sim"
+
   # build plugin
   pushd "$ROOT_DIR/packages/expo-cocoapods-proxy" >/dev/null 2>&1
   if command -v brew &> /dev/null; then
@@ -111,3 +126,4 @@ tar zcf $OUTPUT_FILE -C $target_root_dir .
 echo "Tarball is ready: $OUTPUT_FILE"
 
 rm -rf $tmp_dir
+rm -rf $record_sim_build_dir

--- a/packages/worker/package.sh
+++ b/packages/worker/package.sh
@@ -22,6 +22,18 @@ fi
 
 echo "Building $OUTPUT_FILE"
 
+tmp_dir=""
+record_sim_build_dir=""
+cleanup() {
+  if [[ -n "$tmp_dir" ]]; then
+    rm -rf "$tmp_dir"
+  fi
+  if [[ -n "$record_sim_build_dir" ]]; then
+    rm -rf "$record_sim_build_dir"
+  fi
+}
+trap cleanup EXIT
+
 tmp_dir=$(mktemp -d)
 target_root_dir="$tmp_dir"
 target_worker_dir="$tmp_dir/packages/worker"
@@ -129,6 +141,3 @@ ln -s ../../../../packages/worker/dist/main.js "$target_root_dir/src/services/wo
 tar zcf $OUTPUT_FILE -C $target_root_dir .
 
 echo "Tarball is ready: $OUTPUT_FILE"
-
-rm -rf "$tmp_dir"
-rm -rf "$record_sim_build_dir"

--- a/packages/worker/package.sh
+++ b/packages/worker/package.sh
@@ -93,11 +93,16 @@ if [[ "$PLATFORM" == "ios" ]]; then
   record_sim_package_dir="$ROOT_DIR/packages/build-tools/resources/record-sim"
   record_sim_bin_dir="$target_root_dir/packages/build-tools/bin"
   mkdir -p "$record_sim_bin_dir"
+  record_sim_bin_path=$(swift build \
+    -c release \
+    --package-path "$record_sim_package_dir" \
+    --build-path "$record_sim_build_dir" \
+    --show-bin-path)
   swift build \
     -c release \
     --package-path "$record_sim_package_dir" \
     --build-path "$record_sim_build_dir"
-  cp "$record_sim_build_dir/release/record-sim" "$record_sim_bin_dir/record-sim"
+  cp "$record_sim_bin_path/record-sim" "$record_sim_bin_dir/record-sim"
   chmod +x "$record_sim_bin_dir/record-sim"
 
   # build plugin
@@ -125,5 +130,5 @@ tar zcf $OUTPUT_FILE -C $target_root_dir .
 
 echo "Tarball is ready: $OUTPUT_FILE"
 
-rm -rf $tmp_dir
-rm -rf $record_sim_build_dir
+rm -rf "$tmp_dir"
+rm -rf "$record_sim_build_dir"


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Add a small Swift helper for recording iOS Simulator screen output from EAS build workers. The helper produces either segmented fMP4 output with manifest metadata for playlist construction or one continuous MP4 when segmentation is disabled.

# How

- Added a `record-sim` Swift package under `@expo/build-tools` resources.
- Added `yarn workspace @expo/build-tools build:record-sim` for local builds into `packages/build-tools/bin/record-sim`.
- Updated iOS worker packaging to build `record-sim` from source and copy only the executable into the worker archive.
- Ignored the generated local `bin/record-sim` binary.

# Test Plan

- `yarn workspace @expo/build-tools build:record-sim`
- `packages/build-tools/bin/record-sim --help`
- `bash -n packages/worker/package.sh`
- `yarn workspace @expo/build-tools typecheck`
- `./node_modules/.bin/oxfmt --check packages/build-tools/.gitignore packages/build-tools/package.json packages/worker/package.sh packages/build-tools/src/index.ts`