### PR TITLE
[eas-cli] Add simulator session activity command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add experimental `eas simulator:events` command. ([#4001](https://github.com/expo/eas-cli/pull/4001) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Collect and upload Argent tool-server session events during remote simulator sessions, mirroring agent-device event collection. ([#4067](https://github.com/expo/eas-cli/pull/4067) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes

--- a/packages/eas-build-job/src/__tests__/deviceRunSession.test.ts
+++ b/packages/eas-build-job/src/__tests__/deviceRunSession.test.ts
@@ -1,0 +1,50 @@
+import { DeviceRunSessionEvent, parseDeviceRunSessionEvents } from '../deviceRunSession';
+
+describe('parseDeviceRunSessionEvents', () => {
+  it('parses, deduplicates, and sorts events from the dedicated event log', () => {
+    const first = createEvent({
+      eventId: 'first',
+      ts: '2026-07-10T12:00:00.000Z',
+    });
+    const second = createEvent({
+      eventId: 'second',
+      ts: '2026-07-10T12:00:01.000Z',
+    });
+
+    expect(
+      parseDeviceRunSessionEvents(`${second}\nplain text\n${first}\n${second}`).map(
+        ({ eventId }) => eventId
+      )
+    ).toEqual(['first', 'second']);
+  });
+
+  it('ignores malformed events', () => {
+    expect(parseDeviceRunSessionEvents(`plain text\n${JSON.stringify({ v: 1 })}`)).toEqual([]);
+  });
+
+  it('ignores events with invalid timestamps', () => {
+    expect(
+      parseDeviceRunSessionEvents(
+        `${createEvent({ eventId: 'invalid', ts: 'not-a-date' })}\n${createEvent({
+          eventId: 'valid',
+        })}`
+      ).map(({ eventId }) => eventId)
+    ).toEqual(['valid']);
+  });
+});
+
+function createEvent(overrides: Partial<DeviceRunSessionEvent> = {}): string {
+  return JSON.stringify(createEventValue(overrides));
+}
+
+function createEventValue(overrides: Partial<DeviceRunSessionEvent> = {}): DeviceRunSessionEvent {
+  return {
+    v: 1,
+    eventId: 'event-id',
+    ts: '2026-07-10T12:00:00.000Z',
+    producer: 'agent-device',
+    type: 'operation.started',
+    summary: 'Started tap',
+    ...overrides,
+  };
+}

--- a/packages/eas-build-job/src/deviceRunSession.ts
+++ b/packages/eas-build-job/src/deviceRunSession.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+/**
+ * Canonical record format for the activity events emitted during a remote device run (simulator)
+ * session. Producers (e.g. the worker and agent-device) write these as NDJSON to the
+ * session-events artifact and consumers (e.g. EAS CLI and the website) read them back. Keep this
+ * schema in sync across every producer and consumer.
+ */
+export const DeviceRunSessionEventZ = z
+  .object({
+    v: z.literal(1),
+    eventId: z.string(),
+    ts: z.string().refine(ts => !Number.isNaN(new Date(ts).getTime())),
+    producer: z.string(),
+    type: z.string(),
+    operationId: z.string().optional(),
+    outcome: z.enum(['success', 'failure']).optional(),
+    durationMs: z.number().optional(),
+    summary: z.string(),
+    data: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+export type DeviceRunSessionEvent = z.infer<typeof DeviceRunSessionEventZ>;
+
+/**
+ * Parse the NDJSON session-events log into canonical event records, de-duplicating by `eventId`
+ * and sorting chronologically by `ts`. Malformed or incomplete lines (including records with
+ * invalid timestamps) are ignored so that a partially-flushed log is still readable.
+ */
+export function parseDeviceRunSessionEvents(eventLog: string): DeviceRunSessionEvent[] {
+  const events = new Map<string, DeviceRunSessionEvent>();
+
+  for (const line of eventLog.split('\n')) {
+    try {
+      const result = DeviceRunSessionEventZ.safeParse(JSON.parse(line));
+      if (result.success) {
+        events.set(result.data.eventId, result.data);
+      }
+    } catch {
+      // Ignore malformed or incomplete records.
+    }
+  }
+
+  return [...events.values()].sort(
+    (left, right) => new Date(left.ts).getTime() - new Date(right.ts).getTime()
+  );
+}

--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -29,6 +29,7 @@ export * from './step';
 export * from './compositeFunction';
 export * from './submission-config';
 export * from './projectPackage';
+export * from './deviceRunSession';
 
 const version = require('../package.json').version;
 export { version };

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -14631,6 +14631,105 @@
             "deprecationReason": null
           },
           {
+            "name": "overviewEngagement",
+            "description": "Active users and sessions for the Overview engagement band, across all versions.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveOverviewEngagementInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverviewEngagement",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "overviewUpdateComparison",
+            "description": "Per-update comparison within one app version: the embedded bundle plus each OTA update.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveOverviewUpdateComparisonInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverviewUpdateComparison",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "overviewVersionComparison",
+            "description": "Per-version, per-platform metric summaries for the Overview version-comparison matrix.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveOverviewVersionComparisonInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverviewVersionComparison",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "timeSeries",
             "description": null,
             "args": [
@@ -19424,6 +19523,1060 @@
               "kind": "SCALAR",
               "name": "Float",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverviewEngagement",
+        "description": null,
+        "fields": [
+          {
+            "name": "activeUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverviewEngagementStat",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sessions",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverviewEngagementStat",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverviewEngagementBucket",
+        "description": null,
+        "fields": [
+          {
+            "name": "bucketStart",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveOverviewEngagementInput",
+        "description": "Engagement-band filters. No release filters: the band always spans all versions.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "bucketIntervalMinutes",
+            "description": "Series bucket size. Defaults to one day.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObservePlatform",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverviewEngagementStat",
+        "description": null,
+        "fields": [
+          {
+            "name": "previousPeriodTotal",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "series",
+            "description": "Per-bucket approximate uniques; buckets do not sum to `total`.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveOverviewEngagementBucket",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverviewStability",
+        "description": null,
+        "fields": [
+          {
+            "name": "affectedUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "crashFreeSessions",
+            "description": "Fraction (0..1) of active sessions without a fatal error.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "crashFreeUsers",
+            "description": "Fraction (0..1) of active users without a fatal error.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalErrors",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverviewUpdate",
+        "description": null,
+        "fields": [
+          {
+            "name": "appUpdateId",
+            "description": "Null for the embedded bundle.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "downloadCount",
+            "description": "Downloads recorded in range; null when none were recorded (and always for the embedded bundle).",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstSeenAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbedded",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "medianDownloadTime",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": "EAS update message; null for the embedded bundle or when the update row no longer exists.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metrics",
+            "description": "One entry per metric with data in range, all platforms combined.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveOverviewUpdateMetric",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt",
+            "description": "When the update was published; null for the embedded bundle.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stability",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverviewStability",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uniqueUserCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverviewUpdateComparison",
+        "description": null,
+        "fields": [
+          {
+            "name": "updates",
+            "description": "Embedded bundle first, then OTA updates oldest first. Only updates with runtime data appear.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveOverviewUpdate",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveOverviewUpdateComparisonInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metricNames",
+            "description": "Metric names to aggregate. Defaults to all metrics available on the account's plan.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverviewUpdateMetric",
+        "description": null,
+        "fields": [
+          {
+            "name": "eventCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metricName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "statistics",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveVersionMarkerStatistics",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverviewVersion",
+        "description": null,
+        "fields": [
+          {
+            "name": "appVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstSeenAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metrics",
+            "description": "One entry per (metric, platform) with data in range; iOS includes tvOS and iPadOS.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveOverviewVersionMetric",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stability",
+            "description": "Error stats for this version, all platforms combined.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverviewStability",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uniqueUserCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverviewVersionComparison",
+        "description": null,
+        "fields": [
+          {
+            "name": "allVersions",
+            "description": "Every version with data in range, highest version first, for the version picker.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveOverviewVersionSummary",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "versions",
+            "description": "Compared versions, lowest version first. Requested versions with no data are omitted.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveOverviewVersion",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveOverviewVersionComparisonInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appVersions",
+            "description": "Versions to compare (max 10, any order). Defaults to the three highest versions.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metricNames",
+            "description": "Metric names to aggregate. Defaults to all metrics available on the account's plan.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverviewVersionMetric",
+        "description": null,
+        "fields": [
+          {
+            "name": "eventCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metricName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObservePlatform",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "statistics",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveVersionMarkerStatistics",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverviewVersionSummary",
+        "description": null,
+        "fields": [
+          {
+            "name": "appVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstSeenAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uniqueUserCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -76728,6 +77881,18 @@
                   }
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "onboardingOrganization",
+            "description": "The organization created during signup onboarding: the most recently\ncreated organization this user owns. Only resolves for the viewer.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Account",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/commands/simulator/__tests__/events.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/events.test.ts
@@ -6,9 +6,16 @@ import {
   DeviceRunSessionStatus,
 } from '../../../graphql/generated';
 import { DeviceRunSessionQuery } from '../../../graphql/queries/DeviceRunSessionQuery';
+import Log from '../../../log';
 import { loadSimulatorEnvAsync } from '../../../simulator/env';
-import { downloadDeviceRunSessionEventsAsync } from '../../../simulator/events';
+import {
+  type DeviceRunSessionEvent,
+  downloadDeviceRunSessionEventsAsync,
+  formatDeviceRunSessionEvent,
+  projectDeviceRunSessionEventsForDisplay,
+} from '../../../simulator/events';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+import { sleepAsync } from '../../../utils/promise';
 import SimulatorEvents from '../events';
 
 jest.mock('../../../graphql/queries/DeviceRunSessionQuery');
@@ -19,12 +26,17 @@ jest.mock('../../../simulator/env', () => ({
 }));
 jest.mock('../../../simulator/events');
 jest.mock('../../../utils/json');
+jest.mock('../../../utils/promise');
 
 const mockEventsByIdAsync = jest.mocked(DeviceRunSessionQuery.eventsByIdAsync);
 const mockDownloadEventsAsync = jest.mocked(downloadDeviceRunSessionEventsAsync);
+const mockFormatEvent = jest.mocked(formatDeviceRunSessionEvent);
 const mockLoadSimulatorEnvAsync = jest.mocked(loadSimulatorEnvAsync);
 const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
 const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
+const mockProjectEvents = jest.mocked(projectDeviceRunSessionEventsForDisplay);
+const mockSleepAsync = jest.mocked(sleepAsync);
+const mockLog = jest.mocked(Log.log);
 
 function getMockOclifConfig(): Config {
   const config = new Config({ root: __dirname });
@@ -39,6 +51,9 @@ describe(SimulatorEvents, () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockLoadSimulatorEnvAsync.mockResolvedValue();
+    mockProjectEvents.mockImplementation(events => events);
+    mockFormatEvent.mockImplementation(event => `formatted:${event.eventId}`);
+    mockSleepAsync.mockResolvedValue();
   });
 
   it('prints a JSON snapshot for the requested session', async () => {
@@ -82,6 +97,7 @@ describe(SimulatorEvents, () => {
       deviceRunSessionId: 'session-id',
       events,
     });
+    expect(mockProjectEvents).not.toHaveBeenCalled();
   });
 
   it('prints an empty snapshot when the session has no event artifact', async () => {
@@ -105,4 +121,110 @@ describe(SimulatorEvents, () => {
       events: [],
     });
   });
+
+  it('prints a condensed text snapshot', async () => {
+    const session = createSession(DeviceRunSessionStatus.Stopped);
+    const events = [createEvent()];
+    mockEventsByIdAsync.mockResolvedValue(session);
+    mockDownloadEventsAsync.mockResolvedValue(events);
+    const command = createCommand(['--id', 'session-id']);
+
+    await command.runAsync();
+
+    expect(mockProjectEvents).toHaveBeenCalledWith(events, {
+      includeIncompleteOperations: true,
+    });
+    expect(mockFormatEvent).toHaveBeenCalledWith(events[0]);
+    expect(mockLog).toHaveBeenCalledWith('formatted:event-id');
+  });
+
+  it('refreshes twice after a followed running session stops before flushing incomplete events', async () => {
+    const events = [createEvent()];
+    mockEventsByIdAsync
+      .mockResolvedValueOnce(createSession(DeviceRunSessionStatus.InProgress))
+      .mockResolvedValueOnce(createSession(DeviceRunSessionStatus.Stopped))
+      .mockResolvedValueOnce(createSession(DeviceRunSessionStatus.Stopped))
+      .mockResolvedValueOnce(createSession(DeviceRunSessionStatus.Stopped));
+    mockDownloadEventsAsync.mockResolvedValue(events);
+    mockProjectEvents.mockImplementation((projectedEvents, options) =>
+      options?.includeIncompleteOperations ? projectedEvents : []
+    );
+    const command = createCommand(['--id', 'session-id', '--follow']);
+
+    await command.runAsync();
+
+    expect(mockEventsByIdAsync).toHaveBeenCalledTimes(4);
+    expect(mockDownloadEventsAsync).toHaveBeenCalledTimes(4);
+    expect(mockSleepAsync).toHaveBeenCalledTimes(3);
+    expect(
+      mockProjectEvents.mock.calls.map(([, options]) => options?.includeIncompleteOperations)
+    ).toEqual([false, false, false, true]);
+    expect(mockLog).toHaveBeenCalledTimes(1);
+    expect(mockLog).toHaveBeenCalledWith('formatted:event-id');
+  });
+
+  it('removes its interrupt listener when follow mode is interrupted', async () => {
+    const existingInterruptListeners = new Set(process.listeners('SIGINT'));
+    mockEventsByIdAsync.mockResolvedValue(createSession(DeviceRunSessionStatus.InProgress));
+    mockDownloadEventsAsync.mockResolvedValue([]);
+    mockSleepAsync.mockImplementationOnce(async () => {
+      const interruptHandler = process
+        .listeners('SIGINT')
+        .find(listener => !existingInterruptListeners.has(listener));
+      expect(interruptHandler).toBeDefined();
+      interruptHandler?.('SIGINT');
+    });
+    const command = createCommand(['--id', 'session-id', '--follow']);
+
+    await command.runAsync();
+
+    expect(mockEventsByIdAsync).toHaveBeenCalledTimes(1);
+    expect(process.listeners('SIGINT')).toEqual([...existingInterruptListeners]);
+  });
+
+  it('rejects combining JSON and follow output', async () => {
+    const command = new SimulatorEvents(
+      ['--id', 'session-id', '--json', '--follow'],
+      getMockOclifConfig()
+    );
+
+    await expect(command.runAsync()).rejects.toThrow('Use either --json or --follow, not both.');
+  });
 });
+
+function createCommand(args: string[]): SimulatorEvents {
+  const command = new SimulatorEvents(args, getMockOclifConfig());
+  // @ts-expect-error getContextAsync is protected
+  jest.spyOn(command, 'getContextAsync').mockResolvedValue({
+    loggedIn: { graphqlClient: {} as ExpoGraphqlClient },
+    projectDir: '/test/project',
+  });
+  return command;
+}
+
+function createSession(
+  status: DeviceRunSessionStatus
+): DeviceRunSessionEventsByIdQuery['deviceRunSessions']['byId'] {
+  return {
+    id: 'session-id',
+    status,
+    artifacts: [
+      {
+        id: 'event-artifact-id',
+        downloadUrl: 'https://example.test/events',
+        metadata: { __eas_type: 'session-events' },
+      },
+    ],
+  };
+}
+
+function createEvent(): DeviceRunSessionEvent {
+  return {
+    v: 1 as const,
+    eventId: 'event-id',
+    ts: '2026-07-10T12:00:00.000Z',
+    producer: 'agent-device',
+    type: 'operation.started',
+    summary: 'Started tap',
+  };
+}

--- a/packages/eas-cli/src/commands/simulator/__tests__/events.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/events.test.ts
@@ -2,7 +2,7 @@ import { Config } from '@oclif/core';
 
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import {
-  DeviceRunSessionEventLogByIdQuery,
+  DeviceRunSessionEventsByIdQuery,
   DeviceRunSessionStatus,
 } from '../../../graphql/generated';
 import { DeviceRunSessionQuery } from '../../../graphql/queries/DeviceRunSessionQuery';
@@ -20,7 +20,7 @@ jest.mock('../../../simulator/env', () => ({
 jest.mock('../../../simulator/events');
 jest.mock('../../../utils/json');
 
-const mockEventLogByIdAsync = jest.mocked(DeviceRunSessionQuery.eventLogByIdAsync);
+const mockEventsByIdAsync = jest.mocked(DeviceRunSessionQuery.eventsByIdAsync);
 const mockDownloadEventsAsync = jest.mocked(downloadDeviceRunSessionEventsAsync);
 const mockLoadSimulatorEnvAsync = jest.mocked(loadSimulatorEnvAsync);
 const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
@@ -42,10 +42,16 @@ describe(SimulatorEvents, () => {
   });
 
   it('prints a JSON snapshot for the requested session', async () => {
-    const session: DeviceRunSessionEventLogByIdQuery['deviceRunSessions']['byId'] = {
+    const session: DeviceRunSessionEventsByIdQuery['deviceRunSessions']['byId'] = {
       id: 'session-id',
       status: DeviceRunSessionStatus.InProgress,
-      eventLog: { fileUrl: 'https://example.test/events' },
+      artifacts: [
+        {
+          id: 'event-artifact-id',
+          downloadUrl: 'https://example.test/events',
+          metadata: { __eas_device_run_session_events: '1' },
+        },
+      ],
     };
     const events = [
       {
@@ -58,7 +64,7 @@ describe(SimulatorEvents, () => {
         summary: 'Started tap',
       },
     ];
-    mockEventLogByIdAsync.mockResolvedValue(session);
+    mockEventsByIdAsync.mockResolvedValue(session);
     mockDownloadEventsAsync.mockResolvedValue(events);
     const command = new SimulatorEvents(['--id', 'session-id', '--json'], getMockOclifConfig());
     // @ts-expect-error getContextAsync is protected
@@ -71,7 +77,7 @@ describe(SimulatorEvents, () => {
 
     expect(mockEnableJsonOutput).toHaveBeenCalled();
     expect(mockLoadSimulatorEnvAsync).toHaveBeenCalledWith(projectDir);
-    expect(mockEventLogByIdAsync).toHaveBeenCalledWith(graphqlClient, 'session-id');
+    expect(mockEventsByIdAsync).toHaveBeenCalledWith(graphqlClient, 'session-id');
     expect(mockDownloadEventsAsync).toHaveBeenCalledWith(
       'https://example.test/events',
       'session-id'
@@ -79,6 +85,28 @@ describe(SimulatorEvents, () => {
     expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
       deviceRunSessionId: 'session-id',
       events,
+    });
+  });
+
+  it('prints an empty snapshot when the session has no event artifact', async () => {
+    mockEventsByIdAsync.mockResolvedValue({
+      id: 'session-id',
+      status: DeviceRunSessionStatus.Stopped,
+      artifacts: [],
+    });
+    const command = new SimulatorEvents(['--id', 'session-id', '--json'], getMockOclifConfig());
+    // @ts-expect-error getContextAsync is protected
+    jest.spyOn(command, 'getContextAsync').mockResolvedValue({
+      loggedIn: { graphqlClient },
+      projectDir,
+    });
+
+    await command.runAsync();
+
+    expect(mockDownloadEventsAsync).not.toHaveBeenCalled();
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
+      deviceRunSessionId: 'session-id',
+      events: [],
     });
   });
 });

--- a/packages/eas-cli/src/commands/simulator/__tests__/events.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/events.test.ts
@@ -36,6 +36,7 @@ const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
 const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
 const mockProjectEvents = jest.mocked(projectDeviceRunSessionEventsForDisplay);
 const mockSleepAsync = jest.mocked(sleepAsync);
+const mockDebug = jest.mocked(Log.debug);
 const mockLog = jest.mocked(Log.log);
 
 function getMockOclifConfig(): Config {
@@ -163,23 +164,145 @@ describe(SimulatorEvents, () => {
     expect(mockLog).toHaveBeenCalledWith('formatted:event-id');
   });
 
-  it('removes its interrupt listener when follow mode is interrupted', async () => {
+  it('wakes from polling and flushes incomplete events when follow mode is interrupted', async () => {
+    const existingInterruptListeners = new Set(process.listeners('SIGINT'));
+    mockEventsByIdAsync.mockResolvedValue(createSession(DeviceRunSessionStatus.InProgress));
+    const events = [createEvent()];
+    mockDownloadEventsAsync.mockResolvedValue(events);
+    mockProjectEvents.mockImplementation((projectedEvents, options) =>
+      options?.includeIncompleteOperations ? projectedEvents : []
+    );
+    let notifySleepStarted: () => void;
+    const sleepStarted = new Promise<void>(resolve => {
+      notifySleepStarted = resolve;
+    });
+    mockSleepAsync.mockImplementationOnce(() => {
+      notifySleepStarted();
+      return new Promise<void>(() => {});
+    });
+    const command = createCommand(['--id', 'session-id', '--follow']);
+
+    const commandPromise = command.runAsync();
+    await sleepStarted;
+    const interruptHandler = process
+      .listeners('SIGINT')
+      .find(listener => !existingInterruptListeners.has(listener));
+    expect(interruptHandler).toBeDefined();
+    interruptHandler?.('SIGINT');
+    await commandPromise;
+
+    expect(mockEventsByIdAsync).toHaveBeenCalledTimes(1);
+    expect(
+      mockProjectEvents.mock.calls.map(([, options]) => options?.includeIncompleteOperations)
+    ).toEqual([false, true]);
+    expect(mockLog).toHaveBeenCalledWith('formatted:event-id');
+    expect(process.listeners('SIGINT')).toEqual([...existingInterruptListeners]);
+  });
+
+  it('force exits on a second interrupt', async () => {
     const existingInterruptListeners = new Set(process.listeners('SIGINT'));
     mockEventsByIdAsync.mockResolvedValue(createSession(DeviceRunSessionStatus.InProgress));
     mockDownloadEventsAsync.mockResolvedValue([]);
-    mockSleepAsync.mockImplementationOnce(async () => {
+    let notifySleepStarted: () => void;
+    const sleepStarted = new Promise<void>(resolve => {
+      notifySleepStarted = resolve;
+    });
+    mockSleepAsync.mockImplementationOnce(() => {
+      notifySleepStarted();
+      return new Promise<void>(() => {});
+    });
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: string | number | null): never => {
+        throw new Error(`process.exit(${code})`);
+      });
+    const command = createCommand(['--id', 'session-id', '--follow']);
+
+    try {
+      const commandPromise = command.runAsync();
+      await sleepStarted;
       const interruptHandler = process
         .listeners('SIGINT')
         .find(listener => !existingInterruptListeners.has(listener));
       expect(interruptHandler).toBeDefined();
       interruptHandler?.('SIGINT');
-    });
+      expect(() => interruptHandler?.('SIGINT')).toThrow('process.exit(130)');
+      await commandPromise;
+
+      expect(exitSpy).toHaveBeenCalledWith(130);
+      expect(process.listeners('SIGINT')).toEqual([...existingInterruptListeners]);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('retries transient query and artifact download errors in follow mode', async () => {
+    const events = [createEvent()];
+    mockEventsByIdAsync
+      .mockRejectedValueOnce(new Error('query unavailable'))
+      .mockResolvedValueOnce(createSession(DeviceRunSessionStatus.InProgress))
+      .mockResolvedValueOnce(createSession(DeviceRunSessionStatus.Stopped));
+    mockDownloadEventsAsync
+      .mockRejectedValueOnce(new Error('artifact unavailable'))
+      .mockResolvedValueOnce(events);
     const command = createCommand(['--id', 'session-id', '--follow']);
 
     await command.runAsync();
 
-    expect(mockEventsByIdAsync).toHaveBeenCalledTimes(1);
-    expect(process.listeners('SIGINT')).toEqual([...existingInterruptListeners]);
+    expect(mockEventsByIdAsync).toHaveBeenCalledTimes(3);
+    expect(mockDownloadEventsAsync).toHaveBeenCalledTimes(2);
+    expect(mockSleepAsync).toHaveBeenCalledTimes(2);
+    expect(mockDebug).toHaveBeenNthCalledWith(
+      1,
+      'Failed to poll simulator session events: query unavailable'
+    );
+    expect(mockDebug).toHaveBeenNthCalledWith(
+      2,
+      'Failed to poll simulator session events: artifact unavailable'
+    );
+    expect(mockLog).toHaveBeenCalledWith('formatted:event-id');
+  });
+
+  it('does not retry query errors outside follow mode', async () => {
+    const existingInterruptListeners = process.listeners('SIGINT');
+    mockEventsByIdAsync.mockRejectedValue(new Error('query unavailable'));
+    const command = createCommand(['--id', 'session-id']);
+
+    await expect(command.runAsync()).rejects.toThrow('query unavailable');
+
+    expect(mockSleepAsync).not.toHaveBeenCalled();
+    expect(mockDebug).not.toHaveBeenCalled();
+    expect(process.listeners('SIGINT')).toEqual(existingInterruptListeners);
+  });
+
+  it('does not register an interrupt handler outside follow mode', async () => {
+    const existingInterruptListeners = process.listeners('SIGINT');
+    let notifyQueryStarted: () => void;
+    const queryStarted = new Promise<void>(resolve => {
+      notifyQueryStarted = resolve;
+    });
+    let resolveSession: (
+      session: DeviceRunSessionEventsByIdQuery['deviceRunSessions']['byId']
+    ) => void = () => {
+      throw new Error('Session promise was not initialized.');
+    };
+    const pendingSession = new Promise<
+      DeviceRunSessionEventsByIdQuery['deviceRunSessions']['byId']
+    >(resolve => {
+      resolveSession = resolve;
+    });
+    mockEventsByIdAsync.mockImplementationOnce(() => {
+      notifyQueryStarted();
+      return pendingSession;
+    });
+    mockDownloadEventsAsync.mockResolvedValue([]);
+    const command = createCommand(['--id', 'session-id']);
+
+    const commandPromise = command.runAsync();
+    await queryStarted;
+    expect(process.listeners('SIGINT')).toEqual(existingInterruptListeners);
+    resolveSession(createSession(DeviceRunSessionStatus.Stopped));
+    await commandPromise;
   });
 
   it('rejects combining JSON and follow output', async () => {

--- a/packages/eas-cli/src/commands/simulator/__tests__/events.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/events.test.ts
@@ -55,10 +55,9 @@ describe(SimulatorEvents, () => {
     };
     const events = [
       {
-        schemaVersion: 1 as const,
+        v: 1 as const,
         eventId: 'event-id',
-        deviceRunSessionId: 'session-id',
-        occurredAt: '2026-07-10T12:00:00.000Z',
+        ts: '2026-07-10T12:00:00.000Z',
         producer: 'agent-device',
         type: 'operation.started',
         summary: 'Started tap',
@@ -78,10 +77,7 @@ describe(SimulatorEvents, () => {
     expect(mockEnableJsonOutput).toHaveBeenCalled();
     expect(mockLoadSimulatorEnvAsync).toHaveBeenCalledWith(projectDir);
     expect(mockEventsByIdAsync).toHaveBeenCalledWith(graphqlClient, 'session-id');
-    expect(mockDownloadEventsAsync).toHaveBeenCalledWith(
-      'https://example.test/events',
-      'session-id'
-    );
+    expect(mockDownloadEventsAsync).toHaveBeenCalledWith('https://example.test/events');
     expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
       deviceRunSessionId: 'session-id',
       events,

--- a/packages/eas-cli/src/commands/simulator/__tests__/events.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/events.test.ts
@@ -1,0 +1,84 @@
+import { Config } from '@oclif/core';
+
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import {
+  DeviceRunSessionEventLogByIdQuery,
+  DeviceRunSessionStatus,
+} from '../../../graphql/generated';
+import { DeviceRunSessionQuery } from '../../../graphql/queries/DeviceRunSessionQuery';
+import { loadSimulatorEnvAsync } from '../../../simulator/env';
+import { downloadDeviceRunSessionEventsAsync } from '../../../simulator/events';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+import SimulatorEvents from '../events';
+
+jest.mock('../../../graphql/queries/DeviceRunSessionQuery');
+jest.mock('../../../log');
+jest.mock('../../../simulator/env', () => ({
+  ...jest.requireActual('../../../simulator/env'),
+  loadSimulatorEnvAsync: jest.fn(),
+}));
+jest.mock('../../../simulator/events');
+jest.mock('../../../utils/json');
+
+const mockEventLogByIdAsync = jest.mocked(DeviceRunSessionQuery.eventLogByIdAsync);
+const mockDownloadEventsAsync = jest.mocked(downloadDeviceRunSessionEventsAsync);
+const mockLoadSimulatorEnvAsync = jest.mocked(loadSimulatorEnvAsync);
+const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
+const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
+
+function getMockOclifConfig(): Config {
+  const config = new Config({ root: __dirname });
+  config.runHook = async () => ({ failures: [], successes: [] });
+  return config;
+}
+
+describe(SimulatorEvents, () => {
+  const graphqlClient = {} as ExpoGraphqlClient;
+  const projectDir = '/test/project';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoadSimulatorEnvAsync.mockResolvedValue();
+  });
+
+  it('prints a JSON snapshot for the requested session', async () => {
+    const session: DeviceRunSessionEventLogByIdQuery['deviceRunSessions']['byId'] = {
+      id: 'session-id',
+      status: DeviceRunSessionStatus.InProgress,
+      eventLog: { fileUrl: 'https://example.test/events' },
+    };
+    const events = [
+      {
+        schemaVersion: 1 as const,
+        eventId: 'event-id',
+        deviceRunSessionId: 'session-id',
+        occurredAt: '2026-07-10T12:00:00.000Z',
+        producer: 'agent-device',
+        type: 'operation.started',
+        summary: 'Started tap',
+      },
+    ];
+    mockEventLogByIdAsync.mockResolvedValue(session);
+    mockDownloadEventsAsync.mockResolvedValue(events);
+    const command = new SimulatorEvents(['--id', 'session-id', '--json'], getMockOclifConfig());
+    // @ts-expect-error getContextAsync is protected
+    jest.spyOn(command, 'getContextAsync').mockResolvedValue({
+      loggedIn: { graphqlClient },
+      projectDir,
+    });
+
+    await command.runAsync();
+
+    expect(mockEnableJsonOutput).toHaveBeenCalled();
+    expect(mockLoadSimulatorEnvAsync).toHaveBeenCalledWith(projectDir);
+    expect(mockEventLogByIdAsync).toHaveBeenCalledWith(graphqlClient, 'session-id');
+    expect(mockDownloadEventsAsync).toHaveBeenCalledWith(
+      'https://example.test/events',
+      'session-id'
+    );
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
+      deviceRunSessionId: 'session-id',
+      events,
+    });
+  });
+});

--- a/packages/eas-cli/src/commands/simulator/__tests__/events.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/events.test.ts
@@ -49,7 +49,7 @@ describe(SimulatorEvents, () => {
         {
           id: 'event-artifact-id',
           downloadUrl: 'https://example.test/events',
-          metadata: { __eas_device_run_session_events: '1' },
+          metadata: { __eas_type: 'session-events' },
         },
       ],
     };

--- a/packages/eas-cli/src/commands/simulator/events.ts
+++ b/packages/eas-cli/src/commands/simulator/events.ts
@@ -16,11 +16,14 @@ import {
 import {
   type DeviceRunSessionEvent,
   downloadDeviceRunSessionEventsAsync,
+  formatDeviceRunSessionEvent,
+  projectDeviceRunSessionEventsForDisplay,
 } from '../../simulator/events';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import { sleepAsync } from '../../utils/promise';
 
 const POLL_INTERVAL_MS = 5_000;
+const POST_STOP_REFRESH_COUNT = 2;
 
 export default class SimulatorEvents extends EasCommand {
   static override hidden = true;
@@ -66,6 +69,8 @@ export default class SimulatorEvents extends EasCommand {
     }
 
     const printedEventIds = new Set<string>();
+    let observedRunningSession = false;
+    let remainingPostStopRefreshes = 0;
     let interrupted = false;
     const interruptHandler = (): void => {
       interrupted = true;
@@ -90,20 +95,35 @@ export default class SimulatorEvents extends EasCommand {
           return;
         }
 
-        const newEvents = events.filter(event => !printedEventIds.has(event.eventId));
-        printEvents(newEvents);
-        for (const event of newEvents) {
-          printedEventIds.add(event.eventId);
-        }
-
         const isRunning =
           session.status === DeviceRunSessionStatus.New ||
           session.status === DeviceRunSessionStatus.InProgress;
-        if (!flags.follow || !isRunning || interrupted) {
+        if (isRunning) {
+          observedRunningSession = true;
+          remainingPostStopRefreshes = 0;
+        } else if (observedRunningSession) {
+          observedRunningSession = false;
+          remainingPostStopRefreshes = POST_STOP_REFRESH_COUNT;
+        }
+
+        const shouldRefreshAgain = flags.follow && (isRunning || remainingPostStopRefreshes > 0);
+        const displayEvents = projectDeviceRunSessionEventsForDisplay(events, {
+          includeIncompleteOperations: interrupted || !shouldRefreshAgain,
+        });
+        const newDisplayEvents = displayEvents.filter(event => !printedEventIds.has(event.eventId));
+        printEvents(newDisplayEvents);
+        for (const event of newDisplayEvents) {
+          printedEventIds.add(event.eventId);
+        }
+
+        if (!shouldRefreshAgain || interrupted) {
           if (events.length === 0) {
             Log.log('No simulator session activity has been recorded.');
           }
           return;
+        }
+        if (!isRunning) {
+          remainingPostStopRefreshes -= 1;
         }
         await sleepAsync(POLL_INTERVAL_MS);
       } while (!interrupted);
@@ -115,6 +135,6 @@ export default class SimulatorEvents extends EasCommand {
 
 function printEvents(events: DeviceRunSessionEvent[]): void {
   for (const event of events) {
-    Log.log(`${event.ts}  ${event.producer}  ${event.summary}`);
+    Log.log(formatDeviceRunSessionEvent(event));
   }
 }

--- a/packages/eas-cli/src/commands/simulator/events.ts
+++ b/packages/eas-cli/src/commands/simulator/events.ts
@@ -82,7 +82,7 @@ export default class SimulatorEvents extends EasCommand {
           artifact => artifact.metadata?.__eas_type === 'session-events'
         );
         const events = eventArtifact
-          ? await downloadDeviceRunSessionEventsAsync(eventArtifact.downloadUrl, deviceRunSessionId)
+          ? await downloadDeviceRunSessionEventsAsync(eventArtifact.downloadUrl)
           : [];
 
         if (jsonFlag) {
@@ -115,6 +115,6 @@ export default class SimulatorEvents extends EasCommand {
 
 function printEvents(events: DeviceRunSessionEvent[]): void {
   for (const event of events) {
-    Log.log(`${event.occurredAt}  ${event.producer}  ${event.summary}`);
+    Log.log(`${event.ts}  ${event.producer}  ${event.summary}`);
   }
 }

--- a/packages/eas-cli/src/commands/simulator/events.ts
+++ b/packages/eas-cli/src/commands/simulator/events.ts
@@ -5,7 +5,10 @@ import {
   EasNonInteractiveAndJsonFlags,
   resolveNonInteractiveAndJsonFlags,
 } from '../../commandUtils/flags';
-import { DeviceRunSessionStatus } from '../../graphql/generated';
+import {
+  type DeviceRunSessionEventsByIdQuery,
+  DeviceRunSessionStatus,
+} from '../../graphql/generated';
 import { DeviceRunSessionQuery } from '../../graphql/queries/DeviceRunSessionQuery';
 import Log from '../../log';
 import {
@@ -71,24 +74,53 @@ export default class SimulatorEvents extends EasCommand {
     const printedEventIds = new Set<string>();
     let observedRunningSession = false;
     let remainingPostStopRefreshes = 0;
-    let interrupted = false;
+    let latestEvents: DeviceRunSessionEvent[] = [];
+    const abortController = new AbortController();
+    const { signal } = abortController;
+    const abortPromise = new Promise<void>(resolve => {
+      signal.addEventListener(
+        'abort',
+        () => {
+          resolve();
+        },
+        { once: true }
+      );
+    });
     const interruptHandler = (): void => {
-      interrupted = true;
+      if (signal.aborted) {
+        process.exit(130);
+      }
+      abortController.abort();
     };
-    process.on('SIGINT', interruptHandler);
+    if (flags.follow) {
+      process.on('SIGINT', interruptHandler);
+    }
 
     try {
-      do {
-        const session = await DeviceRunSessionQuery.eventsByIdAsync(
-          graphqlClient,
-          deviceRunSessionId
-        );
-        const eventArtifact = session.artifacts.find(
-          artifact => artifact.metadata?.__eas_type === 'session-events'
-        );
-        const events = eventArtifact
-          ? await downloadDeviceRunSessionEventsAsync(eventArtifact.downloadUrl)
-          : [];
+      while (!signal.aborted) {
+        let session: DeviceRunSessionEventsByIdQuery['deviceRunSessions']['byId'];
+        let events: DeviceRunSessionEvent[];
+        try {
+          session = await DeviceRunSessionQuery.eventsByIdAsync(graphqlClient, deviceRunSessionId);
+          const eventArtifact = session.artifacts.find(
+            artifact => artifact.metadata?.__eas_type === 'session-events'
+          );
+          events = eventArtifact
+            ? await downloadDeviceRunSessionEventsAsync(eventArtifact.downloadUrl)
+            : [];
+        } catch (err) {
+          if (!flags.follow) {
+            throw err;
+          }
+          Log.debug(
+            `Failed to poll simulator session events: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+          await Promise.race([sleepAsync(POLL_INTERVAL_MS), abortPromise]);
+          continue;
+        }
+        latestEvents = events;
 
         if (jsonFlag) {
           printJsonOnlyOutput({ deviceRunSessionId, events });
@@ -106,17 +138,11 @@ export default class SimulatorEvents extends EasCommand {
           remainingPostStopRefreshes = POST_STOP_REFRESH_COUNT;
         }
 
-        const shouldRefreshAgain = flags.follow && (isRunning || remainingPostStopRefreshes > 0);
-        const displayEvents = projectDeviceRunSessionEventsForDisplay(events, {
-          includeIncompleteOperations: interrupted || !shouldRefreshAgain,
-        });
-        const newDisplayEvents = displayEvents.filter(event => !printedEventIds.has(event.eventId));
-        printEvents(newDisplayEvents);
-        for (const event of newDisplayEvents) {
-          printedEventIds.add(event.eventId);
-        }
+        const shouldRefreshAgain =
+          flags.follow && !signal.aborted && (isRunning || remainingPostStopRefreshes > 0);
+        printNewEvents(events, printedEventIds, !shouldRefreshAgain);
 
-        if (!shouldRefreshAgain || interrupted) {
+        if (!shouldRefreshAgain) {
           if (events.length === 0) {
             Log.log('No simulator session activity has been recorded.');
           }
@@ -125,16 +151,30 @@ export default class SimulatorEvents extends EasCommand {
         if (!isRunning) {
           remainingPostStopRefreshes -= 1;
         }
-        await sleepAsync(POLL_INTERVAL_MS);
-      } while (!interrupted);
+        await Promise.race([sleepAsync(POLL_INTERVAL_MS), abortPromise]);
+      }
+      printNewEvents(latestEvents, printedEventIds, true);
     } finally {
-      process.removeListener('SIGINT', interruptHandler);
+      if (flags.follow) {
+        process.removeListener('SIGINT', interruptHandler);
+      }
     }
   }
 }
 
-function printEvents(events: DeviceRunSessionEvent[]): void {
-  for (const event of events) {
+function printNewEvents(
+  events: DeviceRunSessionEvent[],
+  printedEventIds: Set<string>,
+  includeIncompleteOperations: boolean
+): void {
+  const displayEvents = projectDeviceRunSessionEventsForDisplay(events, {
+    includeIncompleteOperations,
+  });
+  for (const event of displayEvents) {
+    if (printedEventIds.has(event.eventId)) {
+      continue;
+    }
     Log.log(formatDeviceRunSessionEvent(event));
+    printedEventIds.add(event.eventId);
   }
 }

--- a/packages/eas-cli/src/commands/simulator/events.ts
+++ b/packages/eas-cli/src/commands/simulator/events.ts
@@ -1,0 +1,118 @@
+import { Flags } from '@oclif/core';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import {
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
+} from '../../commandUtils/flags';
+import { DeviceRunSessionStatus } from '../../graphql/generated';
+import { DeviceRunSessionQuery } from '../../graphql/queries/DeviceRunSessionQuery';
+import Log from '../../log';
+import {
+  EAS_SIMULATOR_SESSION_ID,
+  SIMULATOR_DOTENV_FILE_NAME,
+  loadSimulatorEnvAsync,
+} from '../../simulator/env';
+import {
+  type DeviceRunSessionEvent,
+  downloadDeviceRunSessionEventsAsync,
+} from '../../simulator/events';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+import { sleepAsync } from '../../utils/promise';
+
+const POLL_INTERVAL_MS = 5_000;
+
+export default class SimulatorEvents extends EasCommand {
+  static override hidden = true;
+  static override description =
+    '[EXPERIMENTAL] show activity events from a remote simulator session';
+
+  static override flags = {
+    id: Flags.string({
+      description: `Simulator session ID. Defaults to ${SIMULATOR_DOTENV_FILE_NAME}.`,
+    }),
+    follow: Flags.boolean({
+      char: 'f',
+      description: 'Keep watching for new events until the session ends.',
+    }),
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+    ...this.ContextOptions.ProjectDir,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(SimulatorEvents);
+    const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+    if (jsonFlag && flags.follow) {
+      throw new Error('Use either --json or --follow, not both.');
+    }
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    const {
+      projectDir,
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(SimulatorEvents, { nonInteractive });
+    await loadSimulatorEnvAsync(projectDir);
+    const deviceRunSessionId = flags.id ?? process.env[EAS_SIMULATOR_SESSION_ID];
+    if (!deviceRunSessionId) {
+      throw new Error(
+        `No simulator session ID provided. Pass --id, or run \`eas simulator:start\` first to write ${SIMULATOR_DOTENV_FILE_NAME}.`
+      );
+    }
+
+    const printedEventIds = new Set<string>();
+    let interrupted = false;
+    const interruptHandler = (): void => {
+      interrupted = true;
+    };
+    process.on('SIGINT', interruptHandler);
+
+    try {
+      do {
+        const session = await DeviceRunSessionQuery.eventLogByIdAsync(
+          graphqlClient,
+          deviceRunSessionId
+        );
+        const events = await downloadDeviceRunSessionEventsAsync(
+          session.eventLog.fileUrl,
+          deviceRunSessionId
+        );
+
+        if (jsonFlag) {
+          printJsonOnlyOutput({ deviceRunSessionId, events });
+          return;
+        }
+
+        const newEvents = events.filter(event => !printedEventIds.has(event.eventId));
+        printEvents(newEvents);
+        for (const event of newEvents) {
+          printedEventIds.add(event.eventId);
+        }
+
+        const isRunning =
+          session.status === DeviceRunSessionStatus.New ||
+          session.status === DeviceRunSessionStatus.InProgress;
+        if (!flags.follow || !isRunning || interrupted) {
+          if (events.length === 0) {
+            Log.log('No simulator session activity has been recorded.');
+          }
+          return;
+        }
+        await sleepAsync(POLL_INTERVAL_MS);
+      } while (!interrupted);
+    } finally {
+      process.removeListener('SIGINT', interruptHandler);
+    }
+  }
+}
+
+function printEvents(events: DeviceRunSessionEvent[]): void {
+  for (const event of events) {
+    Log.log(`${event.occurredAt}  ${event.producer}  ${event.summary}`);
+  }
+}

--- a/packages/eas-cli/src/commands/simulator/events.ts
+++ b/packages/eas-cli/src/commands/simulator/events.ts
@@ -79,7 +79,7 @@ export default class SimulatorEvents extends EasCommand {
           deviceRunSessionId
         );
         const eventArtifact = session.artifacts.find(
-          artifact => artifact.metadata?.__eas_device_run_session_events === '1'
+          artifact => artifact.metadata?.__eas_type === 'session-events'
         );
         const events = eventArtifact
           ? await downloadDeviceRunSessionEventsAsync(eventArtifact.downloadUrl, deviceRunSessionId)

--- a/packages/eas-cli/src/commands/simulator/events.ts
+++ b/packages/eas-cli/src/commands/simulator/events.ts
@@ -74,14 +74,16 @@ export default class SimulatorEvents extends EasCommand {
 
     try {
       do {
-        const session = await DeviceRunSessionQuery.eventLogByIdAsync(
+        const session = await DeviceRunSessionQuery.eventsByIdAsync(
           graphqlClient,
           deviceRunSessionId
         );
-        const events = await downloadDeviceRunSessionEventsAsync(
-          session.eventLog.fileUrl,
-          deviceRunSessionId
+        const eventArtifact = session.artifacts.find(
+          artifact => artifact.metadata?.__eas_device_run_session_events === '1'
         );
+        const events = eventArtifact
+          ? await downloadDeviceRunSessionEventsAsync(eventArtifact.downloadUrl, deviceRunSessionId)
+          : [];
 
         if (jsonFlag) {
           printJsonOnlyOutput({ deviceRunSessionId, events });

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -14415,6 +14415,13 @@ export type SimulatorAvailabilityQueryVariables = Exact<{
 
 export type SimulatorAvailabilityQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, ownerAccount: { __typename?: 'Account', id: string, name: string, accountFeatureGates: any } } } };
 
+export type DeviceRunSessionEventsByIdQueryVariables = Exact<{
+  deviceRunSessionId: Scalars['ID']['input'];
+}>;
+
+
+export type DeviceRunSessionEventsByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, artifacts: Array<{ __typename?: 'DeviceRunSessionArtifact', id: string, downloadUrl: string, metadata?: any | null }> } } };
+
 export type DeviceRunSessionByIdQueryVariables = Exact<{
   deviceRunSessionId: Scalars['ID']['input'];
 }>;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -2149,6 +2149,12 @@ export type AppObserve = {
   errorTimeSeries: AppObserveErrorTimeSeries;
   events: AppObserveEventsConnection;
   navigationRoutes: AppObserveNavigationRoutesConnection;
+  /** Active users and sessions for the Overview engagement band, across all versions. */
+  overviewEngagement: AppObserveOverviewEngagement;
+  /** Per-update comparison within one app version: the embedded bundle plus each OTA update. */
+  overviewUpdateComparison: AppObserveOverviewUpdateComparison;
+  /** Per-version, per-platform metric summaries for the Overview version-comparison matrix. */
+  overviewVersionComparison: AppObserveOverviewVersionComparison;
   timeSeries: AppObserveTimeSeries;
   totalEventCount: Scalars['Int']['output'];
   /**
@@ -2242,6 +2248,21 @@ export type AppObserveNavigationRoutesArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<AppObserveNavigationRoutesOrderBy>;
+};
+
+
+export type AppObserveOverviewEngagementArgs = {
+  input: AppObserveOverviewEngagementInput;
+};
+
+
+export type AppObserveOverviewUpdateComparisonArgs = {
+  input: AppObserveOverviewUpdateComparisonInput;
+};
+
+
+export type AppObserveOverviewVersionComparisonArgs = {
+  input: AppObserveOverviewVersionComparisonInput;
 };
 
 
@@ -2808,6 +2829,132 @@ export type AppObserveNavigationStat = {
   count: Scalars['Int']['output'];
   median?: Maybe<Scalars['Float']['output']>;
   p90?: Maybe<Scalars['Float']['output']>;
+};
+
+export type AppObserveOverviewEngagement = {
+  __typename?: 'AppObserveOverviewEngagement';
+  activeUsers: AppObserveOverviewEngagementStat;
+  sessions: AppObserveOverviewEngagementStat;
+};
+
+export type AppObserveOverviewEngagementBucket = {
+  __typename?: 'AppObserveOverviewEngagementBucket';
+  bucketStart: Scalars['DateTime']['output'];
+  count: Scalars['Int']['output'];
+};
+
+/** Engagement-band filters. No release filters: the band always spans all versions. */
+export type AppObserveOverviewEngagementInput = {
+  /** Series bucket size. Defaults to one day. */
+  bucketIntervalMinutes?: InputMaybe<Scalars['Int']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  platform?: InputMaybe<AppObservePlatform>;
+  startTime: Scalars['DateTime']['input'];
+};
+
+export type AppObserveOverviewEngagementStat = {
+  __typename?: 'AppObserveOverviewEngagementStat';
+  previousPeriodTotal: Scalars['Int']['output'];
+  /** Per-bucket approximate uniques; buckets do not sum to `total`. */
+  series: Array<AppObserveOverviewEngagementBucket>;
+  total: Scalars['Int']['output'];
+};
+
+export type AppObserveOverviewStability = {
+  __typename?: 'AppObserveOverviewStability';
+  affectedUsers: Scalars['Int']['output'];
+  /** Fraction (0..1) of active sessions without a fatal error. */
+  crashFreeSessions: Scalars['Float']['output'];
+  /** Fraction (0..1) of active users without a fatal error. */
+  crashFreeUsers: Scalars['Float']['output'];
+  totalErrors: Scalars['Int']['output'];
+};
+
+export type AppObserveOverviewUpdate = {
+  __typename?: 'AppObserveOverviewUpdate';
+  /** Null for the embedded bundle. */
+  appUpdateId?: Maybe<Scalars['ID']['output']>;
+  /** Downloads recorded in range; null when none were recorded (and always for the embedded bundle). */
+  downloadCount?: Maybe<Scalars['Int']['output']>;
+  eventCount: Scalars['Int']['output'];
+  firstSeenAt: Scalars['DateTime']['output'];
+  isEmbedded: Scalars['Boolean']['output'];
+  medianDownloadTime?: Maybe<Scalars['Float']['output']>;
+  /** EAS update message; null for the embedded bundle or when the update row no longer exists. */
+  message?: Maybe<Scalars['String']['output']>;
+  /** One entry per metric with data in range, all platforms combined. */
+  metrics: Array<AppObserveOverviewUpdateMetric>;
+  /** When the update was published; null for the embedded bundle. */
+  publishedAt?: Maybe<Scalars['DateTime']['output']>;
+  stability: AppObserveOverviewStability;
+  uniqueUserCount: Scalars['Int']['output'];
+};
+
+export type AppObserveOverviewUpdateComparison = {
+  __typename?: 'AppObserveOverviewUpdateComparison';
+  /** Embedded bundle first, then OTA updates oldest first. Only updates with runtime data appear. */
+  updates: Array<AppObserveOverviewUpdate>;
+};
+
+export type AppObserveOverviewUpdateComparisonInput = {
+  appVersion: Scalars['String']['input'];
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  /** Metric names to aggregate. Defaults to all metrics available on the account's plan. */
+  metricNames?: InputMaybe<Array<Scalars['String']['input']>>;
+  startTime: Scalars['DateTime']['input'];
+};
+
+export type AppObserveOverviewUpdateMetric = {
+  __typename?: 'AppObserveOverviewUpdateMetric';
+  eventCount: Scalars['Int']['output'];
+  metricName: Scalars['String']['output'];
+  statistics: AppObserveVersionMarkerStatistics;
+};
+
+export type AppObserveOverviewVersion = {
+  __typename?: 'AppObserveOverviewVersion';
+  appVersion: Scalars['String']['output'];
+  firstSeenAt: Scalars['DateTime']['output'];
+  /** One entry per (metric, platform) with data in range; iOS includes tvOS and iPadOS. */
+  metrics: Array<AppObserveOverviewVersionMetric>;
+  /** Error stats for this version, all platforms combined. */
+  stability: AppObserveOverviewStability;
+  uniqueUserCount: Scalars['Int']['output'];
+};
+
+export type AppObserveOverviewVersionComparison = {
+  __typename?: 'AppObserveOverviewVersionComparison';
+  /** Every version with data in range, highest version first, for the version picker. */
+  allVersions: Array<AppObserveOverviewVersionSummary>;
+  /** Compared versions, lowest version first. Requested versions with no data are omitted. */
+  versions: Array<AppObserveOverviewVersion>;
+};
+
+export type AppObserveOverviewVersionComparisonInput = {
+  /** Versions to compare (max 10, any order). Defaults to the three highest versions. */
+  appVersions?: InputMaybe<Array<Scalars['String']['input']>>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  /** Metric names to aggregate. Defaults to all metrics available on the account's plan. */
+  metricNames?: InputMaybe<Array<Scalars['String']['input']>>;
+  startTime: Scalars['DateTime']['input'];
+};
+
+export type AppObserveOverviewVersionMetric = {
+  __typename?: 'AppObserveOverviewVersionMetric';
+  eventCount: Scalars['Int']['output'];
+  metricName: Scalars['String']['output'];
+  platform: AppObservePlatform;
+  statistics: AppObserveVersionMarkerStatistics;
+};
+
+export type AppObserveOverviewVersionSummary = {
+  __typename?: 'AppObserveOverviewVersionSummary';
+  appVersion: Scalars['String']['output'];
+  firstSeenAt: Scalars['DateTime']['output'];
+  uniqueUserCount: Scalars['Int']['output'];
 };
 
 export enum AppObservePlatform {
@@ -10746,6 +10893,11 @@ export type User = Actor & UserActor & {
   lastName?: Maybe<Scalars['String']['output']>;
   newEmailPendingVerification?: Maybe<Scalars['String']['output']>;
   oAuthIdentities: Array<OAuthIdentity>;
+  /**
+   * The organization created during signup onboarding: the most recently
+   * created organization this user owns. Only resolves for the viewer.
+   */
+  onboardingOrganization?: Maybe<Account>;
   /** Registered passkey credentials */
   passkeyCredentials: Array<UserPasskeyCredential>;
   /** Pending UserInvitations for this user. Only resolves for the viewer. */

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
@@ -5,29 +5,31 @@ import { withErrorHandlingAsync } from '../client';
 import {
   DeviceRunSessionByIdQuery,
   DeviceRunSessionByIdQueryVariables,
-  DeviceRunSessionEventLogByIdQuery,
-  DeviceRunSessionEventLogByIdQueryVariables,
+  DeviceRunSessionEventsByIdQuery,
+  DeviceRunSessionEventsByIdQueryVariables,
   DeviceRunSessionFilterInput,
   DeviceRunSessionsByAppIdQuery,
   DeviceRunSessionsByAppIdQueryVariables,
 } from '../generated';
 
 export const DeviceRunSessionQuery = {
-  async eventLogByIdAsync(
+  async eventsByIdAsync(
     graphqlClient: ExpoGraphqlClient,
     deviceRunSessionId: string
-  ): Promise<DeviceRunSessionEventLogByIdQuery['deviceRunSessions']['byId']> {
+  ): Promise<DeviceRunSessionEventsByIdQuery['deviceRunSessions']['byId']> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<DeviceRunSessionEventLogByIdQuery, DeviceRunSessionEventLogByIdQueryVariables>(
+        .query<DeviceRunSessionEventsByIdQuery, DeviceRunSessionEventsByIdQueryVariables>(
           gql`
-            query DeviceRunSessionEventLogByIdQuery($deviceRunSessionId: ID!) {
+            query DeviceRunSessionEventsByIdQuery($deviceRunSessionId: ID!) {
               deviceRunSessions {
                 byId(deviceRunSessionId: $deviceRunSessionId) {
                   id
                   status
-                  eventLog {
-                    fileUrl
+                  artifacts {
+                    id
+                    downloadUrl
+                    metadata
                   }
                 }
               }

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
@@ -5,12 +5,41 @@ import { withErrorHandlingAsync } from '../client';
 import {
   DeviceRunSessionByIdQuery,
   DeviceRunSessionByIdQueryVariables,
+  DeviceRunSessionEventLogByIdQuery,
+  DeviceRunSessionEventLogByIdQueryVariables,
   DeviceRunSessionFilterInput,
   DeviceRunSessionsByAppIdQuery,
   DeviceRunSessionsByAppIdQueryVariables,
 } from '../generated';
 
 export const DeviceRunSessionQuery = {
+  async eventLogByIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    deviceRunSessionId: string
+  ): Promise<DeviceRunSessionEventLogByIdQuery['deviceRunSessions']['byId']> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<DeviceRunSessionEventLogByIdQuery, DeviceRunSessionEventLogByIdQueryVariables>(
+          gql`
+            query DeviceRunSessionEventLogByIdQuery($deviceRunSessionId: ID!) {
+              deviceRunSessions {
+                byId(deviceRunSessionId: $deviceRunSessionId) {
+                  id
+                  status
+                  eventLog {
+                    fileUrl
+                  }
+                }
+              }
+            }
+          `,
+          { deviceRunSessionId },
+          { requestPolicy: 'network-only' }
+        )
+        .toPromise()
+    );
+    return data.deviceRunSessions.byId;
+  },
   async byIdAsync(
     graphqlClient: ExpoGraphqlClient,
     deviceRunSessionId: string

--- a/packages/eas-cli/src/simulator/__tests__/events.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/events.test.ts
@@ -1,0 +1,72 @@
+import fetch, { RequestError, Response } from '../../fetch';
+import { downloadDeviceRunSessionEventsAsync, parseDeviceRunSessionEvents } from '../events';
+
+jest.mock('../../fetch', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../fetch'),
+  default: jest.fn(),
+}));
+
+describe(parseDeviceRunSessionEvents, () => {
+  it('parses, deduplicates, and sorts events from the dedicated event log', () => {
+    const first = createEvent({
+      eventId: 'first',
+      occurredAt: '2026-07-10T12:00:00.000Z',
+    });
+    const second = createEvent({
+      eventId: 'second',
+      occurredAt: '2026-07-10T12:00:01.000Z',
+    });
+
+    expect(
+      parseDeviceRunSessionEvents(`${second}\nplain text\n${first}\n${second}`, 'session-id').map(
+        ({ eventId }) => eventId
+      )
+    ).toEqual(['first', 'second']);
+  });
+
+  it('ignores malformed events and events belonging to another session', () => {
+    expect(
+      parseDeviceRunSessionEvents(
+        `${createEvent({ deviceRunSessionId: 'another-session' })}\n${JSON.stringify({
+          schemaVersion: 1,
+        })}`,
+        'session-id'
+      )
+    ).toEqual([]);
+  });
+});
+
+describe(downloadDeviceRunSessionEventsAsync, () => {
+  beforeEach(() => {
+    jest.mocked(fetch).mockReset();
+  });
+
+  it('treats a missing event object as an empty log', async () => {
+    const response = new Response('', { status: 404 });
+    jest.mocked(fetch).mockRejectedValue(new RequestError('not found', response));
+
+    await expect(
+      downloadDeviceRunSessionEventsAsync('https://example.test/events', 'session-id')
+    ).resolves.toEqual([]);
+  });
+});
+
+function createEvent(
+  overrides: Partial<{
+    eventId: string;
+    deviceRunSessionId: string;
+    occurredAt: string;
+  }> = {}
+): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    eventId: 'event-id',
+    deviceRunSessionId: 'session-id',
+    occurredAt: '2026-07-10T12:00:00.000Z',
+    producer: 'agent-device',
+    type: 'operation.started',
+    summary: 'Started tap',
+    ...overrides,
+  });
+}

--- a/packages/eas-cli/src/simulator/__tests__/events.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/events.test.ts
@@ -1,5 +1,11 @@
 import fetch, { RequestError, Response } from '../../fetch';
-import { downloadDeviceRunSessionEventsAsync, parseDeviceRunSessionEvents } from '../events';
+import {
+  type DeviceRunSessionEvent,
+  downloadDeviceRunSessionEventsAsync,
+  formatDeviceRunSessionEvent,
+  parseDeviceRunSessionEvents,
+  projectDeviceRunSessionEventsForDisplay,
+} from '../events';
 
 jest.mock('../../fetch', () => ({
   __esModule: true,
@@ -28,6 +34,162 @@ describe(parseDeviceRunSessionEvents, () => {
   it('ignores malformed events', () => {
     expect(parseDeviceRunSessionEvents(`plain text\n${JSON.stringify({ v: 1 })}`)).toEqual([]);
   });
+
+  it('ignores events with invalid timestamps', () => {
+    expect(
+      parseDeviceRunSessionEvents(
+        `${createEvent({ eventId: 'invalid', ts: 'not-a-date' })}\n${createEvent({
+          eventId: 'valid',
+        })}`
+      ).map(({ eventId }) => eventId)
+    ).toEqual(['valid']);
+  });
+});
+
+describe(projectDeviceRunSessionEventsForDisplay, () => {
+  it('collapses completed operations and carries duration onto the recorded interaction', () => {
+    const events = [
+      createEventValue({
+        eventId: 'started',
+        type: 'operation.started',
+        operationId: 'operation-id',
+        summary: 'Started press',
+      }),
+      createEventValue({
+        eventId: 'interaction',
+        ts: '2026-07-10T12:00:01.000Z',
+        type: 'interaction.recorded',
+        operationId: 'operation-id',
+        summary: 'Tapped @e13',
+      }),
+      createEventValue({
+        eventId: 'completed',
+        ts: '2026-07-10T12:00:02.000Z',
+        type: 'operation.completed',
+        operationId: 'operation-id',
+        outcome: 'success',
+        durationMs: 123,
+        summary: 'Finished press',
+      }),
+    ];
+
+    expect(projectDeviceRunSessionEventsForDisplay(events)).toEqual([
+      {
+        ...events[1],
+        durationMs: 123,
+        outcome: 'success',
+      },
+    ]);
+  });
+
+  it('preserves completed failures and successful operations without interactions', () => {
+    const successful = createEventValue({
+      eventId: 'successful',
+      type: 'operation.completed',
+      operationId: 'successful-operation',
+      outcome: 'success',
+      summary: 'Found 2 devices',
+    });
+    const failed = createEventValue({
+      eventId: 'failed',
+      ts: '2026-07-10T12:00:01.000Z',
+      type: 'operation.completed',
+      operationId: 'failed-operation',
+      outcome: 'failure',
+      summary: 'Failed install: INVALID_ARGS',
+    });
+
+    expect(projectDeviceRunSessionEventsForDisplay([successful, failed])).toEqual([
+      successful,
+      failed,
+    ]);
+  });
+
+  it('can withhold incomplete operations while following a running session', () => {
+    const started = createEventValue({
+      eventId: 'started',
+      type: 'operation.started',
+      operationId: 'operation-id',
+      summary: 'Started install',
+    });
+    const interaction = createEventValue({
+      eventId: 'interaction',
+      type: 'interaction.recorded',
+      operationId: 'another-operation-id',
+      summary: 'Captured screenshot screenshot.png',
+    });
+    const standalone = createEventValue({
+      eventId: 'standalone',
+      type: 'control.recorded',
+      summary: 'Stopping session',
+    });
+
+    expect(
+      projectDeviceRunSessionEventsForDisplay([started, interaction, standalone], {
+        includeIncompleteOperations: false,
+      })
+    ).toEqual([standalone]);
+    expect(projectDeviceRunSessionEventsForDisplay([started, interaction, standalone])).toEqual([
+      started,
+      interaction,
+      standalone,
+    ]);
+  });
+
+  it('keeps matching operation IDs from different producers separate', () => {
+    const agentStarted = createEventValue({
+      eventId: 'agent-started',
+      operationId: 'shared-operation-id',
+      summary: 'Started devices',
+    });
+    const agentCompleted = createEventValue({
+      eventId: 'agent-completed',
+      type: 'operation.completed',
+      operationId: 'shared-operation-id',
+      outcome: 'success',
+      summary: 'Found 2 devices',
+    });
+    const serveSimStarted = createEventValue({
+      eventId: 'serve-sim-started',
+      producer: 'serve-sim',
+      operationId: 'shared-operation-id',
+      summary: 'Started simulator activity',
+    });
+
+    expect(
+      projectDeviceRunSessionEventsForDisplay([agentStarted, agentCompleted, serveSimStarted]).map(
+        ({ eventId }) => eventId
+      )
+    ).toEqual(['agent-completed', 'serve-sim-started']);
+  });
+});
+
+describe(formatDeviceRunSessionEvent, () => {
+  it('formats a compact log line with the producer and duration', () => {
+    expect(
+      formatDeviceRunSessionEvent(
+        createEventValue({
+          ts: '2026-07-10T12:00:01.000Z',
+          summary: 'Found 2 devices',
+          durationMs: 123,
+        })
+      )
+    ).toBe('2026-07-10T12:00:01.000Z  [agent-device] Found 2 devices (123ms)');
+  });
+
+  it('includes a screenshot filename without exposing its full path', () => {
+    expect(
+      formatDeviceRunSessionEvent(
+        createEventValue({
+          summary: 'Ran screenshot',
+          data: {
+            command: 'screenshot',
+            path: '/tmp/private/screenshot.png',
+          },
+        })
+      )
+    ).toBe('2026-07-10T12:00:00.000Z  [agent-device] Ran screenshot screenshot.png');
+  });
 });
 
 describe(downloadDeviceRunSessionEventsAsync, () => {
@@ -45,13 +207,12 @@ describe(downloadDeviceRunSessionEventsAsync, () => {
   });
 });
 
-function createEvent(
-  overrides: Partial<{
-    eventId: string;
-    ts: string;
-  }> = {}
-): string {
-  return JSON.stringify({
+function createEvent(overrides: Partial<DeviceRunSessionEvent> = {}): string {
+  return JSON.stringify(createEventValue(overrides));
+}
+
+function createEventValue(overrides: Partial<DeviceRunSessionEvent> = {}): DeviceRunSessionEvent {
+  return {
     v: 1,
     eventId: 'event-id',
     ts: '2026-07-10T12:00:00.000Z',
@@ -59,5 +220,5 @@ function createEvent(
     type: 'operation.started',
     summary: 'Started tap',
     ...overrides,
-  });
+  };
 }

--- a/packages/eas-cli/src/simulator/__tests__/events.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/events.test.ts
@@ -190,6 +190,18 @@ describe(formatDeviceRunSessionEvent, () => {
       )
     ).toBe('2026-07-10T12:00:00.000Z  [agent-device] Ran screenshot screenshot.png');
   });
+
+  it('strips ANSI escape sequences and control characters from terminal output', () => {
+    expect(
+      formatDeviceRunSessionEvent(
+        createEventValue({
+          ts: '\u001B[31m2026-07-10T12:00:00.000Z\u001B[0m\n',
+          producer: 'agent\u0000-device',
+          summary: 'Found\r2\tdevices\u0007',
+        })
+      )
+    ).toBe('2026-07-10T12:00:00.000Z  [agent-device] Found2devices');
+  });
 });
 
 describe(downloadDeviceRunSessionEventsAsync, () => {

--- a/packages/eas-cli/src/simulator/__tests__/events.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/events.test.ts
@@ -11,29 +11,22 @@ describe(parseDeviceRunSessionEvents, () => {
   it('parses, deduplicates, and sorts events from the dedicated event log', () => {
     const first = createEvent({
       eventId: 'first',
-      occurredAt: '2026-07-10T12:00:00.000Z',
+      ts: '2026-07-10T12:00:00.000Z',
     });
     const second = createEvent({
       eventId: 'second',
-      occurredAt: '2026-07-10T12:00:01.000Z',
+      ts: '2026-07-10T12:00:01.000Z',
     });
 
     expect(
-      parseDeviceRunSessionEvents(`${second}\nplain text\n${first}\n${second}`, 'session-id').map(
+      parseDeviceRunSessionEvents(`${second}\nplain text\n${first}\n${second}`).map(
         ({ eventId }) => eventId
       )
     ).toEqual(['first', 'second']);
   });
 
-  it('ignores malformed events and events belonging to another session', () => {
-    expect(
-      parseDeviceRunSessionEvents(
-        `${createEvent({ deviceRunSessionId: 'another-session' })}\n${JSON.stringify({
-          schemaVersion: 1,
-        })}`,
-        'session-id'
-      )
-    ).toEqual([]);
+  it('ignores malformed events', () => {
+    expect(parseDeviceRunSessionEvents(`plain text\n${JSON.stringify({ v: 1 })}`)).toEqual([]);
   });
 });
 
@@ -47,7 +40,7 @@ describe(downloadDeviceRunSessionEventsAsync, () => {
     jest.mocked(fetch).mockRejectedValue(new RequestError('not found', response));
 
     await expect(
-      downloadDeviceRunSessionEventsAsync('https://example.test/events', 'session-id')
+      downloadDeviceRunSessionEventsAsync('https://example.test/events')
     ).resolves.toEqual([]);
   });
 });
@@ -55,15 +48,13 @@ describe(downloadDeviceRunSessionEventsAsync, () => {
 function createEvent(
   overrides: Partial<{
     eventId: string;
-    deviceRunSessionId: string;
-    occurredAt: string;
+    ts: string;
   }> = {}
 ): string {
   return JSON.stringify({
-    schemaVersion: 1,
+    v: 1,
     eventId: 'event-id',
-    deviceRunSessionId: 'session-id',
-    occurredAt: '2026-07-10T12:00:00.000Z',
+    ts: '2026-07-10T12:00:00.000Z',
     producer: 'agent-device',
     type: 'operation.started',
     summary: 'Started tap',

--- a/packages/eas-cli/src/simulator/__tests__/events.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/events.test.ts
@@ -3,7 +3,6 @@ import {
   type DeviceRunSessionEvent,
   downloadDeviceRunSessionEventsAsync,
   formatDeviceRunSessionEvent,
-  parseDeviceRunSessionEvents,
   projectDeviceRunSessionEventsForDisplay,
 } from '../events';
 
@@ -12,39 +11,6 @@ jest.mock('../../fetch', () => ({
   ...jest.requireActual('../../fetch'),
   default: jest.fn(),
 }));
-
-describe(parseDeviceRunSessionEvents, () => {
-  it('parses, deduplicates, and sorts events from the dedicated event log', () => {
-    const first = createEvent({
-      eventId: 'first',
-      ts: '2026-07-10T12:00:00.000Z',
-    });
-    const second = createEvent({
-      eventId: 'second',
-      ts: '2026-07-10T12:00:01.000Z',
-    });
-
-    expect(
-      parseDeviceRunSessionEvents(`${second}\nplain text\n${first}\n${second}`).map(
-        ({ eventId }) => eventId
-      )
-    ).toEqual(['first', 'second']);
-  });
-
-  it('ignores malformed events', () => {
-    expect(parseDeviceRunSessionEvents(`plain text\n${JSON.stringify({ v: 1 })}`)).toEqual([]);
-  });
-
-  it('ignores events with invalid timestamps', () => {
-    expect(
-      parseDeviceRunSessionEvents(
-        `${createEvent({ eventId: 'invalid', ts: 'not-a-date' })}\n${createEvent({
-          eventId: 'valid',
-        })}`
-      ).map(({ eventId }) => eventId)
-    ).toEqual(['valid']);
-  });
-});
 
 describe(projectDeviceRunSessionEventsForDisplay, () => {
   it('collapses completed operations and carries duration onto the recorded interaction', () => {
@@ -218,10 +184,6 @@ describe(downloadDeviceRunSessionEventsAsync, () => {
     ).resolves.toEqual([]);
   });
 });
-
-function createEvent(overrides: Partial<DeviceRunSessionEvent> = {}): string {
-  return JSON.stringify(createEventValue(overrides));
-}
 
 function createEventValue(overrides: Partial<DeviceRunSessionEvent> = {}): DeviceRunSessionEvent {
   return {

--- a/packages/eas-cli/src/simulator/events.ts
+++ b/packages/eas-cli/src/simulator/events.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+
+import fetch, { RequestError } from '../fetch';
+
+const DeviceRunSessionEventSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    eventId: z.string(),
+    deviceRunSessionId: z.string(),
+    occurredAt: z.string(),
+    producer: z.string(),
+    producerVersion: z.string().optional(),
+    type: z.string(),
+    operationId: z.string().optional(),
+    name: z.string().optional(),
+    outcome: z.enum(['success', 'failure']).optional(),
+    durationMs: z.number().optional(),
+    summary: z.string(),
+    data: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+export type DeviceRunSessionEvent = z.infer<typeof DeviceRunSessionEventSchema>;
+
+export async function downloadDeviceRunSessionEventsAsync(
+  eventLogUrl: string,
+  deviceRunSessionId: string
+): Promise<DeviceRunSessionEvent[]> {
+  try {
+    const response = await fetch(eventLogUrl);
+    return parseDeviceRunSessionEvents(await response.text(), deviceRunSessionId);
+  } catch (error) {
+    if (error instanceof RequestError && error.response.status === 404) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export function parseDeviceRunSessionEvents(
+  eventLog: string,
+  deviceRunSessionId: string
+): DeviceRunSessionEvent[] {
+  const events = new Map<string, DeviceRunSessionEvent>();
+
+  for (const line of eventLog.split('\n')) {
+    try {
+      const result = DeviceRunSessionEventSchema.safeParse(JSON.parse(line));
+      if (result.success && result.data.deviceRunSessionId === deviceRunSessionId) {
+        events.set(result.data.eventId, result.data);
+      }
+    } catch {
+      // Ignore malformed or incomplete records.
+    }
+  }
+
+  return [...events.values()].sort(
+    (left, right) => new Date(left.occurredAt).getTime() - new Date(right.occurredAt).getTime()
+  );
+}

--- a/packages/eas-cli/src/simulator/events.ts
+++ b/packages/eas-cli/src/simulator/events.ts
@@ -1,3 +1,5 @@
+import { stripVTControlCharacters } from 'util';
+
 import { z } from 'zod';
 
 import fetch, { RequestError } from '../fetch';
@@ -124,7 +126,7 @@ export function formatDeviceRunSessionEvent(event: DeviceRunSessionEvent): strin
       : event.summary;
   const duration =
     event.durationMs === undefined ? '' : ` (${formatEventDuration(event.durationMs)})`;
-  return `${event.ts}  [${event.producer}] ${summary}${duration}`;
+  return stripTerminalControlCharacters(`${event.ts}  [${event.producer}] ${summary}${duration}`);
 }
 
 function getOperationKey(event: DeviceRunSessionEvent): string {
@@ -140,4 +142,13 @@ function getScreenshotFilename(event: DeviceRunSessionEvent): string | undefined
     return undefined;
   }
   return event.data.path.split(/[\\/]/).at(-1);
+}
+
+function stripTerminalControlCharacters(value: string): string {
+  return [...stripVTControlCharacters(value)]
+    .filter(character => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint >= 0x20 && !(codePoint >= 0x7f && codePoint <= 0x9f);
+    })
+    .join('');
 }

--- a/packages/eas-cli/src/simulator/events.ts
+++ b/packages/eas-cli/src/simulator/events.ts
@@ -4,15 +4,12 @@ import fetch, { RequestError } from '../fetch';
 
 const DeviceRunSessionEventSchema = z
   .object({
-    schemaVersion: z.literal(1),
+    v: z.literal(1),
     eventId: z.string(),
-    deviceRunSessionId: z.string(),
-    occurredAt: z.string(),
+    ts: z.string(),
     producer: z.string(),
-    producerVersion: z.string().optional(),
     type: z.string(),
     operationId: z.string().optional(),
-    name: z.string().optional(),
     outcome: z.enum(['success', 'failure']).optional(),
     durationMs: z.number().optional(),
     summary: z.string(),
@@ -23,12 +20,11 @@ const DeviceRunSessionEventSchema = z
 export type DeviceRunSessionEvent = z.infer<typeof DeviceRunSessionEventSchema>;
 
 export async function downloadDeviceRunSessionEventsAsync(
-  eventLogUrl: string,
-  deviceRunSessionId: string
+  eventLogUrl: string
 ): Promise<DeviceRunSessionEvent[]> {
   try {
     const response = await fetch(eventLogUrl);
-    return parseDeviceRunSessionEvents(await response.text(), deviceRunSessionId);
+    return parseDeviceRunSessionEvents(await response.text());
   } catch (error) {
     if (error instanceof RequestError && error.response.status === 404) {
       return [];
@@ -37,16 +33,13 @@ export async function downloadDeviceRunSessionEventsAsync(
   }
 }
 
-export function parseDeviceRunSessionEvents(
-  eventLog: string,
-  deviceRunSessionId: string
-): DeviceRunSessionEvent[] {
+export function parseDeviceRunSessionEvents(eventLog: string): DeviceRunSessionEvent[] {
   const events = new Map<string, DeviceRunSessionEvent>();
 
   for (const line of eventLog.split('\n')) {
     try {
       const result = DeviceRunSessionEventSchema.safeParse(JSON.parse(line));
-      if (result.success && result.data.deviceRunSessionId === deviceRunSessionId) {
+      if (result.success) {
         events.set(result.data.eventId, result.data);
       }
     } catch {
@@ -55,6 +48,6 @@ export function parseDeviceRunSessionEvents(
   }
 
   return [...events.values()].sort(
-    (left, right) => new Date(left.occurredAt).getTime() - new Date(right.occurredAt).getTime()
+    (left, right) => new Date(left.ts).getTime() - new Date(right.ts).getTime()
   );
 }

--- a/packages/eas-cli/src/simulator/events.ts
+++ b/packages/eas-cli/src/simulator/events.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod';
 
 import fetch, { RequestError } from '../fetch';
+import { formatMilliseconds } from '../utils/timer';
 
 const DeviceRunSessionEventSchema = z
   .object({
     v: z.literal(1),
     eventId: z.string(),
-    ts: z.string(),
+    ts: z.string().refine(ts => !Number.isNaN(new Date(ts).getTime())),
     producer: z.string(),
     type: z.string(),
     operationId: z.string().optional(),
@@ -50,4 +51,93 @@ export function parseDeviceRunSessionEvents(eventLog: string): DeviceRunSessionE
   return [...events.values()].sort(
     (left, right) => new Date(left.ts).getTime() - new Date(right.ts).getTime()
   );
+}
+
+export function projectDeviceRunSessionEventsForDisplay(
+  events: DeviceRunSessionEvent[],
+  { includeIncompleteOperations = true }: { includeIncompleteOperations?: boolean } = {}
+): DeviceRunSessionEvent[] {
+  const operations = new Map<
+    string,
+    {
+      completed?: DeviceRunSessionEvent;
+      interactions: DeviceRunSessionEvent[];
+    }
+  >();
+
+  for (const event of events) {
+    if (!event.operationId) {
+      continue;
+    }
+    const operationKey = getOperationKey(event);
+    const operation = operations.get(operationKey) ?? { interactions: [] };
+    if (event.type === 'operation.completed') {
+      operation.completed = event;
+    } else if (event.type === 'interaction.recorded') {
+      operation.interactions.push(event);
+    }
+    operations.set(operationKey, operation);
+  }
+
+  return events.flatMap(event => {
+    if (!event.operationId) {
+      return [event];
+    }
+
+    const operation = operations.get(getOperationKey(event));
+    const completed = operation?.completed;
+    const interactions = operation?.interactions ?? [];
+
+    if (
+      !includeIncompleteOperations &&
+      !completed &&
+      (event.type === 'operation.started' || event.type === 'interaction.recorded')
+    ) {
+      return [];
+    }
+    if (event.type === 'operation.started' && (completed || interactions.length > 0)) {
+      return [];
+    }
+    if (event.type === 'interaction.recorded' && completed?.outcome === 'failure') {
+      return [];
+    }
+    if (event.type === 'operation.completed' && completed?.outcome !== 'failure') {
+      return interactions.length > 0 ? [] : [event];
+    }
+    if (
+      event.type === 'interaction.recorded' &&
+      completed &&
+      interactions.at(-1)?.eventId === event.eventId
+    ) {
+      return [{ ...event, durationMs: completed.durationMs, outcome: completed.outcome }];
+    }
+
+    return [event];
+  });
+}
+
+export function formatDeviceRunSessionEvent(event: DeviceRunSessionEvent): string {
+  const screenshotFilename = getScreenshotFilename(event);
+  const summary =
+    screenshotFilename && !event.summary.includes(screenshotFilename)
+      ? `${event.summary} ${screenshotFilename}`
+      : event.summary;
+  const duration =
+    event.durationMs === undefined ? '' : ` (${formatEventDuration(event.durationMs)})`;
+  return `${event.ts}  [${event.producer}] ${summary}${duration}`;
+}
+
+function getOperationKey(event: DeviceRunSessionEvent): string {
+  return JSON.stringify([event.producer, event.operationId]);
+}
+
+function formatEventDuration(durationMs: number): string {
+  return durationMs < 1000 ? `${Math.round(durationMs)}ms` : formatMilliseconds(durationMs);
+}
+
+function getScreenshotFilename(event: DeviceRunSessionEvent): string | undefined {
+  if (event.data?.command !== 'screenshot' || typeof event.data.path !== 'string') {
+    return undefined;
+  }
+  return event.data.path.split(/[\\/]/).at(-1);
 }

--- a/packages/eas-cli/src/simulator/events.ts
+++ b/packages/eas-cli/src/simulator/events.ts
@@ -1,26 +1,11 @@
 import { stripVTControlCharacters } from 'util';
 
-import { z } from 'zod';
+import { type DeviceRunSessionEvent, parseDeviceRunSessionEvents } from '@expo/eas-build-job';
 
 import fetch, { RequestError } from '../fetch';
 import { formatMilliseconds } from '../utils/timer';
 
-const DeviceRunSessionEventSchema = z
-  .object({
-    v: z.literal(1),
-    eventId: z.string(),
-    ts: z.string().refine(ts => !Number.isNaN(new Date(ts).getTime())),
-    producer: z.string(),
-    type: z.string(),
-    operationId: z.string().optional(),
-    outcome: z.enum(['success', 'failure']).optional(),
-    durationMs: z.number().optional(),
-    summary: z.string(),
-    data: z.record(z.string(), z.unknown()).optional(),
-  })
-  .passthrough();
-
-export type DeviceRunSessionEvent = z.infer<typeof DeviceRunSessionEventSchema>;
+export type { DeviceRunSessionEvent };
 
 export async function downloadDeviceRunSessionEventsAsync(
   eventLogUrl: string
@@ -34,25 +19,6 @@ export async function downloadDeviceRunSessionEventsAsync(
     }
     throw error;
   }
-}
-
-export function parseDeviceRunSessionEvents(eventLog: string): DeviceRunSessionEvent[] {
-  const events = new Map<string, DeviceRunSessionEvent>();
-
-  for (const line of eventLog.split('\n')) {
-    try {
-      const result = DeviceRunSessionEventSchema.safeParse(JSON.parse(line));
-      if (result.success) {
-        events.set(result.data.eventId, result.data);
-      }
-    } catch {
-      // Ignore malformed or incomplete records.
-    }
-  }
-
-  return [...events.values()].sort(
-    (left, right) => new Date(left.ts).getTime() - new Date(right.ts).getTime()
-  );
 }
 
 export function projectDeviceRunSessionEventsForDisplay(


### PR DESCRIPTION
## Why

Users running remote simulator sessions from EAS CLI need a terminal view of the same structured activity available on the Website.

## How

- Add the hidden experimental `eas simulator:events` command.
- Resolve the session ID from `--id` or the simulator dotenv file.
- Discover the standard session-events artifact through its `__eas_type: session-events` metadata and parse its NDJSON records with Zod.
- Share the canonical event record schema and NDJSON parser through `@expo/eas-build-job` (`deviceRunSession.ts`) so producers (worker, agent-device) and consumers (CLI, Website) use a single source of truth; the CLI keeps only the display projection, formatting, and download logic.
- Keep `--json` as a raw, lossless snapshot of the canonical event records.
- Make human-readable output log-like and compact by grouping related operation records, preserving the producer's summary, and including the producer, duration, and screenshot basename when available. Strip ANSI escape sequences and terminal control characters before printing artifact-provided text.
- Support `--follow` with five-second updates, withholding incomplete operations until they finish and refreshing twice after the session stops so the worker's final upload is included. Transient poll failures are retried, the first Ctrl-C wakes polling and flushes incomplete events, and a second Ctrl-C force-exits.
- Ignore malformed records, including invalid timestamps, and treat a not-yet-created artifact or object as an empty event stream.
- Regenerate the GraphQL schema snapshot and generated types with `yarn generate-graphql-code`; the only query this PR adds is `DeviceRunSessionEventsByIdQuery`, which uses pre-existing schema fields.

The command does not read or alter worker runtime logs.

## Test Plan

- `yarn test src/simulator/__tests__/events.test.ts src/commands/simulator/__tests__/events.test.ts --runInBand` (in `packages/eas-cli`)
- `yarn test src/__tests__/deviceRunSession.test.ts` (in `packages/eas-build-job`)
- `yarn typecheck`
- `yarn lint`
- `yarn fmt`

Coverage includes artifact discovery, empty snapshots, NDJSON parsing and deduplication, malformed records and timestamps, operation grouping across producers, compact and terminal-safe formatting, screenshot basename handling, post-stop refreshes, transient query and download retries, immediate interrupt wakeup and final flushing, second-interrupt force exit, and the absence of custom SIGINT handling outside follow mode.

### Manual staging verification

Tested from `~/expo/testapp-staging` against stopped agent-device session `019f8ecd-f874-70ec-8f5d-ef18197681d4`, with `EXPO_STAGING=1` on every CLI invocation.

```sh
EXPO_STAGING=1 <path-to-eas-cli-checkout>/packages/eas-cli/bin/run simulator:events \
  --id 019f8ecd-f874-70ec-8f5d-ef18197681d4
```

Representative output (55 canonical records condensed to 21 lines):

```text
2026-07-23T11:52:10.177Z  [agent-device] Finished devices (7s)
2026-07-23T11:52:59.819Z  [agent-device] Failed apps: INVALID_ARGS (12ms)
2026-07-23T11:56:09.840Z  [agent-device] Finished install (10s)
2026-07-23T11:56:35.765Z  [agent-device] Opened com.expo.testapp.szymon (8s)
2026-07-23T11:59:27.332Z  [agent-device] Tapped @e13 (1s)
2026-07-23T11:59:50.296Z  [agent-device] Failed press: COMMAND_FAILED (1ms)
2026-07-23T12:08:55.381Z  [agent-device] Ran scroll (985ms)
2026-07-23T12:11:25.056Z  [agent-device] Ran screenshot agent-device-screenshot-1784808684346-7egl5c.png (524ms)
```

Verified that `--json` returned all 55 canonical records without applying the text projection:

```sh
EXPO_STAGING=1 <path-to-eas-cli-checkout>/packages/eas-cli/bin/run simulator:events \
  --id 019f8ecd-f874-70ec-8f5d-ef18197681d4 --json |
  jq '{deviceRunSessionId, eventCount: (.events | length)}'
```

```json
{
  "deviceRunSessionId": "019f8ecd-f874-70ec-8f5d-ef18197681d4",
  "eventCount": 55
}
```

Also ran `--follow` against the stopped session. It printed the same final 21-line snapshot and exited successfully.

## Rollout

Release after expo/universe#28937 and expo/eas-cli#3999 are deployed. The richer producer summaries from callstackincubator/agent-device#1379 can ship independently and will be displayed automatically.

