### PR TITLE
[build-tools] Fix Argent tool server state discovery

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession.test.ts
@@ -1,8 +1,12 @@
 import { SystemError } from '@expo/eas-build-job';
 import { type bunyan } from '@expo/logger';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   MIN_ARGENT_REMOTE_SESSION_VERSION,
+  waitForArgentToolServerStateAsync,
   warnIfArgentPackageVersionCannotBeVerified,
 } from '../startArgentRemoteSession';
 
@@ -68,5 +72,74 @@ describe(warnIfArgentPackageVersionCannotBeVerified, () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('Continuing and letting bunx resolve it.')
     );
+  });
+});
+
+describe(waitForArgentToolServerStateAsync, () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'argent-state-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(stateDir, { recursive: true, force: true });
+  });
+
+  function stateJson({ port, pid, token }: { port: number; pid: number; token?: string }): string {
+    return JSON.stringify({ port, pid, token });
+  }
+
+  it.each(['tool-server.json', 'tool-server-012345abcdef.json'])(
+    'reads a matching process from %s',
+    async fileName => {
+      await fs.promises.writeFile(
+        path.join(stateDir, fileName),
+        stateJson({ port: 4321, pid: process.pid, token: 'secret' })
+      );
+
+      await expect(
+        waitForArgentToolServerStateAsync({
+          stateDir,
+          ancestorPid: process.ppid,
+          timeoutMs: 100,
+          pollIntervalMs: 1,
+        })
+      ).resolves.toEqual({ port: 4321, pid: process.pid, token: 'secret' });
+    }
+  );
+
+  it('selects the state whose pid belongs to the launched process tree', async () => {
+    await fs.promises.writeFile(
+      path.join(stateDir, 'tool-server-111111111111.json'),
+      stateJson({ port: 1111, pid: Number.MAX_SAFE_INTEGER })
+    );
+    await fs.promises.writeFile(
+      path.join(stateDir, 'tool-server-222222222222.json'),
+      stateJson({ port: 2222, pid: process.pid })
+    );
+
+    await expect(
+      waitForArgentToolServerStateAsync({
+        stateDir,
+        ancestorPid: process.ppid,
+        timeoutMs: 100,
+        pollIntervalMs: 1,
+      })
+    ).resolves.toEqual({ port: 2222, pid: process.pid });
+  });
+
+  it('does not return a state file outside the launched process tree', async () => {
+    const filePath = path.join(stateDir, 'tool-server-012345abcdef.json');
+    await fs.promises.writeFile(filePath, stateJson({ port: 1111, pid: Number.MAX_SAFE_INTEGER }));
+
+    await expect(
+      waitForArgentToolServerStateAsync({
+        stateDir,
+        ancestorPid: process.pid,
+        timeoutMs: 10,
+        pollIntervalMs: 1,
+      })
+    ).rejects.toThrow(`state file belonging to process ${process.pid}`);
   });
 });

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -15,6 +15,8 @@ import { z } from 'zod';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import { Sentry } from '../../sentry';
+import { isProcessDescendantOfAsync } from '../../utils/processes';
+import { sleepAsync } from '../../utils/retry';
 import { pollArgentArtifactsForUploadAsync } from '../utils/argentArtifacts';
 import {
   getDeviceRunSessionIdOrThrow,
@@ -26,19 +28,21 @@ import {
   startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
   waitForDeviceRunSessionStoppedAsync,
-  waitForFileAsync,
 } from '../utils/remoteDeviceRunSession';
 
 const ARGENT_PACKAGE_NAME = '@swmansion/argent';
 export const MIN_ARGENT_REMOTE_SESSION_VERSION = '0.12.0';
 const ARGENT_ARTIFACTS_LIST_ENDPOINT_FLAG = 'artifacts-list-endpoint';
-const ARGENT_STATE_FILE = path.join(os.homedir(), '.argent', 'tool-server.json');
+const ARGENT_STATE_DIR = path.join(os.homedir(), '.argent');
 const STARTUP_TIMEOUT_MS = 60_000;
 
 const ArgentToolServerStateSchema = z.object({
   port: z.number(),
+  pid: z.number(),
   token: z.string().optional(),
 });
+
+type ArgentToolServerState = z.infer<typeof ArgentToolServerStateSchema>;
 
 export function createStartArgentRemoteSessionBuildFunction(
   ctx: CustomBuildContext
@@ -76,8 +80,6 @@ export function createStartArgentRemoteSessionBuildFunction(
         await selectXcodeDeveloperDirectoryAsync({ env, logger });
       }
 
-      // Stale state from a previous run would mask the new server's port.
-      await fs.promises.rm(ARGENT_STATE_FILE, { force: true });
       logger.info('Enabling the Argent artifacts list endpoint flag.');
       await spawn(
         'bunx',
@@ -86,6 +88,8 @@ export function createStartArgentRemoteSessionBuildFunction(
       );
 
       logger.info(`Launching ${ARGENT_PACKAGE_NAME}@${versionSpec} tool-server via bunx.`);
+      // Keep Argent itself in foreground mode under the detached bunx process. This preserves
+      // the bunx -> Argent CLI -> tool-server ancestry used to identify the matching state file.
       const argentServer = spawnDetached({
         command: 'bunx',
         args: [
@@ -96,20 +100,24 @@ export function createStartArgentRemoteSessionBuildFunction(
           '0',
           '--idle-timeout',
           '0',
-          '--detach',
+          '--force',
         ],
         env,
       });
+      if (argentServer.pid === undefined) {
+        throw new SystemError(
+          'Failed to start Argent: could not determine the PID of the launched process.'
+        );
+      }
 
-      logger.info(`Waiting for argent tool-server state at ${ARGENT_STATE_FILE}.`);
+      logger.info(`Waiting for argent tool-server state in ${ARGENT_STATE_DIR}.`);
       let toolServerPort: number;
       let toolServerToken: string | undefined;
       try {
-        const toolServerState = await waitForFileAsync({
-          filePath: ARGENT_STATE_FILE,
+        const toolServerState = await waitForArgentToolServerStateAsync({
+          stateDir: ARGENT_STATE_DIR,
+          ancestorPid: argentServer.pid,
           timeoutMs: STARTUP_TIMEOUT_MS,
-          description: 'argent tool-server state',
-          parse: parseArgentToolServerState,
         });
         toolServerPort = toolServerState.port;
         toolServerToken = toolServerState.token;
@@ -219,12 +227,64 @@ export function warnIfArgentPackageVersionCannotBeVerified({
   }
 }
 
-function parseArgentToolServerState(raw: string): { port: number; token?: string } {
-  const result = ArgentToolServerStateSchema.safeParse(JSON.parse(raw));
+function parseArgentToolServerState(raw: string): ArgentToolServerState {
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (err) {
+    throw new SystemError('Expected tool-server state to contain valid JSON.', { cause: err });
+  }
+  const result = ArgentToolServerStateSchema.safeParse(json);
   if (!result.success) {
     throw new SystemError(
-      `Expected tool-server state to contain { "port": <number>, ... }: ${result.error.message}`
+      `Expected tool-server state to contain { "port": <number>, "pid": <number>, ... }: ${result.error.message}`
     );
   }
   return result.data;
+}
+
+export async function waitForArgentToolServerStateAsync({
+  stateDir,
+  ancestorPid,
+  timeoutMs,
+  pollIntervalMs = 1_000,
+}: {
+  stateDir: string;
+  ancestorPid: number;
+  timeoutMs: number;
+  pollIntervalMs?: number;
+}): Promise<ArgentToolServerState> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const stateFileNames = (await fs.promises.readdir(stateDir)).filter(
+        name => name.startsWith('tool-server') && name.endsWith('.json')
+      );
+      for (const stateFileName of stateFileNames) {
+        try {
+          const state = parseArgentToolServerState(
+            await fs.promises.readFile(path.join(stateDir, stateFileName), 'utf8')
+          );
+          if (await isProcessDescendantOfAsync(state.pid, ancestorPid)) {
+            return state;
+          }
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT' && !(err instanceof SystemError)) {
+            throw err;
+          }
+        }
+      }
+    } catch (err) {
+      lastError = err;
+    }
+    await sleepAsync(pollIntervalMs);
+  }
+
+  throw new SystemError(
+    `Timed out waiting for an argent tool-server state file belonging to process ${ancestorPid} in ${stateDir}${
+      lastError instanceof Error ? `: ${lastError.message}` : ''
+    }.`
+  );
 }

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -293,6 +293,8 @@ export async function uploadRemoteSessionConfigAsync({
 }
 
 export type DetachedProcessHandle = {
+  /** PID of the directly spawned process, if the OS assigned one. */
+  pid: number | undefined;
   getOutput: () => string;
 };
 
@@ -325,7 +327,7 @@ export function spawnDetached({
   promise.child.stdout?.on('data', appendChunk);
   promise.child.stderr?.on('data', appendChunk);
 
-  return { getOutput: () => output };
+  return { pid: promise.child.pid, getOutput: () => output };
 }
 
 export async function startServeSimWithTunnelAsync(

--- a/packages/build-tools/src/utils/processes.ts
+++ b/packages/build-tools/src/utils/processes.ts
@@ -30,3 +30,29 @@ export async function getParentAndDescendantProcessPidsAsync(ppid: number): Prom
   }
   return [...children];
 }
+
+export async function isProcessDescendantOfAsync(
+  pid: number,
+  ancestorPid: number
+): Promise<boolean> {
+  let currentPid = pid;
+  while (currentPid > 0) {
+    if (currentPid === ancestorPid) {
+      return true;
+    }
+
+    try {
+      const result = await spawn('ps', ['-p', String(currentPid), '-o', 'ppid='], {
+        stdio: 'pipe',
+      });
+      const parentPid = Number(result.stdout.toString().trim());
+      if (!Number.isInteger(parentPid) || parentPid <= 0 || parentPid === currentPid) {
+        return false;
+      }
+      currentPid = parentPid;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
# Why

Argent now writes per-install tool-server state files such as `~/.argent/tool-server-<hash>.json`. The remote session step only watched the legacy `tool-server.json`, so it could time out even when the newly launched tool server was running.

# How

- expose the PID of detached processes
- add a process ancestry helper that works on macOS and Linux
- run Argent in the foreground beneath the detached `bunx` process and pass `--force`
- scan legacy and hashed Argent state files, selecting only the state whose PID descends from the launched `bunx` process
- validate the state schema includes the tool-server PID
- cover legacy, hashed, matching, and unrelated state files

# Test Plan

- `yarn workspace @expo/build-tools jest-unit packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession.test.ts --runInBand`
- `yarn workspace @expo/build-tools build`
- `yarn workspace @expo/worker build`
- `yarn workspace eas-cli build`
- `yarn workspace @expo/build-tools typecheck`
- `yarn lint`
- `yarn fmt:check`
