### PR TITLE
[worker] Increase Node heap on capable workers

### DIFF
--- a/packages/worker/src/__unit__/env.test.ts
+++ b/packages/worker/src/__unit__/env.test.ts
@@ -1,9 +1,10 @@
 import { RuntimeSettings } from '@expo/build-tools';
 import { Platform, Workflow } from '@expo/eas-build-job';
 import os from 'os';
+import v8 from 'v8';
 
 import config from '../config';
-import { getBuildEnv, getGradleMemoryOptions } from '../env';
+import { getBuildEnv, getGradleMemoryOptions, getNodeMemoryOptions } from '../env';
 
 describe(getBuildEnv.name, () => {
   const originalSentryDsn = config.sentry.dsn;
@@ -19,6 +20,7 @@ describe(getBuildEnv.name, () => {
     EAS_BUILD_MAVEN_CACHE_URL: process.env.EAS_BUILD_MAVEN_CACHE_URL,
     EAS_BUILD_COCOAPODS_CACHE_URL: process.env.EAS_BUILD_COCOAPODS_CACHE_URL,
     NPM_CONFIG_REGISTRY: process.env.NPM_CONFIG_REGISTRY,
+    NODE_OPTIONS: process.env.NODE_OPTIONS,
   };
 
   beforeEach(() => {
@@ -28,6 +30,7 @@ describe(getBuildEnv.name, () => {
     delete process.env.EAS_BUILD_MAVEN_CACHE_URL;
     delete process.env.EAS_BUILD_COCOAPODS_CACHE_URL;
     delete process.env.NPM_CONFIG_REGISTRY;
+    delete process.env.NODE_OPTIONS;
     jest.spyOn(RuntimeSettings, 'getNpmCacheUrl').mockReturnValue(null);
     jest.spyOn(RuntimeSettings, 'getNodeJsCacheUrl').mockReturnValue(null);
     jest.spyOn(RuntimeSettings, 'getMavenCacheUrl').mockReturnValue(null);
@@ -47,6 +50,7 @@ describe(getBuildEnv.name, () => {
     restoreEnv('EAS_BUILD_MAVEN_CACHE_URL', originalCacheUrls.EAS_BUILD_MAVEN_CACHE_URL);
     restoreEnv('EAS_BUILD_COCOAPODS_CACHE_URL', originalCacheUrls.EAS_BUILD_COCOAPODS_CACHE_URL);
     restoreEnv('NPM_CONFIG_REGISTRY', originalCacheUrls.NPM_CONFIG_REGISTRY);
+    restoreEnv('NODE_OPTIONS', originalCacheUrls.NODE_OPTIONS);
     mockProcessPlatform(originalPlatform);
     jest.restoreAllMocks();
   });
@@ -298,6 +302,63 @@ describe(getBuildEnv.name, () => {
     expect(getGradleMemoryOptions()).toEqual({
       maxHeapSize: '1g',
     });
+  });
+
+  it('increases the Node.js heap limit on workers with enough memory', () => {
+    jest.spyOn(process, 'constrainedMemory').mockReturnValue(6 * 1024 ** 3);
+    jest.spyOn(v8, 'getHeapStatistics').mockReturnValue({
+      heap_size_limit: 2 * 1024 ** 3,
+    } as ReturnType<typeof v8.getHeapStatistics>);
+
+    expect(getNodeMemoryOptions()).toBe('--max-old-space-size=3072');
+  });
+
+  it('does not increase the Node.js heap limit on workers with less than 6 GiB of memory', () => {
+    jest.spyOn(process, 'constrainedMemory').mockReturnValue(6 * 1024 ** 3 - 1);
+    jest.spyOn(v8, 'getHeapStatistics').mockReturnValue({
+      heap_size_limit: 2 * 1024 ** 3,
+    } as ReturnType<typeof v8.getHeapStatistics>);
+
+    expect(getNodeMemoryOptions()).toBeUndefined();
+  });
+
+  it('does not increase an existing Node.js heap limit of at least 3 GiB', () => {
+    jest.spyOn(process, 'constrainedMemory').mockReturnValue(6 * 1024 ** 3);
+    jest.spyOn(v8, 'getHeapStatistics').mockReturnValue({
+      heap_size_limit: 3 * 1024 ** 3,
+    } as ReturnType<typeof v8.getHeapStatistics>);
+
+    expect(getNodeMemoryOptions()).toBeUndefined();
+  });
+
+  it('keeps Node.js options inherited from the worker environment in override position', () => {
+    process.env.NODE_OPTIONS = '--max-old-space-size=2048 --enable-source-maps';
+    jest.spyOn(process, 'constrainedMemory').mockReturnValue(6 * 1024 ** 3);
+    jest.spyOn(v8, 'getHeapStatistics').mockReturnValue({
+      heap_size_limit: 2 * 1024 ** 3,
+    } as ReturnType<typeof v8.getHeapStatistics>);
+
+    const env = getBuildEnv({
+      job: {
+        platform: Platform.ANDROID,
+        type: Workflow.MANAGED,
+        builderEnvironment: {
+          env: {},
+        },
+        username: 'expo-user',
+      } as any,
+      projectId: 'project-id',
+      metadata: {
+        buildProfile: 'production',
+        gitCommitHash: 'abc123',
+        username: 'expo-user',
+      } as any,
+      buildId: 'build-id',
+    });
+
+    expect(env.NODE_OPTIONS).toBe(
+      '--max-old-space-size=3072 --max-old-space-size=2048 --enable-source-maps'
+    );
   });
 });
 

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -4,11 +4,14 @@ import { spawnSync } from 'child_process';
 import micromatch from 'micromatch';
 import os from 'os';
 import path from 'path';
+import v8 from 'v8';
 
 import config from './config';
 import { Environment } from './constants';
 import { androidImagesWithJavaVersionLowerThen11 } from './external/turtle';
 import { getAccessedEnvs } from './utils/env';
+
+const GIB_IN_BYTES = 1024 ** 3;
 
 // keep in sync with local-build-plugin env vars
 // see packages/local-build-plugin/src/build.ts
@@ -49,6 +52,9 @@ export function getBuildEnv({
   setEnv(env, 'LANG', 'en_US.UTF-8');
   setEnv(env, 'EAS_BUILD_WORKINGDIR', path.join(config.workingdir, 'build'));
   setEnv(env, 'EAS_BUILD_PROJECT_ID', projectId);
+
+  // Keep inherited options last so they override singleton options supplied by the worker.
+  setEnv(env, 'NODE_OPTIONS', [getNodeMemoryOptions(), env.NODE_OPTIONS].filter(Boolean).join(' '));
 
   const runnerPlatform = job.platform;
   if (runnerPlatform === Platform.IOS) {
@@ -178,4 +184,18 @@ export function getGradleMemoryOptions() {
   return {
     maxHeapSize: `${Math.max(1, Math.round(totalMemoryGb / 4))}g`,
   };
+}
+
+export function getNodeMemoryOptions(): string | undefined {
+  // constrainedMemory() returns 0 when there is no container or process memory limit.
+  const memoryLimit = process.constrainedMemory() || os.totalmem();
+  const heapLimit = v8.getHeapStatistics().heap_size_limit;
+
+  // V8 defaults to a roughly 2 GiB heap on smaller workers. Raise the ceiling for build child
+  // processes only when the worker has enough memory and Node has not already selected a larger one.
+  if (memoryLimit < 6 * GIB_IN_BYTES || heapLimit >= 3 * GIB_IN_BYTES) {
+    return undefined;
+  }
+
+  return '--max-old-space-size=3072';
 }


### PR DESCRIPTION
## Summary

- set `NODE_OPTIONS=--max-old-space-size=3072` for build child processes when the worker has at least 6 GiB of constrained or physical memory and its effective V8 heap limit is below 3 GiB
- preserve existing worker `NODE_OPTIONS`; project-provided environment values retain their later override position
- leave workers with less memory or an existing heap limit of at least 3 GiB unchanged

## Why

V8 defaults to a roughly 2 GiB heap on our smaller build workers. Dependency installation and Expo export can exhaust that heap even though the VM still has enough memory. Raising the ceiling to 3 GiB gives those child processes additional headroom without preallocating memory or changing larger workers that already receive a higher V8 default.

## Validation

- `yarn build`
- `yarn workspace @expo/worker test:unit --runInBand src/__unit__/env.test.ts`
- `yarn workspace @expo/worker typecheck`
- focused Oxlint and Oxfmt checks