### PR TITLE
[eas-cli] Handle new server-side errors thrown when observe features are blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Handle new server-side errors thrown when observe features are blocked. ([#4042](https://github.com/expo/eas-cli/pull/4042) by [@douglowder](https://github.com/douglowder))
 - [eas-cli] Add `eas project:icon:set` to upload a project icon from the command line. ([#4068](https://github.com/expo/eas-cli/pull/4068) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/commands/observe/__tests__/events.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/events.test.ts
@@ -1,8 +1,12 @@
+import { CombinedError } from '@urql/core';
+import { GraphQLError } from 'graphql';
+
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { getMockOclifConfig } from '../../../__tests__/commands/utils';
 import { AppObservePlatform } from '../../../graphql/generated';
 import { ObserveQuery } from '../../../graphql/queries/ObserveQuery';
 import { fetchObserveCustomEventsAsync } from '../../../observe/fetchCustomEvents';
+import { EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE } from '../../../observe/planGating';
 import {
   buildObserveCustomEventNamesJson,
   buildObserveCustomEventsEmptyWithSuggestionsJson,
@@ -72,6 +76,31 @@ describe(ObserveEvents, () => {
     });
     return command;
   }
+
+  function planGateError(): CombinedError {
+    const serverMessage =
+      'Subscription to EAS is required for this feature. ' +
+      'Subscribe: https://expo.dev/accounts/acme/settings/billing';
+    return new CombinedError({
+      graphQLErrors: [
+        new GraphQLError(serverMessage, null, null, null, null, null, {
+          errorCode: EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE,
+        }),
+      ],
+    });
+  }
+
+  it('surfaces the plan-gate message when listing event names is not available on the plan', async () => {
+    mockCustomEventNamesAsync.mockRejectedValueOnce(planGateError());
+    const command = createCommand([]);
+    await expect(command.runAsync()).rejects.toThrow(/Subscription to EAS is required/);
+  });
+
+  it('surfaces the plan-gate message when querying events is not available on the plan', async () => {
+    mockFetchObserveCustomEventsAsync.mockRejectedValueOnce(planGateError());
+    const command = createCommand(['my_event']);
+    await expect(command.runAsync()).rejects.toThrow(/Subscription to EAS is required/);
+  });
 
   it('passes eventName arg to fetchObserveCustomEventsAsync', async () => {
     mockFetchObserveCustomEventsAsync.mockResolvedValue({

--- a/packages/eas-cli/src/commands/observe/__tests__/metrics-summary.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metrics-summary.test.ts
@@ -1,7 +1,11 @@
+import { CombinedError } from '@urql/core';
+import { GraphQLError } from 'graphql';
+
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { getMockOclifConfig } from '../../../__tests__/commands/utils';
 import { AppPlatform } from '../../../graphql/generated';
 import { fetchObserveMetricsAsync, validateDateFlag } from '../../../observe/fetchMetrics';
+import { EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE } from '../../../observe/planGating';
 import { buildObserveMetricsJson, buildObserveMetricsTable } from '../../../observe/formatMetrics';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
 import ObserveMetricsSummary from '../metrics-summary';
@@ -51,6 +55,24 @@ describe(ObserveMetricsSummary, () => {
     });
     return command;
   }
+
+  it('surfaces the server plan-gate message when a metric is not available on the plan', async () => {
+    const serverMessage =
+      'Subscription to EAS is required for this feature. ' +
+      'Subscribe: https://expo.dev/accounts/acme/settings/billing';
+    mockFetchObserveMetricsSummaryAsync.mockRejectedValueOnce(
+      new CombinedError({
+        graphQLErrors: [
+          new GraphQLError(serverMessage, null, null, null, null, null, {
+            errorCode: EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE,
+          }),
+        ],
+      })
+    );
+
+    const command = createCommand(['--metric', 'nav_tti']);
+    await expect(command.runAsync()).rejects.toThrow(serverMessage);
+  });
 
   it('fetches metrics with default parameters (both platforms)', async () => {
     const now = new Date('2025-06-15T12:00:00.000Z');

--- a/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
@@ -1,3 +1,6 @@
+import { CombinedError } from '@urql/core';
+import { GraphQLError } from 'graphql';
+
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { getMockOclifConfig } from '../../../__tests__/commands/utils';
 import {
@@ -6,6 +9,7 @@ import {
   AppObservePlatform,
 } from '../../../graphql/generated';
 import { fetchObserveEventsAsync, resolveOrderBy } from '../../../observe/fetchEvents';
+import { EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE } from '../../../observe/planGating';
 import { buildObserveEventsJson } from '../../../observe/formatEvents';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
 import ObserveMetrics from '../metrics';
@@ -51,6 +55,24 @@ describe(ObserveMetrics, () => {
     });
     return command;
   }
+
+  it('surfaces the server plan-gate message when the metric is not available on the plan', async () => {
+    const serverMessage =
+      'Subscription to EAS is required for this feature. ' +
+      'Subscribe: https://expo.dev/accounts/acme/settings/billing';
+    mockFetchObserveEventsAsync.mockRejectedValueOnce(
+      new CombinedError({
+        graphQLErrors: [
+          new GraphQLError(serverMessage, null, null, null, null, null, {
+            errorCode: EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE,
+          }),
+        ],
+      })
+    );
+
+    const command = createCommand(['nav_tti']);
+    await expect(command.runAsync()).rejects.toThrow(serverMessage);
+  });
 
   it('accepts a navigation metric alias as the positional arg', async () => {
     const command = createCommand(['nav_tti']);

--- a/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
@@ -1,7 +1,11 @@
+import { CombinedError } from '@urql/core';
+import { GraphQLError } from 'graphql';
+
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { getMockOclifConfig } from '../../../__tests__/commands/utils';
 import { AppPlatform } from '../../../graphql/generated';
 import { fetchObserveNavigationRoutesAsync } from '../../../observe/fetchNavigationRoutes';
+import { EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE } from '../../../observe/planGating';
 import {
   buildObserveNavigationRoutesJson,
   buildObserveNavigationRoutesTable,
@@ -49,6 +53,24 @@ describe(ObserveRoutes, () => {
     });
     return command;
   }
+
+  it('surfaces the server plan-gate message when navigation is not available on the plan', async () => {
+    const serverMessage =
+      'Subscription to EAS is required for this feature. ' +
+      'Subscribe: https://expo.dev/accounts/acme/settings/billing';
+    mockFetchObserveNavigationRoutesAsync.mockRejectedValueOnce(
+      new CombinedError({
+        graphQLErrors: [
+          new GraphQLError(serverMessage, null, null, null, null, null, {
+            errorCode: EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE,
+          }),
+        ],
+      })
+    );
+
+    const command = createCommand([]);
+    await expect(command.runAsync()).rejects.toThrow(serverMessage);
+  });
 
   it('queries both platforms by default with all three navigation metric full names', async () => {
     const command = createCommand([]);

--- a/packages/eas-cli/src/commands/observe/__tests__/session.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/session.test.ts
@@ -9,6 +9,7 @@ import {
   fetchObserveSessionEventsAsync,
   fetchSessionLogCandidatesAsync,
   fetchSessionMetricCandidatesAsync,
+  verifyObserveSessionAccessAsync,
 } from '../../../observe/fetchSessions';
 import {
   buildObserveSessionEventsJson,
@@ -43,6 +44,7 @@ jest.mock('../../../log');
 jest.mock('../../../utils/json');
 
 const mockFetchObserveSessionEventsAsync = jest.mocked(fetchObserveSessionEventsAsync);
+const mockVerifyObserveSessionAccessAsync = jest.mocked(verifyObserveSessionAccessAsync);
 const mockFetchSessionMetricCandidatesAsync = jest.mocked(fetchSessionMetricCandidatesAsync);
 const mockFetchSessionLogCandidatesAsync = jest.mocked(fetchSessionLogCandidatesAsync);
 const mockCustomEventNamesAsync = jest.mocked(ObserveQuery.customEventNamesAsync);
@@ -194,6 +196,36 @@ describe(ObserveSession, () => {
   it('treats --json as non-interactive (requires a session ID)', async () => {
     const command = createCommand(['--json']);
     await expect(command.runAsync()).rejects.toThrow(/session ID argument is required/);
+    expect(mockFetchObserveSessionEventsAsync).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the plan-gate upgrade prompt before the picker when session access is blocked', async () => {
+    mockVerifyObserveSessionAccessAsync.mockRejectedValueOnce(
+      new CombinedError({
+        graphQLErrors: [
+          new GraphQLError(
+            'Upgrade your plan to view session timelines.',
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              errorCode: EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE,
+            }
+          ),
+        ],
+      })
+    );
+
+    const command = createCommand([]);
+    await expect(command.runAsync()).rejects.toThrow(/Upgrade your plan to view session timelines/);
+
+    // The picker is never entered: no prompts, candidate fetches, or drill-down.
+    expect(mockSelectAsync).not.toHaveBeenCalled();
+    expect(mockCustomEventNamesAsync).not.toHaveBeenCalled();
+    expect(mockFetchSessionMetricCandidatesAsync).not.toHaveBeenCalled();
+    expect(mockFetchSessionLogCandidatesAsync).not.toHaveBeenCalled();
     expect(mockFetchObserveSessionEventsAsync).not.toHaveBeenCalled();
   });
 

--- a/packages/eas-cli/src/commands/observe/__tests__/session.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/session.test.ts
@@ -1,5 +1,9 @@
+import { CombinedError } from '@urql/core';
+import { GraphQLError } from 'graphql';
+
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { getMockOclifConfig } from '../../../__tests__/commands/utils';
+import { EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE } from '../../../observe/planGating';
 import { ObserveQuery } from '../../../graphql/queries/ObserveQuery';
 import {
   fetchObserveSessionEventsAsync,
@@ -160,6 +164,23 @@ describe(ObserveSession, () => {
   it('rejects unsupported filter flags like --platform', async () => {
     const command = createCommand(['session-abc', '--platform', 'ios']);
     await expect(command.runAsync()).rejects.toThrow();
+  });
+
+  it('surfaces the server plan-gate message when the timeline is plan-gated', async () => {
+    const serverMessage =
+      'Access to this feature is not included in your current plan. ' +
+      'Upgrade your plan: https://expo.dev/accounts/acme/settings/billing';
+    const gateError = new CombinedError({
+      graphQLErrors: [
+        new GraphQLError(serverMessage, null, null, null, null, null, {
+          errorCode: EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE,
+        }),
+      ],
+    });
+    mockFetchObserveSessionEventsAsync.mockRejectedValueOnce(gateError);
+
+    const command = createCommand(['session-abc']);
+    await expect(command.runAsync()).rejects.toThrow(serverMessage);
   });
 
   // ---- new picker-mode behavior ----

--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -25,6 +25,7 @@ import {
   buildObserveCustomEventsJson,
   buildObserveCustomEventsTable,
 } from '../../observe/formatCustomEvents';
+import { withObservePlanGateHandlingAsync } from '../../observe/planGating';
 import { appObservePlatformFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
@@ -101,12 +102,14 @@ export default class ObserveEvents extends EasCommand {
     const platform = appObservePlatformFromFlag(flags.platform);
 
     if (!args.eventName && !flags['all-events']) {
-      const { names, isTruncated } = await ObserveQuery.customEventNamesAsync(graphqlClient, {
-        appId: projectId,
-        startTime,
-        endTime,
-        platform,
-      });
+      const { names, isTruncated } = await withObservePlanGateHandlingAsync(() =>
+        ObserveQuery.customEventNamesAsync(graphqlClient, {
+          appId: projectId,
+          startTime,
+          endTime,
+          platform,
+        })
+      );
 
       if (json) {
         printJsonOnlyOutput(buildObserveCustomEventNamesJson(names, isTruncated));
@@ -124,17 +127,19 @@ export default class ObserveEvents extends EasCommand {
       return;
     }
 
-    const { events, pageInfo } = await fetchObserveCustomEventsAsync(graphqlClient, projectId, {
-      eventName: args.eventName,
-      limit: flags.limit ?? DEFAULT_EVENTS_LIMIT,
-      ...(flags.after && { after: flags.after }),
-      startTime,
-      endTime,
-      platform,
-      appVersion: flags['app-version'],
-      updateId: flags['update-id'],
-      sessionId: flags['session-id'],
-    });
+    const { events, pageInfo } = await withObservePlanGateHandlingAsync(() =>
+      fetchObserveCustomEventsAsync(graphqlClient, projectId, {
+        eventName: args.eventName,
+        limit: flags.limit ?? DEFAULT_EVENTS_LIMIT,
+        ...(flags.after && { after: flags.after }),
+        startTime,
+        endTime,
+        platform,
+        appVersion: flags['app-version'],
+        updateId: flags['update-id'],
+        sessionId: flags['session-id'],
+      })
+    );
 
     if (args.eventName && events.length === 0) {
       const { names, isTruncated } = await ObserveQuery.customEventNamesAsync(graphqlClient, {

--- a/packages/eas-cli/src/commands/observe/metrics-summary.ts
+++ b/packages/eas-cli/src/commands/observe/metrics-summary.ts
@@ -19,6 +19,7 @@ import {
   resolveStatKey,
 } from '../../observe/formatMetrics';
 import { METRIC_ALIASES, resolveMetricName } from '../../observe/metricNames';
+import { withObservePlanGateHandlingAsync } from '../../observe/planGating';
 import { appPlatformsFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
@@ -99,13 +100,15 @@ export default class ObserveMetricsSummary extends EasCommand {
     const platforms = appPlatformsFromFlag(flags.platform);
 
     const { metricsMap, buildNumbersMap, updateIdsMap, totalEventCounts } =
-      await fetchObserveMetricsAsync(
-        graphqlClient,
-        projectId,
-        metricNames,
-        platforms,
-        startTime,
-        endTime
+      await withObservePlanGateHandlingAsync(() =>
+        fetchObserveMetricsAsync(
+          graphqlClient,
+          projectId,
+          metricNames,
+          platforms,
+          startTime,
+          endTime
+        )
       );
 
     const argumentsStat = flags.stat?.length

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -23,6 +23,7 @@ import {
   ObserveUpdateIdFlag,
 } from '../../observe/flags';
 import { METRIC_ALIASES, METRIC_SHORT_NAMES, resolveMetricName } from '../../observe/metricNames';
+import { withObservePlanGateHandlingAsync } from '../../observe/planGating';
 import { buildObserveEventsJson, buildObserveEventsTable } from '../../observe/formatEvents';
 import { appObservePlatformFromFlag, appPlatformsFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
@@ -110,27 +111,29 @@ export default class ObserveMetrics extends EasCommand {
     const platform = appObservePlatformFromFlag(flags.platform);
     const platforms = appPlatformsFromFlag(flags.platform);
 
-    const [{ events, pageInfo }, totalEventCount] = await Promise.all([
-      fetchObserveEventsAsync(graphqlClient, projectId, {
-        metricName,
-        orderBy,
-        limit: flags.limit ?? DEFAULT_EVENTS_LIMIT,
-        ...(flags.after && { after: flags.after }),
-        startTime,
-        endTime,
-        platform,
-        appVersion: flags['app-version'],
-        updateId: flags['update-id'],
-      }),
-      fetchTotalEventCountAsync(
-        graphqlClient,
-        projectId,
-        metricName,
-        platforms,
-        startTime,
-        endTime
-      ),
-    ]);
+    const [{ events, pageInfo }, totalEventCount] = await withObservePlanGateHandlingAsync(() =>
+      Promise.all([
+        fetchObserveEventsAsync(graphqlClient, projectId, {
+          metricName,
+          orderBy,
+          limit: flags.limit ?? DEFAULT_EVENTS_LIMIT,
+          ...(flags.after && { after: flags.after }),
+          startTime,
+          endTime,
+          platform,
+          appVersion: flags['app-version'],
+          updateId: flags['update-id'],
+        }),
+        fetchTotalEventCountAsync(
+          graphqlClient,
+          projectId,
+          metricName,
+          platforms,
+          startTime,
+          endTime
+        ),
+      ])
+    );
 
     if (json) {
       printJsonOnlyOutput(buildObserveEventsJson(events, pageInfo));

--- a/packages/eas-cli/src/commands/observe/routes.ts
+++ b/packages/eas-cli/src/commands/observe/routes.ts
@@ -24,6 +24,7 @@ import {
   resolveNavigationStatKey,
 } from '../../observe/formatNavigationRoutes';
 import { NAVIGATION_METRIC_ALIASES, resolveNavigationMetricName } from '../../observe/metricNames';
+import { withObservePlanGateHandlingAsync } from '../../observe/planGating';
 import { appPlatformsFromFlag } from '../../observe/platforms';
 import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
 import { resolveTimeRange } from '../../observe/startAndEndTime';
@@ -113,10 +114,8 @@ export default class ObserveRoutes extends EasCommand {
     const { daysBack, startTime, endTime } = resolveTimeRange(flags);
     const platforms = appPlatformsFromFlag(flags.platform);
 
-    const { routes, pageInfoByPlatform } = await fetchObserveNavigationRoutesAsync(
-      graphqlClient,
-      projectId,
-      {
+    const { routes, pageInfoByPlatform } = await withObservePlanGateHandlingAsync(() =>
+      fetchObserveNavigationRoutesAsync(graphqlClient, projectId, {
         startTime,
         endTime,
         platforms,
@@ -126,7 +125,7 @@ export default class ObserveRoutes extends EasCommand {
         updateId: flags['update-id'],
         buildNumber: flags['build-number'],
         routeNames,
-      }
+      })
     );
 
     if (json) {

--- a/packages/eas-cli/src/commands/observe/session.ts
+++ b/packages/eas-cli/src/commands/observe/session.ts
@@ -14,6 +14,7 @@ import {
   fetchObserveSessionEventsAsync,
   fetchSessionLogCandidatesAsync,
   fetchSessionMetricCandidatesAsync,
+  verifyObserveSessionAccessAsync,
 } from '../../observe/fetchSessions';
 import { ObserveProjectIdFlag, ObserveTimeRangeFlags } from '../../observe/flags';
 import { withObservePlanGateHandlingAsync } from '../../observe/planGating';
@@ -113,6 +114,13 @@ export default class ObserveSession extends EasCommand {
         'A session ID argument is required in non-interactive mode. In interactive mode, you can omit the session ID to pick one from a list of events.'
       );
     } else {
+      // Session timelines are a paid feature. Verify access before walking the
+      // user through the interactive picker so a blocked plan gets the upgrade
+      // prompt immediately, rather than after selecting an event (or a
+      // misleading "No events found" when there are no candidates).
+      await withObservePlanGateHandlingAsync(() =>
+        verifyObserveSessionAccessAsync(graphqlClient, projectId)
+      );
       sessionId = await pickSessionIdInteractivelyAsync({
         graphqlClient,
         projectId,

--- a/packages/eas-cli/src/commands/observe/session.ts
+++ b/packages/eas-cli/src/commands/observe/session.ts
@@ -16,6 +16,7 @@ import {
   fetchSessionMetricCandidatesAsync,
 } from '../../observe/fetchSessions';
 import { ObserveProjectIdFlag, ObserveTimeRangeFlags } from '../../observe/flags';
+import { withObservePlanGateHandlingAsync } from '../../observe/planGating';
 import {
   buildObserveSessionEventsJson,
   buildObserveSessionEventsTable,
@@ -122,10 +123,12 @@ export default class ObserveSession extends EasCommand {
     }
 
     const { entries, metadata, hasMoreMetricEvents, hasMoreLogEvents } =
-      await fetchObserveSessionEventsAsync(graphqlClient, projectId, {
-        sessionId,
-        limit: SESSION_PAGE_SIZE,
-      });
+      await withObservePlanGateHandlingAsync(() =>
+        fetchObserveSessionEventsAsync(graphqlClient, projectId, {
+          sessionId,
+          limit: SESSION_PAGE_SIZE,
+        })
+      );
 
     if (json) {
       printJsonOnlyOutput(

--- a/packages/eas-cli/src/observe/__tests__/fetchEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchEvents.test.ts
@@ -1,10 +1,20 @@
+import { CombinedError } from '@urql/core';
+import { GraphQLError } from 'graphql';
+
 import {
   AppObserveEventsOrderByDirection,
   AppObserveEventsOrderByField,
   AppObservePlatform,
+  AppPlatform,
 } from '../../graphql/generated';
 import { ObserveQuery } from '../../graphql/queries/ObserveQuery';
-import { EventsOrderPreset, fetchObserveEventsAsync, resolveOrderBy } from '../fetchEvents';
+import {
+  EventsOrderPreset,
+  fetchObserveEventsAsync,
+  fetchTotalEventCountAsync,
+  resolveOrderBy,
+} from '../fetchEvents';
+import { EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE } from '../planGating';
 
 jest.mock('../../graphql/queries/ObserveQuery');
 
@@ -272,5 +282,59 @@ describe(fetchObserveEventsAsync, () => {
 
     const calledVars = mockEventsAsync.mock.calls[0][1];
     expect(calledVars).not.toHaveProperty('after');
+  });
+});
+
+describe(fetchTotalEventCountAsync, () => {
+  const mockAppVersionsAsync = jest.mocked(ObserveQuery.appVersionsAsync);
+  const mockGraphqlClient = {} as any;
+
+  beforeEach(() => {
+    mockAppVersionsAsync.mockReset();
+  });
+
+  it('rethrows plan-gate errors instead of swallowing them as zero', async () => {
+    const gateError = new CombinedError({
+      graphQLErrors: [
+        new GraphQLError(
+          'Subscription to EAS is required for this feature.',
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            errorCode: EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE,
+          }
+        ),
+      ],
+    });
+    mockAppVersionsAsync.mockRejectedValue(gateError);
+
+    await expect(
+      fetchTotalEventCountAsync(
+        mockGraphqlClient,
+        'project-123',
+        'expo.navigation.tti',
+        [AppPlatform.Ios, AppPlatform.Android],
+        '2025-01-01T00:00:00.000Z',
+        '2025-03-01T00:00:00.000Z'
+      )
+    ).rejects.toBe(gateError);
+  });
+
+  it('swallows non-gate errors and counts them as zero', async () => {
+    mockAppVersionsAsync.mockRejectedValue(new Error('Network error'));
+
+    const total = await fetchTotalEventCountAsync(
+      mockGraphqlClient,
+      'project-123',
+      'expo.app_startup.tti',
+      [AppPlatform.Ios],
+      '2025-01-01T00:00:00.000Z',
+      '2025-03-01T00:00:00.000Z'
+    );
+
+    expect(total).toBe(0);
   });
 });

--- a/packages/eas-cli/src/observe/__tests__/fetchMetrics.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchMetrics.test.ts
@@ -1,7 +1,11 @@
+import { CombinedError } from '@urql/core';
+import { GraphQLError } from 'graphql';
+
 import { AppObserveAppVersion, AppObservePlatform, AppPlatform } from '../../graphql/generated';
 import { ObserveQuery } from '../../graphql/queries/ObserveQuery';
 import { makeMetricsKey } from '../formatMetrics';
 import { fetchObserveMetricsAsync } from '../fetchMetrics';
+import { EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE } from '../planGating';
 
 jest.mock('../../graphql/queries/ObserveQuery');
 jest.mock('../../log');
@@ -205,6 +209,36 @@ describe('fetchObserveMetricsAsync', () => {
     );
 
     expect(metricsMap.size).toBe(0);
+  });
+
+  it('rethrows plan-gate errors instead of swallowing them as a partial failure', async () => {
+    const gateError = new CombinedError({
+      graphQLErrors: [
+        new GraphQLError(
+          'Subscription to EAS is required for this feature.',
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            errorCode: EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE,
+          }
+        ),
+      ],
+    });
+    mockAppVersionsAsync.mockRejectedValue(gateError);
+
+    await expect(
+      fetchObserveMetricsAsync(
+        mockGraphqlClient,
+        'project-123',
+        ['expo.navigation.tti'],
+        [AppPlatform.Ios, AppPlatform.Android],
+        '2025-01-01T00:00:00.000Z',
+        '2025-03-01T00:00:00.000Z'
+      )
+    ).rejects.toBe(gateError);
   });
 
   it('maps AppObservePlatform back to AppPlatform correctly in metricsMap keys', async () => {

--- a/packages/eas-cli/src/observe/__tests__/fetchNavigationRoutes.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchNavigationRoutes.test.ts
@@ -1,3 +1,6 @@
+import { CombinedError } from '@urql/core';
+import { GraphQLError } from 'graphql';
+
 import {
   AppObserveEventsOrderByDirection,
   AppObserveNavigationRoute,
@@ -7,6 +10,7 @@ import {
 } from '../../graphql/generated';
 import { ObserveQuery } from '../../graphql/queries/ObserveQuery';
 import { fetchObserveNavigationRoutesAsync } from '../fetchNavigationRoutes';
+import { EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE } from '../planGating';
 
 jest.mock('../../graphql/queries/ObserveQuery');
 jest.mock('../../log');
@@ -186,5 +190,33 @@ describe('fetchObserveNavigationRoutesAsync', () => {
     expect(routes).toHaveLength(1);
     expect(routes[0].platform).toBe(AppPlatform.Ios);
     expect(pageInfoByPlatform.has(AppPlatform.Android)).toBe(false);
+  });
+
+  it('rethrows plan-gate errors instead of swallowing them as a partial failure', async () => {
+    const gateError = new CombinedError({
+      graphQLErrors: [
+        new GraphQLError(
+          'Subscription to EAS is required for this feature.',
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            errorCode: EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE,
+          }
+        ),
+      ],
+    });
+    mockNavigationRoutesAsync.mockRejectedValue(gateError);
+
+    await expect(
+      fetchObserveNavigationRoutesAsync(mockGraphqlClient, 'project-123', {
+        startTime: '2025-01-01T00:00:00.000Z',
+        endTime: '2025-03-01T00:00:00.000Z',
+        platforms: [AppPlatform.Ios, AppPlatform.Android],
+        limit: 50,
+      })
+    ).rejects.toBe(gateError);
   });
 });

--- a/packages/eas-cli/src/observe/__tests__/planGating.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/planGating.test.ts
@@ -1,0 +1,49 @@
+import { CombinedError } from '@urql/core';
+import { GraphQLError } from 'graphql';
+
+import { EasCommandError } from '../../commandUtils/errors';
+import {
+  EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE,
+  withObservePlanGateHandlingAsync,
+} from '../planGating';
+
+function graphqlErrorWithCode(errorCode: string, message = 'server message'): CombinedError {
+  const graphQLError = new GraphQLError(message, null, null, null, null, null, { errorCode });
+  return new CombinedError({ graphQLErrors: [graphQLError] });
+}
+
+describe(withObservePlanGateHandlingAsync, () => {
+  it('returns the value when the operation succeeds', async () => {
+    await expect(withObservePlanGateHandlingAsync(async () => 42)).resolves.toBe(42);
+  });
+
+  it('surfaces the server plan-gate message as an EasCommandError', async () => {
+    const serverMessage =
+      'Access to this feature is not included in your current plan. ' +
+      'Upgrade your plan: https://expo.dev/accounts/acme/settings/billing';
+    const promise = withObservePlanGateHandlingAsync(() => {
+      throw graphqlErrorWithCode(EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE, serverMessage);
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(EasCommandError);
+    await expect(promise).rejects.toThrow(serverMessage);
+  });
+
+  it('passes through GraphQL errors with a different code unchanged', async () => {
+    const original = graphqlErrorWithCode('SOME_OTHER_ERROR');
+    await expect(
+      withObservePlanGateHandlingAsync(() => {
+        throw original;
+      })
+    ).rejects.toBe(original);
+  });
+
+  it('passes through non-GraphQL errors unchanged', async () => {
+    const original = new Error('network down');
+    await expect(
+      withObservePlanGateHandlingAsync(() => {
+        throw original;
+      })
+    ).rejects.toBe(original);
+  });
+});

--- a/packages/eas-cli/src/observe/__tests__/planGating.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/planGating.test.ts
@@ -3,7 +3,9 @@ import { GraphQLError } from 'graphql';
 
 import { EasCommandError } from '../../commandUtils/errors';
 import {
+  EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE,
   EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE,
+  isObservePlanGateError,
   withObservePlanGateHandlingAsync,
 } from '../planGating';
 
@@ -17,12 +19,13 @@ describe(withObservePlanGateHandlingAsync, () => {
     await expect(withObservePlanGateHandlingAsync(async () => 42)).resolves.toBe(42);
   });
 
-  it('surfaces the server plan-gate message as an EasCommandError', async () => {
-    const serverMessage =
-      'Access to this feature is not included in your current plan. ' +
-      'Upgrade your plan: https://expo.dev/accounts/acme/settings/billing';
+  it.each([
+    ['plan-upgrade-required', EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE],
+    ['free-tier', EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE],
+  ])('surfaces the server %s message as an EasCommandError', async (_label, errorCode) => {
+    const serverMessage = `gate message for ${errorCode}`;
     const promise = withObservePlanGateHandlingAsync(() => {
-      throw graphqlErrorWithCode(EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE, serverMessage);
+      throw graphqlErrorWithCode(errorCode, serverMessage);
     });
 
     await expect(promise).rejects.toBeInstanceOf(EasCommandError);
@@ -45,5 +48,22 @@ describe(withObservePlanGateHandlingAsync, () => {
         throw original;
       })
     ).rejects.toBe(original);
+  });
+});
+
+describe(isObservePlanGateError, () => {
+  it.each([
+    EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE,
+    EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE,
+  ])('is true for %s', errorCode => {
+    expect(isObservePlanGateError(graphqlErrorWithCode(errorCode))).toBe(true);
+  });
+
+  it('is false for a different GraphQL error code', () => {
+    expect(isObservePlanGateError(graphqlErrorWithCode('SOME_OTHER_ERROR'))).toBe(false);
+  });
+
+  it('is false for a non-GraphQL error', () => {
+    expect(isObservePlanGateError(new Error('network down'))).toBe(false);
   });
 });

--- a/packages/eas-cli/src/observe/fetchEvents.ts
+++ b/packages/eas-cli/src/observe/fetchEvents.ts
@@ -10,6 +10,7 @@ import {
   PageInfo,
 } from '../graphql/generated';
 import { ObserveQuery } from '../graphql/queries/ObserveQuery';
+import { isObservePlanGateError } from './planGating';
 
 export enum EventsOrderPreset {
   Slowest = 'SLOWEST',
@@ -112,7 +113,12 @@ export async function fetchTotalEventCountAsync(
         const metric = v.metrics.find(m => m.metricName === metricName);
         return sum + (metric?.eventCount ?? 0);
       }, 0);
-    } catch {
+    } catch (error) {
+      // A plan gate is an account-wide rejection, not a per-platform failure —
+      // let it propagate so the command surfaces the upgrade prompt.
+      if (isObservePlanGateError(error)) {
+        throw error;
+      }
       return 0;
     }
   });

--- a/packages/eas-cli/src/observe/fetchMetrics.ts
+++ b/packages/eas-cli/src/observe/fetchMetrics.ts
@@ -10,6 +10,7 @@ import {
   UpdateIdsMap,
   makeMetricsKey,
 } from './formatMetrics';
+import { isObservePlanGateError } from './planGating';
 import { appPlatformToObservePlatform } from './platforms';
 
 export function validateDateFlag(value: string, flagName: string): void {
@@ -48,6 +49,11 @@ export async function fetchObserveMetricsAsync(
       });
       return { appPlatform, appVersions };
     } catch (error: any) {
+      // A plan gate is an account-wide rejection, not a per-platform failure —
+      // let it propagate so the command surfaces the upgrade prompt.
+      if (isObservePlanGateError(error)) {
+        throw error;
+      }
       Log.warn(`Failed to fetch observe data on ${observePlatform}: ${error.message}`);
       return null;
     }

--- a/packages/eas-cli/src/observe/fetchNavigationRoutes.ts
+++ b/packages/eas-cli/src/observe/fetchNavigationRoutes.ts
@@ -9,6 +9,7 @@ import {
 } from '../graphql/generated';
 import { ObserveQuery } from '../graphql/queries/ObserveQuery';
 import Log from '../log';
+import { isObservePlanGateError } from './planGating';
 import { appPlatformToObservePlatform } from './platforms';
 
 export interface NavigationRouteWithPlatform {
@@ -64,6 +65,11 @@ export async function fetchObserveNavigationRoutesAsync(
       });
       return { appPlatform, ...result };
     } catch (error: any) {
+      // A plan gate is an account-wide rejection, not a per-platform failure —
+      // let it propagate so the command surfaces the upgrade prompt.
+      if (isObservePlanGateError(error)) {
+        throw error;
+      }
       Log.warn(`Failed to fetch navigation routes on ${observePlatform}: ${error.message}`);
       return null;
     }

--- a/packages/eas-cli/src/observe/fetchSessions.ts
+++ b/packages/eas-cli/src/observe/fetchSessions.ts
@@ -99,6 +99,26 @@ export interface FetchSessionEventsResult {
   hasMoreLogEvents: boolean;
 }
 
+// A syntactically valid UUID that matches no real session, used only to trip
+// the server-side session-timeline plan gate without fetching real data.
+const SESSION_ACCESS_PROBE_ID = '00000000-0000-0000-0000-000000000000';
+
+/**
+ * Issues a throwaway session-scoped query so the server-side session-timeline
+ * plan gate fires (or doesn't) up front. Blocked plans reject with the coded
+ * plan-gate error; allowed plans get an empty result that is discarded. Used to
+ * check access before the interactive session picker runs.
+ */
+export async function verifyObserveSessionAccessAsync(
+  graphqlClient: ExpoGraphqlClient,
+  appId: string
+): Promise<void> {
+  await fetchObserveSessionEventsAsync(graphqlClient, appId, {
+    sessionId: SESSION_ACCESS_PROBE_ID,
+    limit: 1,
+  });
+}
+
 export async function fetchObserveSessionEventsAsync(
   graphqlClient: ExpoGraphqlClient,
   appId: string,

--- a/packages/eas-cli/src/observe/planGating.ts
+++ b/packages/eas-cli/src/observe/planGating.ts
@@ -1,18 +1,34 @@
 import { EasCommandError } from '../commandUtils/errors';
 import { GraphqlError } from '../graphql/client';
 
-// Must match the server's `ExpoErrorCode.EAS_OBSERVE_PLAN_UPGRADE_REQUIRED`.
-// The server throws this for any EAS Observe feature not included in the
-// account's current billing plan.
+// Must match the server's Observe plan-gate error codes (`ExpoErrorCode`). Both
+// signal "this Observe feature is not available on the account's current plan";
+// they differ only in which plans are blocked, which is decided server-side.
 export const EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE = 'EAS_OBSERVE_PLAN_UPGRADE_REQUIRED';
+export const EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE =
+  'EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER';
+
+const OBSERVE_PLAN_GATE_ERROR_CODES: ReadonlySet<string> = new Set([
+  EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE,
+  EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE,
+]);
 
 function findObservePlanGateMessage(error: unknown): string | undefined {
   if (!(error instanceof GraphqlError)) {
     return undefined;
   }
-  return error.graphQLErrors.find(
-    e => e?.extensions?.errorCode === EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE
+  return error.graphQLErrors.find(e =>
+    OBSERVE_PLAN_GATE_ERROR_CODES.has(e?.extensions?.errorCode as string)
   )?.message;
+}
+
+/**
+ * Whether an error is a server Observe plan-gate rejection. Useful where a
+ * plan-gate error must escape error handling that would otherwise swallow it
+ * (e.g. per-platform fetch loops that treat failures as empty results).
+ */
+export function isObservePlanGateError(error: unknown): boolean {
+  return findObservePlanGateMessage(error) !== undefined;
 }
 
 /**

--- a/packages/eas-cli/src/observe/planGating.ts
+++ b/packages/eas-cli/src/observe/planGating.ts
@@ -1,0 +1,34 @@
+import { EasCommandError } from '../commandUtils/errors';
+import { GraphqlError } from '../graphql/client';
+
+// Must match the server's `ExpoErrorCode.EAS_OBSERVE_PLAN_UPGRADE_REQUIRED`.
+// The server throws this for any EAS Observe feature not included in the
+// account's current billing plan.
+export const EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE = 'EAS_OBSERVE_PLAN_UPGRADE_REQUIRED';
+
+function findObservePlanGateMessage(error: unknown): string | undefined {
+  if (!(error instanceof GraphqlError)) {
+    return undefined;
+  }
+  return error.graphQLErrors.find(
+    e => e?.extensions?.errorCode === EAS_OBSERVE_PLAN_UPGRADE_REQUIRED_ERROR_CODE
+  )?.message;
+}
+
+/**
+ * Runs an Observe GraphQL operation and, when the server rejects it because the
+ * feature is not included in the account's plan, rethrows the server's upgrade
+ * message (which links to the account's billing page) as an `EasCommandError`.
+ * Reusable across Observe commands.
+ */
+export async function withObservePlanGateHandlingAsync<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    const planGateMessage = findObservePlanGateMessage(error);
+    if (planGateMessage !== undefined) {
+      throw new EasCommandError(planGateMessage);
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
# Why

New server code for observe features may throw errors when a feature is not available for an account.

# How

Handle these errors correctly, and surface the correct server-side error message.

# Test Plan

- Testing against accounts in staging
- New unit tests added