### PR TITLE
[reviewer] Switch the credential to the ChatGPT ACCESS token

### DIFF
--- a/.expo-code-review/config.jsonc
+++ b/.expo-code-review/config.jsonc
@@ -30,15 +30,17 @@
   "breakGlass": { "marker": "/skip-review" },
   "commentTag": "expo-ai-code-reviewer",
 
-  // ChatGPT/Codex subscription (OAuth): tokenEnv holds the REFRESH token from an
-  // `opencode auth login` ChatGPT sign-in (copy `.openai.refresh` out of OpenCode's
-  // auth.json); OpenCode mints short-lived access tokens from it on demand. All
-  // models above are on the subscription's allowlist, so reviews draw no metered
-  // spend. (To add pro-tier models later, see the mixed auth.providers setup in
-  // the @expo/code-review-cli README.)
+  // ChatGPT/Codex subscription (OAuth): tokenEnv holds the ACCESS token from an
+  // `opencode auth login` ChatGPT sign-in (`ecr setup-auth` extracts it) — a
+  // plain bearer with no rotation involvement; re-mint before its ~10-day expiry
+  // (doctor + the run preflight warn first). NEVER use the refresh token here:
+  // it is single-use and dies on first rotation. All models above are on the
+  // subscription's allowlist, so reviews draw no metered spend. (To add pro-tier
+  // models later, see the mixed auth.providers setup in the @expo/code-review-cli
+  // README.)
   "auth": {
     "mode": "oauth",
     "provider": "openai",
-    "tokenEnv": "CODEX_OAUTH_REFRESH_TOKEN"
+    "tokenEnv": "CODEX_OAUTH_ACCESS_TOKEN"
   }
 }

--- a/.github/workflows/expo-code-review-command.yml
+++ b/.github/workflows/expo-code-review-command.yml
@@ -104,8 +104,8 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CODEX_OAUTH_REFRESH_TOKEN: ${{ secrets.CODEX_OAUTH_REFRESH_TOKEN }}
-          ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CODEX_OAUTH_REFRESH_TOKEN' }}
+          CODEX_OAUTH_ACCESS_TOKEN: ${{ secrets.CODEX_OAUTH_ACCESS_TOKEN }}
+          ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CODEX_OAUTH_ACCESS_TOKEN' }}
           REVIEWER_MODEL: ${{ vars.REVIEWER_MODEL }}
           AGENTS: ${{ steps.cmd.outputs.agents }}
           ROUTE: ${{ steps.cmd.outputs.route }}

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Guard config.jsonc tokenEnv
         if: steps.resolve.outputs.run == 'true'
         env:
-          EXPECTED: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CODEX_OAUTH_REFRESH_TOKEN' }}
+          EXPECTED: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CODEX_OAUTH_ACCESS_TOKEN' }}
         run: |
           values=$(grep -oE '"tokenEnv"[[:space:]]*:[[:space:]]*"[A-Za-z0-9_]+"' .expo-code-review/config.jsonc | sed -E 's/.*"([A-Za-z0-9_]+)"$/\1/')
           count=$(printf '%s\n' "$values" | grep -c .)
@@ -135,13 +135,14 @@ jobs:
         env:
           # GitHub token scoped by the permissions block above (PR comments only).
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # ChatGPT/Codex subscription refresh token (auth.mode "oauth" in
-          # .expo-code-review/config.jsonc reads this env var); OpenCode mints
-          # access tokens from it. All reviews run on the subscription.
-          CODEX_OAUTH_REFRESH_TOKEN: ${{ secrets.CODEX_OAUTH_REFRESH_TOKEN }}
+          # ChatGPT/Codex subscription ACCESS token (auth.mode "oauth" in
+          # .expo-code-review/config.jsonc reads this env var) — used as-is, no
+          # rotation involvement; re-mint before its ~10-day expiry. All reviews
+          # run on the subscription.
+          CODEX_OAUTH_ACCESS_TOKEN: ${{ secrets.CODEX_OAUTH_ACCESS_TOKEN }}
           # Layer-1 runtime auth lock (mirrors the guard step): the CLI refuses to
           # run when the tokenEnv the loaded config honors differs from this.
-          ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CODEX_OAUTH_REFRESH_TOKEN' }}
+          ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CODEX_OAUTH_ACCESS_TOKEN' }}
           # Optional: override the model used by every agent.
           REVIEWER_MODEL: ${{ vars.REVIEWER_MODEL }}
           AGENTS: ${{ steps.resolve.outputs.agents }}


### PR DESCRIPTION
Refresh tokens are single-use (rotation): the shared refresh-token secret was spent by its first CI use and the sign-in died with it. The access token is a rotation-free bearer — @expo/code-review-cli 0.5.2 detects the kind, uses it as-is, and warns (doctor + preflight) before its ~10-day expiry. The `CODEX_OAUTH_ACCESS_TOKEN` secret is already set and the old refresh secret deleted; the token-rotator cron (top roadmap item in code-review-cli) will keep it fresh automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)