### PR TITLE
[worker] warn on unknown build environment

### DIFF
--- a/packages/worker/src/__unit__/build.test.ts
+++ b/packages/worker/src/__unit__/build.test.ts
@@ -1,0 +1,75 @@
+import { BuildContext, Builders } from '@expo/build-tools';
+import { Platform } from '@expo/eas-build-job';
+
+import { build, warnOnUnknownEnvironment } from '../build';
+import { Analytics } from '../external/analytics';
+
+jest.mock('@expo/build-tools', () => {
+  const actual = jest.requireActual('@expo/build-tools');
+  return {
+    ...actual,
+    Builders: {
+      androidBuilder: jest.fn(async () => ({})),
+      iosBuilder: jest.fn(async () => ({})),
+    },
+  };
+});
+jest.mock('../displayRuntimeInfo', () => ({ displayWorkerRuntimeInfo: jest.fn() }));
+jest.mock('../workingdir', () => ({ cleanUpWorkingdir: jest.fn() }));
+jest.mock('../external/analytics', () => ({
+  ...jest.requireActual('../external/analytics'),
+  logProjectDependenciesAsync: jest.fn(),
+}));
+
+function createEnvironmentWarningCtx(environment?: string) {
+  return {
+    metadata: environment === undefined ? undefined : { environment },
+    markBuildPhaseHasWarnings: jest.fn(),
+    logger: { warn: jest.fn() },
+  };
+}
+
+describe(warnOnUnknownEnvironment.name, () => {
+  it('warns and marks the phase for an unknown environment', () => {
+    const ctx = createEnvironmentWarningCtx('staging');
+    warnOnUnknownEnvironment(ctx);
+    expect(ctx.markBuildPhaseHasWarnings).toHaveBeenCalled();
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown environment "staging"')
+    );
+  });
+
+  it.each(['development', 'preview', 'production'])('does not warn for %s', environment => {
+    const ctx = createEnvironmentWarningCtx(environment);
+    warnOnUnknownEnvironment(ctx);
+    expect(ctx.markBuildPhaseHasWarnings).not.toHaveBeenCalled();
+    expect(ctx.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when no environment is set', () => {
+    const ctx = createEnvironmentWarningCtx(undefined);
+    warnOnUnknownEnvironment(ctx);
+    expect(ctx.logger.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe(build.name, () => {
+  it('warns during spin-up when the job environment is unknown', async () => {
+    const warn = jest.fn();
+    const markBuildPhaseHasWarnings = jest.fn();
+    const ctx = {
+      metadata: { environment: 'staging' },
+      job: { platform: Platform.ANDROID },
+      logger: { info: jest.fn(), warn, child: jest.fn() },
+      markBuildPhaseHasWarnings,
+      runBuildPhase: jest.fn(async (_phase, callback) => callback()),
+    } as unknown as BuildContext;
+    const analytics = { logEvent: jest.fn(), flushEventsAsync: jest.fn() } as unknown as Analytics;
+
+    await build({ ctx, buildId: 'build-id', analytics });
+
+    expect(Builders.androidBuilder).toHaveBeenCalled();
+    expect(markBuildPhaseHasWarnings).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Unknown environment "staging"'));
+  });
+});

--- a/packages/worker/src/build.ts
+++ b/packages/worker/src/build.ts
@@ -19,6 +19,26 @@ import { Analytics, Event, logProjectDependenciesAsync } from './external/analyt
 import { prepareRuntimeEnvironment } from './runtimeEnvironment';
 import { cleanUpWorkingdir } from './workingdir';
 
+const KNOWN_BUILD_ENVIRONMENTS = ['development', 'preview', 'production'];
+
+type EnvironmentWarningContext = {
+  metadata?: { environment?: string };
+  logger: Pick<bunyan, 'warn'>;
+  markBuildPhaseHasWarnings: () => void;
+};
+
+export function warnOnUnknownEnvironment(ctx: EnvironmentWarningContext): void {
+  const environment = ctx.metadata?.environment;
+  if (environment && !KNOWN_BUILD_ENVIRONMENTS.includes(environment)) {
+    ctx.markBuildPhaseHasWarnings();
+    ctx.logger.warn(
+      `Unknown environment "${environment}". Expected one of: ${KNOWN_BUILD_ENVIRONMENTS.join(
+        ', '
+      )}. No environment variables were added for it.`
+    );
+  }
+}
+
 export async function build({
   ctx,
   buildId,
@@ -40,6 +60,7 @@ export async function build({
           { job: omit(ctx.job, 'secrets', 'projectArchive') },
           'Builder is ready, starting build'
         );
+        warnOnUnknownEnvironment(ctx);
       },
       { doNotMarkStart: true }
     );


### PR DESCRIPTION
# Why

A workflow job with an environment that doesn't exist (e.g. `staging`, vs `development`/`preview`/`production`) gets no warning. It silently resolves to zero environment variables and fails later in a confusing, unrelated-looking way (e.g. the app config failing to read).

# How

Warn in the "Spin up build environment" phase when the job's environment isn't `development`/`preview`/`production`.

# Test Plan

Ran this job against a local worker:

```yaml
jobs:
  verify_fingerprint_job_outputs:
    name: Verify fingerprint job outputs
    type: custom
    environment: staging
    runs_on: linux-medium
    steps:
      - run: echo "=== test job ==="
```

<img width="1315" height="773" alt="Screenshot 2026-07-03 at 4 18 14 PM" src="https://github.com/user-attachments/assets/819de481-e222-4e8e-a034-4b7636e73b60" />
<img width="1321" height="618" alt="Screenshot 2026-07-03 at 4 21 17 PM" src="https://github.com/user-attachments/assets/6c91166c-b0db-4153-a7b9-558d3aba62f5" />

