### PR TITLE
[eas-cli] Improve build request error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Skip embedded bundle upload for development client builds instead of warning that the bundle is missing. ([#3940](https://github.com/expo/eas-cli/pull/3940) by [@gwdp](https://github.com/gwdp))
 - [eas-cli] Retry uploading assets that don't finish processing during `eas update`, instead of failing the update. ([#3918](https://github.com/expo/eas-cli/pull/3918) by [@gwdp](https://github.com/gwdp))
+- [eas-cli] Show network and HTTP response details for EAS Build request failures when GraphQL errors are empty. ([#3982](https://github.com/expo/eas-cli/pull/3982) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
+++ b/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
@@ -25,23 +25,26 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-const EXPECTED_STRINGIFIED_GRAPHQL_ERROR_JSON = `[
-  {
-    "name": "GraphQLError",
-    "extensions": {},
-    "message": "Error 1"
-  },
-  {
-    "name": "GraphQLError",
-    "extensions": {},
-    "message": "Error 2"
-  },
-  {
-    "name": "GraphQLError",
-    "extensions": {},
-    "message": "Error 3"
-  }
-]`;
+const EXPECTED_STRINGIFIED_GRAPHQL_ERROR_JSON = `Build request error details:
+{
+  "graphQLErrors": [
+    {
+      "name": "GraphQLError",
+      "extensions": {},
+      "message": "Error 1"
+    },
+    {
+      "name": "GraphQLError",
+      "extensions": {},
+      "message": "Error 2"
+    },
+    {
+      "name": "GraphQLError",
+      "extensions": {},
+      "message": "Error 3"
+    }
+  ]
+}`;
 
 const EXPECTED_EAS_BUILD_DOWN_MESSAGE = `EAS Build is down for maintenance. Try again later. Check ${link(
   'https://status.expo.dev/'
@@ -110,7 +113,7 @@ describe(Build.name, () => {
           handleBuildRequestError(error, platform);
         } catch {}
 
-        expect(logDebugSpy).toBeCalledWith(undefined);
+        expect(logDebugSpy).not.toHaveBeenCalled();
       });
 
       it('does it with iOS', async () => {
@@ -122,7 +125,7 @@ describe(Build.name, () => {
           handleBuildRequestError(error, platform);
         } catch {}
 
-        expect(logDebugSpy).toBeCalledWith(undefined);
+        expect(logDebugSpy).not.toHaveBeenCalled();
       });
     });
 
@@ -508,6 +511,67 @@ describe(Build.name, () => {
             });
 
             assertReThrownError(handleBuildRequestErrorThrownError, Error, expectedMessage);
+          });
+        });
+        describe('with empty GraphQL errors and network response details', () => {
+          it('throws base Error class with network and response details', async () => {
+            const platform = Platform.ANDROID;
+            const error = new CombinedError({
+              graphQLErrors: [],
+              networkError: new Error('Request failed: 400 (Bad Request)'),
+              response: {
+                status: 400,
+                statusText: 'Bad Request',
+                headers: {
+                  get: (headerName: string) =>
+                    headerName === 'expo-request-id' ? mockRequestId : null,
+                },
+              },
+            });
+            const expectedMessage =
+              `${EXPECTED_GENERIC_MESSAGE}\n` +
+              'Network error: Request failed: 400 (Bad Request)\n' +
+              'Response status: 400 Bad Request\n' +
+              `Request ID: ${mockRequestId}`;
+
+            const handleBuildRequestErrorThrownError = getError<Error>(() => {
+              handleBuildRequestError(error, platform);
+            });
+
+            assertReThrownError(handleBuildRequestErrorThrownError, Error, expectedMessage);
+          });
+
+          it('logs network and response details to debug', async () => {
+            const platform = Platform.ANDROID;
+            const logDebugSpy = jest.spyOn(Log, 'debug');
+            const error = new CombinedError({
+              graphQLErrors: [],
+              networkError: new Error('Request failed: 400 (Bad Request)'),
+              response: {
+                status: 400,
+                statusText: 'Bad Request',
+                headers: {
+                  get: (headerName: string) =>
+                    headerName === 'expo-request-id' ? mockRequestId : null,
+                },
+              },
+            });
+
+            try {
+              handleBuildRequestError(error, platform);
+            } catch {}
+
+            expect(logDebugSpy).toBeCalledWith(expect.stringContaining('"graphQLErrors": []'));
+            expect(logDebugSpy).toBeCalledWith(
+              expect.stringContaining('"message": "[Network] Request failed: 400 (Bad Request)"')
+            );
+            expect(logDebugSpy).toBeCalledWith(
+              expect.stringContaining('"message": "Request failed: 400 (Bad Request)"')
+            );
+            expect(logDebugSpy).toBeCalledWith(expect.stringContaining('"status": 400'));
+            expect(logDebugSpy).toBeCalledWith(
+              expect.stringContaining(`"expo-request-id": "${mockRequestId}"`)
+            );
           });
         });
       });

--- a/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
+++ b/packages/eas-cli/src/build/__tests__/handleBuildRequestError-test.ts
@@ -27,6 +27,7 @@ beforeEach(() => {
 
 const EXPECTED_STRINGIFIED_GRAPHQL_ERROR_JSON = `Build request error details:
 {
+  "message": "[GraphQL] Error 1\\n[GraphQL] Error 2\\n[GraphQL] Error 3",
   "graphQLErrors": [
     {
       "name": "GraphQLError",
@@ -572,6 +573,74 @@ describe(Build.name, () => {
             expect(logDebugSpy).toBeCalledWith(
               expect.stringContaining(`"expo-request-id": "${mockRequestId}"`)
             );
+          });
+
+          it('includes the request ID from the x-request-id header when expo-request-id is missing', async () => {
+            const platform = Platform.ANDROID;
+            const error = new CombinedError({
+              graphQLErrors: [],
+              networkError: new Error('Request failed: 400 (Bad Request)'),
+              response: {
+                status: 400,
+                statusText: 'Bad Request',
+                headers: {
+                  get: (headerName: string) =>
+                    headerName === 'x-request-id' ? mockRequestId : null,
+                },
+              },
+            });
+            const expectedMessage =
+              `${EXPECTED_GENERIC_MESSAGE}\n` +
+              'Network error: Request failed: 400 (Bad Request)\n' +
+              'Response status: 400 Bad Request\n' +
+              `Request ID: ${mockRequestId}`;
+
+            const handleBuildRequestErrorThrownError = getError<Error>(() => {
+              handleBuildRequestError(error, platform);
+            });
+
+            assertReThrownError(handleBuildRequestErrorThrownError, Error, expectedMessage);
+          });
+        });
+        describe('with the same request ID in GraphQL error extensions and response headers', () => {
+          it('does not duplicate the request ID line', async () => {
+            const platform = Platform.ANDROID;
+            const graphQLError = getGraphQLError('Error 1', 'UNKNOWN_GRAPHQL_ERROR');
+            const error = new CombinedError({
+              graphQLErrors: [graphQLError],
+              response: {
+                status: 400,
+                statusText: 'Bad Request',
+                headers: {
+                  get: (headerName: string) =>
+                    headerName === 'expo-request-id' ? mockRequestId : null,
+                },
+              },
+            });
+            const expectedMessage =
+              `${EXPECTED_GENERIC_MESSAGE}\n` +
+              `Request ID: ${mockRequestId}\n` +
+              'Error message: Error 1\n' +
+              'Response status: 400 Bad Request';
+
+            const handleBuildRequestErrorThrownError = getError<Error>(() => {
+              handleBuildRequestError(error, platform);
+            });
+
+            assertReThrownError(handleBuildRequestErrorThrownError, Error, expectedMessage);
+          });
+        });
+        describe('with no GraphQL, network, or response details', () => {
+          it('falls back to the top-level error message', async () => {
+            const platform = Platform.ANDROID;
+            const error = { graphQLErrors: [], message: 'Something went wrong' };
+            const expectedMessage = `${EXPECTED_GENERIC_MESSAGE}\nError message: Something went wrong`;
+
+            const handleBuildRequestErrorThrownError = getError<Error>(() => {
+              handleBuildRequestError(error, platform);
+            });
+
+            assertReThrownError(handleBuildRequestErrorThrownError, Error, expectedMessage);
           });
         });
       });

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -231,12 +231,17 @@ const SERVER_SIDE_DEFINED_ERRORS: Record<string, typeof EasCommandError> = {
 };
 
 export function handleBuildRequestError(error: any, platform: Platform): never {
-  Log.debug(JSON.stringify(error.graphQLErrors, null, 2));
+  logBuildRequestErrorDebugInfo(error);
 
-  const graphQLErrorCode: string = error?.graphQLErrors?.[0]?.extensions?.errorCode;
-  if (graphQLErrorCode in SERVER_SIDE_DEFINED_ERRORS) {
+  const graphQLErrors: GraphQLError[] = Array.isArray(error?.graphQLErrors)
+    ? error.graphQLErrors
+    : [];
+  const graphQLErrorCode: string | undefined = graphQLErrors[0]?.extensions?.errorCode as
+    | string
+    | undefined;
+  if (graphQLErrorCode && graphQLErrorCode in SERVER_SIDE_DEFINED_ERRORS) {
     const ErrorClass: typeof EasCommandError = SERVER_SIDE_DEFINED_ERRORS[graphQLErrorCode];
-    throw new ErrorClass(error?.graphQLErrors?.[0]?.message);
+    throw new ErrorClass(graphQLErrors[0]?.message);
   } else if (graphQLErrorCode === 'EAS_BUILD_DOWN_FOR_MAINTENANCE') {
     throw new EasBuildDownForMaintenanceError(
       `EAS Build is down for maintenance. Try again later. Check ${link(
@@ -247,23 +252,141 @@ export function handleBuildRequestError(error: any, platform: Platform): never {
     throw new EasBuildTooManyPendingBuildsError(
       `You have already reached the maximum number of pending ${requestedPlatformDisplayNames[platform]} builds for your account. Try again later.`
     );
-  } else if (error?.graphQLErrors) {
-    const errorMessage = error.graphQLErrors
-      .map((graphQLError: GraphQLError) => {
-        const requestIdLine = graphQLError?.extensions?.requestId
-          ? `\nRequest ID: ${graphQLError.extensions.requestId}`
-          : '';
-        const errorMessageLine = graphQLError?.message
-          ? `\nError message: ${graphQLError.message}`
-          : '';
-        return `${requestIdLine}${errorMessageLine}`;
-      })
-      .join('');
+  } else if (Array.isArray(error?.graphQLErrors)) {
+    const errorMessage = formatBuildRequestErrorDetails(error);
     throw new Error(
       `Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.${errorMessage}`
     );
   }
   throw error;
+}
+
+function formatBuildRequestErrorDetails(error: any): string {
+  const graphQLErrors: GraphQLError[] = Array.isArray(error?.graphQLErrors)
+    ? error.graphQLErrors
+    : [];
+  const details: string[] = graphQLErrors
+    .map((graphQLError: GraphQLError) => {
+      const requestIdLine = graphQLError?.extensions?.requestId
+        ? `\nRequest ID: ${graphQLError.extensions.requestId}`
+        : '';
+      const errorMessageLine = graphQLError?.message
+        ? `\nError message: ${graphQLError.message}`
+        : '';
+      return `${requestIdLine}${errorMessageLine}`;
+    })
+    .filter(Boolean);
+
+  if (error?.networkError?.message) {
+    details.push(`\nNetwork error: ${error.networkError.message}`);
+  }
+
+  const responseStatusLine = formatResponseStatusLine(error?.response);
+  if (responseStatusLine) {
+    details.push(responseStatusLine);
+  }
+
+  const responseRequestIdLine = formatResponseRequestIdLine(error?.response);
+  if (responseRequestIdLine && !details.some(detail => detail.includes(responseRequestIdLine))) {
+    details.push(responseRequestIdLine);
+  }
+
+  if (details.length === 0 && error?.message) {
+    details.push(`\nError message: ${error.message}`);
+  }
+
+  return details.join('');
+}
+
+function logBuildRequestErrorDebugInfo(error: any): void {
+  const debugInfo = formatBuildRequestErrorDebugInfo(error);
+  if (debugInfo) {
+    Log.debug(`Build request error details:\n${JSON.stringify(debugInfo, null, 2)}`);
+  }
+}
+
+function formatBuildRequestErrorDebugInfo(error: any): Record<string, unknown> | null {
+  const hasGraphQLErrors = Array.isArray(error?.graphQLErrors);
+  const hasResponse = !!error?.response;
+  const hasNetworkError = !!error?.networkError;
+
+  if (!hasGraphQLErrors && !hasResponse && !hasNetworkError) {
+    return null;
+  }
+
+  const debugInfo: Record<string, unknown> = {};
+  if (hasGraphQLErrors) {
+    debugInfo.graphQLErrors = error.graphQLErrors;
+  }
+  if (error?.message && (error.graphQLErrors?.length === 0 || hasNetworkError || hasResponse)) {
+    debugInfo.message = error.message;
+  }
+  if (hasNetworkError) {
+    debugInfo.networkError = formatErrorForDebug(error.networkError);
+  }
+
+  const response = formatResponseForDebug(error?.response);
+  if (response) {
+    debugInfo.response = response;
+  }
+
+  return debugInfo;
+}
+
+function formatErrorForDebug(error: any): Record<string, unknown> {
+  const formattedError: Record<string, unknown> = {};
+  for (const property of ['name', 'message', 'code', 'type', 'errno', 'syscall', 'stack']) {
+    if (error?.[property]) {
+      formattedError[property] = error[property];
+    }
+  }
+  return formattedError;
+}
+
+function formatResponseForDebug(response: any): Record<string, unknown> | null {
+  if (!response) {
+    return null;
+  }
+
+  const formattedResponse: Record<string, unknown> = {};
+  for (const property of ['status', 'statusText', 'url']) {
+    if (response[property] !== undefined && response[property] !== '') {
+      formattedResponse[property] = response[property];
+    }
+  }
+
+  const headers = getResponseHeadersForDebug(response);
+  if (Object.keys(headers).length > 0) {
+    formattedResponse.headers = headers;
+  }
+
+  return Object.keys(formattedResponse).length > 0 ? formattedResponse : null;
+}
+
+function getResponseHeadersForDebug(response: any): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const headerName of ['expo-request-id', 'x-request-id', 'content-type']) {
+    const headerValue = response?.headers?.get?.(headerName);
+    if (headerValue) {
+      headers[headerName] = headerValue;
+    }
+  }
+  return headers;
+}
+
+function formatResponseStatusLine(response: any): string | null {
+  if (response?.status === undefined && !response?.statusText) {
+    return null;
+  }
+  return `\nResponse status: ${[response.status, response.statusText]
+    .filter(value => value !== undefined && value !== '')
+    .join(' ')}`;
+}
+
+function formatResponseRequestIdLine(response: any): string | null {
+  const responseRequestId =
+    response?.headers?.get?.('expo-request-id') ?? response?.headers?.get?.('x-request-id');
+  return responseRequestId ? `\nRequest ID: ${responseRequestId}` : null;
 }
 
 async function uploadProjectAsync<TPlatform extends Platform>(

--- a/packages/eas-cli/src/build/build.ts
+++ b/packages/eas-cli/src/build/build.ts
@@ -253,18 +253,15 @@ export function handleBuildRequestError(error: any, platform: Platform): never {
       `You have already reached the maximum number of pending ${requestedPlatformDisplayNames[platform]} builds for your account. Try again later.`
     );
   } else if (Array.isArray(error?.graphQLErrors)) {
-    const errorMessage = formatBuildRequestErrorDetails(error);
+    const errorDetails = formatBuildRequestErrorDetails(error, graphQLErrors);
     throw new Error(
-      `Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.${errorMessage}`
+      `Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.${errorDetails}`
     );
   }
   throw error;
 }
 
-function formatBuildRequestErrorDetails(error: any): string {
-  const graphQLErrors: GraphQLError[] = Array.isArray(error?.graphQLErrors)
-    ? error.graphQLErrors
-    : [];
+function formatBuildRequestErrorDetails(error: any, graphQLErrors: GraphQLError[]): string {
   const details: string[] = graphQLErrors
     .map((graphQLError: GraphQLError) => {
       const requestIdLine = graphQLError?.extensions?.requestId
@@ -281,14 +278,20 @@ function formatBuildRequestErrorDetails(error: any): string {
     details.push(`\nNetwork error: ${error.networkError.message}`);
   }
 
-  const responseStatusLine = formatResponseStatusLine(error?.response);
-  if (responseStatusLine) {
-    details.push(responseStatusLine);
+  const response = error?.response;
+  if (response?.status !== undefined || response?.statusText) {
+    const status = [response.status, response.statusText]
+      .filter(value => value !== undefined && value !== '')
+      .join(' ');
+    details.push(`\nResponse status: ${status}`);
   }
 
-  const responseRequestIdLine = formatResponseRequestIdLine(error?.response);
-  if (responseRequestIdLine && !details.some(detail => detail.includes(responseRequestIdLine))) {
-    details.push(responseRequestIdLine);
+  const responseRequestId = getResponseRequestId(response);
+  const graphQLRequestIds = new Set(
+    graphQLErrors.map(graphQLError => graphQLError?.extensions?.requestId)
+  );
+  if (responseRequestId && !graphQLRequestIds.has(responseRequestId)) {
+    details.push(`\nRequest ID: ${responseRequestId}`);
   }
 
   if (details.length === 0 && error?.message) {
@@ -298,34 +301,36 @@ function formatBuildRequestErrorDetails(error: any): string {
   return details.join('');
 }
 
+function getResponseRequestId(response: any): string | null {
+  return (
+    response?.headers?.get?.('expo-request-id') ?? response?.headers?.get?.('x-request-id') ?? null
+  );
+}
+
 function logBuildRequestErrorDebugInfo(error: any): void {
-  const debugInfo = formatBuildRequestErrorDebugInfo(error);
+  const debugInfo = collectBuildRequestErrorDebugInfo(error);
   if (debugInfo) {
     Log.debug(`Build request error details:\n${JSON.stringify(debugInfo, null, 2)}`);
   }
 }
 
-function formatBuildRequestErrorDebugInfo(error: any): Record<string, unknown> | null {
-  const hasGraphQLErrors = Array.isArray(error?.graphQLErrors);
-  const hasResponse = !!error?.response;
-  const hasNetworkError = !!error?.networkError;
-
-  if (!hasGraphQLErrors && !hasResponse && !hasNetworkError) {
+function collectBuildRequestErrorDebugInfo(error: any): Record<string, unknown> | null {
+  if (!Array.isArray(error?.graphQLErrors) && !error?.response && !error?.networkError) {
     return null;
   }
 
   const debugInfo: Record<string, unknown> = {};
-  if (hasGraphQLErrors) {
-    debugInfo.graphQLErrors = error.graphQLErrors;
-  }
-  if (error?.message && (error.graphQLErrors?.length === 0 || hasNetworkError || hasResponse)) {
+  if (error?.message) {
     debugInfo.message = error.message;
   }
-  if (hasNetworkError) {
-    debugInfo.networkError = formatErrorForDebug(error.networkError);
+  if (Array.isArray(error?.graphQLErrors)) {
+    debugInfo.graphQLErrors = error.graphQLErrors;
+  }
+  if (error?.networkError) {
+    debugInfo.networkError = collectErrorDebugInfo(error.networkError);
   }
 
-  const response = formatResponseForDebug(error?.response);
+  const response = collectResponseDebugInfo(error?.response);
   if (response) {
     debugInfo.response = response;
   }
@@ -333,37 +338,28 @@ function formatBuildRequestErrorDebugInfo(error: any): Record<string, unknown> |
   return debugInfo;
 }
 
-function formatErrorForDebug(error: any): Record<string, unknown> {
-  const formattedError: Record<string, unknown> = {};
+function collectErrorDebugInfo(error: any): Record<string, unknown> {
+  const debugInfo: Record<string, unknown> = {};
   for (const property of ['name', 'message', 'code', 'type', 'errno', 'syscall', 'stack']) {
     if (error?.[property]) {
-      formattedError[property] = error[property];
+      debugInfo[property] = error[property];
     }
   }
-  return formattedError;
+  return debugInfo;
 }
 
-function formatResponseForDebug(response: any): Record<string, unknown> | null {
+function collectResponseDebugInfo(response: any): Record<string, unknown> | null {
   if (!response) {
     return null;
   }
 
-  const formattedResponse: Record<string, unknown> = {};
+  const debugInfo: Record<string, unknown> = {};
   for (const property of ['status', 'statusText', 'url']) {
     if (response[property] !== undefined && response[property] !== '') {
-      formattedResponse[property] = response[property];
+      debugInfo[property] = response[property];
     }
   }
 
-  const headers = getResponseHeadersForDebug(response);
-  if (Object.keys(headers).length > 0) {
-    formattedResponse.headers = headers;
-  }
-
-  return Object.keys(formattedResponse).length > 0 ? formattedResponse : null;
-}
-
-function getResponseHeadersForDebug(response: any): Record<string, string> {
   const headers: Record<string, string> = {};
   for (const headerName of ['expo-request-id', 'x-request-id', 'content-type']) {
     const headerValue = response?.headers?.get?.(headerName);
@@ -371,22 +367,11 @@ function getResponseHeadersForDebug(response: any): Record<string, string> {
       headers[headerName] = headerValue;
     }
   }
-  return headers;
-}
-
-function formatResponseStatusLine(response: any): string | null {
-  if (response?.status === undefined && !response?.statusText) {
-    return null;
+  if (Object.keys(headers).length > 0) {
+    debugInfo.headers = headers;
   }
-  return `\nResponse status: ${[response.status, response.statusText]
-    .filter(value => value !== undefined && value !== '')
-    .join(' ')}`;
-}
 
-function formatResponseRequestIdLine(response: any): string | null {
-  const responseRequestId =
-    response?.headers?.get?.('expo-request-id') ?? response?.headers?.get?.('x-request-id');
-  return responseRequestId ? `\nRequest ID: ${responseRequestId}` : null;
+  return Object.keys(debugInfo).length > 0 ? debugInfo : null;
 }
 
 async function uploadProjectAsync<TPlatform extends Platform>(


### PR DESCRIPTION
<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Build request failures can currently hide useful underlying details when the GraphQL client returns an empty `graphQLErrors` array. In the reported case, `EXPO_DEBUG=1` only surfaced `[]`, while the user-facing error stayed generic despite the HTTP 400 response carrying more context.

# How

Updated `handleBuildRequestError` to preserve existing friendly handling for known server-side EAS error codes, while enriching the generic build request failure path with network error messages, HTTP response status, and request IDs when available. Example output for the reported case (HTTP 400 with empty `graphQLErrors`):

```
Build request failed. Make sure you are using the latest eas-cli version. If the problem persists, report the issue.
Network error: Request failed: 400 (Bad Request)
Response status: 400 Bad Request
Request ID: 8f14e45f-ceea-467f-a1d2-91b50fabc001
```

Also changed debug logging to emit structured build request details, including GraphQL errors, network error fields, response status/url, and selected response headers. Response headers are read through an allowlist (`expo-request-id`, `x-request-id`, `content-type`) and the response body is never serialized, so no sensitive data can end up in the output.

Follow-up refinements:

- The response request ID is deduplicated against the GraphQL extension request IDs by comparing the IDs themselves, instead of substring matching on formatted lines.
- Debug output always includes the top-level error message, instead of a conditional that guessed when it was redundant.
- Collapsed the single-use formatting helpers, renamed the object-building ones from `format*` to `collect*`, and `formatBuildRequestErrorDetails` now receives the already-parsed `graphQLErrors` array instead of re-deriving it.

# Test Plan

- `corepack yarn test src/build` — 102 passed, including new tests for the `x-request-id` fallback, the request-ID dedupe, and the top-level error message fallback
- `corepack yarn workspace eas-cli typecheck`
- `yarn fmt` / `yarn lint`
- Smoke test against the compiled output with `EXPO_DEBUG=1`, simulating an HTTP 400 with empty `graphQLErrors` (the reported case), a pure network failure (`ENOTFOUND`), and a GraphQL error + response sharing the same request ID — all produced the expected user-facing message and structured debug output