### PR TITLE
[build-tools] collect serve-sim session metrics with a start/collect step pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Load local composite function catalogs at build time so custom builds and generic jobs can resolve local composite functions referenced via `uses:`. ([#3930](https://github.com/expo/eas-cli/pull/3930) by [@sswrk](https://github.com/sswrk))
 - [eas-cli] Validate local composite functions referenced in workflow files during `eas workflow:validate`, checking that the YAML files exist and are well-formed. ([#3931](https://github.com/expo/eas-cli/pull/3931) by [@sswrk](https://github.com/sswrk))
 - [build-tools] Pass a metrics CORS origin to serve-sim so the dashboard can read a session's live CPU/memory stream cross-origin. ([#3990](https://github.com/expo/eas-cli/pull/3990) by [@gwdp](https://github.com/gwdp))
+- [build-tools] Collect each iOS session's serve-sim CPU/memory `/metrics` to a file and upload it as a device run session artifact at teardown. ([#3995](https://github.com/expo/eas-cli/pull/3995) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -49,6 +49,8 @@ import { createStartCuttlefishDeviceBuildFunction } from './functions/startCuttl
 import { createStartIosSimulatorBuildFunction } from './functions/startIosSimulator';
 import { createStartIosSimulatorRecordingsBuildFunction } from './functions/startIosSimulatorRecordings';
 import { createStartServeSimRemoteSessionBuildFunction } from './functions/startServeSimRemoteSession';
+import { createStartServeSimMetricsBuildFunction } from './functions/startServeSimMetrics';
+import { createCollectServeSimMetricsBuildFunction } from './functions/collectServeSimMetrics';
 import { createUploadArtifactBuildFunction } from './functions/uploadArtifact';
 import { createUploadDeviceRunSessionScreenRecordingsBuildFunction } from './functions/uploadDeviceRunSessionScreenRecordings';
 import { createUploadToAscBuildFunction } from './functions/uploadToAsc';
@@ -99,6 +101,8 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     createFinishIosSimulatorRecordingsBuildFunction(),
     createUploadDeviceRunSessionScreenRecordingsBuildFunction(ctx),
     createStartServeSimRemoteSessionBuildFunction(ctx),
+    createStartServeSimMetricsBuildFunction(),
+    createCollectServeSimMetricsBuildFunction(ctx),
     createInstallMaestroBuildFunction(),
 
     createInstallPodsBuildFunction(),

--- a/packages/build-tools/src/steps/functions/__tests__/collectServeSimMetrics.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/collectServeSimMetrics.test.ts
@@ -2,6 +2,7 @@ import { type bunyan } from '@expo/logger';
 import { BuildStepContext, BuildStepEnv } from '@expo/steps';
 
 import { type CustomBuildContext } from '../../../customBuildContext';
+import { Sentry } from '../../../sentry';
 import { getDeviceRunSessionIdOrThrow } from '../../utils/remoteDeviceRunSession';
 import { uploadServeSimMetricsFileAsync } from '../../utils/serveSimMetricsArtifacts';
 import { ServeSimMetricsRecorder } from '../../utils/serveSimMetricsRecorder';
@@ -10,6 +11,7 @@ import { createCollectServeSimMetricsBuildFunction } from '../collectServeSimMet
 jest.mock('../../utils/serveSimMetricsRecorder');
 jest.mock('../../utils/serveSimMetricsArtifacts');
 jest.mock('../../utils/remoteDeviceRunSession');
+jest.mock('../../../sentry');
 
 function createLoggerMock(): bunyan {
   return { info: jest.fn(), warn: jest.fn() } as unknown as bunyan;
@@ -33,8 +35,8 @@ describe(createCollectServeSimMetricsBuildFunction, () => {
 
   it('uploads a metrics file per collected device', async () => {
     jest.mocked(ServeSimMetricsRecorder.finishAsync).mockResolvedValue([
-      { udid: 'AAAA', filePath: '/tmp/AAAA.ndjson' },
-      { udid: 'BBBB', filePath: '/tmp/BBBB.ndjson' },
+      { udid: 'AAAA', filePath: '/tmp/AAAA.ndjson', meta: { hostCores: 8 } },
+      { udid: 'BBBB', filePath: '/tmp/BBBB.ndjson', meta: undefined },
     ]);
     const logger = createLoggerMock();
 
@@ -45,6 +47,7 @@ describe(createCollectServeSimMetricsBuildFunction, () => {
       deviceRunSessionId: 'session-id',
       udid: 'AAAA',
       filePath: '/tmp/AAAA.ndjson',
+      meta: { hostCores: 8 },
       logger,
     });
   });
@@ -60,7 +63,7 @@ describe(createCollectServeSimMetricsBuildFunction, () => {
   it('warns instead of failing the session when the session id is missing', async () => {
     jest
       .mocked(ServeSimMetricsRecorder.finishAsync)
-      .mockResolvedValue([{ udid: 'AAAA', filePath: '/tmp/AAAA.ndjson' }]);
+      .mockResolvedValue([{ udid: 'AAAA', filePath: '/tmp/AAAA.ndjson', meta: undefined }]);
     jest.mocked(getDeviceRunSessionIdOrThrow).mockImplementation(() => {
       throw new Error('missing DEVICE_RUN_SESSION_ID');
     });
@@ -69,6 +72,10 @@ describe(createCollectServeSimMetricsBuildFunction, () => {
     await expect(runAsync(logger)).resolves.toBeUndefined();
 
     expect(uploadServeSimMetricsFileAsync).not.toHaveBeenCalled();
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Could not upload serve-sim metrics',
+      expect.any(Error)
+    );
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ err: expect.any(Error) }),
       'Could not upload serve-sim metrics.'

--- a/packages/build-tools/src/steps/functions/__tests__/collectServeSimMetrics.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/collectServeSimMetrics.test.ts
@@ -1,0 +1,77 @@
+import { type bunyan } from '@expo/logger';
+import { BuildStepContext, BuildStepEnv } from '@expo/steps';
+
+import { type CustomBuildContext } from '../../../customBuildContext';
+import { getDeviceRunSessionIdOrThrow } from '../../utils/remoteDeviceRunSession';
+import { uploadServeSimMetricsFileAsync } from '../../utils/serveSimMetricsArtifacts';
+import { ServeSimMetricsRecorder } from '../../utils/serveSimMetricsRecorder';
+import { createCollectServeSimMetricsBuildFunction } from '../collectServeSimMetrics';
+
+jest.mock('../../utils/serveSimMetricsRecorder');
+jest.mock('../../utils/serveSimMetricsArtifacts');
+jest.mock('../../utils/remoteDeviceRunSession');
+
+function createLoggerMock(): bunyan {
+  return { info: jest.fn(), warn: jest.fn() } as unknown as bunyan;
+}
+
+const ctx = {} as CustomBuildContext;
+
+async function runAsync(logger: bunyan): Promise<void> {
+  const fn = createCollectServeSimMetricsBuildFunction(ctx).fn;
+  await fn?.({ logger } as unknown as BuildStepContext, {
+    inputs: {},
+    outputs: {},
+    env: {} as BuildStepEnv,
+  });
+}
+
+describe(createCollectServeSimMetricsBuildFunction, () => {
+  beforeEach(() => {
+    jest.mocked(getDeviceRunSessionIdOrThrow).mockReturnValue('session-id');
+  });
+
+  it('uploads a metrics file per collected device', async () => {
+    jest.mocked(ServeSimMetricsRecorder.finishAsync).mockResolvedValue([
+      { udid: 'AAAA', filePath: '/tmp/AAAA.ndjson' },
+      { udid: 'BBBB', filePath: '/tmp/BBBB.ndjson' },
+    ]);
+    const logger = createLoggerMock();
+
+    await runAsync(logger);
+
+    expect(uploadServeSimMetricsFileAsync).toHaveBeenCalledTimes(2);
+    expect(uploadServeSimMetricsFileAsync).toHaveBeenCalledWith(ctx, {
+      deviceRunSessionId: 'session-id',
+      udid: 'AAAA',
+      filePath: '/tmp/AAAA.ndjson',
+      logger,
+    });
+  });
+
+  it('skips the upload when nothing was collected', async () => {
+    jest.mocked(ServeSimMetricsRecorder.finishAsync).mockResolvedValue([]);
+
+    await runAsync(createLoggerMock());
+
+    expect(uploadServeSimMetricsFileAsync).not.toHaveBeenCalled();
+  });
+
+  it('warns instead of failing the session when the session id is missing', async () => {
+    jest
+      .mocked(ServeSimMetricsRecorder.finishAsync)
+      .mockResolvedValue([{ udid: 'AAAA', filePath: '/tmp/AAAA.ndjson' }]);
+    jest.mocked(getDeviceRunSessionIdOrThrow).mockImplementation(() => {
+      throw new Error('missing DEVICE_RUN_SESSION_ID');
+    });
+    const logger = createLoggerMock();
+
+    await expect(runAsync(logger)).resolves.toBeUndefined();
+
+    expect(uploadServeSimMetricsFileAsync).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      'Could not upload serve-sim metrics.'
+    );
+  });
+});

--- a/packages/build-tools/src/steps/functions/__tests__/collectServeSimMetrics.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/collectServeSimMetrics.test.ts
@@ -35,8 +35,8 @@ describe(createCollectServeSimMetricsBuildFunction, () => {
 
   it('uploads a metrics file per collected device', async () => {
     jest.mocked(ServeSimMetricsRecorder.finishAsync).mockResolvedValue([
-      { udid: 'AAAA', filePath: '/tmp/AAAA.ndjson', meta: { hostCores: 8 } },
-      { udid: 'BBBB', filePath: '/tmp/BBBB.ndjson', meta: undefined },
+      { udid: 'AAAA', filePath: '/tmp/AAAA.ndjson', metadata: { hostCores: 8 } },
+      { udid: 'BBBB', filePath: '/tmp/BBBB.ndjson', metadata: undefined },
     ]);
     const logger = createLoggerMock();
 
@@ -47,7 +47,7 @@ describe(createCollectServeSimMetricsBuildFunction, () => {
       deviceRunSessionId: 'session-id',
       udid: 'AAAA',
       filePath: '/tmp/AAAA.ndjson',
-      meta: { hostCores: 8 },
+      metadata: { hostCores: 8 },
       logger,
     });
   });
@@ -63,7 +63,7 @@ describe(createCollectServeSimMetricsBuildFunction, () => {
   it('warns instead of failing the session when the session id is missing', async () => {
     jest
       .mocked(ServeSimMetricsRecorder.finishAsync)
-      .mockResolvedValue([{ udid: 'AAAA', filePath: '/tmp/AAAA.ndjson', meta: undefined }]);
+      .mockResolvedValue([{ udid: 'AAAA', filePath: '/tmp/AAAA.ndjson', metadata: undefined }]);
     jest.mocked(getDeviceRunSessionIdOrThrow).mockImplementation(() => {
       throw new Error('missing DEVICE_RUN_SESSION_ID');
     });

--- a/packages/build-tools/src/steps/functions/__tests__/startServeSimMetrics.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startServeSimMetrics.test.ts
@@ -1,0 +1,24 @@
+import { type bunyan } from '@expo/logger';
+import { BuildStepContext, BuildStepEnv } from '@expo/steps';
+
+import { ServeSimMetricsRecorder } from '../../utils/serveSimMetricsRecorder';
+import { createStartServeSimMetricsBuildFunction } from '../startServeSimMetrics';
+
+jest.mock('../../utils/serveSimMetricsRecorder');
+
+function createLoggerMock(): bunyan {
+  return { info: jest.fn(), warn: jest.fn() } as unknown as bunyan;
+}
+
+describe(createStartServeSimMetricsBuildFunction, () => {
+  it('starts serve-sim metrics polling', async () => {
+    const logger = createLoggerMock();
+    const fn = createStartServeSimMetricsBuildFunction().fn;
+    await fn?.({ logger } as unknown as BuildStepContext, {
+      inputs: {},
+      outputs: {},
+      env: {} as BuildStepEnv,
+    });
+    expect(ServeSimMetricsRecorder.startAsync).toHaveBeenCalledWith({ logger });
+  });
+});

--- a/packages/build-tools/src/steps/functions/collectServeSimMetrics.ts
+++ b/packages/build-tools/src/steps/functions/collectServeSimMetrics.ts
@@ -1,6 +1,7 @@
 import { BuildFunction, BuildRuntimePlatform } from '@expo/steps';
 
 import { type CustomBuildContext } from '../../customBuildContext';
+import { Sentry } from '../../sentry';
 import { getDeviceRunSessionIdOrThrow } from '../utils/remoteDeviceRunSession';
 import { uploadServeSimMetricsFileAsync } from '../utils/serveSimMetricsArtifacts';
 import { ServeSimMetricsRecorder } from '../utils/serveSimMetricsRecorder';
@@ -20,11 +21,19 @@ export function createCollectServeSimMetricsBuildFunction(ctx: CustomBuildContex
       }
       try {
         const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
-        for (const { udid, filePath } of collected) {
-          await uploadServeSimMetricsFileAsync(ctx, { deviceRunSessionId, udid, filePath, logger });
+        for (const { udid, filePath, meta } of collected) {
+          await uploadServeSimMetricsFileAsync(ctx, {
+            deviceRunSessionId,
+            udid,
+            filePath,
+            meta,
+            logger,
+          });
         }
       } catch (err) {
-        logger.warn({ err }, 'Could not upload serve-sim metrics.');
+        const error = err instanceof Error ? err : new Error(String(err));
+        Sentry.capture('Could not upload serve-sim metrics', error);
+        logger.warn({ err: error }, 'Could not upload serve-sim metrics.');
       }
     },
   });

--- a/packages/build-tools/src/steps/functions/collectServeSimMetrics.ts
+++ b/packages/build-tools/src/steps/functions/collectServeSimMetrics.ts
@@ -1,0 +1,31 @@
+import { BuildFunction, BuildRuntimePlatform } from '@expo/steps';
+
+import { type CustomBuildContext } from '../../customBuildContext';
+import { getDeviceRunSessionIdOrThrow } from '../utils/remoteDeviceRunSession';
+import { uploadServeSimMetricsFileAsync } from '../utils/serveSimMetricsArtifacts';
+import { ServeSimMetricsRecorder } from '../utils/serveSimMetricsRecorder';
+
+export function createCollectServeSimMetricsBuildFunction(ctx: CustomBuildContext): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'collect_serve_sim_metrics',
+    name: 'Collect serve-sim metrics',
+    __metricsId: 'eas/collect_serve_sim_metrics',
+    supportedRuntimePlatforms: [BuildRuntimePlatform.DARWIN],
+    fn: async ({ logger }, { env }) => {
+      const collected = await ServeSimMetricsRecorder.finishAsync({ logger });
+      if (collected.length === 0) {
+        logger.info('No serve-sim metrics collected; skipping upload.');
+        return;
+      }
+      try {
+        const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
+        for (const { udid, filePath } of collected) {
+          await uploadServeSimMetricsFileAsync(ctx, { deviceRunSessionId, udid, filePath, logger });
+        }
+      } catch (err) {
+        logger.warn({ err }, 'Could not upload serve-sim metrics.');
+      }
+    },
+  });
+}

--- a/packages/build-tools/src/steps/functions/collectServeSimMetrics.ts
+++ b/packages/build-tools/src/steps/functions/collectServeSimMetrics.ts
@@ -21,12 +21,12 @@ export function createCollectServeSimMetricsBuildFunction(ctx: CustomBuildContex
       }
       try {
         const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
-        for (const { udid, filePath, meta } of collected) {
+        for (const { udid, filePath, metadata } of collected) {
           await uploadServeSimMetricsFileAsync(ctx, {
             deviceRunSessionId,
             udid,
             filePath,
-            meta,
+            metadata,
             logger,
           });
         }

--- a/packages/build-tools/src/steps/functions/startServeSimMetrics.ts
+++ b/packages/build-tools/src/steps/functions/startServeSimMetrics.ts
@@ -1,0 +1,16 @@
+import { BuildFunction, BuildRuntimePlatform } from '@expo/steps';
+
+import { ServeSimMetricsRecorder } from '../utils/serveSimMetricsRecorder';
+
+export function createStartServeSimMetricsBuildFunction(): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'start_serve_sim_metrics',
+    name: 'Start serve-sim metrics',
+    __metricsId: 'eas/start_serve_sim_metrics',
+    supportedRuntimePlatforms: [BuildRuntimePlatform.DARWIN],
+    fn: async ({ logger }) => {
+      await ServeSimMetricsRecorder.startAsync({ logger });
+    },
+  });
+}

--- a/packages/build-tools/src/steps/utils/__tests__/serveSimMetricsArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/serveSimMetricsArtifacts.test.ts
@@ -1,0 +1,109 @@
+import { bunyan } from '@expo/logger';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+import { CustomBuildContext } from '../../../customBuildContext';
+import { uploadDeviceRunSessionArtifactAsync } from '../deviceRunSessionArtifacts';
+import { uploadServeSimMetricsFileAsync } from '../serveSimMetricsArtifacts';
+
+jest.mock('../deviceRunSessionArtifacts');
+jest.mock('../../../sentry');
+
+function createLoggerMock(): bunyan {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as bunyan;
+}
+
+async function readStreamAsync(stream: NodeJS.ReadableStream): Promise<string> {
+  let out = '';
+  for await (const chunk of stream as Readable) {
+    out += chunk.toString();
+  }
+  return out;
+}
+
+const ctx = {} as CustomBuildContext;
+const NDJSON = '{"t":1000,"cpuPct":1,"memBytes":2}\n';
+
+let workDir: string;
+let filePath: string;
+
+beforeEach(async () => {
+  jest.mocked(uploadDeviceRunSessionArtifactAsync).mockReset();
+  workDir = await mkdtemp(path.join(os.tmpdir(), 'serve-sim-metrics-art-test-'));
+  filePath = path.join(workDir, 'AAAA.ndjson');
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe(uploadServeSimMetricsFileAsync, () => {
+  it('uploads the file as a metrics.ndjson artifact keyed by udid', async () => {
+    await writeFile(filePath, NDJSON);
+    let uploaded = '';
+    jest
+      .mocked(uploadDeviceRunSessionArtifactAsync)
+      .mockImplementation(async (_ctx, { stream }) => {
+        uploaded = await readStreamAsync(stream);
+      });
+
+    await uploadServeSimMetricsFileAsync(ctx, {
+      deviceRunSessionId: 'session-id',
+      udid: 'AAAA',
+      filePath,
+      logger: createLoggerMock(),
+    });
+
+    expect(uploaded).toBe(NDJSON);
+    expect(uploadDeviceRunSessionArtifactAsync).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        deviceRunSessionId: 'session-id',
+        artifactId: 'metrics-AAAA',
+        filename: 'metrics.ndjson',
+        size: Buffer.byteLength(NDJSON),
+      })
+    );
+  });
+
+  it('skips the upload when the file is missing', async () => {
+    await uploadServeSimMetricsFileAsync(ctx, {
+      deviceRunSessionId: 'session-id',
+      udid: 'AAAA',
+      filePath,
+      logger: createLoggerMock(),
+    });
+    expect(uploadDeviceRunSessionArtifactAsync).not.toHaveBeenCalled();
+  });
+
+  it('skips the upload when the file is empty', async () => {
+    await writeFile(filePath, '');
+    await uploadServeSimMetricsFileAsync(ctx, {
+      deviceRunSessionId: 'session-id',
+      udid: 'AAAA',
+      filePath,
+      logger: createLoggerMock(),
+    });
+    expect(uploadDeviceRunSessionArtifactAsync).not.toHaveBeenCalled();
+  });
+
+  it('swallows an upload failure (best-effort)', async () => {
+    await writeFile(filePath, NDJSON);
+    jest.mocked(uploadDeviceRunSessionArtifactAsync).mockRejectedValue(new Error('R2 down'));
+    await expect(
+      uploadServeSimMetricsFileAsync(ctx, {
+        deviceRunSessionId: 'session-id',
+        udid: 'AAAA',
+        filePath,
+        logger: createLoggerMock(),
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/build-tools/src/steps/utils/__tests__/serveSimMetricsArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/serveSimMetricsArtifacts.test.ts
@@ -58,6 +58,7 @@ describe(uploadServeSimMetricsFileAsync, () => {
       deviceRunSessionId: 'session-id',
       udid: 'AAAA',
       filePath,
+      meta: { hostCores: 8, sampleIntervalMs: 1000, schemaVersion: 1 },
       logger: createLoggerMock(),
     });
 
@@ -67,7 +68,16 @@ describe(uploadServeSimMetricsFileAsync, () => {
       expect.objectContaining({
         deviceRunSessionId: 'session-id',
         artifactId: 'metrics-AAAA',
+        name: 'Performance metrics (AAAA)',
         filename: 'metrics.ndjson',
+        kind: 'performance-metrics',
+        metadata: {
+          __eas_type: 'performance-metrics',
+          udid: 'AAAA',
+          hostCores: 8,
+          sampleIntervalMs: 1000,
+          schemaVersion: 1,
+        },
         size: Buffer.byteLength(NDJSON),
       })
     );

--- a/packages/build-tools/src/steps/utils/__tests__/serveSimMetricsArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/serveSimMetricsArtifacts.test.ts
@@ -58,7 +58,7 @@ describe(uploadServeSimMetricsFileAsync, () => {
       deviceRunSessionId: 'session-id',
       udid: 'AAAA',
       filePath,
-      meta: { hostCores: 8, sampleIntervalMs: 1000, schemaVersion: 1 },
+      metadata: { hostCores: 8, sampleIntervalMs: 1000, schemaVersion: 1 },
       logger: createLoggerMock(),
     });
 

--- a/packages/build-tools/src/steps/utils/__tests__/serveSimMetricsRecorder.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/serveSimMetricsRecorder.test.ts
@@ -40,8 +40,8 @@ const SSE_STREAM = [
   '',
 ].join('\n');
 
+// The `event: meta` frame is skipped; only sample frames are written.
 const EXPECTED_NDJSON =
-  '{"schemaVersion":1,"udid":"U","hostCores":8,"sampleIntervalMs":1000}\n' +
   '{"t":1000,"bundleId":"dev.expo.MyApp","cpuPct":0,"memBytes":100}\n' +
   '{"t":2000,"bundleId":"dev.expo.MyApp","cpuPct":40,"memBytes":120}\n';
 
@@ -174,7 +174,7 @@ describe(streamServeSimMetricsToFileAsync, () => {
         signal: new AbortController().signal,
         logger,
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ receivedData: false, meta: undefined });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ err: expect.any(Error) }),
       expect.stringContaining('stream ended')
@@ -196,6 +196,13 @@ describe('ServeSimMetricsRecorder', () => {
     expect(collected).toHaveLength(1);
     expect(collected[0].udid).toBe('AAAA');
     expect(await readFile(collected[0].filePath, 'utf-8')).toBe(EXPECTED_NDJSON);
+    // The meta frame is captured for the artifact metadata, not written to the NDJSON.
+    expect(collected[0].meta).toEqual({
+      schemaVersion: 1,
+      udid: 'U',
+      hostCores: 8,
+      sampleIntervalMs: 1000,
+    });
   });
 
   it('reconnects a device whose first /metrics attempt fails', async () => {
@@ -246,6 +253,50 @@ describe('ServeSimMetricsRecorder', () => {
     await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() });
 
     expect(jest.mocked(fetch)).toHaveBeenCalledTimes(10);
+  });
+
+  it('keeps reconnecting past the failure cap while streams keep yielding data', async () => {
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(stateDir, { recursive: true });
+    await writeServerStateAsync('FFFF', { device: 'FFFF', url: 'https://sim-f.example' });
+    // Each connection yields a sample then ends, forcing a reconnect every tick. A data-yielding
+    // stream resets the failure count, so the per-device cap must never trip on a healthy session.
+    jest.mocked(fetch).mockImplementation(async () => sseResponse());
+
+    await ServeSimMetricsRecorder.startAsync({
+      logger: createLoggerMock(),
+      stateDir,
+      pollIntervalMs: 5,
+    });
+    await delay(200);
+    await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() });
+
+    expect(jest.mocked(fetch).mock.calls.length).toBeGreaterThan(10);
+  });
+
+  it('forgets the failure count for a device that leaves the registry', async () => {
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(stateDir, { recursive: true });
+    await writeServerStateAsync('GGGG', { device: 'GGGG', url: 'https://sim-g.example' });
+    // Fail fast until it trips the cap, then remove it from the registry.
+    jest.mocked(fetch).mockResolvedValue(new Response('nope', { status: 502 }));
+
+    await ServeSimMetricsRecorder.startAsync({
+      logger: createLoggerMock(),
+      stateDir,
+      pollIntervalMs: 5,
+    });
+    await delay(120);
+    await rm(path.join(stateDir, 'server-GGGG.json'));
+    await delay(60);
+    // The same device returns and now streams: it's retried only because leaving the
+    // registry cleared its (capped-out) failure count.
+    jest.mocked(fetch).mockImplementation(async () => sseResponse());
+    await writeServerStateAsync('GGGG', { device: 'GGGG', url: 'https://sim-g.example' });
+    await delay(120);
+
+    const collected = await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() });
+    expect(collected.some(entry => entry.udid === 'GGGG')).toBe(true);
   });
 
   it('skips a device already streaming and aborts it on finish', async () => {

--- a/packages/build-tools/src/steps/utils/__tests__/serveSimMetricsRecorder.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/serveSimMetricsRecorder.test.ts
@@ -1,0 +1,312 @@
+import { bunyan } from '@expo/logger';
+import fetch from 'node-fetch';
+import { EventEmitter } from 'node:events';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { Sentry } from '../../../sentry';
+import {
+  ServeSimMetricsRecorder,
+  readServeSimServersAsync,
+  streamServeSimMetricsToFileAsync,
+} from '../serveSimMetricsRecorder';
+
+jest.mock('../../../sentry');
+jest.mock('node-fetch');
+
+const { Response } = jest.requireActual('node-fetch') as typeof import('node-fetch');
+
+function createLoggerMock(): bunyan {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as bunyan;
+}
+
+const SSE_STREAM = [
+  'event: meta',
+  'data: {"schemaVersion":1,"udid":"U","hostCores":8,"sampleIntervalMs":1000}',
+  '',
+  ': heartbeat',
+  '',
+  'data: {"t":1000,"bundleId":"dev.expo.MyApp","cpuPct":0,"memBytes":100}',
+  '',
+  'data: {"t":2000,"bundleId":"dev.expo.MyApp","cpuPct":40,"memBytes":120}',
+  '',
+].join('\n');
+
+const EXPECTED_NDJSON =
+  '{"schemaVersion":1,"udid":"U","hostCores":8,"sampleIntervalMs":1000}\n' +
+  '{"t":1000,"bundleId":"dev.expo.MyApp","cpuPct":0,"memBytes":100}\n' +
+  '{"t":2000,"bundleId":"dev.expo.MyApp","cpuPct":40,"memBytes":120}\n';
+
+function sseResponse(): InstanceType<typeof Response> {
+  return new Response(Readable.from([Buffer.from(SSE_STREAM)]));
+}
+
+let workDir: string;
+let stateDir: string;
+
+beforeEach(async () => {
+  jest.mocked(fetch).mockReset();
+  workDir = await mkdtemp(path.join(os.tmpdir(), 'serve-sim-metrics-rec-test-'));
+  stateDir = path.join(workDir, 'serve-sim-state');
+});
+
+afterEach(async () => {
+  await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() });
+  await rm(workDir, { recursive: true, force: true });
+});
+
+async function writeServerStateAsync(
+  udid: string,
+  value: unknown = { pid: 1, port: 4000, device: udid, url: 'https://sim.example' }
+): Promise<void> {
+  await writeFile(path.join(stateDir, `server-${udid}.json`), JSON.stringify(value));
+}
+
+describe(readServeSimServersAsync, () => {
+  beforeEach(async () => {
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(stateDir, { recursive: true });
+  });
+
+  it('returns each server-*.json with a device + url, ignoring other files', async () => {
+    await writeServerStateAsync('A', { device: 'A', url: 'http://127.0.0.1:1' });
+    await writeServerStateAsync('B', { device: 'B', url: 'http://127.0.0.1:2' });
+    await writeFile(path.join(stateDir, 'not-a-server.json'), '{"device":"X","url":"http://x"}');
+
+    const servers = await readServeSimServersAsync(stateDir);
+    expect(servers).toEqual(
+      expect.arrayContaining([
+        { udid: 'A', url: 'http://127.0.0.1:1' },
+        { udid: 'B', url: 'http://127.0.0.1:2' },
+      ])
+    );
+    expect(servers).toHaveLength(2);
+  });
+
+  it('tolerates malformed/incomplete state files', async () => {
+    await writeFile(path.join(stateDir, 'server-bad.json'), 'not json');
+    await writeServerStateAsync('C', { device: 'C' }); // missing url
+    await writeServerStateAsync('D', { device: 'D', url: 'http://127.0.0.1:4' });
+
+    expect(await readServeSimServersAsync(stateDir)).toEqual([
+      { udid: 'D', url: 'http://127.0.0.1:4' },
+    ]);
+  });
+
+  it('returns [] when the state dir does not exist', async () => {
+    expect(await readServeSimServersAsync(path.join(workDir, 'nope'))).toEqual([]);
+  });
+});
+
+describe(streamServeSimMetricsToFileAsync, () => {
+  it('appends the data payloads to the file as NDJSON, ignoring event/heartbeat lines', async () => {
+    jest.mocked(fetch).mockResolvedValue(sseResponse());
+    const filePath = path.join(workDir, 'stream.ndjson');
+    await streamServeSimMetricsToFileAsync({
+      serveSimUrl: 'https://sim.example',
+      filePath,
+      signal: new AbortController().signal,
+      logger: createLoggerMock(),
+    });
+    expect(await readFile(filePath, 'utf-8')).toBe(EXPECTED_NDJSON);
+    expect(String(jest.mocked(fetch).mock.calls[0][0])).toBe('https://sim.example/metrics');
+  });
+
+  it('writes nothing on a non-ok response', async () => {
+    jest.mocked(fetch).mockResolvedValue(new Response('nope', { status: 502 }));
+    const filePath = path.join(workDir, 'empty.ndjson');
+    await streamServeSimMetricsToFileAsync({
+      serveSimUrl: 'https://sim.example',
+      filePath,
+      signal: new AbortController().signal,
+      logger: createLoggerMock(),
+    });
+    expect(await readFile(filePath, 'utf-8')).toBe('');
+  });
+
+  it('warns when the output file emits a write error', async () => {
+    const fakeFile = Object.assign(new EventEmitter(), {
+      write: jest.fn(),
+      end: (cb: () => void) => cb(),
+    });
+    const fs = jest.requireMock<typeof import('node:fs')>('node:fs');
+    const realCreateWriteStream = fs.createWriteStream;
+    fs.createWriteStream = (() => {
+      queueMicrotask(() => fakeFile.emit('error', new Error('disk full')));
+      return fakeFile as unknown as ReturnType<typeof realCreateWriteStream>;
+    }) as typeof realCreateWriteStream;
+    jest.mocked(fetch).mockResolvedValue(new Response('nope', { status: 502 }));
+    const logger = createLoggerMock();
+
+    try {
+      await streamServeSimMetricsToFileAsync({
+        serveSimUrl: 'https://sim.example',
+        filePath: path.join(workDir, 'unwritable.ndjson'),
+        signal: new AbortController().signal,
+        logger,
+      });
+    } finally {
+      fs.createWriteStream = realCreateWriteStream;
+    }
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      expect.stringContaining('file write failed')
+    );
+  });
+
+  it('warns without throwing when the request errors', async () => {
+    jest.mocked(fetch).mockRejectedValue(new Error('ECONNRESET'));
+    const filePath = path.join(workDir, 'errored.ndjson');
+    const logger = createLoggerMock();
+    await expect(
+      streamServeSimMetricsToFileAsync({
+        serveSimUrl: 'https://sim.example',
+        filePath,
+        signal: new AbortController().signal,
+        logger,
+      })
+    ).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      expect.stringContaining('stream ended')
+    );
+  });
+});
+
+describe('ServeSimMetricsRecorder', () => {
+  it('discovers running servers and collects a per-device NDJSON file', async () => {
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(stateDir, { recursive: true });
+    await writeServerStateAsync('AAAA', { device: 'AAAA', url: 'https://sim-a.example' });
+    jest.mocked(fetch).mockResolvedValue(sseResponse());
+
+    await ServeSimMetricsRecorder.startAsync({ logger: createLoggerMock(), stateDir });
+    await delay(200);
+
+    const collected = await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() });
+    expect(collected).toHaveLength(1);
+    expect(collected[0].udid).toBe('AAAA');
+    expect(await readFile(collected[0].filePath, 'utf-8')).toBe(EXPECTED_NDJSON);
+  });
+
+  it('reconnects a device whose first /metrics attempt fails', async () => {
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(stateDir, { recursive: true });
+    await writeServerStateAsync('CCCC', { device: 'CCCC', url: 'https://sim-c.example' });
+    jest
+      .mocked(fetch)
+      .mockResolvedValueOnce(new Response('nope', { status: 502 }))
+      .mockImplementation(async () => sseResponse());
+
+    await ServeSimMetricsRecorder.startAsync({
+      logger: createLoggerMock(),
+      stateDir,
+      pollIntervalMs: 20,
+    });
+    await delay(200);
+
+    const collected = await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() });
+    expect(collected).toHaveLength(1);
+    // The 502 didn't permanently stop collection — a later attempt recovered samples.
+    expect(await readFile(collected[0].filePath, 'utf-8')).toContain('"cpuPct"');
+  });
+
+  it('returns [] from finishAsync when nothing is running', async () => {
+    expect(await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() })).toEqual([]);
+  });
+
+  it('defaults to the serve-sim state dir when none is given', async () => {
+    // No state dir exists at the default location, so there is nothing to collect.
+    await ServeSimMetricsRecorder.startAsync({ logger: createLoggerMock() });
+    expect(await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() })).toEqual([]);
+  });
+
+  it('stops reconnecting a device after the per-attempt cap', async () => {
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(stateDir, { recursive: true });
+    await writeServerStateAsync('DDDD', { device: 'DDDD', url: 'https://sim-d.example' });
+    // Every attempt fails fast, freeing the slot so the poller keeps retrying until the cap.
+    jest.mocked(fetch).mockResolvedValue(new Response('nope', { status: 502 }));
+
+    await ServeSimMetricsRecorder.startAsync({
+      logger: createLoggerMock(),
+      stateDir,
+      pollIntervalMs: 5,
+    });
+    await delay(200);
+    await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() });
+
+    expect(jest.mocked(fetch)).toHaveBeenCalledTimes(10);
+  });
+
+  it('skips a device already streaming and aborts it on finish', async () => {
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(stateDir, { recursive: true });
+    await writeServerStateAsync('EEEE', { device: 'EEEE', url: 'https://sim-e.example' });
+    // A stream that stays open across several poll ticks, so finish has an active stream to abort.
+    jest.mocked(fetch).mockImplementation(async () => {
+      const stream = new Readable({ read() {} });
+      stream.push(Buffer.from('data: {"t":1,"cpuPct":1,"memBytes":1}\n\n'));
+      setTimeout(() => stream.push(null), 80).unref();
+      return new Response(stream);
+    });
+
+    await ServeSimMetricsRecorder.startAsync({
+      logger: createLoggerMock(),
+      stateDir,
+      pollIntervalMs: 5,
+    });
+    await delay(30);
+    const collected = await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() });
+
+    expect(collected).toHaveLength(1);
+    // Only one stream was opened despite many poll ticks — the rest were skipped as already active.
+    expect(jest.mocked(fetch)).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports an unexpected poller error to Sentry', async () => {
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(stateDir, { recursive: true });
+    await writeServerStateAsync('FFFF', { device: 'FFFF', url: 'https://sim-f.example' });
+    jest.mocked(fetch).mockResolvedValue(sseResponse());
+    const logger = createLoggerMock();
+    jest.mocked(logger.info).mockImplementation((...args: unknown[]) => {
+      if (typeof args[0] === 'string' && args[0].startsWith('Collecting')) {
+        throw new Error('boom');
+      }
+    });
+
+    await ServeSimMetricsRecorder.startAsync({ logger, stateDir, pollIntervalMs: 5 });
+    await delay(50);
+    await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() });
+
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'serve-sim metrics poller failed',
+      expect.any(Error)
+    );
+  });
+
+  it('is a no-op when start is called twice (single session)', async () => {
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(stateDir, { recursive: true });
+    await writeServerStateAsync('BBBB', { device: 'BBBB', url: 'https://sim-b.example' });
+    jest.mocked(fetch).mockResolvedValue(sseResponse());
+
+    await ServeSimMetricsRecorder.startAsync({ logger: createLoggerMock(), stateDir });
+    await ServeSimMetricsRecorder.startAsync({ logger: createLoggerMock(), stateDir });
+    await delay(200);
+
+    const collected = await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() });
+    expect(collected).toHaveLength(1);
+    expect(await ServeSimMetricsRecorder.finishAsync({ logger: createLoggerMock() })).toEqual([]);
+  });
+});

--- a/packages/build-tools/src/steps/utils/__tests__/serveSimMetricsRecorder.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/serveSimMetricsRecorder.test.ts
@@ -174,7 +174,7 @@ describe(streamServeSimMetricsToFileAsync, () => {
         signal: new AbortController().signal,
         logger,
       })
-    ).resolves.toEqual({ receivedData: false, meta: undefined });
+    ).resolves.toEqual({ receivedData: false, metadata: undefined });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ err: expect.any(Error) }),
       expect.stringContaining('stream ended')
@@ -196,8 +196,8 @@ describe('ServeSimMetricsRecorder', () => {
     expect(collected).toHaveLength(1);
     expect(collected[0].udid).toBe('AAAA');
     expect(await readFile(collected[0].filePath, 'utf-8')).toBe(EXPECTED_NDJSON);
-    // The meta frame is captured for the artifact metadata, not written to the NDJSON.
-    expect(collected[0].meta).toEqual({
+    // The metadata frame is captured for the artifact metadata, not written to the NDJSON.
+    expect(collected[0].metadata).toEqual({
       schemaVersion: 1,
       udid: 'U',
       hostCores: 8,

--- a/packages/build-tools/src/steps/utils/serveSimMetricsArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/serveSimMetricsArtifacts.ts
@@ -15,11 +15,13 @@ export async function uploadServeSimMetricsFileAsync(
     deviceRunSessionId,
     udid,
     filePath,
+    meta,
     logger,
   }: {
     deviceRunSessionId: string;
     udid: string;
     filePath: string;
+    meta?: Record<string, unknown>;
     logger: bunyan;
   }
 ): Promise<void> {
@@ -27,11 +29,11 @@ export async function uploadServeSimMetricsFileAsync(
   try {
     ({ size } = await stat(filePath));
   } catch {
-    logger.info(`No serve-sim metrics captured for ${udid}; skipping upload.`);
+    logger.info(`No serve-sim metrics file was written for ${udid}; skipping upload.`);
     return;
   }
   if (size === 0) {
-    logger.info(`No serve-sim metrics captured for ${udid}; skipping upload.`);
+    logger.info(`serve-sim metrics file for ${udid} is empty; skipping upload.`);
     return;
   }
   try {
@@ -39,9 +41,18 @@ export async function uploadServeSimMetricsFileAsync(
     await uploadDeviceRunSessionArtifactAsync(ctx, {
       deviceRunSessionId,
       artifactId: `metrics-${udid}`,
-      name: METRICS_ARTIFACT_FILENAME,
+      name: `Performance metrics (${udid.slice(0, 8)})`,
       filename: METRICS_ARTIFACT_FILENAME,
-      kind: undefined,
+      kind: 'performance-metrics',
+      metadata: {
+        __eas_type: 'performance-metrics',
+        udid,
+        ...(meta && {
+          hostCores: meta.hostCores,
+          sampleIntervalMs: meta.sampleIntervalMs,
+          schemaVersion: meta.schemaVersion,
+        }),
+      },
       size,
       stream: createReadStream(filePath),
     });

--- a/packages/build-tools/src/steps/utils/serveSimMetricsArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/serveSimMetricsArtifacts.ts
@@ -1,0 +1,53 @@
+import { type bunyan } from '@expo/logger';
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+
+import { CustomBuildContext } from '../../customBuildContext';
+import { Sentry } from '../../sentry';
+import { formatBytes } from '../../utils/artifacts';
+import { uploadDeviceRunSessionArtifactAsync } from './deviceRunSessionArtifacts';
+
+const METRICS_ARTIFACT_FILENAME = 'metrics.ndjson';
+
+export async function uploadServeSimMetricsFileAsync(
+  ctx: CustomBuildContext,
+  {
+    deviceRunSessionId,
+    udid,
+    filePath,
+    logger,
+  }: {
+    deviceRunSessionId: string;
+    udid: string;
+    filePath: string;
+    logger: bunyan;
+  }
+): Promise<void> {
+  let size: number;
+  try {
+    ({ size } = await stat(filePath));
+  } catch {
+    logger.info(`No serve-sim metrics captured for ${udid}; skipping upload.`);
+    return;
+  }
+  if (size === 0) {
+    logger.info(`No serve-sim metrics captured for ${udid}; skipping upload.`);
+    return;
+  }
+  try {
+    logger.info(`Uploading serve-sim metrics for ${udid} (${formatBytes(size)}).`);
+    await uploadDeviceRunSessionArtifactAsync(ctx, {
+      deviceRunSessionId,
+      artifactId: `metrics-${udid}`,
+      name: METRICS_ARTIFACT_FILENAME,
+      filename: METRICS_ARTIFACT_FILENAME,
+      kind: undefined,
+      size,
+      stream: createReadStream(filePath),
+    });
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    Sentry.capture('Could not upload serve-sim metrics artifact', error);
+    logger.warn({ err: error }, `Could not upload serve-sim metrics artifact for ${udid}.`);
+  }
+}

--- a/packages/build-tools/src/steps/utils/serveSimMetricsArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/serveSimMetricsArtifacts.ts
@@ -15,13 +15,13 @@ export async function uploadServeSimMetricsFileAsync(
     deviceRunSessionId,
     udid,
     filePath,
-    meta,
+    metadata,
     logger,
   }: {
     deviceRunSessionId: string;
     udid: string;
     filePath: string;
-    meta?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
     logger: bunyan;
   }
 ): Promise<void> {
@@ -47,10 +47,10 @@ export async function uploadServeSimMetricsFileAsync(
       metadata: {
         __eas_type: 'performance-metrics',
         udid,
-        ...(meta && {
-          hostCores: meta.hostCores,
-          sampleIntervalMs: meta.sampleIntervalMs,
-          schemaVersion: meta.schemaVersion,
+        ...(metadata && {
+          hostCores: metadata.hostCores,
+          sampleIntervalMs: metadata.sampleIntervalMs,
+          schemaVersion: metadata.schemaVersion,
         }),
       },
       size,

--- a/packages/build-tools/src/steps/utils/serveSimMetricsRecorder.ts
+++ b/packages/build-tools/src/steps/utils/serveSimMetricsRecorder.ts
@@ -1,6 +1,6 @@
 import { type bunyan } from '@expo/logger';
 import fetch from 'node-fetch';
-import { createWriteStream } from 'node:fs';
+import { type WriteStream, createWriteStream } from 'node:fs';
 import { mkdtemp, readFile, readdir } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -9,7 +9,9 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { Sentry } from '../../sentry';
 
 const POLL_INTERVAL_MS = 2_000;
-const MAX_STREAM_ATTEMPTS_PER_DEVICE = 10;
+// Consecutive failed connects per device; reset once a stream yields a sample.
+const MAX_CONSECUTIVE_STREAM_FAILURES_PER_DEVICE = 10;
+const END_STREAM_TIMEOUT_MS = 2_000;
 // serve-sim's own per-device registry while serving: `${tmpdir}/serve-sim/server-<udid>.json`.
 const SERVE_SIM_STATE_DIR = path.join(os.tmpdir(), 'serve-sim');
 
@@ -22,6 +24,7 @@ type ServeSimMetricsSession = {
   outputDirectory: string;
   files: Map<string, string>;
   attempts: Map<string, number>;
+  meta: Map<string, Record<string, unknown>>;
   activeStreams: Map<string, { abortController: AbortController; donePromise: Promise<void> }>;
   pollingPromise: Promise<void>;
   abortController: AbortController;
@@ -51,6 +54,7 @@ export namespace ServeSimMetricsRecorder {
       outputDirectory,
       files: new Map(),
       attempts: new Map(),
+      meta: new Map(),
       activeStreams: new Map(),
       pollingPromise: Promise.resolve(),
       abortController: new AbortController(),
@@ -69,7 +73,7 @@ export namespace ServeSimMetricsRecorder {
     logger,
   }: {
     logger: bunyan;
-  }): Promise<{ udid: string; filePath: string }[]> {
+  }): Promise<{ udid: string; filePath: string; meta: Record<string, unknown> | undefined }[]> {
     const session = activeSession;
     if (!session) {
       logger.info('No serve-sim metrics polling is running.');
@@ -85,22 +89,35 @@ export namespace ServeSimMetricsRecorder {
         await stream.donePromise;
       })
     );
-    return [...session.files.entries()].map(([udid, filePath]) => ({ udid, filePath }));
+    return [...session.files.entries()].map(([udid, filePath]) => ({
+      udid,
+      filePath,
+      meta: session.meta.get(udid),
+    }));
   }
 }
 
 async function pollServeSimMetricsAsync(session: ServeSimMetricsSession): Promise<void> {
   const { abortController, logger } = session;
   while (!abortController.signal.aborted) {
-    for (const server of await readServeSimServersAsync(session.stateDir)) {
+    const servers = await readServeSimServersAsync(session.stateDir);
+    // Forget the failure count for a device that has left the registry, so a
+    // serve-sim that restarts for the same udid is retried (mirrors the recordings poller).
+    const present = new Set(servers.map(server => server.udid));
+    for (const udid of session.attempts.keys()) {
+      if (!present.has(udid)) {
+        session.attempts.delete(udid);
+      }
+    }
+    for (const server of servers) {
       if (session.activeStreams.has(server.udid)) {
         continue;
       }
-      const attempts = session.attempts.get(server.udid) ?? 0;
-      if (attempts >= MAX_STREAM_ATTEMPTS_PER_DEVICE) {
+      const failures = session.attempts.get(server.udid) ?? 0;
+      if (failures >= MAX_CONSECUTIVE_STREAM_FAILURES_PER_DEVICE) {
         continue;
       }
-      session.attempts.set(server.udid, attempts + 1);
+      session.attempts.set(server.udid, failures + 1);
 
       let filePath = session.files.get(server.udid);
       if (!filePath) {
@@ -111,16 +128,23 @@ async function pollServeSimMetricsAsync(session: ServeSimMetricsSession): Promis
       const streamAbortController = new AbortController();
       const streamSignal = AbortSignal.any([abortController.signal, streamAbortController.signal]);
       logger.info(`Collecting serve-sim metrics for ${server.udid}.`);
-      // Free the slot when the stream ends so the poller reconnects if the server is still up (an
-      // early race or a mid-session drop), up to the per-device attempt cap.
       const donePromise = streamServeSimMetricsToFileAsync({
         serveSimUrl: server.url,
         filePath,
         signal: streamSignal,
         logger,
-      }).finally(() => {
-        session.activeStreams.delete(server.udid);
-      });
+      })
+        .then(({ receivedData, meta }) => {
+          if (receivedData) {
+            session.attempts.set(server.udid, 0);
+          }
+          if (meta) {
+            session.meta.set(server.udid, meta);
+          }
+        })
+        .finally(() => {
+          session.activeStreams.delete(server.udid);
+        });
       session.activeStreams.set(server.udid, {
         abortController: streamAbortController,
         donePromise,
@@ -169,28 +193,46 @@ export async function streamServeSimMetricsToFileAsync({
   filePath: string;
   signal: AbortSignal;
   logger: bunyan;
-}): Promise<void> {
+}): Promise<{ receivedData: boolean; meta: Record<string, unknown> | undefined }> {
   const file = createWriteStream(filePath, { flags: 'a' });
   file.on('error', err => {
     logger.warn({ err }, `serve-sim metrics file write failed for ${filePath}.`);
   });
+  let receivedData = false;
+  let meta: Record<string, unknown> | undefined;
   try {
     const response = await fetch(new URL('/metrics', serveSimUrl).toString(), { signal });
     if (!response.ok || !response.body) {
       logger.warn(`serve-sim /metrics responded ${response.status} for ${serveSimUrl}.`);
-      return;
+      return { receivedData, meta };
     }
+    // One decoder so a multi-byte character split across chunks isn't corrupted.
+    const decoder = new TextDecoder();
     let buffer = '';
+    let event = 'message';
     for await (const chunk of response.body) {
-      buffer += chunk.toString();
+      buffer += decoder.decode(chunk as Buffer, { stream: true });
       let newline: number;
       while ((newline = buffer.indexOf('\n')) !== -1) {
         const line = buffer.slice(0, newline);
         buffer = buffer.slice(newline + 1);
-        if (line.startsWith('data:')) {
+        if (line === '') {
+          event = 'message';
+        } else if (line.startsWith('event:')) {
+          event = line.slice('event:'.length).trim();
+        } else if (line.startsWith('data:')) {
           const payload = line.slice('data:'.length).trim();
-          if (payload) {
+          if (payload && event === 'meta') {
+            // Keep the meta out of the NDJSON (so it stays homogeneous and reconnects
+            // don't re-append it) but hold onto it for the artifact metadata.
+            try {
+              meta = JSON.parse(payload) as Record<string, unknown>;
+            } catch {
+              // ignore a malformed meta frame
+            }
+          } else if (payload) {
             file.write(payload + '\n');
+            receivedData = true;
           }
         }
       }
@@ -202,6 +244,28 @@ export async function streamServeSimMetricsToFileAsync({
       logger.warn({ err }, `serve-sim /metrics stream ended for ${serveSimUrl}.`);
     }
   } finally {
-    await new Promise<void>(resolve => file.end(() => resolve()));
+    await endWriteStreamAsync(file);
   }
+  return { receivedData, meta };
+}
+
+// An errored write stream may never fire `end`'s callback, so also settle on
+// close/error and a timeout to avoid hanging teardown.
+async function endWriteStreamAsync(file: WriteStream): Promise<void> {
+  await new Promise<void>(resolve => {
+    let settled = false;
+    const done = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(done, END_STREAM_TIMEOUT_MS);
+    timer.unref();
+    file.once('close', done);
+    file.once('error', done);
+    file.end(done);
+  });
 }

--- a/packages/build-tools/src/steps/utils/serveSimMetricsRecorder.ts
+++ b/packages/build-tools/src/steps/utils/serveSimMetricsRecorder.ts
@@ -1,0 +1,207 @@
+import { type bunyan } from '@expo/logger';
+import fetch from 'node-fetch';
+import { createWriteStream } from 'node:fs';
+import { mkdtemp, readFile, readdir } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { Sentry } from '../../sentry';
+
+const POLL_INTERVAL_MS = 2_000;
+const MAX_STREAM_ATTEMPTS_PER_DEVICE = 10;
+// serve-sim's own per-device registry while serving: `${tmpdir}/serve-sim/server-<udid>.json`.
+const SERVE_SIM_STATE_DIR = path.join(os.tmpdir(), 'serve-sim');
+
+type ServeSimServer = { udid: string; url: string };
+
+type ServeSimMetricsSession = {
+  logger: bunyan;
+  stateDir: string;
+  pollIntervalMs: number;
+  outputDirectory: string;
+  files: Map<string, string>;
+  attempts: Map<string, number>;
+  activeStreams: Map<string, { abortController: AbortController; donePromise: Promise<void> }>;
+  pollingPromise: Promise<void>;
+  abortController: AbortController;
+};
+
+let activeSession: ServeSimMetricsSession | null = null;
+
+export namespace ServeSimMetricsRecorder {
+  export async function startAsync({
+    logger,
+    stateDir = SERVE_SIM_STATE_DIR,
+    pollIntervalMs = POLL_INTERVAL_MS,
+  }: {
+    logger: bunyan;
+    stateDir?: string;
+    pollIntervalMs?: number;
+  }): Promise<void> {
+    if (activeSession) {
+      logger.info('serve-sim metrics polling is already running.');
+      return;
+    }
+    const outputDirectory = await mkdtemp(path.join(os.tmpdir(), 'serve-sim-metrics-'));
+    const session: ServeSimMetricsSession = {
+      logger,
+      stateDir,
+      pollIntervalMs,
+      outputDirectory,
+      files: new Map(),
+      attempts: new Map(),
+      activeStreams: new Map(),
+      pollingPromise: Promise.resolve(),
+      abortController: new AbortController(),
+    };
+    activeSession = session;
+
+    logger.info('Started polling serve-sim for cpu/mem metrics.');
+    session.pollingPromise = pollServeSimMetricsAsync(session).catch(err => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      Sentry.capture('serve-sim metrics poller failed', error);
+      logger.warn({ err: error }, 'serve-sim metrics poller failed.');
+    });
+  }
+
+  export async function finishAsync({
+    logger,
+  }: {
+    logger: bunyan;
+  }): Promise<{ udid: string; filePath: string }[]> {
+    const session = activeSession;
+    if (!session) {
+      logger.info('No serve-sim metrics polling is running.');
+      return [];
+    }
+    activeSession = null;
+
+    session.abortController.abort();
+    await session.pollingPromise;
+    await Promise.all(
+      [...session.activeStreams.values()].map(async stream => {
+        stream.abortController.abort();
+        await stream.donePromise;
+      })
+    );
+    return [...session.files.entries()].map(([udid, filePath]) => ({ udid, filePath }));
+  }
+}
+
+async function pollServeSimMetricsAsync(session: ServeSimMetricsSession): Promise<void> {
+  const { abortController, logger } = session;
+  while (!abortController.signal.aborted) {
+    for (const server of await readServeSimServersAsync(session.stateDir)) {
+      if (session.activeStreams.has(server.udid)) {
+        continue;
+      }
+      const attempts = session.attempts.get(server.udid) ?? 0;
+      if (attempts >= MAX_STREAM_ATTEMPTS_PER_DEVICE) {
+        continue;
+      }
+      session.attempts.set(server.udid, attempts + 1);
+
+      let filePath = session.files.get(server.udid);
+      if (!filePath) {
+        filePath = path.join(session.outputDirectory, `${server.udid}.ndjson`);
+        session.files.set(server.udid, filePath);
+      }
+
+      const streamAbortController = new AbortController();
+      const streamSignal = AbortSignal.any([abortController.signal, streamAbortController.signal]);
+      logger.info(`Collecting serve-sim metrics for ${server.udid}.`);
+      // Free the slot when the stream ends so the poller reconnects if the server is still up (an
+      // early race or a mid-session drop), up to the per-device attempt cap.
+      const donePromise = streamServeSimMetricsToFileAsync({
+        serveSimUrl: server.url,
+        filePath,
+        signal: streamSignal,
+        logger,
+      }).finally(() => {
+        session.activeStreams.delete(server.udid);
+      });
+      session.activeStreams.set(server.udid, {
+        abortController: streamAbortController,
+        donePromise,
+      });
+    }
+    await delay(session.pollIntervalMs, undefined, { signal: abortController.signal }).catch(
+      () => {}
+    );
+  }
+}
+
+export async function readServeSimServersAsync(stateDir: string): Promise<ServeSimServer[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(stateDir);
+  } catch {
+    return [];
+  }
+  const servers: ServeSimServer[] = [];
+  for (const entry of entries) {
+    if (!/^server-.+\.json$/.test(entry)) {
+      continue;
+    }
+    try {
+      const state = JSON.parse(await readFile(path.join(stateDir, entry), 'utf-8')) as {
+        device?: unknown;
+        url?: unknown;
+      };
+      if (typeof state.device === 'string' && typeof state.url === 'string') {
+        servers.push({ udid: state.device, url: state.url });
+      }
+    } catch {
+      continue;
+    }
+  }
+  return servers;
+}
+
+export async function streamServeSimMetricsToFileAsync({
+  serveSimUrl,
+  filePath,
+  signal,
+  logger,
+}: {
+  serveSimUrl: string;
+  filePath: string;
+  signal: AbortSignal;
+  logger: bunyan;
+}): Promise<void> {
+  const file = createWriteStream(filePath, { flags: 'a' });
+  file.on('error', err => {
+    logger.warn({ err }, `serve-sim metrics file write failed for ${filePath}.`);
+  });
+  try {
+    const response = await fetch(new URL('/metrics', serveSimUrl).toString(), { signal });
+    if (!response.ok || !response.body) {
+      logger.warn(`serve-sim /metrics responded ${response.status} for ${serveSimUrl}.`);
+      return;
+    }
+    let buffer = '';
+    for await (const chunk of response.body) {
+      buffer += chunk.toString();
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (line.startsWith('data:')) {
+          const payload = line.slice('data:'.length).trim();
+          if (payload) {
+            file.write(payload + '\n');
+          }
+        }
+      }
+    }
+  } catch (err) {
+    // Stream ends (teardown abort, serve-sim exit/restart) are expected and reconnected by the
+    // poller, so log rather than report — best-effort telemetry shouldn't page.
+    if (!signal.aborted) {
+      logger.warn({ err }, `serve-sim /metrics stream ended for ${serveSimUrl}.`);
+    }
+  } finally {
+    await new Promise<void>(resolve => file.end(() => resolve()));
+  }
+}

--- a/packages/build-tools/src/steps/utils/serveSimMetricsRecorder.ts
+++ b/packages/build-tools/src/steps/utils/serveSimMetricsRecorder.ts
@@ -24,7 +24,7 @@ type ServeSimMetricsSession = {
   outputDirectory: string;
   files: Map<string, string>;
   attempts: Map<string, number>;
-  meta: Map<string, Record<string, unknown>>;
+  metadata: Map<string, Record<string, unknown>>;
   activeStreams: Map<string, { abortController: AbortController; donePromise: Promise<void> }>;
   pollingPromise: Promise<void>;
   abortController: AbortController;
@@ -54,7 +54,7 @@ export namespace ServeSimMetricsRecorder {
       outputDirectory,
       files: new Map(),
       attempts: new Map(),
-      meta: new Map(),
+      metadata: new Map(),
       activeStreams: new Map(),
       pollingPromise: Promise.resolve(),
       abortController: new AbortController(),
@@ -73,7 +73,7 @@ export namespace ServeSimMetricsRecorder {
     logger,
   }: {
     logger: bunyan;
-  }): Promise<{ udid: string; filePath: string; meta: Record<string, unknown> | undefined }[]> {
+  }): Promise<{ udid: string; filePath: string; metadata: Record<string, unknown> | undefined }[]> {
     const session = activeSession;
     if (!session) {
       logger.info('No serve-sim metrics polling is running.');
@@ -92,7 +92,7 @@ export namespace ServeSimMetricsRecorder {
     return [...session.files.entries()].map(([udid, filePath]) => ({
       udid,
       filePath,
-      meta: session.meta.get(udid),
+      metadata: session.metadata.get(udid),
     }));
   }
 }
@@ -134,12 +134,12 @@ async function pollServeSimMetricsAsync(session: ServeSimMetricsSession): Promis
         signal: streamSignal,
         logger,
       })
-        .then(({ receivedData, meta }) => {
+        .then(({ receivedData, metadata }) => {
           if (receivedData) {
             session.attempts.set(server.udid, 0);
           }
-          if (meta) {
-            session.meta.set(server.udid, meta);
+          if (metadata) {
+            session.metadata.set(server.udid, metadata);
           }
         })
         .finally(() => {
@@ -193,18 +193,18 @@ export async function streamServeSimMetricsToFileAsync({
   filePath: string;
   signal: AbortSignal;
   logger: bunyan;
-}): Promise<{ receivedData: boolean; meta: Record<string, unknown> | undefined }> {
+}): Promise<{ receivedData: boolean; metadata: Record<string, unknown> | undefined }> {
   const file = createWriteStream(filePath, { flags: 'a' });
   file.on('error', err => {
     logger.warn({ err }, `serve-sim metrics file write failed for ${filePath}.`);
   });
   let receivedData = false;
-  let meta: Record<string, unknown> | undefined;
+  let metadata: Record<string, unknown> | undefined;
   try {
     const response = await fetch(new URL('/metrics', serveSimUrl).toString(), { signal });
     if (!response.ok || !response.body) {
       logger.warn(`serve-sim /metrics responded ${response.status} for ${serveSimUrl}.`);
-      return { receivedData, meta };
+      return { receivedData, metadata };
     }
     // One decoder so a multi-byte character split across chunks isn't corrupted.
     const decoder = new TextDecoder();
@@ -223,12 +223,12 @@ export async function streamServeSimMetricsToFileAsync({
         } else if (line.startsWith('data:')) {
           const payload = line.slice('data:'.length).trim();
           if (payload && event === 'meta') {
-            // Keep the meta out of the NDJSON (so it stays homogeneous and reconnects
+            // Keep the metadata out of the NDJSON (so it stays homogeneous and reconnects
             // don't re-append it) but hold onto it for the artifact metadata.
             try {
-              meta = JSON.parse(payload) as Record<string, unknown>;
+              metadata = JSON.parse(payload) as Record<string, unknown>;
             } catch {
-              // ignore a malformed meta frame
+              // ignore a malformed metadata frame
             }
           } else if (payload) {
             file.write(payload + '\n');
@@ -246,7 +246,7 @@ export async function streamServeSimMetricsToFileAsync({
   } finally {
     await endWriteStreamAsync(file);
   }
-  return { receivedData, meta };
+  return { receivedData, metadata };
 }
 
 // An errored write stream may never fire `end`'s callback, so also settle on


### PR DESCRIPTION
Ref [ENG-23622](https://linear.app/expo/issue/ENG-23622/eas-simulator-cpumemory-inspector-in-the-ui)

# Why

So a simulator session's CPU/memory shows up in the dashboard — live while it runs, and from an artifact after it ends.

# How

* `eas/start_serve_sim_metrics` starts a background poller that discovers each running serve-sim from its local registry (`${tmpdir}/serve-sim/server-<udid>.json`) and streams its `/metrics` to a per-device NDJSON file, reconnecting if a stream drops.
* `eas/collect_serve_sim_metrics` (run with `if: always()`, universe side) stops the poller and uploads the files as artifacts.
* Every iOS session type runs serve-sim (serve-sim, argent, agent-device), so all three are covered. Best-effort throughout.

# Test Plan

CI passes. Unit tests cover registry discovery (malformed/missing files), the SSE → NDJSON stream, the start→collect lifecycle including reconnect after a failed attempt, and the upload (skips missing/empty, swallows failures).  <br>Also ran the full flow locally via `eas simulator start --type serve-sim` against a local worker: the poller streamed `/metrics` and the NDJSON uploaded as an artifact.

https://github.com/user-attachments/assets/369d97e6-bb62-48fd-9ce5-070f495ee047