### PR TITLE
[eas-build-job] add update hook key

### DIFF
--- a/packages/eas-build-job/src/__tests__/hooks.test.ts
+++ b/packages/eas-build-job/src/__tests__/hooks.test.ts
@@ -1,13 +1,14 @@
 import { HOOK_ANCHORS, parseHookKey } from '../hooks';
 
 describe('HOOK_ANCHORS', () => {
-  it('contains the v1 anchors', () => {
+  it('contains the registered anchors', () => {
     expect([...HOOK_ANCHORS].sort()).toEqual([
       'checkout',
       'install_node_modules',
       'maestro_cloud',
       'maestro_tests',
       'submit',
+      'update',
     ]);
   });
 });

--- a/packages/eas-build-job/src/hooks.ts
+++ b/packages/eas-build-job/src/hooks.ts
@@ -18,6 +18,7 @@ export const HOOK_ANCHORS = [
   'maestro_tests',
   'maestro_cloud',
   'checkout',
+  'update',
 ] as const;
 
 export type HookAnchorId = (typeof HOOK_ANCHORS)[number];


### PR DESCRIPTION
# Why

EAS Workflows' `update` job is getting `before_update` / `after_update` hooks (ENG-25364). First concrete ask: uploading PostHog sourcemaps right after `eas update` publishes — sourcemaps only exist inside the job, and we don't want a vendor-specific step for every provider.

# How

`update` joins `HOOK_ANCHORS`. It is a stamp-only anchor: the server stamps `__hook_id: 'update'` on the update job's generated publish step (expo/universe#29311); no eas-cli function declares it.

# Test Plan

CI passes.
