### PR TITLE
[build-tools][steps] Load composite function catalogs for hook steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] Validate local composite functions referenced in workflow files during `eas workflow:validate`, checking that the YAML files exist and are well-formed. ([#3931](https://github.com/expo/eas-cli/pull/3931) by [@sswrk](https://github.com/sswrk))
 - [build-tools] Pass a metrics CORS origin to serve-sim so the dashboard can read a session's live CPU/memory stream cross-origin. ([#3990](https://github.com/expo/eas-cli/pull/3990) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Collect each iOS session's serve-sim CPU/memory `/metrics` to a file and upload it as a device run session artifact at teardown. ([#3995](https://github.com/expo/eas-cli/pull/3995) by [@gwdp](https://github.com/gwdp))
+- [build-tools] Load local composite function catalogs for hook steps, in both steps-based and native builds. ([#4063](https://github.com/expo/eas-cli/pull/4063) by [@sswrk](https://github.com/sswrk))
 
 ### 🐛 Bug fixes
 

--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -69,7 +69,7 @@ export async function runCustomBuildAsync(ctx: BuildContext<BuildJob>): Promise<
             hooks: ctx.job.hooks,
             compositeFunctionCatalog: await buildCompositeFunctionCatalogAsync(
               ctx.getReactNativeProjectDirectory(customBuildCtx.projectSourceDirectory),
-              { steps: ctx.job.steps, logger: ctx.logger }
+              { steps: ctx.job.steps, hooks: ctx.job.hooks, logger: ctx.logger }
             ),
           })
         : new BuildConfigParser(globalContext, {

--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -17,7 +17,10 @@ import { Artifacts, BuildContext } from '../context';
 import { CustomBuildContext } from '../customBuildContext';
 import { Datadog } from '../datadog';
 import { findAndUploadXcodeBuildLogsAsync } from '../ios/xcodeBuildLogs';
-import { buildCompositeFunctionCatalogAsync } from '../steps/compositeFunctions';
+import {
+  buildCompositeFunctionCatalogAsync,
+  createCompositeFunctionLoader,
+} from '../steps/compositeFunctions';
 import { getEasFunctionGroups } from '../steps/easFunctionGroups';
 import { getEasFunctions } from '../steps/easFunctions';
 import { retryAsync } from '../utils/retry';
@@ -61,22 +64,25 @@ export async function runCustomBuildAsync(ctx: BuildContext<BuildJob>): Promise<
   const easFunctionGroups = getEasFunctionGroups(customBuildCtx);
   const workflow = await ctx.runBuildPhase(BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG, async () => {
     try {
+      const projectRoot = ctx.getReactNativeProjectDirectory(customBuildCtx.projectSourceDirectory);
       const parser = ctx.job.steps
         ? new StepsConfigParser(globalContext, {
             externalFunctions: easFunctions,
             externalFunctionGroups: easFunctionGroups,
             steps: ctx.job.steps,
             hooks: ctx.job.hooks,
-            compositeFunctionCatalog: await buildCompositeFunctionCatalogAsync(
-              ctx.getReactNativeProjectDirectory(customBuildCtx.projectSourceDirectory),
-              { steps: ctx.job.steps, hooks: ctx.job.hooks, logger: ctx.logger }
-            ),
+            // Eager for job steps (always run), lazy loader for hooks (running anchors only).
+            compositeFunctionCatalog: await buildCompositeFunctionCatalogAsync(projectRoot, {
+              steps: ctx.job.steps,
+              logger: ctx.logger,
+            }),
+            loadCompositeFunction: createCompositeFunctionLoader(projectRoot, ctx.logger),
           })
         : new BuildConfigParser(globalContext, {
             externalFunctions: easFunctions,
             externalFunctionGroups: easFunctionGroups,
             configPath: path.join(
-              ctx.getReactNativeProjectDirectory(customBuildCtx.projectSourceDirectory),
+              projectRoot,
               nullthrows(
                 ctx.job.customBuildConfig?.path,
                 'Steps or custom build config path are required in custom jobs'

--- a/packages/build-tools/src/common/__tests__/jobHooks.test.ts
+++ b/packages/build-tools/src/common/__tests__/jobHooks.test.ts
@@ -1,3 +1,7 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
 import { BuildTrigger, ErrorCode, Hooks, Ios, UserError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 
@@ -7,7 +11,10 @@ import { parseJobHooksAsync } from '../jobHooks';
 
 const INSTALL: ['install_node_modules'] = ['install_node_modules'];
 
-function createCtx(hooks: Hooks | undefined): {
+function createCtx(
+  hooks: Hooks | undefined,
+  { workingdir = '/tmp/wd' }: { workingdir?: string } = {}
+): {
   ctx: BuildContext<Ios.Job>;
   warn: jest.Mock;
 } {
@@ -26,10 +33,22 @@ function createCtx(hooks: Hooks | undefined): {
       logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
       logger,
       uploadArtifact: jest.fn(),
-      workingdir: '/tmp/wd',
+      workingdir,
     }
   );
   return { ctx, warn };
+}
+
+// Project checkout lives at <workingdir>/build (job projectRootDirectory is '.').
+async function makeWorkingdirWithCompositeFunctionAsync(
+  functionName: string,
+  contents: string
+): Promise<string> {
+  const workingdir = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-hooks-composite-'));
+  const functionDir = path.join(workingdir, 'build', '.eas', 'functions', functionName);
+  await fs.mkdir(functionDir, { recursive: true });
+  await fs.writeFile(path.join(functionDir, 'function.yml'), contents, 'utf-8');
+  return workingdir;
 }
 
 describe(parseJobHooksAsync, () => {
@@ -122,6 +141,46 @@ describe(parseJobHooksAsync, () => {
     const after = parsed!.hookEntriesByKey.after_install_node_modules![0];
     expect(before.steps[0].ctx.global).toBe(parsed!.globalContext);
     expect(after.steps[0].ctx.global).toBe(parsed!.globalContext);
+  });
+
+  it('parses a composite function under a wrapped key into ONE entry with the expansion inside', async () => {
+    const workingdir = await makeWorkingdirWithCompositeFunctionAsync(
+      'setup',
+      [
+        'runs:',
+        '  steps:',
+        '    - id: prepare',
+        '      run: echo prepare',
+        '    - run: echo hi',
+      ].join('\n')
+    );
+    const { ctx } = createCtx(
+      { before_install_node_modules: [{ uses: './.eas/functions/setup', id: 'setup' }] },
+      { workingdir }
+    );
+    const parsed = await parseJobHooksAsync(ctx, INSTALL);
+    expect(parsed!.hookEntriesByKey.before_install_node_modules).toHaveLength(1);
+    expect(
+      parsed!.hookEntriesByKey.before_install_node_modules![0].steps.map(step => step.id)
+    ).toEqual(['setup__prepare', 'setup__composite_function_step_1']);
+  });
+
+  it('fails with a hooks error when a wrapped key references a missing composite function', async () => {
+    const workingdir = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-hooks-missing-'));
+    const { ctx } = createCtx(
+      { before_install_node_modules: [{ uses: './.eas/functions/missing' }] },
+      { workingdir }
+    );
+    const result = parseJobHooksAsync(ctx, INSTALL);
+    await expect(result).rejects.toThrow('no such composite function exists');
+    await expect(result).rejects.toMatchObject({ errorCode: ErrorCode.HOOKS_ERROR });
+  });
+
+  it('never loads a composite function referenced under a registered-but-unwrapped key', async () => {
+    const { ctx, warn } = createCtx({ before_submit: [{ uses: './.eas/functions/missing' }] });
+    const parsed = await parseJobHooksAsync(ctx, INSTALL);
+    expect(parsed!.hookEntriesByKey).toEqual({});
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('hooks.before_submit'));
   });
 
   it('wraps a cross-key duplicate step id in the aggregate error', async () => {

--- a/packages/build-tools/src/common/__tests__/jobHooks.test.ts
+++ b/packages/build-tools/src/common/__tests__/jobHooks.test.ts
@@ -172,7 +172,22 @@ describe(parseJobHooksAsync, () => {
       { workingdir }
     );
     const result = parseJobHooksAsync(ctx, INSTALL);
-    await expect(result).rejects.toThrow('no such composite function exists');
+    await expect(result).rejects.toThrow(
+      'Failed to parse hooks.before_install_node_modules: Local composite function "./.eas/functions/missing" was referenced by a step but no such composite function exists'
+    );
+    await expect(result).rejects.toMatchObject({ errorCode: ErrorCode.HOOKS_ERROR });
+  });
+
+  it('reports the hook key when a composite function call sets working_directory', async () => {
+    const { ctx } = createCtx({
+      before_install_node_modules: [
+        { uses: './.eas/functions/setup', working_directory: 'subdir' },
+      ],
+    });
+    const result = parseJobHooksAsync(ctx, INSTALL);
+    await expect(result).rejects.toThrow(
+      'Failed to parse hooks.before_install_node_modules: "working_directory" is not supported'
+    );
     await expect(result).rejects.toMatchObject({ errorCode: ErrorCode.HOOKS_ERROR });
   });
 

--- a/packages/build-tools/src/common/jobHooks.ts
+++ b/packages/build-tools/src/common/jobHooks.ts
@@ -1,6 +1,5 @@
 import {
   BuildJob,
-  CompositeFunctionCatalog,
   ErrorCode,
   HookAnchorId,
   HookKey,
@@ -91,30 +90,6 @@ export async function parseJobHooksAsync<TJob extends BuildJob>(
     }
   }
 
-  // Only load composites for anchors this build actually wraps.
-  // Unwrapped registered keys warn-and-skip above.
-  const catalogRootSteps = wrappedAnchors.flatMap(anchor =>
-    (['before', 'after'] as const).flatMap(side => {
-      const steps = hooks[`${side}_${anchor}`];
-      return Array.isArray(steps) ? steps : [];
-    })
-  );
-  let compositeFunctionCatalog: CompositeFunctionCatalog;
-  try {
-    compositeFunctionCatalog = await buildCompositeFunctionCatalogAsync(
-      ctx.getReactNativeProjectDirectory(),
-      { steps: catalogRootSteps, logger: ctx.logger }
-    );
-  } catch (err) {
-    throw new UserError(
-      ErrorCode.HOOKS_ERROR,
-      `Failed to load a local composite function referenced from the job's hooks: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-      { cause: err }
-    );
-  }
-
   // Construct entries for the wrapped anchors in EXECUTION order (per anchor,
   // before_ then after_) so generated step ids and output references follow the
   // order steps actually run. All entries share one globalContext, so env and
@@ -130,6 +105,11 @@ export async function parseJobHooksAsync<TJob extends BuildJob>(
       }
       let entries: HookEntry[];
       try {
+        // Per key so a bad `uses:` path is attributed to that hook key.
+        const compositeFunctionCatalog = await buildCompositeFunctionCatalogAsync(
+          ctx.getReactNativeProjectDirectory(),
+          { steps, logger: ctx.logger }
+        );
         entries = await constructHookEntriesAsync(globalContext, steps, {
           externalFunctions,
           externalFunctionGroups,

--- a/packages/build-tools/src/common/jobHooks.ts
+++ b/packages/build-tools/src/common/jobHooks.ts
@@ -1,5 +1,6 @@
 import {
   BuildJob,
+  CompositeFunctionCatalog,
   ErrorCode,
   HookAnchorId,
   HookKey,
@@ -12,12 +13,13 @@ import {
   BuildStepGlobalContext,
   HookEntry,
   constructHookEntriesAsync,
+  extendCompositeFunctionCatalogFromStepsAsync,
   validateHookStepsAsync,
 } from '@expo/steps';
 
 import { BuildContext } from '../context';
 import { CustomBuildContext } from '../customBuildContext';
-import { buildCompositeFunctionCatalogAsync } from '../steps/compositeFunctions';
+import { createCompositeFunctionLoader } from '../steps/compositeFunctions';
 import { getEasFunctionGroups } from '../steps/easFunctionGroups';
 import { getEasFunctions } from '../steps/easFunctions';
 
@@ -96,6 +98,11 @@ export async function parseJobHooksAsync<TJob extends BuildJob>(
   // outputs accumulate across keys.
   const hookEntriesByKey: Partial<Record<HookKey, HookEntry[]>> = {};
   const orderedSteps: BuildStep[] = [];
+  const compositeFunctionCatalog: CompositeFunctionCatalog = {};
+  const loadCompositeFunction = createCompositeFunctionLoader(
+    ctx.getReactNativeProjectDirectory(),
+    ctx.logger
+  );
   for (const anchor of wrappedAnchors) {
     for (const side of ['before', 'after'] as const) {
       const key: HookKey = `${side}_${anchor}`;
@@ -105,11 +112,12 @@ export async function parseJobHooksAsync<TJob extends BuildJob>(
       }
       let entries: HookEntry[];
       try {
-        // Per key so a bad `uses:` path is attributed to that hook key.
-        const compositeFunctionCatalog = await buildCompositeFunctionCatalogAsync(
-          ctx.getReactNativeProjectDirectory(),
-          { steps, logger: ctx.logger }
-        );
+        // Extended per key so a bad `uses:` path is attributed to that hook key.
+        await extendCompositeFunctionCatalogFromStepsAsync({
+          catalog: compositeFunctionCatalog,
+          rootSteps: steps,
+          loadCompositeFunction,
+        });
         entries = await constructHookEntriesAsync(globalContext, steps, {
           externalFunctions,
           externalFunctionGroups,

--- a/packages/build-tools/src/common/jobHooks.ts
+++ b/packages/build-tools/src/common/jobHooks.ts
@@ -1,5 +1,6 @@
 import {
   BuildJob,
+  CompositeFunctionCatalog,
   ErrorCode,
   HookAnchorId,
   HookKey,
@@ -17,6 +18,7 @@ import {
 
 import { BuildContext } from '../context';
 import { CustomBuildContext } from '../customBuildContext';
+import { buildCompositeFunctionCatalogAsync } from '../steps/compositeFunctions';
 import { getEasFunctionGroups } from '../steps/easFunctionGroups';
 import { getEasFunctions } from '../steps/easFunctions';
 
@@ -89,6 +91,30 @@ export async function parseJobHooksAsync<TJob extends BuildJob>(
     }
   }
 
+  // Only load composites for anchors this build actually wraps.
+  // Unwrapped registered keys warn-and-skip above.
+  const catalogRootSteps = wrappedAnchors.flatMap(anchor =>
+    (['before', 'after'] as const).flatMap(side => {
+      const steps = hooks[`${side}_${anchor}`];
+      return Array.isArray(steps) ? steps : [];
+    })
+  );
+  let compositeFunctionCatalog: CompositeFunctionCatalog;
+  try {
+    compositeFunctionCatalog = await buildCompositeFunctionCatalogAsync(
+      ctx.getReactNativeProjectDirectory(),
+      { steps: catalogRootSteps, logger: ctx.logger }
+    );
+  } catch (err) {
+    throw new UserError(
+      ErrorCode.HOOKS_ERROR,
+      `Failed to load a local composite function referenced from the job's hooks: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      { cause: err }
+    );
+  }
+
   // Construct entries for the wrapped anchors in EXECUTION order (per anchor,
   // before_ then after_) so generated step ids and output references follow the
   // order steps actually run. All entries share one globalContext, so env and
@@ -107,6 +133,7 @@ export async function parseJobHooksAsync<TJob extends BuildJob>(
         entries = await constructHookEntriesAsync(globalContext, steps, {
           externalFunctions,
           externalFunctionGroups,
+          compositeFunctionCatalog,
         });
       } catch (err) {
         throw new UserError(

--- a/packages/build-tools/src/generic.ts
+++ b/packages/build-tools/src/generic.ts
@@ -48,7 +48,7 @@ export async function runGenericJobAsync(
     try {
       const compositeFunctionCatalog = await buildCompositeFunctionCatalogAsync(
         ctx.getReactNativeProjectDirectory(customBuildCtx.projectSourceDirectory),
-        { steps: ctx.job.steps, logger: ctx.logger }
+        { steps: ctx.job.steps, hooks: ctx.job.hooks, logger: ctx.logger }
       );
 
       const parser = new StepsConfigParser(globalContext, {

--- a/packages/build-tools/src/generic.ts
+++ b/packages/build-tools/src/generic.ts
@@ -7,7 +7,10 @@ import nullthrows from 'nullthrows';
 import { prepareProjectSourcesAsync } from './common/projectSources';
 import { BuildContext } from './context';
 import { CustomBuildContext } from './customBuildContext';
-import { buildCompositeFunctionCatalogAsync } from './steps/compositeFunctions';
+import {
+  buildCompositeFunctionCatalogAsync,
+  createCompositeFunctionLoader,
+} from './steps/compositeFunctions';
 import { getEasFunctionGroups } from './steps/easFunctionGroups';
 import { getEasFunctions } from './steps/easFunctions';
 import { uploadJobOutputsToWwwAsync } from './utils/outputs';
@@ -46,10 +49,12 @@ export async function runGenericJobAsync(
 
   const workflow = await ctx.runBuildPhase(BuildPhase.PARSE_CUSTOM_WORKFLOW_CONFIG, async () => {
     try {
-      const compositeFunctionCatalog = await buildCompositeFunctionCatalogAsync(
-        ctx.getReactNativeProjectDirectory(customBuildCtx.projectSourceDirectory),
-        { steps: ctx.job.steps, hooks: ctx.job.hooks, logger: ctx.logger }
-      );
+      const projectRoot = ctx.getReactNativeProjectDirectory(customBuildCtx.projectSourceDirectory);
+      // Eager for job steps (always run), lazy loader for hooks (running anchors only).
+      const compositeFunctionCatalog = await buildCompositeFunctionCatalogAsync(projectRoot, {
+        steps: ctx.job.steps,
+        logger: ctx.logger,
+      });
 
       const parser = new StepsConfigParser(globalContext, {
         externalFunctions: getEasFunctions(customBuildCtx),
@@ -57,6 +62,7 @@ export async function runGenericJobAsync(
         steps: ctx.job.steps,
         hooks: ctx.job.hooks,
         compositeFunctionCatalog,
+        loadCompositeFunction: createCompositeFunctionLoader(projectRoot, ctx.logger),
       });
 
       return await parser.parseAsync();

--- a/packages/build-tools/src/steps/__tests__/compositeFunctions.test.ts
+++ b/packages/build-tools/src/steps/__tests__/compositeFunctions.test.ts
@@ -159,6 +159,35 @@ describe(buildCompositeFunctionCatalogAsync, () => {
     );
   });
 
+  it('loads composite functions referenced from registered hook keys', async () => {
+    const projectRoot = await makeProjectWithCompositeFunctionAsync(
+      'setup',
+      setupCompositeFunctionContents
+    );
+
+    const catalog = await buildCompositeFunctionCatalogAsync(projectRoot, {
+      steps: [{ run: 'echo hi' }],
+      hooks: { before_install_node_modules: [{ uses: './.eas/functions/setup' }] },
+    });
+
+    expect(Object.keys(catalog)).toEqual(['./.eas/functions/setup']);
+  });
+
+  it('ignores composite references under unregistered hook keys and non-array hook values', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-functions-hooks-'));
+
+    const catalog = await buildCompositeFunctionCatalogAsync(projectRoot, {
+      steps: [{ run: 'echo hi' }],
+      hooks: {
+        before_some_future_anchor: [{ uses: './.eas/functions/missing' }],
+        not_a_hook_key: [{ uses: './.eas/functions/missing' }],
+        before_install_node_modules: 'garbage' as never,
+      },
+    });
+
+    expect(catalog).toEqual({});
+  });
+
   it('throws a clear error for a malformed referenced composite function config', async () => {
     const projectRoot = await makeProjectWithCompositeFunctionAsync(
       'broken',

--- a/packages/build-tools/src/steps/__tests__/compositeFunctions.test.ts
+++ b/packages/build-tools/src/steps/__tests__/compositeFunctions.test.ts
@@ -2,7 +2,10 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { buildCompositeFunctionCatalogAsync } from '../compositeFunctions';
+import {
+  buildCompositeFunctionCatalogAsync,
+  createCompositeFunctionLoader,
+} from '../compositeFunctions';
 
 async function makeProjectWithCompositeFunctionAsync(
   functionName: string,
@@ -159,35 +162,6 @@ describe(buildCompositeFunctionCatalogAsync, () => {
     );
   });
 
-  it('loads composite functions referenced from registered hook keys', async () => {
-    const projectRoot = await makeProjectWithCompositeFunctionAsync(
-      'setup',
-      setupCompositeFunctionContents
-    );
-
-    const catalog = await buildCompositeFunctionCatalogAsync(projectRoot, {
-      steps: [{ run: 'echo hi' }],
-      hooks: { before_install_node_modules: [{ uses: './.eas/functions/setup' }] },
-    });
-
-    expect(Object.keys(catalog)).toEqual(['./.eas/functions/setup']);
-  });
-
-  it('ignores composite references under unregistered hook keys and non-array hook values', async () => {
-    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-functions-hooks-'));
-
-    const catalog = await buildCompositeFunctionCatalogAsync(projectRoot, {
-      steps: [{ run: 'echo hi' }],
-      hooks: {
-        before_some_future_anchor: [{ uses: './.eas/functions/missing' }],
-        not_a_hook_key: [{ uses: './.eas/functions/missing' }],
-        before_install_node_modules: 'garbage' as never,
-      },
-    });
-
-    expect(catalog).toEqual({});
-  });
-
   it('throws a clear error for a malformed referenced composite function config', async () => {
     const projectRoot = await makeProjectWithCompositeFunctionAsync(
       'broken',
@@ -198,5 +172,30 @@ describe(buildCompositeFunctionCatalogAsync, () => {
         steps: [{ uses: './.eas/functions/broken', id: 'broken' }],
       })
     ).rejects.toThrow(/must declare at least one step under "runs.steps"/);
+  });
+});
+
+describe(createCompositeFunctionLoader, () => {
+  it('loads function.yml from disk for a normalized path', async () => {
+    const projectRoot = await makeProjectWithCompositeFunctionAsync(
+      'setup',
+      setupCompositeFunctionContents
+    );
+
+    const loader = createCompositeFunctionLoader(projectRoot);
+    const config = await loader('./.eas/functions/setup');
+
+    expect(config.name).toBe('Setup');
+    expect(config.runs.steps).toHaveLength(1);
+  });
+
+  it('rejects for a path with no composite function on disk', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-functions-loader-'));
+
+    const loader = createCompositeFunctionLoader(projectRoot);
+
+    await expect(loader('./.eas/functions/missing')).rejects.toThrow(
+      /no such composite function exists/
+    );
   });
 });

--- a/packages/build-tools/src/steps/compositeFunctions.ts
+++ b/packages/build-tools/src/steps/compositeFunctions.ts
@@ -7,9 +7,7 @@ import {
   CompositeFunctionCatalog,
   CompositeFunctionConfig,
   CompositeFunctionConfigZ,
-  Hooks,
   Step,
-  parseHookKey,
 } from '@expo/eas-build-job';
 import {
   buildCompositeFunctionCatalogFromStepsAsync,
@@ -76,22 +74,20 @@ async function loadLocalCompositeFunctionConfigAsync(
   );
 }
 
-export async function buildCompositeFunctionCatalogAsync(
+export function createCompositeFunctionLoader(
   projectRoot: string,
-  { steps, hooks, logger }: { steps: readonly Step[]; hooks?: Hooks; logger?: bunyan }
-): Promise<CompositeFunctionCatalog> {
-  return buildCompositeFunctionCatalogFromStepsAsync({
-    rootSteps: [...steps, ...hookCatalogRootSteps(hooks)],
-    loadCompositeFunction: compositeFunctionPath =>
-      loadLocalCompositeFunctionConfigAsync(projectRoot, compositeFunctionPath, { logger }),
-  });
+  logger?: bunyan
+): (compositeFunctionPath: string) => Promise<CompositeFunctionConfig> {
+  return compositeFunctionPath =>
+    loadLocalCompositeFunctionConfigAsync(projectRoot, compositeFunctionPath, { logger });
 }
 
-function hookCatalogRootSteps(hooks: Hooks | undefined): Step[] {
-  if (!hooks) {
-    return [];
-  }
-  return Object.entries(hooks).flatMap(([key, steps]) =>
-    parseHookKey(key) !== null && Array.isArray(steps) ? steps : []
-  );
+export async function buildCompositeFunctionCatalogAsync(
+  projectRoot: string,
+  { steps, logger }: { steps: readonly Step[]; logger?: bunyan }
+): Promise<CompositeFunctionCatalog> {
+  return buildCompositeFunctionCatalogFromStepsAsync({
+    rootSteps: steps,
+    loadCompositeFunction: createCompositeFunctionLoader(projectRoot, logger),
+  });
 }

--- a/packages/build-tools/src/steps/compositeFunctions.ts
+++ b/packages/build-tools/src/steps/compositeFunctions.ts
@@ -7,7 +7,9 @@ import {
   CompositeFunctionCatalog,
   CompositeFunctionConfig,
   CompositeFunctionConfigZ,
+  Hooks,
   Step,
+  parseHookKey,
 } from '@expo/eas-build-job';
 import {
   buildCompositeFunctionCatalogFromStepsAsync,
@@ -76,11 +78,20 @@ async function loadLocalCompositeFunctionConfigAsync(
 
 export async function buildCompositeFunctionCatalogAsync(
   projectRoot: string,
-  { steps, logger }: { steps: readonly Step[]; logger?: bunyan }
+  { steps, hooks, logger }: { steps: readonly Step[]; hooks?: Hooks; logger?: bunyan }
 ): Promise<CompositeFunctionCatalog> {
   return buildCompositeFunctionCatalogFromStepsAsync({
-    rootSteps: steps,
+    rootSteps: [...steps, ...hookCatalogRootSteps(hooks)],
     loadCompositeFunction: compositeFunctionPath =>
       loadLocalCompositeFunctionConfigAsync(projectRoot, compositeFunctionPath, { logger }),
   });
+}
+
+function hookCatalogRootSteps(hooks: Hooks | undefined): Step[] {
+  if (!hooks) {
+    return [];
+  }
+  return Object.entries(hooks).flatMap(([key, steps]) =>
+    parseHookKey(key) !== null && Array.isArray(steps) ? steps : []
+  );
 }

--- a/packages/steps/src/StepsConfigParser.ts
+++ b/packages/steps/src/StepsConfigParser.ts
@@ -213,6 +213,7 @@ export class StepsConfigParser extends AbstractConfigParser {
       // worker lacks).
       const parsed = parseHookKey(hookKey);
       if (parsed === null) {
+        this.ctx.baseLogger.warn(`Ignoring unknown hook key "${hookKey}".`);
         continue;
       }
       // An empty array is a deliberate no-op (e.g. opting out of a default);

--- a/packages/steps/src/StepsConfigParser.ts
+++ b/packages/steps/src/StepsConfigParser.ts
@@ -3,6 +3,7 @@ import {
   CompositeFunctionConfig,
   FunctionStep,
   HookAnchorId,
+  HookKey,
   Hooks,
   Step,
   isHookAnchorId,
@@ -36,6 +37,8 @@ import {
   isLocalCompositeFunctionPath,
   parseLocalCompositeFunctionPath,
 } from './utils/localCompositeFunctions';
+
+type ValidatedHooks = ReadonlyMap<HookKey, { anchorId: HookAnchorId; steps: Step[] }>;
 
 export class StepsConfigParser extends AbstractConfigParser {
   private readonly steps: Step[];
@@ -187,11 +190,10 @@ export class StepsConfigParser extends AbstractConfigParser {
       }
     }
 
-    for (const hookKey of Object.keys(validatedHooks)) {
-      const parsed = parseHookKey(hookKey);
-      if (parsed !== null && !seenAnchorIds.has(parsed.anchorId)) {
+    for (const [hookKey, { anchorId }] of validatedHooks) {
+      if (!seenAnchorIds.has(anchorId)) {
         this.ctx.baseLogger.warn(
-          `Ignoring "hooks.${hookKey}": this build does not run the "${parsed.anchorId}" step.`
+          `Ignoring "hooks.${hookKey}": this build does not run the "${anchorId}" step.`
         );
       }
     }
@@ -203,13 +205,14 @@ export class StepsConfigParser extends AbstractConfigParser {
     };
   }
 
-  private validateHooks(): Record<string, Step[]> {
-    const validatedHooks: Record<string, Step[]> = {};
+  private validateHooks(): ValidatedHooks {
+    const validatedHooks = new Map<HookKey, { anchorId: HookAnchorId; steps: Step[] }>();
     for (const [hookKey, hookSteps] of Object.entries(this.hooks)) {
       // A worker must not fail on a hook key newer than itself, so unregistered
       // keys skip validation entirely (their steps may reference functions this
       // worker lacks).
-      if (parseHookKey(hookKey) === null) {
+      const parsed = parseHookKey(hookKey);
+      if (parsed === null) {
         continue;
       }
       // An empty array is a deliberate no-op (e.g. opting out of a default);
@@ -219,7 +222,10 @@ export class StepsConfigParser extends AbstractConfigParser {
         continue;
       }
       try {
-        validatedHooks[hookKey] = validateSteps(hookSteps);
+        validatedHooks.set(`${parsed.side}_${parsed.anchorId}`, {
+          anchorId: parsed.anchorId,
+          steps: validateSteps(hookSteps),
+        });
       } catch (err) {
         throw new BuildConfigError(
           `Invalid steps in "hooks.${hookKey}": ${err instanceof Error ? err.message : String(err)}`
@@ -252,7 +258,7 @@ export class StepsConfigParser extends AbstractConfigParser {
 
   private async constructAnchorHooksAsync(
     anchorId: HookAnchorId,
-    validatedHooks: Record<string, Step[]>,
+    validatedHooks: ValidatedHooks,
     compositeFunctionExpander: CompositeFunctionExpander
   ): Promise<AnchorHooks | undefined> {
     const before = await this.constructHookSideEntriesAsync(
@@ -276,10 +282,10 @@ export class StepsConfigParser extends AbstractConfigParser {
   private async constructHookSideEntriesAsync(
     anchorId: HookAnchorId,
     side: 'before' | 'after',
-    validatedHooks: Record<string, Step[]>,
+    validatedHooks: ValidatedHooks,
     compositeFunctionExpander: CompositeFunctionExpander
   ): Promise<HookEntry[]> {
-    const hookSteps = validatedHooks[`${side}_${anchorId}`];
+    const hookSteps = validatedHooks.get(`${side}_${anchorId}`)?.steps;
     if (hookSteps === undefined) {
       return [];
     }

--- a/packages/steps/src/StepsConfigParser.ts
+++ b/packages/steps/src/StepsConfigParser.ts
@@ -86,9 +86,7 @@ export class StepsConfigParser extends AbstractConfigParser {
   }> {
     const validatedSteps = validateSteps(this.steps);
     const validatedHooks = this.validateHooks();
-    // Hook steps are validated like job steps: a hook `uses:` naming an
-    // unknown function must be a BuildConfigError, not an assertion crash.
-    validateAllStepFunctionsExist([...validatedSteps, ...Object.values(validatedHooks).flat()], {
+    validateAllStepFunctionsExist(validatedSteps, {
       externalFunctionIds: this.getExternalFunctionFullIds(),
       externalFunctionGroupIds: this.getExternalFunctionGroupFullIds(),
     });
@@ -284,6 +282,18 @@ export class StepsConfigParser extends AbstractConfigParser {
     const hookSteps = validatedHooks[`${side}_${anchorId}`];
     if (hookSteps === undefined) {
       return [];
+    }
+    try {
+      validateAllStepFunctionsExist(hookSteps, {
+        externalFunctionIds: this.getExternalFunctionFullIds(),
+        externalFunctionGroupIds: this.getExternalFunctionGroupFullIds(),
+      });
+    } catch (err) {
+      throw new BuildConfigError(
+        `Invalid steps in "hooks.${side}_${anchorId}": ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
     }
     if (this.loadCompositeFunction !== undefined) {
       // Load only once the anchor runs, so unused anchors do not fail on missing composites.

--- a/packages/steps/src/StepsConfigParser.ts
+++ b/packages/steps/src/StepsConfigParser.ts
@@ -1,5 +1,6 @@
 import {
   CompositeFunctionCatalog,
+  CompositeFunctionConfig,
   FunctionStep,
   HookAnchorId,
   Hooks,
@@ -31,6 +32,7 @@ import {
   validateAllStepFunctionsExist,
 } from './hooks';
 import {
+  extendCompositeFunctionCatalogFromStepsAsync,
   isLocalCompositeFunctionPath,
   parseLocalCompositeFunctionPath,
 } from './utils/localCompositeFunctions';
@@ -40,6 +42,9 @@ export class StepsConfigParser extends AbstractConfigParser {
   private readonly hooks: Hooks;
   /** Pre-loaded composite function configs keyed by normalized path (e.g. `./.eas/functions/setup`). */
   private readonly compositeFunctionCatalog: CompositeFunctionCatalog;
+  private readonly loadCompositeFunction?: (
+    compositeFunctionPath: string
+  ) => Promise<CompositeFunctionConfig>;
 
   constructor(
     ctx: BuildStepGlobalContext,
@@ -49,6 +54,7 @@ export class StepsConfigParser extends AbstractConfigParser {
       externalFunctions,
       externalFunctionGroups,
       compositeFunctionCatalog,
+      loadCompositeFunction,
     }: {
       steps: Step[];
       // Required (not `hooks?:`) so a call site cannot silently forget to pass
@@ -57,6 +63,8 @@ export class StepsConfigParser extends AbstractConfigParser {
       externalFunctions?: BuildFunction[];
       externalFunctionGroups?: BuildFunctionGroup[];
       compositeFunctionCatalog?: CompositeFunctionCatalog;
+      /** Loads a hook composite missing from the catalog. When omitted, missing entries fail as unknown. */
+      loadCompositeFunction?: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
     }
   ) {
     super(ctx, {
@@ -66,7 +74,9 @@ export class StepsConfigParser extends AbstractConfigParser {
 
     this.steps = steps;
     this.hooks = hooks ?? {};
-    this.compositeFunctionCatalog = compositeFunctionCatalog ?? {};
+    // Shallow copy so lazy loading never mutates a caller-owned catalog.
+    this.compositeFunctionCatalog = { ...(compositeFunctionCatalog ?? {}) };
+    this.loadCompositeFunction = loadCompositeFunction;
   }
 
   protected async parseConfigToBuildStepsAndBuildFunctionByIdMappingAsync(): Promise<{
@@ -87,6 +97,7 @@ export class StepsConfigParser extends AbstractConfigParser {
     const buildFunctionGroupById = createBuildFunctionGroupByIdMapping(
       this.externalFunctionGroups ?? []
     );
+    // Expander shares this catalog by reference; it grows as hook composites load.
     const compositeFunctionExpander = new CompositeFunctionExpander(
       this.ctx,
       this.compositeFunctionCatalog,
@@ -102,6 +113,7 @@ export class StepsConfigParser extends AbstractConfigParser {
     // step ids identical across the splicing→engine rollout.
     const buildSteps: BuildStep[] = [];
     const hooksByAnchorStep = new Map<BuildStep, AnchorHooks>();
+    const seenAnchorIds = new Set<HookAnchorId>();
 
     for (const stepConfig of validatedSteps) {
       const maybeFunctionGroup =
@@ -122,7 +134,8 @@ export class StepsConfigParser extends AbstractConfigParser {
           if (anchorId === undefined) {
             continue;
           }
-          const anchorHooks = this.constructAnchorHooks(
+          seenAnchorIds.add(anchorId);
+          const anchorHooks = await this.constructAnchorHooksAsync(
             anchorId,
             validatedHooks,
             compositeFunctionExpander
@@ -148,7 +161,8 @@ export class StepsConfigParser extends AbstractConfigParser {
           'Hook anchors are not supported on local composite function steps.'
         );
       }
-      const before = this.constructHookSideEntries(
+      seenAnchorIds.add(anchorId);
+      const before = await this.constructHookSideEntriesAsync(
         anchorId,
         'before',
         validatedHooks,
@@ -164,7 +178,7 @@ export class StepsConfigParser extends AbstractConfigParser {
       );
       const anchorStep = createdSteps[0];
       buildSteps.push(anchorStep);
-      const after = this.constructHookSideEntries(
+      const after = await this.constructHookSideEntriesAsync(
         anchorId,
         'after',
         validatedHooks,
@@ -172,6 +186,15 @@ export class StepsConfigParser extends AbstractConfigParser {
       );
       if (before.length > 0 || after.length > 0) {
         hooksByAnchorStep.set(anchorStep, { anchor: anchorId, before, after });
+      }
+    }
+
+    for (const hookKey of Object.keys(validatedHooks)) {
+      const parsed = parseHookKey(hookKey);
+      if (parsed !== null && !seenAnchorIds.has(parsed.anchorId)) {
+        this.ctx.baseLogger.warn(
+          `Ignoring "hooks.${hookKey}": this build does not run the "${parsed.anchorId}" step.`
+        );
       }
     }
 
@@ -229,18 +252,18 @@ export class StepsConfigParser extends AbstractConfigParser {
     return undefined;
   }
 
-  private constructAnchorHooks(
+  private async constructAnchorHooksAsync(
     anchorId: HookAnchorId,
     validatedHooks: Record<string, Step[]>,
     compositeFunctionExpander: CompositeFunctionExpander
-  ): AnchorHooks | undefined {
-    const before = this.constructHookSideEntries(
+  ): Promise<AnchorHooks | undefined> {
+    const before = await this.constructHookSideEntriesAsync(
       anchorId,
       'before',
       validatedHooks,
       compositeFunctionExpander
     );
-    const after = this.constructHookSideEntries(
+    const after = await this.constructHookSideEntriesAsync(
       anchorId,
       'after',
       validatedHooks,
@@ -252,15 +275,34 @@ export class StepsConfigParser extends AbstractConfigParser {
     return { anchor: anchorId, before, after };
   }
 
-  private constructHookSideEntries(
+  private async constructHookSideEntriesAsync(
     anchorId: HookAnchorId,
     side: 'before' | 'after',
     validatedHooks: Record<string, Step[]>,
     compositeFunctionExpander: CompositeFunctionExpander
-  ): HookEntry[] {
+  ): Promise<HookEntry[]> {
     const hookSteps = validatedHooks[`${side}_${anchorId}`];
     if (hookSteps === undefined) {
       return [];
+    }
+    if (this.loadCompositeFunction !== undefined) {
+      // Load only once the anchor runs, so unused anchors do not fail on missing composites.
+      try {
+        await extendCompositeFunctionCatalogFromStepsAsync({
+          catalog: this.compositeFunctionCatalog,
+          rootSteps: hookSteps,
+          loadCompositeFunction: this.loadCompositeFunction,
+        });
+      } catch (err) {
+        if (err instanceof BuildConfigError) {
+          throw err;
+        }
+        throw new BuildConfigError(
+          `Failed to load a local composite function referenced from "hooks.${side}_${anchorId}": ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
     }
     return constructHookEntriesFromValidatedSteps(this.ctx, hookSteps, compositeFunctionExpander);
   }

--- a/packages/steps/src/StepsConfigParser.ts
+++ b/packages/steps/src/StepsConfigParser.ts
@@ -323,7 +323,14 @@ export class StepsConfigParser extends AbstractConfigParser {
         );
       }
     }
-    return constructHookEntriesFromValidatedSteps(this.ctx, hookSteps, compositeFunctionExpander);
+    try {
+      return constructHookEntriesFromValidatedSteps(this.ctx, hookSteps, compositeFunctionExpander);
+    } catch (err) {
+      if (err instanceof BuildConfigError) {
+        throw new BuildConfigError(`Invalid steps in "hooks.${side}_${anchorId}": ${err.message}`);
+      }
+      throw err;
+    }
   }
 
   private createBuildStepsFromNonGroupStepConfig(

--- a/packages/steps/src/StepsConfigParser.ts
+++ b/packages/steps/src/StepsConfigParser.ts
@@ -312,7 +312,9 @@ export class StepsConfigParser extends AbstractConfigParser {
         });
       } catch (err) {
         if (err instanceof BuildConfigError) {
-          throw err;
+          throw new BuildConfigError(
+            `Invalid steps in "hooks.${side}_${anchorId}": ${err.message}`
+          );
         }
         throw new BuildConfigError(
           `Failed to load a local composite function referenced from "hooks.${side}_${anchorId}": ${

--- a/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
@@ -885,7 +885,7 @@ describe('StepsConfigParser lazy hook composite loading', () => {
     expect(error.message).toMatch(/hooks\.after_install_node_modules/);
   });
 
-  it('surfaces a BuildConfigError from catalog extension unwrapped (working_directory on a composite call)', async () => {
+  it('names the hook key when a composite hook call sets working_directory', async () => {
     const error = await getErrorAsync<BuildConfigError>(async () => {
       await parseWorkflowAsync({
         ctx,
@@ -901,6 +901,7 @@ describe('StepsConfigParser lazy hook composite loading', () => {
       });
     });
     expect(error).toBeInstanceOf(BuildConfigError);
+    expect(error.message).toMatch(/hooks\.before_install_node_modules/);
     expect(error.message).toMatch(/"working_directory" is not supported/);
     expect(error.message).not.toMatch(/Failed to load/);
   });

--- a/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
@@ -847,6 +847,17 @@ describe('StepsConfigParser lazy hook composite loading', () => {
     );
   });
 
+  it('warns for an unknown hook key', async () => {
+    await parseWorkflowAsync({
+      ctx,
+      steps: [{ uses: 'eas/checkout' }],
+      hooks: { before_install_node_module: [{ run: 'echo typo' }] },
+    });
+    expect(ctx.baseLogger.warn).toHaveBeenCalledWith(
+      'Ignoring unknown hook key "before_install_node_module".'
+    );
+  });
+
   it('wraps a loader failure in a BuildConfigError naming the before-side hook key', async () => {
     const error = await getErrorAsync<BuildConfigError>(async () => {
       await parseWorkflowAsync({

--- a/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
@@ -272,6 +272,20 @@ describe('StepsConfigParser hook construction', () => {
     });
     expect(error).toBeInstanceOf(BuildConfigError);
     expect(error.message).toMatch(/nonexistent_function/);
+    expect(error.message).toMatch(/hooks\.before_install_node_modules/);
+  });
+
+  it('ignores a registered hook key whose anchor is absent even when its steps use unknown functions', async () => {
+    const workflow = await parseWorkflowAsync({
+      ctx,
+      steps: [{ uses: 'eas/checkout' }],
+      hooks: { before_install_node_modules: [{ uses: 'eas/some_newer_function' }] },
+    });
+    expect(orderedDisplayNames(workflow)).toEqual(['Checkout']);
+    expect(workflow.hooksByAnchorStep.size).toBe(0);
+    expect(ctx.baseLogger.warn).toHaveBeenCalledWith(
+      'Ignoring "hooks.before_install_node_modules": this build does not run the "install_node_modules" step.'
+    );
   });
 
   it('rejects a hook step using a composite function missing from the catalog with BuildConfigError', async () => {

--- a/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
@@ -698,6 +698,28 @@ describe('StepsConfigParser hooks with composite functions', () => {
     expect(error.message).toMatch(/"working_directory" is not supported/);
   });
 
+  it('reports the hook key on composite expansion errors', async () => {
+    const error = await getErrorAsync<BuildConfigError>(async () => {
+      await parseWorkflowAsync({
+        ctx,
+        steps: [{ uses: 'eas/install_node_modules' }],
+        hooks: {
+          before_install_node_modules: [{ uses: './.eas/functions/notify', id: 'notify' }],
+        },
+        compositeFunctionCatalog: makeCatalog({
+          './.eas/functions/notify': {
+            inputs: [{ name: 'message', type: 'string', required: true }],
+            runs: { steps: [{ run: 'echo hi' }] },
+          },
+        }),
+      });
+    });
+    expect(error).toBeInstanceOf(BuildConfigError);
+    expect(error.message).toMatch(
+      /^Invalid steps in "hooks\.before_install_node_modules": Input parameter "message"/
+    );
+  });
+
   it('flattens nested composite calls into a single hook entry', async () => {
     const workflow = await parseWorkflowAsync({
       ctx,

--- a/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
@@ -1,4 +1,10 @@
-import { CompositeFunctionCatalog, Hooks, Step } from '@expo/eas-build-job';
+import {
+  CompositeFunctionCatalog,
+  CompositeFunctionConfig,
+  CompositeFunctionConfigZ,
+  Hooks,
+  Step,
+} from '@expo/eas-build-job';
 
 import { makeCatalog } from './StepsConfigParser-composite-functions-test-utils';
 import { createGlobalContextMock } from './utils/context';
@@ -40,6 +46,7 @@ async function parseWorkflowAsync({
   externalFunctions,
   externalFunctionGroups,
   compositeFunctionCatalog,
+  loadCompositeFunction,
 }: {
   ctx: BuildStepGlobalContext;
   steps: Step[];
@@ -47,6 +54,7 @@ async function parseWorkflowAsync({
   externalFunctions?: BuildFunction[];
   externalFunctionGroups?: BuildFunctionGroup[];
   compositeFunctionCatalog?: CompositeFunctionCatalog;
+  loadCompositeFunction?: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
 }): Promise<BuildWorkflow> {
   const parser = new StepsConfigParser(ctx, {
     steps,
@@ -57,6 +65,7 @@ async function parseWorkflowAsync({
     ],
     externalFunctionGroups,
     compositeFunctionCatalog,
+    loadCompositeFunction,
   });
   return await parser.parseAsync();
 }
@@ -744,6 +753,217 @@ describe('StepsConfigParser hooks with composite functions', () => {
       });
     });
     expect(error).toBeInstanceOf(BuildWorkflowError);
+  });
+});
+
+describe('StepsConfigParser lazy hook composite loading', () => {
+  let ctx: BuildStepGlobalContext;
+
+  beforeEach(() => {
+    ctx = createGlobalContextMock();
+  });
+
+  function createLoader(entries: Record<string, unknown>): {
+    loadCompositeFunction: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
+    loadedPaths: string[];
+  } {
+    const loadedPaths: string[] = [];
+    return {
+      loadedPaths,
+      loadCompositeFunction: async compositeFunctionPath => {
+        loadedPaths.push(compositeFunctionPath);
+        const raw = entries[compositeFunctionPath];
+        if (raw === undefined) {
+          throw new Error(`no such composite function: ${compositeFunctionPath}`);
+        }
+        return CompositeFunctionConfigZ.parse(raw);
+      },
+    };
+  }
+
+  function rejectingLoader(): (compositeFunctionPath: string) => Promise<CompositeFunctionConfig> {
+    return async compositeFunctionPath => {
+      throw new Error(`must not be called, got: ${compositeFunctionPath}`);
+    };
+  }
+
+  it('loads a hook composite through the loader (normalized path) when the anchor is present', async () => {
+    const { loadCompositeFunction, loadedPaths } = createLoader({
+      './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
+    });
+    const workflow = await parseWorkflowAsync({
+      ctx,
+      steps: [{ uses: 'eas/install_node_modules' }],
+      hooks: {
+        // Trailing slash must normalize before the loader is called.
+        before_install_node_modules: [{ uses: './.eas/functions/setup/', id: 'setup' }],
+      },
+      loadCompositeFunction,
+    });
+    expect(loadedPaths).toEqual(['./.eas/functions/setup']);
+    const anchorHooks = [...workflow.hooksByAnchorStep.values()][0];
+    expect(anchorHooks.before).toHaveLength(1);
+    expect(anchorHooks.before[0].steps.map(step => step.id)).toEqual([
+      'setup__composite_function_step_1',
+    ]);
+  });
+
+  it('never calls the loader and parses successfully when the hook anchor is absent', async () => {
+    // www merges defaults.hooks into every job; absent anchors must not fail on
+    // composites that only resolve under another job's project root.
+    const workflow = await parseWorkflowAsync({
+      ctx,
+      steps: [{ uses: 'eas/checkout' }],
+      hooks: {
+        before_install_node_modules: [{ uses: './.eas/functions/only-elsewhere' }],
+      },
+      loadCompositeFunction: rejectingLoader(),
+    });
+    expect(orderedDisplayNames(workflow)).toEqual(['Checkout']);
+  });
+
+  it('warns for a registered hook key whose anchor never appeared', async () => {
+    await parseWorkflowAsync({
+      ctx,
+      steps: [{ uses: 'eas/checkout' }],
+      hooks: { before_install_node_modules: [{ run: 'echo never' }] },
+    });
+    expect(ctx.baseLogger.warn).toHaveBeenCalledWith(
+      'Ignoring "hooks.before_install_node_modules": this build does not run the "install_node_modules" step.'
+    );
+  });
+
+  it('wraps a loader failure in a BuildConfigError naming the before-side hook key', async () => {
+    const error = await getErrorAsync<BuildConfigError>(async () => {
+      await parseWorkflowAsync({
+        ctx,
+        steps: [{ uses: 'eas/install_node_modules' }],
+        hooks: { before_install_node_modules: [{ uses: './.eas/functions/missing' }] },
+        loadCompositeFunction: createLoader({}).loadCompositeFunction,
+      });
+    });
+    expect(error).toBeInstanceOf(BuildConfigError);
+    expect(error.message).toMatch(/hooks\.before_install_node_modules/);
+    expect(error.message).toMatch(/no such composite function: \.\/\.eas\/functions\/missing/);
+  });
+
+  it('names the after-side hook key in the wrapped loader failure', async () => {
+    const error = await getErrorAsync<BuildConfigError>(async () => {
+      await parseWorkflowAsync({
+        ctx,
+        steps: [{ uses: 'eas/install_node_modules' }],
+        hooks: { after_install_node_modules: [{ uses: './.eas/functions/missing' }] },
+        loadCompositeFunction: createLoader({}).loadCompositeFunction,
+      });
+    });
+    expect(error).toBeInstanceOf(BuildConfigError);
+    expect(error.message).toMatch(/hooks\.after_install_node_modules/);
+  });
+
+  it('surfaces a BuildConfigError from catalog extension unwrapped (working_directory on a composite call)', async () => {
+    const error = await getErrorAsync<BuildConfigError>(async () => {
+      await parseWorkflowAsync({
+        ctx,
+        steps: [{ uses: 'eas/install_node_modules' }],
+        hooks: {
+          before_install_node_modules: [
+            { uses: './.eas/functions/setup', id: 'setup', working_directory: 'app' },
+          ],
+        },
+        loadCompositeFunction: createLoader({
+          './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
+        }).loadCompositeFunction,
+      });
+    });
+    expect(error).toBeInstanceOf(BuildConfigError);
+    expect(error.message).toMatch(/"working_directory" is not supported/);
+    expect(error.message).not.toMatch(/Failed to load/);
+  });
+
+  it('calls the loader once per composite across repeated occurrences of the same anchor', async () => {
+    const { loadCompositeFunction, loadedPaths } = createLoader({
+      './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
+    });
+    await parseWorkflowAsync({
+      ctx,
+      steps: [{ uses: 'eas/install_node_modules' }, { uses: 'eas/install_node_modules' }],
+      hooks: { before_install_node_modules: [{ uses: './.eas/functions/setup' }] },
+      loadCompositeFunction,
+    });
+    expect(loadedPaths).toEqual(['./.eas/functions/setup']);
+  });
+
+  it('never calls the loader for a composite already present in the prebuilt catalog', async () => {
+    const workflow = await parseWorkflowAsync({
+      ctx,
+      steps: [{ uses: 'eas/install_node_modules' }],
+      hooks: { before_install_node_modules: [{ uses: './.eas/functions/setup' }] },
+      compositeFunctionCatalog: makeCatalog({
+        './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
+      }),
+      loadCompositeFunction: rejectingLoader(),
+    });
+    expect(workflow.hooksByAnchorStep.size).toBe(1);
+  });
+
+  it('loads composites transitively referenced by a hook composite', async () => {
+    const { loadCompositeFunction, loadedPaths } = createLoader({
+      './.eas/functions/outer': {
+        runs: { steps: [{ uses: './.eas/functions/inner', id: 'mid' }] },
+      },
+      './.eas/functions/inner': { runs: { steps: [{ run: 'echo inner' }] } },
+    });
+    const workflow = await parseWorkflowAsync({
+      ctx,
+      steps: [{ uses: 'eas/install_node_modules' }],
+      hooks: { before_install_node_modules: [{ uses: './.eas/functions/outer', id: 'top' }] },
+      loadCompositeFunction,
+    });
+    expect(loadedPaths.sort()).toEqual(['./.eas/functions/inner', './.eas/functions/outer']);
+    const anchorHooks = [...workflow.hooksByAnchorStep.values()][0];
+    expect(anchorHooks.before[0].steps.map(step => step.id)).toEqual([
+      'top__mid__composite_function_step_1',
+    ]);
+  });
+
+  it('loads hook composites for an anchor discovered inside a function-group expansion', async () => {
+    const checkoutFunction = createCheckoutFunction();
+    const installFunction = createInstallNodeModulesFunction();
+    const group = new BuildFunctionGroup({
+      namespace: 'test',
+      id: 'group',
+      createBuildStepsFromFunctionGroupCall: globalCtx => [
+        checkoutFunction.createBuildStepFromFunctionCall(globalCtx),
+        installFunction.createBuildStepFromFunctionCall(globalCtx),
+      ],
+    });
+    const { loadCompositeFunction, loadedPaths } = createLoader({
+      './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
+    });
+    const workflow = await parseWorkflowAsync({
+      ctx,
+      steps: [{ uses: 'test/group' }],
+      hooks: { before_install_node_modules: [{ uses: './.eas/functions/setup', id: 'setup' }] },
+      externalFunctions: [checkoutFunction, installFunction],
+      externalFunctionGroups: [group],
+      loadCompositeFunction,
+    });
+    expect(loadedPaths).toEqual(['./.eas/functions/setup']);
+    expect(workflow.hooksByAnchorStep.size).toBe(1);
+  });
+
+  it('does not mutate the caller-owned catalog when loading lazily', async () => {
+    const callerCatalog = makeCatalog({});
+    await parseWorkflowAsync({
+      ctx,
+      steps: [{ uses: 'eas/install_node_modules' }],
+      hooks: { before_install_node_modules: [{ uses: './.eas/functions/setup' }] },
+      compositeFunctionCatalog: callerCatalog,
+      loadCompositeFunction: createLoader({
+        './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
+      }).loadCompositeFunction,
+    });
+    expect(Object.keys(callerCatalog)).toEqual([]);
   });
 });
 

--- a/packages/steps/src/utils/__tests__/localCompositeFunctions-test.ts
+++ b/packages/steps/src/utils/__tests__/localCompositeFunctions-test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import {
   buildCompositeFunctionCatalogFromStepsAsync,
+  extendCompositeFunctionCatalogFromStepsAsync,
   isLocalCompositeFunctionPath,
   parseLocalCompositeFunctionPath,
   resolveLocalCompositeFunctionPath,
@@ -211,6 +212,65 @@ describe(buildCompositeFunctionCatalogFromStepsAsync, () => {
         CompositeFunctionConfigZ.parse({ runs: { steps: [{ run: 'echo setup' }] } }),
     });
     expect(Object.keys(catalog)).toEqual([]);
+  });
+});
+
+describe(extendCompositeFunctionCatalogFromStepsAsync, () => {
+  it('extends the given catalog in place', async () => {
+    const catalog = {
+      './.eas/functions/existing': CompositeFunctionConfigZ.parse({
+        runs: { steps: [{ run: 'echo existing' }] },
+      }),
+    };
+    await extendCompositeFunctionCatalogFromStepsAsync({
+      catalog,
+      rootSteps: [{ uses: './.eas/functions/setup' }],
+      loadCompositeFunction: async () =>
+        CompositeFunctionConfigZ.parse({ runs: { steps: [{ run: 'echo setup' }] } }),
+    });
+    expect(Object.keys(catalog).sort()).toEqual([
+      './.eas/functions/existing',
+      './.eas/functions/setup',
+    ]);
+  });
+
+  it('skips paths already present without calling the loader', async () => {
+    const loadedPaths: string[] = [];
+    const catalog = {
+      './.eas/functions/setup': CompositeFunctionConfigZ.parse({
+        runs: { steps: [{ run: 'echo setup' }] },
+      }),
+    };
+    await extendCompositeFunctionCatalogFromStepsAsync({
+      catalog,
+      rootSteps: [{ uses: './.eas/functions/setup' }],
+      loadCompositeFunction: async compositeFunctionPath => {
+        loadedPaths.push(compositeFunctionPath);
+        throw new Error(`must not be called: ${compositeFunctionPath}`);
+      },
+    });
+    expect(loadedPaths).toEqual([]);
+    expect(Object.keys(catalog)).toEqual(['./.eas/functions/setup']);
+  });
+
+  it('recurses into nested references', async () => {
+    const catalog = {};
+    await extendCompositeFunctionCatalogFromStepsAsync({
+      catalog,
+      rootSteps: [{ uses: './.eas/functions/outer' }],
+      loadCompositeFunction: async compositeFunctionPath => {
+        if (compositeFunctionPath === './.eas/functions/outer') {
+          return CompositeFunctionConfigZ.parse({
+            runs: { steps: [{ uses: './.eas/functions/inner' }] },
+          });
+        }
+        return CompositeFunctionConfigZ.parse({ runs: { steps: [{ run: 'echo inner' }] } });
+      },
+    });
+    expect(Object.keys(catalog).sort()).toEqual([
+      './.eas/functions/inner',
+      './.eas/functions/outer',
+    ]);
   });
 });
 

--- a/packages/steps/src/utils/localCompositeFunctions.ts
+++ b/packages/steps/src/utils/localCompositeFunctions.ts
@@ -51,7 +51,20 @@ export async function buildCompositeFunctionCatalogFromStepsAsync({
   loadCompositeFunction: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
 }): Promise<CompositeFunctionCatalog> {
   const catalog: CompositeFunctionCatalog = {};
+  await extendCompositeFunctionCatalogFromStepsAsync({ catalog, rootSteps, loadCompositeFunction });
+  return catalog;
+}
 
+/** Extends `catalog` in place with functions transitively referenced by `rootSteps`. Skips paths already present. */
+export async function extendCompositeFunctionCatalogFromStepsAsync({
+  catalog,
+  rootSteps,
+  loadCompositeFunction,
+}: {
+  catalog: CompositeFunctionCatalog;
+  rootSteps: readonly Step[];
+  loadCompositeFunction: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
+}): Promise<void> {
   const loadRecursiveAsync = async (compositeFunctionPath: string): Promise<void> => {
     if (compositeFunctionPath in catalog) {
       return;
@@ -68,8 +81,6 @@ export async function buildCompositeFunctionCatalogFromStepsAsync({
   for (const compositeFunctionPath of collectLocalCompositeFunctionPathsFromSteps(rootSteps)) {
     await loadRecursiveAsync(compositeFunctionPath);
   }
-
-  return catalog;
 }
 
 export function resolveLocalCompositeFunctionPath(


### PR DESCRIPTION
# Why

Local composite functions can be referenced from hook steps (`uses: ./...`), but build-tools only builds the composite catalog from job `steps`.

# How

- Steps-based jobs: eager catalog loag from job `steps`, pass a lazy `loadCompositeFunction` loader so hook composites load only when their anchor runs
- Native jobs: load only from wrapped anchors
- Warn and skip for registered hook keys whose anchors never appear
 
# Test Plan

Added unit tests.