### PR TITLE
[build-tools] Collect agent-device session activity

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/startAgentDeviceRemoteSession.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startAgentDeviceRemoteSession.test.ts
@@ -1,0 +1,39 @@
+import { type bunyan } from '@expo/logger';
+
+import { Sentry } from '../../../sentry';
+import { stopAgentDeviceEventCollectionSafelyAsync } from '../startAgentDeviceRemoteSession';
+
+jest.mock('../../../sentry');
+
+describe(stopAgentDeviceEventCollectionSafelyAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports an unexpected stop failure without rejecting', async () => {
+    const error = new Error('stop failed');
+    const logger = { warn: jest.fn() } as unknown as bunyan;
+
+    await expect(
+      stopAgentDeviceEventCollectionSafelyAsync({
+        eventCollection: { stopAsync: jest.fn().mockRejectedValue(error) },
+        deviceRunSessionId: 'session-id',
+        logger,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Could not finish agent-device session event collection',
+      error,
+      {
+        level: 'warning',
+        tags: { phase: 'agent-device-event-collection', operation: 'stop' },
+        extras: { deviceRunSessionId: 'session-id' },
+      }
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: error },
+      'Could not finish agent-device session event collection.'
+    );
+  });
+});

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -128,7 +128,6 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
         ctx,
         deviceRunSessionId,
         stateDir: AGENT_DEVICE_STATE_DIR,
-        producerVersion: packageVersion,
         logger,
       });
 

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -139,10 +139,36 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
           signal,
         });
       } finally {
-        await eventCollection.stopAsync();
+        await stopAgentDeviceEventCollectionSafelyAsync({
+          eventCollection,
+          deviceRunSessionId,
+          logger,
+        });
       }
     },
   });
+}
+
+export async function stopAgentDeviceEventCollectionSafelyAsync({
+  eventCollection,
+  deviceRunSessionId,
+  logger,
+}: {
+  eventCollection: { stopAsync: () => Promise<void> };
+  deviceRunSessionId: string;
+  logger: bunyan;
+}): Promise<void> {
+  try {
+    await eventCollection.stopAsync();
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    Sentry.capture('Could not finish agent-device session event collection', error, {
+      level: 'warning',
+      tags: { phase: 'agent-device-event-collection', operation: 'stop' },
+      extras: { deviceRunSessionId },
+    });
+    logger.warn({ err: error }, 'Could not finish agent-device session event collection.');
+  }
 }
 
 async function startAgentDeviceDaemonAsync({

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -15,6 +15,7 @@ import path from 'node:path';
 import { type CustomBuildContext } from '../../customBuildContext';
 import { Sentry } from '../../sentry';
 import { pollAgentDeviceArtifactsForUploadAsync } from '../utils/agentDeviceArtifacts';
+import { startAgentDeviceEventCollectionAsync } from '../utils/deviceRunSessionEvents';
 import {
   type DetachedProcessHandle,
   getDeviceRunSessionIdOrThrow,
@@ -32,7 +33,8 @@ import {
 const AGENT_DEVICE_PACKAGE_NAME = 'agent-device';
 const AGENT_DEVICE_REPO_URL = 'https://github.com/callstack/agent-device.git';
 const SRC_DIR = '/tmp/agent-device-src';
-const DAEMON_JSON_PATH = path.join(os.homedir(), '.agent-device', 'daemon.json');
+const AGENT_DEVICE_STATE_DIR = path.join(os.homedir(), '.agent-device');
+const DAEMON_JSON_PATH = path.join(AGENT_DEVICE_STATE_DIR, 'daemon.json');
 const STARTUP_TIMEOUT_MS = 60_000;
 const AGENT_DEVICE_DAEMON_ENV = {
   AGENT_DEVICE_DAEMON_SERVER_MODE: 'http',
@@ -122,12 +124,24 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
         logger,
       });
 
-      await waitForDeviceRunSessionStoppedAsync({
+      const eventCollection = await startAgentDeviceEventCollectionAsync({
         ctx,
         deviceRunSessionId,
+        stateDir: AGENT_DEVICE_STATE_DIR,
+        producerVersion: packageVersion,
         logger,
-        signal,
       });
+
+      try {
+        await waitForDeviceRunSessionStoppedAsync({
+          ctx,
+          deviceRunSessionId,
+          logger,
+          signal,
+        });
+      } finally {
+        await eventCollection.stopAsync();
+      }
     },
   });
 }

--- a/packages/build-tools/src/steps/utils/__tests__/deviceRunSessionEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/deviceRunSessionEvents.test.ts
@@ -48,7 +48,6 @@ describe(startAgentDeviceEventCollectionAsync, () => {
       ctx,
       deviceRunSessionId: 'session-id',
       stateDir,
-      producerVersion: '0.19.1',
       logger,
       pollIntervalMs: 10,
     });
@@ -99,15 +98,12 @@ describe(startAgentDeviceEventCollectionAsync, () => {
     expect(mockEventLogStream.init).toHaveBeenCalledTimes(1);
     expect(mockEventLogStream.cleanUp).toHaveBeenCalledTimes(1);
     expect(mockEventLogStream.write).toHaveBeenNthCalledWith(2, {
-      schemaVersion: 1,
+      v: 1,
       eventId: 'agent-device:session-id:default:2',
-      deviceRunSessionId: 'session-id',
-      occurredAt: '2026-07-10T12:00:01.000Z',
+      ts: '2026-07-10T12:00:01.000Z',
       producer: 'agent-device',
-      producerVersion: '0.19.1',
       type: 'operation.completed',
       operationId: 'request-1',
-      name: 'tap',
       outcome: 'success',
       durationMs: 25,
       summary: 'Finished tap',
@@ -161,10 +157,9 @@ describe(startAgentDeviceEventCollectionAsync, () => {
     }
 
     expect(mockEventLogStream.write).toHaveBeenCalledWith({
-      schemaVersion: 1,
+      v: 1,
       eventId: 'agent-device:session-id:default:1',
-      deviceRunSessionId: 'session-id',
-      occurredAt: '2026-07-10T12:00:00.000Z',
+      ts: '2026-07-10T12:00:00.000Z',
       producer: 'agent-device',
       type: 'snapshot.recorded',
       summary: 'snapshot.recorded',

--- a/packages/build-tools/src/steps/utils/__tests__/deviceRunSessionEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/deviceRunSessionEvents.test.ts
@@ -1,0 +1,520 @@
+import { type bunyan } from '@expo/logger';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { type CustomBuildContext } from '../../../customBuildContext';
+import RemoteLoggerStream from '../../../logging/RemoteLoggerStream';
+import { Sentry } from '../../../sentry';
+import { startAgentDeviceEventCollectionAsync } from '../deviceRunSessionEvents';
+
+const mockEventLogStream = {
+  init: jest.fn(async () => undefined),
+  write: jest.fn(),
+  cleanUp: jest.fn(async () => undefined),
+};
+
+jest.mock('../../../logging/RemoteLoggerStream', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockEventLogStream),
+}));
+jest.mock('../../../sentry');
+
+describe(startAgentDeviceEventCollectionAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uploads normalized events to the session event artifact once', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-events-'));
+    const eventsDir = path.join(stateDir, 'sessions', 'default');
+    const eventsFile = path.join(eventsDir, 'events.ndjson');
+    await fs.promises.mkdir(eventsDir, { recursive: true });
+    await fs.promises.writeFile(
+      eventsFile,
+      `${JSON.stringify({
+        version: 1,
+        ts: '2026-07-10T12:00:00.000Z',
+        session: 'default',
+        kind: 'request.started',
+        requestId: 'request-1',
+        command: 'tap',
+        summary: 'Started tap',
+      })}\n`
+    );
+    const ctx = createContext();
+    const logger = createLogger();
+    const collection = await startAgentDeviceEventCollectionAsync({
+      ctx,
+      deviceRunSessionId: 'session-id',
+      stateDir,
+      producerVersion: '0.19.1',
+      logger,
+      pollIntervalMs: 10,
+    });
+
+    try {
+      await waitForAsync(() => expect(mockEventLogStream.write).toHaveBeenCalledTimes(1));
+      await fs.promises.appendFile(
+        eventsFile,
+        `${JSON.stringify({
+          version: 1,
+          ts: '2026-07-10T12:00:01.000Z',
+          session: 'default',
+          kind: 'request.finished',
+          requestId: 'request-1',
+          command: 'tap',
+          status: 'ok',
+          summary: 'Finished tap',
+          details: { durationMs: 25 },
+        })}\n${JSON.stringify({
+          version: 1,
+          ts: 123,
+          session: 'default',
+          kind: 'request.started',
+        })}\n`
+      );
+      await waitForAsync(() => expect(mockEventLogStream.write).toHaveBeenCalledTimes(2));
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+
+    expect(ctx.graphqlClient.mutation).toHaveBeenCalledWith(expect.anything(), {
+      deviceRunSessionId: 'session-id',
+    });
+    expect(RemoteLoggerStream).toHaveBeenCalledWith({
+      logger,
+      uploadMethod: {
+        signedUrl: {
+          url: 'https://uploads.expo.test/events',
+          headers: {
+            'content-disposition': 'attachment; filename="events.ndjson"',
+            'x-goog-content-length-range': '0,104857600',
+          },
+        },
+      },
+      options: { uploadIntervalMs: 5_000 },
+    });
+    expect(mockEventLogStream.init).toHaveBeenCalledTimes(1);
+    expect(mockEventLogStream.cleanUp).toHaveBeenCalledTimes(1);
+    expect(mockEventLogStream.write).toHaveBeenNthCalledWith(2, {
+      schemaVersion: 1,
+      eventId: 'agent-device:session-id:default:2',
+      deviceRunSessionId: 'session-id',
+      occurredAt: '2026-07-10T12:00:01.000Z',
+      producer: 'agent-device',
+      producerVersion: '0.19.1',
+      type: 'operation.completed',
+      operationId: 'request-1',
+      name: 'tap',
+      outcome: 'success',
+      durationMs: 25,
+      summary: 'Finished tap',
+      data: {
+        session: 'default',
+        sourceVersion: 1,
+        sourceStatus: 'ok',
+        durationMs: 25,
+      },
+    });
+    expect(Sentry.capture).toHaveBeenCalledTimes(1);
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Could not parse an agent-device event log record',
+      {
+        level: 'warning',
+        tags: { phase: 'agent-device-event-collection', reason: 'invalid-event' },
+        extras: { deviceRunSessionId: 'session-id', lineNumber: 3 },
+      }
+    );
+  });
+
+  it('preserves unknown kinds and tolerates optional upstream field changes', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-events-'));
+    const eventsDir = path.join(stateDir, 'sessions', 'default');
+    await fs.promises.mkdir(eventsDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(eventsDir, 'events.ndjson'),
+      `${JSON.stringify({
+        version: 2,
+        ts: '2026-07-10T12:00:00.000Z',
+        session: 'default',
+        kind: 'snapshot.recorded',
+        requestId: 123,
+        status: 'queued',
+        newUpstreamField: true,
+      })}\n`
+    );
+    const collection = await startAgentDeviceEventCollectionAsync({
+      ctx: createContext(),
+      deviceRunSessionId: 'session-id',
+      stateDir,
+      logger: createLogger(),
+      pollIntervalMs: 10,
+    });
+
+    try {
+      await waitForAsync(() => expect(mockEventLogStream.write).toHaveBeenCalledTimes(1));
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+
+    expect(mockEventLogStream.write).toHaveBeenCalledWith({
+      schemaVersion: 1,
+      eventId: 'agent-device:session-id:default:1',
+      deviceRunSessionId: 'session-id',
+      occurredAt: '2026-07-10T12:00:00.000Z',
+      producer: 'agent-device',
+      type: 'snapshot.recorded',
+      summary: 'snapshot.recorded',
+      data: { session: 'default', sourceVersion: 2, sourceStatus: 'queued' },
+    });
+    expect(Sentry.capture).not.toHaveBeenCalled();
+  });
+
+  it('preserves a multi-byte character split across polls', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-events-'));
+    const eventsDir = path.join(stateDir, 'sessions', 'unicode-session');
+    const eventsFile = path.join(eventsDir, 'events.ndjson');
+    await fs.promises.mkdir(eventsDir, { recursive: true });
+    const completeEvent = `${JSON.stringify(
+      createAgentDeviceEvent({ summary: 'Complete event before split character' })
+    )}\n`;
+    const splitEvent = `${JSON.stringify(
+      createAgentDeviceEvent({ session: 'upstream-session', summary: 'Tapped 🙂 successfully' })
+    )}\n`;
+    const serializedText = `${completeEvent}${splitEvent}`;
+    const emojiCharacterOffset = serializedText.indexOf('🙂');
+    expect(emojiCharacterOffset).toBeGreaterThanOrEqual(0);
+    const encoder = new TextEncoder();
+    const serializedEvent = encoder.encode(serializedText);
+    const splitOffset =
+      encoder.encode(serializedText.slice(0, emojiCharacterOffset)).byteLength + 2;
+    await fs.promises.writeFile(eventsFile, serializedEvent.subarray(0, splitOffset));
+
+    const collection = await startAgentDeviceEventCollectionAsync({
+      ctx: createContext(),
+      deviceRunSessionId: 'session-id',
+      stateDir,
+      logger: createLogger(),
+      pollIntervalMs: 60_000,
+    });
+
+    try {
+      await waitForAsync(() => expect(mockEventLogStream.write).toHaveBeenCalledTimes(1));
+      await fs.promises.appendFile(eventsFile, serializedEvent.subarray(splitOffset));
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+
+    expect(mockEventLogStream.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventId: 'agent-device:session-id:unicode-session:2',
+        summary: 'Tapped 🙂 successfully',
+      })
+    );
+  });
+
+  it('reassembles a partial line across polls', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-events-'));
+    const eventsDir = path.join(stateDir, 'sessions', 'partial-line-session');
+    const eventsFile = path.join(eventsDir, 'events.ndjson');
+    await fs.promises.mkdir(eventsDir, { recursive: true });
+    const completeEvent = `${JSON.stringify(
+      createAgentDeviceEvent({ summary: 'Complete event before partial line' })
+    )}\n`;
+    const partialEvent = `${JSON.stringify(
+      createAgentDeviceEvent({ summary: 'Completed after two writes' })
+    )}\n`;
+    const serializedEvent = `${completeEvent}${partialEvent}`;
+    const splitOffset = completeEvent.length + Math.floor(partialEvent.length / 2);
+    await fs.promises.writeFile(eventsFile, serializedEvent.slice(0, splitOffset));
+
+    const collection = await startAgentDeviceEventCollectionAsync({
+      ctx: createContext(),
+      deviceRunSessionId: 'session-id',
+      stateDir,
+      logger: createLogger(),
+      pollIntervalMs: 60_000,
+    });
+
+    try {
+      await waitForAsync(() => expect(mockEventLogStream.write).toHaveBeenCalledTimes(1));
+      await fs.promises.appendFile(eventsFile, serializedEvent.slice(splitOffset));
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+
+    expect(mockEventLogStream.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventId: 'agent-device:session-id:partial-line-session:2',
+        summary: 'Completed after two writes',
+      })
+    );
+  });
+
+  it('does not reuse event IDs after the source file is truncated', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-events-'));
+    const eventsDir = path.join(stateDir, 'sessions', 'rotated-session');
+    const eventsFile = path.join(eventsDir, 'events.ndjson');
+    await fs.promises.mkdir(eventsDir, { recursive: true });
+    await fs.promises.writeFile(
+      eventsFile,
+      `${JSON.stringify(createAgentDeviceEvent({ summary: 'First event before truncation' }))}\n${JSON.stringify(
+        createAgentDeviceEvent({ summary: 'Second event before truncation' })
+      )}\n`
+    );
+
+    const collection = await startAgentDeviceEventCollectionAsync({
+      ctx: createContext(),
+      deviceRunSessionId: 'session-id',
+      stateDir,
+      logger: createLogger(),
+      pollIntervalMs: 60_000,
+    });
+
+    try {
+      await waitForAsync(() => expect(mockEventLogStream.write).toHaveBeenCalledTimes(2));
+      await fs.promises.writeFile(
+        eventsFile,
+        `${JSON.stringify(createAgentDeviceEvent({ summary: 'After truncation' }))}\n`
+      );
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+
+    expect(mockEventLogStream.write).toHaveBeenCalledTimes(3);
+    expect(mockEventLogStream.write).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        eventId: 'agent-device:session-id:rotated-session:3',
+        summary: 'After truncation',
+      })
+    );
+  });
+
+  it('namespaces events by their source session directory', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-events-'));
+    const firstEventsDir = path.join(stateDir, 'sessions', 'first-directory');
+    const secondEventsDir = path.join(stateDir, 'sessions', 'second-directory');
+    await Promise.all([
+      fs.promises.mkdir(firstEventsDir, { recursive: true }),
+      fs.promises.mkdir(secondEventsDir, { recursive: true }),
+    ]);
+    await Promise.all([
+      fs.promises.writeFile(
+        path.join(firstEventsDir, 'events.ndjson'),
+        `${JSON.stringify(
+          createAgentDeviceEvent({ session: 'shared-upstream-session', summary: 'First directory' })
+        )}\n`
+      ),
+      fs.promises.writeFile(
+        path.join(secondEventsDir, 'events.ndjson'),
+        `${JSON.stringify(
+          createAgentDeviceEvent({
+            session: 'shared-upstream-session',
+            summary: 'Second directory',
+          })
+        )}\n`
+      ),
+    ]);
+
+    const collection = await startAgentDeviceEventCollectionAsync({
+      ctx: createContext(),
+      deviceRunSessionId: 'session-id',
+      stateDir,
+      logger: createLogger(),
+      pollIntervalMs: 60_000,
+    });
+
+    try {
+      await waitForAsync(() => expect(mockEventLogStream.write).toHaveBeenCalledTimes(2));
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+
+    expect(mockEventLogStream.write.mock.calls.map(([event]) => event.eventId).sort()).toEqual([
+      'agent-device:session-id:first-directory:1',
+      'agent-device:session-id:second-directory:1',
+    ]);
+  });
+
+  it('reports an aggregate summary when multiple records cannot be parsed', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-events-'));
+    const eventsDir = path.join(stateDir, 'sessions', 'default');
+    await fs.promises.mkdir(eventsDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(eventsDir, 'events.ndjson'),
+      `not-json\n${JSON.stringify({
+        version: 1,
+        ts: 123,
+        session: 'default',
+        kind: 'request.started',
+      })}\n`
+    );
+    const logger = createLogger();
+    const collection = await startAgentDeviceEventCollectionAsync({
+      ctx: createContext(),
+      deviceRunSessionId: 'session-id',
+      stateDir,
+      logger,
+      pollIntervalMs: 60_000,
+    });
+
+    try {
+      await waitForAsync(() => expect(Sentry.capture).toHaveBeenCalledTimes(1));
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      {
+        agentDeviceEventParseFailures: { 'invalid-json': 1, 'invalid-event': 1 },
+        parseFailureCount: 2,
+      },
+      'Could not parse 2 agent-device event log records.'
+    );
+    expect(Sentry.capture).toHaveBeenCalledTimes(2);
+    expect(Sentry.capture).toHaveBeenNthCalledWith(
+      2,
+      'Could not parse multiple agent-device event log records',
+      {
+        level: 'warning',
+        tags: { phase: 'agent-device-event-collection' },
+        extras: {
+          deviceRunSessionId: 'session-id',
+          parseFailureCount: 2,
+          parseFailureCounts: { 'invalid-json': 1, 'invalid-event': 1 },
+        },
+      }
+    );
+  });
+
+  it('reports a continuous collection failure only once', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-events-'));
+    await fs.promises.writeFile(path.join(stateDir, 'sessions'), 'not a directory');
+    const collection = await startAgentDeviceEventCollectionAsync({
+      ctx: createContext(),
+      deviceRunSessionId: 'session-id',
+      stateDir,
+      logger: createLogger(),
+      pollIntervalMs: 10,
+    });
+
+    try {
+      await waitForAsync(() => expect(Sentry.capture).toHaveBeenCalledTimes(1));
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+
+    expect(Sentry.capture).toHaveBeenCalledTimes(1);
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Could not collect agent-device events',
+      expect.any(Error),
+      {
+        level: 'warning',
+        tags: { phase: 'agent-device-event-collection' },
+        extras: { deviceRunSessionId: 'session-id' },
+      }
+    );
+  });
+
+  it('does not fail the session when event log setup fails', async () => {
+    const error = new Error('WWW unavailable');
+    const ctx = createContext();
+    jest.mocked(ctx.graphqlClient.mutation).mockReturnValueOnce({
+      toPromise: async () => ({ error }),
+    } as unknown as ReturnType<CustomBuildContext['graphqlClient']['mutation']>);
+    const logger = createLogger();
+
+    const collection = await startAgentDeviceEventCollectionAsync({
+      ctx,
+      deviceRunSessionId: 'session-id',
+      stateDir: '/does/not/matter',
+      logger,
+      pollIntervalMs: 10,
+    });
+    await collection.stopAsync();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      {
+        err: expect.objectContaining({
+          message: 'Failed to create device run session event log upload session: WWW unavailable',
+          cause: error,
+        }),
+      },
+      'Could not start device run session event collection.'
+    );
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Could not persist device run session events',
+      expect.objectContaining({
+        message: 'Failed to create device run session event log upload session: WWW unavailable',
+        cause: error,
+      }),
+      {
+        level: 'warning',
+        tags: { phase: 'device-run-session-event-collection', operation: 'setup' },
+        extras: { deviceRunSessionId: 'session-id' },
+      }
+    );
+    expect(mockEventLogStream.init).not.toHaveBeenCalled();
+  });
+});
+
+function createContext(): CustomBuildContext {
+  const mutation = jest.fn().mockReturnValue({
+    toPromise: async () => ({
+      data: {
+        deviceRunSession: {
+          createEventLogUploadSession: {
+            uploadSession: {
+              url: 'https://uploads.expo.test/events',
+              headers: {
+                'content-disposition': 'attachment; filename="events.ndjson"',
+                'x-goog-content-length-range': '0,104857600',
+              },
+            },
+          },
+        },
+      },
+    }),
+  });
+  return { graphqlClient: { mutation } } as unknown as CustomBuildContext;
+}
+
+function createLogger(): bunyan {
+  return { info: jest.fn(), warn: jest.fn() } as unknown as bunyan;
+}
+
+function createAgentDeviceEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    version: 1,
+    ts: '2026-07-10T12:00:00.000Z',
+    session: 'default',
+    kind: 'request.started',
+    summary: 'Started activity',
+    ...overrides,
+  };
+}
+
+async function waitForAsync(assertion: () => void): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  for (;;) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      if (Date.now() >= deadline) {
+        throw err;
+      }
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+  }
+}

--- a/packages/build-tools/src/steps/utils/__tests__/deviceRunSessionEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/deviceRunSessionEvents.test.ts
@@ -421,6 +421,53 @@ describe(startAgentDeviceEventCollectionAsync, () => {
     );
   });
 
+  it('handles a polling rejection even when reporting it fails', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-events-'));
+    await fs.promises.writeFile(path.join(stateDir, 'sessions'), 'not a directory');
+    const reportingError = new Error('Sentry unavailable');
+    jest
+      .mocked(Sentry.capture)
+      .mockImplementationOnce(() => {
+        throw reportingError;
+      })
+      .mockImplementationOnce(() => {
+        throw reportingError;
+      });
+    const logger = createLogger();
+    const collection = await startAgentDeviceEventCollectionAsync({
+      ctx: createContext(),
+      deviceRunSessionId: 'session-id',
+      stateDir,
+      logger,
+      pollIntervalMs: 10,
+    });
+
+    try {
+      await waitForAsync(() =>
+        expect(logger.warn).toHaveBeenCalledWith(
+          { err: reportingError },
+          'Agent-device event collection poller failed.'
+        )
+      );
+      await expect(collection.stopAsync()).resolves.toBeUndefined();
+    } finally {
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+
+    expect(Sentry.capture).toHaveBeenCalledTimes(2);
+    expect(Sentry.capture).toHaveBeenNthCalledWith(
+      2,
+      'Agent-device event collection poller failed',
+      reportingError,
+      {
+        level: 'warning',
+        tags: { phase: 'agent-device-event-collection', operation: 'poll' },
+        extras: { deviceRunSessionId: 'session-id' },
+      }
+    );
+    expect(mockEventLogStream.cleanUp).toHaveBeenCalledTimes(1);
+  });
+
   it('does not fail the session when event log setup fails', async () => {
     const error = new Error('WWW unavailable');
     const ctx = createContext();

--- a/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
+++ b/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
@@ -197,7 +197,19 @@ export async function startAgentDeviceEventCollectionAsync({
         }
       }
     }
-  })();
+  })()
+    .catch(err => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      logger.warn({ err: error }, 'Agent-device event collection poller failed.');
+      Sentry.capture('Agent-device event collection poller failed', error, {
+        level: 'warning',
+        tags: { phase: 'agent-device-event-collection', operation: 'poll' },
+        extras: { deviceRunSessionId },
+      });
+    })
+    .catch(() => {
+      // A diagnostics failure must not recreate an unhandled rejection in this best-effort poller.
+    });
 
   return {
     stopAsync: async () => {

--- a/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
+++ b/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
@@ -1,0 +1,401 @@
+import { SystemError } from '@expo/eas-build-job';
+import { type bunyan } from '@expo/logger';
+import { graphql } from 'gql.tada';
+import fs from 'node:fs';
+import path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
+import { setTimeout as setTimeoutAsync } from 'node:timers/promises';
+import { z } from 'zod';
+
+import { type CustomBuildContext } from '../../customBuildContext';
+import RemoteLoggerStream from '../../logging/RemoteLoggerStream';
+import { Sentry } from '../../sentry';
+
+const POLL_INTERVAL_MS = 1_000;
+const UPLOAD_INTERVAL_MS = 5_000;
+
+const AGENT_DEVICE_EVENT_KIND_TO_TYPE: Record<string, string> = {
+  'request.started': 'operation.started',
+  'request.finished': 'operation.completed',
+  'action.recorded': 'interaction.recorded',
+};
+
+const AgentDeviceEventSchema = z
+  .object({
+    version: z.number(),
+    ts: z.string(),
+    session: z.string(),
+    kind: z.string(),
+    requestId: z.string().optional().catch(undefined),
+    command: z.string().optional().catch(undefined),
+    status: z.string().optional().catch(undefined),
+    summary: z.string().optional().catch(undefined),
+    details: z.record(z.string(), z.unknown()).optional().catch(undefined),
+  })
+  .passthrough();
+
+const CREATE_DEVICE_RUN_SESSION_EVENT_LOG_UPLOAD_SESSION_MUTATION = graphql(`
+  mutation CreateDeviceRunSessionEventLogUploadSession($deviceRunSessionId: ID!) {
+    deviceRunSession {
+      createEventLogUploadSession(deviceRunSessionId: $deviceRunSessionId) {
+        uploadSession {
+          url
+          headers
+        }
+      }
+    }
+  }
+`);
+
+type AgentDeviceEvent = z.infer<typeof AgentDeviceEventSchema>;
+
+export type DeviceRunSessionEvent = {
+  schemaVersion: 1;
+  eventId: string;
+  deviceRunSessionId: string;
+  occurredAt: string;
+  producer: string;
+  producerVersion?: string;
+  type: string;
+  operationId?: string;
+  name?: string;
+  outcome?: 'success' | 'failure';
+  durationMs?: number;
+  summary: string;
+  data?: Record<string, unknown>;
+};
+
+type EventFileState = {
+  offset: number;
+  nextSequenceNumber: number;
+  nextLineNumber: number;
+  pending: string;
+  decoder: StringDecoder;
+};
+
+type AgentDeviceEventParseFailure = 'invalid-json' | 'invalid-event';
+type AgentDeviceEventParseResult = {
+  event?: AgentDeviceEvent;
+  failure?: AgentDeviceEventParseFailure;
+};
+
+export async function startAgentDeviceEventCollectionAsync({
+  ctx,
+  deviceRunSessionId,
+  stateDir,
+  producerVersion,
+  logger,
+  pollIntervalMs = POLL_INTERVAL_MS,
+}: {
+  ctx: CustomBuildContext;
+  deviceRunSessionId: string;
+  stateDir: string;
+  producerVersion?: string;
+  logger: bunyan;
+  pollIntervalMs?: number;
+}): Promise<{ stopAsync: () => Promise<void> }> {
+  let didReportEventLogFailure = false;
+  const reportEventLogFailure = (error: Error, operation: 'setup' | 'cleanup'): void => {
+    if (didReportEventLogFailure) {
+      return;
+    }
+    didReportEventLogFailure = true;
+    Sentry.capture('Could not persist device run session events', error, {
+      level: 'warning',
+      tags: { phase: 'device-run-session-event-collection', operation },
+      extras: { deviceRunSessionId },
+    });
+  };
+
+  let eventLogStream: RemoteLoggerStream;
+  try {
+    const uploadSession = await createEventLogUploadSessionAsync(ctx, deviceRunSessionId);
+    eventLogStream = new RemoteLoggerStream({
+      logger,
+      uploadMethod: { signedUrl: uploadSession },
+      options: {
+        uploadIntervalMs: UPLOAD_INTERVAL_MS,
+      },
+    });
+    await eventLogStream.init();
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.warn({ err: error }, 'Could not start device run session event collection.');
+    reportEventLogFailure(error, 'setup');
+    return { stopAsync: async () => {} };
+  }
+
+  const states = new Map<string, EventFileState>();
+  const controller = new AbortController();
+  let parseFailureCount = 0;
+  const parseFailureCounts: Record<AgentDeviceEventParseFailure, number> = {
+    'invalid-json': 0,
+    'invalid-event': 0,
+  };
+  let didReportCollectionFailure = false;
+  const collectAsync = async (): Promise<void> => {
+    const eventFiles = await findAgentDeviceEventFilesAsync(stateDir);
+    await Promise.all(
+      eventFiles.map(async eventFile => {
+        const state = states.get(eventFile) ?? {
+          offset: 0,
+          nextSequenceNumber: 1,
+          nextLineNumber: 1,
+          pending: '',
+          decoder: new StringDecoder('utf8'),
+        };
+        states.set(eventFile, state);
+        await collectEventFileAsync({
+          eventFile,
+          state,
+          deviceRunSessionId,
+          producerVersion,
+          writeEvent: event => eventLogStream.write(event),
+          onParseFailure: ({ failure, lineNumber }) => {
+            parseFailureCount += 1;
+            parseFailureCounts[failure] += 1;
+            if (parseFailureCount !== 1) {
+              return;
+            }
+            logger.warn(
+              { agentDeviceEventParseFailure: failure, lineNumber },
+              'Could not parse an agent-device event log record.'
+            );
+            Sentry.capture('Could not parse an agent-device event log record', {
+              level: 'warning',
+              tags: { phase: 'agent-device-event-collection', reason: failure },
+              extras: { deviceRunSessionId, lineNumber },
+            });
+          },
+        });
+      })
+    );
+  };
+  const collectSafelyAsync = async (): Promise<void> => {
+    try {
+      await collectAsync();
+      didReportCollectionFailure = false;
+    } catch (err) {
+      if (didReportCollectionFailure) {
+        return;
+      }
+      didReportCollectionFailure = true;
+      const error = err instanceof Error ? err : new Error(String(err));
+      logger.warn({ err: error }, 'Could not collect agent-device events.');
+      Sentry.capture('Could not collect agent-device events', error, {
+        level: 'warning',
+        tags: { phase: 'agent-device-event-collection' },
+        extras: { deviceRunSessionId },
+      });
+    }
+  };
+
+  const pollingPromise = (async () => {
+    while (!controller.signal.aborted) {
+      await collectSafelyAsync();
+
+      try {
+        await setTimeoutAsync(pollIntervalMs, undefined, { signal: controller.signal });
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          throw err;
+        }
+      }
+    }
+  })();
+
+  return {
+    stopAsync: async () => {
+      controller.abort();
+      await pollingPromise;
+      await collectSafelyAsync();
+      if (parseFailureCount > 1) {
+        logger.warn(
+          { agentDeviceEventParseFailures: parseFailureCounts, parseFailureCount },
+          `Could not parse ${parseFailureCount} agent-device event log records.`
+        );
+        Sentry.capture('Could not parse multiple agent-device event log records', {
+          level: 'warning',
+          tags: { phase: 'agent-device-event-collection' },
+          extras: { deviceRunSessionId, parseFailureCount, parseFailureCounts },
+        });
+      }
+      try {
+        await eventLogStream.cleanUp();
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        logger.warn({ err: error }, 'Could not finish device run session event collection.');
+        reportEventLogFailure(error, 'cleanup');
+      }
+    },
+  };
+}
+
+async function createEventLogUploadSessionAsync(
+  ctx: CustomBuildContext,
+  deviceRunSessionId: string
+): Promise<{ url: string; headers: Record<string, string> }> {
+  const result = await ctx.graphqlClient
+    .mutation(CREATE_DEVICE_RUN_SESSION_EVENT_LOG_UPLOAD_SESSION_MUTATION, {
+      deviceRunSessionId,
+    })
+    .toPromise();
+  if (result.error) {
+    throw new SystemError(
+      `Failed to create device run session event log upload session: ${result.error.message}`,
+      { cause: result.error }
+    );
+  }
+  const uploadSession = result.data!.deviceRunSession.createEventLogUploadSession.uploadSession;
+  return {
+    url: uploadSession.url,
+    headers: uploadSession.headers as Record<string, string>,
+  };
+}
+
+async function findAgentDeviceEventFilesAsync(stateDir: string): Promise<string[]> {
+  const sessionsDir = path.join(stateDir, 'sessions');
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+
+  return entries
+    .filter(entry => entry.isDirectory())
+    .map(entry => path.join(sessionsDir, entry.name, 'events.ndjson'));
+}
+
+async function collectEventFileAsync({
+  eventFile,
+  state,
+  deviceRunSessionId,
+  producerVersion,
+  writeEvent,
+  onParseFailure,
+}: {
+  eventFile: string;
+  state: EventFileState;
+  deviceRunSessionId: string;
+  producerVersion?: string;
+  writeEvent: (event: DeviceRunSessionEvent) => void;
+  onParseFailure: (failure: { failure: AgentDeviceEventParseFailure; lineNumber: number }) => void;
+}): Promise<void> {
+  let fileSize: number;
+  try {
+    fileSize = (await fs.promises.stat(eventFile)).size;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+    throw err;
+  }
+
+  if (fileSize < state.offset) {
+    state.offset = 0;
+    state.pending = '';
+    state.decoder = new StringDecoder('utf8');
+  }
+  if (fileSize === state.offset) {
+    return;
+  }
+
+  const handle = await fs.promises.open(eventFile, 'r');
+  try {
+    const buffer = new Uint8Array(new ArrayBuffer(fileSize - state.offset));
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, state.offset);
+    state.offset += bytesRead;
+    const text = state.decoder.write(buffer.subarray(0, bytesRead));
+    const lines = `${state.pending}${text}`.split('\n');
+    state.pending = lines.pop() ?? '';
+
+    for (const line of lines) {
+      const lineNumber = state.nextLineNumber++;
+      const sequenceNumber = state.nextSequenceNumber++;
+      const { event, failure } = parseAgentDeviceEvent(line);
+      if (failure) {
+        onParseFailure({ failure, lineNumber });
+      }
+      if (!event) {
+        continue;
+      }
+      const deviceRunSessionEvent = normalizeAgentDeviceEvent({
+        event,
+        sequenceNumber,
+        sourceSessionDirectory: path.basename(path.dirname(eventFile)),
+        deviceRunSessionId,
+        producerVersion,
+      });
+      writeEvent(deviceRunSessionEvent);
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+function parseAgentDeviceEvent(line: string): AgentDeviceEventParseResult {
+  if (!line.trim()) {
+    return {};
+  }
+  try {
+    const result = AgentDeviceEventSchema.safeParse(JSON.parse(line));
+    return result.success ? { event: result.data } : { failure: 'invalid-event' };
+  } catch {
+    return { failure: 'invalid-json' };
+  }
+}
+
+function normalizeAgentDeviceEvent({
+  event,
+  sequenceNumber,
+  sourceSessionDirectory,
+  deviceRunSessionId,
+  producerVersion,
+}: {
+  event: AgentDeviceEvent;
+  sequenceNumber: number;
+  sourceSessionDirectory: string;
+  deviceRunSessionId: string;
+  producerVersion?: string;
+}): DeviceRunSessionEvent {
+  const type = AGENT_DEVICE_EVENT_KIND_TO_TYPE[event.kind] ?? event.kind;
+  const durationMs = event.details?.durationMs;
+  const outcome =
+    event.status === 'ok' ? 'success' : event.status === 'error' ? 'failure' : undefined;
+  const summary =
+    event.summary ??
+    (event.kind === 'request.started'
+      ? `Started ${event.command ?? 'activity'}`
+      : event.kind === 'request.finished'
+        ? `Finished ${event.command ?? 'activity'}`
+        : event.kind === 'action.recorded'
+          ? `Recorded ${event.command ?? 'activity'}`
+          : `${event.kind}${event.command ? `: ${event.command}` : ''}`);
+
+  return {
+    schemaVersion: 1,
+    // Consumers use eventId to deduplicate events across polls. Keep the per-file sequence
+    // monotonic across source-file truncations so an ID is never reused during collection.
+    eventId: `agent-device:${deviceRunSessionId}:${sourceSessionDirectory}:${sequenceNumber}`,
+    deviceRunSessionId,
+    occurredAt: event.ts,
+    producer: 'agent-device',
+    ...(producerVersion ? { producerVersion } : {}),
+    type,
+    ...(event.requestId ? { operationId: event.requestId } : {}),
+    ...(event.command ? { name: event.command } : {}),
+    ...(outcome ? { outcome } : {}),
+    ...(typeof durationMs === 'number' ? { durationMs } : {}),
+    summary,
+    data: {
+      ...event.details,
+      session: event.session,
+      sourceVersion: event.version,
+      ...(event.status ? { sourceStatus: event.status } : {}),
+    },
+  };
+}

--- a/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
+++ b/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import { type CustomBuildContext } from '../../customBuildContext';
 import RemoteLoggerStream from '../../logging/RemoteLoggerStream';
 import { Sentry } from '../../sentry';
+import { type SignedUrl } from '../../storage/uploadWithSignedUrl';
 
 const POLL_INTERVAL_MS = 1_000;
 const UPLOAD_INTERVAL_MS = 5_000;
@@ -228,7 +229,7 @@ export async function startAgentDeviceEventCollectionAsync({
 async function createEventLogUploadSessionAsync(
   ctx: CustomBuildContext,
   deviceRunSessionId: string
-): Promise<{ url: string; headers: Record<string, string> }> {
+): Promise<SignedUrl> {
   const result = await ctx.graphqlClient
     .mutation(CREATE_DEVICE_RUN_SESSION_EVENT_LOG_UPLOAD_SESSION_MUTATION, {
       deviceRunSessionId,

--- a/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
+++ b/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
@@ -50,15 +50,12 @@ const CREATE_DEVICE_RUN_SESSION_EVENT_LOG_UPLOAD_SESSION_MUTATION = graphql(`
 type AgentDeviceEvent = z.infer<typeof AgentDeviceEventSchema>;
 
 export type DeviceRunSessionEvent = {
-  schemaVersion: 1;
+  v: 1;
   eventId: string;
-  deviceRunSessionId: string;
-  occurredAt: string;
+  ts: string;
   producer: string;
-  producerVersion?: string;
   type: string;
   operationId?: string;
-  name?: string;
   outcome?: 'success' | 'failure';
   durationMs?: number;
   summary: string;
@@ -83,14 +80,12 @@ export async function startAgentDeviceEventCollectionAsync({
   ctx,
   deviceRunSessionId,
   stateDir,
-  producerVersion,
   logger,
   pollIntervalMs = POLL_INTERVAL_MS,
 }: {
   ctx: CustomBuildContext;
   deviceRunSessionId: string;
   stateDir: string;
-  producerVersion?: string;
   logger: bunyan;
   pollIntervalMs?: number;
 }): Promise<{ stopAsync: () => Promise<void> }> {
@@ -149,7 +144,6 @@ export async function startAgentDeviceEventCollectionAsync({
           eventFile,
           state,
           deviceRunSessionId,
-          producerVersion,
           writeEvent: event => eventLogStream.write(event),
           onParseFailure: ({ failure, lineNumber }) => {
             parseFailureCount += 1;
@@ -274,14 +268,12 @@ async function collectEventFileAsync({
   eventFile,
   state,
   deviceRunSessionId,
-  producerVersion,
   writeEvent,
   onParseFailure,
 }: {
   eventFile: string;
   state: EventFileState;
   deviceRunSessionId: string;
-  producerVersion?: string;
   writeEvent: (event: DeviceRunSessionEvent) => void;
   onParseFailure: (failure: { failure: AgentDeviceEventParseFailure; lineNumber: number }) => void;
 }): Promise<void> {
@@ -328,7 +320,6 @@ async function collectEventFileAsync({
         sequenceNumber,
         sourceSessionDirectory: path.basename(path.dirname(eventFile)),
         deviceRunSessionId,
-        producerVersion,
       });
       writeEvent(deviceRunSessionEvent);
     }
@@ -354,13 +345,11 @@ function normalizeAgentDeviceEvent({
   sequenceNumber,
   sourceSessionDirectory,
   deviceRunSessionId,
-  producerVersion,
 }: {
   event: AgentDeviceEvent;
   sequenceNumber: number;
   sourceSessionDirectory: string;
   deviceRunSessionId: string;
-  producerVersion?: string;
 }): DeviceRunSessionEvent {
   const type = AGENT_DEVICE_EVENT_KIND_TO_TYPE[event.kind] ?? event.kind;
   const durationMs = event.details?.durationMs;
@@ -377,17 +366,14 @@ function normalizeAgentDeviceEvent({
           : `${event.kind}${event.command ? `: ${event.command}` : ''}`);
 
   return {
-    schemaVersion: 1,
+    v: 1,
     // Consumers use eventId to deduplicate events across polls. Keep the per-file sequence
     // monotonic across source-file truncations so an ID is never reused during collection.
     eventId: `agent-device:${deviceRunSessionId}:${sourceSessionDirectory}:${sequenceNumber}`,
-    deviceRunSessionId,
-    occurredAt: event.ts,
+    ts: event.ts,
     producer: 'agent-device',
-    ...(producerVersion ? { producerVersion } : {}),
     type,
     ...(event.requestId ? { operationId: event.requestId } : {}),
-    ...(event.command ? { name: event.command } : {}),
     ...(outcome ? { outcome } : {}),
     ...(typeof durationMs === 'number' ? { durationMs } : {}),
     summary,


### PR DESCRIPTION
## Why

`agent-device` writes privacy-shaped usage events to per-session `events.ndjson` files. DeviceRunSession consumers need those records independently of the Bunyan runtime-log stream.

## How

- Incrementally tail every `~/.agent-device/sessions/*/events.ndjson` file and preserve partial UTF-8 characters and partial lines across polls.
- Validate the stable source envelope with Zod while accepting new source versions, event kinds, optional fields, and extra fields.
- Normalize records into a producer-neutral DeviceRunSession event format that future Argent and serve-sim collectors can also emit.
- Use `RemoteLoggerStream` to overwrite the marked GCS artifact with a complete snapshot every five seconds.
- Rely on the GCS upload session to enforce the 100 MiB limit with `x-goog-content-length-range`.
- Namespace event IDs by source directory and keep them monotonic across truncation.
- Report bounded setup, parse, collection, and cleanup failures to Sentry without including event payloads.

Collection remains best-effort, so an event reporting failure cannot fail the simulator session. Worker runtime logs are unchanged.

## Test Plan

- `corepack yarn workspace @expo/build-tools typecheck`
- `corepack yarn workspace @expo/build-tools jest-unit --runInBand src/steps/utils/__tests__/deviceRunSessionEvents.test.ts`
- Coverage includes split UTF-8 characters, partial lines, truncation, multiple source directories, upstream schema changes, parse summaries, continuous collection failures, setup failures, and GCS upload headers.

## Rollout

#4027 has merged. Deploy this collector after expo/universe#28937 is available. Website and CLI consumers can deploy after this begins producing marked artifacts.
