### PR TITLE
[cli] add agent detection to telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] add agent detection to analytics events. ([#3983](https://github.com/expo/eas-cli/pull/3983) by [@davidmokos](https://github.com/davidmokos))
+
 ## [20.5.1](https://github.com/expo/eas-cli/releases/tag/v20.5.1) - 2026-07-01
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -72,6 +72,7 @@
     "@sentry/node": "7.77.0",
     "@urql/core": "4.0.11",
     "@urql/exchange-retry": "1.2.0",
+    "agent-cli-detector": "0.1.2",
     "ajv": "8.11.0",
     "ajv-formats": "2.1.1",
     "better-opn": "3.0.2",

--- a/packages/eas-cli/src/analytics/AnalyticsManager.ts
+++ b/packages/eas-cli/src/analytics/AnalyticsManager.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Actor, getActorDisplayName } from '../user/User';
 import UserSettings from '../user/UserSettings';
 import { easCliVersion } from '../utils/easCli';
+import { getAgentTelemetryContext } from './agent';
 
 const PLATFORM_TO_ANALYTICS_PLATFORM: Partial<Record<NodeJS.Platform, string>> = {
   darwin: 'Mac',
@@ -225,10 +226,12 @@ class RudderstackAnalytics implements AnalyticsWithOrchestration {
 
   private getRudderStackContext(): Record<string, any> {
     const platform = PLATFORM_TO_ANALYTICS_PLATFORM[os.platform()] || os.platform();
+    const agent = getAgentTelemetryContext();
     return {
       os: { name: platform, version: os.release() },
       device: { type: platform, model: platform },
       app: { name: 'eas cli', version: easCliVersion ?? undefined },
+      ...(agent ? { agent } : {}),
     };
   }
 }

--- a/packages/eas-cli/src/analytics/__tests__/AnalyticsManager-test.ts
+++ b/packages/eas-cli/src/analytics/__tests__/AnalyticsManager-test.ts
@@ -1,0 +1,99 @@
+import RudderAnalytics from '@expo/rudder-sdk-node';
+
+import UserSettings from '../../user/UserSettings';
+import { CommandEvent, createAnalyticsAsync } from '../AnalyticsManager';
+import { getAgentTelemetryContext } from '../agent';
+
+const mockIdentify = jest.fn();
+const mockTrack = jest.fn();
+const mockFlush = jest.fn();
+
+jest.mock('@expo/rudder-sdk-node', () =>
+  jest.fn().mockImplementation(() => ({
+    identify: mockIdentify,
+    track: mockTrack,
+    flush: mockFlush,
+  }))
+);
+
+jest.mock('../../user/UserSettings', () => ({
+  __esModule: true,
+  default: {
+    deleteKeyAsync: jest.fn(),
+    getAsync: jest.fn(),
+    setAsync: jest.fn(),
+  },
+}));
+
+jest.mock('../agent', () => ({
+  getAgentTelemetryContext: jest.fn(),
+}));
+
+const getAgentTelemetryContextMock = jest.mocked(getAgentTelemetryContext);
+const userSettingsMock = jest.mocked(UserSettings);
+
+const originalHttpsProxy = process.env.https_proxy;
+const originalDisableEasAnalytics = process.env.DISABLE_EAS_ANALYTICS;
+
+beforeEach(() => {
+  mockIdentify.mockClear();
+  mockTrack.mockClear();
+  mockFlush.mockClear();
+  jest.mocked(RudderAnalytics).mockClear();
+  getAgentTelemetryContextMock.mockReset();
+  getAgentTelemetryContextMock.mockReturnValue(null);
+  userSettingsMock.getAsync.mockImplementation(async (key, defaultValue) => {
+    if (key === 'analyticsDeviceId') {
+      return 'persistent-device-id';
+    }
+
+    return defaultValue;
+  });
+  userSettingsMock.setAsync.mockResolvedValue({});
+  userSettingsMock.deleteKeyAsync.mockResolvedValue({});
+  delete process.env.https_proxy;
+  delete process.env.DISABLE_EAS_ANALYTICS;
+});
+
+afterAll(() => {
+  if (originalHttpsProxy === undefined) {
+    delete process.env.https_proxy;
+  } else {
+    process.env.https_proxy = originalHttpsProxy;
+  }
+  if (originalDisableEasAnalytics === undefined) {
+    delete process.env.DISABLE_EAS_ANALYTICS;
+  } else {
+    process.env.DISABLE_EAS_ANALYTICS = originalDisableEasAnalytics;
+  }
+});
+
+it('omits agent context when no agent is detected', async () => {
+  const analytics = await createAnalyticsAsync();
+
+  analytics.logEvent(CommandEvent.ACTION, { action: 'eas build' });
+
+  expect(mockTrack).toHaveBeenCalledWith(
+    expect.objectContaining({
+      context: expect.not.objectContaining({ agent: expect.anything() }),
+    })
+  );
+});
+
+it('adds detected agent context to analytics events', async () => {
+  getAgentTelemetryContextMock.mockReturnValue({ id: 'codex', sessionId: 'zzz' });
+  const analytics = await createAnalyticsAsync();
+
+  analytics.logEvent(CommandEvent.ACTION, { action: 'eas build' });
+
+  expect(mockTrack).toHaveBeenCalledWith(
+    expect.objectContaining({
+      context: expect.objectContaining({
+        agent: {
+          id: 'codex',
+          sessionId: 'zzz',
+        },
+      }),
+    })
+  );
+});

--- a/packages/eas-cli/src/analytics/__tests__/agent-test.ts
+++ b/packages/eas-cli/src/analytics/__tests__/agent-test.ts
@@ -1,0 +1,58 @@
+const detectAgentMock = jest.fn();
+const logDebugMock = jest.fn();
+
+jest.mock('agent-cli-detector', () => ({
+  detectAgent: detectAgentMock,
+}));
+
+jest.mock('../../log', () => ({
+  __esModule: true,
+  default: {
+    debug: logDebugMock,
+  },
+}));
+
+beforeEach(() => {
+  jest.resetModules();
+  detectAgentMock.mockReset();
+  logDebugMock.mockReset();
+});
+
+it('returns detected agent telemetry context', async () => {
+  detectAgentMock.mockReturnValue({
+    detected: true,
+    agent: { id: 'codex', name: 'Codex', sessionId: 'session-id' },
+  });
+  const { getAgentTelemetryContext } = await import('../agent');
+
+  expect(getAgentTelemetryContext()).toEqual({ id: 'codex', sessionId: 'session-id' });
+});
+
+it('returns null when no known agent is detected', async () => {
+  detectAgentMock.mockReturnValue({ detected: false, agent: null });
+  const { getAgentTelemetryContext } = await import('../agent');
+
+  expect(getAgentTelemetryContext()).toBeNull();
+});
+
+it('caches the detected agent telemetry context', async () => {
+  detectAgentMock.mockReturnValue({
+    detected: true,
+    agent: { id: 'codex', name: 'Codex', sessionId: undefined },
+  });
+  const { getAgentTelemetryContext } = await import('../agent');
+
+  expect(getAgentTelemetryContext()).toEqual({ id: 'codex', sessionId: undefined });
+  expect(getAgentTelemetryContext()).toEqual({ id: 'codex', sessionId: undefined });
+  expect(detectAgentMock).toHaveBeenCalledTimes(1);
+});
+
+it('returns null and logs debug details when detection throws', async () => {
+  detectAgentMock.mockImplementation(() => {
+    throw new Error('boom');
+  });
+  const { getAgentTelemetryContext } = await import('../agent');
+
+  expect(getAgentTelemetryContext()).toBeNull();
+  expect(logDebugMock).toHaveBeenCalledWith('Failed to detect coding agent:', 'boom');
+});

--- a/packages/eas-cli/src/analytics/agent.ts
+++ b/packages/eas-cli/src/analytics/agent.ts
@@ -1,0 +1,32 @@
+import { detectAgent } from 'agent-cli-detector';
+
+import Log from '../log';
+
+export type AgentTelemetryContext = {
+  id: string;
+  sessionId: string | undefined;
+};
+
+let agentTelemetryContext: AgentTelemetryContext | null | undefined;
+
+export function getAgentTelemetryContext(): AgentTelemetryContext | null {
+  if (agentTelemetryContext === undefined) {
+    agentTelemetryContext = resolveAgentTelemetryContext();
+  }
+
+  return agentTelemetryContext;
+}
+
+function resolveAgentTelemetryContext(): AgentTelemetryContext | null {
+  try {
+    const { agent, detected } = detectAgent();
+    if (!detected || agent == null) {
+      return null;
+    }
+
+    return { id: agent.id, sessionId: agent.sessionId };
+  } catch (error: any) {
+    Log.debug('Failed to detect coding agent:', error?.message ?? error);
+    return null;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8645,6 +8645,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"agent-cli-detector@npm:0.1.2":
+  version: 0.1.2
+  resolution: "agent-cli-detector@npm:0.1.2"
+  bin:
+    agent-cli-detector: dist/cli.js
+  checksum: 10c0/d7751eab293c4543f079988ffe519951859c254edb204fd3105ff49c114ac466d8ef05ba00b3b574fdd5038f9c4e24414d977918f5bccfe9a147628f83d013c3
+  languageName: node
+  linkType: hard
+
 "aggregate-error@npm:^3.0.0":
   version: 3.1.0
   resolution: "aggregate-error@npm:3.1.0"
@@ -11208,6 +11217,7 @@ __metadata:
     "@types/wrap-ansi": "npm:3.0.0"
     "@urql/core": "npm:4.0.11"
     "@urql/exchange-retry": "npm:1.2.0"
+    agent-cli-detector: "npm:0.1.2"
     ajv: "npm:8.11.0"
     ajv-formats: "npm:2.1.1"
     axios: "npm:1.11.0"


### PR DESCRIPTION
Ports the Expo CLI agent telemetry integration from https://github.com/expo/expo/pull/47248 to EAS CLI.

Adds `agent-cli-detector` to EAS CLI telemetry so events recorded from known coding agents include lightweight agent context. The CLI uses `agent-cli-detector@0.1.2`, which exposes a CommonJS entry point, so detection stays synchronous and does not participate in telemetry initialization.

When a known agent is detected, telemetry event context includes:

```ts
context.agent = {
  id: string,
  sessionId: string | undefined,
}
```

When no known agent is detected, `context.agent` is omitted to keep RudderStack and BigQuery payloads sparse. CLI version is already available in telemetry, so analysis can distinguish newer CLI versions with no detected agent from older CLI versions without this integration.

Tests cover detected and undetected telemetry payloads. Locally verified with `yarn workspace eas-cli test src/analytics/__tests__/AnalyticsManager-test.ts --runInBand`, `yarn workspace eas-cli typecheck`, `yarn lint-changelog`, and targeted `oxlint`.
