### PR TITLE
[eas-cli] Bump node-forge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Bump `jws` to a patched version in the root lockfile. ([#3978](https://github.com/expo/eas-cli/pull/3978) by [@szdziedzic](https://github.com/szdziedzic))
 - [worker] Bump `koa` to `3.1.2`. ([#3974](https://github.com/expo/eas-cli/pull/3974) by [@szdziedzic](https://github.com/szdziedzic))
 - [steps] Bump `cross-spawn` to a patched version in the TypeScript custom function fixture. ([#3977](https://github.com/expo/eas-cli/pull/3977) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Bump `node-forge` to `1.4.0`. ([#3970](https://github.com/expo/eas-cli/pull/3970) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Bump `fast-xml-builder` to `1.2.1` to resolve [Dependabot alert 400](https://github.com/expo/eas-cli/security/dependabot/400). ([#3966](https://github.com/expo/eas-cli/pull/3966) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Bump `form-data` to patched releases to resolve [Dependabot alert 465](https://github.com/expo/eas-cli/security/dependabot/465). ([#3962](https://github.com/expo/eas-cli/pull/3962) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Bump `fast-xml-parser` to `4.5.7` to resolve [Dependabot alert 286](https://github.com/expo/eas-cli/security/dependabot/286). ([#3960](https://github.com/expo/eas-cli/pull/3960) by [@szdziedzic](https://github.com/szdziedzic))

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -107,7 +107,7 @@
     "minizlib": "3.0.1",
     "nanoid": "3.3.8",
     "node-fetch": "2.6.7",
-    "node-forge": "1.3.1",
+    "node-forge": "1.4.0",
     "node-stream-zip": "1.15.0",
     "nullthrows": "1.1.1",
     "ora": "5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11266,7 +11266,7 @@ __metadata:
     nanoid: "npm:3.3.8"
     nock: "npm:13.4.0"
     node-fetch: "npm:2.6.7"
-    node-forge: "npm:1.3.1"
+    node-forge: "npm:1.4.0"
     node-stream-zip: "npm:1.15.0"
     nullthrows: "npm:1.1.1"
     ora: "npm:5.1.0"
@@ -16410,17 +16410,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:1.3.1, node-forge@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "node-forge@npm:1.3.1"
-  checksum: 10c0/e882819b251a4321f9fc1d67c85d1501d3004b4ee889af822fd07f64de3d1a8e272ff00b689570af0465d65d6bf5074df9c76e900e0aff23e60b847f2a46fbe8
-  languageName: node
-  linkType: hard
-
-"node-forge@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "node-forge@npm:1.2.1"
-  checksum: 10c0/0563bef5c6abfd031018ebd9cae41432811faef0b25ca7651489fb5f946250c3f8c433f42e76e9fd98f0d7617c12b700f8cbea134a1d284df84f8104c79127c0
+"node-forge@npm:1.4.0, node-forge@npm:^1.2.1, node-forge@npm:^1.3.1":
+  version: 1.4.0
+  resolution: "node-forge@npm:1.4.0"
+  checksum: 10c0/67330a5f1f95257a4c8a93b7d555abe87b5f15e350123aa396c97a21a8ca94f9c6549008eb2c73668a91e0d7e3a905785acbd8f8bd0751c29401292011f8f8e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

Resolve https://github.com/expo/eas-cli/security/dependabot/330 by upgrading node-forge to a patched version.

# How

Bumped node-forge to 1.4.0 and refreshed the Yarn lockfile so all workspace and transitive node-forge paths resolve to the patched release.

Added a changelog entry for the dependency bump.

# Test Plan

- corepack yarn fmt
- corepack yarn install --immutable
- git diff --check
- corepack yarn why node-forge
- corepack yarn lint-changelog