### PR TITLE
[build-tools] Remove serve-sim stream URL output

### DIFF
--- a/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
@@ -29,19 +29,18 @@ export function createStartServeSimRemoteSessionBuildFunction(
 
       await selectXcodeDeveloperDirectoryAsync({ env, logger });
 
-      const { previewUrl, streamUrl } = await startServeSimWithTunnelAsync(ctx, {
+      const { previewUrl } = await startServeSimWithTunnelAsync(ctx, {
         baseDomain: ngrokTunnelDomain,
         env,
         logger,
         timeoutMs: STARTUP_TIMEOUT_MS,
       });
       logger.info(`Preview URL: ${previewUrl}`);
-      logger.info(`Stream URL: ${streamUrl}`);
 
       await uploadRemoteSessionConfigAsync({
         ctx,
         deviceRunSessionId,
-        remoteConfig: { previewUrl, streamUrl },
+        remoteConfig: { previewUrl },
         logger,
       });
 

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -343,7 +343,7 @@ export async function startServeSimWithTunnelAsync(
     logger: bunyan;
     timeoutMs: number;
   }
-): Promise<{ previewUrl: string; streamUrl: string }> {
+): Promise<{ previewUrl: string }> {
   logger.info('Launching serve-sim with tunnel.');
   const turnArgs = await fetchServeSimTurnArgsAsync(ctx, { env, logger });
   const serveSim = spawnDetached({
@@ -366,33 +366,30 @@ export async function startServeSimWithTunnelAsync(
     env,
   });
 
-  logger.info('Waiting for serve-sim to report tunnel and stream URLs.');
+  logger.info('Waiting for serve-sim to report tunnel URL.');
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const output = serveSim.getOutput();
-    const previewUrl = matchLabeledUrl({ output, label: 'Tunnel', baseDomain });
-    const streamUrl = matchLabeledUrl({ output, label: 'Stream', baseDomain });
-    if (previewUrl && streamUrl) {
-      return { previewUrl, streamUrl };
+    const previewUrl = matchTunnelUrl({ output, baseDomain });
+    if (previewUrl) {
+      return { previewUrl };
     }
     await sleepAsync(1_000);
   }
   throw new SystemError(
-    `Timed out waiting for serve-sim to report Tunnel and Stream URLs. Last output:\n${serveSim.getOutput() || '<empty>'}`
+    `Timed out waiting for serve-sim to report Tunnel URL. Last output:\n${serveSim.getOutput() || '<empty>'}`
   );
 }
 
-function matchLabeledUrl({
+function matchTunnelUrl({
   output,
-  label,
   baseDomain,
 }: {
   output: string;
-  label: string;
   baseDomain: string;
 }): string | null {
   const labelPattern = new RegExp(
-    `${label}:\\s*(https:\\/\\/[a-z0-9-]+\\.${escapeRegExp(baseDomain)})`
+    `Tunnel:\\s*(https:\\/\\/[a-z0-9-]+\\.${escapeRegExp(baseDomain)})`
   );
   const match = labelPattern.exec(output);
   return match ? match[1] : null;

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -67765,16 +67765,12 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use previewUrl instead."
           }
         ],
         "inputFields": null,

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -9560,7 +9560,8 @@ export type SentryProjectMutationDeleteSentryProjectArgs = {
 export type ServeSimRunSessionRemoteConfig = {
   __typename?: 'ServeSimRunSessionRemoteConfig';
   previewUrl: Scalars['String']['output'];
-  streamUrl: Scalars['String']['output'];
+  /** @deprecated Use previewUrl instead. */
+  streamUrl?: Maybe<Scalars['String']['output']>;
 };
 
 export type SetupConvexProjectInput = {
@@ -14374,7 +14375,7 @@ export type DeviceRunSessionByIdQueryVariables = Exact<{
 export type DeviceRunSessionByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, type: DeviceRunSessionType, platform: AppPlatform, createdAt: any, startedAt?: any | null, finishedAt?: any | null, updatedAt: any, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, artifacts: Array<{ __typename?: 'DeviceRunSessionArtifact', id: string, name: string, filename: string, downloadUrl: string, fileSizeBytes?: number | null, metadata?: any | null, createdAt: any, updatedAt: any }>, remoteConfig?:
         | { __typename: 'AgentDeviceRunSessionRemoteConfig', agentDeviceRemoteSessionUrl: string, agentDeviceRemoteSessionToken: string, webPreviewUrl?: string | null }
         | { __typename: 'ArgentRunSessionRemoteConfig', toolsUrl: string, toolsAuthToken?: string | null, webPreviewUrl?: string | null }
-        | { __typename: 'ServeSimRunSessionRemoteConfig', previewUrl: string, streamUrl: string }
+        | { __typename: 'ServeSimRunSessionRemoteConfig', previewUrl: string }
        | null, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } } };
 
 export type DeviceRunSessionsByAppIdQueryVariables = Exact<{

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
@@ -62,7 +62,6 @@ export const DeviceRunSessionQuery = {
                     }
                     ... on ServeSimRunSessionRemoteConfig {
                       previewUrl
-                      streamUrl
                     }
                   }
                   turtleJobRun {


### PR DESCRIPTION
I found it sometimes isn't printed.

---

## Summary

- Stop waiting for `serve-sim` to emit a `Stream:` URL before reporting startup success.
- Upload only `previewUrl` in the serve-sim remote config payload.
- Remove `streamUrl` from the simulator session query selection and generated query result type.
- Simplify the serve-sim URL parser to match only the tunnel URL.

## Why

The stream URL is no longer part of the expected serve-sim output path. Keeping it in the startup contract made the build step wait for and upload a value that is not needed by the CLI display flow.

## Test plan

- `yarn --cwd packages/build-tools typecheck`
- `yarn --cwd packages/eas-cli typecheck`
- `yarn --cwd packages/build-tools jest-unit src/steps/utils/__tests__/remoteDeviceRunSession.test.ts`
- `yarn --cwd packages/eas-cli test src/commands/simulator/__tests__/get.test.ts src/commands/simulator/__tests__/start.test.ts --runInBand`
- `git diff --check`