### PR TITLE
[codex] Remove stale changelog PR template instruction

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,4 +1,3 @@
-<!-- If this PR requires a changelog entry, add it by commenting the PR with the command `/changelog-entry [breaking-change|new-feature|bug-fix|chore] [message]`. -->
 <!-- You can skip the changelog check by labeling the PR with "no changelog". -->
 
 # Why


### PR DESCRIPTION
# Why

The PR template tells contributors to add changelog entries by commenting with `/changelog-entry ...`, but the repository changelog workflow only checks whether `CHANGELOG.md` changed on pull request events. There is no `issue_comment` workflow handling that slash command, so the instruction points contributors at a no-op path.

https://github.com/expo/eas-cli/pull/3982#issuecomment-4903759256

# How

Removed the stale `/changelog-entry` instruction from `.github/PULL_REQUEST_TEMPLATE`. The rest of the template remains intact, including the guidance for using the `no changelog` label when a changelog entry is not required.

# Test Plan

- `git diff --check`
- `./node_modules/.bin/oxfmt .`