### PR TITLE
[eas-cli] clean up build inspect temp directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Remove temporary working directories after `eas build:inspect` copies inspect output, avoiding leftover disk usage after failed builds. ([#3981](https://github.com/expo/eas-cli/pull/3981) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 - [worker] Bump `ws` to patched releases to resolve [Dependabot alert 462](https://github.com/expo/eas-cli/security/dependabot/462). ([#3963](https://github.com/expo/eas-cli/pull/3963) by [@szdziedzic](https://github.com/szdziedzic))

--- a/packages/eas-cli/src/commands/build/__tests__/inspect.test.ts
+++ b/packages/eas-cli/src/commands/build/__tests__/inspect.test.ts
@@ -36,13 +36,17 @@ describe(BuildInspect, () => {
   const tmpWorkingdir = '/tmp/eas-cli/tmp-id';
   const tmpBuildDir = path.join(tmpWorkingdir, 'build');
   const outputDirectory = path.join(process.cwd(), 'inspect-output');
+  const mockPathExists = fs.pathExists as jest.Mock;
+  const mockMkdirp = fs.mkdirp as jest.Mock;
+  const mockCopy = fs.copy as jest.Mock;
+  const mockRemove = fs.remove as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.mocked(fs.pathExists).mockResolvedValue(false);
-    jest.mocked(fs.mkdirp).mockResolvedValue(undefined);
-    jest.mocked(fs.copy).mockResolvedValue(undefined);
-    jest.mocked(fs.remove).mockResolvedValue(undefined);
+    mockPathExists.mockResolvedValue(false);
+    mockMkdirp.mockResolvedValue(undefined);
+    mockCopy.mockResolvedValue(undefined);
+    mockRemove.mockResolvedValue(undefined);
     jest.mocked(runBuildAndSubmitAsync).mockResolvedValue({ buildIds: [] });
   });
 
@@ -51,7 +55,7 @@ describe(BuildInspect, () => {
       ['--platform', 'ios', '--stage', 'pre-build', '--output', 'inspect-output'],
       mockConfig
     );
-    jest.spyOn(command, 'getContextAsync').mockResolvedValue({
+    jest.spyOn(command as any, 'getContextAsync').mockResolvedValue({
       loggedIn: {
         actor: {},
         graphqlClient: {},
@@ -66,10 +70,7 @@ describe(BuildInspect, () => {
 
   it('removes the temporary working directory after copying output when the build fails', async () => {
     jest.mocked(runBuildAndSubmitAsync).mockRejectedValue(new Error('build failed'));
-    jest
-      .mocked(fs.pathExists)
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(true);
+    mockPathExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
     await createCommand().runAsync();
 
@@ -80,11 +81,8 @@ describe(BuildInspect, () => {
 
   it('keeps the temporary working directory when copying output fails', async () => {
     jest.mocked(runBuildAndSubmitAsync).mockRejectedValue(new Error('build failed'));
-    jest
-      .mocked(fs.pathExists)
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(true);
-    jest.mocked(fs.copy).mockRejectedValue(new Error('copy failed'));
+    mockPathExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockCopy.mockRejectedValue(new Error('copy failed'));
 
     await expect(createCommand().runAsync()).rejects.toThrow('copy failed');
 

--- a/packages/eas-cli/src/commands/build/__tests__/inspect.test.ts
+++ b/packages/eas-cli/src/commands/build/__tests__/inspect.test.ts
@@ -1,0 +1,94 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+import { getMockOclifConfig } from '../../../__tests__/commands/utils';
+import { runBuildAndSubmitAsync } from '../../../build/runBuildAndSubmit';
+import BuildInspect from '../inspect';
+
+jest.mock('fs-extra', () => ({
+  pathExists: jest.fn(),
+  remove: jest.fn(),
+  mkdirp: jest.fn(),
+  copy: jest.fn(),
+}));
+jest.mock('../../../build/runBuildAndSubmit', () => ({
+  runBuildAndSubmitAsync: jest.fn(),
+}));
+jest.mock('../../../log');
+jest.mock('../../../ora', () => ({
+  ora: jest.fn(() => ({
+    start: jest.fn(() => ({
+      succeed: jest.fn(),
+      fail: jest.fn(),
+    })),
+  })),
+}));
+jest.mock('../../../utils/paths', () => ({
+  ...jest.requireActual('../../../utils/paths'),
+  getTmpDirectory: jest.fn(() => '/tmp/eas-cli'),
+}));
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'tmp-id'),
+}));
+
+describe(BuildInspect, () => {
+  const mockConfig = getMockOclifConfig();
+  const tmpWorkingdir = '/tmp/eas-cli/tmp-id';
+  const tmpBuildDir = path.join(tmpWorkingdir, 'build');
+  const outputDirectory = path.join(process.cwd(), 'inspect-output');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(fs.pathExists).mockResolvedValue(false);
+    jest.mocked(fs.mkdirp).mockResolvedValue(undefined);
+    jest.mocked(fs.copy).mockResolvedValue(undefined);
+    jest.mocked(fs.remove).mockResolvedValue(undefined);
+    jest.mocked(runBuildAndSubmitAsync).mockResolvedValue({ buildIds: [] });
+  });
+
+  function createCommand(): BuildInspect {
+    const command = new BuildInspect(
+      ['--platform', 'ios', '--stage', 'pre-build', '--output', 'inspect-output'],
+      mockConfig
+    );
+    jest.spyOn(command, 'getContextAsync').mockResolvedValue({
+      loggedIn: {
+        actor: {},
+        graphqlClient: {},
+      },
+      getDynamicPrivateProjectConfigAsync: jest.fn(),
+      projectDir: '/project',
+      analytics: {},
+      vcsClient: {},
+    } as any);
+    return command;
+  }
+
+  it('removes the temporary working directory after copying output when the build fails', async () => {
+    jest.mocked(runBuildAndSubmitAsync).mockRejectedValue(new Error('build failed'));
+    jest
+      .mocked(fs.pathExists)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    await createCommand().runAsync();
+
+    expect(fs.copy).toHaveBeenCalledWith(tmpBuildDir, outputDirectory);
+    expect(fs.remove).toHaveBeenCalledWith(tmpBuildDir);
+    expect(fs.remove).toHaveBeenCalledWith(tmpWorkingdir);
+  });
+
+  it('keeps the temporary working directory when copying output fails', async () => {
+    jest.mocked(runBuildAndSubmitAsync).mockRejectedValue(new Error('build failed'));
+    jest
+      .mocked(fs.pathExists)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    jest.mocked(fs.copy).mockRejectedValue(new Error('copy failed'));
+
+    await expect(createCommand().runAsync()).rejects.toThrow('copy failed');
+
+    expect(fs.remove).not.toHaveBeenCalledWith(tmpBuildDir);
+    expect(fs.remove).not.toHaveBeenCalledWith(tmpWorkingdir);
+  });
+});

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -135,6 +135,7 @@ export default class BuildInspect extends EasCommand {
         }
       } finally {
         await this.copyToOutputDirAsync(path.join(tmpWorkingdir, 'build'), outputDirectory);
+        await this.cleanUpTmpWorkingdirAsync(tmpWorkingdir);
       }
     }
   }
@@ -161,6 +162,15 @@ export default class BuildInspect extends EasCommand {
     } catch (err) {
       spinner.fail();
       throw err;
+    }
+  }
+
+  private async cleanUpTmpWorkingdirAsync(tmpWorkingdir: string): Promise<void> {
+    try {
+      await fs.remove(tmpWorkingdir);
+    } catch (err) {
+      Log.warn(`Failed to remove temporary directory ${tmpWorkingdir}`);
+      Log.debug(err);
     }
   }
 }


### PR DESCRIPTION
# Why

`eas build:inspect` disables local-build-plugin cleanup so the CLI can copy the inspectable build output into the requested output directory. Once `tmpWorkingdir/build` has been copied, the parent temp working directory no longer needs to stick around. Leaving it behind wastes disk space, especially after failed inspect runs.

# How

- Remove the command-owned temp working directory after `copyToOutputDirAsync` succeeds.
- Preserve the temp working directory if copying the inspect output fails, so the only inspectable state is not deleted.
- Warn and continue if the final temp cleanup itself fails.
- Add regression coverage for failed builds and copy failures, plus a changelog entry.

# Test Plan

- `corepack yarn typecheck`
- `corepack yarn --cwd packages/eas-cli test src/commands/build/__tests__/inspect.test.ts --runInBand`
- `corepack yarn fmt:check`
- `corepack yarn lint-changelog`
