### PR TITLE
[eas-cli] Use npx in agent-device simulator instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Suggest running `agent-device` via `npx` in EAS Simulator session instructions. ([#4070](https://github.com/expo/eas-cli/pull/4070) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 - [eas-cli] Calibrate the experimental AI code reviewer's agent prompts and noise config to eas-cli's conventions. ([#4065](https://github.com/expo/eas-cli/pull/4065) by [@brentvatne](https://github.com/brentvatne))

--- a/packages/eas-cli/src/commands/simulator/__tests__/start.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/start.test.ts
@@ -231,7 +231,7 @@ describe(SimulatorStart, () => {
       [
         '🔑 Run the following to use agent-device with the simulator:',
         '',
-        'eas simulator:exec agent-device <command>',
+        'eas simulator:exec npx agent-device <command>',
         '',
         '🌐 Open the following URL in your browser to preview the simulator:',
         '',

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -54,7 +54,7 @@ export function formatRemoteSessionInstructions(
           ? [
               '🔑 Run the following to use agent-device with the simulator:',
               '',
-              'eas simulator:exec agent-device <command>',
+              'eas simulator:exec npx agent-device <command>',
             ]
           : [
               '🔑 Run the following in your shell to attach to the agent-device daemon:',


### PR DESCRIPTION
# Why

EAS Simulator currently suggests running `agent-device` as if it were installed globally. Using `npx` makes the suggested command work with an on-demand local package invocation.

# How

Update the agent-device session instructions to print:

```sh
eas simulator:exec npx agent-device <command>
```

Update the matching simulator start command test expectation.

# Test Plan

- `corepack yarn build`
- `corepack yarn test src/commands/simulator/__tests__/start.test.ts --runInBand` (10 tests passed)
- `oxfmt --check` on both modified files