### PR TITLE
[codex] fix lodash dependabot alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Resolve `lodash` to `4.18.1` to resolve [Dependabot alert 354](https://github.com/expo/eas-cli/security/dependabot/354). ([#3968](https://github.com/expo/eas-cli/pull/3968) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [20.5.1](https://github.com/expo/eas-cli/releases/tag/v20.5.1) - 2026-07-01
 
 ### 🐛 Bug fixes

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "ts-jest": "29.1.1",
     "typescript": "5.5.4"
   },
+  "resolutions": {
+    "lodash": "4.18.1"
+  },
   "packageManager": "yarn@4.12.0"
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -39,7 +39,7 @@
     "koa": "3.1.1",
     "koa-body": "7.0.1",
     "koa-router": "14.0.0",
-    "lodash": "4.17.21",
+    "lodash": "4.18.1",
     "micromatch": "4.0.8",
     "node-fetch": "2.7.0",
     "node-os-utils": "1.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3593,7 +3593,7 @@ __metadata:
     koa: "npm:3.1.1"
     koa-body: "npm:7.0.1"
     koa-router: "npm:14.0.0"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.18.1"
     memfs: "npm:3.4.1"
     micromatch: "npm:4.0.8"
     node-fetch: "npm:2.7.0"
@@ -15413,17 +15413,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.5, lodash@npm:~4.17.0":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
-  languageName: node
-  linkType: hard
-
-"lodash@npm:^4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+"lodash@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

Dependabot reported [alert 354](https://github.com/expo/eas-cli/security/dependabot/354) for `lodash` (`GHSA-r5fr-rjxr-66jc`, `CVE-2026-4800`). Versions `4.17.23` and below are vulnerable to code injection via `_.template` imports key names.

# How

Added a root Yarn resolution for `lodash@4.18.1` so all transitive lodash ranges, including `~4.17.0`, resolve to a patched release. Updated the worker package's exact lodash pin to `4.18.1`, regenerated the lockfile, and added a changelog entry for the security fix.

# Test Plan

- `corepack yarn fmt`
- `corepack yarn install --immutable`
- `corepack yarn why lodash`
- `corepack yarn lint-changelog`
- `git diff --check`

`corepack yarn install --immutable` still reports the existing peer dependency warnings for `graphql`, `oxlint-tsgolint`, `eslint`, and `@types/node`.