### PR TITLE
[eas-cli] add simulator:availability command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add `eas simulator:availability` to check whether EAS Simulator is enabled for the current project account. ([#4045](https://github.com/expo/eas-cli/pull/4045) by [@gwdp](https://github.com/gwdp))
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [eas-cli] Add `eas simulator:availability` to check whether EAS Simulator is enabled for the current project account. ([#4045](https://github.com/expo/eas-cli/pull/4045) by [@gwdp](https://github.com/gwdp))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -327,6 +327,22 @@
             "deprecationReason": null
           },
           {
+            "name": "deviceRunSessionsEnabled",
+            "description": "Whether EAS Simulator (remote device run sessions) is available for this account.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "activityTimelineProjectActivities",
             "description": "Coalesced project activity for all apps belonging to this account.",
             "args": [

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -327,22 +327,6 @@
             "deprecationReason": null
           },
           {
-            "name": "deviceRunSessionsEnabled",
-            "description": "Whether EAS Simulator (remote device run sessions) is available for this account.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "activityTimelineProjectActivities",
             "description": "Coalesced project activity for all apps belonging to this account.",
             "args": [

--- a/packages/eas-cli/src/commands/simulator/__tests__/availability.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/availability.test.ts
@@ -99,7 +99,9 @@ describe(SimulatorAvailability, () => {
     await command.runAsync();
 
     expect(mockByAppIdAsync).toHaveBeenCalledWith(graphqlClient, projectId);
-    expect(mockLog).toHaveBeenCalledWith('EAS Simulator is not enabled for testuser.');
+    expect(mockLog).toHaveBeenCalledWith(
+      "EAS Simulator isn't available on testuser yet — it's coming soon."
+    );
     expect(mockPrintJsonOnlyOutput).not.toHaveBeenCalled();
   });
 });

--- a/packages/eas-cli/src/commands/simulator/__tests__/availability.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/availability.test.ts
@@ -1,0 +1,105 @@
+import { Config } from '@oclif/core';
+
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { SimulatorAvailabilityQuery } from '../../../graphql/generated';
+import { DeviceRunSessionAvailabilityQuery } from '../../../graphql/queries/DeviceRunSessionAvailabilityQuery';
+import Log from '../../../log';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+import SimulatorAvailability from '../availability';
+
+jest.mock('../../../graphql/queries/DeviceRunSessionAvailabilityQuery');
+jest.mock('../../../log');
+jest.mock('../../../ora', () => ({
+  ora: jest.fn(() => {
+    const spinner = {
+      fail: jest.fn(),
+      start: jest.fn(),
+      stop: jest.fn(),
+      succeed: jest.fn(),
+    };
+    spinner.start.mockReturnValue(spinner);
+    return spinner;
+  }),
+}));
+jest.mock('../../../utils/json');
+
+type OwnerAccount = SimulatorAvailabilityQuery['app']['byId']['ownerAccount'];
+
+const mockByAppIdAsync = jest.mocked(DeviceRunSessionAvailabilityQuery.byAppIdAsync);
+const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
+const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
+const mockLog = jest.mocked(Log.log);
+
+function makeOwnerAccount(deviceRunSessionsEnabled: boolean): OwnerAccount {
+  return {
+    id: 'account-123',
+    name: 'testuser',
+    deviceRunSessionsEnabled,
+  };
+}
+
+function getMockOclifConfig(): Config {
+  const config = new Config({ root: __dirname });
+  config.runHook = async () => ({
+    failures: [],
+    successes: [],
+  });
+  return config;
+}
+
+describe(SimulatorAvailability, () => {
+  const graphqlClient = {} as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+  const projectId = 'project-123';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createCommand(argv: string[]): SimulatorAvailability {
+    const command = new SimulatorAvailability(argv, mockConfig);
+    // @ts-expect-error getContextAsync is protected
+    jest.spyOn(command, 'getContextAsync').mockResolvedValue({
+      projectId,
+      loggedIn: { graphqlClient },
+    });
+    return command;
+  }
+
+  it('emits JSON with available true when enabled', async () => {
+    mockByAppIdAsync.mockResolvedValue(makeOwnerAccount(true));
+
+    const command = createCommand(['--json']);
+    await command.runAsync();
+
+    expect(mockEnableJsonOutput).toHaveBeenCalled();
+    expect(mockByAppIdAsync).toHaveBeenCalledWith(graphqlClient, projectId);
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
+      available: true,
+      accountName: 'testuser',
+    });
+  });
+
+  it('emits JSON with available false when not enabled', async () => {
+    mockByAppIdAsync.mockResolvedValue(makeOwnerAccount(false));
+
+    const command = createCommand(['--json']);
+    await command.runAsync();
+
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
+      available: false,
+      accountName: 'testuser',
+    });
+  });
+
+  it('logs a graceful message when not enabled', async () => {
+    mockByAppIdAsync.mockResolvedValue(makeOwnerAccount(false));
+
+    const command = createCommand([]);
+    await command.runAsync();
+
+    expect(mockByAppIdAsync).toHaveBeenCalledWith(graphqlClient, projectId);
+    expect(mockLog).toHaveBeenCalledWith('EAS Simulator is not enabled for testuser.');
+    expect(mockPrintJsonOnlyOutput).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/commands/simulator/__tests__/availability.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/availability.test.ts
@@ -104,4 +104,21 @@ describe(SimulatorAvailability, () => {
     );
     expect(mockPrintJsonOnlyOutput).not.toHaveBeenCalled();
   });
+
+  it('logs the enabled message when available', async () => {
+    mockByAppIdAsync.mockResolvedValue(makeOwnerAccount(true));
+
+    const command = createCommand([]);
+    await command.runAsync();
+
+    expect(mockLog).toHaveBeenCalledWith('✅ EAS Simulator is enabled for testuser.');
+    expect(mockPrintJsonOnlyOutput).not.toHaveBeenCalled();
+  });
+
+  it('propagates a query failure', async () => {
+    mockByAppIdAsync.mockRejectedValue(new Error('network down'));
+
+    const command = createCommand([]);
+    await expect(command.runAsync()).rejects.toThrow('network down');
+  });
 });

--- a/packages/eas-cli/src/commands/simulator/__tests__/availability.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/availability.test.ts
@@ -1,7 +1,6 @@
 import { Config } from '@oclif/core';
 
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
-import { SimulatorAvailabilityQuery } from '../../../graphql/generated';
 import { DeviceRunSessionAvailabilityQuery } from '../../../graphql/queries/DeviceRunSessionAvailabilityQuery';
 import Log from '../../../log';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
@@ -23,20 +22,10 @@ jest.mock('../../../ora', () => ({
 }));
 jest.mock('../../../utils/json');
 
-type OwnerAccount = SimulatorAvailabilityQuery['app']['byId']['ownerAccount'];
-
 const mockByAppIdAsync = jest.mocked(DeviceRunSessionAvailabilityQuery.byAppIdAsync);
 const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
 const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
 const mockLog = jest.mocked(Log.log);
-
-function makeOwnerAccount(deviceRunSessionsEnabled: boolean): OwnerAccount {
-  return {
-    id: 'account-123',
-    name: 'testuser',
-    deviceRunSessionsEnabled,
-  };
-}
 
 function getMockOclifConfig(): Config {
   const config = new Config({ root: __dirname });
@@ -67,7 +56,7 @@ describe(SimulatorAvailability, () => {
   }
 
   it('emits JSON with available true when enabled', async () => {
-    mockByAppIdAsync.mockResolvedValue(makeOwnerAccount(true));
+    mockByAppIdAsync.mockResolvedValue({ accountName: 'testuser', available: true });
 
     const command = createCommand(['--json']);
     await command.runAsync();
@@ -81,7 +70,7 @@ describe(SimulatorAvailability, () => {
   });
 
   it('emits JSON with available false when not enabled', async () => {
-    mockByAppIdAsync.mockResolvedValue(makeOwnerAccount(false));
+    mockByAppIdAsync.mockResolvedValue({ accountName: 'testuser', available: false });
 
     const command = createCommand(['--json']);
     await command.runAsync();
@@ -93,7 +82,7 @@ describe(SimulatorAvailability, () => {
   });
 
   it('logs a graceful message when not enabled', async () => {
-    mockByAppIdAsync.mockResolvedValue(makeOwnerAccount(false));
+    mockByAppIdAsync.mockResolvedValue({ accountName: 'testuser', available: false });
 
     const command = createCommand([]);
     await command.runAsync();
@@ -106,7 +95,7 @@ describe(SimulatorAvailability, () => {
   });
 
   it('logs the enabled message when available', async () => {
-    mockByAppIdAsync.mockResolvedValue(makeOwnerAccount(true));
+    mockByAppIdAsync.mockResolvedValue({ accountName: 'testuser', available: true });
 
     const command = createCommand([]);
     await command.runAsync();

--- a/packages/eas-cli/src/commands/simulator/availability.ts
+++ b/packages/eas-cli/src/commands/simulator/availability.ts
@@ -1,0 +1,69 @@
+import EasCommand from '../../commandUtils/EasCommand';
+import {
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
+} from '../../commandUtils/flags';
+import { DeviceRunSessionAvailabilityQuery } from '../../graphql/queries/DeviceRunSessionAvailabilityQuery';
+import Log from '../../log';
+import { ora } from '../../ora';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+
+export default class SimulatorAvailability extends EasCommand {
+  static override hidden = true;
+  static override description =
+    '[EXPERIMENTAL] check whether EAS Simulator is enabled for the current project account';
+
+  static override flags = {
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectId,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(SimulatorAvailability);
+    const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
+
+    const {
+      projectId,
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(SimulatorAvailability, {
+      nonInteractive,
+    });
+
+    const fetchSpinner = jsonFlag ? null : ora('Checking EAS Simulator availability').start();
+    let account;
+    try {
+      account = await DeviceRunSessionAvailabilityQuery.byAppIdAsync(graphqlClient, projectId);
+      fetchSpinner?.stop();
+    } catch (err) {
+      fetchSpinner?.fail('Failed to check EAS Simulator availability');
+      throw err;
+    }
+
+    const available = account.deviceRunSessionsEnabled;
+
+    if (jsonFlag) {
+      printJsonOnlyOutput({ available, accountName: account.name });
+      return;
+    }
+
+    if (available) {
+      Log.log(`✅ EAS Simulator is enabled for ${account.name}.`);
+      return;
+    }
+
+    Log.log(`EAS Simulator is not enabled for ${account.name}.`);
+    Log.newLine();
+    Log.log(
+      'EAS Simulator is a limited-access EAS feature that is still rolling out. ' +
+        'To register interest, visit https://expo.dev/eas.'
+    );
+  }
+}

--- a/packages/eas-cli/src/commands/simulator/availability.ts
+++ b/packages/eas-cli/src/commands/simulator/availability.ts
@@ -59,11 +59,6 @@ export default class SimulatorAvailability extends EasCommand {
       return;
     }
 
-    Log.log(`EAS Simulator is not enabled for ${account.name}.`);
-    Log.newLine();
-    Log.log(
-      'EAS Simulator is a limited-access EAS feature that is still rolling out. ' +
-        'To register interest, visit https://expo.dev/eas.'
-    );
+    Log.log(`EAS Simulator isn't available on ${account.name} yet — it's coming soon.`);
   }
 }

--- a/packages/eas-cli/src/commands/simulator/availability.ts
+++ b/packages/eas-cli/src/commands/simulator/availability.ts
@@ -38,27 +38,29 @@ export default class SimulatorAvailability extends EasCommand {
     });
 
     const fetchSpinner = jsonFlag ? null : ora('Checking EAS Simulator availability').start();
-    let account;
+    let accountName: string;
+    let available: boolean;
     try {
-      account = await DeviceRunSessionAvailabilityQuery.byAppIdAsync(graphqlClient, projectId);
+      ({ accountName, available } = await DeviceRunSessionAvailabilityQuery.byAppIdAsync(
+        graphqlClient,
+        projectId
+      ));
       fetchSpinner?.stop();
     } catch (err) {
       fetchSpinner?.fail('Failed to check EAS Simulator availability');
       throw err;
     }
 
-    const available = account.deviceRunSessionsEnabled;
-
     if (jsonFlag) {
-      printJsonOnlyOutput({ available, accountName: account.name });
+      printJsonOnlyOutput({ available, accountName });
       return;
     }
 
     if (available) {
-      Log.log(`✅ EAS Simulator is enabled for ${account.name}.`);
+      Log.log(`✅ EAS Simulator is enabled for ${accountName}.`);
       return;
     }
 
-    Log.log(`EAS Simulator isn't available on ${account.name} yet — it's coming soon.`);
+    Log.log(`EAS Simulator isn't available on ${accountName} yet — it's coming soon.`);
   }
 }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -14157,6 +14157,13 @@ export type AccountBillingPeriodQueryVariables = Exact<{
 
 export type AccountBillingPeriodQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byId: { __typename?: 'Account', id: string, name: string, billingPeriod: { __typename?: 'BillingPeriod', id: string, start: any, end: any, anchor: any } } } };
 
+export type SimulatorAvailabilityQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+}>;
+
+
+export type SimulatorAvailabilityQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, ownerAccount: { __typename?: 'Account', id: string, name: string, deviceRunSessionsEnabled: boolean } } } };
+
 export type AppByIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];
 }>;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -14162,7 +14162,7 @@ export type SimulatorAvailabilityQueryVariables = Exact<{
 }>;
 
 
-export type SimulatorAvailabilityQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, ownerAccount: { __typename?: 'Account', id: string, name: string, deviceRunSessionsEnabled: boolean } } } };
+export type SimulatorAvailabilityQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, ownerAccount: { __typename?: 'Account', id: string, name: string, accountFeatureGates: any } } } };
 
 export type AppByIdQueryVariables = Exact<{
   appId: Scalars['String']['input'];

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -14159,6 +14159,7 @@ export type AccountBillingPeriodQuery = { __typename?: 'RootQuery', account: { _
 
 export type SimulatorAvailabilityQueryVariables = Exact<{
   appId: Scalars['String']['input'];
+  filter?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
 }>;
 
 

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionAvailabilityQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionAvailabilityQuery.ts
@@ -15,20 +15,20 @@ export const DeviceRunSessionAvailabilityQuery = {
       graphqlClient
         .query<SimulatorAvailabilityQuery, SimulatorAvailabilityQueryVariables>(
           gql`
-            query SimulatorAvailabilityQuery($appId: String!) {
+            query SimulatorAvailabilityQuery($appId: String!, $filter: [String!]) {
               app {
                 byId(appId: $appId) {
                   id
                   ownerAccount {
                     id
                     name
-                    accountFeatureGates(filter: ["device-run-sessions"])
+                    accountFeatureGates(filter: $filter)
                   }
                 }
               }
             }
           `,
-          { appId },
+          { appId, filter: [DEVICE_RUN_SESSIONS_GATE] },
           { additionalTypenames: ['Account'] }
         )
         .toPromise()

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionAvailabilityQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionAvailabilityQuery.ts
@@ -2,10 +2,7 @@ import gql from 'graphql-tag';
 
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
 import { withErrorHandlingAsync } from '../client';
-import {
-  SimulatorAvailabilityQuery,
-  SimulatorAvailabilityQueryVariables,
-} from '../generated';
+import { SimulatorAvailabilityQuery, SimulatorAvailabilityQueryVariables } from '../generated';
 
 export const DeviceRunSessionAvailabilityQuery = {
   async byAppIdAsync(

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionAvailabilityQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionAvailabilityQuery.ts
@@ -1,0 +1,40 @@
+import gql from 'graphql-tag';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
+import {
+  SimulatorAvailabilityQuery,
+  SimulatorAvailabilityQueryVariables,
+} from '../generated';
+
+export const DeviceRunSessionAvailabilityQuery = {
+  async byAppIdAsync(
+    graphqlClient: ExpoGraphqlClient,
+    appId: string
+  ): Promise<SimulatorAvailabilityQuery['app']['byId']['ownerAccount']> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<SimulatorAvailabilityQuery, SimulatorAvailabilityQueryVariables>(
+          gql`
+            query SimulatorAvailabilityQuery($appId: String!) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  ownerAccount {
+                    id
+                    name
+                    deviceRunSessionsEnabled
+                  }
+                }
+              }
+            }
+          `,
+          { appId },
+          { additionalTypenames: ['Account'] }
+        )
+        .toPromise()
+    );
+
+    return data.app.byId.ownerAccount;
+  },
+};

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionAvailabilityQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionAvailabilityQuery.ts
@@ -4,11 +4,13 @@ import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/creat
 import { withErrorHandlingAsync } from '../client';
 import { SimulatorAvailabilityQuery, SimulatorAvailabilityQueryVariables } from '../generated';
 
+const DEVICE_RUN_SESSIONS_GATE = 'device-run-sessions';
+
 export const DeviceRunSessionAvailabilityQuery = {
   async byAppIdAsync(
     graphqlClient: ExpoGraphqlClient,
     appId: string
-  ): Promise<SimulatorAvailabilityQuery['app']['byId']['ownerAccount']> {
+  ): Promise<{ accountName: string; available: boolean }> {
     const data = await withErrorHandlingAsync(
       graphqlClient
         .query<SimulatorAvailabilityQuery, SimulatorAvailabilityQueryVariables>(
@@ -20,7 +22,7 @@ export const DeviceRunSessionAvailabilityQuery = {
                   ownerAccount {
                     id
                     name
-                    deviceRunSessionsEnabled
+                    accountFeatureGates(filter: ["device-run-sessions"])
                   }
                 }
               }
@@ -32,6 +34,11 @@ export const DeviceRunSessionAvailabilityQuery = {
         .toPromise()
     );
 
-    return data.app.byId.ownerAccount;
+    const ownerAccount = data.app.byId.ownerAccount;
+    const gates: Record<string, boolean> = ownerAccount.accountFeatureGates;
+    return {
+      accountName: ownerAccount.name,
+      available: gates[DEVICE_RUN_SESSIONS_GATE] === true,
+    };
   },
 };

--- a/packages/eas-cli/src/graphql/queries/__tests__/DeviceRunSessionAvailabilityQuery-test.ts
+++ b/packages/eas-cli/src/graphql/queries/__tests__/DeviceRunSessionAvailabilityQuery-test.ts
@@ -1,25 +1,37 @@
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { DeviceRunSessionAvailabilityQuery } from '../DeviceRunSessionAvailabilityQuery';
 
-function makeGraphqlClient(data: unknown): ExpoGraphqlClient {
+function makeGraphqlClient(accountFeatureGates: Record<string, boolean>): ExpoGraphqlClient {
   return {
     query: jest.fn().mockReturnValue({
-      toPromise: jest.fn().mockResolvedValue({ data }),
+      toPromise: jest.fn().mockResolvedValue({
+        data: {
+          app: {
+            byId: {
+              id: 'app-1',
+              ownerAccount: { id: 'account-1', name: 'testuser', accountFeatureGates },
+            },
+          },
+        },
+      }),
     }),
   } as unknown as ExpoGraphqlClient;
 }
 
 describe('DeviceRunSessionAvailabilityQuery.byAppIdAsync', () => {
-  it('returns the owner account availability from the GraphQL response', async () => {
-    const ownerAccount = {
-      id: 'account-1',
-      name: 'testuser',
-      deviceRunSessionsEnabled: true,
-    };
-    const graphqlClient = makeGraphqlClient({ app: { byId: { id: 'app-1', ownerAccount } } });
+  it('returns available true when the feature gate is enabled', async () => {
+    const graphqlClient = makeGraphqlClient({ 'device-run-sessions': true });
 
     const result = await DeviceRunSessionAvailabilityQuery.byAppIdAsync(graphqlClient, 'app-1');
 
-    expect(result).toEqual(ownerAccount);
+    expect(result).toEqual({ accountName: 'testuser', available: true });
+  });
+
+  it('returns available false when the feature gate is disabled or absent', async () => {
+    const graphqlClient = makeGraphqlClient({});
+
+    const result = await DeviceRunSessionAvailabilityQuery.byAppIdAsync(graphqlClient, 'app-1');
+
+    expect(result).toEqual({ accountName: 'testuser', available: false });
   });
 });

--- a/packages/eas-cli/src/graphql/queries/__tests__/DeviceRunSessionAvailabilityQuery-test.ts
+++ b/packages/eas-cli/src/graphql/queries/__tests__/DeviceRunSessionAvailabilityQuery-test.ts
@@ -1,0 +1,25 @@
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { DeviceRunSessionAvailabilityQuery } from '../DeviceRunSessionAvailabilityQuery';
+
+function makeGraphqlClient(data: unknown): ExpoGraphqlClient {
+  return {
+    query: jest.fn().mockReturnValue({
+      toPromise: jest.fn().mockResolvedValue({ data }),
+    }),
+  } as unknown as ExpoGraphqlClient;
+}
+
+describe('DeviceRunSessionAvailabilityQuery.byAppIdAsync', () => {
+  it('returns the owner account availability from the GraphQL response', async () => {
+    const ownerAccount = {
+      id: 'account-1',
+      name: 'testuser',
+      deviceRunSessionsEnabled: true,
+    };
+    const graphqlClient = makeGraphqlClient({ app: { byId: { id: 'app-1', ownerAccount } } });
+
+    const result = await DeviceRunSessionAvailabilityQuery.byAppIdAsync(graphqlClient, 'app-1');
+
+    expect(result).toEqual(ownerAccount);
+  });
+});


### PR DESCRIPTION
# Why

Tooling and agents need a way to check whether EAS Simulator is available for an account before invoking it, so they can check up front and degrade gracefully instead of failing partway through (some flows build on EAS first, so failing only at `simulator:start` means waiting through a full build to hit the wall).

# How

Adds a hidden `eas simulator:availability` command that reads the current project owner account's EAS Simulator availability via the existing `accountFeatureGates` field and prints whether it's enabled, with `--json`. No schema change.

# Test Plan

Unit tests cover the enabled/disabled JSON output and the graceful not-enabled message.
