### PR TITLE
[build-tools] fetch session-scoped ngrok authtokens from www

### DIFF
--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -17,8 +17,8 @@ import { Sentry } from '../../sentry';
 import { pollAgentDeviceArtifactsForUploadAsync } from '../utils/agentDeviceArtifacts';
 import {
   type DetachedProcessHandle,
+  fetchNgrokCredentialAsync,
   getDeviceRunSessionIdOrThrow,
-  getNgrokAuthtokenOrThrow,
   getNgrokTunnelDomainOrThrow,
   selectXcodeDeveloperDirectoryAsync,
   spawnDetached,
@@ -55,13 +55,14 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       }),
     ],
     fn: async ({ logger, global }, { inputs, env, signal }) => {
-      // Fail fast before any expensive setup if the injected env
-      // vars are missing: DEVICE_RUN_SESSION_ID (to report the remote config
-      // back to the API server), EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN (base domain
-      // for our ngrok tunnels), and NGROK_AUTHTOKEN (to authenticate them).
+      // Fail fast before any expensive setup if the session context is
+      // incomplete: DEVICE_RUN_SESSION_ID (to report the remote config back to
+      // the API server), EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN (base domain for our
+      // ngrok tunnels), and a session-scoped ngrok authtoken minted by the API
+      // server (to authenticate them).
       const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
       const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
-      const ngrokAuthtoken = getNgrokAuthtokenOrThrow(env);
+      const ngrokCredential = await fetchNgrokCredentialAsync(ctx, { env, logger });
 
       const packageVersion = inputs.package_version.value as string | undefined;
       const { runtimePlatform } = global;
@@ -86,7 +87,8 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
         port: daemonPort,
         subdomainPrefix: 'agent-device',
         baseDomain: ngrokTunnelDomain,
-        authtoken: ngrokAuthtoken,
+        hostname: ngrokCredential.remoteSessionHostname,
+        authtoken: ngrokCredential.authtoken,
         logger,
       });
       logger.info(`Tunnel is ready at ${agentDeviceRemoteSessionUrl}.`);
@@ -97,6 +99,7 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
         const { previewUrl } = await startServeSimWithTunnelAsync(ctx, {
           baseDomain: ngrokTunnelDomain,
+          ngrokCredential,
           env,
           logger,
           timeoutMs: STARTUP_TIMEOUT_MS,

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -19,8 +19,8 @@ import { isProcessDescendantOfAsync } from '../../utils/processes';
 import { sleepAsync } from '../../utils/retry';
 import { pollArgentArtifactsForUploadAsync } from '../utils/argentArtifacts';
 import {
+  fetchNgrokCredentialAsync,
   getDeviceRunSessionIdOrThrow,
-  getNgrokAuthtokenOrThrow,
   getNgrokTunnelDomainOrThrow,
   selectXcodeDeveloperDirectoryAsync,
   spawnDetached,
@@ -60,13 +60,14 @@ export function createStartArgentRemoteSessionBuildFunction(
       }),
     ],
     fn: async ({ logger, global }, { inputs, env, signal }) => {
-      // Fail fast before any expensive setup if the injected env
-      // vars are missing: DEVICE_RUN_SESSION_ID (to report the remote config
-      // back to the API server), EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN (base domain
-      // for our ngrok tunnels), and NGROK_AUTHTOKEN (to authenticate them).
+      // Fail fast before any expensive setup if the session context is
+      // incomplete: DEVICE_RUN_SESSION_ID (to report the remote config back to
+      // the API server), EAS_SIMULATOR_NGROK_TUNNEL_DOMAIN (base domain for our
+      // ngrok tunnels), and a session-scoped ngrok authtoken minted by the API
+      // server (to authenticate them).
       const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
       const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
-      const ngrokAuthtoken = getNgrokAuthtokenOrThrow(env);
+      const ngrokCredential = await fetchNgrokCredentialAsync(ctx, { env, logger });
 
       const packageVersion = inputs.package_version.value as string | undefined;
       warnIfArgentPackageVersionCannotBeVerified({ packageVersion, logger });
@@ -147,7 +148,8 @@ export function createStartArgentRemoteSessionBuildFunction(
           port: toolServerPort,
           subdomainPrefix: 'argent',
           baseDomain: ngrokTunnelDomain,
-          authtoken: ngrokAuthtoken,
+          hostname: ngrokCredential.remoteSessionHostname,
+          authtoken: ngrokCredential.authtoken,
           rewriteHostHeader: true,
           logger,
         });
@@ -158,6 +160,7 @@ export function createStartArgentRemoteSessionBuildFunction(
         if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
           const serveSim = await startServeSimWithTunnelAsync(ctx, {
             baseDomain: ngrokTunnelDomain,
+            ngrokCredential,
             env,
             logger,
             timeoutMs: STARTUP_TIMEOUT_MS,

--- a/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
@@ -2,6 +2,7 @@ import { BuildFunction, BuildRuntimePlatform } from '@expo/steps';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import {
+  fetchNgrokCredentialAsync,
   getDeviceRunSessionIdOrThrow,
   getNgrokTunnelDomainOrThrow,
   selectXcodeDeveloperDirectoryAsync,
@@ -24,6 +25,7 @@ export function createStartServeSimRemoteSessionBuildFunction(
     fn: async ({ logger }, { env, signal }) => {
       const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
       const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
+      const ngrokCredential = await fetchNgrokCredentialAsync(ctx, { env, logger });
 
       logger.info('Starting serve-sim remote session.');
 
@@ -31,6 +33,7 @@ export function createStartServeSimRemoteSessionBuildFunction(
 
       const { previewUrl } = await startServeSimWithTunnelAsync(ctx, {
         baseDomain: ngrokTunnelDomain,
+        ngrokCredential,
         env,
         logger,
         timeoutMs: STARTUP_TIMEOUT_MS,

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -6,6 +6,7 @@ import { CustomBuildContext } from '../../../customBuildContext';
 import { Sentry } from '../../../sentry';
 import { turtleFetch } from '../../../utils/turtleFetch';
 import {
+  fetchNgrokCredentialAsync,
   fetchServeSimTurnArgsAsync,
   turnIceServersToServeSimArgs,
   waitForDeviceRunSessionStoppedAsync,
@@ -194,6 +195,91 @@ describe(fetchServeSimTurnArgsAsync, () => {
     expect(args).toEqual([]);
     expect(logger.warn).toHaveBeenCalled();
     expect(jest.mocked(Sentry).capture).toHaveBeenCalled();
+  });
+});
+
+describe(fetchNgrokCredentialAsync, () => {
+  beforeEach(() => {
+    jest.mocked(turtleFetch).mockReset();
+    jest.mocked(Sentry).capture.mockReset();
+  });
+
+  it('fetches a session-scoped credential with its exact ACL hostnames', async () => {
+    jest.mocked(turtleFetch).mockResolvedValue({
+      json: async () => ({
+        data: {
+          authtoken: 'scoped-authtoken',
+          hostnames: {
+            remoteSession: 'agent-device-abc123.tunnels.test',
+            serveSim: 'serve-sim-abc123.tunnels.test',
+          },
+        },
+      }),
+    } as unknown as Awaited<ReturnType<typeof turtleFetch>>);
+
+    const credential = await fetchNgrokCredentialAsync(createCtxMock(), {
+      env: createEnvMock(),
+      logger: createLoggerMock(),
+    });
+
+    expect(credential).toEqual({
+      authtoken: 'scoped-authtoken',
+      remoteSessionHostname: 'agent-device-abc123.tunnels.test',
+      serveSimHostname: 'serve-sim-abc123.tunnels.test',
+    });
+    expect(jest.mocked(turtleFetch)).toHaveBeenCalledWith(
+      'https://api.expo.test/v2/device-run-sessions/drs-id/ngrok-credential',
+      'POST',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer robot-token' },
+        json: { supportsProvidedHostnames: true },
+      })
+    );
+  });
+
+  it('returns no hostnames when the server does not provide them', async () => {
+    jest.mocked(turtleFetch).mockResolvedValue({
+      json: async () => ({ data: { authtoken: 'scoped-authtoken' } }),
+    } as unknown as Awaited<ReturnType<typeof turtleFetch>>);
+
+    const credential = await fetchNgrokCredentialAsync(createCtxMock(), {
+      env: createEnvMock(),
+      logger: createLoggerMock(),
+    });
+
+    expect(credential).toEqual({
+      authtoken: 'scoped-authtoken',
+      remoteSessionHostname: undefined,
+      serveSimHostname: undefined,
+    });
+  });
+
+  it('falls back to the shared NGROK_AUTHTOKEN job secret when the request fails', async () => {
+    jest.mocked(turtleFetch).mockRejectedValue(new Error('boom'));
+    const logger = createLoggerMock();
+
+    const credential = await fetchNgrokCredentialAsync(createCtxMock(), {
+      env: {
+        ...createEnvMock(),
+        NGROK_AUTHTOKEN: 'shared-authtoken',
+      } as unknown as BuildStepEnv,
+      logger,
+    });
+
+    expect(credential).toEqual({ authtoken: 'shared-authtoken' });
+    expect(logger.warn).toHaveBeenCalled();
+    expect(jest.mocked(Sentry).capture).toHaveBeenCalled();
+  });
+
+  it('throws when the request fails and no shared NGROK_AUTHTOKEN is available', async () => {
+    jest.mocked(turtleFetch).mockRejectedValue(new Error('boom'));
+
+    await expect(
+      fetchNgrokCredentialAsync(createCtxMock(), {
+        env: createEnvMock(),
+        logger: createLoggerMock(),
+      })
+    ).rejects.toThrow('Could not fetch an ngrok authtoken for this device run session: boom.');
   });
 });
 

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -4,6 +4,7 @@ import { BuildStepEnv, spawnAsync } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
 import * as ngrok from '@ngrok/ngrok';
 import { graphql } from 'gql.tada';
+import fetch from 'node-fetch';
 import nullthrows from 'nullthrows';
 import { z } from 'zod';
 import { randomBytes } from 'node:crypto';
@@ -68,16 +69,94 @@ export function getNgrokTunnelDomainOrThrow(env: BuildStepEnv): string {
   return baseDomain;
 }
 
-export function getNgrokAuthtokenOrThrow(env: BuildStepEnv): string {
-  const authtoken = env.NGROK_AUTHTOKEN;
-  if (!authtoken) {
+const NgrokCredentialResponseSchema = z.object({
+  data: z.object({
+    authtoken: z.string(),
+    hostnames: z
+      .object({
+        remoteSession: z.string().optional(),
+        serveSim: z.string().optional(),
+      })
+      .optional(),
+  }),
+});
+
+export type NgrokCredential = {
+  authtoken: string;
+  /**
+   * Exact hostname the credential's ACL allows for the agent-device/argent
+   * tunnel. Absent on the legacy shared-token fallback path, where a random
+   * hostname is generated instead.
+   */
+  remoteSessionHostname?: string;
+  /** Exact ACL'd hostname for the serve-sim preview tunnel; see above. */
+  serveSimHostname?: string;
+};
+
+/**
+ * Fetch a session-scoped ngrok credential from www, minted on demand for this
+ * device run session. The authtoken's ACL is pinned to the exact returned
+ * hostnames and www revokes it when the session ends, so it is useless if it
+ * leaks from the worker. Falls back to the legacy shared NGROK_AUTHTOKEN job
+ * secret while the www endpoint rolls out; once www stops injecting that
+ * secret, a failed fetch fails the step.
+ */
+export async function fetchNgrokCredentialAsync(
+  ctx: CustomBuildContext,
+  { env, logger }: { env: BuildStepEnv; logger: bunyan }
+): Promise<NgrokCredential> {
+  try {
+    const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
+    const expoApiServerUrl = nullthrows(ctx.env.__API_SERVER_URL, '__API_SERVER_URL is not set');
+    const robotAccessToken = nullthrows(
+      ctx.job.secrets?.robotAccessToken,
+      'robot access token is not set'
+    );
+
+    const response = await turtleFetch(
+      new URL(
+        `/v2/device-run-sessions/${deviceRunSessionId}/ngrok-credential`,
+        expoApiServerUrl
+      ).toString(),
+      'POST',
+      {
+        headers: {
+          Authorization: `Bearer ${robotAccessToken}`,
+        },
+        json: { supportsProvidedHostnames: true },
+        timeout: 10000,
+        retries: 2,
+        logger,
+      }
+    );
+
+    const { data } = NgrokCredentialResponseSchema.parse(await response.json());
+    logger.info('Using a session-scoped ngrok authtoken.');
+    return {
+      authtoken: data.authtoken,
+      remoteSessionHostname: data.hostnames?.remoteSession,
+      serveSimHostname: data.hostnames?.serveSim,
+    };
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    const sharedAuthtoken = env.NGROK_AUTHTOKEN;
+    if (sharedAuthtoken) {
+      Sentry.capture('Could not fetch a session-scoped ngrok authtoken', error, {
+        level: 'warning',
+      });
+      logger.warn(
+        { err: error },
+        'Could not fetch a session-scoped ngrok authtoken; falling back to the shared NGROK_AUTHTOKEN job secret.'
+      );
+      return { authtoken: sharedAuthtoken };
+    }
     throw new SystemError(
-      'NGROK_AUTHTOKEN is not set. ' +
-        'This step must run as part of a device run session ' +
-        'which injects NGROK_AUTHTOKEN into the job environment.'
+      `Could not fetch an ngrok authtoken for this device run session: ${error.message}. ` +
+        'The step must run as part of a device run session whose robot access token can call ' +
+        'the ngrok-credential endpoint on the API server (or, during rollout, with a ' +
+        'NGROK_AUTHTOKEN job secret).'
     );
   }
-  return authtoken;
 }
 
 const TurnIceServersSchema = z.array(
@@ -330,31 +409,32 @@ export function spawnDetached({
   return { pid: promise.child.pid, getOutput: () => output };
 }
 
+const SERVE_SIM_PORT = 3200;
+
 export async function startServeSimWithTunnelAsync(
   ctx: CustomBuildContext,
   {
     baseDomain,
+    ngrokCredential,
     env,
     logger,
     timeoutMs,
   }: {
     baseDomain: string;
+    ngrokCredential: NgrokCredential;
     env: BuildStepEnv;
     logger: bunyan;
     timeoutMs: number;
   }
 ): Promise<{ previewUrl: string }> {
-  logger.info('Launching serve-sim with tunnel.');
+  logger.info('Launching serve-sim.');
   const turnArgs = await fetchServeSimTurnArgsAsync(ctx, { env, logger });
   const serveSim = spawnDetached({
     command: 'npx',
     args: [
       'serve-sim-szdziedzic@latest',
-      '--tunnel',
-      '--tunnel-provider',
-      'ngrok',
-      '--tunnel-domain',
-      baseDomain,
+      '--port',
+      String(SERVE_SIM_PORT),
       '--stream-max-dimension',
       '1280',
       '--stream-quality',
@@ -366,39 +446,53 @@ export async function startServeSimWithTunnelAsync(
     env,
   });
 
-  logger.info('Waiting for serve-sim to report tunnel URL.');
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const output = serveSim.getOutput();
-    const previewUrl = matchTunnelUrl({ output, baseDomain });
-    if (previewUrl) {
-      return { previewUrl };
-    }
-    await sleepAsync(1_000);
-  }
-  throw new SystemError(
-    `Timed out waiting for serve-sim to report Tunnel URL. Last output:\n${serveSim.getOutput() || '<empty>'}`
-  );
+  logger.info(`Waiting for serve-sim to listen on port ${SERVE_SIM_PORT}.`);
+  await waitForLocalHttpServerAsync({ port: SERVE_SIM_PORT, timeoutMs, processHandle: serveSim });
+
+  // The tunnel is owned here rather than by serve-sim so the ngrok authtoken
+  // never enters serve-sim's environment and the exact ACL'd hostname is
+  // bound. serve-sim adapts its URLs to the request hostname, so it serves
+  // tunnel viewers the same either way.
+  const previewUrl = await startNgrokTunnelAsync({
+    port: SERVE_SIM_PORT,
+    subdomainPrefix: 'serve-sim',
+    baseDomain,
+    hostname: ngrokCredential.serveSimHostname,
+    authtoken: ngrokCredential.authtoken,
+    logger,
+  });
+  return { previewUrl };
 }
 
-function matchTunnelUrl({
-  output,
-  baseDomain,
+async function waitForLocalHttpServerAsync({
+  port,
+  timeoutMs,
+  processHandle,
 }: {
-  output: string;
-  baseDomain: string;
-}): string | null {
-  const labelPattern = new RegExp(
-    `Tunnel:\\s*(https:\\/\\/[a-z0-9-]+\\.${escapeRegExp(baseDomain)})`
+  port: number;
+  timeoutMs: number;
+  processHandle: DetachedProcessHandle;
+}): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      // Any HTTP response means the server is up; the status does not matter.
+      await fetch(`http://127.0.0.1:${port}/`);
+      return;
+    } catch {
+      await sleepAsync(1_000);
+    }
+  }
+  throw new SystemError(
+    `Timed out waiting for serve-sim to listen on port ${port}. Last output:\n${processHandle.getOutput() || '<empty>'}`
   );
-  const match = labelPattern.exec(output);
-  return match ? match[1] : null;
 }
 
 export async function startNgrokTunnelAsync({
   port,
   subdomainPrefix,
   baseDomain,
+  hostname,
   authtoken,
   rewriteHostHeader,
   logger,
@@ -406,11 +500,18 @@ export async function startNgrokTunnelAsync({
   port: number;
   subdomainPrefix: string;
   baseDomain: string;
+  /**
+   * Exact hostname to bind, matching the credential's ACL when www provided
+   * one. A `<subdomainPrefix>-<random>` hostname under `baseDomain` is
+   * generated on the legacy shared-token path, where the ACL permits any
+   * subdomain.
+   */
+  hostname?: string;
   authtoken: string;
   rewriteHostHeader?: boolean;
   logger: bunyan;
 }): Promise<string> {
-  const domain = `${subdomainPrefix}-${randomBytes(8).toString('hex')}.${baseDomain}`;
+  const domain = hostname ?? `${subdomainPrefix}-${randomBytes(8).toString('hex')}.${baseDomain}`;
   logger.info(`Starting ngrok tunnel ${domain} -> http://localhost:${port}.`);
   // Run the ngrok agent in-process via the SDK; it keeps the session alive until
   // the process exits, and the step blocks forever to hold it open.
@@ -425,10 +526,6 @@ export async function startNgrokTunnelAsync({
     throw new SystemError(`ngrok tunnel for ${domain} did not return a public URL.`);
   }
   return url;
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 export async function waitForFileAsync<T>({


### PR DESCRIPTION
Part of ENG-25342

## Why

Remote-session steps read a shared, account-wide `NGROK_AUTHTOKEN` injected into the job env of every device run session VM, which runs user-supplied app code. Leaked once, it allows arbitrary tunnels on Expo's paid ngrok account until the shared token is rotated.

## How

Steps now fetch a per-session credential from www (`POST /v2/device-run-sessions/:id/ngrok-credential`, expo/universe#29262), declaring that they support server-provided hostnames. www pins the token's ACL to exact per-session hostnames and returns them, and the steps bind exactly those — a leaked token cannot bind anything the session isn't already using.

The serve-sim preview tunnel moved into build-tools: serve-sim runs tunnel-less on a fixed local port and the step opens the ngrok listener itself, same as the agent-device/argent tunnels. serve-sim never sees the ngrok authtoken and needs no changes for this — it already adapts its URLs to the request hostname, and readiness is detected by polling the local port instead of parsing its tunnel output.

While www still injects the shared secret, a failed fetch falls back to it with self-generated hostnames (the legacy wildcard ACL permits them); after expo/universe#29263 removes the secret, a failed fetch fails the step.

## Test plan

Unit tests cover the credential fetch (including the hostname handshake and hostname-less responses), the shared-token fallback, and the no-fallback failure. CI passes. I could not exercise a real device run session; a staging session before undrafting would confirm serve-sim behaves identically behind the step-owned tunnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
