### PR TITLE
[reviewer] Use gpt-5.5 @expo/code-review-cli@0.5.0

### DIFF
--- a/.expo-code-review/agents/security.md
+++ b/.expo-code-review/agents/security.md
@@ -1,11 +1,10 @@
 ---
 description: Security and secrets. Injection, credential or secret leakage, unsafe shell/child-process use, missing validation at trust boundaries.
 alwaysRun: true
-# Security is the highest-stakes agent and benefits most from stronger threat-model
-# reasoning, so it runs on Opus even though the other specialists use the Sonnet
-# default. Scoped to this one agent to limit the extra latency/rate-limit cost;
-# subdivide-on-timeout + the per-fetch deadline keep a slow Opus pass from hanging.
-model: anthropic/claude-opus-4-8
+# No model override: security runs on the config default (gpt-5.5, on the
+# subscription). To give it a stronger model, use the metered openai-api alias
+# from the mixed auth.providers setup (see the @expo/code-review-cli README) —
+# pro-tier models are excluded from the subscription.
 ---
 
 # Security & secrets

--- a/.expo-code-review/config.jsonc
+++ b/.expo-code-review/config.jsonc
@@ -1,10 +1,9 @@
 {
-  // Default model for the specialist reviewers (and the cross-file pass). Sonnet
-  // is the quality/speed sweet spot for finding real bugs. Per-agent frontmatter
-  // can override this; the coordinator runs on Haiku (see coordinator.md) since it
-  // only consolidates text. Override everything at runtime with REVIEWER_MODEL
-  // (e.g. REVIEWER_MODEL=openai/gpt-5.4-mini-fast for a cheaper local run).
-  "model": "anthropic/claude-sonnet-5",
+  // Default model for every pass — served by the ChatGPT/Codex subscription (see
+  // auth below), so reviews have no marginal cost. Per-agent frontmatter can
+  // override this. Override everything at runtime with REVIEWER_MODEL
+  // (e.g. REVIEWER_MODEL=openai/gpt-5.4-mini for a cheaper local run).
+  "model": "openai/gpt-5.5",
 
   // Agents are every markdown file in agents/. shared.md (prepended to all) and
   // coordinator.md are reserved. Per-agent overrides go in each file's frontmatter.
@@ -31,12 +30,15 @@
   "breakGlass": { "marker": "/skip-review" },
   "commentTag": "expo-ai-code-reviewer",
 
-  // Use a Claude Pro/Max OAuth token (from `claude setup-token`) rather than an
-  // x-api-key. The token is read from this env var and injected into an isolated
-  // OpenCode auth.json as a bearer credential.
+  // ChatGPT/Codex subscription (OAuth): tokenEnv holds the REFRESH token from an
+  // `opencode auth login` ChatGPT sign-in (copy `.openai.refresh` out of OpenCode's
+  // auth.json); OpenCode mints short-lived access tokens from it on demand. All
+  // models above are on the subscription's allowlist, so reviews draw no metered
+  // spend. (To add pro-tier models later, see the mixed auth.providers setup in
+  // the @expo/code-review-cli README.)
   "auth": {
     "mode": "oauth",
-    "provider": "anthropic",
-    "tokenEnv": "ANTHROPIC_OAUTH_API_KEY"
+    "provider": "openai",
+    "tokenEnv": "CODEX_OAUTH_REFRESH_TOKEN"
   }
 }

--- a/.expo-code-review/coordinator.md
+++ b/.expo-code-review/coordinator.md
@@ -1,8 +1,7 @@
 ---
-# The coordinator makes the final call — de-duping, re-judging severity, and
-# deciding — so it runs on Opus: consolidation quality matters more here than the
-# small serial-tail latency it adds (no repo tools, so it's a single bounded pass).
-model: anthropic/claude-opus-4-8
+# No model override: the coordinator runs on the config default (gpt-5.5, on the
+# subscription). It only consolidates text (no repo tools), so the default is
+# plenty; override here if consolidation quality ever needs a stronger model.
 ---
 
 # Coordinator — consolidation & decision

--- a/.github/workflows/expo-code-review-command.yml
+++ b/.github/workflows/expo-code-review-command.yml
@@ -19,7 +19,7 @@ permissions:
 
 env:
   # Published reviewer run via npx (override with repo variable ECR_VERSION).
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.4.0' }}
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.5.0' }}
 
 concurrency:
   group: ai-code-review-cmd-${{ github.event.issue.number }}
@@ -104,7 +104,8 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANTHROPIC_OAUTH_API_KEY: ${{ secrets.ANTHROPIC_OAUTH_API_KEY }}
+          CODEX_OAUTH_REFRESH_TOKEN: ${{ secrets.CODEX_OAUTH_REFRESH_TOKEN }}
+          ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CODEX_OAUTH_REFRESH_TOKEN' }}
           REVIEWER_MODEL: ${{ vars.REVIEWER_MODEL }}
           AGENTS: ${{ steps.cmd.outputs.agents }}
           ROUTE: ${{ steps.cmd.outputs.route }}

--- a/.github/workflows/expo-code-review-dismiss.yml
+++ b/.github/workflows/expo-code-review-dismiss.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   # Published reviewer run via npx (override with repo variable ECR_VERSION).
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.4.0' }}
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.5.0' }}
 
 concurrency:
   group: ai-code-review-dismiss-${{ github.event.issue.number }}

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -13,8 +13,8 @@ permissions:
 env:
   # The reviewer is the published @expo/code-review-cli package, run via npx — the
   # repo only carries the `.expo-code-review/` config, not the engine source.
-  # Override with a repo variable ECR_VERSION to pin/bump; defaults to 0.4.x.
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.4.0' }}
+  # Override with a repo variable ECR_VERSION to pin/bump; defaults to 0.5.x.
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.5.0' }}
 
 concurrency:
   group: ai-code-review-${{ github.event.pull_request.number }}
@@ -98,7 +98,7 @@ jobs:
       - name: Guard config.jsonc tokenEnv
         if: steps.resolve.outputs.run == 'true'
         env:
-          EXPECTED: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'ANTHROPIC_OAUTH_API_KEY' }}
+          EXPECTED: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CODEX_OAUTH_REFRESH_TOKEN' }}
         run: |
           values=$(grep -oE '"tokenEnv"[[:space:]]*:[[:space:]]*"[A-Za-z0-9_]+"' .expo-code-review/config.jsonc | sed -E 's/.*"([A-Za-z0-9_]+)"$/\1/')
           count=$(printf '%s\n' "$values" | grep -c .)
@@ -135,9 +135,13 @@ jobs:
         env:
           # GitHub token scoped by the permissions block above (PR comments only).
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Claude Pro/Max OAuth token (auth.mode "oauth" in .expo-code-review/
-          # config.jsonc reads this env var). Not an x-api-key.
-          ANTHROPIC_OAUTH_API_KEY: ${{ secrets.ANTHROPIC_OAUTH_API_KEY }}
+          # ChatGPT/Codex subscription refresh token (auth.mode "oauth" in
+          # .expo-code-review/config.jsonc reads this env var); OpenCode mints
+          # access tokens from it. All reviews run on the subscription.
+          CODEX_OAUTH_REFRESH_TOKEN: ${{ secrets.CODEX_OAUTH_REFRESH_TOKEN }}
+          # Layer-1 runtime auth lock (mirrors the guard step): the CLI refuses to
+          # run when the tokenEnv the loaded config honors differs from this.
+          ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CODEX_OAUTH_REFRESH_TOKEN' }}
           # Optional: override the model used by every agent.
           REVIEWER_MODEL: ${{ vars.REVIEWER_MODEL }}
           AGENTS: ${{ steps.resolve.outputs.agents }}


### PR DESCRIPTION
## Why

The reviewer's anthropic-oauth setup never actually worked: OpenCode has no Anthropic OAuth support (Anthropic prohibits subscription tokens in third-party tools), so the credential was silently dropped and every "successful" review here ran on OpenCode's free gateway model — including the 37-minute zero-findings review on #4084 (~139 output tokens/pass, throttle-stalled). @expo/code-review-cli@0.5.0 fails fast on unusable credentials/model ids and logs which model actually answered each pass, so this can't recur silently.

## What

- **All passes on `openai/gpt-5.5`, served by the ChatGPT/Codex subscription** (OpenAI permits subscription auth in third-party tools) — zero metered spend. Security/coordinator drop their Opus overrides; pro-tier models are subscription-excluded and can be added later via the CLI's mixed `auth.providers` setup with the metered key.
- `auth.tokenEnv` → `CODEX_OAUTH_REFRESH_TOKEN` (the refresh token from an `opencode auth login` ChatGPT sign-in; OpenCode mints access tokens from it — reuse across CI runs verified). The repo secret is already set.
- Workflows: `@expo/code-review-cli` `^0.4.0` → `^0.5.0`, guard default swapped to the new env name, and the runtime `ECR_EXPECTED_TOKEN_ENV` lock is now also passed to `ecr ci` (layer 1, mirroring the guard step).

Every run's job log now prints `Models used — …` per pass, and the step summary gets a model column — so if the provider ever substitutes a model again, it's loud instead of invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)