### PR TITLE
[eas-cli] avoid splitting emoji when truncating git commit message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [eas-cli] Fix `eas update` failing with a server error when run inside an EAS Build. ([#4048](https://github.com/expo/eas-cli/pull/4048) by [@gwdp](https://github.com/gwdp))
+- [eas-cli] Avoid splitting an emoji when truncating a long git commit message, which produced an invalid commit message the build server rejected. ([#4055](https://github.com/expo/eas-cli/pull/4055) by [@gwdp](https://github.com/gwdp))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/build/__tests__/metadata-test.ts
+++ b/packages/eas-cli/src/build/__tests__/metadata-test.ts
@@ -11,4 +11,19 @@ describe(truncateGitCommitMessage, () => {
   it('truncates long commit messages', () => {
     expect(truncateGitCommitMessage('a'.repeat(5000))).toBe(`${'a'.repeat(4093)}...`);
   });
+
+  it('does not leave a split emoji (lone surrogate) at the truncation boundary', () => {
+    const message = 'a'.repeat(4092) + '🎉' + 'b'.repeat(10);
+    expect(truncateGitCommitMessage(message)).toBe(`${'a'.repeat(4092)}...`);
+  });
+
+  it('keeps a complete emoji that ends exactly at the truncation boundary', () => {
+    const message = 'a'.repeat(4091) + '🎉' + 'b'.repeat(10);
+    expect(truncateGitCommitMessage(message)).toBe(`${'a'.repeat(4091)}🎉...`);
+  });
+
+  it('preserves emoji before the truncation boundary', () => {
+    const message = '🎉' + 'a'.repeat(5000);
+    expect(truncateGitCommitMessage(message)).toBe(`🎉${'a'.repeat(4091)}...`);
+  });
 });

--- a/packages/eas-cli/src/build/metadata.ts
+++ b/packages/eas-cli/src/build/metadata.ts
@@ -185,5 +185,9 @@ export function truncateGitCommitMessage(
   if (msg === undefined) {
     return undefined;
   }
-  return msg.length > maxLength ? `${msg.substring(0, maxLength - 3)}...` : msg;
+  if (msg.length <= maxLength) {
+    return msg;
+  }
+  const truncated = msg.substring(0, maxLength - 3).replace(/[\uD800-\uDBFF]$/, '');
+  return `${truncated}...`;
 }


### PR DESCRIPTION
# Why

Long git commit messages are truncated before being sent as build metadata. When the cut lands in the middle of an emoji, it leaves half a surrogate pair — invalid Unicode that the build server rejects, failing the build with "Unexpected server error." Reported in #3827.

# How

Truncate as before, then drop a trailing lone high surrogate so the result is always valid Unicode.

This is the client-side root-cause fix; the server also sanitizes this input, so already-shipped CLIs are covered there.

# Test Plan

Unit tests: split emoji is trimmed at the boundary; a complete emoji at or before the boundary is preserved.