### PR TITLE
[eas-cli] Accept navigation metric aliases as positional args to observe:metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [build-tools] Skip embedded bundle upload for development client builds instead of warning that the bundle is missing. ([#3940](https://github.com/expo/eas-cli/pull/3940) by [@gwdp](https://github.com/gwdp))
+- [eas-cli] Accept a navigation metric name in observe:metrics when passed in on the command line. ([#3973](https://github.com/expo/eas-cli/pull/3973) by [@douglowder](https://github.com/douglowder))
 - [eas-cli] Retry uploading assets that don't finish processing during `eas update`, instead of failing the update. ([#3918](https://github.com/expo/eas-cli/pull/3918) by [@gwdp](https://github.com/gwdp))
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
@@ -52,6 +52,23 @@ describe(ObserveMetrics, () => {
     return command;
   }
 
+  it('accepts a navigation metric alias as the positional arg', async () => {
+    const command = createCommand(['nav_tti']);
+    await command.runAsync();
+
+    expect(mockFetchObserveEventsAsync).toHaveBeenCalledTimes(1);
+    expect(mockFetchObserveEventsAsync.mock.calls[0][2].metricName).toBe('expo.navigation.tti');
+  });
+
+  it('accepts nav_cold_ttr as a positional arg and resolves it to the navigation full name', async () => {
+    const command = createCommand(['nav_cold_ttr']);
+    await command.runAsync();
+
+    expect(mockFetchObserveEventsAsync.mock.calls[0][2].metricName).toBe(
+      'expo.navigation.cold_ttr'
+    );
+  });
+
   it('uses --days to compute start/end time range', async () => {
     const now = new Date('2025-06-15T12:00:00.000Z');
     jest.useFakeTimers({ now });

--- a/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
@@ -79,9 +79,9 @@ describe(ObserveRoutes, () => {
   it('resolves --metric short aliases to navigation metric full names and deduplicates', async () => {
     const command = createCommand([
       '--metric',
-      'cold_ttr',
+      'nav_cold_ttr',
       '--metric',
-      'cold_ttr',
+      'nav_cold_ttr',
       '--metric',
       'nav_tti',
     ]);

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -19,12 +19,7 @@ import {
   ObserveTimeRangeFlags,
   ObserveUpdateIdFlag,
 } from '../../observe/flags';
-import {
-  METRIC_ALIASES,
-  METRIC_SHORT_NAMES,
-  NAVIGATION_METRIC_ALIASES,
-  resolveMetricName,
-} from '../../observe/metricNames';
+import { METRIC_ALIASES, METRIC_SHORT_NAMES, resolveMetricName } from '../../observe/metricNames';
 import { buildObserveEventsJson, buildObserveEventsTable } from '../../observe/formatEvents';
 import { appObservePlatformFromFlag, appPlatformsFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
@@ -41,7 +36,7 @@ export default class ObserveMetrics extends EasCommand {
     metric: Args.string({
       description: 'Metric to query (e.g. tti, cold_launch, nav_tti)',
       required: false,
-      options: [...Object.keys(METRIC_ALIASES), ...Object.keys(NAVIGATION_METRIC_ALIASES)],
+      options: Object.keys(METRIC_ALIASES),
     }),
   };
 
@@ -95,7 +90,7 @@ export default class ObserveMetrics extends EasCommand {
     } else if (flags['non-interactive']) {
       throw new EasCommandError(
         'A metric argument is required in non-interactive mode. Available metrics: ' +
-          [...Object.keys(METRIC_ALIASES), ...Object.keys(NAVIGATION_METRIC_ALIASES)].join(', ')
+          Object.keys(METRIC_ALIASES).join(', ')
       );
     } else {
       const choices = Object.entries(METRIC_SHORT_NAMES).map(([fullName, displayName]) => ({

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -19,7 +19,12 @@ import {
   ObserveTimeRangeFlags,
   ObserveUpdateIdFlag,
 } from '../../observe/flags';
-import { METRIC_ALIASES, METRIC_SHORT_NAMES, resolveMetricName } from '../../observe/metricNames';
+import {
+  METRIC_ALIASES,
+  METRIC_SHORT_NAMES,
+  NAVIGATION_METRIC_ALIASES,
+  resolveMetricName,
+} from '../../observe/metricNames';
 import { buildObserveEventsJson, buildObserveEventsTable } from '../../observe/formatEvents';
 import { appObservePlatformFromFlag, appPlatformsFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
@@ -34,9 +39,9 @@ export default class ObserveMetrics extends EasCommand {
 
   static override args = {
     metric: Args.string({
-      description: 'Metric to query (e.g. tti, cold_launch)',
+      description: 'Metric to query (e.g. tti, cold_launch, nav_tti)',
       required: false,
-      options: Object.keys(METRIC_ALIASES),
+      options: [...Object.keys(METRIC_ALIASES), ...Object.keys(NAVIGATION_METRIC_ALIASES)],
     }),
   };
 
@@ -90,7 +95,7 @@ export default class ObserveMetrics extends EasCommand {
     } else if (flags['non-interactive']) {
       throw new EasCommandError(
         'A metric argument is required in non-interactive mode. Available metrics: ' +
-          Object.keys(METRIC_ALIASES).join(', ')
+          [...Object.keys(METRIC_ALIASES), ...Object.keys(NAVIGATION_METRIC_ALIASES)].join(', ')
       );
     } else {
       const choices = Object.entries(METRIC_SHORT_NAMES).map(([fullName, displayName]) => ({

--- a/packages/eas-cli/src/observe/__tests__/__snapshots__/metricNames.test.ts.snap
+++ b/packages/eas-cli/src/observe/__tests__/__snapshots__/metricNames.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`resolveMetricName lists both app-startup and navigation aliases in the error message on unknown alias 1`] = `"Unknown metric: "bogus". Use a full metric name (e.g. expo.app_startup.tti) or a short alias: tti, ttr, cold_launch, warm_launch, bundle_load, update_download, nav_cold_ttr, nav_warm_ttr, nav_tti"`;

--- a/packages/eas-cli/src/observe/__tests__/__snapshots__/metricNames.test.ts.snap
+++ b/packages/eas-cli/src/observe/__tests__/__snapshots__/metricNames.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`resolveMetricName lists both app-startup and navigation aliases in the error message on unknown alias 1`] = `"Unknown metric: "bogus". Use a full metric name (e.g. expo.app_startup.tti) or a short alias: tti, ttr, cold_launch, warm_launch, bundle_load, update_download, nav_cold_ttr, nav_warm_ttr, nav_tti"`;
+exports[`resolveMetricName lists both app-startup and navigation aliases in the error message on unknown alias 1`] = `"Unknown metric: "bogus". Use a full metric name (e.g. expo.app_startup.tti) or a short alias: nav_cold_ttr, nav_warm_ttr, nav_tti, tti, ttr, cold_launch, warm_launch, bundle_load, update_download"`;

--- a/packages/eas-cli/src/observe/__tests__/metricNames.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/metricNames.test.ts
@@ -57,8 +57,11 @@ describe(resolveMetricName, () => {
   });
 
   it('lists both app-startup and navigation aliases in the error message on unknown alias', () => {
-    expect(() => resolveMetricName('bogus')).toThrow(/nav_tti/);
-    expect(() => resolveMetricName('bogus')).toThrow(/cold_launch/);
+    try {
+      resolveMetricName('bogus');
+    } catch (e: any) {
+      expect(e.message).toMatchSnapshot();
+    }
   });
 });
 

--- a/packages/eas-cli/src/observe/__tests__/metricNames.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/metricNames.test.ts
@@ -43,12 +43,29 @@ describe(resolveMetricName, () => {
   it('passes through dot-containing custom metric names', () => {
     expect(resolveMetricName('custom.metric.name')).toBe('custom.metric.name');
   });
+
+  it('resolves navigation short aliases so they can be passed on the observe:metrics command line', () => {
+    expect(resolveMetricName('nav_cold_ttr')).toBe('expo.navigation.cold_ttr');
+    expect(resolveMetricName('nav_warm_ttr')).toBe('expo.navigation.warm_ttr');
+    expect(resolveMetricName('nav_tti')).toBe('expo.navigation.tti');
+  });
+
+  it('passes through navigation full metric names unchanged', () => {
+    expect(resolveMetricName('expo.navigation.cold_ttr')).toBe('expo.navigation.cold_ttr');
+    expect(resolveMetricName('expo.navigation.warm_ttr')).toBe('expo.navigation.warm_ttr');
+    expect(resolveMetricName('expo.navigation.tti')).toBe('expo.navigation.tti');
+  });
+
+  it('lists both app-startup and navigation aliases in the error message on unknown alias', () => {
+    expect(() => resolveMetricName('bogus')).toThrow(/nav_tti/);
+    expect(() => resolveMetricName('bogus')).toThrow(/cold_launch/);
+  });
 });
 
 describe(resolveNavigationMetricName, () => {
   it('resolves short aliases to navigation metric full names', () => {
-    expect(resolveNavigationMetricName('cold_ttr')).toBe('expo.navigation.cold_ttr');
-    expect(resolveNavigationMetricName('warm_ttr')).toBe('expo.navigation.warm_ttr');
+    expect(resolveNavigationMetricName('nav_cold_ttr')).toBe('expo.navigation.cold_ttr');
+    expect(resolveNavigationMetricName('nav_warm_ttr')).toBe('expo.navigation.warm_ttr');
     expect(resolveNavigationMetricName('nav_tti')).toBe('expo.navigation.tti');
   });
 

--- a/packages/eas-cli/src/observe/metricNames.ts
+++ b/packages/eas-cli/src/observe/metricNames.ts
@@ -10,8 +10,8 @@ export const METRIC_ALIASES: Record<string, string> = {
 };
 
 export const NAVIGATION_METRIC_ALIASES: Record<string, string> = {
-  cold_ttr: 'expo.navigation.cold_ttr',
-  warm_ttr: 'expo.navigation.warm_ttr',
+  nav_cold_ttr: 'expo.navigation.cold_ttr',
+  nav_warm_ttr: 'expo.navigation.warm_ttr',
   nav_tti: 'expo.navigation.tti',
 };
 
@@ -34,11 +34,21 @@ export function resolveMetricName(input: string): string {
   if (METRIC_ALIASES[input]) {
     return METRIC_ALIASES[input];
   }
-  if (KNOWN_FULL_NAMES.has(input) || input.includes('.')) {
+  if (NAVIGATION_METRIC_ALIASES[input]) {
+    return NAVIGATION_METRIC_ALIASES[input];
+  }
+  if (
+    KNOWN_FULL_NAMES.has(input) ||
+    KNOWN_FULL_NAVIGATION_NAMES.has(input) ||
+    input.includes('.')
+  ) {
     return input;
   }
   throw new EasCommandError(
-    `Unknown metric: "${input}". Use a full metric name (e.g. expo.app_startup.tti) or a short alias: ${Object.keys(METRIC_ALIASES).join(', ')}`
+    `Unknown metric: "${input}". Use a full metric name (e.g. expo.app_startup.tti) or a short alias: ${[
+      ...Object.keys(METRIC_ALIASES),
+      ...Object.keys(NAVIGATION_METRIC_ALIASES),
+    ].join(', ')}`
   );
 }
 

--- a/packages/eas-cli/src/observe/metricNames.ts
+++ b/packages/eas-cli/src/observe/metricNames.ts
@@ -1,5 +1,11 @@
 import { EasCommandError } from '../commandUtils/errors';
 
+export const NAVIGATION_METRIC_ALIASES: Record<string, string> = {
+  nav_cold_ttr: 'expo.navigation.cold_ttr',
+  nav_warm_ttr: 'expo.navigation.warm_ttr',
+  nav_tti: 'expo.navigation.tti',
+};
+
 export const METRIC_ALIASES: Record<string, string> = {
   tti: 'expo.app_startup.tti',
   ttr: 'expo.app_startup.ttr',
@@ -7,12 +13,7 @@ export const METRIC_ALIASES: Record<string, string> = {
   warm_launch: 'expo.app_startup.warm_launch_time',
   bundle_load: 'expo.app_startup.bundle_load_time',
   update_download: 'expo.updates.download_time',
-};
-
-export const NAVIGATION_METRIC_ALIASES: Record<string, string> = {
-  nav_cold_ttr: 'expo.navigation.cold_ttr',
-  nav_warm_ttr: 'expo.navigation.warm_ttr',
-  nav_tti: 'expo.navigation.tti',
+  ...NAVIGATION_METRIC_ALIASES,
 };
 
 const KNOWN_FULL_NAMES = new Set(Object.values(METRIC_ALIASES));
@@ -34,21 +35,11 @@ export function resolveMetricName(input: string): string {
   if (METRIC_ALIASES[input]) {
     return METRIC_ALIASES[input];
   }
-  if (NAVIGATION_METRIC_ALIASES[input]) {
-    return NAVIGATION_METRIC_ALIASES[input];
-  }
-  if (
-    KNOWN_FULL_NAMES.has(input) ||
-    KNOWN_FULL_NAVIGATION_NAMES.has(input) ||
-    input.includes('.')
-  ) {
+  if (KNOWN_FULL_NAMES.has(input) || input.includes('.')) {
     return input;
   }
   throw new EasCommandError(
-    `Unknown metric: "${input}". Use a full metric name (e.g. expo.app_startup.tti) or a short alias: ${[
-      ...Object.keys(METRIC_ALIASES),
-      ...Object.keys(NAVIGATION_METRIC_ALIASES),
-    ].join(', ')}`
+    `Unknown metric: "${input}". Use a full metric name (e.g. expo.app_startup.tti) or a short alias: ${Object.keys(METRIC_ALIASES).join(', ')}`
   );
 }
 

--- a/packages/eas-cli/src/observe/metricNames.ts
+++ b/packages/eas-cli/src/observe/metricNames.ts
@@ -7,13 +7,13 @@ export const NAVIGATION_METRIC_ALIASES: Record<string, string> = {
 };
 
 export const METRIC_ALIASES: Record<string, string> = {
+  ...NAVIGATION_METRIC_ALIASES,
   tti: 'expo.app_startup.tti',
   ttr: 'expo.app_startup.ttr',
   cold_launch: 'expo.app_startup.cold_launch_time',
   warm_launch: 'expo.app_startup.warm_launch_time',
   bundle_load: 'expo.app_startup.bundle_load_time',
   update_download: 'expo.updates.download_time',
-  ...NAVIGATION_METRIC_ALIASES,
 };
 
 const KNOWN_FULL_NAMES = new Set(Object.values(METRIC_ALIASES));


### PR DESCRIPTION
# Why

When running `observe:metrics` in non-interactive mode, navigation metric names could not be passed into the command; only app startup metrics were accepted.

# How

- Included the navigation metrics in the validation check
- Renamed the short names (keys) for the navigation metrics to avoid confusion with app startup metric short names

# Test Plan

- Tested locally
- Unit tests added and updated