### PR TITLE
Bump @expo/code-review-cli default to ^0.4.0

### DIFF
--- a/.github/workflows/expo-code-review-command.yml
+++ b/.github/workflows/expo-code-review-command.yml
@@ -19,7 +19,7 @@ permissions:
 
 env:
   # Published reviewer run via npx (override with repo variable ECR_VERSION).
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.2.3' }}
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.4.0' }}
 
 concurrency:
   group: ai-code-review-cmd-${{ github.event.issue.number }}

--- a/.github/workflows/expo-code-review-dismiss.yml
+++ b/.github/workflows/expo-code-review-dismiss.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   # Published reviewer run via npx (override with repo variable ECR_VERSION).
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.2.3' }}
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.4.0' }}
 
 concurrency:
   group: ai-code-review-dismiss-${{ github.event.issue.number }}

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -13,8 +13,8 @@ permissions:
 env:
   # The reviewer is the published @expo/code-review-cli package, run via npx — the
   # repo only carries the `.expo-code-review/` config, not the engine source.
-  # Override with a repo variable ECR_VERSION to pin/bump; defaults to 0.2.x.
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.2.3' }}
+  # Override with a repo variable ECR_VERSION to pin/bump; defaults to 0.4.x.
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.4.0' }}
 
 concurrency:
   group: ai-code-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Why

`@expo/code-review-cli` 0.4.0 is published (monorepo routing, tag-driven publish); the workflows here still default to `^0.2.3`, which caret-locks eas-cli to 0.2.x.

## How

Verified the upgrade is a no-op for a single-package repo: the config schema changes are additive, the comment fingerprint format is unchanged (0.4.0 updates the existing 0.2.x reviewer comment instead of posting a duplicate), and the new trigger gate sits behind the existing `ai-review` label gate.

## Test plan

`ecr doctor` on 0.4.0 validates the existing `.expo-code-review/` config. This PR carries the `ai-review` label, so the reviewer itself runs on 0.4.0 here — that run is the smoke test.