### PR TITLE
[eas-cli] Add --ssh to workflow:run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,6 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] Prompt for the Expo SDK version in `eas new` and add a `--sdk-version` flag. The template now downloads from npm instead of GitHub to support SDK-specific versions. ([#4301](https://github.com/expo/eas-cli/pull/4301) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli] Clean up template metadata in projects created with `eas new`: remove the template LICENSE file and reset the package.json name, version, and license fields. ([#4301](https://github.com/expo/eas-cli/pull/4301) by [@brentvatne](https://github.com/brentvatne))
 - [build-tools] Support `EAS_PNPM_FILTER_WORKSPACE` to install only the selected workspace's dependencies with `pnpm install --filter`. ([#4302](https://github.com/expo/eas-cli/pull/4302) by [@robingullo](https://github.com/robingullo))
-- [eas-cli] Add `eas workflow:ssh <workflow-job-id> [command...]` to open an ssh session on the worker running a workflow job. ([#4032](https://github.com/expo/eas-cli/pull/4032) by [@gwdp](https://github.com/gwdp))
-- [eas-cli] Add `--ssh` (and `--ssh-idle-timeout`) to `eas workflow:run` to enable ssh on the run's VM jobs. ([#4033](https://github.com/expo/eas-cli/pull/4033) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Add worker-side SSH session helpers (upterm relay + session create/report/close). ([#4030](https://github.com/expo/eas-cli/pull/4030) by [@gwdp](https://github.com/gwdp))
 - [worker] Wire an SSH session into the build lifecycle behind the workflow ssh flag. ([#4031](https://github.com/expo/eas-cli/pull/4031) by [@gwdp](https://github.com/gwdp))
 - [eas-cli] Add `eas workflow:ssh <workflow-job-id> [command...]` to open an ssh session on the worker running a workflow job. ([#4032](https://github.com/expo/eas-cli/pull/4032) by [@gwdp](https://github.com/gwdp))
+- [eas-cli] Add `--ssh` (and `--ssh-idle-timeout`) to `eas workflow:run` to enable ssh on the run's VM jobs. ([#4033](https://github.com/expo/eas-cli/pull/4033) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] Update workflow run logs in real time, instead of every 10 seconds. ([#4228](https://github.com/expo/eas-cli/pull/4228) by [@AHGIJMKLKKZNPJKQR](https://github.com/AHGIJMKLKKZNPJKQR))
 - [build-tools] Add `expo-device-hub` web previews to Android web-preview-only, Agent Device, Argent, and Appium remote sessions. ([#4304](https://github.com/expo/eas-cli/pull/4304) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - [eas-cli] Add `eas workflow:ssh <workflow-job-id> [command...]` to open an ssh session on the worker running a workflow job. ([#4032](https://github.com/expo/eas-cli/pull/4032) by [@gwdp](https://github.com/gwdp))
+- [eas-cli] Add `--ssh` (and `--ssh-idle-timeout`) to `eas workflow:run` to enable ssh on the run's VM jobs. ([#4033](https://github.com/expo/eas-cli/pull/4033) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] Prompt for the Expo SDK version in `eas new` and add a `--sdk-version` flag. The template now downloads from npm instead of GitHub to support SDK-specific versions. ([#4301](https://github.com/expo/eas-cli/pull/4301) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli] Clean up template metadata in projects created with `eas new`: remove the template LICENSE file and reset the package.json name, version, and license fields. ([#4301](https://github.com/expo/eas-cli/pull/4301) by [@brentvatne](https://github.com/brentvatne))
 - [build-tools] Support `EAS_PNPM_FILTER_WORKSPACE` to install only the selected workspace's dependencies with `pnpm install --filter`. ([#4302](https://github.com/expo/eas-cli/pull/4302) by [@robingullo](https://github.com/robingullo))
+- [eas-cli] Add `eas workflow:ssh <workflow-job-id> [command...]` to open an ssh session on the worker running a workflow job. ([#4032](https://github.com/expo/eas-cli/pull/4032) by [@gwdp](https://github.com/gwdp))
+- [eas-cli] Add `--ssh` (and `--ssh-idle-timeout`) to `eas workflow:run` to enable ssh on the run's VM jobs. ([#4033](https://github.com/expo/eas-cli/pull/4033) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -46304,7 +46304,7 @@
         "fields": [
           {
             "name": "completeMessage",
-            "description": "Mark a message as completed (sets completedAt).\nmetadata is accepted for backward compatibility but ignored \u2014 use echoTurn.completeTurn instead.",
+            "description": "Mark a message as completed (sets completedAt).\nmetadata is accepted for backward compatibility but ignored — use echoTurn.completeTurn instead.",
             "args": [
               {
                 "name": "id",
@@ -52851,7 +52851,7 @@
           },
           {
             "name": "submitFeedback",
-            "description": "Record a control-variant one-shot feedback submission. Emits the\nfeedback-submitted event to RudderStack. No Slack notification, no\ntagging \u2014 those pipelines are scoped to the treatment chat flow via\ncomplete.",
+            "description": "Record a control-variant one-shot feedback submission. Emits the\nfeedback-submitted event to RudderStack. No Slack notification, no\ntagging — those pipelines are scoped to the treatment chat flow via\ncomplete.",
             "args": [
               {
                 "name": "input",
@@ -74954,7 +74954,7 @@
           },
           {
             "name": "listSupabaseOrganizations",
-            "description": "Live list of Supabase organizations this connection can access (Management API). Used once at\nconnect-time for the org picker \u2014 not a type field, so casual connection reads stay cheap.",
+            "description": "Live list of Supabase organizations this connection can access (Management API). Used once at\nconnect-time for the org picker — not a type field, so casual connection reads stay cheap.",
             "args": [
               {
                 "name": "accountId",
@@ -75329,7 +75329,7 @@
           },
           {
             "name": "fetchSupabasePublishableKey",
-            "description": "Live publishable (anon) key for the app's linked Supabase project (Management API). Never\nstored \u2014 null while the project is still provisioning. Used by the CLI to write EAS env vars.",
+            "description": "Live publishable (anon) key for the app's linked Supabase project (Management API). Never\nstored — null while the project is still provisioning. Used by the CLI to write EAS env vars.",
             "args": [
               {
                 "name": "appId",
@@ -75391,7 +75391,7 @@
           },
           {
             "name": "provisionAdditionalSupabaseProject",
-            "description": "Schedules an additional hosted Supabase project for selected EAS environments. Does not replace\nthe app's primary linked project \u2014 poll the receipt for ref/url/publishableKey in resultData.",
+            "description": "Schedules an additional hosted Supabase project for selected EAS environments. Does not replace\nthe app's primary linked project — poll the receipt for ref/url/publishableKey in resultData.",
             "args": [
               {
                 "name": "input",
@@ -85273,7 +85273,7 @@
         "fields": [
           {
             "name": "aaguid",
-            "description": "Authenticator Attestation Globally Unique Identifier \u2014 identifies the authenticator model\n(e.g., 1Password, iCloud Keychain). See https://passkeydeveloper.github.io/passkey-authenticator-aaguids/explorer/",
+            "description": "Authenticator Attestation Globally Unique Identifier — identifies the authenticator model\n(e.g., 1Password, iCloud Keychain). See https://passkeydeveloper.github.io/passkey-authenticator-aaguids/explorer/",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -92748,7 +92748,7 @@
       {
         "kind": "OBJECT",
         "name": "WorkflowDeviceTestCaseInsightsMetric",
-        "description": "A count metric returned for the current window AND the equivalent prior window\n(start \u2212 duration \u2192 start). The frontend uses (current, previous) to compute\ntrend deltas. Trend ratios are NOT pre-computed server-side \u2014 see\nWorkflowsInsightsMetric for the equivalent convention.\n\nFloat (not Int) to match WorkflowsInsightsMetric and avoid the GraphQL Int32\nceiling: year-long uniqExact counts on a high-volume project can plausibly\nexceed 2.1B. Values are integer-valued; the frontend reads them as JS numbers.",
+        "description": "A count metric returned for the current window AND the equivalent prior window\n(start − duration → start). The frontend uses (current, previous) to compute\ntrend deltas. Trend ratios are NOT pre-computed server-side — see\nWorkflowsInsightsMetric for the equivalent convention.\n\nFloat (not Int) to match WorkflowsInsightsMetric and avoid the GraphQL Int32\nceiling: year-long uniqExact counts on a high-volume project can plausibly\nexceed 2.1B. Values are integer-valued; the frontend reads them as JS numbers.",
         "fields": [
           {
             "name": "currentValue",
@@ -92791,7 +92791,7 @@
       {
         "kind": "OBJECT",
         "name": "WorkflowDeviceTestCaseInsightsNullableMetric",
-        "description": "Same shape as WorkflowDeviceTestCaseInsightsMetric but nullable on both sides \u2014\nused for metrics like avgDurationMs / p90DurationMs where \"no data in the\nwindow\" is meaningful and must not collapse to 0.",
+        "description": "Same shape as WorkflowDeviceTestCaseInsightsMetric but nullable on both sides —\nused for metrics like avgDurationMs / p90DurationMs where \"no data in the\nwindow\" is meaningful and must not collapse to 0.",
         "fields": [
           {
             "name": "currentValue",
@@ -93021,7 +93021,7 @@
       {
         "kind": "OBJECT",
         "name": "WorkflowDeviceTestCaseRecentRun",
-        "description": "One row per execution (is_final_attempt=1). The is_flaky boolean drives the\nFLAKY pill \u2014 no per-attempt timeline is exposed in v1.",
+        "description": "One row per execution (is_final_attempt=1). The is_flaky boolean drives the\nFLAKY pill — no per-attempt timeline is exposed in v1.",
         "fields": [
           {
             "name": "commitSha",
@@ -94016,7 +94016,7 @@
       {
         "kind": "ENUM",
         "name": "WorkflowDeviceTestCaseStatusFilter",
-        "description": "Mutually exclusive \u2014 matches the chart bucket semantics (passedClean / flaky / failed).\nPASSED_CLEAN  = is_final_attempt=1 AND status=passed AND is_flaky=0\nFLAKY         = is_final_attempt=1 AND is_flaky=1 (still a pass, just with retries)\nFAILED        = is_final_attempt=1 AND status=failed",
+        "description": "Mutually exclusive — matches the chart bucket semantics (passedClean / flaky / failed).\nPASSED_CLEAN  = is_final_attempt=1 AND status=passed AND is_flaky=0\nFLAKY         = is_final_attempt=1 AND is_flaky=1 (still a pass, just with retries)\nFAILED        = is_final_attempt=1 AND status=failed",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -96829,6 +96829,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "ssh",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "WorkflowRunSshInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "workflowRevisionId",
                 "description": null,
                 "type": {
@@ -96839,18 +96851,6 @@
                     "name": "ID",
                     "ofType": null
                   }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "ssh",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "WorkflowRunSshInput",
-                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -96886,6 +96886,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "ssh",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "WorkflowRunSshInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "workflowRunId",
                 "description": null,
                 "type": {
@@ -96896,18 +96908,6 @@
                     "name": "ID",
                     "ofType": null
                   }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "ssh",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "WorkflowRunSshInput",
-                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -44189,7 +44189,7 @@
         "fields": [
           {
             "name": "completeMessage",
-            "description": "Mark a message as completed (sets completedAt).\nmetadata is accepted for backward compatibility but ignored — use echoTurn.completeTurn instead.",
+            "description": "Mark a message as completed (sets completedAt).\nmetadata is accepted for backward compatibility but ignored \u2014 use echoTurn.completeTurn instead.",
             "args": [
               {
                 "name": "id",
@@ -50730,7 +50730,7 @@
           },
           {
             "name": "submitFeedback",
-            "description": "Record a control-variant one-shot feedback submission. Emits the\nfeedback-submitted event to RudderStack. No Slack notification, no\ntagging — those pipelines are scoped to the treatment chat flow via\ncomplete.",
+            "description": "Record a control-variant one-shot feedback submission. Emits the\nfeedback-submitted event to RudderStack. No Slack notification, no\ntagging \u2014 those pipelines are scoped to the treatment chat flow via\ncomplete.",
             "args": [
               {
                 "name": "input",
@@ -72679,7 +72679,7 @@
           },
           {
             "name": "listSupabaseOrganizations",
-            "description": "Live list of Supabase organizations this connection can access (Management API). Used once at\nconnect-time for the org picker — not a type field, so casual connection reads stay cheap.",
+            "description": "Live list of Supabase organizations this connection can access (Management API). Used once at\nconnect-time for the org picker \u2014 not a type field, so casual connection reads stay cheap.",
             "args": [
               {
                 "name": "accountId",
@@ -73054,7 +73054,7 @@
           },
           {
             "name": "fetchSupabasePublishableKey",
-            "description": "Live publishable (anon) key for the app's linked Supabase project (Management API). Never\nstored — null while the project is still provisioning. Used by the CLI to write EAS env vars.",
+            "description": "Live publishable (anon) key for the app's linked Supabase project (Management API). Never\nstored \u2014 null while the project is still provisioning. Used by the CLI to write EAS env vars.",
             "args": [
               {
                 "name": "appId",
@@ -73116,7 +73116,7 @@
           },
           {
             "name": "provisionAdditionalSupabaseProject",
-            "description": "Schedules an additional hosted Supabase project for selected EAS environments. Does not replace\nthe app's primary linked project — poll the receipt for ref/url/publishableKey in resultData.",
+            "description": "Schedules an additional hosted Supabase project for selected EAS environments. Does not replace\nthe app's primary linked project \u2014 poll the receipt for ref/url/publishableKey in resultData.",
             "args": [
               {
                 "name": "input",
@@ -82768,7 +82768,7 @@
         "fields": [
           {
             "name": "aaguid",
-            "description": "Authenticator Attestation Globally Unique Identifier — identifies the authenticator model\n(e.g., 1Password, iCloud Keychain). See https://passkeydeveloper.github.io/passkey-authenticator-aaguids/explorer/",
+            "description": "Authenticator Attestation Globally Unique Identifier \u2014 identifies the authenticator model\n(e.g., 1Password, iCloud Keychain). See https://passkeydeveloper.github.io/passkey-authenticator-aaguids/explorer/",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -90216,7 +90216,7 @@
       {
         "kind": "OBJECT",
         "name": "WorkflowDeviceTestCaseInsightsMetric",
-        "description": "A count metric returned for the current window AND the equivalent prior window\n(start − duration → start). The frontend uses (current, previous) to compute\ntrend deltas. Trend ratios are NOT pre-computed server-side — see\nWorkflowsInsightsMetric for the equivalent convention.\n\nFloat (not Int) to match WorkflowsInsightsMetric and avoid the GraphQL Int32\nceiling: year-long uniqExact counts on a high-volume project can plausibly\nexceed 2.1B. Values are integer-valued; the frontend reads them as JS numbers.",
+        "description": "A count metric returned for the current window AND the equivalent prior window\n(start \u2212 duration \u2192 start). The frontend uses (current, previous) to compute\ntrend deltas. Trend ratios are NOT pre-computed server-side \u2014 see\nWorkflowsInsightsMetric for the equivalent convention.\n\nFloat (not Int) to match WorkflowsInsightsMetric and avoid the GraphQL Int32\nceiling: year-long uniqExact counts on a high-volume project can plausibly\nexceed 2.1B. Values are integer-valued; the frontend reads them as JS numbers.",
         "fields": [
           {
             "name": "currentValue",
@@ -90259,7 +90259,7 @@
       {
         "kind": "OBJECT",
         "name": "WorkflowDeviceTestCaseInsightsNullableMetric",
-        "description": "Same shape as WorkflowDeviceTestCaseInsightsMetric but nullable on both sides —\nused for metrics like avgDurationMs / p90DurationMs where \"no data in the\nwindow\" is meaningful and must not collapse to 0.",
+        "description": "Same shape as WorkflowDeviceTestCaseInsightsMetric but nullable on both sides \u2014\nused for metrics like avgDurationMs / p90DurationMs where \"no data in the\nwindow\" is meaningful and must not collapse to 0.",
         "fields": [
           {
             "name": "currentValue",
@@ -90489,7 +90489,7 @@
       {
         "kind": "OBJECT",
         "name": "WorkflowDeviceTestCaseRecentRun",
-        "description": "One row per execution (is_final_attempt=1). The is_flaky boolean drives the\nFLAKY pill — no per-attempt timeline is exposed in v1.",
+        "description": "One row per execution (is_final_attempt=1). The is_flaky boolean drives the\nFLAKY pill \u2014 no per-attempt timeline is exposed in v1.",
         "fields": [
           {
             "name": "commitSha",
@@ -91484,7 +91484,7 @@
       {
         "kind": "ENUM",
         "name": "WorkflowDeviceTestCaseStatusFilter",
-        "description": "Mutually exclusive — matches the chart bucket semantics (passedClean / flaky / failed).\nPASSED_CLEAN  = is_final_attempt=1 AND status=passed AND is_flaky=0\nFLAKY         = is_final_attempt=1 AND is_flaky=1 (still a pass, just with retries)\nFAILED        = is_final_attempt=1 AND status=failed",
+        "description": "Mutually exclusive \u2014 matches the chart bucket semantics (passedClean / flaky / failed).\nPASSED_CLEAN  = is_final_attempt=1 AND status=passed AND is_flaky=0\nFLAKY         = is_final_attempt=1 AND is_flaky=1 (still a pass, just with retries)\nFAILED        = is_final_attempt=1 AND status=failed",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -93877,6 +93877,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "ssh",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "WorkflowRunSshInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -94094,6 +94106,18 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "ssh",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "WorkflowRunSshInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -94135,6 +94159,18 @@
                     "name": "ID",
                     "ofType": null
                   }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "ssh",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "WorkflowRunSshInput",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -94200,6 +94236,29 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "WorkflowRunSshInput",
+        "description": "Enables ssh on the run's VM jobs. Presence turns ssh on; idleTimeoutSeconds is optional,\ndefaults server-side, and is validated against a supported range.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "idleTimeoutSeconds",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -46304,7 +46304,7 @@
         "fields": [
           {
             "name": "completeMessage",
-            "description": "Mark a message as completed (sets completedAt).\nmetadata is accepted for backward compatibility but ignored — use echoTurn.completeTurn instead.",
+            "description": "Mark a message as completed (sets completedAt).\nmetadata is accepted for backward compatibility but ignored \u2014 use echoTurn.completeTurn instead.",
             "args": [
               {
                 "name": "id",
@@ -52851,7 +52851,7 @@
           },
           {
             "name": "submitFeedback",
-            "description": "Record a control-variant one-shot feedback submission. Emits the\nfeedback-submitted event to RudderStack. No Slack notification, no\ntagging — those pipelines are scoped to the treatment chat flow via\ncomplete.",
+            "description": "Record a control-variant one-shot feedback submission. Emits the\nfeedback-submitted event to RudderStack. No Slack notification, no\ntagging \u2014 those pipelines are scoped to the treatment chat flow via\ncomplete.",
             "args": [
               {
                 "name": "input",
@@ -74954,7 +74954,7 @@
           },
           {
             "name": "listSupabaseOrganizations",
-            "description": "Live list of Supabase organizations this connection can access (Management API). Used once at\nconnect-time for the org picker — not a type field, so casual connection reads stay cheap.",
+            "description": "Live list of Supabase organizations this connection can access (Management API). Used once at\nconnect-time for the org picker \u2014 not a type field, so casual connection reads stay cheap.",
             "args": [
               {
                 "name": "accountId",
@@ -75329,7 +75329,7 @@
           },
           {
             "name": "fetchSupabasePublishableKey",
-            "description": "Live publishable (anon) key for the app's linked Supabase project (Management API). Never\nstored — null while the project is still provisioning. Used by the CLI to write EAS env vars.",
+            "description": "Live publishable (anon) key for the app's linked Supabase project (Management API). Never\nstored \u2014 null while the project is still provisioning. Used by the CLI to write EAS env vars.",
             "args": [
               {
                 "name": "appId",
@@ -75391,7 +75391,7 @@
           },
           {
             "name": "provisionAdditionalSupabaseProject",
-            "description": "Schedules an additional hosted Supabase project for selected EAS environments. Does not replace\nthe app's primary linked project — poll the receipt for ref/url/publishableKey in resultData.",
+            "description": "Schedules an additional hosted Supabase project for selected EAS environments. Does not replace\nthe app's primary linked project \u2014 poll the receipt for ref/url/publishableKey in resultData.",
             "args": [
               {
                 "name": "input",
@@ -85273,7 +85273,7 @@
         "fields": [
           {
             "name": "aaguid",
-            "description": "Authenticator Attestation Globally Unique Identifier — identifies the authenticator model\n(e.g., 1Password, iCloud Keychain). See https://passkeydeveloper.github.io/passkey-authenticator-aaguids/explorer/",
+            "description": "Authenticator Attestation Globally Unique Identifier \u2014 identifies the authenticator model\n(e.g., 1Password, iCloud Keychain). See https://passkeydeveloper.github.io/passkey-authenticator-aaguids/explorer/",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -92748,7 +92748,7 @@
       {
         "kind": "OBJECT",
         "name": "WorkflowDeviceTestCaseInsightsMetric",
-        "description": "A count metric returned for the current window AND the equivalent prior window\n(start − duration → start). The frontend uses (current, previous) to compute\ntrend deltas. Trend ratios are NOT pre-computed server-side — see\nWorkflowsInsightsMetric for the equivalent convention.\n\nFloat (not Int) to match WorkflowsInsightsMetric and avoid the GraphQL Int32\nceiling: year-long uniqExact counts on a high-volume project can plausibly\nexceed 2.1B. Values are integer-valued; the frontend reads them as JS numbers.",
+        "description": "A count metric returned for the current window AND the equivalent prior window\n(start \u2212 duration \u2192 start). The frontend uses (current, previous) to compute\ntrend deltas. Trend ratios are NOT pre-computed server-side \u2014 see\nWorkflowsInsightsMetric for the equivalent convention.\n\nFloat (not Int) to match WorkflowsInsightsMetric and avoid the GraphQL Int32\nceiling: year-long uniqExact counts on a high-volume project can plausibly\nexceed 2.1B. Values are integer-valued; the frontend reads them as JS numbers.",
         "fields": [
           {
             "name": "currentValue",
@@ -92791,7 +92791,7 @@
       {
         "kind": "OBJECT",
         "name": "WorkflowDeviceTestCaseInsightsNullableMetric",
-        "description": "Same shape as WorkflowDeviceTestCaseInsightsMetric but nullable on both sides —\nused for metrics like avgDurationMs / p90DurationMs where \"no data in the\nwindow\" is meaningful and must not collapse to 0.",
+        "description": "Same shape as WorkflowDeviceTestCaseInsightsMetric but nullable on both sides \u2014\nused for metrics like avgDurationMs / p90DurationMs where \"no data in the\nwindow\" is meaningful and must not collapse to 0.",
         "fields": [
           {
             "name": "currentValue",
@@ -93021,7 +93021,7 @@
       {
         "kind": "OBJECT",
         "name": "WorkflowDeviceTestCaseRecentRun",
-        "description": "One row per execution (is_final_attempt=1). The is_flaky boolean drives the\nFLAKY pill — no per-attempt timeline is exposed in v1.",
+        "description": "One row per execution (is_final_attempt=1). The is_flaky boolean drives the\nFLAKY pill \u2014 no per-attempt timeline is exposed in v1.",
         "fields": [
           {
             "name": "commitSha",
@@ -94016,7 +94016,7 @@
       {
         "kind": "ENUM",
         "name": "WorkflowDeviceTestCaseStatusFilter",
-        "description": "Mutually exclusive — matches the chart bucket semantics (passedClean / flaky / failed).\nPASSED_CLEAN  = is_final_attempt=1 AND status=passed AND is_flaky=0\nFLAKY         = is_final_attempt=1 AND is_flaky=1 (still a pass, just with retries)\nFAILED        = is_final_attempt=1 AND status=failed",
+        "description": "Mutually exclusive \u2014 matches the chart bucket semantics (passedClean / flaky / failed).\nPASSED_CLEAN  = is_final_attempt=1 AND status=passed AND is_flaky=0\nFLAKY         = is_final_attempt=1 AND is_flaky=1 (still a pass, just with retries)\nFAILED        = is_final_attempt=1 AND status=failed",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -96614,6 +96614,18 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "ssh",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "WorkflowRunSshInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -96831,6 +96843,18 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "ssh",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "WorkflowRunSshInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {
@@ -96872,6 +96896,18 @@
                     "name": "ID",
                     "ofType": null
                   }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "ssh",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "WorkflowRunSshInput",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -96937,6 +96973,29 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "WorkflowRunSshInput",
+        "description": "Enables ssh on the run's VM jobs. Presence turns ssh on; idleTimeoutSeconds is optional,\ndefaults server-side, and is validated against a supported range.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "idleTimeoutSeconds",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/packages/eas-cli/src/commands/workflow/__tests__/run-ssh.test.ts
+++ b/packages/eas-cli/src/commands/workflow/__tests__/run-ssh.test.ts
@@ -1,0 +1,171 @@
+import spawnAsync from '@expo/spawn-async';
+import { Config } from '@oclif/core';
+
+import { fileExistsAsync, maybeReadStdinAsync } from '../../../commandUtils/workflow/utils';
+import { WorkflowRevisionMutation } from '../../../graphql/mutations/WorkflowRevisionMutation';
+import { WorkflowRunMutation } from '../../../graphql/mutations/WorkflowRunMutation';
+import Log from '../../../log';
+import { getOwnerAccountForProjectIdAsync } from '../../../project/projectUtils';
+import { uploadAccountScopedFileAsync } from '../../../project/uploadAccountScopedFileAsync';
+import { uploadAccountScopedProjectSourceAsync } from '../../../project/uploadAccountScopedProjectSourceAsync';
+import { WorkflowFile } from '../../../utils/workflowFile';
+import WorkflowRun from '../run';
+
+jest.mock('@expo/spawn-async', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../../../graphql/mutations/WorkflowRevisionMutation');
+jest.mock('../../../graphql/mutations/WorkflowRunMutation');
+jest.mock('../../../project/projectUtils');
+jest.mock('../../../project/uploadAccountScopedFileAsync');
+jest.mock('../../../project/uploadAccountScopedProjectSourceAsync');
+jest.mock('../../../utils/workflowFile');
+jest.mock('../../../commandUtils/workflow/utils', () => ({
+  ...jest.requireActual('../../../commandUtils/workflow/utils'),
+  fileExistsAsync: jest.fn(),
+  maybeReadStdinAsync: jest.fn(),
+}));
+jest.mock('../../../log', () => ({
+  __esModule: true,
+  default: {
+    log: jest.fn(),
+    newLine: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  link: jest.fn((url: string) => url),
+}));
+
+const mockSpawn = jest.mocked(spawnAsync);
+const mockValidate = jest.mocked(WorkflowRevisionMutation.validateWorkflowYamlConfigAsync);
+const mockGetOrCreateRevision = jest.mocked(
+  WorkflowRevisionMutation.getOrCreateWorkflowRevisionFromGitRefAsync
+);
+const mockCreateFromGitRef = jest.mocked(WorkflowRunMutation.createWorkflowRunFromGitRefAsync);
+const mockCreateRun = jest.mocked(WorkflowRunMutation.createWorkflowRunAsync);
+const mockGetOwner = jest.mocked(getOwnerAccountForProjectIdAsync);
+const mockUploadProject = jest.mocked(uploadAccountScopedProjectSourceAsync);
+const mockUploadFile = jest.mocked(uploadAccountScopedFileAsync);
+const mockReadWorkflow = jest.mocked(WorkflowFile.readWorkflowFileContentsAsync);
+const mockFileExists = jest.mocked(fileExistsAsync);
+const mockReadStdin = jest.mocked(maybeReadStdinAsync);
+
+describe('WorkflowRun --ssh', () => {
+  let mockConfig: Config;
+  let exitSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    mockConfig = new Config({ root: __dirname });
+    mockConfig.runHook = async () => ({ failures: [], successes: [] });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+    }) as never);
+    mockReadStdin.mockResolvedValue(null);
+    mockGetOwner.mockResolvedValue({ id: 'acct-1', name: 'testuser' } as never);
+    mockValidate.mockResolvedValue(undefined as never);
+    mockReadWorkflow.mockResolvedValue({
+      filePath: '.eas/workflows/test.yml',
+      yamlConfig: 'jobs:\n  a:\n    steps: []\n',
+    } as never);
+    mockFileExists.mockResolvedValue(false);
+    mockUploadProject.mockResolvedValue({ projectArchiveBucketKey: 'archive-key' } as never);
+    mockUploadFile.mockResolvedValue({ fileBucketKey: 'file-key' } as never);
+    mockCreateRun.mockResolvedValue({ id: 'run-1' } as never);
+    mockCreateFromGitRef.mockResolvedValue({ id: 'run-git-1' } as never);
+    mockSpawn.mockResolvedValue({ output: ['abc123\n'] } as never);
+    mockGetOrCreateRevision.mockResolvedValue({
+      id: 'rev-1',
+      yamlConfig: 'jobs:\n  a:\n    steps: []\n',
+    } as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  function createCommand(flags: {
+    ssh?: boolean;
+    'ssh-idle-timeout'?: number;
+    ref?: string;
+  }): WorkflowRun {
+    const command = new WorkflowRun(['.eas/workflows/test.yml'], mockConfig);
+    // @ts-expect-error getContextAsync/parse are protected
+    jest.spyOn(command, 'getContextAsync').mockResolvedValue({
+      getDynamicPrivateProjectConfigAsync: async () => ({
+        projectId: 'app-1',
+        exp: { slug: 'testapp' },
+      }),
+      loggedIn: { graphqlClient: {} },
+      vcsClient: { getRootPathAsync: async () => '/test/project' },
+      projectDir: '/test/project',
+    });
+    // @ts-expect-error parse is protected on the oclif base
+    jest.spyOn(command, 'parse').mockResolvedValue({
+      flags: {
+        json: false,
+        wait: false,
+        'non-interactive': true,
+        input: undefined,
+        ref: flags.ref,
+        ssh: flags.ssh ?? false,
+        'ssh-idle-timeout': flags['ssh-idle-timeout'],
+      },
+      args: { file: '.eas/workflows/test.yml' },
+    });
+    return command;
+  }
+
+  it('passes ssh input into createWorkflowRunAsync and logs that SSH is enabled', async () => {
+    await expect(createCommand({ ssh: true, 'ssh-idle-timeout': 120 }).runAsync()).rejects.toThrow(
+      'process.exit:0'
+    );
+
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        workflowRunInput: expect.objectContaining({
+          ssh: { idleTimeoutSeconds: 120 },
+        }),
+      })
+    );
+    expect(Log.log).toHaveBeenCalledWith(
+      'SSH enabled. Each VM job logs the `eas workflow:ssh` command to connect.'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('does not log the SSH banner when --ssh is unset', async () => {
+    await expect(createCommand({ ssh: false }).runAsync()).rejects.toThrow('process.exit:0');
+
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        workflowRunInput: expect.objectContaining({
+          ssh: null,
+        }),
+      })
+    );
+    expect(Log.log).not.toHaveBeenCalledWith(
+      'SSH enabled. Each VM job logs the `eas workflow:ssh` command to connect.'
+    );
+  });
+
+  it('passes ssh input into createWorkflowRunFromGitRefAsync when --ref is set', async () => {
+    await expect(createCommand({ ssh: true, ref: 'main' }).runAsync()).rejects.toThrow(
+      'process.exit:0'
+    );
+
+    expect(mockCreateFromGitRef).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        ssh: { idleTimeoutSeconds: undefined },
+      })
+    );
+    expect(Log.log).toHaveBeenCalledWith(
+      'SSH enabled. Each VM job logs the `eas workflow:ssh` command to connect.'
+    );
+  });
+});

--- a/packages/eas-cli/src/commands/workflow/__tests__/run.test.ts
+++ b/packages/eas-cli/src/commands/workflow/__tests__/run.test.ts
@@ -3,6 +3,31 @@ import {
   parseJsonInputs,
   parseWorkflowInputsFromYaml,
 } from '../../../commandUtils/workflow/inputs';
+import { resolveWorkflowRunSshInput } from '../run';
+
+describe(resolveWorkflowRunSshInput, () => {
+  it('is null when --ssh is not set', () => {
+    expect(resolveWorkflowRunSshInput({ ssh: false, idleTimeoutSeconds: undefined })).toBeNull();
+  });
+
+  it('forwards ssh with an undefined timeout when --ssh is set alone', () => {
+    expect(resolveWorkflowRunSshInput({ ssh: true, idleTimeoutSeconds: undefined })).toEqual({
+      idleTimeoutSeconds: undefined,
+    });
+  });
+
+  it('forwards the requested idle timeout when both flags are set', () => {
+    expect(resolveWorkflowRunSshInput({ ssh: true, idleTimeoutSeconds: 60 })).toEqual({
+      idleTimeoutSeconds: 60,
+    });
+  });
+
+  it('rejects --ssh-idle-timeout without --ssh', () => {
+    expect(() => resolveWorkflowRunSshInput({ ssh: false, idleTimeoutSeconds: 60 })).toThrow(
+      '--ssh-idle-timeout requires --ssh.'
+    );
+  });
+});
 
 describe('parseInputs', () => {
   it('should parse single key=value pair', () => {

--- a/packages/eas-cli/src/commands/workflow/run.ts
+++ b/packages/eas-cli/src/commands/workflow/run.ts
@@ -78,6 +78,19 @@ import { uploadAccountScopedProjectSourceAsync } from '../../project/uploadAccou
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import { WorkflowFile } from '../../utils/workflowFile';
 
+export function resolveWorkflowRunSshInput({
+  ssh,
+  idleTimeoutSeconds,
+}: {
+  ssh: boolean;
+  idleTimeoutSeconds: number | undefined;
+}): { idleTimeoutSeconds: number | undefined } | null {
+  if (idleTimeoutSeconds !== undefined && !ssh) {
+    throw new Error('--ssh-idle-timeout requires --ssh.');
+  }
+  return ssh ? { idleTimeoutSeconds } : null;
+}
+
 export default class WorkflowRun extends EasCommand {
   static override description =
     'run an EAS workflow. The entire local project directory will be packaged and uploaded to EAS servers for the workflow run, unless the --ref flag is used.';
@@ -110,6 +123,18 @@ export default class WorkflowRun extends EasCommand {
         "The git reference must exist in the project's git repository, and the workflow file must exist at that reference. When this flag is used, the local project is not uploaded; instead, the workflow is run from the exact state of the project at the chosen reference.",
       summary: 'Git reference to run the workflow on',
     }),
+    ssh: Flags.boolean({
+      default: false,
+      description: 'Open an SSH session on each VM job for live debugging with `eas workflow:ssh`.',
+      summary: '[EXPERIMENTAL] Enable SSH on the run',
+    }),
+    'ssh-idle-timeout': Flags.integer({
+      description:
+        'Seconds to keep an SSH session open after its job finishes, while no client is connected. The session is always available for the whole job. Requires --ssh. Must be between 0 and 3600; defaults to 0 (close as soon as the job finishes and nobody is connected).',
+      summary: '[EXPERIMENTAL] SSH idle timeout in seconds',
+      min: 0,
+      max: 3600,
+    }),
     ...EasJsonOnlyFlag,
   };
 
@@ -126,6 +151,11 @@ export default class WorkflowRun extends EasCommand {
     if (flags.json) {
       enableJsonOutput();
     }
+
+    const sshInput = resolveWorkflowRunSshInput({
+      ssh: flags.ssh,
+      idleTimeoutSeconds: flags['ssh-idle-timeout'],
+    });
 
     const {
       getDynamicPrivateProjectConfigAsync,
@@ -272,6 +302,7 @@ export default class WorkflowRun extends EasCommand {
           workflowRevisionId: workflowRevisionId ?? '',
           gitRef,
           inputs,
+          ssh: sshInput,
         });
       } catch (err) {
         throw new Error(`Failed to create workflow run: ${err}`);
@@ -341,6 +372,7 @@ export default class WorkflowRun extends EasCommand {
               packageJsonBucketKey,
               projectRootDirectory,
             },
+            ssh: sshInput,
           },
         }));
       } catch (err) {
@@ -352,6 +384,10 @@ export default class WorkflowRun extends EasCommand {
 
     Log.newLine();
     Log.log(`See logs: ${link(getWorkflowRunUrl(account.name, projectName, workflowRunId))}`);
+
+    if (sshInput) {
+      Log.log('SSH enabled. Each VM job logs the `eas workflow:ssh` command to connect.');
+    }
 
     if (!flags.wait) {
       if (flags.json) {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -13552,6 +13552,7 @@ export type WorkflowRunGitBranchFilterInput = {
 export type WorkflowRunInput = {
   inputs?: InputMaybe<Scalars['JSONObject']['input']>;
   projectSource: WorkflowProjectSourceInput;
+  ssh?: InputMaybe<WorkflowRunSshInput>;
 };
 
 export type WorkflowRunMutation = {
@@ -13586,12 +13587,14 @@ export type WorkflowRunMutationCreateWorkflowRunArgs = {
 export type WorkflowRunMutationCreateWorkflowRunFromGitRefArgs = {
   gitRef: Scalars['String']['input'];
   inputs?: InputMaybe<Scalars['JSONObject']['input']>;
+  ssh?: InputMaybe<WorkflowRunSshInput>;
   workflowRevisionId: Scalars['ID']['input'];
 };
 
 
 export type WorkflowRunMutationRetryWorkflowRunArgs = {
   fromFailedJobs?: InputMaybe<Scalars['Boolean']['input']>;
+  ssh?: InputMaybe<WorkflowRunSshInput>;
   workflowRunId: Scalars['ID']['input'];
 };
 
@@ -13603,6 +13606,14 @@ export type WorkflowRunQuery = {
 
 export type WorkflowRunQueryByIdArgs = {
   workflowRunId: Scalars['ID']['input'];
+};
+
+/**
+ * Enables ssh on the run's VM jobs. Presence turns ssh on; idleTimeoutSeconds is optional,
+ * defaults server-side, and is validated against a supported range.
+ */
+export type WorkflowRunSshInput = {
+  idleTimeoutSeconds?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type WorkflowRunSshSettings = {
@@ -14893,6 +14904,7 @@ export type CreateWorkflowRunFromGitRefMutationVariables = Exact<{
   workflowRevisionId: Scalars['ID']['input'];
   gitRef: Scalars['String']['input'];
   inputs?: InputMaybe<Scalars['JSONObject']['input']>;
+  ssh?: InputMaybe<WorkflowRunSshInput>;
 }>;
 
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -13071,6 +13071,7 @@ export type WorkflowRunGitBranchFilterInput = {
 export type WorkflowRunInput = {
   inputs?: InputMaybe<Scalars['JSONObject']['input']>;
   projectSource: WorkflowProjectSourceInput;
+  ssh?: InputMaybe<WorkflowRunSshInput>;
 };
 
 export type WorkflowRunMutation = {
@@ -13105,12 +13106,14 @@ export type WorkflowRunMutationCreateWorkflowRunArgs = {
 export type WorkflowRunMutationCreateWorkflowRunFromGitRefArgs = {
   gitRef: Scalars['String']['input'];
   inputs?: InputMaybe<Scalars['JSONObject']['input']>;
+  ssh?: InputMaybe<WorkflowRunSshInput>;
   workflowRevisionId: Scalars['ID']['input'];
 };
 
 
 export type WorkflowRunMutationRetryWorkflowRunArgs = {
   fromFailedJobs?: InputMaybe<Scalars['Boolean']['input']>;
+  ssh?: InputMaybe<WorkflowRunSshInput>;
   workflowRunId: Scalars['ID']['input'];
 };
 
@@ -13122,6 +13125,14 @@ export type WorkflowRunQuery = {
 
 export type WorkflowRunQueryByIdArgs = {
   workflowRunId: Scalars['ID']['input'];
+};
+
+/**
+ * Enables ssh on the run's VM jobs. Presence turns ssh on; idleTimeoutSeconds is optional,
+ * defaults server-side, and is validated against a supported range.
+ */
+export type WorkflowRunSshInput = {
+  idleTimeoutSeconds?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type WorkflowRunSshSettings = {
@@ -14489,6 +14500,7 @@ export type CreateWorkflowRunFromGitRefMutationVariables = Exact<{
   workflowRevisionId: Scalars['ID']['input'];
   gitRef: Scalars['String']['input'];
   inputs?: InputMaybe<Scalars['JSONObject']['input']>;
+  ssh?: InputMaybe<WorkflowRunSshInput>;
 }>;
 
 

--- a/packages/eas-cli/src/graphql/mutations/WorkflowRunMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/WorkflowRunMutation.ts
@@ -12,6 +12,7 @@ import {
   WorkflowProjectSourceInput,
   WorkflowRevisionInput,
   WorkflowRunInput,
+  WorkflowRunSshInput,
 } from '../generated';
 
 export namespace WorkflowRunMutation {
@@ -64,10 +65,12 @@ export namespace WorkflowRunMutation {
       workflowRevisionId,
       gitRef,
       inputs,
+      ssh,
     }: {
       workflowRevisionId: string;
       gitRef: string;
       inputs?: Record<string, any>;
+      ssh?: WorkflowRunSshInput | null;
     }
   ): Promise<{ id: string }> {
     const data = await withErrorHandlingAsync(
@@ -81,12 +84,14 @@ export namespace WorkflowRunMutation {
               $workflowRevisionId: ID!
               $gitRef: String!
               $inputs: JSONObject
+              $ssh: WorkflowRunSshInput
             ) {
               workflowRun {
                 createWorkflowRunFromGitRef(
                   workflowRevisionId: $workflowRevisionId
                   gitRef: $gitRef
                   inputs: $inputs
+                  ssh: $ssh
                 ) {
                   id
                 }
@@ -97,6 +102,7 @@ export namespace WorkflowRunMutation {
             workflowRevisionId,
             gitRef,
             inputs,
+            ssh,
           }
         )
         .toPromise()


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Lets you enable SSH when starting a run, so you can connect to it afterwards with `eas workflow:ssh`:

```
eas workflow:run --ssh
```

# How

Adds `--ssh` and `--ssh-idle-timeout` to `workflow:run`, feeding a single SSH input on both run-creation mutations that marks the run's VM jobs as SSH-enabled.

- `--ssh-idle-timeout` without `--ssh` is rejected.
- The server owns the timeout default and clamp.

# Test Plan

Unit tests cover input resolution, including the timeout-without-`--ssh` rejection. CI passes.
