### PR TITLE
[build-tools] Delay remote artifact listing errors

### DIFF
--- a/packages/build-tools/src/steps/utils/__tests__/agentDeviceArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/agentDeviceArtifacts.test.ts
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 import { Readable } from 'node:stream';
 
 import { CustomBuildContext } from '../../../customBuildContext';
+import { Sentry } from '../../../sentry';
 import { uploadDeviceRunSessionArtifactAsync } from '../deviceRunSessionArtifacts';
 import {
   listAgentDeviceArtifactsAsync,
@@ -11,6 +12,7 @@ import {
 } from '../agentDeviceArtifacts';
 
 jest.mock('../deviceRunSessionArtifacts');
+jest.mock('../../../sentry');
 jest.mock('node-fetch');
 
 const { Response } = jest.requireActual('node-fetch') as typeof import('node-fetch');
@@ -185,12 +187,53 @@ describe(pollAgentDeviceArtifactsForUploadAsync, () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.mocked(fetch).mockReset();
+    jest.mocked(Sentry.capture).mockReset();
     jest.mocked(uploadDeviceRunSessionArtifactAsync).mockReset();
   });
 
   afterEach(() => {
     jest.clearAllTimers();
     jest.useRealTimers();
+  });
+
+  it('reports artifact listing errors on every fifth consecutive failure', async () => {
+    const logger = createLoggerMock();
+    const ctx = {} as unknown as CustomBuildContext;
+    const error = new Error('daemon is not ready');
+
+    jest.mocked(fetch).mockRejectedValue(error);
+
+    void pollAgentDeviceArtifactsForUploadAsync(ctx, {
+      deviceRunSessionId: 'drs-id',
+      daemonUrl: 'http://127.0.0.1:1234',
+      daemonToken: 'daemon-token',
+      logger,
+    });
+
+    await flushPromisesAsync();
+    expect(jest.mocked(fetch)).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(Sentry.capture).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(20_000);
+    await flushPromisesAsync();
+    expect(jest.mocked(fetch)).toHaveBeenCalledTimes(5);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenLastCalledWith(
+      { err: error, failedArtifactListCount: 5 },
+      'Could not list agent-device remote session artifacts.'
+    );
+    expect(Sentry.capture).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(25_000);
+    await flushPromisesAsync();
+    expect(jest.mocked(fetch)).toHaveBeenCalledTimes(10);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenLastCalledWith(
+      { err: error, failedArtifactListCount: 10 },
+      'Could not list agent-device remote session artifacts.'
+    );
+    expect(Sentry.capture).toHaveBeenCalledTimes(2);
   });
 
   it('retries an artifact after a failed upload', async () => {

--- a/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
@@ -1,8 +1,10 @@
 import { bunyan } from '@expo/logger';
 import fetch from 'node-fetch';
 import { Readable } from 'node:stream';
+import * as timersPromises from 'node:timers/promises';
 
 import { CustomBuildContext } from '../../../customBuildContext';
+import { Sentry } from '../../../sentry';
 import { uploadDeviceRunSessionArtifactAsync } from '../deviceRunSessionArtifacts';
 import {
   listArgentArtifactsAsync,
@@ -13,8 +15,15 @@ import {
 jest.mock('../deviceRunSessionArtifacts');
 jest.mock('../../../sentry');
 jest.mock('node-fetch');
+jest.mock('node:timers/promises', () => {
+  const actual = jest.requireActual('node:timers/promises');
+  return { ...actual, setTimeout: jest.fn(actual.setTimeout) };
+});
 
 const { Response } = jest.requireActual('node-fetch') as typeof import('node-fetch');
+const { setTimeout: actualSetTimeoutAsync } = jest.requireActual(
+  'node:timers/promises'
+) as typeof import('node:timers/promises');
 
 async function readStreamAsync(stream: NodeJS.ReadableStream): Promise<void> {
   for await (const chunk of stream as Readable) {
@@ -135,7 +144,50 @@ describe(uploadArgentArtifactAsync, () => {
 describe(pollArgentArtifactsForUploadAsync, () => {
   beforeEach(() => {
     jest.mocked(fetch).mockReset();
+    jest.mocked(Sentry.capture).mockReset();
     jest.mocked(uploadDeviceRunSessionArtifactAsync).mockReset();
+  });
+
+  it('reports artifact listing errors on every fifth consecutive failure', async () => {
+    const logger = createLoggerMock();
+    const ctx = {} as unknown as CustomBuildContext;
+    const abortController = new AbortController();
+    const error = new Error('tool server is not ready');
+    let listCallCount = 0;
+    jest.mocked(timersPromises.setTimeout).mockResolvedValue(undefined);
+
+    jest.mocked(fetch).mockImplementation(async () => {
+      listCallCount += 1;
+      if (listCallCount === 11) {
+        abortController.abort();
+      }
+      throw error;
+    });
+
+    try {
+      await pollArgentArtifactsForUploadAsync(ctx, {
+        deviceRunSessionId: 'drs-id',
+        toolsUrl: 'http://127.0.0.1:1234',
+        toolsAuthToken: 'tools-token',
+        logger,
+        signal: abortController.signal,
+      });
+
+      expect(logger.warn).toHaveBeenCalledTimes(2);
+      expect(logger.warn).toHaveBeenNthCalledWith(
+        1,
+        { err: error, failedArtifactListCount: 5 },
+        'Could not list Argent remote session artifacts.'
+      );
+      expect(logger.warn).toHaveBeenNthCalledWith(
+        2,
+        { err: error, failedArtifactListCount: 10 },
+        'Could not list Argent remote session artifacts.'
+      );
+      expect(Sentry.capture).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.mocked(timersPromises.setTimeout).mockImplementation(actualSetTimeoutAsync);
+    }
   });
 
   it('stops polling when aborted, performs a final drain, and waits for uploads', async () => {

--- a/packages/build-tools/src/steps/utils/agentDeviceArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/agentDeviceArtifacts.ts
@@ -83,7 +83,7 @@ export async function pollAgentDeviceArtifactsForUploadAsync(
       }
       const error = err instanceof Error ? err : new Error(String(err));
       listArtifactsErrorCount += 1;
-      if (listArtifactsErrorCount === 1 || listArtifactsErrorCount % 5 === 0) {
+      if (listArtifactsErrorCount % 5 === 0) {
         Sentry.capture('Could not list agent-device remote session artifacts', error);
         logger.warn(
           { err: error, failedArtifactListCount: listArtifactsErrorCount },

--- a/packages/build-tools/src/steps/utils/argentArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/argentArtifacts.ts
@@ -89,7 +89,7 @@ export async function pollArgentArtifactsForUploadAsync(
 
       const error = err instanceof Error ? err : new Error(String(err));
       listArtifactsErrorCount += 1;
-      if (listArtifactsErrorCount === 1 || listArtifactsErrorCount % 5 === 0) {
+      if (listArtifactsErrorCount % 5 === 0) {
         Sentry.capture('Could not list Argent remote session artifacts', error);
         logger.warn(
           { err: error, failedArtifactListCount: listArtifactsErrorCount },


### PR DESCRIPTION
# Why

The Argent tool-server and agent-device daemon can be queried for artifacts before their endpoints are ready. Reporting the first transient failure produces a noisy warning and Sentry event even when a later poll succeeds normally.

# How

Only report artifact listing errors on every fifth consecutive failure for both Argent and agent-device instead of reporting the first failure and then every fifth. A successful listing continues to reset each failure count.

Add regression tests covering reports at the fifth and tenth consecutive failures for both pollers.

# Test Plan

CI should pass.