### PR TITLE
[build-tools] Handle detached Android emulator exits

### DIFF
--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -329,6 +329,9 @@ export namespace AndroidEmulatorUtils {
       await emulatorPromise;
     }
     emulatorPromise.child.unref();
+    // The emulator is detached and managed through adb. Observe its process promise
+    // immediately so expected exits during retry cleanup do not become unhandled rejections.
+    void asyncResult(emulatorPromise);
 
     const serialId = await retryAsync(
       async () => {


### PR DESCRIPTION
## Summary

Observe the detached Android emulator process promise immediately after startup so expected exits during retry cleanup do not surface as unhandled promise rejections.

The emulator is managed through adb after launch. When a startup attempt times out and cleanup kills the emulator, the underlying SpawnPromise can reject while the retry loop is handling the readiness failure. Observing the promise keeps Sentry from capturing that cleanup path as an unhandled SIGKILL while preserving the returned promise for callers that still await it later.

## Test plan

- yarn run -T oxfmt packages/build-tools/src/utils/AndroidEmulatorUtils.ts
- yarn workspace @expo/build-tools typecheck