### PR TITLE
Restore automated BSL change date updates

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -7,9 +7,6 @@ on:
       - main
     paths:
       - .github/workflows/license.yml
-  pull_request:
-    paths:
-      - .github/workflows/license.yml
   workflow_dispatch:
 
 jobs:
@@ -20,10 +17,6 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.EXPO_BOT_PAT }}
-          ref: ${{ github.head_ref || github.ref_name }}
-      - name: Verify Expo Bot token can push
-        if: github.event_name == 'pull_request'
-        run: git push origin "HEAD:refs/heads/$GITHUB_HEAD_REF"
       - name: Check last commit date
         run: |
           # The date in the license

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -7,6 +7,9 @@ on:
       - main
     paths:
       - .github/workflows/license.yml
+  pull_request:
+    paths:
+      - .github/workflows/license.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -20,6 +20,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.EXPO_BOT_PAT }}
+          ref: ${{ github.head_ref || github.ref_name }}
+      - name: Verify Expo Bot token can push
+        if: github.event_name == 'pull_request'
+        run: git push origin "HEAD:refs/heads/$GITHUB_HEAD_REF"
       - name: Check last commit date
         run: |
           # The date in the license

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,37 @@
+name: License
+on:
+  schedule:
+    - cron: '0 0 1 1-12/3 *' # Run every three months
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/license.yml
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    name: Update BSL change date
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.EXPO_BOT_PAT }}
+      - name: Check last commit date
+        run: |
+          # The date in the license
+          change_date=$(sed --quiet --regexp-extended 's/^Change Date:\s+([0-9]{4}-[0-9]{2}-[0-9]{2})/\1/p' < LICENSE-BUSL)
+          [ -z "$change_date" ] && exit 1
+
+          new_change_date=$(date --date "+3 years" --iso-8601)
+
+          if [ "$(date --date "$new_change_date" +%s)" -gt "$(date --date "$change_date" +%s)" ]; then
+            sed --in-place "s/$change_date/$new_change_date/" LICENSE-BUSL
+            git config user.name 'Expo Bot'
+            git config user.email bot@expo.dev
+            git add LICENSE-BUSL
+            git commit -m "[license] Update BSL Change Date to $new_change_date"
+            if [ "$(git branch --show-current)" = main ]; then
+              git push
+            fi
+          fi


### PR DESCRIPTION
## Summary

- restore the quarterly Business Source License change-date workflow from `expo/eas-build`
- update `LICENSE-BUSL` instead of the former repository's root `LICENSE`
- run once when the workflow lands on `main`, then every three months

## Why

The EAS Build packages moved into this repository, but their scheduled BSL change-date automation was not moved with them. As a result, `LICENSE-BUSL` still has the last date written by the archived repository.

After this workflow lands on `main`, its path-based push trigger will advance the stale change date and future scheduled runs will keep it three years ahead.

The workflow deliberately does not run on pull requests because it uses the write-capable `EXPO_BOT_PAT`. Existing production evidence confirms that token can update the protected default branch: [`Release workflow` run 29394979387](https://github.com/expo/eas-cli/actions/runs/29394979387) successfully pushed `main -> main` on July 15, 2026 using the same repository secret.

## Validation

- `actionlint .github/workflows/license.yml`
- YAML parse check
- embedded Bash syntax check
- `git diff --check`