### PR TITLE
[eas-cli] add feedback nudge for coding agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Prompt detected coding agents to report actionable feedback after non-interactive commands. ([#4039](https://github.com/expo/eas-cli/pull/4039) by [@davidmokos](https://github.com/davidmokos))
 - [eas-cli] Support drill-down from event lists in observe:session. ([#3987](https://github.com/expo/eas-cli/pull/3987) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/commandUtils/EasCommand.ts
+++ b/packages/eas-cli/src/commandUtils/EasCommand.ts
@@ -31,6 +31,7 @@ import Sentry from '../sentry';
 import SessionManager from '../user/SessionManager';
 import { getActorDisplayName } from '../user/User';
 import { Client } from '../vcs/vcs';
+import { printAgentFeedbackIfNeeded } from './agentFeedback';
 
 export type ContextInput<
   T extends {
@@ -252,7 +253,9 @@ export default abstract class EasCommand extends Command {
   override async finally(err: Error): Promise<any> {
     await this.analytics.flushAsync();
     await Sentry.flush(2000);
-    return await super.finally(err);
+    const result = await super.finally(err);
+    printAgentFeedbackIfNeeded(this.id, this.argv);
+    return result;
   }
 
   protected override catch(err: Error): Promise<any> {

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -23,6 +23,9 @@ jest.mock('../../analytics/AnalyticsManager', () => {
   };
 });
 jest.mock('../../log');
+jest.mock('../agentFeedback', () => ({
+  printAgentFeedbackIfNeeded: jest.fn(),
+}));
 
 let originalProcessArgv: string[];
 const mockRequestId = uuidv4();
@@ -98,6 +101,14 @@ describe('EasCommand', () => {
 
       const Sentry = jest.requireMock('../../sentry').default;
       expect(Sentry.flush).toHaveBeenCalled();
+    });
+
+    it('checks whether to print agent feedback instructions after the command finishes', async () => {
+      const TestEasCommand = createTestEasCommand();
+      await TestEasCommand.run();
+
+      const { printAgentFeedbackIfNeeded } = jest.requireMock('../agentFeedback');
+      expect(printAgentFeedbackIfNeeded).toHaveBeenCalledWith(TestEasCommand.id, expect.any(Array));
     });
 
     it('logs events', async () => {

--- a/packages/eas-cli/src/commandUtils/__tests__/agentFeedback-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/agentFeedback-test.ts
@@ -25,7 +25,7 @@ it.each([['--non-interactive'], ['--json']])(
     printAgentFeedbackIfNeeded('build:list', [flag]);
 
     expect(stderrWriteSpy).toHaveBeenCalledWith(
-      '\nEAS CLI issue? Report it: npx --yes submit-expo-feedback --category eas-cli --subject "build:list" "<what happened and how to reproduce>"\n'
+      '\nEAS CLI issue? Report it: npx --yes submit-expo-feedback@latest --category eas-cli --subject "build:list" "<what happened and how to reproduce>"\n'
     );
   }
 );

--- a/packages/eas-cli/src/commandUtils/__tests__/agentFeedback-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/agentFeedback-test.ts
@@ -1,0 +1,57 @@
+import { getAgentTelemetryContext } from '../../analytics/agent';
+import { printAgentFeedbackIfNeeded } from '../agentFeedback';
+import { isNonInteractiveByDefault } from '../flags';
+
+jest.mock('../../analytics/agent');
+jest.mock('../flags');
+
+const getAgentTelemetryContextMock = jest.mocked(getAgentTelemetryContext);
+const isNonInteractiveByDefaultMock = jest.mocked(isNonInteractiveByDefault);
+
+beforeEach(() => {
+  getAgentTelemetryContextMock.mockReturnValue({ id: 'codex', sessionId: undefined });
+  isNonInteractiveByDefaultMock.mockReturnValue(false);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it.each([['--non-interactive'], ['--json']])(
+  'prints feedback instructions for agent commands run with %s',
+  flag => {
+    const stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    printAgentFeedbackIfNeeded('build:list', [flag]);
+
+    expect(stderrWriteSpy).toHaveBeenCalledWith(
+      '\nEAS CLI issue? Report it: npx --yes submit-expo-feedback --category eas-cli --subject "build:list" "<what happened and how to reproduce>"\n'
+    );
+  }
+);
+
+it('prints feedback instructions when non-interactive mode is inferred', () => {
+  isNonInteractiveByDefaultMock.mockReturnValue(true);
+  const stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+  printAgentFeedbackIfNeeded('build', []);
+
+  expect(stderrWriteSpy).toHaveBeenCalledTimes(1);
+});
+
+it('does not print feedback instructions in interactive mode', () => {
+  const stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+  printAgentFeedbackIfNeeded('build', []);
+
+  expect(stderrWriteSpy).not.toHaveBeenCalled();
+});
+
+it('does not print feedback instructions without a detected agent', () => {
+  getAgentTelemetryContextMock.mockReturnValue(null);
+  const stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+  printAgentFeedbackIfNeeded('build', ['--non-interactive']);
+
+  expect(stderrWriteSpy).not.toHaveBeenCalled();
+});

--- a/packages/eas-cli/src/commandUtils/agentFeedback.ts
+++ b/packages/eas-cli/src/commandUtils/agentFeedback.ts
@@ -1,0 +1,20 @@
+import { getAgentTelemetryContext } from '../analytics/agent';
+import { isNonInteractiveByDefault } from './flags';
+
+export function printAgentFeedbackIfNeeded(
+  commandId: string | undefined,
+  argv: readonly string[]
+): void {
+  const isNonInteractive =
+    isNonInteractiveByDefault() || argv.includes('--non-interactive') || argv.includes('--json');
+
+  if (!isNonInteractive || !getAgentTelemetryContext()) {
+    return;
+  }
+
+  process.stderr.write(
+    `\nEAS CLI issue? Report it: npx --yes submit-expo-feedback --category eas-cli --subject "${
+      commandId ?? 'unknown'
+    }" "<what happened and how to reproduce>"\n`
+  );
+}

--- a/packages/eas-cli/src/commandUtils/agentFeedback.ts
+++ b/packages/eas-cli/src/commandUtils/agentFeedback.ts
@@ -13,7 +13,7 @@ export function printAgentFeedbackIfNeeded(
   }
 
   process.stderr.write(
-    `\nEAS CLI issue? Report it: npx --yes submit-expo-feedback --category eas-cli --subject "${
+    `\nEAS CLI issue? Report it: npx --yes submit-expo-feedback@latest --category eas-cli --subject "${
       commandId ?? 'unknown'
     }" "<what happened and how to reproduce>"\n`
   );


### PR DESCRIPTION
Adds a compact feedback command at the end of non-interactive EAS CLI runs when a coding agent is detected. The nudge is emitted on stderr so JSON and machine-readable stdout remain intact, and it includes the EAS command ID as the feedback subject. Tests cover explicit and inferred non-interactive modes, JSON mode, interactive use, missing agent detection, and command finalization.

> [!IMPORTANT]
> Do not merge until https://github.com/expo/expo/pull/47904 is published to npm; merging that PR alone is not sufficient.

## Example outputs

LLM harnesses typically receive stdout and stderr together, although the feedback nudge itself is written to stderr.

### Successful command

```text
$ eas account:view --non-interactive
david

EAS CLI issue? Report it: npx --yes submit-expo-feedback@latest --category eas-cli --subject "account:view" "<what happened and how to reproduce>"
```

### JSON output

```text
stdout:
{
  "builds": [
    {
      "id": "abc123",
      "status": "finished"
    }
  ]
}

stderr:
EAS CLI issue? Report it: npx --yes submit-expo-feedback@latest --category eas-cli --subject "build:list" "<what happened and how to reproduce>"
```

### Failed command

```text
$ eas build --non-interactive
The --platform flag is required when building in non-interactive mode.

EAS CLI issue? Report it: npx --yes submit-expo-feedback@latest --category eas-cli --subject "build" "<what happened and how to reproduce>"
```

### Inferred non-interactive mode

```text
$ eas account:view
david@example.com

Accounts:
• example (Role: Owner)

EAS CLI issue? Report it: npx --yes submit-expo-feedback@latest --category eas-cli --subject "account:view" "<what happened and how to reproduce>"
```

Interactive use or execution without a detected coding agent receives no feedback line.