### PR TITLE
[eas-cli] Open the PostHog dashboard via a signed-in deep link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] `eas integrations:posthog:dashboard` now opens PostHog via a signed-in link, skipping the login prompt. ([#3975](https://github.com/expo/eas-cli/pull/3975) by [@gwdp](https://github.com/gwdp))
+
 ### 🐛 Bug fixes
 
 - [build-tools] Skip embedded bundle upload for development client builds instead of warning that the bundle is missing. ([#3940](https://github.com/expo/eas-cli/pull/3940) by [@gwdp](https://github.com/gwdp))

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -37365,6 +37365,57 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "CreatePostHogDeepLinkInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": "When set, deep-links to this app's linked PostHog project; otherwise lands on the organization home.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "posthogOrganizationConnectionId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "purpose",
+            "description": "Which EAS surface opened the link; omitted lets PostHog apply its own default.",
+            "type": {
+              "kind": "ENUM",
+              "name": "PostHogDeepLinkPurpose",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "CreateSentryProjectInput",
         "description": null,
         "fields": null,
@@ -40914,7 +40965,7 @@
         "fields": [
           {
             "name": "createArtifactUploadSession",
-            "description": "Create an upload session for an artifact produced by an active device run session",
+            "description": "Create an upload session for an artifact while the backing job run is not in a final state",
             "args": [
               {
                 "name": "deviceRunSessionId",
@@ -60845,6 +60896,78 @@
       },
       {
         "kind": "OBJECT",
+        "name": "PostHogDeepLink",
+        "description": "A one-time, signed-in PostHog link. Expires in 10 minutes and opens once.",
+        "fields": [
+          {
+            "name": "expiresAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "PostHogDeepLinkPurpose",
+        "description": "Which EAS surface a deep link was opened from; PostHog records it as an analytics label.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DASHBOARD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OBSERVABILITY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PROJECT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "PostHogIntegrationQuery",
         "description": null,
         "fields": [
@@ -61082,6 +61205,39 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "PostHogOrganizationConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createPostHogDeepLink",
+            "description": "Mints a one-time, signed-in PostHog link. The URL expires in 10 minutes and can be\nopened once, so request it at click time rather than pre-rendering it.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreatePostHogDeepLinkInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PostHogDeepLink",
                 "ofType": null
               }
             },
@@ -70657,6 +70813,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "paymentFailedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
               "ofType": null
             },
             "isDeprecated": false,

--- a/packages/eas-cli/src/commands/integrations/posthog/__tests__/dashboard.test.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/__tests__/dashboard.test.ts
@@ -3,7 +3,8 @@ import openBrowserAsync from 'better-opn';
 import { getMockOclifConfig } from '../../../../__tests__/commands/utils';
 import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { testProjectId } from '../../../../credentials/__tests__/fixtures-constants';
-import { PostHogRegion } from '../../../../graphql/generated';
+import { PostHogDeepLinkPurpose, PostHogRegion } from '../../../../graphql/generated';
+import { PostHogMutation } from '../../../../graphql/mutations/PostHogMutation';
 import { PostHogQuery } from '../../../../graphql/queries/PostHogQuery';
 import {
   PostHogOrganizationConnectionData,
@@ -16,6 +17,7 @@ import IntegrationsPostHogDashboard from '../dashboard';
 
 jest.mock('better-opn');
 jest.mock('../../../../graphql/queries/PostHogQuery');
+jest.mock('../../../../graphql/mutations/PostHogMutation');
 jest.mock('../../../../log');
 jest.mock('../../../../utils/json');
 jest.mock('../../../../ora', () => ({
@@ -50,6 +52,8 @@ describe(IntegrationsPostHogDashboard, () => {
     posthogOrganizationConnection: mockConnection,
   };
 
+  const deepLinkUrl = 'https://us.posthog.com/agentic/login?token=deeplink&team_id=res-123';
+
   function createCommand(argv: string[] = []): IntegrationsPostHogDashboard {
     const command = new IntegrationsPostHogDashboard(argv, mockConfig);
     jest.spyOn(command as any, 'getContextAsync').mockReturnValue({
@@ -67,6 +71,7 @@ describe(IntegrationsPostHogDashboard, () => {
     jest.spyOn(Log, 'warn').mockImplementation(() => {});
     jest.spyOn(Log, 'log').mockImplementation(() => {});
     jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(mockProject);
+    jest.mocked(PostHogMutation.createPostHogDeepLinkAsync).mockResolvedValue(deepLinkUrl);
     jest.mocked(openBrowserAsync).mockResolvedValue({} as never);
     jest.mocked(ora).mockReturnValue({
       start: jest.fn().mockReturnThis(),
@@ -75,13 +80,50 @@ describe(IntegrationsPostHogDashboard, () => {
     } as any);
   });
 
-  it('opens the linked PostHog project dashboard', async () => {
+  it('mints a signed-in deep link for the linked project and opens it', async () => {
     await createCommand().runAsync();
 
-    expect(openBrowserAsync).toHaveBeenCalledWith('https://us.posthog.com/project/res-123');
+    expect(PostHogMutation.createPostHogDeepLinkAsync).toHaveBeenCalledWith(graphqlClient, {
+      posthogOrganizationConnectionId: 'connection-1',
+      appId: testProjectId,
+      purpose: PostHogDeepLinkPurpose.Dashboard,
+    });
+    expect(openBrowserAsync).toHaveBeenCalledWith(deepLinkUrl);
   });
 
-  it('normalizes a trailing-slash host and percent-encodes the project identifier', async () => {
+  it('does not print the one-time deep-link token by default', async () => {
+    const spinner = {
+      start: jest.fn().mockReturnThis(),
+      succeed: jest.fn().mockReturnThis(),
+      fail: jest.fn().mockReturnThis(),
+    };
+    jest.mocked(ora).mockReturnValue(spinner as any);
+
+    await createCommand().runAsync();
+
+    expect(openBrowserAsync).toHaveBeenCalledWith(deepLinkUrl);
+    expect(spinner.succeed).toHaveBeenCalledWith('Opened your PostHog dashboard');
+    expect(spinner.succeed).not.toHaveBeenCalledWith(expect.stringContaining('token='));
+  });
+
+  it('prints the signed-in deep-link URL when --show-link is set', async () => {
+    const spinner = {
+      start: jest.fn().mockReturnThis(),
+      succeed: jest.fn().mockReturnThis(),
+      fail: jest.fn().mockReturnThis(),
+    };
+    jest.mocked(ora).mockReturnValue(spinner as any);
+
+    await createCommand(['--show-link']).runAsync();
+
+    expect(openBrowserAsync).toHaveBeenCalledWith(deepLinkUrl);
+    expect(spinner.succeed).toHaveBeenCalledWith(`Opened ${deepLinkUrl}`);
+  });
+
+  it('falls back to the static (login-required) URL when minting a deep link fails', async () => {
+    jest
+      .mocked(PostHogMutation.createPostHogDeepLinkAsync)
+      .mockRejectedValue(new Error('deep links not enabled'));
     jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue({
       ...mockProject,
       posthogHost: 'https://us.posthog.com/',
@@ -118,19 +160,25 @@ describe(IntegrationsPostHogDashboard, () => {
     expect(spinner.fail).toHaveBeenCalledWith(
       expect.stringContaining('Unable to open a web browser')
     );
+    expect(spinner.fail).toHaveBeenCalledWith(
+      expect.stringContaining('https://us.posthog.com/project/res-123')
+    );
+    expect(spinner.fail).not.toHaveBeenCalledWith(expect.stringContaining('token='));
   });
 
-  it('prints the dashboard URL in non-interactive mode without opening a browser', async () => {
+  it('prints the stable static URL (not a one-time deep link) in non-interactive mode', async () => {
     await createCommand(['--non-interactive']).runAsync();
 
     expect(openBrowserAsync).not.toHaveBeenCalled();
+    expect(PostHogMutation.createPostHogDeepLinkAsync).not.toHaveBeenCalled();
     expect(Log.log).toHaveBeenCalledWith('https://us.posthog.com/project/res-123');
   });
 
-  it('emits the dashboard URL as JSON with --json', async () => {
+  it('emits the stable static URL as JSON with --json (not a one-time deep link)', async () => {
     await createCommand(['--json']).runAsync();
 
     expect(openBrowserAsync).not.toHaveBeenCalled();
+    expect(PostHogMutation.createPostHogDeepLinkAsync).not.toHaveBeenCalled();
     expect(printJsonOnlyOutput).toHaveBeenCalledWith({
       dashboardUrl: 'https://us.posthog.com/project/res-123',
     });

--- a/packages/eas-cli/src/commands/integrations/posthog/dashboard.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/dashboard.ts
@@ -1,3 +1,4 @@
+import { Flags } from '@oclif/core';
 import openBrowserAsync from 'better-opn';
 
 import EasCommand from '../../../commandUtils/EasCommand';
@@ -6,6 +7,8 @@ import {
   resolveNonInteractiveAndJsonFlags,
 } from '../../../commandUtils/flags';
 import { getPostHogProjectDashboardUrl, logNoPostHogProject } from '../../../commandUtils/posthog';
+import { PostHogDeepLinkPurpose } from '../../../graphql/generated';
+import { PostHogMutation } from '../../../graphql/mutations/PostHogMutation';
 import { PostHogQuery } from '../../../graphql/queries/PostHogQuery';
 import Log from '../../../log';
 import { ora } from '../../../ora';
@@ -15,6 +18,11 @@ export default class IntegrationsPostHogDashboard extends EasCommand {
   static override description = 'open the PostHog dashboard for the linked PostHog project';
 
   static override flags = {
+    'show-link': Flags.boolean({
+      default: false,
+      description:
+        'Print the signed-in dashboard URL in addition to opening it. The URL contains a single-use login token.',
+    }),
     ...EasNonInteractiveAndJsonFlags,
   };
 
@@ -25,6 +33,7 @@ export default class IntegrationsPostHogDashboard extends EasCommand {
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(IntegrationsPostHogDashboard);
     const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+    const showLink = flags['show-link'];
     if (jsonFlag) {
       enableJsonOutput();
     }
@@ -51,24 +60,42 @@ export default class IntegrationsPostHogDashboard extends EasCommand {
       return;
     }
 
-    const dashboardUrl = getPostHogProjectDashboardUrl(posthogProject);
+    const staticDashboardUrl = getPostHogProjectDashboardUrl(posthogProject);
 
+    // Signed-in deep links are single-use and expire in 10 minutes, so only the interactive
+    // browser-open benefits from one. JSON/non-interactive consumers may store the URL, so give
+    // them the stable (login-required) dashboard URL instead.
     if (jsonFlag) {
-      printJsonOnlyOutput({ dashboardUrl });
+      printJsonOnlyOutput({ dashboardUrl: staticDashboardUrl });
       return;
     }
 
     if (nonInteractive) {
-      Log.log(dashboardUrl);
+      Log.log(staticDashboardUrl);
       return;
     }
 
-    const failedMessage = `Unable to open a web browser. PostHog dashboard is available at: ${dashboardUrl}`;
-    const spinner = ora(`Opening ${dashboardUrl}`).start();
+    let dashboardUrl: string;
+    try {
+      dashboardUrl = await PostHogMutation.createPostHogDeepLinkAsync(graphqlClient, {
+        posthogOrganizationConnectionId: posthogProject.posthogOrganizationConnection.id,
+        appId: projectId,
+        purpose: PostHogDeepLinkPurpose.Dashboard,
+      });
+    } catch (error) {
+      Log.debug(`Failed to mint a PostHog deep link; opening the static dashboard URL: ${error}`);
+      dashboardUrl = staticDashboardUrl;
+    }
+
+    const openLabel = showLink ? dashboardUrl : 'your PostHog dashboard';
+    const failedMessage = `Unable to open a web browser. PostHog dashboard is available at: ${
+      showLink ? dashboardUrl : staticDashboardUrl
+    }`;
+    const spinner = ora(`Opening ${openLabel}`).start();
     try {
       const opened = await openBrowserAsync(dashboardUrl);
       if (opened) {
-        spinner.succeed(`Opened ${dashboardUrl}`);
+        spinner.succeed(`Opened ${openLabel}`);
       } else {
         spinner.fail(failedMessage);
       }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -5230,6 +5230,14 @@ export type CreatePostHogAccountRequestInput = {
   region: PostHogRegion;
 };
 
+export type CreatePostHogDeepLinkInput = {
+  /** When set, deep-links to this app's linked PostHog project; otherwise lands on the organization home. */
+  appId?: InputMaybe<Scalars['ID']['input']>;
+  posthogOrganizationConnectionId: Scalars['ID']['input'];
+  /** Which EAS surface opened the link; omitted lets PostHog apply its own default. */
+  purpose?: InputMaybe<PostHogDeepLinkPurpose>;
+};
+
 export type CreateSentryProjectInput = {
   appId: Scalars['ID']['input'];
   sentryProjectId: Scalars['String']['input'];
@@ -5735,7 +5743,7 @@ export type DeviceRunSessionFilterInput = {
 
 export type DeviceRunSessionMutation = {
   __typename?: 'DeviceRunSessionMutation';
-  /** Create an upload session for an artifact produced by an active device run session */
+  /** Create an upload session for an artifact while the backing job run is not in a final state */
   createArtifactUploadSession: CreateDeviceRunSessionArtifactUploadSessionResult;
   /** Create a device run session */
   createDeviceRunSession: DeviceRunSession;
@@ -8633,6 +8641,20 @@ export type PinnedDashboardView = {
 
 export type PlanEnablement = Concurrencies | EasTotalPlanEnablement;
 
+/** A one-time, signed-in PostHog link. Expires in 10 minutes and opens once. */
+export type PostHogDeepLink = {
+  __typename?: 'PostHogDeepLink';
+  expiresAt: Scalars['DateTime']['output'];
+  url: Scalars['String']['output'];
+};
+
+/** Which EAS surface a deep link was opened from; PostHog records it as an analytics label. */
+export enum PostHogDeepLinkPurpose {
+  Dashboard = 'DASHBOARD',
+  Observability = 'OBSERVABILITY',
+  Project = 'PROJECT'
+}
+
 export type PostHogIntegrationQuery = {
   __typename?: 'PostHogIntegrationQuery';
   clientIdentifier: Scalars['String']['output'];
@@ -8658,6 +8680,11 @@ export type PostHogOrganizationConnectionMutation = {
    */
   completePostHogConnection: PostHogOrganizationConnection;
   createPostHogAccountRequest: PostHogOrganizationConnection;
+  /**
+   * Mints a one-time, signed-in PostHog link. The URL expires in 10 minutes and can be
+   * opened once, so request it at click time rather than pre-rendering it.
+   */
+  createPostHogDeepLink: PostHogDeepLink;
   /** Removes the Expo-side connection only; the PostHog organization is preserved. */
   deletePostHogOrganizationConnection: Scalars['ID']['output'];
   /**
@@ -8675,6 +8702,11 @@ export type PostHogOrganizationConnectionMutationCompletePostHogConnectionArgs =
 
 export type PostHogOrganizationConnectionMutationCreatePostHogAccountRequestArgs = {
   input: CreatePostHogAccountRequestInput;
+};
+
+
+export type PostHogOrganizationConnectionMutationCreatePostHogDeepLinkArgs = {
+  input: CreatePostHogDeepLinkInput;
 };
 
 
@@ -9996,6 +10028,7 @@ export type SubscriptionDetails = {
   name?: Maybe<Scalars['String']['output']>;
   nextInvoice?: Maybe<Scalars['DateTime']['output']>;
   nextInvoiceAmountDueCents?: Maybe<Scalars['Int']['output']>;
+  paymentFailedAt?: Maybe<Scalars['DateTime']['output']>;
   planEnablement?: Maybe<PlanEnablement>;
   planId?: Maybe<Scalars['String']['output']>;
   price: Scalars['Int']['output'];
@@ -13713,6 +13746,13 @@ export type DeletePostHogProjectMutationVariables = Exact<{
 
 
 export type DeletePostHogProjectMutation = { __typename?: 'RootMutation', posthogProject: { __typename?: 'PostHogProjectMutation', deletePostHogProject: string } };
+
+export type CreatePostHogDeepLinkMutationVariables = Exact<{
+  input: CreatePostHogDeepLinkInput;
+}>;
+
+
+export type CreatePostHogDeepLinkMutation = { __typename?: 'RootMutation', posthogOrganizationConnection: { __typename?: 'PostHogOrganizationConnectionMutation', createPostHogDeepLink: { __typename?: 'PostHogDeepLink', url: string } } };
 
 export type GetSignedUploadMutationVariables = Exact<{
   contentTypes: Array<Scalars['String']['input']> | Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/mutations/PostHogMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PostHogMutation.ts
@@ -3,7 +3,11 @@ import gql from 'graphql-tag';
 
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { withErrorHandlingAsync } from '../client';
-import { CreatePostHogAccountRequestInput, SetupPostHogProjectInput } from '../generated';
+import {
+  CreatePostHogAccountRequestInput,
+  CreatePostHogDeepLinkInput,
+  SetupPostHogProjectInput,
+} from '../generated';
 import {
   PostHogOrganizationConnectionFragmentNode,
   PostHogProjectData,
@@ -39,6 +43,16 @@ type DeletePostHogProjectMutation = {
 
 type DeletePostHogProjectMutationVariables = {
   id: string;
+};
+
+type CreatePostHogDeepLinkMutation = {
+  posthogOrganizationConnection: {
+    createPostHogDeepLink: { url: string };
+  };
+};
+
+type CreatePostHogDeepLinkMutationVariables = {
+  input: CreatePostHogDeepLinkInput;
 };
 
 export const PostHogMutation = {
@@ -117,5 +131,28 @@ export const PostHogMutation = {
         .toPromise()
     );
     return data.posthogProject.deletePostHogProject;
+  },
+
+  async createPostHogDeepLinkAsync(
+    graphqlClient: ExpoGraphqlClient,
+    input: CreatePostHogDeepLinkInput
+  ): Promise<string> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<CreatePostHogDeepLinkMutation, CreatePostHogDeepLinkMutationVariables>(
+          gql`
+            mutation CreatePostHogDeepLink($input: CreatePostHogDeepLinkInput!) {
+              posthogOrganizationConnection {
+                createPostHogDeepLink(input: $input) {
+                  url
+                }
+              }
+            }
+          `,
+          { input }
+        )
+        .toPromise()
+    );
+    return data.posthogOrganizationConnection.createPostHogDeepLink.url;
   },
 };


### PR DESCRIPTION
# Why

`eas integrations:posthog:dashboard` should open the linked PostHog project already signed in, instead of a static URL that hits a login wall.

# How

Mints a one-time, signed-in link via the new `createPostHogDeepLink` mutation and opens it. The link carries a single-use token, so it isn't printed by default; pass `--show-link` to print it. `--json` / `--non-interactive` return the stable static URL, which minting failures also fall back to.

# Test Plan

Unit tests + verified end-to-end with `easd`

<img width="1548" height="484" alt="carbon (5)" src="https://github.com/user-attachments/assets/c00961e5-da49-456c-af1e-c4a2700eece4" />
