### PR TITLE
[eas-cli] send turtleJobRunId only for job runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Fix `eas update` failing with a server error when run inside an EAS Build. ([#4048](https://github.com/expo/eas-cli/pull/4048) by [@gwdp](https://github.com/gwdp))
+
 ### 🧹 Chores
 
 ## [21.0.3](https://github.com/expo/eas-cli/releases/tag/v21.0.3) - 2026-07-22

--- a/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/PublishMutation.ts
@@ -17,7 +17,9 @@ import {
 } from '../generated';
 import { UpdateFragmentNode } from '../types/Update';
 
-const turtleJobRunId = process.env.EAS_BUILD_ID;
+function getTurtleJobRunId(): string | undefined {
+  return process.env.EAS_BUILD_PLATFORM ? undefined : process.env.EAS_BUILD_ID;
+}
 
 export const PublishMutation = {
   async getUploadURLsAsync(
@@ -48,6 +50,7 @@ export const PublishMutation = {
     graphqlClient: ExpoGraphqlClient,
     publishUpdateGroupsInput: PublishUpdateGroupInput[]
   ): Promise<UpdateFragment[]> {
+    const turtleJobRunId = getTurtleJobRunId();
     const data = await withErrorHandlingAsync(
       graphqlClient
         .mutation<UpdatePublishMutation>(

--- a/packages/eas-cli/src/graphql/mutations/__tests__/PublishMutation-test.ts
+++ b/packages/eas-cli/src/graphql/mutations/__tests__/PublishMutation-test.ts
@@ -1,0 +1,62 @@
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { PublishUpdateGroupInput } from '../../generated';
+import { PublishMutation } from '../PublishMutation';
+
+function makeGraphqlClient(): ExpoGraphqlClient {
+  return {
+    mutation: jest.fn().mockReturnValue({
+      toPromise: jest.fn().mockResolvedValue({
+        data: { updateBranch: { publishUpdateGroups: [] } },
+      }),
+    }),
+  } as unknown as ExpoGraphqlClient;
+}
+
+const input: PublishUpdateGroupInput = { branchId: 'branch-id', runtimeVersion: '1.0.0' };
+
+describe('PublishMutation.publishUpdateGroupAsync', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.EAS_BUILD_PLATFORM;
+    delete process.env.EAS_BUILD_ID;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('sends the id as turtleJobRunId when running inside a job run', async () => {
+    process.env.EAS_BUILD_ID = 'job-run-id';
+    const client = makeGraphqlClient();
+
+    await PublishMutation.publishUpdateGroupAsync(client, [input]);
+
+    expect(client.mutation).toHaveBeenCalledWith(expect.anything(), {
+      publishUpdateGroupsInput: [{ ...input, turtleJobRunId: 'job-run-id' }],
+    });
+  });
+
+  it('omits turtleJobRunId when running inside a build', async () => {
+    process.env.EAS_BUILD_PLATFORM = 'android';
+    process.env.EAS_BUILD_ID = 'build-id';
+    const client = makeGraphqlClient();
+
+    await PublishMutation.publishUpdateGroupAsync(client, [input]);
+
+    expect(client.mutation).toHaveBeenCalledWith(expect.anything(), {
+      publishUpdateGroupsInput: [{ ...input, turtleJobRunId: undefined }],
+    });
+  });
+
+  it('omits turtleJobRunId when not running in EAS', async () => {
+    const client = makeGraphqlClient();
+
+    await PublishMutation.publishUpdateGroupAsync(client, [input]);
+
+    expect(client.mutation).toHaveBeenCalledWith(expect.anything(), {
+      publishUpdateGroupsInput: [{ ...input, turtleJobRunId: undefined }],
+    });
+  });
+});


### PR DESCRIPTION
# Why

`eas update` run inside an EAS Build 500s: it sends the build id as `turtleJobRunId`, which violates a job-run foreign key on the server.

Closes #3873.

# How

Only send `turtleJobRunId` when not running inside a build. Builds set `EAS_BUILD_PLATFORM` and job runs don't, so its presence tells them apart.

# Test Plan

Unit tests.