### PR TITLE
[build-tools] Improve simulator recording finalization diagnostics

### DIFF
--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/RecordingModels.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/RecordingModels.swift
@@ -59,6 +59,11 @@ public struct FirstFrameWallClock: Codable, Sendable {
     public let iso8601: String
 }
 
+public enum RecordingFinalizationStage: Sendable {
+    case captureStopped
+    case videoSaved
+}
+
 public struct RecordingManifest: Codable, Sendable {
     public let firstFrameWallClock: FirstFrameWallClock
     public let width: Int

--- a/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
+++ b/packages/build-tools/resources/record-sim/Sources/RecordSim/SimulatorRecorder.swift
@@ -7,6 +7,7 @@ import UniformTypeIdentifiers
 public final class SimulatorRecorder {
     public var onSegment: ((SegmentOutput) -> Void)?
     public var onSimulatorStopped: ((String) -> Void)?
+    public var onFinalizationStage: ((RecordingFinalizationStage) -> Void)?
 
     private static let callbackStalenessTimeout: TimeInterval = 5
     private static let firstFrameRewireInterval: TimeInterval = 1
@@ -115,6 +116,7 @@ public final class SimulatorRecorder {
             displaySource?.stop()
             displaySource = nil
         }
+        onFinalizationStage?(.captureStopped)
 
         return try writerQueue.sync {
             if let firstError {
@@ -141,6 +143,7 @@ public final class SimulatorRecorder {
             if let error = outputWriter.error {
                 throw error
             }
+            onFinalizationStage?(.videoSaved)
             guard let firstAcceptedWallClock else {
                 throw RecorderError.make(25, "Missing first frame wall-clock timestamp")
             }

--- a/packages/build-tools/resources/record-sim/Sources/record-sim/main.swift
+++ b/packages/build-tools/resources/record-sim/Sources/record-sim/main.swift
@@ -10,15 +10,15 @@ struct CLIOptions {
     var codec: RecorderCodec = .h264
 }
 
-private var stopRequested: CInt = 0
+private var requestedStopSignal: CInt = 0
 private var simulatorStopped: CInt = 0
 
-private func handleStopSignal(_: CInt) {
-    stopRequested = 1
+private func handleStopSignal(_ signal: CInt) {
+    requestedStopSignal = signal
 }
 
 private func isStopRequested() -> Bool {
-    stopRequested != 0 || simulatorStopped != 0
+    requestedStopSignal != 0 || simulatorStopped != 0
 }
 
 func usage() -> String {
@@ -112,6 +112,14 @@ do {
         simulatorStopped = 1
         fputs("[record-sim] simulator stopped state=\(state); finalizing recording\n", stderr)
     }
+    recorder.onFinalizationStage = { stage in
+        switch stage {
+        case .captureStopped:
+            fputs("[record-sim] screen capture stopped; saving final video\n", stderr)
+        case .videoSaved:
+            fputs("[record-sim] final video saved; writing recording details\n", stderr)
+        }
+    }
     recorder.onSegment = { segment in
         switch segment.kind {
         case .initialization:
@@ -130,6 +138,14 @@ do {
         Thread.sleep(forTimeInterval: 0.1)
     }
 
+    if requestedStopSignal != 0 {
+        let signalName = switch requestedStopSignal {
+        case SIGINT: "SIGINT"
+        case SIGTERM: "SIGTERM"
+        default: "signal \(requestedStopSignal)"
+        }
+        fputs("[record-sim] received \(signalName); finishing recording\n", stderr)
+    }
     let manifest = try recorder.stop()
     if let recording = manifest.recording {
         fputs("[record-sim] done recording=\(recording)\n", stderr)

--- a/packages/build-tools/src/steps/utils/IosSimulatorRecordingUtils.ts
+++ b/packages/build-tools/src/steps/utils/IosSimulatorRecordingUtils.ts
@@ -12,7 +12,7 @@ import { Sentry } from '../../sentry';
 import { IosSimulatorUtils, type IosSimulatorUuid } from '../../utils/IosSimulatorUtils';
 
 const IOS_SIMULATOR_RECORDING_POLL_INTERVAL_MS = 2_000;
-const RECORD_SIM_FINISH_TIMEOUT_MS = 30_000;
+const RECORD_SIM_FINISH_TIMEOUT_MS = 70_000;
 const RECORD_SIM_FORCE_STOP_TIMEOUT_MS = 5_000;
 const RECORD_SIM_MAX_ATTEMPTS_PER_BOOT = 3;
 const RECORD_SIM_COMMAND = 'record-sim';
@@ -114,7 +114,15 @@ export namespace IosSimulatorRecordingUtils {
           return;
         }
 
-        logger.warn(`Forcing iOS Simulator recording process for ${recording.deviceName} to stop.`);
+        const recordSimOutput = recording.getOutput().trim();
+        logger.warn(
+          { recordSimOutput },
+          `Screen recording for ${recording.deviceName} did not finish within 70 seconds and will be stopped.${
+            recordSimOutput
+              ? `\nRecent recorder messages:\n${recordSimOutput}`
+              : '\nNo recorder messages were captured.'
+          }`
+        );
         recording.recordingProcess.kill('SIGKILL');
         const killed = await Promise.race([
           recording.completionPromise.then(() => true),

--- a/packages/build-tools/src/steps/utils/IosSimulatorRecordingUtils.ts
+++ b/packages/build-tools/src/steps/utils/IosSimulatorRecordingUtils.ts
@@ -115,9 +115,10 @@ export namespace IosSimulatorRecordingUtils {
         }
 
         const recordSimOutput = recording.getOutput().trim();
+        const finishTimeoutSeconds = Math.round(RECORD_SIM_FINISH_TIMEOUT_MS / 1_000);
         logger.warn(
           { recordSimOutput },
-          `Screen recording for ${recording.deviceName} did not finish within 70 seconds and will be stopped.${
+          `Screen recording for ${recording.deviceName} did not finish within ${finishTimeoutSeconds} seconds and will be stopped.${
             recordSimOutput
               ? `\nRecent recorder messages:\n${recordSimOutput}`
               : '\nNo recorder messages were captured.'


### PR DESCRIPTION
## Summary

- increase the graceful `record-sim` shutdown timeout from 30 to 70 seconds
- record readable finalization milestones after a termination signal
- include the recorder's recent stdout/stderr when build-tools must force-stop it

## Why

A production device run session finalized two simulator recordings concurrently. One recording completed normally, while the other was force-killed after exactly 30 seconds and was therefore unable to write its manifest or upload its MP4.

The parent timeout was shorter than the recorder's own valid finalization window: `record-sim` can spend up to 5 seconds appending its final frame and up to 60 seconds waiting for `AVAssetWriter.finishWriting()`. Killing it after 30 seconds could therefore interrupt legitimate finalization.

The existing logs also could not distinguish between a process that failed to observe `SIGINT` and one that observed it but stalled later. The new milestones identify whether the recorder:

1. observed the termination signal,
2. stopped screen capture and began saving the video,
3. saved the video and began writing recording details.

These messages stay buffered during successful recordings. They are added to the user-visible forced-stop warning only when finalization exceeds 70 seconds, keeping normal job logs concise while making failures diagnosable.

## Validation

- built the release `record-sim` executable
- ran the build-tools TypeScript typecheck
- ran all 88 build-tools unit test suites (831 tests)