### PR TITLE
[build-tools] Wire agent-device artifact kinds

### DIFF
--- a/packages/build-tools/src/steps/utils/__tests__/agentDeviceArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/agentDeviceArtifacts.test.ts
@@ -49,9 +49,19 @@ describe(listAgentDeviceArtifactsAsync, () => {
           artifacts: [
             {
               id: 'artifact-id',
+              artifactType: 'agent-device-test-report',
               filename: 'report.json',
               mimeType: 'application/json',
               sizeBytes: 123,
+              createdAt: '2026-07-02T12:00:00.000Z',
+              expiresAt: '2026-07-02T12:15:00.000Z',
+            },
+            {
+              id: 'untyped-artifact-id',
+              artifactType: null,
+              filename: 'untyped-report.json',
+              mimeType: 'application/json',
+              sizeBytes: 456,
               createdAt: '2026-07-02T12:00:00.000Z',
               expiresAt: '2026-07-02T12:15:00.000Z',
             },
@@ -68,7 +78,13 @@ describe(listAgentDeviceArtifactsAsync, () => {
     expect(artifacts).toEqual([
       {
         id: 'artifact-id',
+        artifactType: 'agent-device-test-report',
         filename: 'report.json',
+      },
+      {
+        id: 'untyped-artifact-id',
+        artifactType: null,
+        filename: 'untyped-report.json',
       },
     ]);
     expect(jest.mocked(fetch)).toHaveBeenCalledWith('http://127.0.0.1:1234/artifacts', {
@@ -113,6 +129,7 @@ describe(uploadAgentDeviceArtifactAsync, () => {
       logger,
       artifact: {
         id: 'artifact-id',
+        artifactType: 'agent-device-test-report',
         filename: 'report.json',
       },
     });
@@ -125,9 +142,42 @@ describe(uploadAgentDeviceArtifactAsync, () => {
       artifactId: 'artifact-id',
       name: 'report.json (artifact-id)',
       filename: 'report.json',
+      kind: 'agent-device-test-report',
       size: data.length,
       stream: expect.anything(),
     });
+  });
+
+  it('uploads null artifact types as an explicit undefined kind', async () => {
+    const data = Buffer.from('artifact-data');
+    const logger = createLoggerMock();
+    const ctx = {} as unknown as CustomBuildContext;
+
+    jest.mocked(fetch).mockResolvedValueOnce(new Response(Readable.from([data])));
+    jest
+      .mocked(uploadDeviceRunSessionArtifactAsync)
+      .mockImplementationOnce(async (_ctx, { stream }) => {
+        await readStreamAsync(stream);
+      });
+
+    await uploadAgentDeviceArtifactAsync(ctx, {
+      deviceRunSessionId: 'drs-id',
+      daemonUrl: 'http://127.0.0.1:1234',
+      daemonToken: 'daemon-token',
+      logger,
+      artifact: {
+        id: 'artifact-id',
+        artifactType: null,
+        filename: 'report.json',
+      },
+    });
+
+    expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        kind: undefined,
+      })
+    );
   });
 });
 

--- a/packages/build-tools/src/steps/utils/__tests__/deviceRunSessionArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/deviceRunSessionArtifacts.test.ts
@@ -46,6 +46,7 @@ describe(uploadDeviceRunSessionArtifactAsync, () => {
       artifactId: 'artifact-id',
       name: 'Artifact report.json (artifact-id)',
       filename: 'report.json',
+      kind: 'agent-device-test-report',
       size: reportedSize,
       stream,
     });
@@ -57,6 +58,7 @@ describe(uploadDeviceRunSessionArtifactAsync, () => {
         input: {
           name: 'Artifact report.json (artifact-id)',
           filename: 'report.json',
+          kind: 'agent-device-test-report',
           size: reportedSize,
         },
       })

--- a/packages/build-tools/src/steps/utils/agentDeviceArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/agentDeviceArtifacts.ts
@@ -18,6 +18,7 @@ const AGENT_DEVICE_ARTIFACT_UPLOAD_POLL_INTERVAL_MS = 5_000;
 
 const AgentDeviceArtifactSchema = z.object({
   id: z.string(),
+  artifactType: z.string().nullish(),
   filename: z.string(),
 });
 const AgentDeviceArtifactsListResponseSchema = z.object({
@@ -152,6 +153,7 @@ export async function uploadAgentDeviceArtifactAsync(
       artifactId: artifact.id,
       name: `${artifact.filename} (${artifact.id})`,
       filename: artifact.filename,
+      kind: artifact.artifactType ?? undefined,
       size,
       stream: createReadStream(temporaryArtifactPath),
     });

--- a/packages/build-tools/src/steps/utils/argentArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/argentArtifacts.ts
@@ -138,6 +138,7 @@ export async function uploadArgentArtifactAsync(
       artifactId: artifact.id,
       name: `${filename} (${artifact.id})`,
       filename,
+      kind: undefined,
       size,
       stream: createReadStream(temporaryArtifactPath),
     });

--- a/packages/build-tools/src/steps/utils/deviceRunSessionArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/deviceRunSessionArtifacts.ts
@@ -27,6 +27,7 @@ export async function uploadDeviceRunSessionArtifactAsync(
     artifactId,
     name,
     filename,
+    kind,
     size,
     stream,
   }: {
@@ -34,6 +35,7 @@ export async function uploadDeviceRunSessionArtifactAsync(
     artifactId: string;
     name: string;
     filename: string;
+    kind: string | undefined;
     size: number;
     stream: NodeJS.ReadableStream;
   }
@@ -43,6 +45,7 @@ export async function uploadDeviceRunSessionArtifactAsync(
     artifactId,
     name,
     filename,
+    kind,
     size,
   });
   const response = await fetch(uploadSession.url, {
@@ -65,12 +68,14 @@ async function createDeviceRunSessionArtifactUploadSessionAsync(
     artifactId,
     name,
     filename,
+    kind,
     size,
   }: {
     deviceRunSessionId: string;
     artifactId: string;
     name: string;
     filename: string;
+    kind: string | undefined;
     size: number;
   }
 ) {
@@ -80,6 +85,7 @@ async function createDeviceRunSessionArtifactUploadSessionAsync(
       input: {
         name,
         filename,
+        ...(kind !== undefined ? { kind } : {}),
         size,
       },
     })

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -14557,6 +14557,18 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveCustomEventListOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -16832,6 +16844,66 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveCustomEventListOrderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveEventsOrderByDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveCustomEventListOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppObserveCustomEventListOrderByField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "TIMESTAMP",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "AppObserveCustomEventName",
         "description": null,
@@ -17289,6 +17361,30 @@
             "deprecationReason": null
           },
           {
+            "name": "platformCounts",
+            "description": "Per-platform occurrence and unique-user counts, sorted by eventCount descending. Covers every device OS seen (iOS, Android, iPadOS, ...), so the counts sum to the group totals.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveErrorGroupPlatformCount",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "platforms",
             "description": "Distinct device OS values seen for this group (e.g. Android, iOS).",
             "args": [],
@@ -17323,6 +17419,30 @@
                 "kind": "ENUM",
                 "name": "AppObserveErrorSeverity",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timeSeries",
+            "description": "Occurrences over the query window, bucketed ascending. Sparse (empty buckets omitted); the client fills gaps. Renders as the list sparkline. Bucket width is set via AppObserveErrorGroupsInput.bucketIntervalMinutes.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveErrorTimeSeriesBucket",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -17562,6 +17682,65 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AppObserveErrorGroupPlatformCount",
+        "description": null,
+        "fields": [
+          {
+            "name": "eventCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": "Device OS value, e.g. iOS, Android, iPadOS.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uniqueUserCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AppObserveErrorGroups",
         "description": null,
         "fields": [
@@ -17659,6 +17838,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bucketIntervalMinutes",
+            "description": "Bucket width in minutes for the per-group timeSeries field. Only used when timeSeries is selected. Defaults to 1440 (daily).",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "defaultValue": null,
@@ -18166,6 +18357,22 @@
         "name": "AppObserveErrorTimeSeriesBucket",
         "description": null,
         "fields": [
+          {
+            "name": "affectedUsers",
+            "description": "Approximate count of unique affected users in this bucket. Not summable across buckets.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "bucket",
             "description": "Start of the bucket interval.",
@@ -33557,6 +33764,121 @@
         "possibleTypes": null
       },
       {
+        "kind": "UNION",
+        "name": "ChannelBuildOrEmbeddedUpdate",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "Build",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "EmbeddedUpdate",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ChannelBuildOrEmbeddedUpdateEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "UNION",
+                "name": "ChannelBuildOrEmbeddedUpdate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ChannelBuildsAndEmbeddedUpdatesConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ChannelBuildOrEmbeddedUpdateEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "ChannelFilterInput",
         "description": null,
@@ -35302,6 +35624,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -40354,6 +40688,18 @@
             "deprecationReason": null
           },
           {
+            "name": "kind",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "metadata",
             "description": null,
             "args": [],
@@ -41218,6 +41564,12 @@
             "deprecationReason": null
           },
           {
+            "name": "OBSERVE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "UPDATES",
             "description": null,
             "isDeprecated": false,
@@ -41272,6 +41624,12 @@
           },
           {
             "name": "MCP_REQUESTS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OBSERVE_EVENTS",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -41358,6 +41716,12 @@
           },
           {
             "name": "CONCURRENCY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EVENT",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -65792,6 +66156,35 @@
             "deprecationReason": null
           },
           {
+            "name": "embeddedUpdateCount",
+            "description": null,
+            "args": [
+              {
+                "name": "channel",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "fingerprint",
             "description": null,
             "args": [],
@@ -72192,6 +72585,87 @@
             "deprecationReason": null
           },
           {
+            "name": "buildCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buildsAndEmbeddedUpdatesPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ChannelBuildsAndEmbeddedUpdatesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createdAt",
             "description": null,
             "args": [],
@@ -72201,6 +72675,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "embeddedUpdateCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               }
             },
@@ -75826,6 +76316,12 @@
           },
           {
             "name": "CREDIT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EVENT",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -88612,6 +89108,150 @@
       },
       {
         "kind": "OBJECT",
+        "name": "WorkflowDispatchInput",
+        "description": null,
+        "fields": [
+          {
+            "name": "default",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "description",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "options",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "required",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "WorkflowDispatchInputType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "WorkflowDispatchInputType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BOOLEAN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CHOICE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ENVIRONMENT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NUMBER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STRING",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "WorkflowJob",
         "description": null,
         "fields": [
@@ -89772,6 +90412,30 @@
                 "kind": "SCALAR",
                 "name": "ID",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "inputs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "WorkflowDispatchInput",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2272,6 +2272,7 @@ export type AppObserveCustomEventListArgs = {
   filter?: InputMaybe<AppObserveCustomEventListFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AppObserveCustomEventListOrderBy>;
 };
 
 
@@ -2532,6 +2533,15 @@ export type AppObserveCustomEventListFilter = {
   startTime?: InputMaybe<Scalars['DateTime']['input']>;
 };
 
+export type AppObserveCustomEventListOrderBy = {
+  direction: AppObserveEventsOrderByDirection;
+  field: AppObserveCustomEventListOrderByField;
+};
+
+export enum AppObserveCustomEventListOrderByField {
+  Timestamp = 'TIMESTAMP'
+}
+
 export type AppObserveCustomEventName = {
   __typename?: 'AppObserveCustomEventName';
   count: Scalars['Int']['output'];
@@ -2594,10 +2604,14 @@ export type AppObserveErrorGroup = {
   firstSeenAt: Scalars['DateTime']['output'];
   isFatal: Scalars['Boolean']['output'];
   lastSeenAt: Scalars['DateTime']['output'];
+  /** Per-platform occurrence and unique-user counts, sorted by eventCount descending. Covers every device OS seen (iOS, Android, iPadOS, ...), so the counts sum to the group totals. */
+  platformCounts: Array<AppObserveErrorGroupPlatformCount>;
   /** Distinct device OS values seen for this group (e.g. Android, iOS). */
   platforms: Array<Scalars['String']['output']>;
   /** FATAL if any occurrence in the group was fatal, otherwise ERROR. */
   severity: AppObserveErrorSeverity;
+  /** Occurrences over the query window, bucketed ascending. Sparse (empty buckets omitted); the client fills gaps. Renders as the list sparkline. Bucket width is set via AppObserveErrorGroupsInput.bucketIntervalMinutes. */
+  timeSeries: Array<AppObserveErrorTimeSeriesBucket>;
   uniqueUserCount: Scalars['Int']['output'];
 };
 
@@ -2624,6 +2638,14 @@ export type AppObserveErrorGroupBreakdownInput = {
   startTime: Scalars['DateTime']['input'];
 };
 
+export type AppObserveErrorGroupPlatformCount = {
+  __typename?: 'AppObserveErrorGroupPlatformCount';
+  eventCount: Scalars['Int']['output'];
+  /** Device OS value, e.g. iOS, Android, iPadOS. */
+  platform: Scalars['String']['output'];
+  uniqueUserCount: Scalars['Int']['output'];
+};
+
 export type AppObserveErrorGroups = {
   __typename?: 'AppObserveErrorGroups';
   groups: Array<AppObserveErrorGroup>;
@@ -2636,6 +2658,8 @@ export type AppObserveErrorGroupsInput = {
   appEasBuildId?: InputMaybe<Scalars['String']['input']>;
   appUpdateId?: InputMaybe<Scalars['String']['input']>;
   appVersion?: InputMaybe<Scalars['String']['input']>;
+  /** Bucket width in minutes for the per-group timeSeries field. Only used when timeSeries is selected. Defaults to 1440 (daily). */
+  bucketIntervalMinutes?: InputMaybe<Scalars['Int']['input']>;
   endTime: Scalars['DateTime']['input'];
   environment?: InputMaybe<Scalars['String']['input']>;
   /** Restrict to a single group, e.g. to fetch one group's header on the detail page. */
@@ -2702,6 +2726,8 @@ export type AppObserveErrorTimeSeries = {
 
 export type AppObserveErrorTimeSeriesBucket = {
   __typename?: 'AppObserveErrorTimeSeriesBucket';
+  /** Approximate count of unique affected users in this bucket. Not summable across buckets. */
+  affectedUsers: Scalars['Int']['output'];
   /** Start of the bucket interval. */
   bucket: Scalars['DateTime']['output'];
   fatalCount: Scalars['Int']['output'];
@@ -4775,6 +4801,20 @@ export type Card = {
   last4?: Maybe<Scalars['String']['output']>;
 };
 
+export type ChannelBuildOrEmbeddedUpdate = Build | EmbeddedUpdate;
+
+export type ChannelBuildOrEmbeddedUpdateEdge = {
+  __typename?: 'ChannelBuildOrEmbeddedUpdateEdge';
+  cursor: Scalars['String']['output'];
+  node: ChannelBuildOrEmbeddedUpdate;
+};
+
+export type ChannelBuildsAndEmbeddedUpdatesConnection = {
+  __typename?: 'ChannelBuildsAndEmbeddedUpdatesConnection';
+  edges: Array<ChannelBuildOrEmbeddedUpdateEdge>;
+  pageInfo: PageInfo;
+};
+
 export type ChannelFilterInput = {
   searchTerm?: InputMaybe<Scalars['String']['input']>;
 };
@@ -5000,6 +5040,7 @@ export type CreateConvexTeamConnectionInput = {
 
 export type CreateDeviceRunSessionArtifactUploadSessionInput = {
   filename: Scalars['String']['input'];
+  kind?: InputMaybe<Scalars['String']['input']>;
   metadata?: InputMaybe<Scalars['JSONObject']['input']>;
   name: Scalars['String']['input'];
   size: Scalars['Int']['input'];
@@ -5664,6 +5705,7 @@ export type DeviceRunSessionArtifact = {
   fileSizeBytes?: Maybe<Scalars['Float']['output']>;
   filename: Scalars['String']['output'];
   id: Scalars['ID']['output'];
+  kind?: Maybe<Scalars['String']['output']>;
   metadata?: Maybe<Scalars['JSONObject']['output']>;
   name: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];
@@ -5812,6 +5854,7 @@ export enum EasService {
   Builds = 'BUILDS',
   Jobs = 'JOBS',
   Mcp = 'MCP',
+  Observe = 'OBSERVE',
   Updates = 'UPDATES'
 }
 
@@ -5823,6 +5866,7 @@ export enum EasServiceMetric {
   LocalBuilds = 'LOCAL_BUILDS',
   ManifestRequests = 'MANIFEST_REQUESTS',
   McpRequests = 'MCP_REQUESTS',
+  ObserveEvents = 'OBSERVE_EVENTS',
   RunTime = 'RUN_TIME',
   UniqueUpdaters = 'UNIQUE_UPDATERS',
   UniqueUsers = 'UNIQUE_USERS'
@@ -5838,6 +5882,7 @@ export enum EasTotalPlanEnablementUnit {
   Build = 'BUILD',
   Byte = 'BYTE',
   Concurrency = 'CONCURRENCY',
+  Event = 'EVENT',
   Request = 'REQUEST',
   Updater = 'UPDATER',
   User = 'USER'
@@ -9283,6 +9328,7 @@ export type Runtime = {
   builds: AppBuildsConnection;
   createdAt: Scalars['DateTime']['output'];
   deployments: DeploymentsConnection;
+  embeddedUpdateCount: Scalars['Int']['output'];
   fingerprint?: Maybe<Fingerprint>;
   firstBuildCreatedAt?: Maybe<Scalars['DateTime']['output']>;
   id: Scalars['ID']['output'];
@@ -9314,6 +9360,11 @@ export type RuntimeDeploymentsArgs = {
   filter?: InputMaybe<RuntimeDeploymentsFilterInput>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type RuntimeEmbeddedUpdateCountArgs = {
+  channel?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -10194,7 +10245,10 @@ export type UpdateChannel = {
   app: App;
   appId: Scalars['ID']['output'];
   branchMapping: Scalars['String']['output'];
+  buildCount: Scalars['Int']['output'];
+  buildsAndEmbeddedUpdatesPaginated: ChannelBuildsAndEmbeddedUpdatesConnection;
   createdAt: Scalars['DateTime']['output'];
+  embeddedUpdateCount: Scalars['Int']['output'];
   id: Scalars['ID']['output'];
   isPaused: Scalars['Boolean']['output'];
   lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
@@ -10203,6 +10257,14 @@ export type UpdateChannel = {
   runtimeInsights: UpdateChannelRuntimeInsights;
   updateBranches: Array<UpdateBranch>;
   updatedAt: Scalars['DateTime']['output'];
+};
+
+
+export type UpdateChannelBuildsAndEmbeddedUpdatesPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -10696,6 +10758,7 @@ export enum UsageMetricType {
   Bandwidth = 'BANDWIDTH',
   Build = 'BUILD',
   Credit = 'CREDIT',
+  Event = 'EVENT',
   Minute = 'MINUTE',
   Request = 'REQUEST',
   Update = 'UPDATE',
@@ -12405,6 +12468,24 @@ export type WorkflowDeviceTestCaseWorkflowFacet = {
   name: Scalars['String']['output'];
 };
 
+export type WorkflowDispatchInput = {
+  __typename?: 'WorkflowDispatchInput';
+  default?: Maybe<Scalars['JSON']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  options?: Maybe<Array<Scalars['String']['output']>>;
+  required: Scalars['Boolean']['output'];
+  type: WorkflowDispatchInputType;
+};
+
+export enum WorkflowDispatchInputType {
+  Boolean = 'BOOLEAN',
+  Choice = 'CHOICE',
+  Environment = 'ENVIRONMENT',
+  Number = 'NUMBER',
+  String = 'STRING'
+}
+
 export type WorkflowJob = {
   __typename?: 'WorkflowJob';
   allDeviceTestCaseResults: Array<WorkflowDeviceTestCaseResult>;
@@ -12566,6 +12647,7 @@ export type WorkflowRevision = {
   commitSha?: Maybe<Scalars['String']['output']>;
   createdAt: Scalars['DateTime']['output'];
   id: Scalars['ID']['output'];
+  inputs: Array<WorkflowDispatchInput>;
   workflow: Workflow;
   yamlConfig: Scalars['String']['output'];
 };

--- a/packages/eas-cli/src/update/__tests__/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync-test.ts
+++ b/packages/eas-cli/src/update/__tests__/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync-test.ts
@@ -155,6 +155,12 @@ function mockUpdateChannel({
   return {
     id: 'a2a1fa12-9d6a-433a-a432-49c64ef8439f',
     app: {} as App,
+    buildCount: 0,
+    buildsAndEmbeddedUpdatesPaginated: {
+      edges: [],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    },
+    embeddedUpdateCount: 0,
     latestRuntimes: { edges: [], pageInfo: { hasNextPage: false, hasPreviousPage: false } },
     runtimeInsights: {} as UpdateChannelRuntimeInsights,
     name: channelName ?? 'default-channel-name',


### PR DESCRIPTION
## Summary

- Preserve `artifactType` from agent-device artifact inventory responses.
- Send that value to the device run session artifact upload-session mutation as `kind`.
- Make the local device run session artifact upload helper require an explicit `kind: string | undefined` so untyped uploads are intentional.
- Regenerate EAS CLI GraphQL schema/types with the repository codegen script and update the one fixture affected by regenerated schema drift.

## Why

agent-device now emits semantic artifact types, and universe now stores them on device run session artifacts. This wires the build-tools upload path between those two changes so users can see producer-owned artifact kinds instead of relying on filenames.

## Validation

- `yarn workspace eas-cli generate-graphql-code`
- `yarn oxfmt packages/build-tools/src/steps/utils/agentDeviceArtifacts.ts packages/build-tools/src/steps/utils/deviceRunSessionArtifacts.ts packages/build-tools/src/steps/utils/argentArtifacts.ts packages/build-tools/src/steps/utils/__tests__/agentDeviceArtifacts.test.ts packages/build-tools/src/steps/utils/__tests__/deviceRunSessionArtifacts.test.ts packages/eas-cli/src/graphql/generated.ts packages/eas-cli/graphql.schema.json`
- `yarn oxfmt --check packages/build-tools/src/steps/utils/agentDeviceArtifacts.ts packages/build-tools/src/steps/utils/deviceRunSessionArtifacts.ts packages/build-tools/src/steps/utils/argentArtifacts.ts packages/build-tools/src/steps/utils/__tests__/agentDeviceArtifacts.test.ts packages/build-tools/src/steps/utils/__tests__/deviceRunSessionArtifacts.test.ts packages/eas-cli/src/graphql/generated.ts packages/eas-cli/graphql.schema.json`
- `yarn workspace @expo/build-tools jest-unit packages/build-tools/src/steps/utils/__tests__/agentDeviceArtifacts.test.ts packages/build-tools/src/steps/utils/__tests__/deviceRunSessionArtifacts.test.ts packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts`
- `yarn workspace @expo/build-tools typecheck`
- `yarn workspace eas-cli typecheck`
- `git diff --check`
