### PR TITLE
[eas-cli] Add `eas env:set`, deprecate `env:create` and `env:update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add `eas env:set`, which creates or updates an environment variable in one command. `eas env:create` and `eas env:update` are now deprecated. ([#4002](https://github.com/expo/eas-cli/pull/4002) by [@jonsamp](https://github.com/jonsamp))
 - [eas-cli] Improve `eas workflow:create`: add a `--template` flag, generate a placeholder workflow when a file name is passed, use shorter default file names (`build.yml`, `update.yml`, `deploy.yml`), configure EAS Build and EAS Update automatically when the chosen template requires them, set default app identifiers without prompting for the development build and deploy templates, install `expo-dev-client` during development build setup, and tighten the generated comments and next steps. ([#3943](https://github.com/expo/eas-cli/pull/3943) by [@jonsamp](https://github.com/jonsamp))
 - [eas-cli] `eas integrations:posthog:dashboard` now opens PostHog via a signed-in link, skipping the login prompt. ([#3975](https://github.com/expo/eas-cli/pull/3975) by [@gwdp](https://github.com/gwdp))
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -1503,7 +1503,7 @@ set (create or update) an environment variable on the current project or account
 ```
 USAGE
   $ eas env:set [ENVIRONMENT] [--name <value>] [--value <value>] [--type string|file] [--visibility
-    plaintext|sensitive|secret] [--scope project|account] [--environment <value>...] [--non-interactive]
+    plaintext|sensitive|secret] [--scope project|account] [--environment <value>...] [--json] [--non-interactive]
 
 ARGUMENTS
   [ENVIRONMENT]  Environment to set the variable in. Default environments are 'production', 'preview', and
@@ -1511,13 +1511,14 @@ ARGUMENTS
 
 FLAGS
   --environment=<value>...  Environment variable's environment, e.g. 'production', 'preview', 'development'
+  --json                    Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.
   --name=<value>            Name of the variable
   --non-interactive         Run the command in non-interactive mode.
   --scope=<option>          [default: project] Scope for the variable
                             <options: project|account>
   --type=<option>           The type of variable
                             <options: string|file>
-  --value=<value>           Text value or the variable
+  --value=<value>           Text value of the variable
   --visibility=<option>     Visibility of the variable
                             <options: plaintext|sensitive|secret>
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -112,6 +112,7 @@ eas --help COMMAND
 * [`eas env:list [ENVIRONMENT]`](#eas-envlist-environment)
 * [`eas env:pull [ENVIRONMENT]`](#eas-envpull-environment)
 * [`eas env:push [ENVIRONMENT]`](#eas-envpush-environment)
+* [`eas env:set [ENVIRONMENT]`](#eas-envset-environment)
 * [`eas env:update [ENVIRONMENT]`](#eas-envupdate-environment)
 * [`eas fingerprint:compare [HASH1] [HASH2]`](#eas-fingerprintcompare-hash1-hash2)
 * [`eas fingerprint:generate`](#eas-fingerprintgenerate)
@@ -1316,7 +1317,7 @@ _See code: [packages/eas-cli/src/commands/diagnostics.ts](https://github.com/exp
 
 ## `eas env:create [ENVIRONMENT]`
 
-create an environment variable for the current project or account
+create an environment variable for the current project or account (deprecated, use eas env:set)
 
 ```
 USAGE
@@ -1341,7 +1342,7 @@ FLAGS
                             <options: plaintext|sensitive|secret>
 
 DESCRIPTION
-  create an environment variable for the current project or account
+  create an environment variable for the current project or account (deprecated, use eas env:set)
 ```
 
 _See code: [packages/eas-cli/src/commands/env/create.ts](https://github.com/expo/eas-cli/blob/v20.5.1/packages/eas-cli/src/commands/env/create.ts)_
@@ -1495,9 +1496,40 @@ DESCRIPTION
 
 _See code: [packages/eas-cli/src/commands/env/push.ts](https://github.com/expo/eas-cli/blob/v20.5.1/packages/eas-cli/src/commands/env/push.ts)_
 
+## `eas env:set [ENVIRONMENT]`
+
+set (create or update) an environment variable on the current project or account
+
+```
+USAGE
+  $ eas env:set [ENVIRONMENT] [--name <value>] [--value <value>] [--type string|file] [--visibility
+    plaintext|sensitive|secret] [--scope project|account] [--environment <value>...] [--non-interactive]
+
+ARGUMENTS
+  [ENVIRONMENT]  Environment to set the variable in. Default environments are 'production', 'preview', and
+                 'development'.
+
+FLAGS
+  --environment=<value>...  Environment variable's environment, e.g. 'production', 'preview', 'development'
+  --name=<value>            Name of the variable
+  --non-interactive         Run the command in non-interactive mode.
+  --scope=<option>          [default: project] Scope for the variable
+                            <options: project|account>
+  --type=<option>           The type of variable
+                            <options: string|file>
+  --value=<value>           Text value or the variable
+  --visibility=<option>     Visibility of the variable
+                            <options: plaintext|sensitive|secret>
+
+DESCRIPTION
+  set (create or update) an environment variable on the current project or account
+```
+
+_See code: [packages/eas-cli/src/commands/env/set.ts](https://github.com/expo/eas-cli/blob/v20.5.1/packages/eas-cli/src/commands/env/set.ts)_
+
 ## `eas env:update [ENVIRONMENT]`
 
-update an environment variable on the current project or account
+update an environment variable on the current project or account (deprecated, use eas env:set)
 
 ```
 USAGE
@@ -1524,7 +1556,7 @@ FLAGS
                                   <options: plaintext|sensitive|secret>
 
 DESCRIPTION
-  update an environment variable on the current project or account
+  update an environment variable on the current project or account (deprecated, use eas env:set)
 ```
 
 _See code: [packages/eas-cli/src/commands/env/update.ts](https://github.com/expo/eas-cli/blob/v20.5.1/packages/eas-cli/src/commands/env/update.ts)_
@@ -1860,11 +1892,13 @@ open the PostHog dashboard for the linked PostHog project
 
 ```
 USAGE
-  $ eas integrations:posthog:dashboard [--json] [--non-interactive]
+  $ eas integrations:posthog:dashboard [--show-link] [--json] [--non-interactive]
 
 FLAGS
   --json             Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.
   --non-interactive  Run the command in non-interactive mode.
+  --show-link        Print the signed-in dashboard URL in addition to opening it. The URL contains a single-use login
+                     token.
 
 DESCRIPTION
   open the PostHog dashboard for the linked PostHog project
@@ -2049,7 +2083,8 @@ USAGE
     <value>] [--project-id <value>] [--json] [--non-interactive]
 
 ARGUMENTS
-  [METRIC]  (tti|ttr|cold_launch|warm_launch|bundle_load|update_download) Metric to query (e.g. tti, cold_launch)
+  [METRIC]  (nav_cold_ttr|nav_warm_ttr|nav_tti|tti|ttr|cold_launch|warm_launch|bundle_load|update_download) Metric to
+            query (e.g. tti, cold_launch, nav_tti)
 
 FLAGS
   --after=<value>        Cursor for pagination. Use the endCursor from a previous query to fetch the next page.
@@ -2080,7 +2115,7 @@ display aggregated performance metric statistics grouped by app version
 ```
 USAGE
   $ eas observe:metrics-summary [--platform android|ios] [--metric
-    tti|ttr|cold_launch|warm_launch|bundle_load|update_download...] [--stat
+    nav_cold_ttr|nav_warm_ttr|nav_tti|tti|ttr|cold_launch|warm_launch|bundle_load|update_download...] [--stat
     min|median|max|average|p80|p90|p99|eventCount...] [--start <value> | --days <value>] [--end <value> | ]
     [--project-id <value>] [--json] [--non-interactive]
 
@@ -2089,7 +2124,8 @@ FLAGS
   --end=<value>         End of time range (ISO date)
   --json                Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.
   --metric=<option>...  Metric name to display (can be specified multiple times).
-                        <options: tti|ttr|cold_launch|warm_launch|bundle_load|update_download>
+                        <options:
+                        nav_cold_ttr|nav_warm_ttr|nav_tti|tti|ttr|cold_launch|warm_launch|bundle_load|update_download>
   --non-interactive     Run the command in non-interactive mode.
   --platform=<option>   Filter by platform
                         <options: android|ios>
@@ -2110,7 +2146,7 @@ display app navigation route metrics (Cold TTR, Warm TTR, TTI) grouped by route 
 
 ```
 USAGE
-  $ eas observe:routes [--platform android|ios] [--metric cold_ttr|warm_ttr|nav_tti...] [--stat
+  $ eas observe:routes [--platform android|ios] [--metric nav_cold_ttr|nav_warm_ttr|nav_tti...] [--stat
     median|med|p90|count|event_count|eventCount...] [--after <value>] [--limit <value>] [--start <value> | --days
     <value>] [--end <value> | ] [--app-version <value>] [--update-id <value>] [--build-number <value>] [--route-name
     <value>...] [--project-id <value>] [--json] [--non-interactive]
@@ -2124,7 +2160,7 @@ FLAGS
   --json                   Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.
   --limit=<value>          The number of items to fetch each query. Defaults to 50 and is capped at 200.
   --metric=<option>...     Navigation metric to display (can be specified multiple times). Defaults to all three.
-                           <options: cold_ttr|warm_ttr|nav_tti>
+                           <options: nav_cold_ttr|nav_warm_ttr|nav_tti>
   --non-interactive        Run the command in non-interactive mode.
   --platform=<option>      Filter by platform
                            <options: android|ios>

--- a/packages/eas-cli/src/commands/env/__tests__/EnvSet.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvSet.test.ts
@@ -1,3 +1,5 @@
+import fs from 'fs-extra';
+
 import { getMockAppFragment, getMockOclifConfig } from '../../../__tests__/commands/utils';
 import { DefaultEnvironment } from '../../../build/utils/environment';
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
@@ -10,6 +12,7 @@ import {
 import { EnvironmentVariableMutation } from '../../../graphql/mutations/EnvironmentVariableMutation';
 import { AppQuery } from '../../../graphql/queries/AppQuery';
 import { EnvironmentVariablesQuery } from '../../../graphql/queries/EnvironmentVariablesQuery';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
 import {
   parseVisibility,
   promptVariableEnvironmentAsync,
@@ -23,6 +26,8 @@ jest.mock('../../../graphql/mutations/EnvironmentVariableMutation');
 jest.mock('../../../graphql/queries/AppQuery');
 jest.mock('../../../graphql/queries/EnvironmentVariablesQuery');
 jest.mock('../../../utils/prompts');
+jest.mock('../../../utils/json');
+jest.mock('fs-extra');
 
 describe(EnvSet, () => {
   const graphqlClient = {} as any as ExpoGraphqlClient;
@@ -318,6 +323,155 @@ describe(EnvSet, () => {
         type: EnvironmentSecretType.String,
       },
       testProjectId
+    );
+  });
+
+  it('preserves the file type when updating a file variable with --value but no --type', async () => {
+    const testFilePath = '/path/to/creds.json';
+    const testFileBase64 = 'dGVzdCBmaWxlIGNvbnRlbnQ=';
+    const testFileName = 'creds.json';
+    const otherVariableId = 'otherId';
+
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
+      // @ts-expect-error
+      .mockImplementation(async () => [
+        {
+          id: otherVariableId,
+          name: 'VarName',
+          environments: [DefaultEnvironment.Production],
+          scope: EnvironmentVariableScope.Project,
+          type: EnvironmentSecretType.FileBase64,
+        },
+      ]);
+
+    jest.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(true));
+    jest.mocked(fs.readFile).mockImplementation(() => Promise.resolve(testFileBase64));
+
+    const command = new EnvSet(
+      [
+        '--name',
+        'VarName',
+        '--value',
+        testFilePath,
+        '--environment',
+        'production',
+        '--visibility',
+        'secret',
+        '--non-interactive',
+      ],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    await command.runAsync();
+
+    expect(fs.pathExists).toHaveBeenCalledWith(testFilePath);
+    expect(fs.readFile).toHaveBeenCalledWith(testFilePath, 'base64');
+    expect(EnvironmentVariableMutation.updateAsync).toHaveBeenCalledWith(graphqlClient, {
+      id: otherVariableId,
+      name: 'VarName',
+      value: testFileBase64,
+      visibility: EnvironmentVariableVisibility.Secret,
+      environments: [DefaultEnvironment.Production],
+      type: EnvironmentSecretType.FileBase64,
+      fileName: testFileName,
+    });
+  });
+
+  it('throws when updating a file variable with a value that is not a valid file path and no --type', async () => {
+    const plainStringValue = 'some-new-value';
+    const otherVariableId = 'otherId';
+
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
+      // @ts-expect-error
+      .mockImplementation(async () => [
+        {
+          id: otherVariableId,
+          name: 'VarName',
+          environments: [DefaultEnvironment.Production],
+          scope: EnvironmentVariableScope.Project,
+          type: EnvironmentSecretType.FileBase64,
+        },
+      ]);
+
+    jest.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(false));
+
+    const command = new EnvSet(
+      [
+        '--name',
+        'VarName',
+        '--value',
+        plainStringValue,
+        '--environment',
+        'production',
+        '--visibility',
+        'secret',
+        '--non-interactive',
+      ],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    await expect(command.runAsync()).rejects.toThrow(
+      `Variable "VarName" is a file type, but "${plainStringValue}" does not exist as a file. If you want to convert it to a string, pass --type string.`
+    );
+    expect(EnvironmentVariableMutation.updateAsync).not.toHaveBeenCalled();
+  });
+
+  it('outputs the created variable as JSON with --json and does not print a tick', async () => {
+    const command = new EnvSet(
+      [
+        '--name',
+        'VarName',
+        '--value',
+        'VarValue',
+        '--environment',
+        'production',
+        '--visibility',
+        'plaintext',
+        '--json',
+      ],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    await command.runAsync();
+
+    expect(enableJsonOutput).toHaveBeenCalled();
+    expect(EnvironmentVariableMutation.createForAppAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      {
+        name: 'VarName',
+        value: 'VarValue',
+        environments: [DefaultEnvironment.Production],
+        visibility: EnvironmentVariableVisibility.Public,
+        type: EnvironmentSecretType.String,
+      },
+      testProjectId
+    );
+    expect(printJsonOnlyOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: variableId,
+        name: 'VarName',
+        value: 'VarValue',
+      })
     );
   });
 });

--- a/packages/eas-cli/src/commands/env/__tests__/EnvSet.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvSet.test.ts
@@ -1,0 +1,323 @@
+import { getMockAppFragment, getMockOclifConfig } from '../../../__tests__/commands/utils';
+import { DefaultEnvironment } from '../../../build/utils/environment';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../../credentials/__tests__/fixtures-constants';
+import {
+  EnvironmentSecretType,
+  EnvironmentVariableScope,
+  EnvironmentVariableVisibility,
+} from '../../../graphql/generated';
+import { EnvironmentVariableMutation } from '../../../graphql/mutations/EnvironmentVariableMutation';
+import { AppQuery } from '../../../graphql/queries/AppQuery';
+import { EnvironmentVariablesQuery } from '../../../graphql/queries/EnvironmentVariablesQuery';
+import {
+  parseVisibility,
+  promptVariableEnvironmentAsync,
+  promptVariableNameAsync,
+  promptVariableTypeAsync,
+  promptVariableValueAsync,
+} from '../../../utils/prompts';
+import EnvSet from '../set';
+
+jest.mock('../../../graphql/mutations/EnvironmentVariableMutation');
+jest.mock('../../../graphql/queries/AppQuery');
+jest.mock('../../../graphql/queries/EnvironmentVariablesQuery');
+jest.mock('../../../utils/prompts');
+
+describe(EnvSet, () => {
+  const graphqlClient = {} as any as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+  const variableId = 'testId';
+  const testAccountId = 'test-account-id';
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest
+      .mocked(parseVisibility)
+      .mockImplementation(jest.requireActual('../../../utils/prompts').parseVisibility);
+
+    jest.mocked(AppQuery.byIdAsync).mockImplementation(async () => getMockAppFragment());
+    jest
+      .mocked(EnvironmentVariableMutation.createForAppAsync)
+      .mockImplementation(async (_client, input, _appId) => ({
+        ...input,
+        id: variableId,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        scope: EnvironmentVariableScope.Project,
+        type: EnvironmentSecretType.String,
+      }));
+    jest
+      .mocked(EnvironmentVariableMutation.createSharedVariableAsync)
+      .mockImplementation(async (_client, input, _appId) => ({
+        ...input,
+        id: variableId,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        scope: EnvironmentVariableScope.Shared,
+        type: EnvironmentSecretType.String,
+      }));
+    jest
+      .mocked(EnvironmentVariableMutation.updateAsync)
+      .mockImplementation(async (_client, input) => ({
+        ...input,
+        id: variableId,
+        name: 'VarName',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        scope: EnvironmentVariableScope.Project,
+        type: EnvironmentSecretType.String,
+      }));
+    jest.mocked(EnvironmentVariablesQuery.byAppIdAsync).mockImplementation(async () => []);
+    jest.mocked(EnvironmentVariablesQuery.sharedAsync).mockImplementation(async () => []);
+  });
+
+  it('creates a project variable when none exists', async () => {
+    const command = new EnvSet(
+      [
+        '--name',
+        'VarName',
+        '--value',
+        'VarValue',
+        '--environment',
+        'production',
+        '--visibility',
+        'secret',
+      ],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    await command.runAsync();
+
+    expect(EnvironmentVariableMutation.createForAppAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      {
+        name: 'VarName',
+        value: 'VarValue',
+        environments: [DefaultEnvironment.Production],
+        visibility: EnvironmentVariableVisibility.Secret,
+        type: EnvironmentSecretType.String,
+      },
+      testProjectId
+    );
+    expect(EnvironmentVariableMutation.updateAsync).not.toHaveBeenCalled();
+  });
+
+  it('updates an existing project variable in the same environment without --force', async () => {
+    const command = new EnvSet(
+      [
+        '--name',
+        'VarName',
+        '--value',
+        'VarValue',
+        '--environment',
+        'production',
+        '--visibility',
+        'secret',
+      ],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    const otherVariableId = 'otherId';
+
+    jest
+      .mocked(EnvironmentVariablesQuery.byAppIdAsync)
+      // @ts-expect-error
+      .mockImplementation(async () => [
+        {
+          id: otherVariableId,
+          environments: [DefaultEnvironment.Production],
+          scope: EnvironmentVariableScope.Project,
+        },
+      ]);
+
+    await command.runAsync();
+
+    expect(EnvironmentVariablesQuery.byAppIdAsync).toHaveBeenCalledWith(graphqlClient, {
+      appId: testProjectId,
+      filterNames: ['VarName'],
+    });
+
+    expect(EnvironmentVariableMutation.updateAsync).toHaveBeenCalledWith(graphqlClient, {
+      id: otherVariableId,
+      name: 'VarName',
+      value: 'VarValue',
+      environments: [DefaultEnvironment.Production],
+      visibility: EnvironmentVariableVisibility.Secret,
+      type: undefined,
+      fileName: undefined,
+    });
+    expect(EnvironmentVariableMutation.createForAppAsync).not.toHaveBeenCalled();
+  });
+
+  it('creates an account-wide variable when none exists', async () => {
+    const command = new EnvSet(
+      [
+        '--name',
+        'VarName',
+        '--value',
+        'VarValue',
+        '--environment',
+        'production',
+        '--scope',
+        'account',
+      ],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    await command.runAsync();
+
+    expect(EnvironmentVariableMutation.createSharedVariableAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      {
+        name: 'VarName',
+        value: 'VarValue',
+        environments: [DefaultEnvironment.Production],
+        visibility: EnvironmentVariableVisibility.Public,
+        type: EnvironmentSecretType.String,
+      },
+      testAccountId
+    );
+  });
+
+  it('updates an existing account-wide variable without --force', async () => {
+    const command = new EnvSet(
+      [
+        '--name',
+        'VarName',
+        '--value',
+        'VarValue',
+        '--environment',
+        'production',
+        '--scope',
+        'account',
+      ],
+      mockConfig
+    );
+
+    const otherVariableId = 'otherId';
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    jest
+      .mocked(EnvironmentVariablesQuery.sharedAsync)
+      // @ts-expect-error
+      .mockImplementation(async () => [
+        {
+          id: otherVariableId,
+          environments: [DefaultEnvironment.Production],
+          scope: EnvironmentVariableScope.Shared,
+        },
+      ]);
+
+    await command.runAsync();
+
+    expect(EnvironmentVariableMutation.updateAsync).toHaveBeenCalledWith(graphqlClient, {
+      id: otherVariableId,
+      name: 'VarName',
+      value: 'VarValue',
+      environments: [DefaultEnvironment.Production],
+      visibility: EnvironmentVariableVisibility.Public,
+      type: undefined,
+    });
+    expect(EnvironmentVariableMutation.createSharedVariableAsync).not.toHaveBeenCalled();
+  });
+
+  it('accepts the environment as a positional argument', async () => {
+    const command = new EnvSet(
+      [
+        'development',
+        '--name',
+        'TEST_VAR',
+        '--value',
+        'test-value',
+        '--visibility',
+        'plaintext',
+        '--scope',
+        'project',
+        '--non-interactive',
+      ],
+      mockConfig
+    );
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    await command.runAsync();
+
+    expect(EnvironmentVariableMutation.createForAppAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      {
+        name: 'TEST_VAR',
+        value: 'test-value',
+        environments: [DefaultEnvironment.Development],
+        visibility: EnvironmentVariableVisibility.Public,
+        type: EnvironmentSecretType.String,
+      },
+      testProjectId
+    );
+  });
+
+  it('prompts for missing arguments', async () => {
+    const command = new EnvSet([], mockConfig);
+
+    jest.mocked(promptVariableNameAsync).mockImplementation(async () => 'VarName');
+    jest.mocked(promptVariableValueAsync).mockImplementation(async () => 'VarValue');
+    jest
+      .mocked(promptVariableTypeAsync)
+      .mockImplementation(async () => EnvironmentSecretType.String);
+
+    jest
+      .mocked(promptVariableEnvironmentAsync)
+      // @ts-expect-error
+      .mockImplementation(async () => [DefaultEnvironment.Production]);
+
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      loggedIn: { graphqlClient },
+      projectId: testProjectId,
+    });
+
+    await command.runAsync();
+
+    expect(promptVariableNameAsync).toHaveBeenCalled();
+    expect(promptVariableValueAsync).toHaveBeenCalled();
+    expect(promptVariableEnvironmentAsync).toHaveBeenCalled();
+    expect(EnvironmentVariableMutation.createForAppAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      {
+        name: 'VarName',
+        value: 'VarValue',
+        environments: [DefaultEnvironment.Production],
+        visibility: EnvironmentVariableVisibility.Public,
+        type: EnvironmentSecretType.String,
+      },
+      testProjectId
+    );
+  });
+});

--- a/packages/eas-cli/src/commands/env/set.ts
+++ b/packages/eas-cli/src/commands/env/set.ts
@@ -9,11 +9,13 @@ import {
   EASEnvironmentVariableScopeFlag,
   EASEnvironmentVariableScopeFlagValue,
   EASMultiEnvironmentFlag,
-  EASNonInteractiveFlag,
   EASVariableVisibilityFlag,
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
 } from '../../commandUtils/flags';
 import {
   EnvironmentSecretType,
+  EnvironmentVariableFragment,
   EnvironmentVariableScope,
   EnvironmentVariableVisibility,
 } from '../../graphql/generated';
@@ -24,6 +26,7 @@ import {
   getDisplayNameForProjectIdAsync,
   getOwnerAccountForProjectIdAsync,
 } from '../../project/projectUtils';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import {
   parseVisibility,
   promptVariableEnvironmentAsync,
@@ -41,6 +44,7 @@ interface RawSetFlags {
   scope: EASEnvironmentVariableScopeFlagValue;
   environment?: string[];
   'non-interactive': boolean;
+  json: boolean;
 }
 
 interface SetFlags {
@@ -51,6 +55,14 @@ interface SetFlags {
   scope: EnvironmentVariableScope;
   environment?: string[];
   'non-interactive': boolean;
+  json: boolean;
+}
+
+interface ResolvedVariableDetails {
+  value: string;
+  visibility: EnvironmentVariableVisibility;
+  type: EnvironmentSecretType | undefined;
+  fileName: string | undefined;
 }
 
 export default class EnvSet extends EasCommand {
@@ -70,7 +82,7 @@ export default class EnvSet extends EasCommand {
       description: 'Name of the variable',
     }),
     value: Flags.string({
-      description: 'Text value or the variable',
+      description: 'Text value of the variable',
     }),
     type: Flags.option({
       description: 'The type of variable',
@@ -79,7 +91,7 @@ export default class EnvSet extends EasCommand {
     ...EASVariableVisibilityFlag,
     ...EASEnvironmentVariableScopeFlag,
     ...EASMultiEnvironmentFlag,
-    ...EASNonInteractiveFlag,
+    ...EasNonInteractiveAndJsonFlags,
   };
 
   static override contextDefinition = {
@@ -91,27 +103,51 @@ export default class EnvSet extends EasCommand {
   async runAsync(): Promise<void> {
     const { args, flags } = await this.parse(EnvSet);
 
-    const validatedFlags = this.sanitizeFlags(flags);
+    const {
+      name: nameFlag,
+      value,
+      type,
+      visibility,
+      scope,
+      environment,
+    } = this.sanitizeFlags(flags);
+    const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
 
     const {
       projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(EnvSet, {
-      nonInteractive: validatedFlags['non-interactive'],
+      nonInteractive,
     });
 
-    const {
-      name,
-      value,
-      scope,
-      environment: environments,
-      visibility,
-      type,
-      fileName,
-    } = await this.promptForMissingFlagsAsync(validatedFlags, args, {
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    const name = nameFlag ?? (await promptVariableNameAsync(nonInteractive));
+
+    const environments = await this.resolveEnvironmentsAsync(environment, args.environment, {
+      nonInteractive,
       graphqlClient,
       projectId,
     });
+
+    const existingVariable = await this.findExistingVariableAsync(graphqlClient, {
+      scope,
+      projectId,
+      name,
+      environments,
+    });
+
+    const {
+      value: resolvedValue,
+      visibility: resolvedVisibility,
+      type: resolvedType,
+      fileName,
+    } = await this.resolveVariableDetailsAsync(
+      { name, value, type, visibility, nonInteractive },
+      existingVariable
+    );
 
     const [projectDisplayName, ownerAccount] = await Promise.all([
       getDisplayNameForProjectIdAsync(graphqlClient, projectId),
@@ -119,35 +155,24 @@ export default class EnvSet extends EasCommand {
     ]);
 
     if (scope === EnvironmentVariableScope.Project) {
-      const existingVariables = await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, {
-        appId: projectId,
-        filterNames: [name],
-      });
-
-      const existingVariable = existingVariables.find(
-        variable =>
-          variable.scope === EnvironmentVariableScope.Project &&
-          (!environments || variable.environments?.some(env => environments?.includes(env)))
-      );
-
       const variable = existingVariable
         ? await EnvironmentVariableMutation.updateAsync(graphqlClient, {
             id: existingVariable.id,
             name,
-            value,
-            visibility,
+            value: resolvedValue,
+            visibility: resolvedVisibility,
             environments,
-            type,
+            type: resolvedType,
             fileName,
           })
         : await EnvironmentVariableMutation.createForAppAsync(
             graphqlClient,
             {
               name,
-              value,
+              value: resolvedValue,
               environments,
-              visibility,
-              type: type ?? EnvironmentSecretType.String,
+              visibility: resolvedVisibility,
+              type: resolvedType ?? EnvironmentSecretType.String,
               fileName,
             },
             projectId
@@ -159,38 +184,33 @@ export default class EnvSet extends EasCommand {
         );
       }
 
-      Log.withTick(
-        `${existingVariable ? 'Updated' : 'Created'} variable ${chalk.bold(name)} on project ${chalk.bold(
-          projectDisplayName
-        )}.`
-      );
+      if (jsonFlag) {
+        printJsonOnlyOutput(variable);
+      } else {
+        Log.withTick(
+          `${existingVariable ? 'Updated' : 'Created'} variable ${chalk.bold(name)} on project ${chalk.bold(
+            projectDisplayName
+          )}.`
+        );
+      }
     } else if (scope === EnvironmentVariableScope.Shared) {
-      const existingVariables = await EnvironmentVariablesQuery.sharedAsync(graphqlClient, {
-        appId: projectId,
-        filterNames: [name],
-      });
-
-      const existingVariable = existingVariables.find(
-        variable => !environments || variable.environments?.some(env => environments?.includes(env))
-      );
-
       const variable = existingVariable
         ? await EnvironmentVariableMutation.updateAsync(graphqlClient, {
             id: existingVariable.id,
             name,
-            value,
-            visibility,
+            value: resolvedValue,
+            visibility: resolvedVisibility,
             environments,
-            type,
+            type: resolvedType,
           })
         : await EnvironmentVariableMutation.createSharedVariableAsync(
             graphqlClient,
             {
               name,
-              value,
-              visibility,
+              value: resolvedValue,
+              visibility: resolvedVisibility,
               environments,
-              type: type ?? EnvironmentSecretType.String,
+              type: resolvedType ?? EnvironmentSecretType.String,
             },
             ownerAccount.id
           );
@@ -199,103 +219,156 @@ export default class EnvSet extends EasCommand {
         throw new Error(`Could not set variable with name ${name} on account ${ownerAccount.name}`);
       }
 
-      Log.withTick(
-        `${existingVariable ? 'Updated' : 'Created'} variable ${chalk.bold(name)} on account ${chalk.bold(
-          ownerAccount.name
-        )}.`
-      );
+      if (jsonFlag) {
+        printJsonOnlyOutput(variable);
+      } else {
+        Log.withTick(
+          `${existingVariable ? 'Updated' : 'Created'} variable ${chalk.bold(name)} on account ${chalk.bold(
+            ownerAccount.name
+          )}.`
+        );
+      }
     }
   }
 
-  private async promptForMissingFlagsAsync(
+  private async resolveEnvironmentsAsync(
+    environmentFlag: string[] | undefined,
+    environmentArg: string | undefined,
+    {
+      nonInteractive,
+      graphqlClient,
+      projectId,
+    }: { nonInteractive: boolean; graphqlClient: ExpoGraphqlClient; projectId: string }
+  ): Promise<string[]> {
+    const environments = environmentFlag ?? (environmentArg ? [environmentArg] : undefined);
+    if (environments && environments.length > 0) {
+      return environments;
+    }
+
+    const promptedEnvironments = await promptVariableEnvironmentAsync({
+      nonInteractive,
+      multiple: true,
+      canEnterCustomEnvironment: true,
+      graphqlClient,
+      projectId,
+    });
+
+    if (!promptedEnvironments || promptedEnvironments.length === 0) {
+      throw new Error('No environments selected');
+    }
+
+    return promptedEnvironments;
+  }
+
+  private async findExistingVariableAsync(
+    graphqlClient: ExpoGraphqlClient,
+    {
+      scope,
+      projectId,
+      name,
+      environments,
+    }: {
+      scope: EnvironmentVariableScope;
+      projectId: string;
+      name: string;
+      environments: string[];
+    }
+  ): Promise<EnvironmentVariableFragment | undefined> {
+    if (scope === EnvironmentVariableScope.Project) {
+      const existingVariables = await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, {
+        appId: projectId,
+        filterNames: [name],
+      });
+
+      return existingVariables.find(
+        variable =>
+          variable.scope === EnvironmentVariableScope.Project &&
+          variable.environments?.some(env => environments.includes(env))
+      );
+    }
+
+    const existingVariables = await EnvironmentVariablesQuery.sharedAsync(graphqlClient, {
+      appId: projectId,
+      filterNames: [name],
+    });
+
+    return existingVariables.find(variable =>
+      variable.environments?.some(env => environments.includes(env))
+    );
+  }
+
+  private async resolveVariableDetailsAsync(
     {
       name,
       value,
-      environment: environments,
-      visibility,
-      'non-interactive': nonInteractive,
       type,
-      ...rest
-    }: SetFlags,
-    { environment }: { environment?: string },
-    { graphqlClient, projectId }: { graphqlClient: ExpoGraphqlClient; projectId: string }
-  ): Promise<
-    Required<
-      Omit<SetFlags, 'type' | 'visibility'> & {
-        type: EnvironmentSecretType | undefined;
-        visibility: EnvironmentVariableVisibility;
-      }
-    > & { fileName?: string }
-  > {
-    if (!name) {
-      name = await promptVariableNameAsync(nonInteractive);
-    }
-
-    let newType;
-    let newVisibility = visibility ? parseVisibility(visibility) : undefined;
-
+      visibility,
+      nonInteractive,
+    }: {
+      name: string;
+      value?: string;
+      type?: 'string' | 'file';
+      visibility?: 'plaintext' | 'sensitive' | 'secret';
+      nonInteractive: boolean;
+    },
+    existingVariable: EnvironmentVariableFragment | undefined
+  ): Promise<ResolvedVariableDetails> {
+    let newType: EnvironmentSecretType | undefined;
     if (type === 'file') {
       newType = EnvironmentSecretType.FileBase64;
     } else if (type === 'string') {
       newType = EnvironmentSecretType.String;
     }
 
+    let newVisibility = visibility ? parseVisibility(visibility) : undefined;
+
     if (!type && !value && !nonInteractive) {
-      newType = await promptVariableTypeAsync(nonInteractive);
+      newType = await promptVariableTypeAsync(nonInteractive, existingVariable?.type);
     }
 
     if (!newVisibility) {
-      newVisibility = await promptVariableVisibilityAsync(nonInteractive);
+      newVisibility = await promptVariableVisibilityAsync(
+        nonInteractive,
+        existingVariable?.visibility
+      );
+    }
+
+    // When a value is provided without an explicit --type, keep the existing variable's type so
+    // that updating a file variable does not silently convert it to a plain string.
+    if (value && !newType) {
+      newType = existingVariable?.type;
     }
 
     if (!value) {
       value = await promptVariableValueAsync({
         nonInteractive,
         hidden: newVisibility !== EnvironmentVariableVisibility.Public,
-        filePath: newType === EnvironmentSecretType.FileBase64,
+        filePath: (newType ?? existingVariable?.type) === EnvironmentSecretType.FileBase64,
       });
-    }
-
-    let environmentFilePath: string | undefined;
-    let fileName: string | undefined;
-
-    if (newType === EnvironmentSecretType.FileBase64) {
-      environmentFilePath = path.resolve(value);
-      if (!(await fs.pathExists(environmentFilePath))) {
-        throw new Error(`File "${value}" does not exist`);
-      }
-      fileName = path.basename(environmentFilePath);
-    }
-
-    value = environmentFilePath ? await fs.readFile(environmentFilePath, 'base64') : value;
-
-    let newEnvironments = environments ?? (environment ? [environment] : undefined);
-
-    if (!newEnvironments) {
-      newEnvironments = await promptVariableEnvironmentAsync({
-        nonInteractive,
-        multiple: true,
-        canEnterCustomEnvironment: true,
-        graphqlClient,
-        projectId,
-      });
-
-      if (!newEnvironments || newEnvironments.length === 0) {
-        throw new Error('No environments selected');
-      }
     }
 
     newVisibility = newVisibility ?? EnvironmentVariableVisibility.Public;
 
+    let fileName: string | undefined;
+    if (newType === EnvironmentSecretType.FileBase64) {
+      const environmentFilePath = path.resolve(value);
+      if (!(await fs.pathExists(environmentFilePath))) {
+        if (type === 'file') {
+          throw new Error(`File "${value}" does not exist`);
+        }
+        throw new Error(
+          `Variable "${name}" is a file type, but "${value}" does not exist as a file. If you want to convert it to a string, pass --type string.`
+        );
+      }
+      fileName = path.basename(environmentFilePath);
+      value = await fs.readFile(environmentFilePath, 'base64');
+    }
+
     return {
-      name,
       value,
-      environment: newEnvironments,
       visibility: newVisibility,
-      'non-interactive': nonInteractive,
       type: newType,
       fileName,
-      ...rest,
     };
   }
 

--- a/packages/eas-cli/src/commands/env/set.ts
+++ b/packages/eas-cli/src/commands/env/set.ts
@@ -24,7 +24,6 @@ import {
   getDisplayNameForProjectIdAsync,
   getOwnerAccountForProjectIdAsync,
 } from '../../project/projectUtils';
-import { confirmAsync } from '../../prompts';
 import {
   parseVisibility,
   promptVariableEnvironmentAsync,
@@ -34,10 +33,9 @@ import {
   promptVariableVisibilityAsync,
 } from '../../utils/prompts';
 
-interface RawCreateFlags {
+interface RawSetFlags {
   name?: string;
   value?: string;
-  force?: boolean;
   type?: 'string' | 'file';
   visibility?: 'plaintext' | 'sensitive' | 'secret';
   scope: EASEnvironmentVariableScopeFlagValue;
@@ -45,10 +43,9 @@ interface RawCreateFlags {
   'non-interactive': boolean;
 }
 
-interface CreateFlags {
+interface SetFlags {
   name?: string;
   value?: string;
-  force?: boolean;
   type?: 'string' | 'file';
   visibility?: 'plaintext' | 'sensitive' | 'secret';
   scope: EnvironmentVariableScope;
@@ -56,14 +53,14 @@ interface CreateFlags {
   'non-interactive': boolean;
 }
 
-export default class EnvCreate extends EasCommand {
+export default class EnvSet extends EasCommand {
   static override description =
-    'create an environment variable for the current project or account (deprecated, use eas env:set)';
+    'set (create or update) an environment variable on the current project or account';
 
   static override args = {
     environment: Args.string({
       description:
-        "Environment to create the variable in. Default environments are 'production', 'preview', and 'development'.",
+        "Environment to set the variable in. Default environments are 'production', 'preview', and 'development'.",
       required: false,
     }),
   };
@@ -74,10 +71,6 @@ export default class EnvCreate extends EasCommand {
     }),
     value: Flags.string({
       description: 'Text value or the variable',
-    }),
-    force: Flags.boolean({
-      description: 'Overwrite existing variable',
-      default: false,
     }),
     type: Flags.option({
       description: 'The type of variable',
@@ -96,17 +89,14 @@ export default class EnvCreate extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
-    Log.warn('This command is deprecated. Use eas env:set instead.');
-    Log.newLine();
-
-    const { args, flags } = await this.parse(EnvCreate);
+    const { args, flags } = await this.parse(EnvSet);
 
     const validatedFlags = this.sanitizeFlags(flags);
 
     const {
       projectId,
       loggedIn: { graphqlClient },
-    } = await this.getContextAsync(EnvCreate, {
+    } = await this.getContextAsync(EnvSet, {
       nonInteractive: validatedFlags['non-interactive'],
     });
 
@@ -114,10 +104,8 @@ export default class EnvCreate extends EasCommand {
       name,
       value,
       scope,
-      'non-interactive': nonInteractive,
       environment: environments,
       visibility,
-      force,
       type,
       fileName,
     } = await this.promptForMissingFlagsAsync(validatedFlags, args, {
@@ -130,8 +118,6 @@ export default class EnvCreate extends EasCommand {
       getOwnerAccountForProjectIdAsync(graphqlClient, projectId),
     ]);
 
-    let overwrite = false;
-
     if (scope === EnvironmentVariableScope.Project) {
       const existingVariables = await EnvironmentVariablesQuery.byAppIdAsync(graphqlClient, {
         appId: projectId,
@@ -139,53 +125,44 @@ export default class EnvCreate extends EasCommand {
       });
 
       const existingVariable = existingVariables.find(
-        variable => !environments || variable.environments?.some(env => environments?.includes(env))
+        variable =>
+          variable.scope === EnvironmentVariableScope.Project &&
+          (!environments || variable.environments?.some(env => environments?.includes(env)))
       );
 
-      if (existingVariable) {
-        if (existingVariable.scope === EnvironmentVariableScope.Project) {
-          await this.promptForOverwriteAsync({
-            nonInteractive,
-            force,
-            message: `Variable ${name} already exists on this project.`,
-            suggestion: 'Do you want to overwrite it?',
-          });
-          overwrite = true;
-        }
-      }
-
-      const variable =
-        overwrite && existingVariable
-          ? await EnvironmentVariableMutation.updateAsync(graphqlClient, {
-              id: existingVariable.id,
+      const variable = existingVariable
+        ? await EnvironmentVariableMutation.updateAsync(graphqlClient, {
+            id: existingVariable.id,
+            name,
+            value,
+            visibility,
+            environments,
+            type,
+            fileName,
+          })
+        : await EnvironmentVariableMutation.createForAppAsync(
+            graphqlClient,
+            {
               name,
               value,
-              visibility,
               environments,
-              type,
+              visibility,
+              type: type ?? EnvironmentSecretType.String,
               fileName,
-            })
-          : await EnvironmentVariableMutation.createForAppAsync(
-              graphqlClient,
-              {
-                name,
-                value,
-                environments,
-                visibility,
-                type: type ?? EnvironmentSecretType.String,
-                fileName,
-              },
-              projectId
-            );
+            },
+            projectId
+          );
 
       if (!variable) {
         throw new Error(
-          `Could not create variable with name ${name} on project ${projectDisplayName}`
+          `Could not set variable with name ${name} on project ${projectDisplayName}`
         );
       }
 
       Log.withTick(
-        `Created a new variable ${chalk.bold(name)} on project ${chalk.bold(projectDisplayName)}.`
+        `${existingVariable ? 'Updated' : 'Created'} variable ${chalk.bold(name)} on project ${chalk.bold(
+          projectDisplayName
+        )}.`
       );
     } else if (scope === EnvironmentVariableScope.Shared) {
       const existingVariables = await EnvironmentVariablesQuery.sharedAsync(graphqlClient, {
@@ -197,73 +174,36 @@ export default class EnvCreate extends EasCommand {
         variable => !environments || variable.environments?.some(env => environments?.includes(env))
       );
 
-      if (existingVariable) {
-        if (force) {
-          overwrite = true;
-        } else {
-          throw new Error(
-            `Account-wide variable with ${name} name already exists on this account.\n` +
-              `Use a different name or delete the existing variable on website or by using the "eas env:delete --name ${name} --scope account" command.`
-          );
-        }
-      }
-
-      const variable =
-        overwrite && existingVariable
-          ? await EnvironmentVariableMutation.updateAsync(graphqlClient, {
-              id: existingVariable.id,
+      const variable = existingVariable
+        ? await EnvironmentVariableMutation.updateAsync(graphqlClient, {
+            id: existingVariable.id,
+            name,
+            value,
+            visibility,
+            environments,
+            type,
+          })
+        : await EnvironmentVariableMutation.createSharedVariableAsync(
+            graphqlClient,
+            {
               name,
               value,
               visibility,
               environments,
-              type,
-            })
-          : await EnvironmentVariableMutation.createSharedVariableAsync(
-              graphqlClient,
-              {
-                name,
-                value,
-                visibility,
-                environments,
-                type: type ?? EnvironmentSecretType.String,
-              },
-              ownerAccount.id
-            );
+              type: type ?? EnvironmentSecretType.String,
+            },
+            ownerAccount.id
+          );
 
       if (!variable) {
-        throw new Error(
-          `Could not create variable with name ${name} on account ${ownerAccount.name}`
-        );
+        throw new Error(`Could not set variable with name ${name} on account ${ownerAccount.name}`);
       }
 
       Log.withTick(
-        `Created a new variable ${chalk.bold(name)} on account ${chalk.bold(ownerAccount.name)}.`
+        `${existingVariable ? 'Updated' : 'Created'} variable ${chalk.bold(name)} on account ${chalk.bold(
+          ownerAccount.name
+        )}.`
       );
-    }
-  }
-
-  private async promptForOverwriteAsync({
-    nonInteractive,
-    force,
-    message,
-    suggestion,
-  }: {
-    nonInteractive: boolean;
-    force: boolean;
-    message: string;
-    suggestion: string;
-  }): Promise<void> {
-    if (!nonInteractive) {
-      const confirmation = await confirmAsync({
-        message: `${message} ${suggestion}`,
-      });
-
-      if (!confirmation) {
-        Log.log('Aborting');
-        throw new Error(`${message}`);
-      }
-    } else if (!force) {
-      throw new Error(`${message} Use --force to overwrite it.`);
     }
   }
 
@@ -276,12 +216,12 @@ export default class EnvCreate extends EasCommand {
       'non-interactive': nonInteractive,
       type,
       ...rest
-    }: CreateFlags,
+    }: SetFlags,
     { environment }: { environment?: string },
     { graphqlClient, projectId }: { graphqlClient: ExpoGraphqlClient; projectId: string }
   ): Promise<
     Required<
-      Omit<CreateFlags, 'type' | 'visibility'> & {
+      Omit<SetFlags, 'type' | 'visibility'> & {
         type: EnvironmentSecretType | undefined;
         visibility: EnvironmentVariableVisibility;
       }
@@ -352,7 +292,6 @@ export default class EnvCreate extends EasCommand {
       value,
       environment: newEnvironments,
       visibility: newVisibility,
-      force: rest.force ?? false,
       'non-interactive': nonInteractive,
       type: newType,
       fileName,
@@ -360,7 +299,7 @@ export default class EnvCreate extends EasCommand {
     };
   }
 
-  private sanitizeFlags(flags: RawCreateFlags): CreateFlags {
+  private sanitizeFlags(flags: RawSetFlags): SetFlags {
     return {
       ...flags,
       scope:

--- a/packages/eas-cli/src/commands/env/update.ts
+++ b/packages/eas-cli/src/commands/env/update.ts
@@ -63,7 +63,8 @@ interface UpdateFlags {
 }
 
 export default class EnvUpdate extends EasCommand {
-  static override description = 'update an environment variable on the current project or account';
+  static override description =
+    'update an environment variable on the current project or account (deprecated, use eas env:set)';
 
   static override flags = {
     'variable-name': Flags.string({
@@ -104,6 +105,9 @@ export default class EnvUpdate extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
+    Log.warn('This command is deprecated. Use eas env:set instead.');
+    Log.newLine();
+
     const { args, flags } = await this.parse(EnvUpdate);
     const {
       name,


### PR DESCRIPTION
# Why

`eas env:create` and `eas env:update` force users to know up front whether a variable already exists, and the two commands use inconsistent flags (`--name` means the identifier in `create` but the rename target in `update`). This is janky. A single `eas env:set` that figures out create-vs-update is a much simpler mental model and mirrors the `eas env:get` / `env:set` verb pair (and `gh secret set` / `gh variable set`).

Closes ENG-15351.

# How

- Added `eas env:set`, which looks the variable up by name + scope + environment and **updates it if it exists, creates it if it doesn't** (idempotent upsert). No `--force`, no "already exists" error, no overwrite prompt. It logs `Created`/`Updated` so the outcome is clear.
- Kept the existing flag model for now (`--name` + positional environment) so `env:set` is consistent with the rest of the `env` command family. A `gh`-style positional-name overhaul across `get`/`set`/`delete` is a deliberate follow-up.
- Rename stays out of `set` (it isn't a "set" operation); it remains available on the deprecated `env:update`.
- Deprecated `eas env:create` and `eas env:update`: both now print a deprecation notice pointing to `env:set` and say so in their descriptions, but keep their exact existing behavior/flags (incl. `--force`, `--variable-name`, rename) for backwards compatibility. They are intentionally **not** oclif aliases of `set`, because their flag surfaces are incompatible and a pure alias would break existing usage.

Follow-ups (not in this PR): documenting `env:set` on the docs site, the eventual removal of `create`/`update` after a deprecation window, and the positional-name overhaul.

# Test Plan

- New `EnvSet.test.ts` covering create-when-absent, update-when-present without `--force` (project + account scope), the positional `environment` argument, and prompting for missing flags.
- Existing `EnvCreate` / `EnvUpdate` tests still pass with the added deprecation warning.
- `yarn test` (env suite) 24/24, `yarn typecheck` clean, `yarn lint` 0 errors, `yarn fmt:check` clean.
- Smoke-tested `./packages/eas-cli/bin/run env:set --help`.
