### PR TITLE
[codex] fix axios dependabot alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Bump `axios` to patched releases to resolve [Dependabot alert 439](https://github.com/expo/eas-cli/security/dependabot/439). ([#3964](https://github.com/expo/eas-cli/pull/3964) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [21.0.1](https://github.com/expo/eas-cli/releases/tag/v21.0.1) - 2026-07-15
 
 ### 🎉 New features

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -160,7 +160,7 @@
     "@types/tough-cookie": "4.0.2",
     "@types/uuid": "9.0.7",
     "@types/wrap-ansi": "3.0.0",
-    "axios": "1.16.0",
+    "axios": "1.18.1",
     "eslint-plugin-graphql": "4.0.0",
     "express": "4.20.0",
     "jest": "29.7.0",

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -160,7 +160,7 @@
     "@types/tough-cookie": "4.0.2",
     "@types/uuid": "9.0.7",
     "@types/wrap-ansi": "3.0.0",
-    "axios": "1.11.0",
+    "axios": "1.16.0",
     "eslint-plugin-graphql": "4.0.0",
     "express": "4.20.0",
     "jest": "29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8989,25 +8989,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.11.0":
-  version: 1.11.0
-  resolution: "axios@npm:1.11.0"
+"axios@npm:1.16.0":
+  version: 1.16.0
+  resolution: "axios@npm:1.16.0"
   dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.4"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/5de273d33d43058610e4d252f0963cc4f10714da0bfe872e8ef2cbc23c2c999acc300fd357b6bce0fc84a2ca9bd45740fa6bb28199ce2c1266c8b1a393f2b36e
+    follow-redirects: "npm:^1.16.0"
+    form-data: "npm:^4.0.5"
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10c0/1c91a5221b77b76072026b4cc95ecdf38f7c3e33e63423abec09a85e6e9a12279637dcc9ac2ba1fc333e0c447fb3b0f46d7965acb5d7cea02d188e9c6d425c0b
   languageName: node
   linkType: hard
 
 "axios@npm:^1.12.0":
-  version: 1.13.3
-  resolution: "axios@npm:1.13.3"
+  version: 1.18.1
+  resolution: "axios@npm:1.18.1"
   dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.4"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/86f0770624d9f14a3f8f8738c8b8f7f7fbb7b0d4ad38757db1de2d71007a0311bc597661c5ff4b4a9ee6350c6956a7282e3a281fcdf7b5b32054e35a8801e2ce
+    follow-redirects: "npm:^1.16.0"
+    form-data: "npm:^4.0.5"
+    https-proxy-agent: "npm:^5.0.1"
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10c0/9d9378a3af0d0ad730a52ad9d15ec7201f3926ad6e7e8bbffc5ae21ca2835ad11d1d9598698f5dd9718917486039f55ea1d7dc23d8e44fa827a55cc3262c02fc
   languageName: node
   linkType: hard
 
@@ -11227,7 +11228,7 @@ __metadata:
     agent-cli-detector: "npm:0.1.2"
     ajv: "npm:8.11.0"
     ajv-formats: "npm:2.1.1"
-    axios: "npm:1.11.0"
+    axios: "npm:1.16.0"
     better-opn: "npm:3.0.2"
     bplist-parser: "npm:^0.3.0"
     chalk: "npm:4.1.2"
@@ -12156,13 +12157,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.6":
-  version: 1.15.9
-  resolution: "follow-redirects@npm:1.15.9"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/5829165bd112c3c0e82be6c15b1a58fa9dcfaede3b3c54697a82fe4a62dd5ae5e8222956b448d2f98e331525f05d00404aba7d696de9e761ef6e42fdc780244f
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 
@@ -13371,7 +13372,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:5.0.1":
+"https-proxy-agent@npm:5.0.1, https-proxy-agent@npm:^5.0.1":
   version: 5.0.1
   resolution: "https-proxy-agent@npm:5.0.1"
   dependencies:
@@ -18036,10 +18037,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "proxy-from-env@npm:1.1.0"
-  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8989,18 +8989,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.16.0":
-  version: 1.16.0
-  resolution: "axios@npm:1.16.0"
-  dependencies:
-    follow-redirects: "npm:^1.16.0"
-    form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/1c91a5221b77b76072026b4cc95ecdf38f7c3e33e63423abec09a85e6e9a12279637dcc9ac2ba1fc333e0c447fb3b0f46d7965acb5d7cea02d188e9c6d425c0b
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.12.0":
+"axios@npm:1.18.1, axios@npm:^1.12.0":
   version: 1.18.1
   resolution: "axios@npm:1.18.1"
   dependencies:
@@ -11228,7 +11217,7 @@ __metadata:
     agent-cli-detector: "npm:0.1.2"
     ajv: "npm:8.11.0"
     ajv-formats: "npm:2.1.1"
-    axios: "npm:1.16.0"
+    axios: "npm:1.18.1"
     better-opn: "npm:3.0.2"
     bplist-parser: "npm:^0.3.0"
     chalk: "npm:4.1.2"


### PR DESCRIPTION
# Why

Dependabot reported [security alert 439](https://github.com/expo/eas-cli/security/dependabot/439) for `axios` (`GHSA-p92q-9vqr-4j8v`, `CVE-2026-44487`). The `eas-cli` package pinned vulnerable `axios@1.11.0`, and the lockfile also contained vulnerable transitive `axios@1.13.3`. `1.16.0` is the first patched 1.x release; this PR uses `1.18.1` to align with the version already resolved for Nx.

# How

Updated `eas-cli` to depend on `axios@1.18.1` and re-resolved `axios` with Yarn so the direct dependency and Nx's existing `^1.12.0` range share a single `axios@1.18.1` lockfile resolution. Added a `main` changelog chore entry for the security bump.

# Test Plan

- `corepack yarn oxfmt packages/eas-cli/package.json yarn.lock`
- `corepack yarn install --immutable`
- `corepack yarn fmt:check`
- `corepack yarn why axios`
- `corepack yarn lint-changelog`
- `git diff --check`

`corepack yarn install --immutable` still reports the same pre-existing peer dependency warnings for `graphql`, `oxlint-tsgolint`, `eslint`, and `@types/node`.
