### PR TITLE
[eas-cli] Rethrow Apple errors during capability sync instead of silently succeeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Rethrow Apple errors during capability sync instead of silently succeeding. ([#3989](https://github.com/expo/eas-cli/pull/3989) by [@douglowder](https://github.com/douglowder))
 - [build-tools] Skip embedded bundle upload for development client builds instead of warning that the bundle is missing. ([#3940](https://github.com/expo/eas-cli/pull/3940) by [@gwdp](https://github.com/gwdp))
 - [eas-cli] Accept a navigation metric name in observe:metrics when passed in on the command line. ([#3973](https://github.com/expo/eas-cli/pull/3973) by [@douglowder](https://github.com/douglowder))
 - [eas-cli] Retry uploading assets that don't finish processing during `eas update`, instead of failing the update. ([#3918](https://github.com/expo/eas-cli/pull/3918) by [@gwdp](https://github.com/gwdp))

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/bundleIdCapabilities-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/bundleIdCapabilities-test.ts
@@ -654,8 +654,79 @@ describe(syncCapabilitiesForEntitlementsAsync, () => {
         noBroadcastNotificationOption
       )
     ).rejects.toThrowError(
-      `https://developer-mdn.apple.com/account/resources/identifiers/bundleId/edit/XXX333`
+      `https://developer.apple.com/account/resources/identifiers/bundleId/edit/XXX333`
     );
+  });
+
+  it('re-throws generic Apple errors with actionable context and preserves the original message', async () => {
+    const bundleId = {
+      getBundleIdCapabilitiesAsync: jest.fn(() => []),
+      updateBundleIdCapabilityAsync: jest
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            "HTTP 400 — The request entity is not a valid request document object - Unexpected or invalid value at 'data.relationships.bundleIdCapabilities.data.[0].attributes'."
+          )
+        ),
+      attributes: { identifier: 'dev.expo.app' },
+      id: 'XXX333',
+    } as any;
+
+    await expect(
+      syncCapabilitiesForEntitlementsAsync(
+        bundleId,
+        { 'com.apple.developer.associated-domains': ['applinks:example.com'] },
+        noBroadcastNotificationOption
+      )
+    ).rejects.toThrow(/Failed to update Apple capabilities for app "dev\.expo\.app"/);
+
+    await expect(
+      syncCapabilitiesForEntitlementsAsync(
+        bundleId,
+        { 'com.apple.developer.associated-domains': ['applinks:example.com'] },
+        noBroadcastNotificationOption
+      )
+    ).rejects.toThrow(/data\.relationships\.bundleIdCapabilities\.data\.\[0\]\.attributes/);
+  });
+
+  it('mentions EXPO_NO_CAPABILITY_SYNC and the Apple developer console URL in rethrown errors', async () => {
+    const bundleId = {
+      getBundleIdCapabilitiesAsync: jest.fn(() => []),
+      updateBundleIdCapabilityAsync: jest.fn().mockRejectedValue(new Error('Some Apple error')),
+      attributes: { identifier: 'dev.expo.app' },
+      id: 'XXX333',
+    } as any;
+
+    await expect(
+      syncCapabilitiesForEntitlementsAsync(
+        bundleId,
+        { 'com.apple.developer.associated-domains': ['applinks:example.com'] },
+        noBroadcastNotificationOption
+      )
+    ).rejects.toThrow(/EXPO_NO_CAPABILITY_SYNC=1/);
+  });
+
+  it('preserves the original error as .cause when rethrowing generic Apple errors', async () => {
+    const originalError = new Error('Some Apple error');
+    const bundleId = {
+      getBundleIdCapabilitiesAsync: jest.fn(() => []),
+      updateBundleIdCapabilityAsync: jest.fn().mockRejectedValue(originalError),
+      attributes: { identifier: 'dev.expo.app' },
+      id: 'XXX333',
+    } as any;
+
+    let caught: any;
+    try {
+      await syncCapabilitiesForEntitlementsAsync(
+        bundleId,
+        { 'com.apple.developer.associated-domains': ['applinks:example.com'] },
+        noBroadcastNotificationOption
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.cause).toBe(originalError);
   });
 
   it('cannot skip complex duplicates', async () => {

--- a/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/bundleIdCapabilities.ts
@@ -67,15 +67,21 @@ export async function syncCapabilitiesForEntitlementsAsync(
     try {
       await bundleId.updateBundleIdCapabilityAsync(modifiedRequest);
     } catch (error: any) {
-      if (error.message.match(/bundle '[\w\d]+' cannot be deleted. Delete all the Apps/)) {
-        Log.error(
-          'Failed to patch capabilities:',
-          inspect(modifiedRequest, { depth: null, colors: true })
-        );
-        throw new Error(
-          `Unexpected error occurred while attempting to update capabilities for app "${bundleId.attributes.identifier}".\nCapabilities can be modified manually in the Apple developer console at https://developer-mdn.apple.com/account/resources/identifiers/bundleId/edit/${bundleId.id}.\nAuto capability syncing can be disabled with the environment variable \`EXPO_NO_CAPABILITY_SYNC=1\`.\n${error.message}`
-        );
+      Log.error(
+        'Failed to patch capabilities:',
+        inspect(modifiedRequest, { depth: null, colors: true })
+      );
+      const context = `Failed to update Apple capabilities for app "${bundleId.attributes.identifier}".\nYou can enable or disable capabilities manually in the Apple developer console at https://developer.apple.com/account/resources/identifiers/bundleId/edit/${bundleId.id}, then re-run this command.\nAuto capability syncing can be disabled with the environment variable \`EXPO_NO_CAPABILITY_SYNC=1\`.`;
+      if (error.message?.match?.(/bundle '[\w\d]+' cannot be deleted. Delete all the Apps/)) {
+        throw new Error(`${context}\n${error.message}`);
       }
+      // Preserve the underlying Apple error and stack, but attach the same
+      // actionable context so the user knows how to unblock their build.
+      const wrapped: Error & { cause?: unknown } = new Error(
+        `${context}\n\nApple API error: ${error.message}`
+      );
+      wrapped.cause = error;
+      throw wrapped;
     }
   }
 


### PR DESCRIPTION
# Why

`syncCapabilitiesForEntitlementsAsync` in bundleIdCapabilities.ts wrapped `bundleId.updateBundleIdCapabilityAsync` in a try/catch whose block only rethrew for the specific error "bundle '…' cannot be deleted. Delete all the Apps". Every other Apple API error was silently swallowed while the function still returned the intended enabled/disabled lists — leading to undebuggable signing failures downstream. (Reported in issue #3986 against 18.12.3 and 20.5.1.)

# How

Rethrow every non-matching error with the same actionable context we already gave the "cannot be deleted" case — the Apple developer console URL and the EXPO_NO_CAPABILITY_SYNC=1 escape hatch — and preserve the underlying Apple error via `.cause` so EXPO_DEBUG=1 still surfaces the raw response. Log the failing request payload for all failures, not just the matched one, so future variants are debuggable from CLI output.
    
Also fix the "developer-mdn.apple.com" typo in the existing error message (the correct host is developer.apple.com).

Note that capability sync may not work correctly until the fix in https://github.com/expo/third-party/pull/161 is merged and released.

# Test Plan

- Expand the existing "throw useful error message" test to cover generic Apple errors
- Correct expected URL in test assertion
