### PR TITLE
[eas-cli] Prompt for platform in simulator:start instead of erroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Prompt to select a platform in `eas simulator:start` when `--platform` is omitted, instead of erroring out. ([#4043](https://github.com/expo/eas-cli/pull/4043) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/simulator/__tests__/start.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/start.test.ts
@@ -14,6 +14,7 @@ import { DeviceRunSessionMutation } from '../../../graphql/mutations/DeviceRunSe
 import { DeviceRunSessionQuery } from '../../../graphql/queries/DeviceRunSessionQuery';
 import Log from '../../../log';
 import { ora } from '../../../ora';
+import { promptAsync } from '../../../prompts';
 import {
   EAS_SIMULATOR_SESSION_ID,
   SIMULATOR_DOTENV_FILE_HEADER,
@@ -42,6 +43,7 @@ jest.mock('../../../simulator/env', () => ({
   loadSimulatorEnvAsync: jest.fn(),
   resetSimulatorEnvAsync: jest.fn(),
 }));
+jest.mock('../../../prompts');
 jest.mock('../../../ora', () => ({
   ora: jest.fn(() => {
     const spinner = {
@@ -71,6 +73,7 @@ const mockByIdAsync = jest.mocked(DeviceRunSessionQuery.byIdAsync);
 const mockLoadSimulatorEnvAsync = jest.mocked(loadSimulatorEnvAsync);
 const mockResetSimulatorEnvAsync = jest.mocked(resetSimulatorEnvAsync);
 const mockOra = jest.mocked(ora);
+const mockPromptAsync = jest.mocked(promptAsync);
 
 function makeCreatedDeviceRunSession(
   overrides: Partial<CreatedDeviceRunSession> = {}
@@ -320,5 +323,33 @@ describe(SimulatorStart, () => {
     await command.runAsync();
 
     expect(mockResetSimulatorEnvAsync).toHaveBeenCalledWith(projectDir);
+  });
+
+  it('prompts to select the platform when --platform is omitted', async () => {
+    mockPromptAsync.mockResolvedValueOnce({ selectedPlatform: AppPlatform.Android });
+    mockByIdAsync
+      .mockResolvedValueOnce(makeDeviceRunSession())
+      .mockResolvedValueOnce(makeDeviceRunSession({ status: DeviceRunSessionStatus.Stopped }));
+
+    const { command } = createCommand([]);
+    await command.runAsync();
+
+    expect(mockPromptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'select', message: 'Select platform' })
+    );
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ platform: AppPlatform.Android })
+    );
+  });
+
+  it('throws instead of prompting when --platform is omitted in non-interactive mode', async () => {
+    const { command } = createCommand(['--non-interactive']);
+    await expect(command.runAsync()).rejects.toThrow(
+      'The --platform flag must be set when running in non-interactive mode.'
+    );
+
+    expect(mockPromptAsync).not.toHaveBeenCalled();
+    expect(mockCreateDeviceRunSessionAsync).not.toHaveBeenCalled();
   });
 });

--- a/packages/eas-cli/src/commands/simulator/__tests__/start.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/start.test.ts
@@ -343,6 +343,23 @@ describe(SimulatorStart, () => {
     );
   });
 
+  it('prompts for the platform before warning about overwriting an existing session', async () => {
+    process.env[EAS_SIMULATOR_SESSION_ID] = 'existing-session';
+    mockPromptAsync.mockResolvedValueOnce({ selectedPlatform: AppPlatform.Ios });
+    mockByIdAsync
+      .mockResolvedValueOnce(makeDeviceRunSession())
+      .mockResolvedValueOnce(makeDeviceRunSession({ status: DeviceRunSessionStatus.Stopped }));
+
+    const { command } = createCommand([]);
+    await command.runAsync();
+
+    expect(mockPromptAsync).toHaveBeenCalled();
+    expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('Overwriting previous'));
+    expect(mockPromptAsync.mock.invocationCallOrder[0]).toBeLessThan(
+      jest.mocked(Log.warn).mock.invocationCallOrder[0]
+    );
+  });
+
   it('throws instead of prompting when --platform is omitted in non-interactive mode', async () => {
     const { command } = createCommand(['--non-interactive']);
     await expect(command.runAsync()).rejects.toThrow(

--- a/packages/eas-cli/src/commands/simulator/start.ts
+++ b/packages/eas-cli/src/commands/simulator/start.ts
@@ -42,6 +42,12 @@ const OUT_CONFIG_TYPE_VALUES = {
   Env: 'env',
   Dotenv: 'dotenv',
 } as const;
+const PLATFORM_FLAG_VALUES = ['android', 'ios'] as const;
+type PlatformFlagValue = (typeof PLATFORM_FLAG_VALUES)[number];
+const APP_PLATFORM_BY_FLAG_VALUE: Record<PlatformFlagValue, AppPlatform> = {
+  android: AppPlatform.Android,
+  ios: AppPlatform.Ios,
+};
 
 export default class SimulatorStart extends EasCommand {
   static override hidden = true;
@@ -52,7 +58,7 @@ export default class SimulatorStart extends EasCommand {
     platform: Flags.option({
       char: 'p',
       description: 'Device platform',
-      options: ['android', 'ios'] as const,
+      options: PLATFORM_FLAG_VALUES,
     })(),
     type: Flags.option({
       description: 'Type of simulator session to create',
@@ -111,6 +117,9 @@ export default class SimulatorStart extends EasCommand {
         `Existing simulator session in environment. Use --force to create a new simulator session.`
       );
     }
+
+    const platform = await resolvePlatformAsync(flags.platform, nonInteractive);
+
     if (existingDeviceRunSessionId) {
       Log.warn(
         `  Overwriting previous simulator session (id: ${existingDeviceRunSessionId}). ` +
@@ -119,8 +128,6 @@ export default class SimulatorStart extends EasCommand {
       );
       Log.newLine();
     }
-
-    const platform = await resolvePlatformAsync(flags.platform, nonInteractive);
 
     const createSpinner = ora('🚀 Creating simulator session').start();
     let deviceRunSessionId: string;
@@ -244,11 +251,11 @@ export default class SimulatorStart extends EasCommand {
 }
 
 async function resolvePlatformAsync(
-  platform: 'android' | 'ios' | undefined,
+  platform: PlatformFlagValue | undefined,
   nonInteractive: boolean
 ): Promise<AppPlatform> {
   if (platform) {
-    return platform === 'android' ? AppPlatform.Android : AppPlatform.Ios;
+    return APP_PLATFORM_BY_FLAG_VALUE[platform];
   }
 
   if (nonInteractive) {

--- a/packages/eas-cli/src/commands/simulator/start.ts
+++ b/packages/eas-cli/src/commands/simulator/start.ts
@@ -18,6 +18,7 @@ import { DeviceRunSessionMutation } from '../../graphql/mutations/DeviceRunSessi
 import { DeviceRunSessionQuery } from '../../graphql/queries/DeviceRunSessionQuery';
 import Log, { link } from '../../log';
 import { ora } from '../../ora';
+import { promptAsync } from '../../prompts';
 import {
   EAS_SIMULATOR_SESSION_ID,
   SIMULATOR_DOTENV_FILE_NAME,
@@ -52,7 +53,6 @@ export default class SimulatorStart extends EasCommand {
       char: 'p',
       description: 'Device platform',
       options: ['android', 'ios'] as const,
-      required: true,
     })(),
     type: Flags.option({
       description: 'Type of simulator session to create',
@@ -120,7 +120,7 @@ export default class SimulatorStart extends EasCommand {
       Log.newLine();
     }
 
-    const platform = flags.platform === 'android' ? AppPlatform.Android : AppPlatform.Ios;
+    const platform = await resolvePlatformAsync(flags.platform, nonInteractive);
 
     const createSpinner = ora('🚀 Creating simulator session').start();
     let deviceRunSessionId: string;
@@ -241,6 +241,30 @@ export default class SimulatorStart extends EasCommand {
       projectDir,
     });
   }
+}
+
+async function resolvePlatformAsync(
+  platform: 'android' | 'ios' | undefined,
+  nonInteractive: boolean
+): Promise<AppPlatform> {
+  if (platform) {
+    return platform === 'android' ? AppPlatform.Android : AppPlatform.Ios;
+  }
+
+  if (nonInteractive) {
+    throw new Error('The --platform flag must be set when running in non-interactive mode.');
+  }
+
+  const { selectedPlatform } = await promptAsync({
+    type: 'select',
+    message: 'Select platform',
+    name: 'selectedPlatform',
+    choices: [
+      { title: 'Android', value: AppPlatform.Android },
+      { title: 'iOS', value: AppPlatform.Ios },
+    ],
+  });
+  return selectedPlatform;
 }
 
 async function writeSimulatorEnvSafelyAsync(


### PR DESCRIPTION
# Why

Running `eas simulator:start` without `--platform` failed with `Missing required flag platform`. Since the command already has an interactive session-wait flow, it's friendlier to prompt the user to pick a platform rather than erroring out.

# How

- Made the `--platform` flag optional in `eas simulator:start`.
- Added a `resolvePlatformAsync` helper that:
  - Maps the flag value to `AppPlatform` when `--platform` is provided.
  - Shows a `Select platform` dropdown (Android / iOS) when the flag is omitted in interactive mode, matching the existing pattern used by `eas build:run` and `src/platform.ts`.
  - Throws a clear error (`The --platform flag must be set when running in non-interactive mode.`) when the flag is omitted under `--non-interactive`/`--json`, since a prompt can't be shown without a TTY.

# Test Plan

Added unit tests in `start.test.ts`:
- Prompts to select the platform when `--platform` is omitted, and the selected platform flows into the session mutation.
- Throws (without prompting) when `--platform` is omitted in non-interactive mode.

All simulator `start` tests pass; `yarn typecheck` and `yarn lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)