### PR TITLE
[build-tools] fix maestro screenshot harvest for v2.7.0

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
@@ -7,12 +7,40 @@ import {
   isFileAttrRun,
   junitFileHasFileAttrs,
   mergeJUnitReports,
+  parseFailedFlowNamesFromJUnitFile,
   parseFailedFlowsFromFileAttrs,
   parseFailedFlowsFromJUnit,
   parseJUnitTestCases,
   parseMaestroResults,
   parseMaestroResultsFromFileAttrs,
 } from '../maestroResultParser';
+
+describe(parseFailedFlowNamesFromJUnitFile, () => {
+  it('returns the names of failed testcases, keeping slashes', async () => {
+    vol.fromJSON({
+      '/attempt/android-maestro-junit-attempt-0.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites>',
+        '  <testsuite name="Test Suite" tests="3" failures="2">',
+        '    <testcase name="home" status="SUCCESS"/>',
+        '    <testcase name="sub/login" status="ERROR"><failure>boom</failure></testcase>',
+        '    <testcase name="checkout" status="ERROR"><failure>boom</failure></testcase>',
+        '  </testsuite>',
+        '</testsuites>',
+      ].join('\n'),
+    });
+
+    const failed = await parseFailedFlowNamesFromJUnitFile(
+      '/attempt/android-maestro-junit-attempt-0.xml'
+    );
+
+    expect([...failed].sort()).toEqual(['checkout', 'sub/login']);
+  });
+
+  it('returns an empty set when the file cannot be read', async () => {
+    expect((await parseFailedFlowNamesFromJUnitFile('/missing.xml')).size).toBe(0);
+  });
+});
 
 describe(parseMaestroResults, () => {
   it('parses JUnit results and enriches with name→path map', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/maestroScreenshots.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroScreenshots.test.ts
@@ -80,6 +80,7 @@ describe(harvestFailureScreenshotsAsync, () => {
       testsDirectory,
       capturedSinceMs: sinceMtimeMs,
       attemptIndex: 1,
+      failedFlowNames: new Set(),
       logger,
     });
 
@@ -113,6 +114,7 @@ describe(harvestFailureScreenshotsAsync, () => {
       testsDirectory,
       capturedSinceMs: sinceMtimeMs,
       attemptIndex: 0,
+      failedFlowNames: new Set(),
       logger,
     });
 
@@ -136,6 +138,7 @@ describe(harvestFailureScreenshotsAsync, () => {
       testsDirectory,
       capturedSinceMs: sinceMtimeMs,
       attemptIndex: 0,
+      failedFlowNames: new Set(),
       logger,
     });
 
@@ -154,6 +157,7 @@ describe(harvestFailureScreenshotsAsync, () => {
       testsDirectory,
       capturedSinceMs: sinceMtimeMs,
       attemptIndex: 0,
+      failedFlowNames: new Set(),
       logger,
     });
 
@@ -175,6 +179,7 @@ describe(harvestFailureScreenshotsAsync, () => {
       testsDirectory,
       capturedSinceMs: sinceMtimeMs,
       attemptIndex: 1,
+      failedFlowNames: new Set(),
       logger,
     });
 
@@ -186,10 +191,303 @@ describe(harvestFailureScreenshotsAsync, () => {
       testsDirectory: path.join(testsDirectory, 'does-not-exist'),
       capturedSinceMs: 0,
       attemptIndex: 0,
+      failedFlowNames: new Set(),
       logger,
     });
 
     expect(shots).toEqual([]);
+  });
+
+  // --- Maestro >= 2.7.0 bundle layout: <session>/<flow>[-shard-N]/screenshots/step-<NNN>-<slug>.png ---
+
+  async function makeBundle(args: {
+    sessionDir: string;
+    flowDir: string;
+    stepFiles: { name: string; mtimeMs: number }[];
+    sessionDirMtimeMs: number;
+  }): Promise<void> {
+    const sessionDir = path.join(testsDirectory, args.sessionDir);
+    const screenshotsDir = path.join(sessionDir, args.flowDir, 'screenshots');
+    await fs.mkdir(screenshotsDir, { recursive: true });
+    for (const { name, mtimeMs } of args.stepFiles) {
+      const filePath = path.join(screenshotsDir, name);
+      await fs.writeFile(filePath, '');
+      const when = new Date(mtimeMs);
+      await fs.utimes(filePath, when, when);
+    }
+    const dirWhen = new Date(args.sessionDirMtimeMs);
+    await fs.utimes(sessionDir, dirWhen, dirWhen);
+  }
+
+  it('picks the highest step-NNN screenshot in a failed flow bundle (mtime as capturedAtMs)', async () => {
+    const since = 1_000_000;
+    await makeBundle({
+      sessionDir: '2026-01-01_100000',
+      flowDir: 'Login Flow',
+      stepFiles: [
+        { name: 'step-001-launchApp.png', mtimeMs: since + 1_000 },
+        { name: 'step-003-assertVisible-Welcome.png', mtimeMs: since + 3_000 },
+      ],
+      sessionDirMtimeMs: since + 5_000,
+    });
+
+    const shots = await harvestFailureScreenshotsAsync({
+      testsDirectory,
+      capturedSinceMs: since,
+      attemptIndex: 0,
+      failedFlowNames: new Set(['Login Flow']),
+      logger,
+    });
+
+    expect(shots).toEqual([
+      {
+        fileAbsPath: path.join(
+          testsDirectory,
+          '2026-01-01_100000',
+          'Login Flow',
+          'screenshots',
+          'step-003-assertVisible-Welcome.png'
+        ),
+        displayName: 'Failure Screenshot: Login Flow (attempt 1)',
+        metadata: {
+          kind: 'maestro-test-screenshot',
+          flowName: 'Login Flow',
+          attemptIndex: 0,
+          capturedAtMs: since + 3_000,
+        },
+      },
+    ]);
+  });
+
+  it('ignores final.png and non-step pngs in the bundle', async () => {
+    const since = 1_000_000;
+    await makeBundle({
+      sessionDir: 'session',
+      flowDir: 'Flow',
+      stepFiles: [
+        { name: 'step-002-tapOn.png', mtimeMs: since + 2_000 },
+        { name: 'final.png', mtimeMs: since + 9_000 },
+      ],
+      sessionDirMtimeMs: since + 9_000,
+    });
+
+    const shots = await harvestFailureScreenshotsAsync({
+      testsDirectory,
+      capturedSinceMs: since,
+      attemptIndex: 0,
+      failedFlowNames: new Set(['Flow']),
+      logger,
+    });
+
+    expect(shots).toHaveLength(1);
+    expect(shots[0].fileAbsPath.endsWith('step-002-tapOn.png')).toBe(true);
+  });
+
+  it('harvests only flows that JUnit reports as failed', async () => {
+    const since = 1_000_000;
+    await makeBundle({
+      sessionDir: 'session',
+      flowDir: 'Failed Flow',
+      stepFiles: [{ name: 'step-001-tapOn.png', mtimeMs: since + 1_000 }],
+      sessionDirMtimeMs: since + 5_000,
+    });
+    // A passing flow can still leave a warned-step screenshot; it must not be harvested.
+    await makeBundle({
+      sessionDir: 'session',
+      flowDir: 'Passed Flow',
+      stepFiles: [{ name: 'step-001-assertVisible.png', mtimeMs: since + 1_000 }],
+      sessionDirMtimeMs: since + 5_000,
+    });
+
+    const shots = await harvestFailureScreenshotsAsync({
+      testsDirectory,
+      capturedSinceMs: since,
+      attemptIndex: 0,
+      failedFlowNames: new Set(['Failed Flow']),
+      logger,
+    });
+
+    expect(shots.map(shot => shot.metadata.flowName)).toEqual(['Failed Flow']);
+  });
+
+  it('strips the -shard-N suffix to match the JUnit flow name', async () => {
+    const since = 1_000_000;
+    await makeBundle({
+      sessionDir: 'session',
+      flowDir: 'Checkout-shard-2',
+      stepFiles: [{ name: 'step-004-tapOn-Pay.png', mtimeMs: since + 1_000 }],
+      sessionDirMtimeMs: since + 5_000,
+    });
+
+    const shots = await harvestFailureScreenshotsAsync({
+      testsDirectory,
+      capturedSinceMs: since,
+      attemptIndex: 0,
+      failedFlowNames: new Set(['Checkout']),
+      logger,
+    });
+
+    expect(shots).toHaveLength(1);
+    expect(shots[0].metadata.flowName).toBe('Checkout');
+  });
+
+  it('resolves a combined shard + collision dir name to the flow', async () => {
+    const since = 1_000_000;
+    await makeBundle({
+      sessionDir: 'session',
+      flowDir: 'Checkout-shard-2-3',
+      stepFiles: [{ name: 'step-004-tapOn-Pay.png', mtimeMs: since + 1_000 }],
+      sessionDirMtimeMs: since + 5_000,
+    });
+
+    const shots = await harvestFailureScreenshotsAsync({
+      testsDirectory,
+      capturedSinceMs: since,
+      attemptIndex: 0,
+      failedFlowNames: new Set(['Checkout']),
+      logger,
+    });
+
+    expect(shots).toHaveLength(1);
+    expect(shots[0].metadata.flowName).toBe('Checkout');
+  });
+
+  it('normalizes / to _ when matching the bundle dir to the JUnit flow name', async () => {
+    const since = 1_000_000;
+    await makeBundle({
+      sessionDir: 'session',
+      flowDir: 'sub_Login',
+      stepFiles: [{ name: 'step-002-tapOn.png', mtimeMs: since + 1_000 }],
+      sessionDirMtimeMs: since + 5_000,
+    });
+
+    const shots = await harvestFailureScreenshotsAsync({
+      testsDirectory,
+      capturedSinceMs: since,
+      attemptIndex: 0,
+      failedFlowNames: new Set(['sub/Login']),
+      logger,
+    });
+
+    expect(shots).toHaveLength(1);
+    expect(shots[0].metadata.flowName).toBe('sub_Login');
+  });
+
+  it('skips a bundle whose dir name is ambiguous against the failed set', async () => {
+    const since = 1_000_000;
+    // 'foo-2' could be the literal flow 'foo-2' or a collision-suffixed 'foo' — unresolvable.
+    await makeBundle({
+      sessionDir: 'session',
+      flowDir: 'foo-2',
+      stepFiles: [{ name: 'step-001-tapOn.png', mtimeMs: since + 1_000 }],
+      sessionDirMtimeMs: since + 5_000,
+    });
+
+    const shots = await harvestFailureScreenshotsAsync({
+      testsDirectory,
+      capturedSinceMs: since,
+      attemptIndex: 0,
+      failedFlowNames: new Set(['foo', 'foo-2']),
+      logger,
+    });
+
+    expect(shots).toEqual([]);
+  });
+
+  it('skips a step screenshot captured before capturedSinceMs (dir touched later)', async () => {
+    const since = 1_000_000;
+    await makeBundle({
+      sessionDir: 'session',
+      flowDir: 'Flow',
+      stepFiles: [{ name: 'step-001-tapOn.png', mtimeMs: since - 5_000 }],
+      sessionDirMtimeMs: since + 5_000,
+    });
+
+    const shots = await harvestFailureScreenshotsAsync({
+      testsDirectory,
+      capturedSinceMs: since,
+      attemptIndex: 0,
+      failedFlowNames: new Set(['Flow']),
+      logger,
+    });
+
+    expect(shots).toEqual([]);
+  });
+
+  it('yields nothing for a failed flow whose screenshots dir is empty', async () => {
+    const since = 1_000_000;
+    await makeBundle({
+      sessionDir: 'session',
+      flowDir: 'Flow',
+      stepFiles: [],
+      sessionDirMtimeMs: since + 5_000,
+    });
+
+    const shots = await harvestFailureScreenshotsAsync({
+      testsDirectory,
+      capturedSinceMs: since,
+      attemptIndex: 0,
+      failedFlowNames: new Set(['Flow']),
+      logger,
+    });
+
+    expect(shots).toEqual([]);
+  });
+
+  it('reduces two bundle dirs that resolve to the same flow to a single shot', async () => {
+    const since = 1_000_000;
+    await makeBundle({
+      sessionDir: 'session',
+      flowDir: 'Dup',
+      stepFiles: [{ name: 'step-001-tapOn.png', mtimeMs: since + 1_000 }],
+      sessionDirMtimeMs: since + 5_000,
+    });
+    await makeBundle({
+      sessionDir: 'session',
+      flowDir: 'Dup-2',
+      stepFiles: [{ name: 'step-001-tapOn.png', mtimeMs: since + 2_000 }],
+      sessionDirMtimeMs: since + 5_000,
+    });
+
+    const shots = await harvestFailureScreenshotsAsync({
+      testsDirectory,
+      capturedSinceMs: since,
+      attemptIndex: 0,
+      failedFlowNames: new Set(['Dup']),
+      logger,
+    });
+
+    expect(shots).toHaveLength(1);
+    expect(shots[0].metadata.flowName).toBe('Dup');
+  });
+
+  it('collects both a legacy flat screenshot and a new-layout bundle in the same session dir', async () => {
+    const since = 1_000_000;
+    const sessionDir = path.join(testsDirectory, 'session');
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionDir, `screenshot-❌-${since + 1_000}-(Legacy Flow).png`),
+      ''
+    );
+    await makeBundle({
+      sessionDir: 'session',
+      flowDir: 'Bundle Flow',
+      stepFiles: [{ name: 'step-002-tapOn.png', mtimeMs: since + 2_000 }],
+      sessionDirMtimeMs: since + 5_000,
+    });
+
+    const shots = await harvestFailureScreenshotsAsync({
+      testsDirectory,
+      capturedSinceMs: since,
+      attemptIndex: 0,
+      failedFlowNames: new Set(['Bundle Flow']),
+      logger,
+    });
+
+    expect(shots.map(shot => shot.metadata.flowName).sort()).toEqual([
+      'Bundle Flow',
+      'Legacy Flow',
+    ]);
   });
 });
 

--- a/packages/build-tools/src/steps/functions/maestroResultParser.ts
+++ b/packages/build-tools/src/steps/functions/maestroResultParser.ts
@@ -122,6 +122,18 @@ async function parseJUnitFile(filePath: string): Promise<JUnitTestCaseResult[]> 
   }
 }
 
+// Raw names (slashes kept) of the testcases a single JUnit file marks failed. Best-effort: an
+// unreadable or malformed file yields an empty set rather than throwing.
+export async function parseFailedFlowNamesFromJUnitFile(junitFile: string): Promise<Set<string>> {
+  const failed = new Set<string>();
+  for (const testcase of await parseJUnitFile(junitFile)) {
+    if (testcase.status === 'failed') {
+      failed.add(testcase.name);
+    }
+  }
+  return failed;
+}
+
 export async function parseJUnitTestCases(junitDirectory: string): Promise<JUnitTestCaseResult[]> {
   let entries: string[];
   try {

--- a/packages/build-tools/src/steps/functions/maestroScreenshots.ts
+++ b/packages/build-tools/src/steps/functions/maestroScreenshots.ts
@@ -8,11 +8,20 @@ export interface ParsedFailureScreenshot {
   capturedAtMs: number;
 }
 
-// Maestro failure screenshot: `screenshot-[shard-N-]❌-<epochMillis>-(<flowName>).png`.
+// pre-v2.7.0 (Maestro <= 2.6.x): failure screenshots are flat files named
+// `screenshot-[shard-N-]❌-<epochMillis>-(<flowName>).png` directly in the session dir.
 // The flow name may contain parentheses, so anchor on the `-(` after the epoch and the
-// `).png` suffix rather than scanning for parens.
+// `).png` suffix rather than scanning for parens. Remove this path once the build fleet is
+// entirely on Maestro >= 2.7.0.
 const FAILURE_SCREENSHOT_PATTERN = /^screenshot-(?:shard-\d+-)?❌-(\d+)-\((.+)\)\.png$/u;
 
+// Maestro >= 2.7.0 bundle layout. Each flow gets its own dir under the session dir, with step
+// screenshots under `screenshots/` named `step-<NNN>-<slug>.png` (NNN is a 1-based, zero-padded
+// monotonic step sequence). Under the CLI (no `--analyze`) only failed/warned steps produce one.
+const STEP_SCREENSHOTS_DIRNAME = 'screenshots';
+const STEP_SCREENSHOT_PATTERN = /^step-(\d+)(?:-.*)?\.png$/;
+
+// pre-v2.7.0: parses the legacy flat failure-screenshot filename.
 export function parseFailureScreenshotFilename(filename: string): ParsedFailureScreenshot | null {
   const match = filename.match(FAILURE_SCREENSHOT_PATTERN);
   if (!match) {
@@ -41,65 +50,212 @@ export interface HarvestedScreenshot {
   };
 }
 
-// Scans every debug dir under testsDirectory whose mtime is recent enough (mtime-based to cover
-// the maestro <2.5.0 bug that splits one invocation across two dirs), then keeps only screenshots
-// whose own capturedAtMs is at/after capturedSinceMs. Never throws: an unreadable dir is logged
-// and skipped so a screenshot harvest can't affect the maestro step outcome.
+// Harvests one attempt's failure screenshots from the maestro debug output. Walks each session
+// dir under testsDirectory whose mtime is recent enough (mtime-based to also cover the maestro
+// <2.5.0 bug that splits one invocation across two dirs). Within a session dir, a child is either
+// a flat pre-v2.7.0 screenshot file or a Maestro >= 2.7.0 per-flow bundle dir — the single
+// structural seam below. Never throws: an unreadable dir/file is logged and skipped so a
+// screenshot harvest can't affect the maestro step outcome.
 export async function harvestFailureScreenshotsAsync(args: {
   testsDirectory: string;
   capturedSinceMs: number;
   attemptIndex: number;
+  // Flow names the JUnit report marks failed for THIS attempt (raw; normalized here). A v2.7.0
+  // bundle dir carries no failure marker, so this is what tells a failed flow's bundle apart from
+  // a passing flow that merely left a warned-step screenshot. Unused by the legacy path.
+  failedFlowNames: ReadonlySet<string>;
   logger: bunyan;
 }): Promise<HarvestedScreenshot[]> {
   // Gate dirs by mtime floored to the second, so a dir created within the same second as the
-  // attempt start isn't stat'd below the baseline. The exact capturedAtMs gate below is what
+  // attempt start isn't stat'd below the baseline. The exact capturedAtMs gate per file is what
   // prevents mis-attributing an earlier attempt's screenshot.
   const dirSinceMtimeMs = Math.floor(args.capturedSinceMs / 1000) * 1000;
-  let entries: Dirent[];
+  // Bundle dir names already have '/' -> '_'; normalize the JUnit names the same way to match.
+  const normalizedFailedFlowNames = new Set([...args.failedFlowNames].map(normalizeFlowName));
+
+  let sessionEntries: Dirent[];
   try {
-    entries = await fs.readdir(args.testsDirectory, { withFileTypes: true });
+    sessionEntries = await fs.readdir(args.testsDirectory, { withFileTypes: true });
   } catch (err: any) {
     args.logger.info({ err }, `Skipping screenshot harvest: cannot read ${args.testsDirectory}.`);
     return [];
   }
 
-  const results: HarvestedScreenshot[] = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory()) {
+  const legacyShots: HarvestedScreenshot[] = [];
+  const bundleShots: HarvestedScreenshot[] = [];
+  for (const sessionEntry of sessionEntries) {
+    if (!sessionEntry.isDirectory()) {
       continue;
     }
-    const dirPath = path.join(args.testsDirectory, entry.name);
-    let filenames: string[];
+    const sessionDir = path.join(args.testsDirectory, sessionEntry.name);
+    let children: Dirent[];
     try {
-      if ((await fs.stat(dirPath)).mtimeMs < dirSinceMtimeMs) {
+      if ((await fs.stat(sessionDir)).mtimeMs < dirSinceMtimeMs) {
         continue;
       }
-      filenames = await fs.readdir(dirPath);
+      children = await fs.readdir(sessionDir, { withFileTypes: true });
     } catch (err: any) {
-      args.logger.info({ err }, `Skipping unreadable debug dir ${dirPath}.`);
+      args.logger.info({ err }, `Skipping unreadable debug dir ${sessionDir}.`);
       continue;
     }
-    for (const filename of filenames) {
-      const parsed = parseFailureScreenshotFilename(filename);
-      // Re-check capture time per file: a dir's mtime can advance after this attempt began (or
-      // fall within the floored-second dir baseline), so the dir gate alone would re-attribute an
-      // earlier attempt's screenshot to this one.
-      if (parsed === null || parsed.capturedAtMs < args.capturedSinceMs) {
-        continue;
-      }
-      results.push({
-        fileAbsPath: path.join(dirPath, filename),
-        displayName: `Failure Screenshot: ${parsed.flowName} (attempt ${args.attemptIndex + 1})`,
-        metadata: {
-          kind: 'maestro-test-screenshot',
-          flowName: parsed.flowName,
+    for (const child of children) {
+      if (child.isDirectory()) {
+        // Maestro >= 2.7.0: a per-flow bundle dir.
+        const shot = await harvestFromBundleAsync({
+          bundleDir: path.join(sessionDir, child.name),
+          bundleName: child.name,
+          normalizedFailedFlowNames,
+          capturedSinceMs: args.capturedSinceMs,
           attemptIndex: args.attemptIndex,
-          capturedAtMs: parsed.capturedAtMs,
-        },
-      });
+          logger: args.logger,
+        });
+        if (shot !== null) {
+          bundleShots.push(shot);
+        }
+      } else {
+        // pre-v2.7.0: a flat failure screenshot file in the session dir.
+        const shot = harvestLegacyFlatShot({
+          fileName: child.name,
+          sessionDir,
+          capturedSinceMs: args.capturedSinceMs,
+          attemptIndex: args.attemptIndex,
+        });
+        if (shot !== null) {
+          legacyShots.push(shot);
+        }
+      }
     }
   }
-  return results;
+  // The website shows one screenshot per (flow, attempt). Two v2.7.0 bundle dirs can resolve to
+  // the same flow — a collision dir (`<flow>-2`) or a duplicate flow name — so keep the latest.
+  // Legacy shots need no dedupe: a flat filename is emitted once per failed flow, so there is no
+  // `<flow>-2` collision to collapse (and deduping them would change historical behavior).
+  return [...legacyShots, ...dedupeBundleShotsByFlowName(bundleShots)];
+}
+
+// Maestro >= 2.7.0: resolve a bundle dir to its owning failed flow and return that flow's failure
+// screenshot — the highest-numbered step in `screenshots/`. A required failure halts the flow, so
+// the failed step is normally the last (highest-numbered) captured step; earlier warned steps have
+// lower numbers. Best-effort limitation: without reading Maestro's per-command JSON we can't tell a
+// failed-step frame from a warned-step frame, so if the failing command captured nothing (e.g. a
+// non-visible command like runScript) but an earlier optional step warned, we return that warned
+// frame instead. Returns null when the bundle isn't a failed flow, its name is ambiguous, or it has
+// no usable step screenshot. Never throws.
+async function harvestFromBundleAsync(args: {
+  bundleDir: string;
+  bundleName: string;
+  normalizedFailedFlowNames: ReadonlySet<string>;
+  capturedSinceMs: number;
+  attemptIndex: number;
+  logger: bunyan;
+}): Promise<HarvestedScreenshot | null> {
+  const flowName = resolveBundleFlowName(args.bundleName, args.normalizedFailedFlowNames);
+  if (flowName === null) {
+    return null;
+  }
+  const screenshotsDir = path.join(args.bundleDir, STEP_SCREENSHOTS_DIRNAME);
+  let filenames: string[];
+  try {
+    filenames = await fs.readdir(screenshotsDir);
+  } catch {
+    // No screenshots/ dir — e.g. the flow failed on a non-visible command, which captures none.
+    return null;
+  }
+
+  let best: { fileAbsPath: string; stepIndex: number; capturedAtMs: number } | null = null;
+  for (const filename of filenames) {
+    const match = filename.match(STEP_SCREENSHOT_PATTERN);
+    if (match === null) {
+      continue; // final.png and any non-step file
+    }
+    const stepIndex = Number(match[1]);
+    const fileAbsPath = path.join(screenshotsDir, filename);
+    let capturedAtMs: number;
+    try {
+      capturedAtMs = Math.round((await fs.stat(fileAbsPath)).mtimeMs);
+    } catch (err: any) {
+      args.logger.info({ err }, `Skipping unreadable screenshot ${fileAbsPath}.`);
+      continue;
+    }
+    if (capturedAtMs < args.capturedSinceMs) {
+      continue; // a prior attempt's frame (bundle dir touched later than this attempt started)
+    }
+    if (best === null || stepIndex > best.stepIndex) {
+      best = { fileAbsPath, stepIndex, capturedAtMs };
+    }
+  }
+  if (best === null) {
+    return null;
+  }
+  return {
+    fileAbsPath: best.fileAbsPath,
+    displayName: `Failure Screenshot: ${flowName} (attempt ${args.attemptIndex + 1})`,
+    metadata: {
+      kind: 'maestro-test-screenshot',
+      flowName,
+      attemptIndex: args.attemptIndex,
+      capturedAtMs: best.capturedAtMs,
+    },
+  };
+}
+
+// Maestro names a bundle dir `<cleanFlow>` optionally + `-shard-<n>` (sharded) + `-<n>` (name
+// collision), where cleanFlow is the flow name with '/' -> '_'. Those suffixes share a namespace
+// with legitimate flow names, so we can't strip blindly (a flow may be named `x-shard-1` or `x-2`).
+// Enumerate the ways the dir name could peel back to a flow name, keep those that match a failed
+// flow, and use the result only if exactly one fits — otherwise skip rather than guess.
+function resolveBundleFlowName(
+  bundleName: string,
+  normalizedFailedFlowNames: ReadonlySet<string>
+): string | null {
+  const withoutCollision = bundleName.replace(/-\d+$/, '');
+  const preimages = [
+    bundleName,
+    withoutCollision,
+    withoutCollision.replace(/-shard-\d+$/, ''),
+    bundleName.replace(/-shard-\d+$/, ''),
+  ];
+  const matches = new Set(preimages.filter(name => normalizedFailedFlowNames.has(name)));
+  return matches.size === 1 ? [...matches][0] : null;
+}
+
+// Keep one screenshot per flow name (attemptIndex is constant within a harvest call), preferring
+// the latest capture when two bundles resolve to the same flow.
+function dedupeBundleShotsByFlowName(shots: HarvestedScreenshot[]): HarvestedScreenshot[] {
+  const byFlowName = new Map<string, HarvestedScreenshot>();
+  for (const shot of shots) {
+    const existing = byFlowName.get(shot.metadata.flowName);
+    if (existing === undefined || shot.metadata.capturedAtMs > existing.metadata.capturedAtMs) {
+      byFlowName.set(shot.metadata.flowName, shot);
+    }
+  }
+  return [...byFlowName.values()];
+}
+
+// pre-v2.7.0 (Maestro <= 2.6.x) reader: a flat `screenshot-...❌...png` file whose name carries the
+// flow name and capture epoch.
+function harvestLegacyFlatShot(args: {
+  fileName: string;
+  sessionDir: string;
+  capturedSinceMs: number;
+  attemptIndex: number;
+}): HarvestedScreenshot | null {
+  const parsed = parseFailureScreenshotFilename(args.fileName);
+  // Re-check capture time per file — a dir's mtime can advance after this attempt began, so the dir
+  // gate alone would re-attribute an earlier attempt's screenshot to this one.
+  if (parsed === null || parsed.capturedAtMs < args.capturedSinceMs) {
+    return null;
+  }
+  return {
+    fileAbsPath: path.join(args.sessionDir, args.fileName),
+    displayName: `Failure Screenshot: ${parsed.flowName} (attempt ${args.attemptIndex + 1})`,
+    metadata: {
+      kind: 'maestro-test-screenshot',
+      flowName: parsed.flowName,
+      attemptIndex: args.attemptIndex,
+      capturedAtMs: parsed.capturedAtMs,
+    },
+  };
 }
 
 // Maestro substitutes '/' -> '_' in screenshot filenames (so HarvestedScreenshot.flowName

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -18,6 +18,7 @@ import {
   copyLatestAttemptXml,
   junitFileHasFileAttrs,
   mergeJUnitReports,
+  parseFailedFlowNamesFromJUnitFile,
   parseFailedFlowsFromFileAttrs,
   parseFailedFlowsFromJUnit,
   parseJUnitTestCases,
@@ -276,11 +277,15 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
         // junit: test-case-result rows (and therefore the summary icons) only exist for junit
         // runs, so harvesting other formats would just create orphan artifacts the website hides.
         if (outputFormat === 'junit') {
+          const failedFlowNames = outputPath
+            ? await parseFailedFlowNamesFromJUnitFile(outputPath)
+            : new Set<string>();
           harvested.push(
             ...(await harvestFailureScreenshotsAsync({
               testsDirectory,
               capturedSinceMs: attemptStartedAtMs,
               attemptIndex: attempt,
+              failedFlowNames,
               logger,
             }))
           );


### PR DESCRIPTION
# Why

Maestro 2.7.0 reorganized per-flow test output into a new bundle layout (`<session>/<flow>/screenshots/step-<NNN>.png`) and dropped the flat `screenshot-❌-<epoch>-(<flow>).png` files our failure-screenshot harvester relied on. On 2.7.0 the harvester silently returns nothing, so Maestro Insights stops showing failure screenshots. We install the latest Maestro by default, so this breaks on its own once build machines pick up 2.7.0.

# How

Rewrite the harvester to handle both layouts behind a single structural seam (per session-dir child: a flat file → legacy path, a bundle dir → new path). For the 2.7.0 bundle:

- Identify which flows failed from the JUnit report (unchanged across Maestro versions) — a passing flow can also leave a warned-step screenshot, so we only harvest flows JUnit marks failed.
- In each failed flow's `screenshots/` dir, take the highest-numbered `step-<NNN>` frame as the failure screenshot (a required failure halts the flow, so it is the last captured step); use file mtime as the capture time.
- Resolve a bundle dir back to its flow by JUnit name (handles `-shard-N` / collision suffixes; skips when ambiguous) and keep one screenshot per (flow, attempt).
- No dependency on Maestro's internal `commands.json` / `manifest.json` — only JUnit, directory structure, and mtime.

The legacy (Maestro <= 2.6.x) path is preserved unchanged and tagged `pre-v2.7.0` so it can be deleted in one pass once the build fleet is fully on 2.7.0.

# Test Plan

- CI
- Tested locally with Maestro v2.6.0 & v2.7.0
