### PR TITLE
[worker] Wire SSH session into build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Add an opt-in `--max-idle-time-minutes` flag to `eas simulator`; the session stops automatically after that many minutes without activity. ([#4156](https://github.com/expo/eas-cli/pull/4156) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Add worker-side SSH session helpers (upterm relay + session create/report/close). ([#4030](https://github.com/expo/eas-cli/pull/4030) by [@gwdp](https://github.com/gwdp))
+- [worker] Wire an SSH session into the build lifecycle behind the workflow ssh flag. ([#4031](https://github.com/expo/eas-cli/pull/4031) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [build-tools] Add worker-side SSH session helpers (upterm relay + session create/report/close). ([#4030](https://github.com/expo/eas-cli/pull/4030) by [@gwdp](https://github.com/gwdp))
+- [worker] Wire an SSH session into the build lifecycle behind the workflow ssh flag. ([#4031](https://github.com/expo/eas-cli/pull/4031) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/packages/worker/package.sh
+++ b/packages/worker/package.sh
@@ -131,6 +131,38 @@ if [[ "$PLATFORM" == "ios" ]]; then
   popd >/dev/null 2>&1
 fi
 
+# Bake the upterm SSH client into the worker package (build-tools/bin/upterm-<arch>) for both
+# arches so jobs use the vendored binary instead of downloading it at runtime; the worker resolves
+# the right one via process.arch, so a mixed-arch worker pool is fine.
+upterm_version="0.24.0"
+case "$PLATFORM" in
+  ios) upterm_os="darwin" ;;
+  android) upterm_os="linux" ;;
+  *) echo "Unsupported platform for the upterm client: $PLATFORM" >&2; exit 1 ;;
+esac
+upterm_bin_dir="$target_root_dir/packages/build-tools/bin"
+mkdir -p "$upterm_bin_dir"
+for upterm_arch in amd64 arm64; do
+  case "${upterm_os}_${upterm_arch}" in
+    darwin_amd64) upterm_sha256="cc65a3c73e993ba22ef0fffd028dfb363529d71968380bf8f2a9804d53fe7f0a" ;;
+    darwin_arm64) upterm_sha256="aafa1330bb452abd308b78ed2cead7c8bdcb1aa2c486468fbd47dd4b567a8b30" ;;
+    linux_amd64) upterm_sha256="a6324d76c6d962236c22e4a27a2c4ffd17aef11dfa3da33d14dfcff4f4de60b3" ;;
+    linux_arm64) upterm_sha256="9015aabeeb837ef4c503db56a54a90139b5965a9f16f162b098b1c5acf8d1584" ;;
+  esac
+  upterm_tarball="$tmp_dir/upterm_${upterm_os}_${upterm_arch}.tar.gz"
+  curl -fsSL -o "$upterm_tarball" \
+    "https://github.com/owenthereal/upterm/releases/download/v${upterm_version}/upterm_${upterm_os}_${upterm_arch}.tar.gz"
+  if command -v sha256sum >/dev/null 2>&1; then
+    echo "${upterm_sha256}  ${upterm_tarball}" | sha256sum -c -
+  else
+    echo "${upterm_sha256}  ${upterm_tarball}" | shasum -a 256 -c -
+  fi
+  tar -xzf "$upterm_tarball" -C "$upterm_bin_dir" upterm
+  mv "$upterm_bin_dir/upterm" "$upterm_bin_dir/upterm-${upterm_arch}"
+  chmod +x "$upterm_bin_dir/upterm-${upterm_arch}"
+  rm -f "$upterm_tarball"
+done
+
 # Create backward-compatible symlink for orchestrator
 # The orchestrator expects ./src/services/worker/dist/main.js
 # but the new structure has ./packages/worker/dist/main.js

--- a/packages/worker/package.sh
+++ b/packages/worker/package.sh
@@ -131,38 +131,6 @@ if [[ "$PLATFORM" == "ios" ]]; then
   popd >/dev/null 2>&1
 fi
 
-# Bake the upterm SSH client into the worker package (build-tools/bin/upterm-<arch>) for both
-# arches so jobs use the vendored binary instead of downloading it at runtime; the worker resolves
-# the right one via process.arch, so a mixed-arch worker pool is fine.
-upterm_version="0.24.0"
-case "$PLATFORM" in
-  ios) upterm_os="darwin" ;;
-  android) upterm_os="linux" ;;
-  *) echo "Unsupported platform for the upterm client: $PLATFORM" >&2; exit 1 ;;
-esac
-upterm_bin_dir="$target_root_dir/packages/build-tools/bin"
-mkdir -p "$upterm_bin_dir"
-for upterm_arch in amd64 arm64; do
-  case "${upterm_os}_${upterm_arch}" in
-    darwin_amd64) upterm_sha256="cc65a3c73e993ba22ef0fffd028dfb363529d71968380bf8f2a9804d53fe7f0a" ;;
-    darwin_arm64) upterm_sha256="aafa1330bb452abd308b78ed2cead7c8bdcb1aa2c486468fbd47dd4b567a8b30" ;;
-    linux_amd64) upterm_sha256="a6324d76c6d962236c22e4a27a2c4ffd17aef11dfa3da33d14dfcff4f4de60b3" ;;
-    linux_arm64) upterm_sha256="9015aabeeb837ef4c503db56a54a90139b5965a9f16f162b098b1c5acf8d1584" ;;
-  esac
-  upterm_tarball="$tmp_dir/upterm_${upterm_os}_${upterm_arch}.tar.gz"
-  curl -fsSL -o "$upterm_tarball" \
-    "https://github.com/owenthereal/upterm/releases/download/v${upterm_version}/upterm_${upterm_os}_${upterm_arch}.tar.gz"
-  if command -v sha256sum >/dev/null 2>&1; then
-    echo "${upterm_sha256}  ${upterm_tarball}" | sha256sum -c -
-  else
-    echo "${upterm_sha256}  ${upterm_tarball}" | shasum -a 256 -c -
-  fi
-  tar -xzf "$upterm_tarball" -C "$upterm_bin_dir" upterm
-  mv "$upterm_bin_dir/upterm" "$upterm_bin_dir/upterm-${upterm_arch}"
-  chmod +x "$upterm_bin_dir/upterm-${upterm_arch}"
-  rm -f "$upterm_tarball"
-done
-
 # Create backward-compatible symlink for orchestrator
 # The orchestrator expects ./src/services/worker/dist/main.js
 # but the new structure has ./packages/worker/dist/main.js

--- a/packages/worker/src/__unit__/sshSession.test.ts
+++ b/packages/worker/src/__unit__/sshSession.test.ts
@@ -5,14 +5,12 @@ import { startSshSessionPhaseAsync } from '../sshSession';
 
 jest.mock('@expo/build-tools', () => ({
   TurtleSshSession: {
-    getWorkflowJobIdOrThrow: jest.fn(() => 'wj-1'),
-    getTurtleSshTarget: jest.fn(() => ({ turtleJobRunId: 'jr-1' })),
     getSshRelayServerUrl: jest.fn(() => 'wss://relay.expo.dev'),
     getSshIdleTimeoutSeconds: jest.fn(() => 0),
-    formatSshIdleTimeoutForLog: jest.fn(() => '15 minutes'),
     startSshSessionAsync: jest.fn(),
     superviseSshSessionAsync: jest.fn(),
   },
+  formatSecondsForLog: jest.fn(() => '15 minutes'),
 }));
 
 const mocked = jest.mocked(TurtleSshSession);
@@ -85,7 +83,7 @@ describe(startSshSessionPhaseAsync, () => {
       idleTimeoutSeconds: 0,
     });
     expect(logger.info).toHaveBeenCalledWith(
-      'SSH session ready. Connect with: eas workflow:ssh wj-1'
+      'SSH session ready. Connect with: eas workflow:ssh jr-1'
     );
     expect(done).toBeInstanceOf(Promise);
     await done;
@@ -166,15 +164,12 @@ describe(startSshSessionPhaseAsync, () => {
     });
     await done;
 
-    const { hasJobFinished, getConnectedClientCount, ensureConnected } =
+    const { hasJobFinished, handle: passedHandle } =
       mocked.superviseSshSessionAsync.mock.calls[0][0];
     expect(hasJobFinished()).toBe(false);
     jobFinished = true;
     expect(hasJobFinished()).toBe(true);
-    await getConnectedClientCount();
-    await ensureConnected();
-    expect(handle.getConnectedClientCountAsync).toHaveBeenCalled();
-    expect(handle.ensureConnectedAsync).toHaveBeenCalled();
+    expect(passedHandle).toBe(handle);
   });
 
   it('closes the phase with a warning when supervision throws', async () => {

--- a/packages/worker/src/__unit__/sshSession.test.ts
+++ b/packages/worker/src/__unit__/sshSession.test.ts
@@ -69,7 +69,7 @@ describe(startSshSessionPhaseAsync, () => {
     const logger = createLogger();
     const ctx = createContext({ logger });
 
-    const { sessionPromise } = await startSshSessionPhaseAsync({
+    const { done } = await startSshSessionPhaseAsync({
       ctx,
       buildId: 'jr-1',
       logger,
@@ -87,8 +87,8 @@ describe(startSshSessionPhaseAsync, () => {
     expect(logger.info).toHaveBeenCalledWith(
       'SSH session ready. Connect with: eas workflow:ssh wj-1'
     );
-    expect(sessionPromise).toBeInstanceOf(Promise);
-    await sessionPromise;
+    expect(done).toBeInstanceOf(Promise);
+    await done;
   });
 
   it('returns before the session ends so the job is not blocked', async () => {
@@ -102,17 +102,17 @@ describe(startSshSessionPhaseAsync, () => {
         })
     );
 
-    const { sessionPromise } = await startSshSessionPhaseAsync({
+    const { done } = await startSshSessionPhaseAsync({
       ctx,
       buildId: 'jr-1',
       logger,
       hasJobFinished: () => false,
     });
 
-    expect(sessionPromise).toBeDefined();
+    expect(done).toBeDefined();
     expect(handle.stopAsync).not.toHaveBeenCalled();
     releaseSupervision();
-    await sessionPromise;
+    await done;
     expect(handle.stopAsync).toHaveBeenCalled();
   });
 
@@ -120,13 +120,13 @@ describe(startSshSessionPhaseAsync, () => {
     const logger = createLogger();
     const ctx = createContext({ logger });
 
-    const { sessionPromise } = await startSshSessionPhaseAsync({
+    const { done } = await startSshSessionPhaseAsync({
       ctx,
       buildId: 'jr-1',
       logger,
       hasJobFinished: () => true,
     });
-    await sessionPromise;
+    await done;
 
     expect(handle.stopAsync).toHaveBeenCalled();
     expect(endPhaseCalls(logger)).toEqual([
@@ -139,13 +139,13 @@ describe(startSshSessionPhaseAsync, () => {
     const ctx = createContext({ logger });
     let jobFinished = false;
 
-    const { sessionPromise } = await startSshSessionPhaseAsync({
+    const { done } = await startSshSessionPhaseAsync({
       ctx,
       buildId: 'jr-1',
       logger,
       hasJobFinished: () => jobFinished,
     });
-    await sessionPromise;
+    await done;
 
     const { hasJobFinished } = mocked.superviseSshSessionAsync.mock.calls[0][0];
     expect(hasJobFinished()).toBe(false);
@@ -158,13 +158,13 @@ describe(startSshSessionPhaseAsync, () => {
     const ctx = createContext({ logger });
     mocked.superviseSshSessionAsync.mockRejectedValue(new Error('relay went away'));
 
-    const { sessionPromise } = await startSshSessionPhaseAsync({
+    const { done } = await startSshSessionPhaseAsync({
       ctx,
       buildId: 'jr-1',
       logger,
       hasJobFinished: () => true,
     });
-    await sessionPromise;
+    await done;
 
     expect(handle.stopAsync).toHaveBeenCalled();
     expect(endPhaseCalls(logger)).toEqual([
@@ -177,14 +177,14 @@ describe(startSshSessionPhaseAsync, () => {
     const ctx = createContext({ logger });
     mocked.startSshSessionAsync.mockRejectedValue(new Error('no relay'));
 
-    const { sessionPromise } = await startSshSessionPhaseAsync({
+    const { done } = await startSshSessionPhaseAsync({
       ctx,
       buildId: 'jr-1',
       logger,
       hasJobFinished: () => false,
     });
 
-    expect(sessionPromise).toBeUndefined();
+    expect(done).toBeUndefined();
     expect(ctx.markBuildPhaseHasWarnings).toHaveBeenCalled();
     expect(mocked.superviseSshSessionAsync).not.toHaveBeenCalled();
     expect(endPhaseCalls(logger)).toEqual([

--- a/packages/worker/src/__unit__/sshSession.test.ts
+++ b/packages/worker/src/__unit__/sshSession.test.ts
@@ -1,0 +1,194 @@
+import { TurtleSshSession } from '@expo/build-tools';
+import { BuildPhase, BuildPhaseResult, LogMarker } from '@expo/eas-build-job';
+
+import { startSshSessionPhaseAsync } from '../sshSession';
+
+jest.mock('@expo/build-tools', () => ({
+  TurtleSshSession: {
+    getWorkflowJobIdOrThrow: jest.fn(() => 'wj-1'),
+    getTurtleSshTarget: jest.fn(() => ({ turtleJobRunId: 'jr-1' })),
+    getSshRelayServerUrl: jest.fn(() => 'wss://relay.expo.dev'),
+    getSshIdleTimeoutSeconds: jest.fn(() => 0),
+    formatSshIdleTimeoutForLog: jest.fn(() => '15 minutes'),
+    startSshSessionAsync: jest.fn(),
+    superviseSshSessionAsync: jest.fn(),
+  },
+}));
+
+const mocked = jest.mocked(TurtleSshSession);
+
+function createLogger(): any {
+  const logger: any = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  logger.child = jest.fn(() => logger);
+  return logger;
+}
+
+function createContext({ logger }: { logger: any }): any {
+  return {
+    env: { __WORKFLOW_JOB_ID: 'wj-1' },
+    job: { ssh: { idleTimeoutSeconds: 0, relayServerUrl: 'wss://relay.expo.dev' } },
+    logger,
+    markBuildPhaseHasWarnings: jest.fn(),
+    // The real implementation runs the phase body and honors doNotMarkEnd; for these tests we only
+    // need the body to run.
+    runBuildPhase: jest.fn(async (_phase: BuildPhase, body: () => Promise<void>) => {
+      await body();
+    }),
+  };
+}
+
+function endPhaseCalls(logger: any): any[] {
+  return logger.info.mock.calls.filter(
+    ([meta]: any[]) =>
+      meta != null && typeof meta === 'object' && meta.marker === LogMarker.END_PHASE
+  );
+}
+
+describe(startSshSessionPhaseAsync, () => {
+  let handle: {
+    getConnectedClientCountAsync: jest.Mock;
+    ensureConnectedAsync: jest.Mock;
+    stopAsync: jest.Mock;
+  };
+
+  beforeEach(() => {
+    handle = {
+      getConnectedClientCountAsync: jest.fn(async () => 0),
+      ensureConnectedAsync: jest.fn(async () => {}),
+      stopAsync: jest.fn(async () => {}),
+    };
+    mocked.startSshSessionAsync.mockResolvedValue({ handle, idleTimeoutSeconds: 0 } as any);
+    mocked.superviseSshSessionAsync.mockResolvedValue(undefined as any);
+  });
+
+  it('opens the session inside SSH_SESSION and leaves the phase open', async () => {
+    const logger = createLogger();
+    const ctx = createContext({ logger });
+
+    const { sessionPromise } = await startSshSessionPhaseAsync({
+      ctx,
+      buildId: 'jr-1',
+      logger,
+      hasJobFinished: () => false,
+    });
+
+    expect(ctx.runBuildPhase).toHaveBeenCalledWith(BuildPhase.SSH_SESSION, expect.any(Function), {
+      doNotMarkEnd: true,
+    });
+    expect(mocked.startSshSessionAsync).toHaveBeenCalledWith(ctx, {
+      target: { turtleJobRunId: 'jr-1' },
+      relayServerUrl: 'wss://relay.expo.dev',
+      idleTimeoutSeconds: 0,
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      'SSH session ready. Connect with: eas workflow:ssh wj-1'
+    );
+    expect(sessionPromise).toBeInstanceOf(Promise);
+    await sessionPromise;
+  });
+
+  it('returns before the session ends so the job is not blocked', async () => {
+    const logger = createLogger();
+    const ctx = createContext({ logger });
+    let releaseSupervision = (): void => {};
+    mocked.superviseSshSessionAsync.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          releaseSupervision = resolve;
+        })
+    );
+
+    const { sessionPromise } = await startSshSessionPhaseAsync({
+      ctx,
+      buildId: 'jr-1',
+      logger,
+      hasJobFinished: () => false,
+    });
+
+    expect(sessionPromise).toBeDefined();
+    expect(handle.stopAsync).not.toHaveBeenCalled();
+    releaseSupervision();
+    await sessionPromise;
+    expect(handle.stopAsync).toHaveBeenCalled();
+  });
+
+  it('tears the tunnel down and closes the phase once supervision returns', async () => {
+    const logger = createLogger();
+    const ctx = createContext({ logger });
+
+    const { sessionPromise } = await startSshSessionPhaseAsync({
+      ctx,
+      buildId: 'jr-1',
+      logger,
+      hasJobFinished: () => true,
+    });
+    await sessionPromise;
+
+    expect(handle.stopAsync).toHaveBeenCalled();
+    expect(endPhaseCalls(logger)).toEqual([
+      [expect.objectContaining({ result: BuildPhaseResult.SUCCESS }), expect.any(String)],
+    ]);
+  });
+
+  it('passes the job-finished signal through to the supervisor', async () => {
+    const logger = createLogger();
+    const ctx = createContext({ logger });
+    let jobFinished = false;
+
+    const { sessionPromise } = await startSshSessionPhaseAsync({
+      ctx,
+      buildId: 'jr-1',
+      logger,
+      hasJobFinished: () => jobFinished,
+    });
+    await sessionPromise;
+
+    const { hasJobFinished } = mocked.superviseSshSessionAsync.mock.calls[0][0];
+    expect(hasJobFinished()).toBe(false);
+    jobFinished = true;
+    expect(hasJobFinished()).toBe(true);
+  });
+
+  it('closes the phase with a warning when supervision throws', async () => {
+    const logger = createLogger();
+    const ctx = createContext({ logger });
+    mocked.superviseSshSessionAsync.mockRejectedValue(new Error('relay went away'));
+
+    const { sessionPromise } = await startSshSessionPhaseAsync({
+      ctx,
+      buildId: 'jr-1',
+      logger,
+      hasJobFinished: () => true,
+    });
+    await sessionPromise;
+
+    expect(handle.stopAsync).toHaveBeenCalled();
+    expect(endPhaseCalls(logger)).toEqual([
+      [expect.objectContaining({ result: BuildPhaseResult.WARNING }), expect.any(String)],
+    ]);
+  });
+
+  it('lets the job continue and closes the phase when the session cannot be opened', async () => {
+    const logger = createLogger();
+    const ctx = createContext({ logger });
+    mocked.startSshSessionAsync.mockRejectedValue(new Error('no relay'));
+
+    const { sessionPromise } = await startSshSessionPhaseAsync({
+      ctx,
+      buildId: 'jr-1',
+      logger,
+      hasJobFinished: () => false,
+    });
+
+    expect(sessionPromise).toBeUndefined();
+    expect(ctx.markBuildPhaseHasWarnings).toHaveBeenCalled();
+    expect(mocked.superviseSshSessionAsync).not.toHaveBeenCalled();
+    expect(endPhaseCalls(logger)).toEqual([
+      [expect.objectContaining({ result: BuildPhaseResult.WARNING }), expect.any(String)],
+    ]);
+  });
+});

--- a/packages/worker/src/__unit__/sshSession.test.ts
+++ b/packages/worker/src/__unit__/sshSession.test.ts
@@ -91,6 +91,25 @@ describe(startSshSessionPhaseAsync, () => {
     await done;
   });
 
+  it('mentions the idle timeout when it is non-zero', async () => {
+    const logger = createLogger();
+    const ctx = createContext({ logger });
+    mocked.getSshIdleTimeoutSeconds.mockReturnValue(900);
+    mocked.startSshSessionAsync.mockResolvedValue({ handle, idleTimeoutSeconds: 900 } as any);
+
+    const { done } = await startSshSessionPhaseAsync({
+      ctx,
+      buildId: 'jr-1',
+      logger,
+      hasJobFinished: () => true,
+    });
+    await done;
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('then closes after 15 minutes with no client connected')
+    );
+  });
+
   it('returns before the session ends so the job is not blocked', async () => {
     const logger = createLogger();
     const ctx = createContext({ logger });
@@ -147,10 +166,15 @@ describe(startSshSessionPhaseAsync, () => {
     });
     await done;
 
-    const { hasJobFinished } = mocked.superviseSshSessionAsync.mock.calls[0][0];
+    const { hasJobFinished, getConnectedClientCount, ensureConnected } =
+      mocked.superviseSshSessionAsync.mock.calls[0][0];
     expect(hasJobFinished()).toBe(false);
     jobFinished = true;
     expect(hasJobFinished()).toBe(true);
+    await getConnectedClientCount();
+    await ensureConnected();
+    expect(handle.getConnectedClientCountAsync).toHaveBeenCalled();
+    expect(handle.ensureConnectedAsync).toHaveBeenCalled();
   });
 
   it('closes the phase with a warning when supervision throws', async () => {
@@ -169,6 +193,28 @@ describe(startSshSessionPhaseAsync, () => {
     expect(handle.stopAsync).toHaveBeenCalled();
     expect(endPhaseCalls(logger)).toEqual([
       [expect.objectContaining({ result: BuildPhaseResult.WARNING }), expect.any(String)],
+    ]);
+  });
+
+  it('warns when tearing down the tunnel fails after supervision', async () => {
+    const logger = createLogger();
+    const ctx = createContext({ logger });
+    handle.stopAsync.mockRejectedValue(new Error('already gone'));
+
+    const { done } = await startSshSessionPhaseAsync({
+      ctx,
+      buildId: 'jr-1',
+      logger,
+      hasJobFinished: () => true,
+    });
+    await done;
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Failed to tear down the SSH tunnel.'
+    );
+    expect(endPhaseCalls(logger)).toEqual([
+      [expect.objectContaining({ result: BuildPhaseResult.SUCCESS }), expect.any(String)],
     ]);
   });
 

--- a/packages/worker/src/__unit__/sshSession.test.ts
+++ b/packages/worker/src/__unit__/sshSession.test.ts
@@ -78,7 +78,7 @@ describe(startSshSessionPhaseAsync, () => {
       doNotMarkEnd: true,
     });
     expect(mocked.startSshSessionAsync).toHaveBeenCalledWith(ctx, {
-      target: { turtleJobRunId: 'jr-1' },
+      target: { type: 'JOB_RUN', id: 'jr-1' },
       relayServerUrl: 'wss://relay.expo.dev',
       idleTimeoutSeconds: 0,
     });

--- a/packages/worker/src/build.ts
+++ b/packages/worker/src/build.ts
@@ -58,7 +58,7 @@ export async function build({
       }
     });
 
-    if (TurtleSshSession.isWorkflowSshEnabled(ctx.job)) {
+    if (TurtleSshSession.isSshEnabled(ctx.job)) {
       ({ done: sshSessionDone } = await startSshSessionPhaseAsync({
         ctx,
         buildId,

--- a/packages/worker/src/build.ts
+++ b/packages/worker/src/build.ts
@@ -1,4 +1,10 @@
-import { Artifacts, BuildContext, Builders, runGenericJobAsync } from '@expo/build-tools';
+import {
+  Artifacts,
+  BuildContext,
+  Builders,
+  TurtleSshSession,
+  runGenericJobAsync,
+} from '@expo/build-tools';
 import {
   Android,
   BuildJob,
@@ -17,6 +23,7 @@ import config from './config';
 import { displayWorkerRuntimeInfo } from './displayRuntimeInfo';
 import { Analytics, Event, logProjectDependenciesAsync } from './external/analytics';
 import { prepareRuntimeEnvironment } from './runtimeEnvironment';
+import { startSshSessionPhaseAsync } from './sshSession';
 import { cleanUpWorkingdir } from './workingdir';
 
 export async function build({
@@ -29,6 +36,8 @@ export async function build({
   analytics: Analytics;
 }): Promise<Artifacts> {
   const { job, logger } = ctx;
+  let sshSessionPromise: Promise<void> | undefined;
+  let hasJobFinished = false;
   try {
     analytics.logEvent(Event.WORKER_BUILD_START, {});
 
@@ -48,6 +57,15 @@ export async function build({
         await prepareRuntimeEnvironment(ctx, ctx.job.builderEnvironment);
       }
     });
+
+    if (TurtleSshSession.isWorkflowSshEnabled(ctx.job)) {
+      ({ sessionPromise: sshSessionPromise } = await startSshSessionPhaseAsync({
+        ctx,
+        buildId,
+        logger,
+        hasJobFinished: () => hasJobFinished,
+      }));
+    }
 
     let artifacts: Artifacts;
 
@@ -89,6 +107,9 @@ export async function build({
     }
     throw err;
   } finally {
+    // Lets the SSH supervisor start its idle countdown and tear the tunnel down.
+    hasJobFinished = true;
+    await sshSessionPromise;
     if (config.env === 'development') {
       await cleanUpWorkingdir();
     }

--- a/packages/worker/src/build.ts
+++ b/packages/worker/src/build.ts
@@ -36,7 +36,7 @@ export async function build({
   analytics: Analytics;
 }): Promise<Artifacts> {
   const { job, logger } = ctx;
-  let sshSessionPromise: Promise<void> | undefined;
+  let sshSessionDone: Promise<void> | undefined;
   let hasJobFinished = false;
   try {
     analytics.logEvent(Event.WORKER_BUILD_START, {});
@@ -59,7 +59,7 @@ export async function build({
     });
 
     if (TurtleSshSession.isWorkflowSshEnabled(ctx.job)) {
-      ({ sessionPromise: sshSessionPromise } = await startSshSessionPhaseAsync({
+      ({ done: sshSessionDone } = await startSshSessionPhaseAsync({
         ctx,
         buildId,
         logger,
@@ -109,7 +109,7 @@ export async function build({
   } finally {
     // Lets the SSH supervisor start its idle countdown and tear the tunnel down.
     hasJobFinished = true;
-    await sshSessionPromise;
+    await sshSessionDone;
     if (config.env === 'development') {
       await cleanUpWorkingdir();
     }

--- a/packages/worker/src/sshSession.ts
+++ b/packages/worker/src/sshSession.ts
@@ -1,0 +1,99 @@
+import { BuildContext, TurtleSshSession } from '@expo/build-tools';
+import { BuildPhase, BuildPhaseResult, LogMarker } from '@expo/eas-build-job';
+import { bunyan } from '@expo/logger';
+
+/**
+ * Opens the job's SSH session. `sessionPromise` settles once the tunnel is torn down, and is
+ * absent when the session could not be opened. It is wrapped in an object because an async
+ * function flattens a returned promise, which would make callers wait for the whole session.
+ *
+ * SSH_SESSION stays open in the log UI for as long as the tunnel lives: we emit START here, skip
+ * the automatic END (doNotMarkEnd), and write END on teardown. That way there is still a running
+ * step while the worker stays up for SSH.
+ */
+export async function startSshSessionPhaseAsync({
+  ctx,
+  buildId,
+  logger,
+  hasJobFinished,
+}: {
+  ctx: BuildContext;
+  buildId: string;
+  logger: bunyan;
+  hasJobFinished: () => boolean;
+}): Promise<{ sessionPromise?: Promise<void> }> {
+  let sessionPromise: Promise<void> | undefined;
+
+  await ctx.runBuildPhase(
+    BuildPhase.SSH_SESSION,
+    async () => {
+      const phaseStartedAt = Date.now();
+      try {
+        ctx.logger.info('Opening an SSH session for this job.');
+        const workflowJobId = TurtleSshSession.getWorkflowJobIdOrThrow(ctx.env);
+        const target = TurtleSshSession.getTurtleSshTarget({
+          buildId,
+          hasPlatform: Boolean(ctx.job.platform),
+        });
+        const { handle, idleTimeoutSeconds } = await TurtleSshSession.startSshSessionAsync(ctx, {
+          target,
+          relayServerUrl: TurtleSshSession.getSshRelayServerUrl(ctx.job),
+          idleTimeoutSeconds: TurtleSshSession.getSshIdleTimeoutSeconds(ctx.job),
+        });
+        ctx.logger.info(`SSH session ready. Connect with: eas workflow:ssh ${workflowJobId}`);
+        ctx.logger.info(
+          idleTimeoutSeconds === 0
+            ? 'It stays open for the whole job and closes once the job finishes and no client is connected.'
+            : `It stays open for the whole job, then closes after ${TurtleSshSession.formatSshIdleTimeoutForLog(idleTimeoutSeconds)} with no client connected. The worker stays up until then.`
+        );
+
+        const sshLogger = logger.child({ phase: BuildPhase.SSH_SESSION });
+        sessionPromise = (async () => {
+          let result = BuildPhaseResult.SUCCESS;
+          try {
+            await TurtleSshSession.superviseSshSessionAsync({
+              getConnectedClientCount: () => handle.getConnectedClientCountAsync(),
+              ensureConnected: () => handle.ensureConnectedAsync(),
+              idleTimeoutSeconds,
+              hasJobFinished,
+              logger: sshLogger,
+            });
+          } catch (err) {
+            result = BuildPhaseResult.WARNING;
+            sshLogger.warn({ err }, 'The SSH session ended unexpectedly.');
+          } finally {
+            await handle.stopAsync().catch(err => {
+              sshLogger.warn({ err }, 'Failed to tear down the SSH tunnel.');
+            });
+            sshLogger.info(
+              {
+                marker: LogMarker.END_PHASE,
+                result,
+                durationMs: Date.now() - phaseStartedAt,
+              },
+              `End phase: ${BuildPhase.SSH_SESSION}`
+            );
+          }
+        })();
+      } catch (err) {
+        ctx.logger.warn(
+          { err },
+          'Failed to open the SSH session. The job will continue without it.'
+        );
+        ctx.markBuildPhaseHasWarnings();
+        // Setup failed: close the phase now so doNotMarkEnd does not leave it open forever.
+        ctx.logger.info(
+          {
+            marker: LogMarker.END_PHASE,
+            result: BuildPhaseResult.WARNING,
+            durationMs: Date.now() - phaseStartedAt,
+          },
+          `End phase: ${BuildPhase.SSH_SESSION}`
+        );
+      }
+    },
+    { doNotMarkEnd: true }
+  );
+
+  return { sessionPromise };
+}

--- a/packages/worker/src/sshSession.ts
+++ b/packages/worker/src/sshSession.ts
@@ -1,16 +1,8 @@
-import { BuildContext, TurtleSshSession } from '@expo/build-tools';
+import { BuildContext, TurtleSshSession, formatSecondsForLog } from '@expo/build-tools';
 import { BuildPhase, BuildPhaseResult, LogMarker } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
+import { performance } from 'node:perf_hooks';
 
-/**
- * Opens the job's SSH session. `done` settles once the tunnel is torn down, and is absent when
- * the session could not be opened. It is wrapped in an object because an async function flattens
- * a returned promise, which would make callers wait for the whole session.
- *
- * SSH_SESSION stays open in the log UI for as long as the tunnel lives: we emit START here, skip
- * the automatic END (doNotMarkEnd), and write END on teardown. That way there is still a running
- * step while the worker stays up for SSH.
- */
 export async function startSshSessionPhaseAsync({
   ctx,
   buildId,
@@ -27,24 +19,20 @@ export async function startSshSessionPhaseAsync({
   await ctx.runBuildPhase(
     BuildPhase.SSH_SESSION,
     async () => {
-      const phaseStartedAt = Date.now();
+      const phaseStartedAt = performance.now();
       try {
         ctx.logger.info('Opening an SSH session for this job.');
-        const workflowJobId = TurtleSshSession.getWorkflowJobIdOrThrow(ctx.env);
-        const target = TurtleSshSession.getTurtleSshTarget({
-          buildId,
-          hasPlatform: Boolean(ctx.job.platform),
-        });
+        const target = ctx.job.platform ? { turtleBuildId: buildId } : { turtleJobRunId: buildId };
         const { handle, idleTimeoutSeconds } = await TurtleSshSession.startSshSessionAsync(ctx, {
           target,
           relayServerUrl: TurtleSshSession.getSshRelayServerUrl(ctx.job),
           idleTimeoutSeconds: TurtleSshSession.getSshIdleTimeoutSeconds(ctx.job),
         });
-        ctx.logger.info(`SSH session ready. Connect with: eas workflow:ssh ${workflowJobId}`);
+        ctx.logger.info(`SSH session ready. Connect with: eas workflow:ssh ${buildId}`);
         ctx.logger.info(
           idleTimeoutSeconds === 0
             ? 'It stays open for the whole job and closes once the job finishes and no client is connected.'
-            : `It stays open for the whole job, then closes after ${TurtleSshSession.formatSshIdleTimeoutForLog(idleTimeoutSeconds)} with no client connected. The worker stays up until then.`
+            : `It stays open for the whole job, then closes after ${formatSecondsForLog(idleTimeoutSeconds)} with no client connected. The worker stays up until then.`
         );
 
         const sshLogger = logger.child({ phase: BuildPhase.SSH_SESSION });
@@ -52,8 +40,7 @@ export async function startSshSessionPhaseAsync({
           let result = BuildPhaseResult.SUCCESS;
           try {
             await TurtleSshSession.superviseSshSessionAsync({
-              getConnectedClientCount: () => handle.getConnectedClientCountAsync(),
-              ensureConnected: () => handle.ensureConnectedAsync(),
+              handle,
               idleTimeoutSeconds,
               hasJobFinished,
               logger: sshLogger,
@@ -69,7 +56,7 @@ export async function startSshSessionPhaseAsync({
               {
                 marker: LogMarker.END_PHASE,
                 result,
-                durationMs: Date.now() - phaseStartedAt,
+                durationMs: Math.round(performance.now() - phaseStartedAt),
               },
               `End phase: ${BuildPhase.SSH_SESSION}`
             );
@@ -81,12 +68,11 @@ export async function startSshSessionPhaseAsync({
           'Failed to open the SSH session. The job will continue without it.'
         );
         ctx.markBuildPhaseHasWarnings();
-        // Setup failed: close the phase now so doNotMarkEnd does not leave it open forever.
         ctx.logger.info(
           {
             marker: LogMarker.END_PHASE,
             result: BuildPhaseResult.WARNING,
-            durationMs: Date.now() - phaseStartedAt,
+            durationMs: Math.round(performance.now() - phaseStartedAt),
           },
           `End phase: ${BuildPhase.SSH_SESSION}`
         );

--- a/packages/worker/src/sshSession.ts
+++ b/packages/worker/src/sshSession.ts
@@ -3,9 +3,9 @@ import { BuildPhase, BuildPhaseResult, LogMarker } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 
 /**
- * Opens the job's SSH session. `sessionPromise` settles once the tunnel is torn down, and is
- * absent when the session could not be opened. It is wrapped in an object because an async
- * function flattens a returned promise, which would make callers wait for the whole session.
+ * Opens the job's SSH session. `done` settles once the tunnel is torn down, and is absent when
+ * the session could not be opened. It is wrapped in an object because an async function flattens
+ * a returned promise, which would make callers wait for the whole session.
  *
  * SSH_SESSION stays open in the log UI for as long as the tunnel lives: we emit START here, skip
  * the automatic END (doNotMarkEnd), and write END on teardown. That way there is still a running
@@ -21,8 +21,8 @@ export async function startSshSessionPhaseAsync({
   buildId: string;
   logger: bunyan;
   hasJobFinished: () => boolean;
-}): Promise<{ sessionPromise?: Promise<void> }> {
-  let sessionPromise: Promise<void> | undefined;
+}): Promise<{ done?: Promise<void> }> {
+  let done: Promise<void> | undefined;
 
   await ctx.runBuildPhase(
     BuildPhase.SSH_SESSION,
@@ -48,7 +48,7 @@ export async function startSshSessionPhaseAsync({
         );
 
         const sshLogger = logger.child({ phase: BuildPhase.SSH_SESSION });
-        sessionPromise = (async () => {
+        done = (async () => {
           let result = BuildPhaseResult.SUCCESS;
           try {
             await TurtleSshSession.superviseSshSessionAsync({
@@ -95,5 +95,5 @@ export async function startSshSessionPhaseAsync({
     { doNotMarkEnd: true }
   );
 
-  return { sessionPromise };
+  return { done };
 }

--- a/packages/worker/src/sshSession.ts
+++ b/packages/worker/src/sshSession.ts
@@ -22,7 +22,10 @@ export async function startSshSessionPhaseAsync({
       const phaseStartedAt = performance.now();
       try {
         ctx.logger.info('Opening an SSH session for this job.');
-        const target = ctx.job.platform ? { turtleBuildId: buildId } : { turtleJobRunId: buildId };
+        const target = {
+          type: ctx.job.platform ? ('BUILD' as const) : ('JOB_RUN' as const),
+          id: buildId,
+        };
         const { handle, idleTimeoutSeconds } = await TurtleSshSession.startSshSessionAsync(ctx, {
           target,
           relayServerUrl: TurtleSshSession.getSshRelayServerUrl(ctx.job),


### PR DESCRIPTION
## Why

Wiring SSH into the worker build lifecycle: when a job has SSH enabled, open the session in `SSH_SESSION` and keep the VM up until supervision says it is safe to tear down.

## How

- Start the session early in `build()`, pass a `hasJobFinished` signal into the supervisor, and `await` teardown in `finally`
- Leave `SSH_SESSION` open in the log UI for the life of the tunnel (`doNotMarkEnd`, emit END on teardown)
- Opening the session is best-effort: failure warns and the job continues without SSH
- Upterm comes from PATH (image bake) or a runtime download from `gs://turtle-v2/upterm` via build-tools; this PR does not vendor binaries into the worker package

## Test Plan

Worker unit tests for the SSH phase. CI