### PR TITLE
[build-tools] Use unique simulator recording artifact names

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
@@ -70,6 +70,7 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
         expect.objectContaining({
           name: 'iPhone 16 screen recording (01234567-…, started at Jul 10, 2026, 10:00:00.000 UTC)',
           metadata: {
+            __eas_type: 'screen-recording',
             __eas_screen_recording: '1',
             udid: SIMULATOR_UDID,
             deviceName: 'iPhone 16',

--- a/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
@@ -68,7 +68,7 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
       expect(uploadDeviceRunSessionArtifactAsync).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          name: 'iPhone 16 screen recording (simulator 01234567, started at Jul 10, 2026, 10:00:00.000 UTC)',
+          name: 'iPhone 16 screen recording (01234567-…, started at Jul 10, 2026, 10:00:00.000 UTC)',
           metadata: {
             __eas_screen_recording: '1',
             udid: SIMULATOR_UDID,
@@ -130,9 +130,9 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
         .mock.calls.map(([, options]) => options.name);
       expect(names).toEqual(
         expect.arrayContaining([
-          'iPhone 16 screen recording (simulator 01234567, started at Jul 10, 2026, 10:00:00.000 UTC)',
-          'iPhone 16 screen recording (simulator 01234567, started at Jul 10, 2026, 10:05:00.000 UTC)',
-          'iPhone 16 screen recording (simulator FEDCBA98, started at Jul 10, 2026, 10:00:00.000 UTC)',
+          'iPhone 16 screen recording (01234567-…, started at Jul 10, 2026, 10:00:00.000 UTC)',
+          'iPhone 16 screen recording (01234567-…, started at Jul 10, 2026, 10:05:00.000 UTC)',
+          'iPhone 16 screen recording (FEDCBA98-…, started at Jul 10, 2026, 10:00:00.000 UTC)',
         ])
       );
       expect(new Set(names).size).toBe(3);

--- a/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
@@ -65,7 +65,7 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
       expect(uploadDeviceRunSessionArtifactAsync).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          name: 'iPhone 16 screen recording (started at 2026-07-10T10:00:00.000Z)',
+          name: 'iPhone 16 screen recording (started at Jul 10, 2026, 10:00:00.000 UTC)',
           metadata: {
             __eas_screen_recording: '1',
             udid: 'simulator-udid',
@@ -125,8 +125,8 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
         .mock.calls.map(([, options]) => options.name);
       expect(names).toEqual(
         expect.arrayContaining([
-          'iPhone 16 screen recording (started at 2026-07-10T10:00:00.000Z)',
-          'iPhone 16 screen recording (started at 2026-07-10T10:05:00.000Z)',
+          'iPhone 16 screen recording (started at Jul 10, 2026, 10:00:00.000 UTC)',
+          'iPhone 16 screen recording (started at Jul 10, 2026, 10:05:00.000 UTC)',
         ])
       );
       expect(new Set(names).size).toBe(2);

--- a/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
@@ -65,7 +65,7 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
       expect(uploadDeviceRunSessionArtifactAsync).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          name: 'iPhone 16 screen recording (started at Jul 10, 2026, 10:00:00.000 UTC)',
+          name: 'iPhone 16 screen recording (UDID simulator-udid, started at Jul 10, 2026, 10:00:00.000 UTC)',
           metadata: {
             __eas_screen_recording: '1',
             udid: 'simulator-udid',
@@ -82,22 +82,24 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
     }
   });
 
-  it('uses unique names for recordings from the same simulator', async () => {
+  it('uses unique names for recordings from rebooted and same-model simulators', async () => {
     const recordingDirectories = await Promise.all(
-      ['2026-07-10T10:00:00.000Z', '2026-07-10T10:05:00.000Z'].map(async firstFrameAt => {
-        const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'ios-recording-test-'));
-        await fs.writeFile(path.join(directory, 'recording.mp4'), 'recording');
-        await fs.writeFile(
-          path.join(directory, 'session.json'),
-          JSON.stringify({
-            recording: 'recording.mp4',
-            firstFrameWallClock: { iso8601: firstFrameAt },
-            width: 1179,
-            height: 2556,
-          })
-        );
-        return directory;
-      })
+      ['2026-07-10T10:00:00.000Z', '2026-07-10T10:05:00.000Z', '2026-07-10T10:00:00.000Z'].map(
+        async firstFrameAt => {
+          const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'ios-recording-test-'));
+          await fs.writeFile(path.join(directory, 'recording.mp4'), 'recording');
+          await fs.writeFile(
+            path.join(directory, 'session.json'),
+            JSON.stringify({
+              recording: 'recording.mp4',
+              firstFrameWallClock: { iso8601: firstFrameAt },
+              width: 1179,
+              height: 2556,
+            })
+          );
+          return directory;
+        }
+      )
     );
 
     try {
@@ -109,8 +111,8 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
       ).createBuildStepFromFunctionCall(globalContext, {
         env: { DEVICE_RUN_SESSION_ID: 'device-run-session-id' },
         callInputs: {
-          recordings_json: recordingDirectories.map(directory => ({
-            udid: 'simulator-udid',
+          recordings_json: recordingDirectories.map((directory, index) => ({
+            udid: index === 2 ? 'second-simulator-udid' : 'simulator-udid',
             deviceName: 'iPhone 16',
             runtimeDisplayName: 'iOS 18.6',
             directory,
@@ -125,11 +127,12 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
         .mock.calls.map(([, options]) => options.name);
       expect(names).toEqual(
         expect.arrayContaining([
-          'iPhone 16 screen recording (started at Jul 10, 2026, 10:00:00.000 UTC)',
-          'iPhone 16 screen recording (started at Jul 10, 2026, 10:05:00.000 UTC)',
+          'iPhone 16 screen recording (UDID simulator-udid, started at Jul 10, 2026, 10:00:00.000 UTC)',
+          'iPhone 16 screen recording (UDID simulator-udid, started at Jul 10, 2026, 10:05:00.000 UTC)',
+          'iPhone 16 screen recording (UDID second-simulator-udid, started at Jul 10, 2026, 10:00:00.000 UTC)',
         ])
       );
-      expect(new Set(names).size).toBe(2);
+      expect(new Set(names).size).toBe(3);
     } finally {
       await Promise.all(
         recordingDirectories.map(directory => fs.rm(directory, { recursive: true, force: true }))

--- a/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
@@ -12,6 +12,9 @@ jest.mock('../../utils/deviceRunSessionArtifacts', () => ({
   uploadDeviceRunSessionArtifactAsync: jest.fn(),
 }));
 
+const SIMULATOR_UDID = '01234567-89AB-CDEF-0123-456789ABCDEF';
+const SECOND_SIMULATOR_UDID = 'FEDCBA98-7654-3210-FEDC-BA9876543210';
+
 describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
   beforeEach(() => {
     jest
@@ -51,7 +54,7 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
         callInputs: {
           recordings_json: [
             {
-              udid: 'simulator-udid',
+              udid: SIMULATOR_UDID,
               deviceName: 'iPhone 16',
               runtimeDisplayName: 'iOS 18.6',
               directory: recordingDirectory,
@@ -65,10 +68,10 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
       expect(uploadDeviceRunSessionArtifactAsync).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          name: 'iPhone 16 screen recording (UDID simulator-udid, started at Jul 10, 2026, 10:00:00.000 UTC)',
+          name: 'iPhone 16 screen recording (simulator 01234567, started at Jul 10, 2026, 10:00:00.000 UTC)',
           metadata: {
             __eas_screen_recording: '1',
-            udid: 'simulator-udid',
+            udid: SIMULATOR_UDID,
             deviceName: 'iPhone 16',
             runtimeDisplayName: 'iOS 18.6',
             firstFrameAt: '2026-07-10T10:00:00.000Z',
@@ -112,7 +115,7 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
         env: { DEVICE_RUN_SESSION_ID: 'device-run-session-id' },
         callInputs: {
           recordings_json: recordingDirectories.map((directory, index) => ({
-            udid: index === 2 ? 'second-simulator-udid' : 'simulator-udid',
+            udid: index === 2 ? SECOND_SIMULATOR_UDID : SIMULATOR_UDID,
             deviceName: 'iPhone 16',
             runtimeDisplayName: 'iOS 18.6',
             directory,
@@ -127,9 +130,9 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
         .mock.calls.map(([, options]) => options.name);
       expect(names).toEqual(
         expect.arrayContaining([
-          'iPhone 16 screen recording (UDID simulator-udid, started at Jul 10, 2026, 10:00:00.000 UTC)',
-          'iPhone 16 screen recording (UDID simulator-udid, started at Jul 10, 2026, 10:05:00.000 UTC)',
-          'iPhone 16 screen recording (UDID second-simulator-udid, started at Jul 10, 2026, 10:00:00.000 UTC)',
+          'iPhone 16 screen recording (simulator 01234567, started at Jul 10, 2026, 10:00:00.000 UTC)',
+          'iPhone 16 screen recording (simulator 01234567, started at Jul 10, 2026, 10:05:00.000 UTC)',
+          'iPhone 16 screen recording (simulator FEDCBA98, started at Jul 10, 2026, 10:00:00.000 UTC)',
         ])
       );
       expect(new Set(names).size).toBe(3);

--- a/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
@@ -13,6 +13,19 @@ jest.mock('../../utils/deviceRunSessionArtifacts', () => ({
 }));
 
 describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
+  beforeEach(() => {
+    jest
+      .mocked(uploadDeviceRunSessionArtifactAsync)
+      .mockReset()
+      .mockImplementation(async (_ctx, { stream }) => {
+        await new Promise<void>((resolve, reject) => {
+          stream.once('end', resolve);
+          stream.once('error', reject);
+          stream.resume();
+        });
+      });
+  });
+
   it('uploads simulator device metadata', async () => {
     const recordingDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'ios-recording-test-'));
     const recordingPath = path.join(recordingDirectory, 'recording.mp4');
@@ -52,7 +65,7 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
       expect(uploadDeviceRunSessionArtifactAsync).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          name: 'iPhone 16 screen recording',
+          name: 'iPhone 16 screen recording (started at 2026-07-10T10:00:00.000Z)',
           metadata: {
             __eas_screen_recording: '1',
             udid: 'simulator-udid',
@@ -66,6 +79,61 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
       );
     } finally {
       await fs.rm(recordingDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it('uses unique names for recordings from the same simulator', async () => {
+    const recordingDirectories = await Promise.all(
+      ['2026-07-10T10:00:00.000Z', '2026-07-10T10:05:00.000Z'].map(async firstFrameAt => {
+        const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'ios-recording-test-'));
+        await fs.writeFile(path.join(directory, 'recording.mp4'), 'recording');
+        await fs.writeFile(
+          path.join(directory, 'session.json'),
+          JSON.stringify({
+            recording: 'recording.mp4',
+            firstFrameWallClock: { iso8601: firstFrameAt },
+            width: 1179,
+            height: 2556,
+          })
+        );
+        return directory;
+      })
+    );
+
+    try {
+      const globalContext = createGlobalContextMock({
+        runtimePlatform: BuildRuntimePlatform.DARWIN,
+      });
+      const buildStep = createUploadDeviceRunSessionScreenRecordingsBuildFunction(
+        {} as CustomBuildContext
+      ).createBuildStepFromFunctionCall(globalContext, {
+        env: { DEVICE_RUN_SESSION_ID: 'device-run-session-id' },
+        callInputs: {
+          recordings_json: recordingDirectories.map(directory => ({
+            udid: 'simulator-udid',
+            deviceName: 'iPhone 16',
+            runtimeDisplayName: 'iOS 18.6',
+            directory,
+          })),
+        },
+      });
+
+      await buildStep.executeAsync();
+
+      const names = jest
+        .mocked(uploadDeviceRunSessionArtifactAsync)
+        .mock.calls.map(([, options]) => options.name);
+      expect(names).toEqual(
+        expect.arrayContaining([
+          'iPhone 16 screen recording (started at 2026-07-10T10:00:00.000Z)',
+          'iPhone 16 screen recording (started at 2026-07-10T10:05:00.000Z)',
+        ])
+      );
+      expect(new Set(names).size).toBe(2);
+    } finally {
+      await Promise.all(
+        recordingDirectories.map(directory => fs.rm(directory, { recursive: true, force: true }))
+      );
     }
   });
 });

--- a/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
+++ b/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
@@ -90,7 +90,8 @@ export function createUploadDeviceRunSessionScreenRecordingsBuildFunction(
               const startedAt = recordingStartTimeFormatter.format(
                 new Date(metadata.firstFrameWallClock.iso8601)
               );
-              const displayName = `${recording.deviceName} screen recording (UDID ${recording.udid}, started at ${startedAt})`;
+              const shortUdid = recording.udid.slice(0, 8);
+              const displayName = `${recording.deviceName} screen recording (simulator ${shortUdid}, started at ${startedAt})`;
               const recordingPath = path.join(recording.directory, metadata.recording);
               const { size } = await stat(recordingPath);
               const recordingId = path.basename(recording.directory);

--- a/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
+++ b/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
@@ -70,11 +70,11 @@ export function createUploadDeviceRunSessionScreenRecordingsBuildFunction(
       await Promise.all(
         recordings.map(recording =>
           limit(async () => {
-            const displayName = `${recording.deviceName} screen recording`;
             try {
               const metadata = RecordingManifestSchema.parse(
                 JSON.parse(await readFile(path.join(recording.directory, 'session.json'), 'utf-8'))
               );
+              const displayName = `${recording.deviceName} screen recording (started at ${metadata.firstFrameWallClock.iso8601})`;
               const recordingPath = path.join(recording.directory, metadata.recording);
               const { size } = await stat(recordingPath);
               const recordingId = path.basename(recording.directory);

--- a/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
+++ b/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
@@ -90,8 +90,8 @@ export function createUploadDeviceRunSessionScreenRecordingsBuildFunction(
               const startedAt = recordingStartTimeFormatter.format(
                 new Date(metadata.firstFrameWallClock.iso8601)
               );
-              const shortUdid = recording.udid.slice(0, 8);
-              const displayName = `${recording.deviceName} screen recording (simulator ${shortUdid}, started at ${startedAt})`;
+              const shortUdid = `${recording.udid.slice(0, 8)}-…`;
+              const displayName = `${recording.deviceName} screen recording (${shortUdid}, started at ${startedAt})`;
               const recordingPath = path.join(recording.directory, metadata.recording);
               const { size } = await stat(recordingPath);
               const recordingId = path.basename(recording.directory);

--- a/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
+++ b/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
@@ -90,7 +90,7 @@ export function createUploadDeviceRunSessionScreenRecordingsBuildFunction(
               const startedAt = recordingStartTimeFormatter.format(
                 new Date(metadata.firstFrameWallClock.iso8601)
               );
-              const displayName = `${recording.deviceName} screen recording (started at ${startedAt})`;
+              const displayName = `${recording.deviceName} screen recording (UDID ${recording.udid}, started at ${startedAt})`;
               const recordingPath = path.join(recording.directory, metadata.recording);
               const { size } = await stat(recordingPath);
               const recordingId = path.basename(recording.directory);

--- a/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
+++ b/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
@@ -105,6 +105,7 @@ export function createUploadDeviceRunSessionScreenRecordingsBuildFunction(
                 filename: `${recordingId}.mp4`,
                 kind: 'screen-recording',
                 metadata: {
+                  __eas_type: 'screen-recording',
                   __eas_screen_recording: '1',
                   udid: recording.udid,
                   deviceName: recording.deviceName,

--- a/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
+++ b/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
@@ -35,6 +35,19 @@ const RecordingManifestSchema = z.object({
   recording: z.string(),
 });
 
+const recordingStartTimeFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  fractionalSecondDigits: 3,
+  hourCycle: 'h23',
+  timeZone: 'UTC',
+  timeZoneName: 'short',
+});
+
 export function createUploadDeviceRunSessionScreenRecordingsBuildFunction(
   ctx: CustomBuildContext
 ): BuildFunction {
@@ -74,7 +87,10 @@ export function createUploadDeviceRunSessionScreenRecordingsBuildFunction(
               const metadata = RecordingManifestSchema.parse(
                 JSON.parse(await readFile(path.join(recording.directory, 'session.json'), 'utf-8'))
               );
-              const displayName = `${recording.deviceName} screen recording (started at ${metadata.firstFrameWallClock.iso8601})`;
+              const startedAt = recordingStartTimeFormatter.format(
+                new Date(metadata.firstFrameWallClock.iso8601)
+              );
+              const displayName = `${recording.deviceName} screen recording (started at ${startedAt})`;
               const recordingPath = path.join(recording.directory, metadata.recording);
               const { size } = await stat(recordingPath);
               const recordingId = path.basename(recording.directory);


### PR DESCRIPTION
## Summary

- include a shortened simulator UDID and first-frame timestamp in each screen recording artifact name
- format the timestamp as a readable, stable UTC value
- add `__eas_type: "screen-recording"` metadata for typed artifact detection
- cover recordings from a rebooted simulator and simultaneous same-model simulators

Artifact names now use this format:

```
iPhone 16 screen recording (01234567-…, started at Jul 10, 2026, 10:00:00.000 UTC)
```

## Why

A simulator can reboot during one device run session, producing multiple recordings with the same device name and UDID. A session can also contain two same-model simulators whose recordings start at precisely the same time. Device name alone, or device name plus timestamp alone, therefore does not reliably distinguish every recording.

The first eight UDID characters distinguish same-model simulators without putting the full UUID in the user-facing name. The millisecond first-frame timestamp distinguishes subsequent recordings after a reboot. The full UDID and canonical ISO timestamp remain in artifact metadata for exact identity, parsing, and ordering.

The new `__eas_type` marker provides a descriptive discriminator for screen recordings. The existing `__eas_screen_recording: "1"` marker remains temporarily so currently deployed consumers continue recognizing these artifacts during migration.

The artifact metadata also provides `udid`, `deviceName`, `runtimeDisplayName`, `firstFrameAt`, and encoded `width` and `height`.

## Validation

- focused screen recording upload tests covering rebooted and simultaneous same-model simulators
- build-tools TypeScript typecheck