### PR TITLE
[build-tools] pass metrics CORS origin to serve-sim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Add `ref` input to the `eas/checkout` step to check out a different git ref (branch, tag, or commit SHA) than the one that triggered the job. ([#4035](https://github.com/expo/eas-cli/pull/4035) by [@sswrk](https://github.com/sswrk))
 - [build-tools] Load local composite function catalogs at build time so custom builds and generic jobs can resolve local composite functions referenced via `uses:`. ([#3930](https://github.com/expo/eas-cli/pull/3930) by [@sswrk](https://github.com/sswrk))
 - [eas-cli] Validate local composite functions referenced in workflow files during `eas workflow:validate`, checking that the YAML files exist and are well-formed. ([#3931](https://github.com/expo/eas-cli/pull/3931) by [@sswrk](https://github.com/sswrk))
+- [build-tools] Pass a metrics CORS origin to serve-sim so the dashboard can read a session's live CPU/memory stream cross-origin. ([#3990](https://github.com/expo/eas-cli/pull/3990) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -12,6 +12,7 @@ import {
   createServeSimArgs,
   ensureFfmpegInstalledAsync,
   fetchServeSimTurnArgsAsync,
+  metricsCorsOriginToServeSimArgs,
   startNgrokTunnelAsync,
   turnIceServersToServeSimArgs,
   waitForDeviceRunSessionStoppedAsync,
@@ -118,6 +119,47 @@ describe(createServeSimArgs, () => {
       '60',
       '--turn-url',
       'turns:turn.example.test:443',
+    ]);
+  });
+
+  it('appends metrics CORS args after the TURN args when provided', () => {
+    const args = createServeSimArgs({
+      port: 4321,
+      turnArgs: ['--turn-url', 'turns:turn.example.test:443'],
+      metricsCorsArgs: ['--metrics-cors-origin', 'https://expo.dev'],
+    });
+    expect(args.slice(-4)).toEqual([
+      '--turn-url',
+      'turns:turn.example.test:443',
+      '--metrics-cors-origin',
+      'https://expo.dev',
+    ]);
+  });
+});
+
+describe(metricsCorsOriginToServeSimArgs, () => {
+  it('returns no args when the origin is unset or empty', () => {
+    expect(metricsCorsOriginToServeSimArgs({} as BuildStepEnv)).toEqual([]);
+    expect(
+      metricsCorsOriginToServeSimArgs({ EAS_SIMULATOR_METRICS_CORS_ORIGIN: '' } as BuildStepEnv)
+    ).toEqual([]);
+  });
+
+  it('builds one flag per comma-separated origin', () => {
+    expect(
+      metricsCorsOriginToServeSimArgs({
+        EAS_SIMULATOR_METRICS_CORS_ORIGIN: 'https://expo.dev',
+      } as BuildStepEnv)
+    ).toEqual(['--metrics-cors-origin', 'https://expo.dev']);
+    expect(
+      metricsCorsOriginToServeSimArgs({
+        EAS_SIMULATOR_METRICS_CORS_ORIGIN: 'https://expo.dev, https://staging.expo.dev',
+      } as BuildStepEnv)
+    ).toEqual([
+      '--metrics-cors-origin',
+      'https://expo.dev',
+      '--metrics-cors-origin',
+      'https://staging.expo.dev',
     ]);
   });
 });

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -475,12 +475,29 @@ export function spawnDetached({
   };
 }
 
+export function metricsCorsOriginToServeSimArgs(env: BuildStepEnv): string[] {
+  const origin = env.EAS_SIMULATOR_METRICS_CORS_ORIGIN;
+  if (!origin) {
+    return [];
+  }
+  const args: string[] = [];
+  for (const value of origin.split(',')) {
+    const trimmed = value.trim();
+    if (trimmed) {
+      args.push('--metrics-cors-origin', trimmed);
+    }
+  }
+  return args;
+}
+
 export function createServeSimArgs({
   port,
   turnArgs = [],
+  metricsCorsArgs = [],
 }: {
   port: number;
   turnArgs?: string[];
+  metricsCorsArgs?: string[];
 }): string[] {
   return [
     '--yes',
@@ -502,6 +519,7 @@ export function createServeSimArgs({
     '--video-fps',
     SERVE_SIM_VIDEO_FPS,
     ...turnArgs,
+    ...metricsCorsArgs,
   ];
 }
 
@@ -586,9 +604,10 @@ export async function startServeSimWithTunnelAsync(
   const port = await findAvailablePortAsync();
   logger.info(`Launching ${SERVE_SIM_PACKAGE_SPEC} on ${SERVE_SIM_HOST}:${port}.`);
   const turnArgs = await fetchServeSimTurnArgsAsync(ctx, { env, logger });
+  const metricsCorsArgs = metricsCorsOriginToServeSimArgs(env);
   const serveSim = spawnDetached({
     command: 'npx',
-    args: createServeSimArgs({ port, turnArgs }),
+    args: createServeSimArgs({ port, turnArgs, metricsCorsArgs }),
     env,
   });
 


### PR DESCRIPTION
Ref ENG-23622

# Why

So the expo.dev dashboard can read serve-sim's live `/metrics` stream cross-origin.

# How

Reads `EAS_SIMULATOR_METRICS_CORS_ORIGIN` from the worker env and passes it to serve-sim as `--metrics-cors-origin` when launching the tunnel.

# Test Plan

CI passes. Unit tests cover the env getter and the arg builder. Also verified end-to-end locally that the origin reaches serve-sim's `--metrics-cors-origin`.



