### PR TITLE
[worker] set EAS_JOB_TYPE for builds and job runs

### DIFF
--- a/packages/local-build-plugin/src/build.ts
+++ b/packages/local-build-plugin/src/build.ts
@@ -32,6 +32,7 @@ export async function buildAsync(job: BuildJob, metadata: Metadata): Promise<voi
       EAS_BUILD: '1',
       EAS_BUILD_RUNNER: 'local-build-plugin',
       EAS_BUILD_PLATFORM: job.platform,
+      EAS_JOB_TYPE: 'build',
       EAS_BUILD_WORKINGDIR: path.join(workingdir, 'build'),
       EAS_BUILD_PROFILE: metadata.buildProfile,
       EAS_BUILD_GIT_COMMIT_HASH: metadata.gitCommitHash,

--- a/packages/worker/src/__unit__/context.test.ts
+++ b/packages/worker/src/__unit__/context.test.ts
@@ -31,6 +31,7 @@ describe(createBuildContext.name, () => {
     metadata: {},
     projectId: 'project-id',
     buildId: 'build-id',
+    jobType: 'build' as const,
     buildLogger,
   };
 

--- a/packages/worker/src/__unit__/env.test.ts
+++ b/packages/worker/src/__unit__/env.test.ts
@@ -1,5 +1,5 @@
 import { RuntimeSettings } from '@expo/build-tools';
-import { Platform, Workflow } from '@expo/eas-build-job';
+import { Job, Metadata, Platform, Workflow } from '@expo/eas-build-job';
 import os from 'os';
 import v8 from 'v8';
 
@@ -74,9 +74,23 @@ describe(getBuildEnv.name, () => {
         username: 'expo-user',
       } as any,
       buildId: 'build-id',
+      jobType: 'build',
     });
 
     expect(env.EAS_CLI_SENTRY_DSN).toBe(config.sentry.dsn);
+    expect(env.EAS_JOB_TYPE).toBe('build');
+  });
+
+  it('sets EAS_JOB_TYPE to jobRun for a job run', () => {
+    const env = getBuildEnv({
+      job: {} as unknown as Job,
+      projectId: 'project-id',
+      metadata: {} as unknown as Metadata,
+      buildId: 'job-run-id',
+      jobType: 'jobRun',
+    });
+
+    expect(env.EAS_JOB_TYPE).toBe('jobRun');
   });
 
   it('does not add precompiled modules env vars to flagged iOS jobs', () => {
@@ -97,6 +111,7 @@ describe(getBuildEnv.name, () => {
         username: 'expo-user',
       } as any,
       buildId: 'build-id',
+      jobType: 'build',
     });
 
     expect(env.EAS_USE_PRECOMPILED_MODULES).toBeUndefined();
@@ -123,6 +138,7 @@ describe(getBuildEnv.name, () => {
         username: 'expo-user',
       } as any,
       buildId: 'build-id',
+      jobType: 'build',
     });
 
     expect(env.EAS_USE_PRECOMPILED_MODULES).toBe('1');
@@ -147,6 +163,7 @@ describe(getBuildEnv.name, () => {
         username: 'expo-user',
       } as any,
       buildId: 'build-id',
+      jobType: 'build',
     });
 
     expect(env.EAS_USE_PRECOMPILED_MODULES).toBeUndefined();
@@ -173,6 +190,7 @@ describe(getBuildEnv.name, () => {
         username: 'expo-user',
       } as any,
       buildId: 'build-id',
+      jobType: 'build',
     });
 
     expect({ ...baseEnv, ...job.builderEnvironment.env }.EAS_USE_PRECOMPILED_MODULES).toBe('0');
@@ -200,6 +218,7 @@ describe(getBuildEnv.name, () => {
         username: 'expo-user',
       } as any,
       buildId: 'build-id',
+      jobType: 'build',
     });
 
     expect(env.NPM_CACHE_URL).toBeUndefined();
@@ -233,6 +252,7 @@ describe(getBuildEnv.name, () => {
         username: 'expo-user',
       } as any,
       buildId: 'build-id',
+      jobType: 'build',
     });
 
     expect(env.NPM_CACHE_URL).toBeUndefined();
@@ -270,6 +290,7 @@ describe(getBuildEnv.name, () => {
         username: 'expo-user',
       } as any,
       buildId: 'build-id',
+      jobType: 'build',
     });
 
     expect(env.NPM_CACHE_URL).toBeUndefined();
@@ -354,6 +375,7 @@ describe(getBuildEnv.name, () => {
         username: 'expo-user',
       } as any,
       buildId: 'build-id',
+      jobType: 'build',
     });
 
     expect(env.NODE_OPTIONS).toBe(

--- a/packages/worker/src/__unit__/service.test.ts
+++ b/packages/worker/src/__unit__/service.test.ts
@@ -6,6 +6,7 @@ import path from 'path';
 
 import { build } from '../build';
 import { createBuildContext } from '../context';
+import { LauncherMessage } from '../external/turtle';
 import { createBuildLoggerWithSecretsFilter } from '../logger';
 import BuildService, { getExpoPackageVersionAsync } from '../service';
 
@@ -179,5 +180,53 @@ describe('BuildService Datadog setup', () => {
     });
 
     expect(datadogSetupMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('BuildService startBuild job type', () => {
+  function spyOnStartBuildInternal(service: BuildService): jest.SpyInstance {
+    return jest
+      .spyOn(
+        service as unknown as { startBuildInternal: () => Promise<void> },
+        'startBuildInternal'
+      )
+      .mockResolvedValue(undefined);
+  }
+
+  it('forwards jobRun as the job type for a job run dispatch', () => {
+    const service = new BuildService();
+    const startBuildInternalSpy = spyOnStartBuildInternal(service);
+
+    service.startBuild({
+      type: LauncherMessage.MessageType.DISPATCH,
+      job: {},
+      metadata: {},
+      projectId: 'project-id',
+      initiatingUserId: 'user-id',
+      jobType: 'jobRun',
+      jobRunId: 'build-id',
+    } as unknown as LauncherMessage.Dispatch);
+
+    expect(startBuildInternalSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ jobType: 'jobRun' })
+    );
+  });
+
+  it('forwards build as the job type for a build dispatch', () => {
+    const service = new BuildService();
+    const startBuildInternalSpy = spyOnStartBuildInternal(service);
+
+    service.startBuild({
+      type: LauncherMessage.MessageType.DISPATCH,
+      job: {},
+      metadata: {},
+      projectId: 'project-id',
+      initiatingUserId: 'user-id',
+      buildId: 'build-id',
+    } as unknown as LauncherMessage.Dispatch);
+
+    expect(startBuildInternalSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ jobType: 'build' })
+    );
   });
 });

--- a/packages/worker/src/context.ts
+++ b/packages/worker/src/context.ts
@@ -5,7 +5,7 @@ import assert from 'assert';
 
 import { GCSCacheManager } from './CacheManager';
 import config from './config';
-import { getBuildEnv } from './env';
+import { EasJobType, getBuildEnv } from './env';
 import { Analytics } from './external/analytics';
 import { uploadXcodeBuildLogs } from './ios/xcodeLogs';
 import { prepareRuntimeEnvironmentConfigFiles } from './runtimeEnvironment';
@@ -24,6 +24,7 @@ export async function createBuildContext<TJob extends Job>({
   metadata,
   projectId,
   buildId,
+  jobType,
   buildLogger,
 }: {
   job: TJob;
@@ -32,6 +33,7 @@ export async function createBuildContext<TJob extends Job>({
   metadata: Metadata;
   projectId: string;
   buildId: string;
+  jobType: EasJobType;
   buildLogger: bunyan;
 }): Promise<BuildContext<TJob>> {
   const childLogger = buildLogger.child({ buildId });
@@ -40,7 +42,7 @@ export async function createBuildContext<TJob extends Job>({
     env: job.builderEnvironment?.env,
   });
   await prepareRuntimeEnvironmentConfigFiles();
-  const env = getBuildEnv({ job, projectId, metadata, buildId });
+  const env = getBuildEnv({ job, projectId, metadata, buildId, jobType });
 
   const uploadArtifact: BuildContextOptions['uploadArtifact'] = async ({ artifact, logger }) => {
     const { paths, type } = artifact;

--- a/packages/worker/src/env.ts
+++ b/packages/worker/src/env.ts
@@ -13,6 +13,8 @@ import { getAccessedEnvs } from './utils/env';
 
 const GIB_IN_BYTES = 1024 ** 3;
 
+export type EasJobType = 'build' | 'jobRun';
+
 // keep in sync with local-build-plugin env vars
 // see packages/local-build-plugin/src/build.ts
 export function getBuildEnv({
@@ -20,11 +22,13 @@ export function getBuildEnv({
   projectId,
   metadata,
   buildId,
+  jobType,
 }: {
   job: Job;
   projectId: string;
   metadata: Metadata;
   buildId: string;
+  jobType: EasJobType;
 }): Env {
   const env = getFilteredEnv();
 
@@ -49,6 +53,7 @@ export function getBuildEnv({
   setEnv(env, 'EAS_BUILD_PROFILE', metadata.buildProfile);
   setEnv(env, 'EAS_BUILD_GIT_COMMIT_HASH', metadata.gitCommitHash);
   setEnv(env, 'EAS_BUILD_ID', buildId);
+  setEnv(env, 'EAS_JOB_TYPE', jobType);
   setEnv(env, 'LANG', 'en_US.UTF-8');
   setEnv(env, 'EAS_BUILD_WORKINGDIR', path.join(config.workingdir, 'build'));
   setEnv(env, 'EAS_BUILD_PROJECT_ID', projectId);

--- a/packages/worker/src/service.ts
+++ b/packages/worker/src/service.ts
@@ -28,6 +28,7 @@ import { setTimeout as setTimeoutAsync } from 'timers/promises';
 import { build } from './build';
 import config from './config';
 import { createBuildContext } from './context';
+import { EasJobType } from './env';
 import { Analytics } from './external/analytics';
 import { LauncherMessage, Worker, WorkerMessage } from './external/turtle';
 import logger, { createBuildLoggerWithSecretsFilter } from './logger';
@@ -108,7 +109,8 @@ export default class BuildService {
     this.state.buildStarted();
     this._startBuildTime = Date.now();
 
-    this.startBuildInternal({ job, metadata, initiatingUserId, projectId });
+    const jobType: EasJobType = rest.jobType ?? 'build';
+    this.startBuildInternal({ job, metadata, initiatingUserId, projectId, jobType });
   }
 
   public async finishError(err: errors.ExpoError, artifacts: Artifacts | null): Promise<void> {
@@ -264,11 +266,13 @@ export default class BuildService {
     metadata,
     projectId,
     initiatingUserId,
+    jobType,
   }: {
     job: Job;
     metadata: Metadata | undefined;
     projectId: string;
     initiatingUserId: string;
+    jobType: EasJobType;
   }): Promise<void> {
     try {
       const {
@@ -299,6 +303,7 @@ export default class BuildService {
         metadata: metadata ?? {},
         projectId,
         buildId: this.buildId,
+        jobType,
         buildLogger,
       });
       this.buildContext = ctx;


### PR DESCRIPTION
# Why

`eas update` run inside an EAS Build 500s because the publish sends the build id in a job-run-only field. The CLI needs a way to tell a build apart from a job run at publish time.

# How

Set `EAS_JOB_TYPE` (`build` | `jobRun`) in the build environment, derived from the dispatch message's existing job type.

Groundwork for #4048.

# Test Plan

Unit tests cover both job types. CI passes.