### PR TITLE
[build-tools] Distinguish simulator recording artifact names

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts
@@ -52,7 +52,7 @@ describe(createUploadDeviceRunSessionScreenRecordingsBuildFunction, () => {
       expect(uploadDeviceRunSessionArtifactAsync).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          name: 'iPhone 16 screen recording',
+          name: 'iPhone 16 screen recording (2026-07-10T10:00:00.000Z)',
           metadata: {
             __eas_screen_recording: '1',
             udid: 'simulator-udid',

--- a/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
+++ b/packages/build-tools/src/steps/functions/uploadDeviceRunSessionScreenRecordings.ts
@@ -70,7 +70,6 @@ export function createUploadDeviceRunSessionScreenRecordingsBuildFunction(
       await Promise.all(
         recordings.map(recording =>
           limit(async () => {
-            const displayName = `${recording.deviceName} screen recording`;
             try {
               const metadata = RecordingManifestSchema.parse(
                 JSON.parse(await readFile(path.join(recording.directory, 'session.json'), 'utf-8'))
@@ -84,7 +83,7 @@ export function createUploadDeviceRunSessionScreenRecordingsBuildFunction(
               await uploadDeviceRunSessionArtifactAsync(ctx, {
                 deviceRunSessionId,
                 artifactId: recordingId,
-                name: displayName,
+                name: `${recording.deviceName} screen recording (${metadata.firstFrameWallClock.iso8601})`,
                 filename: `${recordingId}.mp4`,
                 kind: 'screen-recording',
                 metadata: {


### PR DESCRIPTION
# Why

A simulator can reboot during a device run session and produce multiple screen recordings for the same device. Those recordings previously shared the same artifact name, which violates the API's per-session artifact-name uniqueness constraint and prevents later recordings from uploading.

[Sentry issue](https://expoio.sentry.io/issues/7604712142/?project=130569&query=is%3Aunresolved%20requestId%3A8e5b9779-0903-4e1c-96d0-e7d698047e31&referrer=issue-stream)

# How

Include the recording's existing first-frame ISO timestamp in its artifact name. Each recording keeps the same device metadata and stable UUID-backed filename, while recordings created after simulator reboots no longer collide on the display name.

# Test Plan

- `yarn jest-unit src/steps/functions/__tests__/uploadDeviceRunSessionScreenRecordings.test.ts --runInBand`
- `yarn typecheck` in `packages/build-tools`
- `yarn lint` (0 errors; existing unrelated warnings only)
- `yarn fmt:check`