### PR TITLE
[codex] fix handlebars dependabot alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - [eas-cli] Bump `axios` to patched releases to resolve [Dependabot alert 439](https://github.com/expo/eas-cli/security/dependabot/439). ([#3964](https://github.com/expo/eas-cli/pull/3964) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Bump `handlebars` to `4.7.9` to resolve [Dependabot alert 334](https://github.com/expo/eas-cli/security/dependabot/334). ([#3958](https://github.com/expo/eas-cli/pull/3958) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [21.0.1](https://github.com/expo/eas-cli/releases/tag/v21.0.1) - 2026-07-15
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13056,8 +13056,8 @@ __metadata:
   linkType: hard
 
 "handlebars@npm:^4.7.7, handlebars@npm:^4.7.8":
-  version: 4.7.8
-  resolution: "handlebars@npm:4.7.8"
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.2"
@@ -13069,7 +13069,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10c0/7aff423ea38a14bb379316f3857fe0df3c5d66119270944247f155ba1f08e07a92b340c58edaa00cfe985c21508870ee5183e0634dcb53dd405f35c93ef7f10d
+  checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

Dependabot reported [security alert 334](https://github.com/expo/eas-cli/security/dependabot/334) for the transitive dev dependency `handlebars` (`GHSA-2w6w-674q-4c4q`, `CVE-2026-33937`). The existing lockfile resolved the `^4.7.7` and `^4.7.8` ranges to vulnerable `4.7.8`; `4.7.9` is the patched release.

# How

Re-resolved `handlebars` with Yarn so the lockfile now pins `handlebars@4.7.9` for the existing transitive ranges. Added a `main` changelog chore entry for the security bump.

# Test Plan

- `corepack yarn fmt`
- `corepack yarn install --immutable`
- `corepack yarn why handlebars`
- `corepack yarn lint-changelog`
- `git diff --check`

`corepack yarn install --immutable` still reports the same pre-existing peer dependency warnings for `graphql`, `oxlint-tsgolint`, `eslint`, and `@types/node`.