### PR TITLE
[codex] fix xmldom dependabot alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Resolve `@xmldom/xmldom` to `0.8.13` to resolve [Dependabot alert 372](https://github.com/expo/eas-cli/security/dependabot/372). ([#3967](https://github.com/expo/eas-cli/pull/3967) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [20.5.1](https://github.com/expo/eas-cli/releases/tag/v20.5.1) - 2026-07-01
 
 ### 🐛 Bug fixes

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "ts-jest": "29.1.1",
     "typescript": "5.5.4"
   },
+  "resolutions": {
+    "@xmldom/xmldom": "0.8.13"
+  },
   "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8510,17 +8510,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.8.8":
-  version: 0.8.10
-  resolution: "@xmldom/xmldom@npm:0.8.10"
-  checksum: 10c0/c7647c442502720182b0d65b17d45d2d95317c1c8c497626fe524bda79b4fb768a9aa4fae2da919f308e7abcff7d67c058b102a9d641097e9a57f0b80187851f
-  languageName: node
-  linkType: hard
-
-"@xmldom/xmldom@npm:~0.7.7":
-  version: 0.7.9
-  resolution: "@xmldom/xmldom@npm:0.7.9"
-  checksum: 10c0/aa664f1e670081dd116d879562dffbd9f80e91dea4867e4af0d6ae4c9f29e1b2dbed6b12b1116b139ebf7221f682fa90c4bc2b2d251342b05b813f1b88a293ac
+"@xmldom/xmldom@npm:0.8.13":
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: 10c0/06405ee6fffba631abf715a305ace338420ebcea8baf1317f19f2752f5c505952b7df45159908e7be8451a42faa54326b780616ab4d08242b20477b2973da24b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

Dependabot reported [alert 372](https://github.com/expo/eas-cli/security/dependabot/372) for `@xmldom/xmldom` (`GHSA-2v35-w6hq-6mfw`, `CVE-2026-41673`). Versions below `0.8.13` are vulnerable to uncontrolled recursion during XML DOM traversal and serialization, which can lead to denial of service.

# How

Added a root Yarn resolution for `@xmldom/xmldom@0.8.13` so all `@expo/plist` and `plist` transitive paths resolve to the patched release, including older `~0.7.7` ranges that cannot naturally select a patched version. Added a changelog entry for the security fix.

# Test Plan

- `corepack yarn fmt`
- `corepack yarn install --immutable`
- `corepack yarn why @xmldom/xmldom`
- `corepack yarn lint-changelog`
- `git diff --check`

`corepack yarn install --immutable` still reports the existing peer dependency warnings for `graphql`, `oxlint-tsgolint`, `eslint`, and `@types/node`.