### PR TITLE
[build-tools] Collect Argent tool-server session events during remote sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [build-tools] Collect and upload Argent tool-server session events during remote simulator sessions, mirroring agent-device event collection. ([#4067](https://github.com/expo/eas-cli/pull/4067) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 - [eas-cli] Suggest running `agent-device` via `npx` in EAS Simulator session instructions. ([#4070](https://github.com/expo/eas-cli/pull/4070) by [@szdziedzic](https://github.com/szdziedzic))

--- a/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
@@ -1,0 +1,138 @@
+import { BuildRuntimePlatform, type BuildStepContext } from '@expo/steps';
+import spawn from '@expo/turtle-spawn';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { type CustomBuildContext } from '../../../customBuildContext';
+import { isProcessDescendantOfAsync } from '../../../utils/processes';
+import { pollArgentArtifactsForUploadAsync } from '../../utils/argentArtifacts';
+import { startArgentEventCollectionAsync } from '../../utils/argentEvents';
+import {
+  getDeviceRunSessionIdOrThrow,
+  getNgrokAuthtokenOrThrow,
+  getNgrokTunnelDomainOrThrow,
+  selectXcodeDeveloperDirectoryAsync,
+  spawnDetached,
+  startNgrokTunnelAsync,
+  uploadRemoteSessionConfigAsync,
+  waitForDeviceRunSessionStoppedAsync,
+} from '../../utils/remoteDeviceRunSession';
+import { createStartArgentRemoteSessionBuildFunction } from '../startArgentRemoteSession';
+
+// Redirect ~/.argent (where the tool-server writes its state file and event log) to a temp
+// home so waitForArgentToolServerStateAsync — which lives in the module under test and cannot
+// be mocked directly — can read a real state file we control.
+jest.mock('node:os', () => {
+  const actual = jest.requireActual('node:os');
+  const actualPath = jest.requireActual('node:path');
+  return {
+    ...actual,
+    homedir: () => actualPath.join(actual.tmpdir(), 'eas-argent-orchestration-home'),
+  };
+});
+jest.mock('@expo/turtle-spawn', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../../../sentry');
+jest.mock('../../../utils/processes', () => ({ isProcessDescendantOfAsync: jest.fn() }));
+jest.mock('../../utils/argentArtifacts', () => ({ pollArgentArtifactsForUploadAsync: jest.fn() }));
+jest.mock('../../utils/argentEvents', () => ({
+  ...jest.requireActual('../../utils/argentEvents'),
+  startArgentEventCollectionAsync: jest.fn(),
+}));
+jest.mock('../../utils/remoteDeviceRunSession', () => ({
+  getDeviceRunSessionIdOrThrow: jest.fn(),
+  getNgrokAuthtokenOrThrow: jest.fn(),
+  getNgrokTunnelDomainOrThrow: jest.fn(),
+  selectXcodeDeveloperDirectoryAsync: jest.fn(),
+  spawnDetached: jest.fn(),
+  startNgrokTunnelAsync: jest.fn(),
+  startServeSimWithTunnelAsync: jest.fn(),
+  uploadRemoteSessionConfigAsync: jest.fn(),
+  waitForDeviceRunSessionStoppedAsync: jest.fn(),
+}));
+
+const TEST_HOME = path.join(os.tmpdir(), 'eas-argent-orchestration-home');
+const ARGENT_STATE_DIR = path.join(TEST_HOME, '.argent');
+const EXPECTED_EVENT_LOG_PATH = path.join(ARGENT_STATE_DIR, 'tool-server-events.jsonl');
+
+const mockStopAsync = jest.fn();
+
+describe('createStartArgentRemoteSessionBuildFunction orchestration', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    jest.mocked(spawn).mockResolvedValue(undefined as never);
+    jest.mocked(isProcessDescendantOfAsync).mockResolvedValue(true);
+    jest.mocked(pollArgentArtifactsForUploadAsync).mockResolvedValue(undefined);
+    mockStopAsync.mockResolvedValue(undefined);
+    jest.mocked(startArgentEventCollectionAsync).mockResolvedValue({ stopAsync: mockStopAsync });
+
+    jest.mocked(getDeviceRunSessionIdOrThrow).mockReturnValue('device-run-session-id');
+    jest.mocked(getNgrokTunnelDomainOrThrow).mockReturnValue('tunnel.example.com');
+    jest.mocked(getNgrokAuthtokenOrThrow).mockReturnValue('ngrok-token');
+    jest.mocked(selectXcodeDeveloperDirectoryAsync).mockResolvedValue(undefined);
+    jest.mocked(spawnDetached).mockReturnValue({ pid: 4242, getOutput: () => '' });
+    jest.mocked(startNgrokTunnelAsync).mockResolvedValue('https://argent-abc.tunnel.example.com');
+    jest.mocked(uploadRemoteSessionConfigAsync).mockResolvedValue(undefined);
+    jest.mocked(waitForDeviceRunSessionStoppedAsync).mockResolvedValue(undefined);
+
+    // The (real) tool-server state wait reads this file from the redirected ~/.argent.
+    await fs.promises.mkdir(ARGENT_STATE_DIR, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(ARGENT_STATE_DIR, 'tool-server-orchestration.json'),
+      JSON.stringify({ port: 5678, pid: 9999, token: 'tool-server-token' })
+    );
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it('enables the event log flag, shares one path, and starts/stops the collector', async () => {
+    const ctx = {} as unknown as CustomBuildContext;
+    const buildFunction = createStartArgentRemoteSessionBuildFunction(ctx);
+
+    await buildFunction.fn!(
+      {
+        logger: { info: jest.fn(), warn: jest.fn() },
+        global: { runtimePlatform: BuildRuntimePlatform.LINUX },
+      } as unknown as BuildStepContext,
+      {
+        inputs: { package_version: { value: undefined } },
+        outputs: {},
+        env: { EXISTING: 'value' },
+      } as never
+    );
+
+    // (1) The event log flag is enabled, before the tool-server is launched.
+    const spawnCalls = jest.mocked(spawn).mock.calls;
+    const enableEventLogIndex = spawnCalls.findIndex(
+      ([command, args]) =>
+        command === 'bunx' && Array.isArray(args) && args.includes('tool-server-event-log')
+    );
+    expect(enableEventLogIndex).toBeGreaterThanOrEqual(0);
+    expect(jest.mocked(spawn).mock.invocationCallOrder[enableEventLogIndex]).toBeLessThan(
+      jest.mocked(spawnDetached).mock.invocationCallOrder[0]
+    );
+
+    // (2) The tool-server and the collector are pinned to the exact same event log path.
+    const serverEnv = jest.mocked(spawnDetached).mock.calls[0][0].env;
+    expect(serverEnv.ARGENT_EVENT_LOG).toBe(EXPECTED_EVENT_LOG_PATH);
+    expect(serverEnv.EXISTING).toBe('value');
+    expect(jest.mocked(startArgentEventCollectionAsync).mock.calls[0][0]).toMatchObject({
+      deviceRunSessionId: 'device-run-session-id',
+      eventLogPath: EXPECTED_EVENT_LOG_PATH,
+    });
+
+    // (3) Collection starts (before we wait for the session to stop) and (4) is torn down
+    // afterwards, exactly once.
+    expect(startArgentEventCollectionAsync).toHaveBeenCalledTimes(1);
+    expect(mockStopAsync).toHaveBeenCalledTimes(1);
+    expect(jest.mocked(startArgentEventCollectionAsync).mock.invocationCallOrder[0]).toBeLessThan(
+      jest.mocked(waitForDeviceRunSessionStoppedAsync).mock.invocationCallOrder[0]
+    );
+    expect(mockStopAsync.mock.invocationCallOrder[0]).toBeGreaterThan(
+      jest.mocked(waitForDeviceRunSessionStoppedAsync).mock.invocationCallOrder[0]
+    );
+  });
+});

--- a/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession.test.ts
@@ -4,11 +4,15 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import { Sentry } from '../../../sentry';
 import {
   MIN_ARGENT_REMOTE_SESSION_VERSION,
+  stopArgentEventCollectionSafelyAsync,
   waitForArgentToolServerStateAsync,
   warnIfArgentPackageVersionCannotBeVerified,
 } from '../startArgentRemoteSession';
+
+jest.mock('../../../sentry');
 
 describe(warnIfArgentPackageVersionCannotBeVerified, () => {
   const warn = jest.fn();
@@ -141,5 +145,38 @@ describe(waitForArgentToolServerStateAsync, () => {
         pollIntervalMs: 1,
       })
     ).rejects.toThrow(`state file belonging to process ${process.pid}`);
+  });
+});
+
+describe(stopArgentEventCollectionSafelyAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports an unexpected stop failure without rejecting', async () => {
+    const error = new Error('stop failed');
+    const logger = { warn: jest.fn() } as unknown as bunyan;
+
+    await expect(
+      stopArgentEventCollectionSafelyAsync({
+        eventCollection: { stopAsync: jest.fn().mockRejectedValue(error) },
+        deviceRunSessionId: 'session-id',
+        logger,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Could not finish argent session event collection',
+      error,
+      {
+        level: 'warning',
+        tags: { phase: 'argent-event-collection', operation: 'stop' },
+        extras: { deviceRunSessionId: 'session-id' },
+      }
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: error },
+      'Could not finish argent session event collection.'
+    );
   });
 });

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -15,7 +15,7 @@ import path from 'node:path';
 import { type CustomBuildContext } from '../../customBuildContext';
 import { Sentry } from '../../sentry';
 import { pollAgentDeviceArtifactsForUploadAsync } from '../utils/agentDeviceArtifacts';
-import { startAgentDeviceEventCollectionAsync } from '../utils/deviceRunSessionEvents';
+import { startAgentDeviceEventCollectionAsync } from '../utils/agentDeviceEvents';
 import {
   type DetachedProcessHandle,
   getDeviceRunSessionIdOrThrow,

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -18,7 +18,7 @@ import { Sentry } from '../../sentry';
 import { isProcessDescendantOfAsync } from '../../utils/processes';
 import { sleepAsync } from '../../utils/retry';
 import { pollArgentArtifactsForUploadAsync } from '../utils/argentArtifacts';
-import { startArgentEventCollectionAsync } from '../utils/argentEvents';
+import { ARGENT_EVENT_LOG_FILENAME, startArgentEventCollectionAsync } from '../utils/argentEvents';
 import {
   getDeviceRunSessionIdOrThrow,
   getNgrokAuthtokenOrThrow,
@@ -39,6 +39,10 @@ const ARGENT_ARTIFACTS_LIST_ENDPOINT_FLAG = 'artifacts-list-endpoint';
 // Tells the tool-server to write its structured event log so we can collect session events.
 const ARGENT_EVENT_LOG_FLAG = 'tool-server-event-log';
 const ARGENT_STATE_DIR = path.join(os.homedir(), '.argent');
+// Pin the event log path explicitly and hand the same value to the tool-server (via
+// ARGENT_EVENT_LOG) and the collector, so an ambient ARGENT_EVENT_LOG or a future change to
+// Argent's default can never make the two disagree.
+const ARGENT_EVENT_LOG_PATH = path.join(ARGENT_STATE_DIR, ARGENT_EVENT_LOG_FILENAME);
 const STARTUP_TIMEOUT_MS = 60_000;
 
 const ArgentToolServerStateSchema = z.object({
@@ -114,7 +118,7 @@ export function createStartArgentRemoteSessionBuildFunction(
           '0',
           '--force',
         ],
-        env,
+        env: { ...env, ARGENT_EVENT_LOG: ARGENT_EVENT_LOG_PATH },
       });
       if (argentServer.pid === undefined) {
         throw new SystemError(
@@ -157,7 +161,7 @@ export function createStartArgentRemoteSessionBuildFunction(
       const eventCollection = await startArgentEventCollectionAsync({
         ctx,
         deviceRunSessionId,
-        stateDir: ARGENT_STATE_DIR,
+        eventLogPath: ARGENT_EVENT_LOG_PATH,
         logger,
       });
 

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -32,9 +32,11 @@ import {
 } from '../utils/remoteDeviceRunSession';
 
 const ARGENT_PACKAGE_NAME = '@swmansion/argent';
-export const MIN_ARGENT_REMOTE_SESSION_VERSION = '0.12.0';
+// 0.16.0 is the first version that exposes the tool-server event log flag; keeping the floor
+// here lets us enable it (and the artifacts list endpoint) unconditionally below.
+export const MIN_ARGENT_REMOTE_SESSION_VERSION = '0.16.0';
 const ARGENT_ARTIFACTS_LIST_ENDPOINT_FLAG = 'artifacts-list-endpoint';
-// Tells the tool-server to write its structured event log; requires @swmansion/argent >= 0.16.0.
+// Tells the tool-server to write its structured event log so we can collect session events.
 const ARGENT_EVENT_LOG_FLAG = 'tool-server-event-log';
 const ARGENT_STATE_DIR = path.join(os.homedir(), '.argent');
 const STARTUP_TIMEOUT_MS = 60_000;
@@ -90,26 +92,12 @@ export function createStartArgentRemoteSessionBuildFunction(
         { env, logger }
       );
 
-      // Best-effort: the tool-server event log flag only exists in @swmansion/argent >= 0.16.0,
-      // and `argent enable` exits non-zero for an unknown flag on older pinned versions. Session
-      // event collection is additive, so a failure here must not fail the remote session.
       logger.info('Enabling the Argent tool-server event log flag.');
-      try {
-        await spawn(
-          'bunx',
-          [`${ARGENT_PACKAGE_NAME}@${versionSpec}`, 'enable', ARGENT_EVENT_LOG_FLAG],
-          { env, logger }
-        );
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err));
-        Sentry.capture('Could not enable the Argent tool-server event log flag', error, {
-          level: 'warning',
-        });
-        logger.warn(
-          { err: error },
-          'Could not enable the Argent tool-server event log flag; session events may not be collected.'
-        );
-      }
+      await spawn(
+        'bunx',
+        [`${ARGENT_PACKAGE_NAME}@${versionSpec}`, 'enable', ARGENT_EVENT_LOG_FLAG],
+        { env, logger }
+      );
 
       logger.info(`Launching ${ARGENT_PACKAGE_NAME}@${versionSpec} tool-server via bunx.`);
       // Keep Argent itself in foreground mode under the detached bunx process. This preserves

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -18,6 +18,7 @@ import { Sentry } from '../../sentry';
 import { isProcessDescendantOfAsync } from '../../utils/processes';
 import { sleepAsync } from '../../utils/retry';
 import { pollArgentArtifactsForUploadAsync } from '../utils/argentArtifacts';
+import { startArgentEventCollectionAsync } from '../utils/argentEvents';
 import {
   getDeviceRunSessionIdOrThrow,
   getNgrokAuthtokenOrThrow,
@@ -33,6 +34,8 @@ import {
 const ARGENT_PACKAGE_NAME = '@swmansion/argent';
 export const MIN_ARGENT_REMOTE_SESSION_VERSION = '0.12.0';
 const ARGENT_ARTIFACTS_LIST_ENDPOINT_FLAG = 'artifacts-list-endpoint';
+// Tells the tool-server to write its structured event log; requires @swmansion/argent >= 0.16.0.
+const ARGENT_EVENT_LOG_FLAG = 'tool-server-event-log';
 const ARGENT_STATE_DIR = path.join(os.homedir(), '.argent');
 const STARTUP_TIMEOUT_MS = 60_000;
 
@@ -86,6 +89,27 @@ export function createStartArgentRemoteSessionBuildFunction(
         [`${ARGENT_PACKAGE_NAME}@${versionSpec}`, 'enable', ARGENT_ARTIFACTS_LIST_ENDPOINT_FLAG],
         { env, logger }
       );
+
+      // Best-effort: the tool-server event log flag only exists in @swmansion/argent >= 0.16.0,
+      // and `argent enable` exits non-zero for an unknown flag on older pinned versions. Session
+      // event collection is additive, so a failure here must not fail the remote session.
+      logger.info('Enabling the Argent tool-server event log flag.');
+      try {
+        await spawn(
+          'bunx',
+          [`${ARGENT_PACKAGE_NAME}@${versionSpec}`, 'enable', ARGENT_EVENT_LOG_FLAG],
+          { env, logger }
+        );
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        Sentry.capture('Could not enable the Argent tool-server event log flag', error, {
+          level: 'warning',
+        });
+        logger.warn(
+          { err: error },
+          'Could not enable the Argent tool-server event log flag; session events may not be collected.'
+        );
+      }
 
       logger.info(`Launching ${ARGENT_PACKAGE_NAME}@${versionSpec} tool-server via bunx.`);
       // Keep Argent itself in foreground mode under the detached bunx process. This preserves
@@ -142,6 +166,13 @@ export function createStartArgentRemoteSessionBuildFunction(
         signal: artifactPollSignal,
       });
 
+      const eventCollection = await startArgentEventCollectionAsync({
+        ctx,
+        deviceRunSessionId,
+        stateDir: ARGENT_STATE_DIR,
+        logger,
+      });
+
       try {
         const publicToolsUrl = await startNgrokTunnelAsync({
           port: toolServerPort,
@@ -184,6 +215,7 @@ export function createStartArgentRemoteSessionBuildFunction(
           signal,
         });
       } finally {
+        await stopArgentEventCollectionSafelyAsync({ eventCollection, deviceRunSessionId, logger });
         artifactPollAbortController.abort();
         try {
           await artifactPollingPromise;
@@ -195,6 +227,28 @@ export function createStartArgentRemoteSessionBuildFunction(
       }
     },
   });
+}
+
+export async function stopArgentEventCollectionSafelyAsync({
+  eventCollection,
+  deviceRunSessionId,
+  logger,
+}: {
+  eventCollection: { stopAsync: () => Promise<void> };
+  deviceRunSessionId: string;
+  logger: bunyan;
+}): Promise<void> {
+  try {
+    await eventCollection.stopAsync();
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    Sentry.capture('Could not finish argent session event collection', error, {
+      level: 'warning',
+      tags: { phase: 'argent-event-collection', operation: 'stop' },
+      extras: { deviceRunSessionId },
+    });
+    logger.warn({ err: error }, 'Could not finish argent session event collection.');
+  }
 }
 
 export function warnIfArgentPackageVersionCannotBeVerified({

--- a/packages/build-tools/src/steps/utils/__tests__/agentDeviceEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/agentDeviceEvents.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { type CustomBuildContext } from '../../../customBuildContext';
 import RemoteLoggerStream from '../../../logging/RemoteLoggerStream';
 import { Sentry } from '../../../sentry';
-import { startAgentDeviceEventCollectionAsync } from '../deviceRunSessionEvents';
+import { startAgentDeviceEventCollectionAsync } from '../agentDeviceEvents';
 
 const mockEventLogStream = {
   init: jest.fn(async () => undefined),
@@ -370,7 +370,8 @@ describe(startAgentDeviceEventCollectionAsync, () => {
 
     expect(logger.warn).toHaveBeenCalledWith(
       {
-        agentDeviceEventParseFailures: { 'invalid-json': 1, 'invalid-event': 1 },
+        producer: 'agent-device',
+        eventParseFailures: { 'invalid-json': 1, 'invalid-event': 1 },
         parseFailureCount: 2,
       },
       'Could not parse 2 agent-device event log records.'
@@ -502,7 +503,11 @@ describe(startAgentDeviceEventCollectionAsync, () => {
       }),
       {
         level: 'warning',
-        tags: { phase: 'device-run-session-event-collection', operation: 'setup' },
+        tags: {
+          phase: 'device-run-session-event-collection',
+          operation: 'setup',
+          producer: 'agent-device',
+        },
         extras: { deviceRunSessionId: 'session-id' },
       }
     );

--- a/packages/build-tools/src/steps/utils/__tests__/agentDeviceEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/agentDeviceEvents.test.ts
@@ -447,7 +447,7 @@ describe(startAgentDeviceEventCollectionAsync, () => {
       await waitForAsync(() =>
         expect(logger.warn).toHaveBeenCalledWith(
           { err: reportingError },
-          'Agent-device event collection poller failed.'
+          'Event collection poller for agent-device failed.'
         )
       );
       await expect(collection.stopAsync()).resolves.toBeUndefined();
@@ -458,7 +458,7 @@ describe(startAgentDeviceEventCollectionAsync, () => {
     expect(Sentry.capture).toHaveBeenCalledTimes(2);
     expect(Sentry.capture).toHaveBeenNthCalledWith(
       2,
-      'Agent-device event collection poller failed',
+      'Event collection poller for agent-device failed',
       reportingError,
       {
         level: 'warning',

--- a/packages/build-tools/src/steps/utils/__tests__/argentEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/argentEvents.test.ts
@@ -1,0 +1,305 @@
+import { type bunyan } from '@expo/logger';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { type CustomBuildContext } from '../../../customBuildContext';
+import RemoteLoggerStream from '../../../logging/RemoteLoggerStream';
+import { Sentry } from '../../../sentry';
+import { startArgentEventCollectionAsync } from '../argentEvents';
+
+const mockEventLogStream = {
+  init: jest.fn(async () => undefined),
+  write: jest.fn(),
+  cleanUp: jest.fn(async () => undefined),
+};
+
+jest.mock('../../../logging/RemoteLoggerStream', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockEventLogStream),
+}));
+jest.mock('../../../sentry');
+
+const EVENT_LOG_FILENAME = 'tool-server-events.jsonl';
+
+describe(startArgentEventCollectionAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('maps tool lifecycle records onto the shared operation vocabulary', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'argent-events-'));
+    const eventLogFile = path.join(stateDir, EVENT_LOG_FILENAME);
+    await fs.promises.writeFile(
+      eventLogFile,
+      `${JSON.stringify(
+        bunyanRecord({
+          level: 30,
+          type: 'tool.invoked',
+          toolId: 'screenshot',
+          toolInvocationId: 'call-1',
+          msg: 'Capturing screenshot.',
+          time: '2026-07-10T12:00:00.000Z',
+        })
+      )}\n`
+    );
+    const ctx = createContext();
+    const logger = createLogger();
+    const collection = await startArgentEventCollectionAsync({
+      ctx,
+      deviceRunSessionId: 'session-id',
+      stateDir,
+      logger,
+      pollIntervalMs: 10,
+    });
+
+    try {
+      await waitForAsync(() => expect(mockEventLogStream.write).toHaveBeenCalledTimes(1));
+      await fs.promises.appendFile(
+        eventLogFile,
+        `${JSON.stringify(
+          bunyanRecord({
+            level: 30,
+            type: 'tool.completed',
+            toolId: 'screenshot',
+            toolInvocationId: 'call-1',
+            durationMs: 12.34,
+            msg: 'Captured screenshot.',
+            time: '2026-07-10T12:00:01.000Z',
+          })
+        )}\n`
+      );
+      await waitForAsync(() => expect(mockEventLogStream.write).toHaveBeenCalledTimes(2));
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+
+    expect(ctx.graphqlClient.mutation).toHaveBeenCalledWith(expect.anything(), {
+      deviceRunSessionId: 'session-id',
+    });
+    expect(RemoteLoggerStream).toHaveBeenCalledWith({
+      logger,
+      uploadMethod: {
+        signedUrl: {
+          url: 'https://uploads.expo.test/events',
+          headers: { 'content-disposition': 'attachment; filename="events.ndjson"' },
+        },
+      },
+      options: { uploadIntervalMs: 5_000 },
+    });
+    expect(mockEventLogStream.init).toHaveBeenCalledTimes(1);
+    expect(mockEventLogStream.cleanUp).toHaveBeenCalledTimes(1);
+    expect(mockEventLogStream.write).toHaveBeenNthCalledWith(1, {
+      v: 1,
+      eventId: 'argent:session-id:tool-server-events:1',
+      ts: '2026-07-10T12:00:00.000Z',
+      producer: 'argent',
+      type: 'operation.started',
+      operationId: 'call-1',
+      summary: 'Capturing screenshot.',
+      data: { toolId: 'screenshot', sourceType: 'tool.invoked', sourceLevel: 30 },
+    });
+    expect(mockEventLogStream.write).toHaveBeenNthCalledWith(2, {
+      v: 1,
+      eventId: 'argent:session-id:tool-server-events:2',
+      ts: '2026-07-10T12:00:01.000Z',
+      producer: 'argent',
+      type: 'operation.completed',
+      operationId: 'call-1',
+      outcome: 'success',
+      durationMs: 12.34,
+      summary: 'Captured screenshot.',
+      data: { toolId: 'screenshot', sourceType: 'tool.completed', sourceLevel: 30 },
+    });
+    expect(Sentry.capture).not.toHaveBeenCalled();
+  });
+
+  it('marks failed tool records as failed operations and keeps their failure signal', async () => {
+    const failureSignal = {
+      error_code: 'REGISTRY_TOOL_FAILURE_UNCLASSIFIED',
+      failure_stage: 'registry_tool_failed_event',
+      failure_area: 'registry',
+      error_kind: 'unknown',
+    };
+    const event = await collectSingleEventAsync(
+      bunyanRecord({
+        level: 50,
+        type: 'tool.failed',
+        toolId: 'screenshot',
+        toolInvocationId: 'call-2',
+        failureSignal,
+        msg: 'Failed to capture screenshot.',
+        time: '2026-07-10T12:00:02.000Z',
+      })
+    );
+
+    expect(event).toEqual({
+      v: 1,
+      eventId: 'argent:session-id:tool-server-events:1',
+      ts: '2026-07-10T12:00:02.000Z',
+      producer: 'argent',
+      type: 'operation.completed',
+      operationId: 'call-2',
+      outcome: 'failure',
+      summary: 'Failed to capture screenshot.',
+      data: {
+        toolId: 'screenshot',
+        failureSignal,
+        sourceType: 'tool.failed',
+        sourceLevel: 50,
+      },
+    });
+  });
+
+  it('passes through non-tool lifecycle records unchanged', async () => {
+    const event = await collectSingleEventAsync(
+      bunyanRecord({
+        level: 30,
+        type: 'service.state_change',
+        serviceId: 'ax-service',
+        from: 'stopped',
+        to: 'running',
+        msg: 'Service ax-service changed state from stopped to running.',
+        time: '2026-07-10T12:00:03.000Z',
+      })
+    );
+
+    expect(event).toEqual({
+      v: 1,
+      eventId: 'argent:session-id:tool-server-events:1',
+      ts: '2026-07-10T12:00:03.000Z',
+      producer: 'argent',
+      type: 'service.state_change',
+      summary: 'Service ax-service changed state from stopped to running.',
+      data: {
+        serviceId: 'ax-service',
+        from: 'stopped',
+        to: 'running',
+        sourceType: 'service.state_change',
+        sourceLevel: 30,
+      },
+    });
+  });
+
+  it('falls back to a generated summary when the record has no message', async () => {
+    const event = await collectSingleEventAsync(
+      bunyanRecord({
+        level: 30,
+        type: 'tool.invoked',
+        toolId: 'tap',
+        toolInvocationId: 'call-3',
+        msg: '',
+        time: '2026-07-10T12:00:04.000Z',
+      })
+    );
+
+    expect(event).toMatchObject({
+      type: 'operation.started',
+      summary: 'Invoked tap',
+    });
+  });
+
+  it('reports an invalid record without emitting an event', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'argent-events-'));
+    await fs.promises.writeFile(
+      path.join(stateDir, EVENT_LOG_FILENAME),
+      // Missing the required `type` field.
+      `${JSON.stringify({ time: '2026-07-10T12:00:00.000Z', msg: 'No type.' })}\n`
+    );
+    const collection = await startArgentEventCollectionAsync({
+      ctx: createContext(),
+      deviceRunSessionId: 'session-id',
+      stateDir,
+      logger: createLogger(),
+      pollIntervalMs: 10,
+    });
+
+    try {
+      await waitForAsync(() => expect(Sentry.capture).toHaveBeenCalledTimes(1));
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+
+    expect(mockEventLogStream.write).not.toHaveBeenCalled();
+    expect(Sentry.capture).toHaveBeenCalledWith('Could not parse an argent event log record', {
+      level: 'warning',
+      tags: { phase: 'argent-event-collection', reason: 'invalid-event' },
+      extras: { deviceRunSessionId: 'session-id', lineNumber: 1 },
+    });
+  });
+});
+
+async function collectSingleEventAsync(
+  record: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'argent-events-'));
+  await fs.promises.writeFile(
+    path.join(stateDir, EVENT_LOG_FILENAME),
+    `${JSON.stringify(record)}\n`
+  );
+  const collection = await startArgentEventCollectionAsync({
+    ctx: createContext(),
+    deviceRunSessionId: 'session-id',
+    stateDir,
+    logger: createLogger(),
+    pollIntervalMs: 10,
+  });
+
+  try {
+    await waitForAsync(() => expect(mockEventLogStream.write).toHaveBeenCalledTimes(1));
+  } finally {
+    await collection.stopAsync();
+    await fs.promises.rm(stateDir, { recursive: true, force: true });
+  }
+
+  return mockEventLogStream.write.mock.calls[0][0];
+}
+
+function bunyanRecord(fields: Record<string, unknown>): Record<string, unknown> {
+  return {
+    name: 'argent-tool-server',
+    hostname: 'test-host',
+    pid: 4242,
+    v: 0,
+    ...fields,
+  };
+}
+
+function createContext(): CustomBuildContext {
+  const mutation = jest.fn().mockReturnValue({
+    toPromise: async () => ({
+      data: {
+        deviceRunSession: {
+          createEventLogUploadSession: {
+            uploadSession: {
+              url: 'https://uploads.expo.test/events',
+              headers: { 'content-disposition': 'attachment; filename="events.ndjson"' },
+            },
+          },
+        },
+      },
+    }),
+  });
+  return { graphqlClient: { mutation } } as unknown as CustomBuildContext;
+}
+
+function createLogger(): bunyan {
+  return { info: jest.fn(), warn: jest.fn() } as unknown as bunyan;
+}
+
+async function waitForAsync(assertion: () => void): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  for (;;) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      if (Date.now() >= deadline) {
+        throw err;
+      }
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+  }
+}

--- a/packages/build-tools/src/steps/utils/__tests__/argentEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/argentEvents.test.ts
@@ -48,7 +48,7 @@ describe(startArgentEventCollectionAsync, () => {
     const collection = await startArgentEventCollectionAsync({
       ctx,
       deviceRunSessionId: 'session-id',
-      stateDir,
+      eventLogPath: eventLogFile,
       logger,
       pollIntervalMs: 10,
     });
@@ -202,15 +202,16 @@ describe(startArgentEventCollectionAsync, () => {
 
   it('reports an invalid record without emitting an event', async () => {
     const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'argent-events-'));
+    const eventLogPath = path.join(stateDir, EVENT_LOG_FILENAME);
     await fs.promises.writeFile(
-      path.join(stateDir, EVENT_LOG_FILENAME),
+      eventLogPath,
       // Missing the required `type` field.
       `${JSON.stringify({ time: '2026-07-10T12:00:00.000Z', msg: 'No type.' })}\n`
     );
     const collection = await startArgentEventCollectionAsync({
       ctx: createContext(),
       deviceRunSessionId: 'session-id',
-      stateDir,
+      eventLogPath,
       logger: createLogger(),
       pollIntervalMs: 10,
     });
@@ -229,20 +230,54 @@ describe(startArgentEventCollectionAsync, () => {
       extras: { deviceRunSessionId: 'session-id', lineNumber: 1 },
     });
   });
+
+  it('surfaces a non-ENOENT discovery error instead of treating it as no events', async () => {
+    // A regular file standing in for the state directory makes access() fail with ENOTDIR
+    // (not ENOENT), which must propagate to the collector's Sentry reporting.
+    const notADirectory = path.join(
+      await fs.promises.mkdtemp(path.join(os.tmpdir(), 'argent-events-')),
+      'regular-file'
+    );
+    await fs.promises.writeFile(notADirectory, '');
+    const eventLogPath = path.join(notADirectory, EVENT_LOG_FILENAME);
+    const collection = await startArgentEventCollectionAsync({
+      ctx: createContext(),
+      deviceRunSessionId: 'session-id',
+      eventLogPath,
+      logger: createLogger(),
+      pollIntervalMs: 10,
+    });
+
+    try {
+      await waitForAsync(() => expect(Sentry.capture).toHaveBeenCalledTimes(1));
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(notADirectory, { force: true });
+    }
+
+    expect(mockEventLogStream.write).not.toHaveBeenCalled();
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Could not collect argent events',
+      expect.objectContaining({ code: 'ENOTDIR' }),
+      {
+        level: 'warning',
+        tags: { phase: 'argent-event-collection' },
+        extras: { deviceRunSessionId: 'session-id' },
+      }
+    );
+  });
 });
 
 async function collectSingleEventAsync(
   record: Record<string, unknown>
 ): Promise<Record<string, unknown>> {
   const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'argent-events-'));
-  await fs.promises.writeFile(
-    path.join(stateDir, EVENT_LOG_FILENAME),
-    `${JSON.stringify(record)}\n`
-  );
+  const eventLogPath = path.join(stateDir, EVENT_LOG_FILENAME);
+  await fs.promises.writeFile(eventLogPath, `${JSON.stringify(record)}\n`);
   const collection = await startArgentEventCollectionAsync({
     ctx: createContext(),
     deviceRunSessionId: 'session-id',
-    stateDir,
+    eventLogPath,
     logger: createLogger(),
     pollIntervalMs: 10,
   });

--- a/packages/build-tools/src/steps/utils/__tests__/argentEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/argentEvents.test.ts
@@ -182,32 +182,16 @@ describe(startArgentEventCollectionAsync, () => {
     });
   });
 
-  it('falls back to a generated summary when the record has no message', async () => {
-    const event = await collectSingleEventAsync(
-      bunyanRecord({
-        level: 30,
-        type: 'tool.invoked',
-        toolId: 'tap',
-        toolInvocationId: 'call-3',
-        msg: '',
-        time: '2026-07-10T12:00:04.000Z',
-      })
-    );
-
-    expect(event).toMatchObject({
-      type: 'operation.started',
-      summary: 'Invoked tap',
-    });
-  });
-
-  it('reports an invalid record without emitting an event', async () => {
+  // `type` and `msg` are both required by Argent's EventLogRecord, so a record missing either
+  // is a broken upstream contract worth reporting — not something to paper over with an
+  // invented summary.
+  it.each([
+    ['type', { time: '2026-07-10T12:00:00.000Z', msg: 'No type.' }],
+    ['msg', { time: '2026-07-10T12:00:00.000Z', type: 'tool.invoked', toolId: 'tap' }],
+  ])('reports a record missing %s without emitting an event', async (_field, record) => {
     const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'argent-events-'));
     const eventLogPath = path.join(stateDir, EVENT_LOG_FILENAME);
-    await fs.promises.writeFile(
-      eventLogPath,
-      // Missing the required `type` field.
-      `${JSON.stringify({ time: '2026-07-10T12:00:00.000Z', msg: 'No type.' })}\n`
-    );
+    await fs.promises.writeFile(eventLogPath, `${JSON.stringify(bunyanRecord(record))}\n`);
     const collection = await startArgentEventCollectionAsync({
       ctx: createContext(),
       deviceRunSessionId: 'session-id',

--- a/packages/build-tools/src/steps/utils/agentDeviceEvents.ts
+++ b/packages/build-tools/src/steps/utils/agentDeviceEvents.ts
@@ -1,0 +1,155 @@
+import { type bunyan } from '@expo/logger';
+import fs from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+
+import { type CustomBuildContext } from '../../customBuildContext';
+import {
+  type DeviceRunSessionEvent,
+  type DeviceRunSessionEventParseFailure,
+  startDeviceRunSessionEventCollectionAsync,
+} from './deviceRunSessionEvents';
+
+const AGENT_DEVICE_PRODUCER = 'agent-device';
+
+const AGENT_DEVICE_EVENT_KIND_TO_TYPE: Record<string, string> = {
+  'request.started': 'operation.started',
+  'request.finished': 'operation.completed',
+  'action.recorded': 'interaction.recorded',
+};
+
+const AgentDeviceEventSchema = z
+  .object({
+    version: z.number(),
+    ts: z.string(),
+    session: z.string(),
+    kind: z.string(),
+    requestId: z.string().optional().catch(undefined),
+    command: z.string().optional().catch(undefined),
+    status: z.string().optional().catch(undefined),
+    summary: z.string().optional().catch(undefined),
+    details: z.record(z.string(), z.unknown()).optional().catch(undefined),
+  })
+  .passthrough();
+
+type AgentDeviceEvent = z.infer<typeof AgentDeviceEventSchema>;
+
+export async function startAgentDeviceEventCollectionAsync({
+  ctx,
+  deviceRunSessionId,
+  stateDir,
+  logger,
+  pollIntervalMs,
+}: {
+  ctx: CustomBuildContext;
+  deviceRunSessionId: string;
+  stateDir: string;
+  logger: bunyan;
+  pollIntervalMs?: number;
+}): Promise<{ stopAsync: () => Promise<void> }> {
+  return startDeviceRunSessionEventCollectionAsync({
+    ctx,
+    deviceRunSessionId,
+    logger,
+    pollIntervalMs,
+    source: {
+      producer: AGENT_DEVICE_PRODUCER,
+      findEventFilesAsync: () => findAgentDeviceEventFilesAsync(stateDir),
+      sourceKeyForFile: eventFile => path.basename(path.dirname(eventFile)),
+      parseLine: ({ line, sourceKey, sequenceNumber, deviceRunSessionId }) => {
+        const { event, failure } = parseAgentDeviceEvent(line);
+        if (!event) {
+          return { failure };
+        }
+        return {
+          event: normalizeAgentDeviceEvent({
+            event,
+            sequenceNumber,
+            sourceSessionDirectory: sourceKey,
+            deviceRunSessionId,
+          }),
+        };
+      },
+    },
+  });
+}
+
+async function findAgentDeviceEventFilesAsync(stateDir: string): Promise<string[]> {
+  const sessionsDir = path.join(stateDir, 'sessions');
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+
+  return entries
+    .filter(entry => entry.isDirectory())
+    .map(entry => path.join(sessionsDir, entry.name, 'events.ndjson'));
+}
+
+type ParsedAgentDeviceEvent = {
+  event?: AgentDeviceEvent;
+  failure?: DeviceRunSessionEventParseFailure;
+};
+
+function parseAgentDeviceEvent(line: string): ParsedAgentDeviceEvent {
+  if (!line.trim()) {
+    return {};
+  }
+  try {
+    const result = AgentDeviceEventSchema.safeParse(JSON.parse(line));
+    return result.success ? { event: result.data } : { failure: 'invalid-event' };
+  } catch {
+    return { failure: 'invalid-json' };
+  }
+}
+
+function normalizeAgentDeviceEvent({
+  event,
+  sequenceNumber,
+  sourceSessionDirectory,
+  deviceRunSessionId,
+}: {
+  event: AgentDeviceEvent;
+  sequenceNumber: number;
+  sourceSessionDirectory: string;
+  deviceRunSessionId: string;
+}): DeviceRunSessionEvent {
+  const type = AGENT_DEVICE_EVENT_KIND_TO_TYPE[event.kind] ?? event.kind;
+  const durationMs = event.details?.durationMs;
+  const outcome =
+    event.status === 'ok' ? 'success' : event.status === 'error' ? 'failure' : undefined;
+  const summary =
+    event.summary ??
+    (event.kind === 'request.started'
+      ? `Started ${event.command ?? 'activity'}`
+      : event.kind === 'request.finished'
+        ? `Finished ${event.command ?? 'activity'}`
+        : event.kind === 'action.recorded'
+          ? `Recorded ${event.command ?? 'activity'}`
+          : `${event.kind}${event.command ? `: ${event.command}` : ''}`);
+
+  return {
+    v: 1,
+    // Consumers use eventId to deduplicate events across polls. Keep the per-file sequence
+    // monotonic across source-file truncations so an ID is never reused during collection.
+    eventId: `agent-device:${deviceRunSessionId}:${sourceSessionDirectory}:${sequenceNumber}`,
+    ts: event.ts,
+    producer: 'agent-device',
+    type,
+    ...(event.requestId ? { operationId: event.requestId } : {}),
+    ...(outcome ? { outcome } : {}),
+    ...(typeof durationMs === 'number' ? { durationMs } : {}),
+    summary,
+    data: {
+      ...event.details,
+      session: event.session,
+      sourceVersion: event.version,
+      ...(event.status ? { sourceStatus: event.status } : {}),
+    },
+  };
+}

--- a/packages/build-tools/src/steps/utils/argentEvents.ts
+++ b/packages/build-tools/src/steps/utils/argentEvents.ts
@@ -1,0 +1,178 @@
+import { type bunyan } from '@expo/logger';
+import fs from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+
+import { type CustomBuildContext } from '../../customBuildContext';
+import {
+  type DeviceRunSessionEvent,
+  type DeviceRunSessionEventParseFailure,
+  startDeviceRunSessionEventCollectionAsync,
+} from './deviceRunSessionEvents';
+
+const ARGENT_PRODUCER = 'argent';
+// Argent's tool-server writes its event log to `~/.argent/tool-server-events.jsonl`
+// (its default $ARGENT_EVENT_LOG path) once the `tool-server-event-log` flag is on.
+export const ARGENT_EVENT_LOG_FILENAME = 'tool-server-events.jsonl';
+
+// Argent records are bunyan log lines tagged with a `type`. Map the tool-lifecycle
+// types onto the shared operation vocabulary; anything else (service.*,
+// tool_server.*, future types) passes through unchanged, mirroring agent-device.
+const ARGENT_EVENT_TYPE_TO_TYPE: Record<string, string> = {
+  'tool.invoked': 'operation.started',
+  'tool.completed': 'operation.completed',
+  'tool.failed': 'operation.completed',
+};
+
+// Bunyan bookkeeping plus the fields we promote to the top level of a
+// DeviceRunSessionEvent — excluded from the free-form `data` bag so it carries
+// only the record's own context (toolId, serviceId, failureSignal, ...).
+const NON_DATA_KEYS = new Set([
+  'name',
+  'hostname',
+  'pid',
+  'v',
+  'time',
+  'msg',
+  'level',
+  'type',
+  'toolInvocationId',
+  'durationMs',
+]);
+
+const ArgentEventSchema = z
+  .object({
+    time: z.string(),
+    type: z.string(),
+    msg: z.string().optional().catch(undefined),
+    level: z.number().optional().catch(undefined),
+    toolId: z.string().optional().catch(undefined),
+    toolInvocationId: z.string().optional().catch(undefined),
+    durationMs: z.number().optional().catch(undefined),
+  })
+  .passthrough();
+
+type ArgentEvent = z.infer<typeof ArgentEventSchema>;
+
+type ParsedArgentEvent = {
+  event?: ArgentEvent;
+  failure?: DeviceRunSessionEventParseFailure;
+};
+
+export async function startArgentEventCollectionAsync({
+  ctx,
+  deviceRunSessionId,
+  stateDir,
+  logger,
+  pollIntervalMs,
+}: {
+  ctx: CustomBuildContext;
+  deviceRunSessionId: string;
+  stateDir: string;
+  logger: bunyan;
+  pollIntervalMs?: number;
+}): Promise<{ stopAsync: () => Promise<void> }> {
+  return startDeviceRunSessionEventCollectionAsync({
+    ctx,
+    deviceRunSessionId,
+    logger,
+    pollIntervalMs,
+    source: {
+      producer: ARGENT_PRODUCER,
+      findEventFilesAsync: () => findArgentEventFilesAsync(stateDir),
+      sourceKeyForFile: eventFile => path.basename(eventFile, path.extname(eventFile)),
+      parseLine: ({ line, sourceKey, sequenceNumber, deviceRunSessionId }) => {
+        const { event, failure } = parseArgentEvent(line);
+        if (!event) {
+          return { failure };
+        }
+        return {
+          event: normalizeArgentEvent({ event, sequenceNumber, sourceKey, deviceRunSessionId }),
+        };
+      },
+    },
+  });
+}
+
+async function findArgentEventFilesAsync(stateDir: string): Promise<string[]> {
+  const eventLogPath = path.join(stateDir, ARGENT_EVENT_LOG_FILENAME);
+  try {
+    await fs.promises.access(eventLogPath);
+    return [eventLogPath];
+  } catch {
+    return [];
+  }
+}
+
+function parseArgentEvent(line: string): ParsedArgentEvent {
+  if (!line.trim()) {
+    return {};
+  }
+  try {
+    const result = ArgentEventSchema.safeParse(JSON.parse(line));
+    return result.success ? { event: result.data } : { failure: 'invalid-event' };
+  } catch {
+    return { failure: 'invalid-json' };
+  }
+}
+
+function normalizeArgentEvent({
+  event,
+  sequenceNumber,
+  sourceKey,
+  deviceRunSessionId,
+}: {
+  event: ArgentEvent;
+  sequenceNumber: number;
+  sourceKey: string;
+  deviceRunSessionId: string;
+}): DeviceRunSessionEvent {
+  const type = ARGENT_EVENT_TYPE_TO_TYPE[event.type] ?? event.type;
+  const outcome =
+    event.type === 'tool.completed'
+      ? 'success'
+      : event.type === 'tool.failed'
+        ? 'failure'
+        : undefined;
+  const summary =
+    event.msg && event.msg.trim().length > 0 ? event.msg : summarizeArgentEvent(event);
+
+  const data: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(event)) {
+    if (!NON_DATA_KEYS.has(key) && value !== undefined) {
+      data[key] = value;
+    }
+  }
+  data.sourceType = event.type;
+  if (typeof event.level === 'number') {
+    data.sourceLevel = event.level;
+  }
+
+  return {
+    v: 1,
+    // Consumers use eventId to deduplicate events across polls. Keep the per-file sequence
+    // monotonic across source-file truncations so an ID is never reused during collection.
+    eventId: `argent:${deviceRunSessionId}:${sourceKey}:${sequenceNumber}`,
+    ts: event.time,
+    producer: 'argent',
+    type,
+    ...(event.toolInvocationId ? { operationId: event.toolInvocationId } : {}),
+    ...(outcome ? { outcome } : {}),
+    ...(typeof event.durationMs === 'number' ? { durationMs: event.durationMs } : {}),
+    summary,
+    data,
+  };
+}
+
+function summarizeArgentEvent(event: ArgentEvent): string {
+  switch (event.type) {
+    case 'tool.invoked':
+      return `Invoked ${event.toolId ?? 'tool'}`;
+    case 'tool.completed':
+      return `Completed ${event.toolId ?? 'tool'}`;
+    case 'tool.failed':
+      return `Failed ${event.toolId ?? 'tool'}`;
+    default:
+      return event.type;
+  }
+}

--- a/packages/build-tools/src/steps/utils/argentEvents.ts
+++ b/packages/build-tools/src/steps/utils/argentEvents.ts
@@ -62,13 +62,15 @@ type ParsedArgentEvent = {
 export async function startArgentEventCollectionAsync({
   ctx,
   deviceRunSessionId,
-  stateDir,
+  eventLogPath,
   logger,
   pollIntervalMs,
 }: {
   ctx: CustomBuildContext;
   deviceRunSessionId: string;
-  stateDir: string;
+  // Absolute path Argent's tool-server writes its event log to (its `ARGENT_EVENT_LOG`).
+  // The caller pins this on both sides so the collector and the tool-server never disagree.
+  eventLogPath: string;
   logger: bunyan;
   pollIntervalMs?: number;
 }): Promise<{ stopAsync: () => Promise<void> }> {
@@ -79,7 +81,7 @@ export async function startArgentEventCollectionAsync({
     pollIntervalMs,
     source: {
       producer: ARGENT_PRODUCER,
-      findEventFilesAsync: () => findArgentEventFilesAsync(stateDir),
+      findEventFilesAsync: () => findArgentEventFilesAsync(eventLogPath),
       sourceKeyForFile: eventFile => path.basename(eventFile, path.extname(eventFile)),
       parseLine: ({ line, sourceKey, sequenceNumber, deviceRunSessionId }) => {
         const { event, failure } = parseArgentEvent(line);
@@ -94,13 +96,17 @@ export async function startArgentEventCollectionAsync({
   });
 }
 
-async function findArgentEventFilesAsync(stateDir: string): Promise<string[]> {
-  const eventLogPath = path.join(stateDir, ARGENT_EVENT_LOG_FILENAME);
+async function findArgentEventFilesAsync(eventLogPath: string): Promise<string[]> {
   try {
     await fs.promises.access(eventLogPath);
     return [eventLogPath];
-  } catch {
-    return [];
+  } catch (err) {
+    // The tool-server has not created the file yet — expected until the first event is written.
+    // Surface any other error (permissions, I/O) to the engine so it reaches Sentry.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw err;
   }
 }
 

--- a/packages/build-tools/src/steps/utils/argentEvents.ts
+++ b/packages/build-tools/src/steps/utils/argentEvents.ts
@@ -44,7 +44,9 @@ const ArgentEventSchema = z
   .object({
     time: z.string(),
     type: z.string(),
-    msg: z.string().optional().catch(undefined),
+    // Argent's EventLogRecord requires `msg` and every emit site sets it to the
+    // human-readable description of the event, so it is our summary verbatim.
+    msg: z.string(),
     level: z.number().optional().catch(undefined),
     toolId: z.string().optional().catch(undefined),
     toolInvocationId: z.string().optional().catch(undefined),
@@ -140,9 +142,6 @@ function normalizeArgentEvent({
       : event.type === 'tool.failed'
         ? 'failure'
         : undefined;
-  const summary =
-    event.msg && event.msg.trim().length > 0 ? event.msg : summarizeArgentEvent(event);
-
   const data: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(event)) {
     if (!NON_DATA_KEYS.has(key) && value !== undefined) {
@@ -165,20 +164,7 @@ function normalizeArgentEvent({
     ...(event.toolInvocationId ? { operationId: event.toolInvocationId } : {}),
     ...(outcome ? { outcome } : {}),
     ...(typeof event.durationMs === 'number' ? { durationMs: event.durationMs } : {}),
-    summary,
+    summary: event.msg,
     data,
   };
-}
-
-function summarizeArgentEvent(event: ArgentEvent): string {
-  switch (event.type) {
-    case 'tool.invoked':
-      return `Invoked ${event.toolId ?? 'tool'}`;
-    case 'tool.completed':
-      return `Completed ${event.toolId ?? 'tool'}`;
-    case 'tool.failed':
-      return `Failed ${event.toolId ?? 'tool'}`;
-    default:
-      return event.type;
-  }
 }

--- a/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
+++ b/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
@@ -2,10 +2,8 @@ import { SystemError } from '@expo/eas-build-job';
 import { type bunyan } from '@expo/logger';
 import { graphql } from 'gql.tada';
 import fs from 'node:fs';
-import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
 import { setTimeout as setTimeoutAsync } from 'node:timers/promises';
-import { z } from 'zod';
 
 import { type CustomBuildContext } from '../../customBuildContext';
 import RemoteLoggerStream from '../../logging/RemoteLoggerStream';
@@ -14,26 +12,6 @@ import { type SignedUrl } from '../../storage/uploadWithSignedUrl';
 
 const POLL_INTERVAL_MS = 1_000;
 const UPLOAD_INTERVAL_MS = 5_000;
-
-const AGENT_DEVICE_EVENT_KIND_TO_TYPE: Record<string, string> = {
-  'request.started': 'operation.started',
-  'request.finished': 'operation.completed',
-  'action.recorded': 'interaction.recorded',
-};
-
-const AgentDeviceEventSchema = z
-  .object({
-    version: z.number(),
-    ts: z.string(),
-    session: z.string(),
-    kind: z.string(),
-    requestId: z.string().optional().catch(undefined),
-    command: z.string().optional().catch(undefined),
-    status: z.string().optional().catch(undefined),
-    summary: z.string().optional().catch(undefined),
-    details: z.record(z.string(), z.unknown()).optional().catch(undefined),
-  })
-  .passthrough();
 
 const CREATE_DEVICE_RUN_SESSION_EVENT_LOG_UPLOAD_SESSION_MUTATION = graphql(`
   mutation CreateDeviceRunSessionEventLogUploadSession($deviceRunSessionId: ID!) {
@@ -48,8 +26,12 @@ const CREATE_DEVICE_RUN_SESSION_EVENT_LOG_UPLOAD_SESSION_MUTATION = graphql(`
   }
 `);
 
-type AgentDeviceEvent = z.infer<typeof AgentDeviceEventSchema>;
-
+/**
+ * The normalized, producer-agnostic event shape uploaded to the API server.
+ * Every remote-session producer (agent-device, argent, ...) tails its own
+ * event log and maps its records onto this common contract so consumers render
+ * a single unified session timeline.
+ */
 export type DeviceRunSessionEvent = {
   v: 1;
   eventId: string;
@@ -63,6 +45,40 @@ export type DeviceRunSessionEvent = {
   data?: Record<string, unknown>;
 };
 
+export type DeviceRunSessionEventParseFailure = 'invalid-json' | 'invalid-event';
+
+export type DeviceRunSessionEventParseResult = {
+  event?: DeviceRunSessionEvent;
+  failure?: DeviceRunSessionEventParseFailure;
+};
+
+/**
+ * Producer-specific adapter plugged into the generic collection engine. It only
+ * has to say where its event files live and how to turn one raw NDJSON line
+ * into a {@link DeviceRunSessionEvent}; the engine owns tailing, upload, polling
+ * and failure reporting.
+ */
+export type DeviceRunSessionEventSource = {
+  /** Stable producer identifier, e.g. `agent-device` or `argent`. */
+  producer: string;
+  /** Discover the NDJSON event files to tail (absolute paths). */
+  findEventFilesAsync: () => Promise<string[]>;
+  /** Namespace component of the event ID derived from a tailed file path. */
+  sourceKeyForFile: (eventFile: string) => string;
+  /**
+   * Parse one raw NDJSON line. `sequenceNumber` is monotonic per file (kept
+   * stable across truncations) and `sourceKey` namespaces the event ID so an ID
+   * is never reused during collection. Blank lines should return an empty
+   * result so they neither emit an event nor count as a parse failure.
+   */
+  parseLine: (args: {
+    line: string;
+    sourceKey: string;
+    sequenceNumber: number;
+    deviceRunSessionId: string;
+  }) => DeviceRunSessionEventParseResult;
+};
+
 type EventFileState = {
   offset: number;
   nextSequenceNumber: number;
@@ -71,25 +87,20 @@ type EventFileState = {
   decoder: StringDecoder;
 };
 
-type AgentDeviceEventParseFailure = 'invalid-json' | 'invalid-event';
-type AgentDeviceEventParseResult = {
-  event?: AgentDeviceEvent;
-  failure?: AgentDeviceEventParseFailure;
-};
-
-export async function startAgentDeviceEventCollectionAsync({
+export async function startDeviceRunSessionEventCollectionAsync({
   ctx,
   deviceRunSessionId,
-  stateDir,
+  source,
   logger,
   pollIntervalMs = POLL_INTERVAL_MS,
 }: {
   ctx: CustomBuildContext;
   deviceRunSessionId: string;
-  stateDir: string;
+  source: DeviceRunSessionEventSource;
   logger: bunyan;
   pollIntervalMs?: number;
 }): Promise<{ stopAsync: () => Promise<void> }> {
+  const { producer } = source;
   let didReportEventLogFailure = false;
   const reportEventLogFailure = (error: Error, operation: 'setup' | 'cleanup'): void => {
     if (didReportEventLogFailure) {
@@ -98,7 +109,7 @@ export async function startAgentDeviceEventCollectionAsync({
     didReportEventLogFailure = true;
     Sentry.capture('Could not persist device run session events', error, {
       level: 'warning',
-      tags: { phase: 'device-run-session-event-collection', operation },
+      tags: { phase: 'device-run-session-event-collection', operation, producer },
       extras: { deviceRunSessionId },
     });
   };
@@ -124,13 +135,13 @@ export async function startAgentDeviceEventCollectionAsync({
   const states = new Map<string, EventFileState>();
   const controller = new AbortController();
   let parseFailureCount = 0;
-  const parseFailureCounts: Record<AgentDeviceEventParseFailure, number> = {
+  const parseFailureCounts: Record<DeviceRunSessionEventParseFailure, number> = {
     'invalid-json': 0,
     'invalid-event': 0,
   };
   let didReportCollectionFailure = false;
   const collectAsync = async (): Promise<void> => {
-    const eventFiles = await findAgentDeviceEventFilesAsync(stateDir);
+    const eventFiles = await source.findEventFilesAsync();
     await Promise.all(
       eventFiles.map(async eventFile => {
         const state = states.get(eventFile) ?? {
@@ -144,6 +155,7 @@ export async function startAgentDeviceEventCollectionAsync({
         await collectEventFileAsync({
           eventFile,
           state,
+          source,
           deviceRunSessionId,
           writeEvent: event => eventLogStream.write(event),
           onParseFailure: ({ failure, lineNumber }) => {
@@ -153,12 +165,12 @@ export async function startAgentDeviceEventCollectionAsync({
               return;
             }
             logger.warn(
-              { agentDeviceEventParseFailure: failure, lineNumber },
-              'Could not parse an agent-device event log record.'
+              { producer, eventParseFailure: failure, lineNumber },
+              `Could not parse an ${producer} event log record.`
             );
-            Sentry.capture('Could not parse an agent-device event log record', {
+            Sentry.capture(`Could not parse an ${producer} event log record`, {
               level: 'warning',
-              tags: { phase: 'agent-device-event-collection', reason: failure },
+              tags: { phase: `${producer}-event-collection`, reason: failure },
               extras: { deviceRunSessionId, lineNumber },
             });
           },
@@ -176,10 +188,10 @@ export async function startAgentDeviceEventCollectionAsync({
       }
       didReportCollectionFailure = true;
       const error = err instanceof Error ? err : new Error(String(err));
-      logger.warn({ err: error }, 'Could not collect agent-device events.');
-      Sentry.capture('Could not collect agent-device events', error, {
+      logger.warn({ err: error }, `Could not collect ${producer} events.`);
+      Sentry.capture(`Could not collect ${producer} events`, error, {
         level: 'warning',
-        tags: { phase: 'agent-device-event-collection' },
+        tags: { phase: `${producer}-event-collection` },
         extras: { deviceRunSessionId },
       });
     }
@@ -200,10 +212,10 @@ export async function startAgentDeviceEventCollectionAsync({
   })()
     .catch(err => {
       const error = err instanceof Error ? err : new Error(String(err));
-      logger.warn({ err: error }, 'Agent-device event collection poller failed.');
-      Sentry.capture('Agent-device event collection poller failed', error, {
+      logger.warn({ err: error }, `${capitalize(producer)} event collection poller failed.`);
+      Sentry.capture(`${capitalize(producer)} event collection poller failed`, error, {
         level: 'warning',
-        tags: { phase: 'agent-device-event-collection', operation: 'poll' },
+        tags: { phase: `${producer}-event-collection`, operation: 'poll' },
         extras: { deviceRunSessionId },
       });
     })
@@ -218,12 +230,12 @@ export async function startAgentDeviceEventCollectionAsync({
       await collectSafelyAsync();
       if (parseFailureCount > 1) {
         logger.warn(
-          { agentDeviceEventParseFailures: parseFailureCounts, parseFailureCount },
-          `Could not parse ${parseFailureCount} agent-device event log records.`
+          { producer, eventParseFailures: parseFailureCounts, parseFailureCount },
+          `Could not parse ${parseFailureCount} ${producer} event log records.`
         );
-        Sentry.capture('Could not parse multiple agent-device event log records', {
+        Sentry.capture(`Could not parse multiple ${producer} event log records`, {
           level: 'warning',
-          tags: { phase: 'agent-device-event-collection' },
+          tags: { phase: `${producer}-event-collection` },
           extras: { deviceRunSessionId, parseFailureCount, parseFailureCounts },
         });
       }
@@ -260,35 +272,23 @@ async function createEventLogUploadSessionAsync(
   };
 }
 
-async function findAgentDeviceEventFilesAsync(stateDir: string): Promise<string[]> {
-  const sessionsDir = path.join(stateDir, 'sessions');
-  let entries: fs.Dirent[];
-  try {
-    entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      return [];
-    }
-    throw err;
-  }
-
-  return entries
-    .filter(entry => entry.isDirectory())
-    .map(entry => path.join(sessionsDir, entry.name, 'events.ndjson'));
-}
-
 async function collectEventFileAsync({
   eventFile,
   state,
+  source,
   deviceRunSessionId,
   writeEvent,
   onParseFailure,
 }: {
   eventFile: string;
   state: EventFileState;
+  source: DeviceRunSessionEventSource;
   deviceRunSessionId: string;
   writeEvent: (event: DeviceRunSessionEvent) => void;
-  onParseFailure: (failure: { failure: AgentDeviceEventParseFailure; lineNumber: number }) => void;
+  onParseFailure: (failure: {
+    failure: DeviceRunSessionEventParseFailure;
+    lineNumber: number;
+  }) => void;
 }): Promise<void> {
   let fileSize: number;
   try {
@@ -309,6 +309,7 @@ async function collectEventFileAsync({
     return;
   }
 
+  const sourceKey = source.sourceKeyForFile(eventFile);
   const handle = await fs.promises.open(eventFile, 'r');
   try {
     const buffer = new Uint8Array(new ArrayBuffer(fileSize - state.offset));
@@ -321,80 +322,25 @@ async function collectEventFileAsync({
     for (const line of lines) {
       const lineNumber = state.nextLineNumber++;
       const sequenceNumber = state.nextSequenceNumber++;
-      const { event, failure } = parseAgentDeviceEvent(line);
+      const { event, failure } = source.parseLine({
+        line,
+        sourceKey,
+        sequenceNumber,
+        deviceRunSessionId,
+      });
       if (failure) {
         onParseFailure({ failure, lineNumber });
       }
       if (!event) {
         continue;
       }
-      const deviceRunSessionEvent = normalizeAgentDeviceEvent({
-        event,
-        sequenceNumber,
-        sourceSessionDirectory: path.basename(path.dirname(eventFile)),
-        deviceRunSessionId,
-      });
-      writeEvent(deviceRunSessionEvent);
+      writeEvent(event);
     }
   } finally {
     await handle.close();
   }
 }
 
-function parseAgentDeviceEvent(line: string): AgentDeviceEventParseResult {
-  if (!line.trim()) {
-    return {};
-  }
-  try {
-    const result = AgentDeviceEventSchema.safeParse(JSON.parse(line));
-    return result.success ? { event: result.data } : { failure: 'invalid-event' };
-  } catch {
-    return { failure: 'invalid-json' };
-  }
-}
-
-function normalizeAgentDeviceEvent({
-  event,
-  sequenceNumber,
-  sourceSessionDirectory,
-  deviceRunSessionId,
-}: {
-  event: AgentDeviceEvent;
-  sequenceNumber: number;
-  sourceSessionDirectory: string;
-  deviceRunSessionId: string;
-}): DeviceRunSessionEvent {
-  const type = AGENT_DEVICE_EVENT_KIND_TO_TYPE[event.kind] ?? event.kind;
-  const durationMs = event.details?.durationMs;
-  const outcome =
-    event.status === 'ok' ? 'success' : event.status === 'error' ? 'failure' : undefined;
-  const summary =
-    event.summary ??
-    (event.kind === 'request.started'
-      ? `Started ${event.command ?? 'activity'}`
-      : event.kind === 'request.finished'
-        ? `Finished ${event.command ?? 'activity'}`
-        : event.kind === 'action.recorded'
-          ? `Recorded ${event.command ?? 'activity'}`
-          : `${event.kind}${event.command ? `: ${event.command}` : ''}`);
-
-  return {
-    v: 1,
-    // Consumers use eventId to deduplicate events across polls. Keep the per-file sequence
-    // monotonic across source-file truncations so an ID is never reused during collection.
-    eventId: `agent-device:${deviceRunSessionId}:${sourceSessionDirectory}:${sequenceNumber}`,
-    ts: event.ts,
-    producer: 'agent-device',
-    type,
-    ...(event.requestId ? { operationId: event.requestId } : {}),
-    ...(outcome ? { outcome } : {}),
-    ...(typeof durationMs === 'number' ? { durationMs } : {}),
-    summary,
-    data: {
-      ...event.details,
-      session: event.session,
-      sourceVersion: event.version,
-      ...(event.status ? { sourceStatus: event.status } : {}),
-    },
-  };
+function capitalize(value: string): string {
+  return value.length === 0 ? value : `${value[0].toUpperCase()}${value.slice(1)}`;
 }

--- a/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
+++ b/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
@@ -59,7 +59,11 @@ export type DeviceRunSessionEventParseResult = {
  * and failure reporting.
  */
 export type DeviceRunSessionEventSource = {
-  /** Stable producer identifier, e.g. `agent-device` or `argent`. */
+  /**
+   * Stable producer identifier, e.g. `agent-device` or `argent`. Also used
+   * verbatim in diagnostic messages, which are phrased so it never needs
+   * recasing.
+   */
   producer: string;
   /** Discover the NDJSON event files to tail (absolute paths). */
   findEventFilesAsync: () => Promise<string[]>;
@@ -212,8 +216,8 @@ export async function startDeviceRunSessionEventCollectionAsync({
   })()
     .catch(err => {
       const error = err instanceof Error ? err : new Error(String(err));
-      logger.warn({ err: error }, `${capitalize(producer)} event collection poller failed.`);
-      Sentry.capture(`${capitalize(producer)} event collection poller failed`, error, {
+      logger.warn({ err: error }, `Event collection poller for ${producer} failed.`);
+      Sentry.capture(`Event collection poller for ${producer} failed`, error, {
         level: 'warning',
         tags: { phase: `${producer}-event-collection`, operation: 'poll' },
         extras: { deviceRunSessionId },
@@ -339,8 +343,4 @@ async function collectEventFileAsync({
   } finally {
     await handle.close();
   }
-}
-
-function capitalize(value: string): string {
-  return value.length === 0 ? value : `${value[0].toUpperCase()}${value.slice(1)}`;
 }


### PR DESCRIPTION
# Why

Agent-device remote simulator sessions already tail agent-device's event log and upload a normalized session-event timeline to the API server (`startAgentDeviceEventCollectionAsync`). Argent gained an equivalent structured event log ([software-mansion/argent](https://github.com/software-mansion/argent), `@swmansion/argent` >= 0.16.0), so Argent remote sessions can now feed the same timeline. This wires that up.

# How

Argent's tool-server writes bunyan JSONL records to its `ARGENT_EVENT_LOG` path (default `~/.argent/tool-server-events.jsonl`) once the `tool-server-event-log` flag is enabled. Each record is tagged with a `type` (`tool.invoked`, `tool.completed`, `tool.failed`, `service.*`, `tool_server.*`, ...).

- **Generic engine.** Extracted the file-tailing (byte-offset + partial-line/multi-byte reassembly + truncation-safe sequence numbering), upload-session creation, poll loop, and failure reporting out of `deviceRunSessionEvents.ts` into a producer-parameterized `startDeviceRunSessionEventCollectionAsync`. A `DeviceRunSessionEventSource` adapter only has to say where its files live and how to normalize one line. Diagnostic messages interpolate the producer id verbatim (no recasing), and phase tags are unchanged for agent-device.
- **Adapters.** Moved the agent-device adapter into `agentDeviceEvents.ts` and added `argentEvents.ts` — mirroring the existing `deviceRunSessionArtifacts.ts` (shared) + `agentDeviceArtifacts.ts`/`argentArtifacts.ts` (per-producer) split. The argent normalizer maps `tool.invoked` → `operation.started` and `tool.completed`/`tool.failed` → `operation.completed` (with `outcome`), correlates them via `toolInvocationId` → `operationId`, and passes other record types through unchanged.
- **Version floor & unconditional enable.** Bumped `MIN_ARGENT_REMOTE_SESSION_VERSION` from `0.12.0` to `0.16.0` — the first version that exposes the event log flag. With that floor guaranteed, `startArgentRemoteSession.ts` enables `tool-server-event-log` **unconditionally** (like the existing `artifacts-list-endpoint` flag). This makes event collection an explicit remote-session contract rather than silently producing no events.
- **Pinned path (review).** The event log path is pinned once and handed to both the tool-server (via `ARGENT_EVENT_LOG` in its spawn env) and the collector, so an ambient `ARGENT_EVENT_LOG` or a change to Argent's default can never make the two disagree.
- **Discovery errors (review).** File discovery treats only `ENOENT` as "no event file yet"; permission/I/O errors propagate to the collector's existing Sentry reporting instead of being silently swallowed.
- **Summary comes from Argent (review).** `summary` is Argent's `msg` verbatim rather than something we synthesize — Argent's `EventLogRecord` requires `msg` and builds it from each tool's `interaction.startedMsg`/`completedMsg`/`failedMsg` hooks, so it is already the human-readable description (parameterized by the actual args/result). `msg` is required in our schema too, so a record without one is a reported contract break rather than invented text.

Stale history is not a concern: Argent truncates the event file when the tool-server starts, and we tail from offset 0 with truncation handling.

Argent was checked against `origin/main` (latest, up to tag `v0.16.1`) — the event log landed in `v0.16.0` (`feat(tool-server): add tool-server event log`, #367). I did not `git pull` the local `~/expo/argent` clone because it had unrelated uncommitted work; I inspected `origin/main` directly instead.

# What we upload, and what the session UI should render

We deliberately upload **every** well-formed record and leave the choice of what to display to the consumer, so a failed session keeps the events that explain it. Filtering here would bake into `@expo/build-tools` (release cadence, and the data is gone for sessions in between); filtering in the UI is reversible with full history intact.

The only records we drop are blank lines and ones failing the schema (missing `time`/`type`/`msg`) — and those are reported to Sentry as `invalid-event`, not silently skipped.

`type` is enough to split the stream; every event also carries the raw Argent type as `data.sourceType`.

| Bucket | Normalized `type` | From Argent `type` |
| --- | --- | --- |
| **Timeline** — what the agent did to the app | `operation.started`, `operation.completed` (+ `outcome: success \| failure`, `durationMs`, `operationId`) | `tool.invoked`, `tool.completed`, `tool.failed` |
| **Diagnostic** — why a session misbehaved | `service.state_change`, `service.error`, `service.registered`, `tool.registered`, `tool_server.started`, `tool_server.stopping`, `tool_server.bind_failed`, `tool_server.start_failed`, `tool_server.deferred_to_existing` | same (passed through unchanged) |

⚠️ **The UI filter is required, not cosmetic.** Argent registers ~38 tools at startup, so an unfiltered timeline opens with ~40 `Tool <id> was registered.` lines before anything the user did. Render `operation.*` in the main timeline and keep the rest for a debug/expandable view.

Two things to know about the timeline text: a tool that has not defined `interaction` hooks yet falls back to Argent's generic strings (`Tool <id> was invoked.`, `Tool <id> completed in 12.34 ms.`), which improves on its own as Argent fills them in; and the diagnostic messages include internal details such as `127.0.0.1:<port>`.

# Test Plan

- `yarn jest-unit` in `packages/build-tools` — full suite passes (898 tests), including:
  - `argentEvents.test.ts` (new): tool lifecycle → operation vocabulary, failure-signal preservation, non-tool passthrough, missing required field (`type`/`msg`) reporting, and a non-`ENOENT` discovery error surfacing to Sentry.
  - `startArgentRemoteSession-orchestration.test.ts` (new): drives the build function's `fn` and verifies the event-log flag is enabled (before launch), the tool-server env and collector share one pinned path, and collection starts before / stops after the session-stop wait.
  - `agentDeviceEvents.test.ts` (moved): agent-device behavior unchanged.
  - `startArgentRemoteSession.test.ts`: version-floor checks + `stopArgentEventCollectionSafelyAsync`.
- `yarn typecheck`, `yarn lint`, `yarn fmt:check` all pass. Rebased onto latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
