### PR TITLE
Bump Koa dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] add agent detection to analytics events. ([#3983](https://github.com/expo/eas-cli/pull/3983) by [@davidmokos](https://github.com/davidmokos))
 - Bump `glob` 10.x to a patched version in the root lockfile. ([#3979](https://github.com/expo/eas-cli/pull/3979) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Bump `jws` to a patched version in the root lockfile. ([#3978](https://github.com/expo/eas-cli/pull/3978) by [@szdziedzic](https://github.com/szdziedzic))
+- [worker] Bump `koa` to `3.1.2`. ([#3974](https://github.com/expo/eas-cli/pull/3974) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [20.5.1](https://github.com/expo/eas-cli/releases/tag/v20.5.1) - 2026-07-01
 

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -36,7 +36,7 @@
     "fast-glob": "3.3.2",
     "filesize": "7.0.0",
     "fs-extra": "11.2.0",
-    "koa": "3.1.1",
+    "koa": "3.1.2",
     "koa-body": "7.0.1",
     "koa-router": "14.0.0",
     "lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3590,7 +3590,7 @@ __metadata:
     filesize: "npm:7.0.0"
     fs-extra: "npm:11.2.0"
     jest: "npm:29.7.0"
-    koa: "npm:3.1.1"
+    koa: "npm:3.1.2"
     koa-body: "npm:7.0.1"
     koa-router: "npm:14.0.0"
     lodash: "npm:4.17.21"
@@ -10265,12 +10265,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-disposition@npm:0.5.4, content-disposition@npm:~0.5.4":
+"content-disposition@npm:0.5.4":
   version: 0.5.4
   resolution: "content-disposition@npm:0.5.4"
   dependencies:
     safe-buffer: "npm:5.2.1"
   checksum: 10c0/bac0316ebfeacb8f381b38285dc691c9939bf0a78b0b7c2d5758acadad242d04783cee5337ba7d12a565a19075af1b3c11c728e1e4946de73c6ff7ce45f3f1bb
+  languageName: node
+  linkType: hard
+
+"content-disposition@npm:~1.0.1":
+  version: 1.0.1
+  resolution: "content-disposition@npm:1.0.1"
+  checksum: 10c0/bd7ff1fe8d2542d3a2b9a29428cc3591f6ac27bb5595bba2c69664408a68f9538b14cbd92479796ea835b317a09a527c8c7209c4200381dedb0c34d3b658849e
   languageName: node
   linkType: hard
 
@@ -15099,12 +15106,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"koa@npm:3.1.1":
-  version: 3.1.1
-  resolution: "koa@npm:3.1.1"
+"koa@npm:3.1.2":
+  version: 3.1.2
+  resolution: "koa@npm:3.1.2"
   dependencies:
     accepts: "npm:^1.3.8"
-    content-disposition: "npm:~0.5.4"
+    content-disposition: "npm:~1.0.1"
     content-type: "npm:^1.0.5"
     cookies: "npm:~0.9.1"
     delegates: "npm:^1.0.0"
@@ -15121,7 +15128,7 @@ __metadata:
     statuses: "npm:^2.0.1"
     type-is: "npm:^2.0.1"
     vary: "npm:^1.1.2"
-  checksum: 10c0/2329fa9b2352dbbed8b5073b3b0d5b71678357222c7b8bc4d29e3383fa31c3dc23c6648a3445efa0e6b01e44de0349f8ec2f43d70cd0d37ce7ba1ce50337be15
+  checksum: 10c0/d686eec15cd185106a67ff19c8e2cf6ccef8a8001340bb81fb5d6dd8c0f6418dbbbf2decbfa7bb3a5d00b7d59ac95bb4053ec90e5041c98ea6f972416d9de5be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

Resolve https://github.com/expo/eas-cli/security/dependabot/284 by upgrading Koa to a patched version.

# How

Bumped the direct @expo/worker Koa dependency from 3.1.1 to 3.1.2 and refreshed the Yarn lockfile.

Added a changelog entry for the dependency bump.

# Test Plan

- corepack yarn fmt
- corepack yarn install --immutable
- corepack yarn build
- corepack yarn workspace @expo/worker test:unit --runInBand
- git diff --check
- corepack yarn why koa
- corepack yarn lint-changelog