### PR TITLE
[eas-cli] Add deno package manager support for builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Detect deno as the package manager for projects with a `deno.lock` lockfile, and use `deno install` / `deno task` during builds. ([#3951](https://github.com/expo/eas-cli/pull/3951) by [@yyq1025](https://github.com/yyq1025))
+
 ### 🐛 Bug fixes
 
 - [eas-cli] Retry uploading assets that don't finish processing during `eas update`, instead of failing the update. ([#3918](https://github.com/expo/eas-cli/pull/3918) by [@gwdp](https://github.com/gwdp))

--- a/packages/build-tools/src/common/__tests__/installDependencies.test.ts
+++ b/packages/build-tools/src/common/__tests__/installDependencies.test.ts
@@ -3,7 +3,10 @@ import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
 import { createMockLogger } from '../../__tests__/utils/logger';
 import { Sentry } from '../../sentry';
 import { PackageManager } from '../../utils/packageManager';
-import { installDependenciesWithNpmCacheFallbackAsync } from '../installDependencies';
+import {
+  installDependenciesAsync,
+  installDependenciesWithNpmCacheFallbackAsync,
+} from '../installDependencies';
 
 jest.mock('@expo/turtle-spawn', () => jest.fn());
 jest.mock('../../sentry', () => ({
@@ -11,6 +14,57 @@ jest.mock('../../sentry', () => ({
     capture: jest.fn(),
   },
 }));
+
+describe(installDependenciesAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('runs "deno install" for deno projects', async () => {
+    const logger = createMockLogger();
+    jest.mocked(spawn).mockReturnValueOnce(createSpawnPromise(Promise.resolve(createSpawnResult())));
+
+    await installDependenciesAsync({
+      packageManager: PackageManager.DENO,
+      env: {},
+      logger,
+      cwd: '/tmp/build',
+      useFrozenLockfile: false,
+    });
+
+    expect(spawn).toHaveBeenCalledWith('deno', ['install'], expect.any(Object));
+  });
+
+  it('runs "deno install --frozen" when using a frozen lockfile', async () => {
+    const logger = createMockLogger();
+    jest.mocked(spawn).mockReturnValueOnce(createSpawnPromise(Promise.resolve(createSpawnResult())));
+
+    await installDependenciesAsync({
+      packageManager: PackageManager.DENO,
+      env: {},
+      logger,
+      cwd: '/tmp/build',
+      useFrozenLockfile: true,
+    });
+
+    expect(spawn).toHaveBeenCalledWith('deno', ['install', '--frozen'], expect.any(Object));
+  });
+
+  it('does not pass --verbose to deno when EAS_VERBOSE is set', async () => {
+    const logger = createMockLogger();
+    jest.mocked(spawn).mockReturnValueOnce(createSpawnPromise(Promise.resolve(createSpawnResult())));
+
+    await installDependenciesAsync({
+      packageManager: PackageManager.DENO,
+      env: { EAS_VERBOSE: '1' },
+      logger,
+      cwd: '/tmp/build',
+      useFrozenLockfile: false,
+    });
+
+    expect(spawn).toHaveBeenCalledWith('deno', ['install'], expect.any(Object));
+  });
+});
 
 describe(installDependenciesWithNpmCacheFallbackAsync, () => {
   beforeEach(() => {

--- a/packages/build-tools/src/common/installDependencies.ts
+++ b/packages/build-tools/src/common/installDependencies.ts
@@ -60,10 +60,14 @@ export async function installDependenciesAsync({
     case PackageManager.BUN:
       args = ['install', ...(useFrozenLockfile ? ['--frozen-lockfile'] : [])];
       break;
+    case PackageManager.DENO:
+      args = ['install', ...(useFrozenLockfile ? ['--frozen'] : [])];
+      break;
     default:
       throw new Error(`Unsupported package manager: ${packageManager}`);
   }
-  if (env['EAS_VERBOSE'] === '1') {
+  // `deno install` does not support a --verbose flag.
+  if (env['EAS_VERBOSE'] === '1' && packageManager !== PackageManager.DENO) {
     args = [...args, '--verbose'];
   }
   logger.info(`Running "${packageManager} ${args.join(' ')}" in ${cwd} directory`);

--- a/packages/build-tools/src/steps/functions/prebuild.ts
+++ b/packages/build-tools/src/steps/functions/prebuild.ts
@@ -59,6 +59,8 @@ export function createPrebuildBuildFunction(): BuildFunction {
         await spawn('pnpm', argsWithExpo, options);
       } else if (packageManager === PackageManager.BUN) {
         await spawn('bun', argsWithExpo, options);
+      } else if (packageManager === PackageManager.DENO) {
+        await spawn('deno', ['run', '-A', 'npm:expo', ...prebuildCommandArgs], options);
       } else {
         throw new Error(`Unsupported package manager: ${packageManager}`);
       }

--- a/packages/build-tools/src/utils/__tests__/hooks.test.ts
+++ b/packages/build-tools/src/utils/__tests__/hooks.test.ts
@@ -98,6 +98,28 @@ describe(runHookIfPresent, () => {
     expect(true).toBe(true);
   });
 
+  it('runs the hook with `deno task` when the project uses deno', async () => {
+    vol.fromJSON(
+      {
+        './package.json': JSON.stringify({
+          scripts: {
+            [Hook.POST_INSTALL]: 'echo post_install',
+          },
+        }),
+        './deno.lock': 'fakelockfile',
+      },
+      '/workingdir/build'
+    );
+
+    await runHookIfPresent(ctx, Hook.POST_INSTALL);
+
+    expect(spawn).toBeCalledWith(
+      PackageManager.DENO,
+      ['task', Hook.POST_INSTALL],
+      expect.anything()
+    );
+  });
+
   it('does not run the hook if not present in package.json', async () => {
     vol.fromJSON(
       {

--- a/packages/build-tools/src/utils/__tests__/packageManager.test.ts
+++ b/packages/build-tools/src/utils/__tests__/packageManager.test.ts
@@ -72,6 +72,34 @@ describe(resolvePackageManager, () => {
     expect(resolvePackageManager(nestedDir, { env: {} })).toBe('yarn');
   });
 
+  it('returns deno when only deno.lock exists', async () => {
+    await fs.writeFile(path.join(rootDir, 'deno.lock'), 'content');
+    expect(resolvePackageManager(rootDir, { env: {} })).toBe(PackageManager.DENO);
+  });
+
+  it('returns yarn when both yarn.lock and deno.lock exist', async () => {
+    // Node package manager lockfiles take precedence over deno.lock.
+    await fs.writeFile(path.join(rootDir, 'yarn.lock'), 'content');
+    await fs.writeFile(path.join(rootDir, 'deno.lock'), 'content');
+    expect(resolvePackageManager(rootDir, { env: {} })).toBe(PackageManager.YARN);
+  });
+
+  it('returns deno within a monorepo with deno.lock at the workspace root', async () => {
+    await fs.writeFile(path.join(rootDir, 'deno.lock'), 'content');
+    await fs.writeJson(path.join(rootDir, 'package.json'), {
+      name: 'monorepo',
+      workspaces: ['packages/*'],
+    });
+
+    const nestedDir = path.join(rootDir, 'packages', 'expo-app');
+    await fs.mkdirp(nestedDir);
+    await fs.writeJson(path.join(nestedDir, 'package.json'), {
+      name: '@monorepo/expo-app',
+    });
+
+    expect(resolvePackageManager(nestedDir, { env: {} })).toBe(PackageManager.DENO);
+  });
+
   it('returns yarn when no lockfile and env var is an empty string', () => {
     expect(
       resolvePackageManager(rootDir, {
@@ -89,6 +117,12 @@ describe(resolvePackageManager, () => {
   it('returns pnpm from EAS_FALLBACK_PACKAGE_MANAGER when no lockfile', () => {
     expect(resolvePackageManager(rootDir, { env: { EAS_FALLBACK_PACKAGE_MANAGER: 'pnpm' } })).toBe(
       PackageManager.PNPM
+    );
+  });
+
+  it('returns deno from EAS_FALLBACK_PACKAGE_MANAGER when no lockfile', () => {
+    expect(resolvePackageManager(rootDir, { env: { EAS_FALLBACK_PACKAGE_MANAGER: 'deno' } })).toBe(
+      PackageManager.DENO
     );
   });
 
@@ -112,7 +146,7 @@ describe(resolvePackageManager, () => {
       const error = e as errors.UserError;
       expect(error.errorCode).toBe('EAS_INVALID_FALLBACK_PACKAGE_MANAGER');
       expect(error.message).toContain('bunn');
-      expect(error.message).toContain('yarn, npm, pnpm, bun');
+      expect(error.message).toContain('yarn, npm, pnpm, bun, deno');
     }
   });
 });

--- a/packages/build-tools/src/utils/__tests__/project.test.ts
+++ b/packages/build-tools/src/utils/__tests__/project.test.ts
@@ -83,6 +83,24 @@ describe(runExpoCliCommand, () => {
       void runExpoCliCommand({ args: ['doctor'], options: {}, packageManager: ctx.packageManager });
       expect(spawn).toHaveBeenCalledWith('bun', ['expo', 'doctor'], expect.any(Object));
     });
+
+    it('spawns expo via "deno" when package manager is deno', () => {
+      const mockExpoConfig = mock<ExpoConfig>();
+      when(mockExpoConfig.sdkVersion).thenReturn('46.0.0');
+      const expoConfig = instance(mockExpoConfig);
+
+      const mockCtx = mock<BuildContext<Android.Job>>();
+      when(mockCtx.packageManager).thenReturn(PackageManager.DENO);
+      when(mockCtx.appConfig).thenReturn(Promise.resolve(expoConfig));
+      const ctx = instance(mockCtx);
+
+      void runExpoCliCommand({ args: ['doctor'], options: {}, packageManager: ctx.packageManager });
+      expect(spawn).toHaveBeenCalledWith(
+        'deno',
+        ['run', '-A', 'npm:expo', 'doctor'],
+        expect.any(Object)
+      );
+    });
   });
 });
 

--- a/packages/build-tools/src/utils/hooks.ts
+++ b/packages/build-tools/src/utils/hooks.ts
@@ -34,7 +34,9 @@ export async function runHookIfPresent<TJob extends BuildJob>(
       ctx.packageManager === PackageManager.YARN && hook === Hook.PRE_INSTALL
         ? PackageManager.NPM
         : ctx.packageManager;
-    await spawn(packageManager, ['run', hook], {
+    // `deno task` is deno's equivalent of `<packageManager> run` for package.json scripts.
+    const runArgs = packageManager === PackageManager.DENO ? ['task', hook] : ['run', hook];
+    await spawn(packageManager, runArgs, {
       cwd: projectDir,
       logger: ctx.logger,
       env: {

--- a/packages/build-tools/src/utils/packageManager.ts
+++ b/packages/build-tools/src/utils/packageManager.ts
@@ -1,8 +1,11 @@
+import path from 'path';
+
 import { errors } from '@expo/eas-build-job';
 import { type bunyan } from '@expo/logger';
 import * as PackageManagerUtils from '@expo/package-manager';
 import { type BuildStepEnv } from '@expo/steps';
 import spawnAsync from '@expo/turtle-spawn';
+import fs from 'fs-extra';
 import semver from 'semver';
 import { z } from 'zod';
 
@@ -11,6 +14,17 @@ export enum PackageManager {
   NPM = 'npm',
   PNPM = 'pnpm',
   BUN = 'bun',
+  DENO = 'deno',
+}
+
+export const DENO_LOCK_FILE = 'deno.lock';
+
+function isUsingDeno(directory: string): boolean {
+  if (fs.existsSync(path.join(directory, DENO_LOCK_FILE))) {
+    return true;
+  }
+  const workspaceRoot = PackageManagerUtils.resolveWorkspaceRoot(directory);
+  return workspaceRoot ? fs.existsSync(path.join(workspaceRoot, DENO_LOCK_FILE)) : false;
 }
 
 export function resolvePackageManager(
@@ -29,6 +43,12 @@ export function resolvePackageManager(
       return PackageManager.YARN;
     }
   } catch {}
+
+  // `@expo/package-manager` does not know about deno (yet), so a Node package
+  // manager lockfile always wins; deno.lock only decides when none is present.
+  if (isUsingDeno(directory)) {
+    return PackageManager.DENO;
+  }
 
   const fallback = env.EAS_FALLBACK_PACKAGE_MANAGER;
   if (fallback) {

--- a/packages/build-tools/src/utils/project.ts
+++ b/packages/build-tools/src/utils/project.ts
@@ -61,6 +61,10 @@ export function runExpoCliCommand({
     return spawn('pnpm', argsWithExpo, options);
   } else if (packageManager === PackageManager.BUN) {
     return spawn('bun', argsWithExpo, options);
+  } else if (packageManager === PackageManager.DENO) {
+    // deno has no bare `deno expo …` bin runner; `deno run -A npm:expo`
+    // resolves the copy from local node_modules when present.
+    return spawn('deno', ['run', '-A', 'npm:expo', ...args], options);
   } else {
     throw new Error(`Unsupported package manager: ${packageManager}`);
   }

--- a/packages/eas-build-job/src/metadata.ts
+++ b/packages/eas-build-job/src/metadata.ts
@@ -153,7 +153,7 @@ export type Metadata = {
   /**
    * Which package manager will be used for the build. Determined based on lockfiles in the project directory.
    */
-  requiredPackageManager?: 'npm' | 'pnpm' | 'yarn' | 'bun';
+  requiredPackageManager?: 'npm' | 'pnpm' | 'yarn' | 'bun' | 'deno';
 
   /**
    * Indicates if this is an iOS build for a simulator
@@ -203,7 +203,7 @@ export const MetadataSchema = Joi.object({
   runWithNoWaitFlag: Joi.boolean(),
   customWorkflowName: Joi.string(),
   developmentClient: Joi.boolean(),
-  requiredPackageManager: Joi.string().valid('npm', 'pnpm', 'yarn', 'bun'),
+  requiredPackageManager: Joi.string().valid('npm', 'pnpm', 'yarn', 'bun', 'deno'),
   simulator: Joi.boolean(),
   selectedImage: Joi.string(),
   customNodeVersion: Joi.string(),

--- a/packages/eas-cli/src/build/__tests__/validateLockfile-test.ts
+++ b/packages/eas-cli/src/build/__tests__/validateLockfile-test.ts
@@ -44,6 +44,11 @@ describe(ensureLockfileExistsAsync, () => {
     await expect(ensureLockfileExistsAsync('/app')).resolves.not.toThrow();
   });
 
+  it('passes when deno.lock exists', async () => {
+    vol.fromJSON({ './deno.lock': '' }, '/app');
+    await expect(ensureLockfileExistsAsync('/app')).resolves.not.toThrow();
+  });
+
   it('throws when no lockfile exists', async () => {
     vol.fromJSON({ './package.json': '{}' }, '/app');
     await expect(ensureLockfileExistsAsync('/app')).rejects.toThrow(

--- a/packages/eas-cli/src/build/validateLockfile.ts
+++ b/packages/eas-cli/src/build/validateLockfile.ts
@@ -9,12 +9,16 @@ import {
 import { pathExists } from 'fs-extra';
 import path from 'path';
 
+// Not exported by @expo/package-manager, which has no deno support (yet).
+const DENO_LOCK_FILE = 'deno.lock';
+
 const LOCKFILE_NAMES = [
   NPM_LOCK_FILE,
   YARN_LOCK_FILE,
   PNPM_LOCK_FILE,
   BUN_LOCK_FILE,
   BUN_TEXT_LOCK_FILE,
+  DENO_LOCK_FILE,
 ];
 
 async function hasLockfileAsync(dir: string): Promise<boolean> {


### PR DESCRIPTION
# Why

Deno 2 works well as a package manager for Expo/React Native projects: `deno install` materializes a Node-compatible `node_modules` tree that Metro, `expo export`, autolinking, and `pod install` all resolve correctly (verified end-to-end on an Expo SDK 56 / RN 0.85 app with native modules). But EAS Build only detects npm / yarn / pnpm / bun lockfiles, so a deno-managed project (which has only `deno.lock`) silently falls back to a `yarn install` with no lockfile — an unpinned dependency tree, the exact drift a lockfile is meant to prevent.

This mirrors how bun support was added (see #2782 for the bun.lock precedent). The immediate audience is `eas build --local`, where deno is already on the user's machine.

Running the Expo CLI itself under the deno runtime is also a supported path upstream: the Deno team tracked Expo compatibility in denoland/deno#22970 and closed it after fixing the blockers.

# How

Following the existing bun pattern across the build pipeline, with three deno-specific semantic mappings:

- **Detection** (`build-tools/utils/packageManager.ts`): a project (or its workspace root) with `deno.lock` resolves to `PackageManager.DENO`. `@expo/package-manager` has no deno support yet, so the check lives here for now — and it only runs when the external resolver finds no Node package manager lockfile, so **any existing npm/yarn/pnpm/bun project is completely unaffected**. Happy to follow up with a PR to `@expo/package-manager` to move detection to its proper layer.
- **Install** (`common/installDependencies.ts`): `deno install`, with `--frozen` when a frozen lockfile is requested (deno's equivalent of `--frozen-lockfile`). `deno install` has no `--verbose` flag, so `EAS_VERBOSE` is not forwarded.
- **Expo CLI** (`utils/project.ts`, `steps/functions/prebuild.ts`): `deno run -A npm:expo <args>` — deno has no bare `deno expo` bin runner; `npm:expo` resolves the copy from local `node_modules` when present.
- **Lifecycle hooks** (`utils/hooks.ts`): `deno task <hook>` — `deno task` is deno's equivalent of `<packageManager> run` for package.json scripts (`deno run` executes files, not scripts).
- `deno.lock` is accepted by `ensureLockfileExistsAsync`, and `'deno'` is a valid `requiredPackageManager` metadata value and `EAS_FALLBACK_PACKAGE_MANAGER` value.

**Scope note:** cloud workers don't have deno installed yet, so this primarily targets `eas build --local`. On cloud, a deno-only project changes from "silent unpinned yarn install" to an explicit spawn failure — arguably more honest, but I'm happy to gate detection to local builds or add worker provisioning (mirroring `installBun()`) if you'd prefer either.

One known follow-up for full parity: deno blocks npm lifecycle scripts by default (`--allow-scripts`); projects relying on postinstall-heavy native deps need a story for that. Left out of this PR to keep it reviewable — flagging for discussion.

# Test Plan

New unit tests mirroring the bun coverage, all passing (`yarn test` in `build-tools`, `eas-cli`, `eas-build-job`; full `lerna run build` passes):

- detection: `deno.lock` only → deno; `deno.lock` + `yarn.lock` → yarn (Node lockfile precedence); monorepo with `deno.lock` at workspace root → deno; `EAS_FALLBACK_PACKAGE_MANAGER=deno`
- install args: `deno install` / `deno install --frozen`; `EAS_VERBOSE` not forwarded to deno
- expo CLI: spawns `deno run -A npm:expo doctor`
- hooks: spawns `deno task eas-build-post-install`
- lockfile validation accepts `deno.lock`

Manual verification of the underlying assumption (deno-installed trees build correctly): on a deno-managed Expo SDK 56 / RN 0.85 monorepo app, `deno install` + `expo export --platform ios` (Hermes + DOM component bundles), `expo-modules-autolinking resolve` (38/38 module parity with the pnpm tree), `expo prebuild`, and `pod install` all succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
