### PR TITLE
[eas-build-job] Add optional ssh field on job payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-build-job] Add optional `ssh` field on build/job payloads. ([#4083](https://github.com/expo/eas-cli/pull/4083) by [@gwdp](https://github.com/gwdp))
 - [eas-build-job] Add an `SSH_SESSION` build phase for upcoming worker SSH support. ([#4029](https://github.com/expo/eas-cli/pull/4029) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Add `ref` input to the `eas/checkout` step to check out a different git ref (branch, tag, or commit SHA) than the one that triggered the job. ([#4035](https://github.com/expo/eas-cli/pull/4035) by [@sswrk](https://github.com/sswrk))
 - [build-tools] Load local composite function catalogs at build time so custom builds and generic jobs can resolve local composite functions referenced via `uses:`. ([#3930](https://github.com/expo/eas-cli/pull/3930) by [@sswrk](https://github.com/sswrk))

--- a/packages/eas-build-job/src/__tests__/common.test.ts
+++ b/packages/eas-build-job/src/__tests__/common.test.ts
@@ -1,4 +1,4 @@
-import { EnvSchema, StaticWorkflowInterpolationContextZ } from '../common';
+import { EnvSchema, SshSettingsZ, StaticWorkflowInterpolationContextZ } from '../common';
 
 describe('EnvSchema', () => {
   it('accepts explicit undefined values', () => {
@@ -11,6 +11,23 @@ describe('EnvSchema', () => {
 
     expect(error).toBeUndefined();
     expect(value).toEqual(env);
+  });
+});
+
+describe('SshSettingsZ', () => {
+  it('accepts ws and wss relay URLs', () => {
+    expect(
+      SshSettingsZ.parse({ idleTimeoutSeconds: 0, relayServerUrl: 'wss://ssh.expo.dev' })
+    ).toEqual({ idleTimeoutSeconds: 0, relayServerUrl: 'wss://ssh.expo.dev' });
+    expect(
+      SshSettingsZ.parse({ idleTimeoutSeconds: 60, relayServerUrl: 'ws://localhost:8080' })
+    ).toEqual({ idleTimeoutSeconds: 60, relayServerUrl: 'ws://localhost:8080' });
+  });
+
+  it('rejects non-websocket relay URL schemes', () => {
+    expect(() =>
+      SshSettingsZ.parse({ idleTimeoutSeconds: 0, relayServerUrl: 'https://ssh.expo.dev' })
+    ).toThrow(/ws:\/\/ or wss:\/\//);
   });
 });
 

--- a/packages/eas-build-job/src/__tests__/common.test.ts
+++ b/packages/eas-build-job/src/__tests__/common.test.ts
@@ -27,7 +27,7 @@ describe('SshSettingsZ', () => {
   it('rejects non-websocket relay URL schemes', () => {
     expect(() =>
       SshSettingsZ.parse({ idleTimeoutSeconds: 0, relayServerUrl: 'https://ssh.expo.dev' })
-    ).toThrow(/ws:\/\/ or wss:\/\//);
+    ).toThrow(/Invalid URL|Invalid protocol/);
   });
 });
 

--- a/packages/eas-build-job/src/__tests__/generic.test.ts
+++ b/packages/eas-build-job/src/__tests__/generic.test.ts
@@ -92,6 +92,41 @@ describe('Generic.JobZ', () => {
     expect(Generic.JobZ.parse(job)).toEqual(job);
   });
 
+  it('accepts optional ssh settings', () => {
+    const job: Generic.Job = {
+      projectArchive: {
+        type: ArchiveSourceType.GIT,
+        repositoryUrl: 'https://github.com/expo/expo.git',
+        gitCommitHash: '1234567890',
+        gitRef: null,
+      },
+      ssh: { idleTimeoutSeconds: 900, relayServerUrl: 'wss://ssh.expo.dev' },
+      steps: [
+        {
+          id: 'step1',
+          name: 'Step 1',
+          run: 'echo Hello, world!',
+          shell: 'sh',
+        },
+      ],
+      secrets: {
+        robotAccessToken: 'token',
+        environmentSecrets: [],
+      },
+      expoDevUrl: 'https://expo.dev/accounts/name/builds/id',
+      builderEnvironment: {
+        image: 'macos-sonoma-14.5-xcode-15.4',
+        node: '20.15.1',
+        corepack: false,
+        env: {},
+      },
+      triggeredBy: BuildTrigger.GIT_BASED_INTEGRATION,
+      appId: randomUUID(),
+      initiatingUserId: randomUUID(),
+    };
+    expect(Generic.JobZ.parse(job)).toEqual(job);
+  });
+
   it('accepts hooks with arbitrary names', () => {
     const job: Generic.Job = {
       projectArchive: {

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -18,6 +18,8 @@ import {
   JobOutputs,
   JobOutputsSchema,
   Platform,
+  SshSettings,
+  SshSettingsSchema,
   StaticWorkflowInterpolationContext,
   StaticWorkflowInterpolationContextZ,
   Workflow,
@@ -111,6 +113,7 @@ export interface Job {
     path: string;
   };
   hooks?: Hooks;
+  ssh?: SshSettings;
   steps?: Step[];
   outputs?: JobOutputs;
 
@@ -178,6 +181,7 @@ export const JobSchema = Joi.object({
   buildType: Joi.string().valid(...Object.values(BuildType)),
   username: Joi.string(),
   hooks: HooksSchema,
+  ssh: SshSettingsSchema,
   outputs: JobOutputsSchema,
 
   experimental: Joi.object({

--- a/packages/eas-build-job/src/android.ts
+++ b/packages/eas-build-job/src/android.ts
@@ -181,7 +181,7 @@ export const JobSchema = Joi.object({
   buildType: Joi.string().valid(...Object.values(BuildType)),
   username: Joi.string(),
   hooks: HooksSchema,
-  ssh: SshSettingsSchema,
+  ssh: SshSettingsSchema.optional(),
   outputs: JobOutputsSchema,
 
   experimental: Joi.object({

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -175,12 +175,8 @@ export const SshSettingsZ = z.object({
     .string()
     .url()
     .refine(value => {
-      try {
-        const { protocol } = new URL(value);
-        return protocol === 'ws:' || protocol === 'wss:';
-      } catch {
-        return false;
-      }
+      const { protocol } = new URL(value);
+      return protocol === 'ws:' || protocol === 'wss:';
     }, 'relayServerUrl must be a ws:// or wss:// URL'),
 });
 

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -157,6 +157,33 @@ export const HooksSchema = Joi.object().pattern(
 );
 export const HooksZ = z.record(z.string(), z.array(StepZ));
 
+/** Worker-side SSH session settings for workflow VM jobs. Presence enables SSH. */
+export type SshSettings = {
+  idleTimeoutSeconds: number;
+  /** The relay the worker dials. Per-deployment config; the public upterm host is not allowed. */
+  relayServerUrl: string;
+};
+export const SshSettingsSchema = Joi.object({
+  idleTimeoutSeconds: Joi.number().integer().min(0).max(3600).required(),
+  relayServerUrl: Joi.string()
+    .uri({ scheme: ['ws', 'wss'] })
+    .required(),
+});
+export const SshSettingsZ = z.object({
+  idleTimeoutSeconds: z.number().int().min(0).max(3600),
+  relayServerUrl: z
+    .string()
+    .url()
+    .refine(value => {
+      try {
+        const { protocol } = new URL(value);
+        return protocol === 'ws:' || protocol === 'wss:';
+      } catch {
+        return false;
+      }
+    }, 'relayServerUrl must be a ws:// or wss:// URL'),
+});
+
 export interface Cache {
   disabled: boolean;
   clear: boolean;

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -171,13 +171,7 @@ export const SshSettingsSchema = Joi.object({
 });
 export const SshSettingsZ = z.object({
   idleTimeoutSeconds: z.number().int().min(0).max(3600),
-  relayServerUrl: z
-    .string()
-    .url()
-    .refine(value => {
-      const { protocol } = new URL(value);
-      return protocol === 'ws:' || protocol === 'wss:';
-    }, 'relayServerUrl must be a ws:// or wss:// URL'),
+  relayServerUrl: z.url({ protocol: /^wss?$/ }),
 });
 
 export interface Cache {

--- a/packages/eas-build-job/src/generic.ts
+++ b/packages/eas-build-job/src/generic.ts
@@ -7,6 +7,7 @@ import {
   EnvironmentSecretZ,
   HooksZ,
   JobOutputsSchemaZ,
+  SshSettingsZ,
   StaticWorkflowInterpolationContextZ,
 } from './common';
 import { StepZ } from './step';
@@ -48,6 +49,7 @@ export namespace Generic {
     appId: z.string(),
 
     hooks: HooksZ.optional(),
+    ssh: SshSettingsZ.optional(),
     steps: z.array(StepZ).min(1),
     outputs: JobOutputsSchemaZ.optional(),
   });

--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -11,6 +11,7 @@ export {
   EnvironmentSecret,
   EnvironmentSecretType,
   Hooks,
+  SshSettings,
   Workflow,
   Platform,
   Cache,

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -217,7 +217,7 @@ export const JobSchema = Joi.object({
 
   username: Joi.string(),
   hooks: HooksSchema,
-  ssh: SshSettingsSchema,
+  ssh: SshSettingsSchema.optional(),
   outputs: JobOutputsSchema,
 
   experimental: Joi.object({

--- a/packages/eas-build-job/src/ios.ts
+++ b/packages/eas-build-job/src/ios.ts
@@ -18,6 +18,8 @@ import {
   JobOutputs,
   JobOutputsSchema,
   Platform,
+  SshSettings,
+  SshSettingsSchema,
   StaticWorkflowInterpolationContext,
   StaticWorkflowInterpolationContextZ,
   Workflow,
@@ -125,6 +127,7 @@ export interface Job {
     path: string;
   };
   hooks?: Hooks;
+  ssh?: SshSettings;
   steps?: Step[];
   outputs?: JobOutputs;
 
@@ -214,6 +217,7 @@ export const JobSchema = Joi.object({
 
   username: Joi.string(),
   hooks: HooksSchema,
+  ssh: SshSettingsSchema,
   outputs: JobOutputsSchema,
 
   experimental: Joi.object({


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We're putting SSH settings on the job itself instead of stuffing them into env. `www` needs the type on `@expo/eas-build-job` for that.

# How

Add an optional `ssh` field on Generic and Build jobs.

# Test Plan

- Unit test that JobZ accepts `ssh`
- `yarn test` in `packages/eas-build-job`