### PR TITLE
[eas-build-job] internal refactor general hook

### DIFF
--- a/packages/eas-build-job/src/__tests__/hooks.test.ts
+++ b/packages/eas-build-job/src/__tests__/hooks.test.ts
@@ -2,19 +2,13 @@ import { HOOK_ANCHORS, parseHookKey } from '../hooks';
 
 describe('HOOK_ANCHORS', () => {
   it('contains the v1 anchors', () => {
-    expect(Object.keys(HOOK_ANCHORS).sort()).toEqual([
+    expect([...HOOK_ANCHORS].sort()).toEqual([
       'checkout',
       'install_node_modules',
       'maestro_cloud',
       'maestro_tests',
       'submit',
     ]);
-  });
-
-  it('every entry has a non-empty description', () => {
-    for (const entry of Object.values(HOOK_ANCHORS)) {
-      expect(entry.description.length).toBeGreaterThan(0);
-    }
   });
 });
 

--- a/packages/eas-build-job/src/hooks.ts
+++ b/packages/eas-build-job/src/hooks.ts
@@ -12,31 +12,24 @@
  * inside a function-group expansion — is an occurrence of the anchor). Several
  * steps and several functions may declare the same anchor.
  */
-export const HOOK_ANCHORS = {
-  install_node_modules: {
-    description: 'The step that installs node modules.',
-  },
-  submit: {
-    description: 'The step that submits the application binary to the store.',
-  },
-  maestro_tests: {
-    description: 'The step that runs Maestro tests.',
-  },
-  maestro_cloud: {
-    description: 'The steps that upload to Maestro Cloud and gather its results.',
-  },
-  checkout: {
-    description: 'The step that checks out the project sources.',
-  },
-} as const satisfies Record<string, { description: string }>;
+export const HOOK_ANCHORS = [
+  'install_node_modules',
+  'submit',
+  'maestro_tests',
+  'maestro_cloud',
+  'checkout',
+] as const;
 
-export type HookAnchorId = keyof typeof HOOK_ANCHORS;
+export type HookAnchorId = (typeof HOOK_ANCHORS)[number];
 export type HookKey = `before_${HookAnchorId}` | `after_${HookAnchorId}`;
 
+export const HOOK_KEYS: readonly HookKey[] = HOOK_ANCHORS.flatMap((anchor): HookKey[] => [
+  `before_${anchor}`,
+  `after_${anchor}`,
+]);
+
 export function isHookAnchorId(value: string): value is HookAnchorId {
-  // Own-property check: `in` would also match Object prototype names
-  // ("toString", "__proto__", …), breaking the unknown-anchors-are-inert rule.
-  return Object.hasOwn(HOOK_ANCHORS, value);
+  return HOOK_ANCHORS.some(anchor => anchor === value);
 }
 
 export function parseHookKey(

--- a/packages/steps/src/StepsConfigParser.ts
+++ b/packages/steps/src/StepsConfigParser.ts
@@ -32,9 +32,6 @@ import {
 export class StepsConfigParser extends AbstractConfigParser {
   private readonly steps: Step[];
   private readonly hooks: Hooks;
-  // Anchors present in the job's own steps, collected during construction.
-  // Used to warn about payload hook keys whose anchor never occurred.
-  private readonly encounteredHookAnchors = new Set<HookAnchorId>();
 
   constructor(
     ctx: BuildStepGlobalContext,
@@ -105,7 +102,6 @@ export class StepsConfigParser extends AbstractConfigParser {
           if (anchorId === undefined) {
             continue;
           }
-          this.encounteredHookAnchors.add(anchorId);
           const anchorHooks = this.constructAnchorHooks(anchorId, validatedHooks, {
             buildFunctionById,
             buildFunctionGroupById,
@@ -122,7 +118,6 @@ export class StepsConfigParser extends AbstractConfigParser {
         buildSteps.push(this.createBuildStepFromNonGroupStepConfig(stepConfig, buildFunctionById));
         continue;
       }
-      this.encounteredHookAnchors.add(anchorId);
       const maps = { buildFunctionById, buildFunctionGroupById };
       const before = this.constructHookSideEntries(anchorId, 'before', validatedHooks, maps);
       const anchorStep = this.createBuildStepFromNonGroupStepConfig(stepConfig, buildFunctionById);
@@ -132,9 +127,6 @@ export class StepsConfigParser extends AbstractConfigParser {
         hooksByAnchorStep.set(anchorStep, { anchor: anchorId, before, after });
       }
     }
-
-    // After construction: group expansions also record encountered anchors.
-    this.warnAboutUnmatchedHookKeys();
 
     return {
       buildSteps,
@@ -146,10 +138,9 @@ export class StepsConfigParser extends AbstractConfigParser {
   private validateHooks(): Record<string, Step[]> {
     const validatedHooks: Record<string, Step[]> = {};
     for (const [hookKey, hookSteps] of Object.entries(this.hooks)) {
-      // Keys that don't name a registered anchor are fully inert — never
-      // validated, never constructed, reported by warnAboutUnmatchedHookKeys.
-      // A worker must not fail on hook keys newer than itself, even when their
-      // steps reference functions it doesn't have yet.
+      // A worker must not fail on a hook key newer than itself, so unregistered
+      // keys skip validation entirely (their steps may reference functions this
+      // worker lacks).
       if (parseHookKey(hookKey) === null) {
         continue;
       }
@@ -221,23 +212,6 @@ export class StepsConfigParser extends AbstractConfigParser {
       return [];
     }
     return constructHookEntriesFromValidatedSteps(this.ctx, hookSteps, maps);
-  }
-
-  private warnAboutUnmatchedHookKeys(): void {
-    for (const hookKey of Object.keys(this.hooks)) {
-      const parsedHookKey = parseHookKey(hookKey);
-      if (parsedHookKey === null) {
-        this.ctx.baseLogger.warn(
-          { hookKey },
-          `Unknown hook key "${hookKey}" in the job payload; its steps did not run.`
-        );
-      } else if (!this.encounteredHookAnchors.has(parsedHookKey.anchorId)) {
-        this.ctx.baseLogger.warn(
-          { hookKey, hookAnchor: parsedHookKey.anchorId },
-          `Hook key "${hookKey}" did not match any step in this job (anchor "${parsedHookKey.anchorId}" never occurred); its steps did not run.`
-        );
-      }
-    }
   }
 
   private createBuildStepFromNonGroupStepConfig(

--- a/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
@@ -468,7 +468,7 @@ describe('StepsConfigParser hooks with function groups', () => {
       externalFunctionGroups: [createGroup()],
     });
     // The group expands normally; the stamp never matches an anchor, so the
-    // submit hook stays unmatched (warned, not run).
+    // submit hook stays unmatched (ignored, not run).
     expect(workflow.buildSteps).toHaveLength(2);
     expect(workflow.hooksByAnchorStep.size).toBe(0);
   });


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Part of unifying how workflow hooks work. This is the `@expo/eas-build-job` + `@expo/steps` side, preparing a simpler, looser hook API for consumers to build on.

# How

- `eas-build-job`: add `PublicStepZ`, the user-authored step shape (`StepZ` without the internal `__metrics_id` / `__hook_id` stamp fields), so consumers don't re-derive it.
- `eas-build-job`: `HOOK_ANCHORS` becomes a plain list of anchor names (was a record keyed by anchor with an unused `description`); add `HOOK_KEYS`, the full set of `before_` / `after_` keys.
- `steps`: drop `warnAboutUnmatchedHookKeys`. A hook key whose anchor never occurs in a job is already inert, so the warning was just noise.

# Test Plan

CI passes. Added a `PublicStepZ` test asserting the internal stamp fields are stripped.
