### PR TITLE
[eas-cli] Add --json flag and usage examples to eas init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] Handle new server-side errors thrown when observe features are blocked. ([#4042](https://github.com/expo/eas-cli/pull/4042) by [@douglowder](https://github.com/douglowder))
 - [eas-cli] Add `eas project:icon:set` to upload a project icon from the command line. ([#4068](https://github.com/expo/eas-cli/pull/4068) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli] Add `--account` flag to `eas init` to choose the account that should own the project, enabling non-interactive project creation (`eas init --account <name> --non-interactive`), and improve unconfigured-project error messages to list the accounts you can create projects in. ([#4057](https://github.com/expo/eas-cli/pull/4057) by [@williamgrosset](https://github.com/williamgrosset))
+- [eas-cli] Add `--json` flag to `eas init` to print the linked project (status, project ID, owner, slug, dashboard URL) as JSON to stdout, and add usage examples to `eas init --help`. ([#4079](https://github.com/expo/eas-cli/pull/4079) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -1624,13 +1624,14 @@ create or link an EAS project
 
 ```
 USAGE
-  $ eas init [--account <value> | --id <value>] [--force] [--non-interactive]
+  $ eas init [--account <value> | --id <value>] [--force] [--json] [--non-interactive]
 
 FLAGS
   --account=<value>  Name of the account that will own the project
   --force            Whether to create a new project/link an existing project without additional prompts or overwrite
                      any existing project ID when running with --id flag
   --id=<value>       ID of the EAS project to link
+  --json             Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.
   --non-interactive  Run the command in non-interactive mode.
 
 DESCRIPTION
@@ -1638,6 +1639,15 @@ DESCRIPTION
 
 ALIASES
   $ eas init
+
+EXAMPLES
+  $ eas init  	 # Create or link a project interactively
+
+  $ eas init --id <project-id>  	 # Link to the project with the given ID
+
+  $ eas init --account my-account --non-interactive  	 # Create or link @my-account/<slug> without prompts
+
+  $ eas init --account my-account --json --non-interactive  	 # Same, and print the result as JSON to stdout
 ```
 
 ## `eas integrations:asc:connect`
@@ -2260,13 +2270,14 @@ create or link an EAS project
 
 ```
 USAGE
-  $ eas project:init [--account <value> | --id <value>] [--force] [--non-interactive]
+  $ eas project:init [--account <value> | --id <value>] [--force] [--json] [--non-interactive]
 
 FLAGS
   --account=<value>  Name of the account that will own the project
   --force            Whether to create a new project/link an existing project without additional prompts or overwrite
                      any existing project ID when running with --id flag
   --id=<value>       ID of the EAS project to link
+  --json             Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.
   --non-interactive  Run the command in non-interactive mode.
 
 DESCRIPTION
@@ -2274,6 +2285,15 @@ DESCRIPTION
 
 ALIASES
   $ eas init
+
+EXAMPLES
+  $ eas init  	 # Create or link a project interactively
+
+  $ eas init --id <project-id>  	 # Link to the project with the given ID
+
+  $ eas init --account my-account --non-interactive  	 # Create or link @my-account/<slug> without prompts
+
+  $ eas init --account my-account --json --non-interactive  	 # Same, and print the result as JSON to stdout
 ```
 
 _See code: [packages/eas-cli/src/commands/project/init.ts](https://github.com/expo/eas-cli/blob/v21.2.0/packages/eas-cli/src/commands/project/init.ts)_

--- a/packages/eas-cli/src/commands/project/__tests__/init.test.ts
+++ b/packages/eas-cli/src/commands/project/__tests__/init.test.ts
@@ -17,6 +17,7 @@ import { createOrModifyExpoConfigAsync } from '../../../project/expoConfig';
 import { findProjectIdByAccountNameAndSlugNullableAsync } from '../../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
 import { isExpoInstalled } from '../../../project/projectUtils';
 import { confirmAsync, promptAsync } from '../../../prompts';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
 import ProjectInit from '../init';
 
 jest.mock('fs');
@@ -37,6 +38,7 @@ jest.mock('../../../ora', () => ({
 jest.mock('../../../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync');
 jest.mock('../../../commandUtils/context/contextUtils/getProjectIdAsync');
 jest.mock('../../../project/projectUtils');
+jest.mock('../../../utils/json');
 
 let originalProcessArgv: string[];
 
@@ -751,6 +753,138 @@ describe(ProjectInit.name, () => {
       );
 
       expect(saveProjectIdToAppConfigAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when json flag is provided', () => {
+    it('prints the created project as JSON', async () => {
+      mockTestProject({});
+      jest.mocked(AppMutation.createAppAsync).mockResolvedValue('0129');
+      jest
+        .mocked(createOrModifyExpoConfigAsync)
+        .mockResolvedValue({ type: 'success', config: {} as any });
+      jest.mocked(AppQuery.byIdAsync).mockResolvedValue({
+        id: '0129',
+        slug: 'testing-123',
+        name: 'testing-123',
+        fullName: '@jester/testing-123',
+        ownerAccount: jester.accounts[0],
+      });
+
+      await new ProjectInit(
+        ['--account', 'jester', '--json', '--non-interactive'],
+        commandOptions
+      ).run();
+
+      expect(enableJsonOutput).toHaveBeenCalled();
+      expect(printJsonOnlyOutput).toHaveBeenCalledWith({
+        status: 'created',
+        projectId: '0129',
+        owner: 'jester',
+        slug: 'testing-123',
+        dashboardUrl: 'https://expo.dev/accounts/jester/projects/testing-123',
+      });
+    });
+
+    it('prints the linked project as JSON when an existing project is found on the server', async () => {
+      mockTestProject({});
+      jest.mocked(findProjectIdByAccountNameAndSlugNullableAsync).mockResolvedValue('123456');
+      jest
+        .mocked(createOrModifyExpoConfigAsync)
+        .mockResolvedValue({ type: 'success', config: {} as any });
+      jest.mocked(AppQuery.byIdAsync).mockResolvedValue({
+        id: '123456',
+        slug: 'testing-123',
+        name: 'testing-123',
+        fullName: '@jester/testing-123',
+        ownerAccount: jester.accounts[0],
+      });
+
+      await new ProjectInit(
+        ['--account', 'jester', '--json', '--non-interactive'],
+        commandOptions
+      ).run();
+
+      expect(printJsonOnlyOutput).toHaveBeenCalledWith({
+        status: 'linked',
+        projectId: '123456',
+        owner: 'jester',
+        slug: 'testing-123',
+        dashboardUrl: 'https://expo.dev/accounts/jester/projects/testing-123',
+      });
+    });
+
+    it('prints already-linked as JSON when the project is already configured', async () => {
+      mockTestProject({ configuredProjectId: '1234', configuredOwner: jester.accounts[0].name });
+      jest.mocked(AppQuery.byIdAsync).mockResolvedValue({
+        id: '1234',
+        slug: 'testing-123',
+        name: 'testing-123',
+        fullName: '@jester/testing-123',
+        ownerAccount: jester.accounts[0],
+      });
+
+      await new ProjectInit(['--json', '--non-interactive'], commandOptions).run();
+
+      expect(printJsonOnlyOutput).toHaveBeenCalledWith({
+        status: 'already-linked',
+        projectId: '1234',
+        owner: 'jester',
+        slug: 'testing-123',
+        dashboardUrl: 'https://expo.dev/accounts/jester/projects/testing-123',
+      });
+    });
+
+    it('prints the linked project as JSON when linking with an explicit id', async () => {
+      mockTestProject({});
+      jest
+        .mocked(createOrModifyExpoConfigAsync)
+        .mockResolvedValue({ type: 'success', config: {} as any });
+      jest.mocked(AppQuery.byIdAsync).mockResolvedValue({
+        id: '1234',
+        slug: 'testing-123',
+        name: 'testing-123',
+        fullName: '@jester/testing-123',
+        ownerAccount: jester.accounts[0],
+      });
+
+      await new ProjectInit(['--id', '1234', '--json', '--non-interactive'], commandOptions).run();
+
+      expect(saveProjectIdToAppConfigAsync).toHaveBeenCalledWith('/test-project', '1234');
+      expect(printJsonOnlyOutput).toHaveBeenCalledWith({
+        status: 'linked',
+        projectId: '1234',
+        owner: 'jester',
+        slug: 'testing-123',
+        dashboardUrl: 'https://expo.dev/accounts/jester/projects/testing-123',
+      });
+    });
+
+    it('implies non-interactive mode', async () => {
+      mockTestProject({});
+
+      await expect(new ProjectInit(['--json'], commandOptions).run()).rejects.toThrowError(
+        'You have access to multiple accounts. Choose the account that should own this project with the --account flag'
+      );
+
+      expect(promptAsync).not.toHaveBeenCalled();
+      expect(printJsonOnlyOutput).not.toHaveBeenCalled();
+    });
+
+    it('does not print JSON without the json flag', async () => {
+      mockTestProject({ configuredProjectId: '1234', configuredOwner: jester.accounts[0].name });
+      jest.mocked(AppQuery.byIdAsync).mockResolvedValue({
+        id: '1234',
+        slug: 'testing-123',
+        name: 'testing-123',
+        fullName: '@jester/testing-123',
+        ownerAccount: jester.accounts[0],
+      });
+
+      await new ProjectInit([], commandOptions).run();
+
+      expect(enableJsonOutput).not.toHaveBeenCalled();
+      expect(printJsonOnlyOutput).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/eas-cli/src/commands/project/init.ts
+++ b/packages/eas-cli/src/commands/project/init.ts
@@ -1,16 +1,29 @@
 import { Flags } from '@oclif/core';
 
+import { getProjectDashboardUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
-import { EASNonInteractiveFlag } from '../../commandUtils/flags';
 import {
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
+} from '../../commandUtils/flags';
+import {
+  ProjectInitResult,
   ensureOwnerSlugConsistencyAsync,
   initializeWithExplicitIDAsync,
   initializeWithoutExplicitIDAsync,
 } from '../../project/projectInitialization';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class ProjectInit extends EasCommand {
   static override description = 'create or link an EAS project';
   static override aliases = ['init'];
+
+  static override examples = [
+    '$ eas init  \t # Create or link a project interactively',
+    '$ eas init --id <project-id>  \t # Link to the project with the given ID',
+    '$ eas init --account my-account --non-interactive  \t # Create or link @my-account/<slug> without prompts',
+    '$ eas init --account my-account --json --non-interactive  \t # Same, and print the result as JSON to stdout',
+  ];
 
   static override flags = {
     id: Flags.string({
@@ -24,7 +37,7 @@ export default class ProjectInit extends EasCommand {
       description:
         'Whether to create a new project/link an existing project without additional prompts or overwrite any existing project ID when running with --id flag',
     }),
-    ...EASNonInteractiveFlag,
+    ...EasNonInteractiveAndJsonFlags,
   };
 
   static override contextDefinition = {
@@ -33,32 +46,50 @@ export default class ProjectInit extends EasCommand {
   };
 
   async runAsync(): Promise<void> {
-    const {
-      flags: { id: idArgument, account: accountArgument, force, 'non-interactive': nonInteractive },
-    } = await this.parse(ProjectInit);
+    const { flags } = await this.parse(ProjectInit);
+    const { id: idArgument, account: accountArgument, force } = flags;
+    const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
     const {
       loggedIn: { actor, graphqlClient },
       projectDir,
     } = await this.getContextAsync(ProjectInit, { nonInteractive });
 
-    let idForConsistency: string;
+    let result: ProjectInitResult;
     if (idArgument) {
-      await initializeWithExplicitIDAsync(idArgument, projectDir, {
+      const status = await initializeWithExplicitIDAsync(idArgument, projectDir, {
         force,
         nonInteractive,
       });
-      idForConsistency = idArgument;
+      result = { projectId: idArgument, status };
     } else {
-      idForConsistency = await initializeWithoutExplicitIDAsync(graphqlClient, actor, projectDir, {
+      result = await initializeWithoutExplicitIDAsync(graphqlClient, actor, projectDir, {
         force,
         nonInteractive,
         accountName: accountArgument,
       });
     }
 
-    await ensureOwnerSlugConsistencyAsync(graphqlClient, idForConsistency, projectDir, {
-      force,
-      nonInteractive,
-    });
+    const { owner, slug } = await ensureOwnerSlugConsistencyAsync(
+      graphqlClient,
+      result.projectId,
+      projectDir,
+      {
+        force,
+        nonInteractive,
+      }
+    );
+
+    if (jsonFlag) {
+      printJsonOnlyOutput({
+        status: result.status,
+        projectId: result.projectId,
+        owner,
+        slug,
+        dashboardUrl: getProjectDashboardUrl(owner, slug),
+      });
+    }
   }
 }

--- a/packages/eas-cli/src/project/projectInitialization.ts
+++ b/packages/eas-cli/src/project/projectInitialization.ts
@@ -24,6 +24,13 @@ export type InitializeMethodOptions = {
   nonInteractive: boolean;
 };
 
+export type ProjectInitStatus = 'created' | 'linked' | 'already-linked';
+
+export type ProjectInitResult = {
+  projectId: string;
+  status: ProjectInitStatus;
+};
+
 async function saveProjectIdAndLogSuccessAsync(
   projectDir: string,
   projectId: string
@@ -85,7 +92,7 @@ export async function ensureOwnerSlugConsistencyAsync(
   projectId: string,
   projectDir: string,
   { force, nonInteractive }: InitializeMethodOptions
-): Promise<void> {
+): Promise<{ owner: string; slug: string }> {
   const exp = await getPrivateExpoConfigAsync(projectDir);
   const appForProjectId = await AppQuery.byIdAsync(graphqlClient, projectId);
   const correctOwner = appForProjectId.ownerAccount.name;
@@ -134,59 +141,60 @@ export async function ensureOwnerSlugConsistencyAsync(
   } else if (!exp.slug) {
     await modifyExpoConfigAsync(projectDir, { slug: correctSlug });
   }
+
+  return { owner: correctOwner, slug: correctSlug };
 }
 
 async function setExplicitIDAsync(
   projectId: string,
   projectDir: string,
   { force, nonInteractive }: InitializeMethodOptions
-): Promise<void> {
+): Promise<ProjectInitStatus> {
   const exp = await getPrivateExpoConfigAsync(projectDir);
   const existingProjectId = exp.extra?.eas?.projectId;
 
   if (projectId === existingProjectId) {
     Log.succeed(`Project already linked (ID: ${chalk.bold(existingProjectId)})`);
-    return;
+    return 'already-linked';
   }
 
   if (!existingProjectId) {
     await saveProjectIdAndLogSuccessAsync(projectDir, projectId);
-    return;
+    return 'linked';
   }
 
-  if (projectId !== existingProjectId) {
-    if (force) {
-      await saveProjectIdAndLogSuccessAsync(projectDir, projectId);
-      return;
-    }
-
-    if (nonInteractive) {
-      throw new Error(
-        `Project is already linked to a different ID: ${chalk.bold(
-          existingProjectId
-        )}. Use --force flag to overwrite.`
-      );
-    }
-
-    const confirm = await confirmAsync({
-      message: `Project is already linked to a different ID: ${chalk.bold(
-        existingProjectId
-      )}. Do you wish to overwrite it?`,
-    });
-    if (!confirm) {
-      throw new Error('Aborting');
-    }
-
+  if (force) {
     await saveProjectIdAndLogSuccessAsync(projectDir, projectId);
+    return 'linked';
   }
+
+  if (nonInteractive) {
+    throw new Error(
+      `Project is already linked to a different ID: ${chalk.bold(
+        existingProjectId
+      )}. Use --force flag to overwrite.`
+    );
+  }
+
+  const confirm = await confirmAsync({
+    message: `Project is already linked to a different ID: ${chalk.bold(
+      existingProjectId
+    )}. Do you wish to overwrite it?`,
+  });
+  if (!confirm) {
+    throw new Error('Aborting');
+  }
+
+  await saveProjectIdAndLogSuccessAsync(projectDir, projectId);
+  return 'linked';
 }
 
 export async function initializeWithExplicitIDAsync(
   projectId: string,
   projectDir: string,
   { force, nonInteractive }: InitializeMethodOptions
-): Promise<void> {
-  await setExplicitIDAsync(projectId, projectDir, {
+): Promise<ProjectInitStatus> {
+  return await setExplicitIDAsync(projectId, projectDir, {
     force,
     nonInteractive,
   });
@@ -201,7 +209,7 @@ export async function initializeWithoutExplicitIDAsync(
     nonInteractive,
     accountName: accountNameArgument,
   }: InitializeMethodOptions & { accountName?: string }
-): Promise<string> {
+): Promise<ProjectInitResult> {
   const exp = await getPrivateExpoConfigAsync(projectDir);
   const existingProjectId = exp.extra?.eas?.projectId;
 
@@ -215,7 +223,7 @@ export async function initializeWithoutExplicitIDAsync(
           existingProjectId
         )}). To re-configure, remove the "extra.eas.projectId" field from your app config.`
       );
-      return existingProjectId;
+      return { projectId: existingProjectId, status: 'already-linked' };
     }
     if (!force) {
       throw new Error(
@@ -317,7 +325,7 @@ export async function initializeWithoutExplicitIDAsync(
     }
 
     await saveProjectIdAndLogSuccessAsync(projectDir, existingProjectIdOnServer);
-    return existingProjectIdOnServer;
+    return { projectId: existingProjectIdOnServer, status: 'linked' };
   }
 
   if (!accountNamesWhereUserHasSufficientPermissionsToCreateApp.has(accountName)) {
@@ -359,5 +367,5 @@ export async function initializeWithoutExplicitIDAsync(
   }
 
   await saveProjectIdAndLogSuccessAsync(projectDir, createdProjectId);
-  return createdProjectId;
+  return { projectId: createdProjectId, status: 'created' };
 }


### PR DESCRIPTION
> [!NOTE]
> Originally stacked on #4057 (`--account` flag), which has since merged; this branch is rebased onto `main`.

# Why

Make `eas init` a better onboarding entry point for coding agents (and CI). With #4057, the whole flow works non-interactively, but the output is still human-oriented — an agent has to regex the project ID out of `Project successfully linked (ID: ...)`. And the `--account --non-interactive` recipe is only discoverable through error messages, not through `eas init --help`, which is the first place agents look.

# How

- Add `--json` (via the standard `EasNonInteractiveAndJsonFlags`, so it implies `--non-interactive`). On success it prints to stdout:

  ```json
  {
    "status": "created" | "linked" | "already-linked",
    "projectId": "...",
    "owner": "...",
    "slug": "...",
    "dashboardUrl": "https://expo.dev/accounts/<owner>/projects/<slug>"
  }
  ```

- To support this, `initializeWithExplicitIDAsync`/`initializeWithoutExplicitIDAsync` now return the init status alongside the project ID, and `ensureOwnerSlugConsistencyAsync` returns the canonical `owner`/`slug` it already fetches (no extra API call). The only other caller (`workflow:create`) ignores the return value, so no behavior change there.

- Add oclif `examples` covering interactive use, `--id`, and the non-interactive `--account` recipes, following the `fingerprint:generate` format.

# Test Plan

- 6 new tests in `init.test.ts` covering JSON output for created/linked/already-linked/explicit-id paths, `--json` implying non-interactive, and no JSON output without the flag (39 total pass).
- `yarn typecheck`, `yarn lint`, `yarn fmt:check` clean; workflow command tests pass.
- Manual: `bin/run init --help` shows the new flag and examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
