### PR TITLE
[eas-cli] Add --client-id and --all-metrics filters to observe commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [eas-cli] Prompt to select a platform in `eas simulator:start` when `--platform` is omitted, instead of erroring out. ([#4043](https://github.com/expo/eas-cli/pull/4043) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Add `--client-id` flag to `eas observe:events` and `eas observe:metrics` to filter by EAS client ID. ([#4059](https://github.com/expo/eas-cli/pull/4059) by [@keith-kurak](https://github.com/keith-kurak))
+- [eas-cli] Add `--all-metrics` flag to `eas observe:metrics` to return samples across all metrics instead of a single one (e.g. all metrics for one `--client-id`). ([#4059](https://github.com/expo/eas-cli/pull/4059) by [@keith-kurak](https://github.com/keith-kurak))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/observe/__tests__/events.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/events.test.ts
@@ -218,7 +218,15 @@ describe(ObserveEvents, () => {
     expect(options.sessionId).toBe('session-xyz');
   });
 
-  it('does not pass platform, appVersion, updateId, or sessionId when flags are not provided', async () => {
+  it('passes --client-id', async () => {
+    const command = createCommand(['my_event', '--client-id', 'client-xyz']);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.easClientId).toBe('client-xyz');
+  });
+
+  it('does not pass platform, appVersion, updateId, sessionId, or easClientId when flags are not provided', async () => {
     const command = createCommand(['my_event']);
     await command.runAsync();
 
@@ -227,6 +235,7 @@ describe(ObserveEvents, () => {
     expect(options.appVersion).toBeUndefined();
     expect(options.updateId).toBeUndefined();
     expect(options.sessionId).toBeUndefined();
+    expect(options.easClientId).toBeUndefined();
   });
 
   it('calls enableJsonOutput and printJsonOnlyOutput when --json is provided with an event name', async () => {

--- a/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
@@ -5,7 +5,11 @@ import {
   AppObserveEventsOrderByField,
   AppObservePlatform,
 } from '../../../graphql/generated';
-import { fetchObserveEventsAsync, resolveOrderBy } from '../../../observe/fetchEvents';
+import {
+  fetchObserveEventsAsync,
+  fetchTotalEventCountAsync,
+  resolveOrderBy,
+} from '../../../observe/fetchEvents';
 import { buildObserveEventsJson } from '../../../observe/formatEvents';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
 import ObserveMetrics from '../metrics';
@@ -15,6 +19,7 @@ jest.mock('../../../observe/fetchEvents', () => {
   return {
     ...actual,
     fetchObserveEventsAsync: jest.fn(),
+    fetchTotalEventCountAsync: jest.fn(),
   };
 });
 jest.mock('../../../observe/formatEvents', () => ({
@@ -25,6 +30,7 @@ jest.mock('../../../log');
 jest.mock('../../../utils/json');
 
 const mockFetchObserveEventsAsync = jest.mocked(fetchObserveEventsAsync);
+const mockFetchTotalEventCountAsync = jest.mocked(fetchTotalEventCountAsync);
 const mockBuildObserveEventsJson = jest.mocked(buildObserveEventsJson);
 const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
 const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
@@ -195,7 +201,15 @@ describe(ObserveMetrics, () => {
     expect(options.updateId).toBe('update-xyz');
   });
 
-  it('does not pass platform, appVersion, or updateId when flags are not provided', async () => {
+  it('passes --client-id to fetchObserveEventsAsync', async () => {
+    const command = createCommand(['tti', '--client-id', 'client-xyz']);
+    await command.runAsync();
+
+    const options = mockFetchObserveEventsAsync.mock.calls[0][2];
+    expect(options.easClientId).toBe('client-xyz');
+  });
+
+  it('does not pass platform, appVersion, updateId, or easClientId when flags are not provided', async () => {
     const command = createCommand(['tti']);
     await command.runAsync();
 
@@ -203,6 +217,7 @@ describe(ObserveMetrics, () => {
     expect(options.platform).toBeUndefined();
     expect(options.appVersion).toBeUndefined();
     expect(options.updateId).toBeUndefined();
+    expect(options.easClientId).toBeUndefined();
   });
 
   it('calls enableJsonOutput and printJsonOnlyOutput when --json is provided', async () => {
@@ -244,6 +259,32 @@ describe(ObserveMetrics, () => {
 
     expect(mockEnableJsonOutput).not.toHaveBeenCalled();
     expect(mockPrintJsonOnlyOutput).not.toHaveBeenCalled();
+  });
+
+  it('omits metricName and skips the total-event-count query with --all-metrics', async () => {
+    const command = createCommand(['--all-metrics']);
+    await command.runAsync();
+
+    const options = mockFetchObserveEventsAsync.mock.calls[0][2];
+    expect(options).not.toHaveProperty('metricName');
+    expect(mockFetchTotalEventCountAsync).not.toHaveBeenCalled();
+  });
+
+  it('forwards --client-id together with --all-metrics', async () => {
+    const command = createCommand(['--all-metrics', '--client-id', 'client-xyz']);
+    await command.runAsync();
+
+    const options = mockFetchObserveEventsAsync.mock.calls[0][2];
+    expect(options).not.toHaveProperty('metricName');
+    expect(options.easClientId).toBe('client-xyz');
+  });
+
+  it('throws when --all-metrics is combined with a metric argument', async () => {
+    const command = createCommand(['tti', '--all-metrics']);
+
+    await expect(command.runAsync()).rejects.toThrow(
+      '--all-metrics cannot be combined with a metric argument'
+    );
   });
 
   it('passes --sort flag through to fetchObserveEventsAsync', async () => {

--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -12,6 +12,7 @@ import { fetchObserveCustomEventsAsync } from '../../observe/fetchCustomEvents';
 import {
   ObserveAfterFlag,
   ObserveAppVersionFlag,
+  ObserveClientIdFlag,
   ObservePlatformFlag,
   ObserveProjectIdFlag,
   ObserveTimeRangeFlags,
@@ -53,6 +54,7 @@ export default class ObserveEvents extends EasCommand {
     ...ObserveTimeRangeFlags,
     ...ObserveAppVersionFlag,
     ...ObserveUpdateIdFlag,
+    ...ObserveClientIdFlag,
     'session-id': Flags.string({
       description: 'Filter by session ID',
     }),
@@ -134,6 +136,7 @@ export default class ObserveEvents extends EasCommand {
       appVersion: flags['app-version'],
       updateId: flags['update-id'],
       sessionId: flags['session-id'],
+      easClientId: flags['client-id'],
     });
 
     if (args.eventName && events.length === 0) {

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -17,6 +17,7 @@ import {
 import {
   ObserveAfterFlag,
   ObserveAppVersionFlag,
+  ObserveClientIdFlag,
   ObservePlatformFlag,
   ObserveProjectIdFlag,
   ObserveTimeRangeFlags,
@@ -44,6 +45,11 @@ export default class ObserveMetrics extends EasCommand {
   };
 
   static override flags = {
+    'all-metrics': Flags.boolean({
+      description:
+        'Return samples across all metrics instead of a single one. Cannot be combined with a metric argument.',
+      default: false,
+    }),
     sort: Flags.option({
       description: 'Sort order for events',
       options: Object.values(EventsOrderPreset).map(s => s.toLowerCase()),
@@ -59,6 +65,7 @@ export default class ObserveMetrics extends EasCommand {
     ...ObserveTimeRangeFlags,
     ...ObserveAppVersionFlag,
     ...ObserveUpdateIdFlag,
+    ...ObserveClientIdFlag,
     ...ObserveProjectIdFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -88,20 +95,33 @@ export default class ObserveMetrics extends EasCommand {
       enableJsonOutput();
     }
 
-    let metricName: string;
+    if (args.metric && flags['all-metrics']) {
+      throw new EasCommandError(
+        '--all-metrics cannot be combined with a metric argument. Pass a metric to filter by it, or pass --all-metrics to return samples across all metrics.'
+      );
+    }
+
+    const ALL_METRICS = '__all__';
+    let metricName: string | undefined;
     if (args.metric) {
       metricName = resolveMetricName(args.metric);
+    } else if (flags['all-metrics']) {
+      metricName = undefined;
     } else if (nonInteractive) {
       throw new EasCommandError(
-        'A metric argument is required in non-interactive mode. Available metrics: ' +
+        'A metric argument is required in non-interactive mode (or pass --all-metrics for all metrics). Available metrics: ' +
           Object.keys(METRIC_ALIASES).join(', ')
       );
     } else {
-      const choices = Object.entries(METRIC_SHORT_NAMES).map(([fullName, displayName]) => ({
-        title: `${displayName} (${fullName})`,
-        value: fullName,
-      }));
-      metricName = await selectAsync('Select a metric', choices);
+      const choices = [
+        { title: 'All metrics', value: ALL_METRICS },
+        ...Object.entries(METRIC_SHORT_NAMES).map(([fullName, displayName]) => ({
+          title: `${displayName} (${fullName})`,
+          value: fullName,
+        })),
+      ];
+      const selected = await selectAsync('Select a metric', choices);
+      metricName = selected === ALL_METRICS ? undefined : selected;
     }
     const orderBy = resolveOrderBy(flags.sort);
 
@@ -110,9 +130,11 @@ export default class ObserveMetrics extends EasCommand {
     const platform = appObservePlatformFromFlag(flags.platform);
     const platforms = appPlatformsFromFlag(flags.platform);
 
+    // The total-event-count query is per-metric, so it only applies when a
+    // single metric is requested.
     const [{ events, pageInfo }, totalEventCount] = await Promise.all([
       fetchObserveEventsAsync(graphqlClient, projectId, {
-        metricName,
+        ...(metricName && { metricName }),
         orderBy,
         limit: flags.limit ?? DEFAULT_EVENTS_LIMIT,
         ...(flags.after && { after: flags.after }),
@@ -121,15 +143,18 @@ export default class ObserveMetrics extends EasCommand {
         platform,
         appVersion: flags['app-version'],
         updateId: flags['update-id'],
+        easClientId: flags['client-id'],
       }),
-      fetchTotalEventCountAsync(
-        graphqlClient,
-        projectId,
-        metricName,
-        platforms,
-        startTime,
-        endTime
-      ),
+      metricName
+        ? fetchTotalEventCountAsync(
+            graphqlClient,
+            projectId,
+            metricName,
+            platforms,
+            startTime,
+            endTime
+          )
+        : Promise.resolve(undefined),
     ]);
 
     if (json) {

--- a/packages/eas-cli/src/observe/__tests__/fetchCustomEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchCustomEvents.test.ts
@@ -60,12 +60,13 @@ describe('fetchObserveCustomEventsAsync', () => {
     expect(filter?.eventName).toBe('my_event');
   });
 
-  it('forwards platform, appVersion, and sessionId filters when provided', async () => {
+  it('forwards platform, appVersion, sessionId, and easClientId filters when provided', async () => {
     await fetchObserveCustomEventsAsync(mockGraphqlClient, 'project-123', {
       limit: 10,
       platform: AppObservePlatform.Ios,
       appVersion: '2.1.0',
       sessionId: 'session-xyz',
+      easClientId: 'client-xyz',
       startTime: '2025-01-01T00:00:00.000Z',
       endTime: '2025-03-01T00:00:00.000Z',
     });
@@ -74,6 +75,7 @@ describe('fetchObserveCustomEventsAsync', () => {
     expect(filter?.platform).toBe(AppObservePlatform.Ios);
     expect(filter?.appVersion).toBe('2.1.0');
     expect(filter?.sessionId).toBe('session-xyz');
+    expect(filter?.easClientId).toBe('client-xyz');
   });
 
   it('maps updateId to appUpdateId when provided', async () => {
@@ -112,6 +114,7 @@ describe('fetchObserveCustomEventsAsync', () => {
     expect(filter).not.toHaveProperty('appVersion');
     expect(filter).not.toHaveProperty('appUpdateId');
     expect(filter).not.toHaveProperty('sessionId');
+    expect(filter).not.toHaveProperty('easClientId');
   });
 
   it('forwards after cursor when provided', async () => {

--- a/packages/eas-cli/src/observe/__tests__/fetchEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchEvents.test.ts
@@ -163,7 +163,35 @@ describe(fetchObserveEventsAsync, () => {
     );
   });
 
-  it('omits platform, appVersion, and appUpdateId from filter when not provided', async () => {
+  it('includes easClientId in filter when provided', async () => {
+    mockEventsAsync.mockResolvedValue({
+      events: [],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    });
+
+    await fetchObserveEventsAsync(mockGraphqlClient, 'app-123', {
+      metricName: 'expo.app_startup.tti',
+      orderBy: {
+        field: AppObserveEventsOrderByField.MetricValue,
+        direction: AppObserveEventsOrderByDirection.Desc,
+      },
+      limit: 10,
+      startTime: '2025-01-01T00:00:00.000Z',
+      endTime: '2025-03-01T00:00:00.000Z',
+      easClientId: 'client-abc-123',
+    });
+
+    expect(mockEventsAsync).toHaveBeenCalledWith(
+      mockGraphqlClient,
+      expect.objectContaining({
+        filter: expect.objectContaining({
+          easClientId: 'client-abc-123',
+        }),
+      })
+    );
+  });
+
+  it('omits platform, appVersion, appUpdateId, and easClientId from filter when not provided', async () => {
     mockEventsAsync.mockResolvedValue({
       events: [],
       pageInfo: { hasNextPage: false, hasPreviousPage: false },
@@ -184,6 +212,7 @@ describe(fetchObserveEventsAsync, () => {
     expect(calledFilter).not.toHaveProperty('platform');
     expect(calledFilter).not.toHaveProperty('appVersion');
     expect(calledFilter).not.toHaveProperty('appUpdateId');
+    expect(calledFilter).not.toHaveProperty('easClientId');
   });
 
   it('returns events and pageInfo from the query result', async () => {

--- a/packages/eas-cli/src/observe/__tests__/formatEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatEvents.test.ts
@@ -85,6 +85,23 @@ describe(buildObserveEventsTable, () => {
     expect(output).toContain('TTI events for the last 30 days');
   });
 
+  it('adds a Metric column and "All metric events" header when options omit metricName', () => {
+    const events = [
+      createMockEvent({ metricName: 'expo.app_startup.tti', metricValue: 1.23 }),
+      createMockEvent({
+        id: 'evt-2',
+        metricName: 'expo.app_startup.cold_launch_time',
+        metricValue: 2.5,
+      }),
+    ];
+    const output = buildObserveEventsTable(events, noNextPage, { daysBack: 30 });
+
+    expect(output).toContain('All metric events for the last 30 days');
+    expect(output).toContain('Metric');
+    expect(output).toContain('Startup TTI');
+    expect(output).toContain('Cold Launch');
+  });
+
   it('shows date range in summary header when start/end provided', () => {
     const events = [createMockEvent()];
     const output = buildObserveEventsTable(events, noNextPage, {

--- a/packages/eas-cli/src/observe/fetchCustomEvents.ts
+++ b/packages/eas-cli/src/observe/fetchCustomEvents.ts
@@ -18,6 +18,7 @@ interface FetchCustomEventsOptions {
   appVersion?: string;
   updateId?: string;
   sessionId?: string;
+  easClientId?: string;
   orderBy?: AppObserveCustomEventListOrderBy;
 }
 
@@ -39,6 +40,7 @@ export async function fetchObserveCustomEventsAsync(
     ...(options.appVersion && { appVersion: options.appVersion }),
     ...(options.updateId && { appUpdateId: options.updateId }),
     ...(options.sessionId && { sessionId: options.sessionId }),
+    ...(options.easClientId && { easClientId: options.easClientId }),
   };
 
   return await ObserveQuery.customEventListAsync(graphqlClient, {

--- a/packages/eas-cli/src/observe/fetchEvents.ts
+++ b/packages/eas-cli/src/observe/fetchEvents.ts
@@ -55,6 +55,7 @@ interface FetchObserveEventsOptions {
   appVersion?: string;
   updateId?: string;
   sessionId?: string;
+  easClientId?: string;
 }
 
 interface FetchObserveEventsResult {
@@ -75,6 +76,7 @@ export async function fetchObserveEventsAsync(
     ...(options.appVersion && { appVersion: options.appVersion }),
     ...(options.updateId && { appUpdateId: options.updateId }),
     ...(options.sessionId && { sessionId: options.sessionId }),
+    ...(options.easClientId && { easClientId: options.easClientId }),
   };
 
   return await ObserveQuery.eventsAsync(graphqlClient, {

--- a/packages/eas-cli/src/observe/flags.ts
+++ b/packages/eas-cli/src/observe/flags.ts
@@ -49,3 +49,9 @@ export const ObserveUpdateIdFlag = {
     description: 'Filter by EAS update ID',
   }),
 };
+
+export const ObserveClientIdFlag = {
+  'client-id': Flags.string({
+    description: 'Filter by EAS client ID (the unique identifier of an app installation)',
+  }),
+};

--- a/packages/eas-cli/src/observe/formatEvents.ts
+++ b/packages/eas-cli/src/observe/formatEvents.ts
@@ -28,7 +28,8 @@ function resolveCustomParams(event: AppObserveEvent): { [key: string]: any } | n
 }
 
 export interface BuildEventsTableOptions {
-  metricName: string;
+  /** Omit to render samples across all metrics (adds a "Metric" column). */
+  metricName?: string;
   daysBack?: number;
   startTime?: string;
   endTime?: string;
@@ -45,8 +46,12 @@ export function buildObserveEventsTable(
   }
 
   const hasUpdates = events.some(e => e.appUpdateId);
+  // When no single metric is requested (--all-metrics), samples span multiple
+  // metrics, so show which metric each row belongs to.
+  const showMetricColumn = !!options && !options.metricName;
 
   const headers = [
+    ...(showMetricColumn ? ['Metric'] : []),
     'Value',
     'App Version',
     ...(hasUpdates ? ['Update'] : []),
@@ -57,6 +62,7 @@ export function buildObserveEventsTable(
   ];
 
   const rows: string[][] = events.map(event => [
+    ...(showMetricColumn ? [getMetricDisplayName(event.metricName)] : []),
     `${event.metricValue.toFixed(2)}s`,
     `${event.appVersion} (${event.appBuildNumber})`,
     ...(hasUpdates ? [event.appUpdateId ?? '-'] : []),
@@ -69,13 +75,15 @@ export function buildObserveEventsTable(
   const lines: string[] = [];
 
   if (options) {
-    const metricDisplay = getMetricDisplayName(options.metricName);
+    const heading = options.metricName
+      ? `${getMetricDisplayName(options.metricName)} events`
+      : 'All metric events';
     const timeDesc = buildTimeRangeDescription(options);
     const totalDesc =
       options.totalEventCount != null
         ? ` — ${options.totalEventCount.toLocaleString()} total events`
         : '';
-    lines.push(chalk.bold(`${metricDisplay} events ${timeDesc}${totalDesc}`.trim()), '');
+    lines.push(chalk.bold(`${heading} ${timeDesc}${totalDesc}`.trim()), '');
   }
 
   lines.push(renderTextTable(headers, rows));


### PR DESCRIPTION
# Why

The Observe web dashboard can filter events and metrics by `easClientId` (a single app installation) — e.g. [this metrics view](https://expo.dev/accounts/expo-production/projects/pancake-theory/observe/metrics?metric=expo.app_startup.cold_launch_time&platform=android&t=30d&environment=production&easClientId=5992f753-6ab3-4320-977e-34326c90bb3c) shows one user's data. The CLI had no equivalent. It also forced picking a single metric, so there was no way to see all of a user's metrics at once.

# How

- **`--client-id` on `observe:events` and `observe:metrics`** — new shared `ObserveClientIdFlag` threaded into the `easClientId` field of `AppObserveCustomEventListFilter` / `AppObserveEventsFilter` (both already supported it server-side; this was purely a missing CLI flag).
- **`--all-metrics` on `observe:metrics`** — omits the metric filter and returns samples across all metrics, mirroring the existing `--all-events` flag on `observe:events`. Pairs with `--client-id` to show every metric for one installation.
  - When no single metric is selected, the table gains a **Metric** column and the per-metric total-count query is skipped.
  - The interactive picker now offers "All metrics" as the first choice; non-interactive callers pass `--all-metrics`. Combining it with a metric argument errors out.

Example (CLI equivalent of the linked dashboard view):

```
eas observe:metrics --all-metrics --platform android --client-id 5992f753-6ab3-4320-977e-34326c90bb3c --days 30
```

Note: `README.md` is intentionally left unchanged — it's regenerated from oclif metadata by a GitHub Action on merge.

# Test Plan

- Added unit tests: `--client-id` passthrough on both commands, `--all-metrics` (omits `metricName`, skips total-count query, combines with `--client-id`, rejects a metric arg), and the multi-metric table rendering (Metric column + "All metric events" heading).
- Full observe suite passes (`yarn test src/commands/observe src/observe` → 275 passed).
- `yarn typecheck`, `yarn lint` (0 errors), and `yarn fmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)