### PR TITLE
[eas-cli] Fix EAS logo not rendering in the root README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - [eas-cli] Refresh README as an EAS product landing page. ([#3844](https://github.com/expo/eas-cli/pull/3844) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Fix the EAS logo not rendering in the repository root README. ([#4093](https://github.com/expo/eas-cli/pull/4093) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [21.3.0](https://github.com/expo/eas-cli/releases/tag/v21.3.0) - 2026-07-27
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -1,8 +1,10 @@
 <!-- Everything above the "# Commands" section is generated from packages/eas-cli/scripts/readme-header.md. Edit that file, not README.md; `yarn version` regenerates README.md and overwrites this content. -->
 
+<!-- The logo src is an absolute URL on purpose: this file is also the repository root README (README.md is a symlink to it), so it renders at two different depths and no single relative path resolves in both. -->
+
 <p align="center">
   <a href="https://expo.dev/services">
-    <img alt="EAS" height="96" src="../../.github/resources/eas.svg">
+    <img alt="EAS" height="96" src="https://raw.githubusercontent.com/expo/eas-cli/main/.github/resources/eas.svg">
   </a>
 </p>
 

--- a/packages/eas-cli/scripts/readme-header.md
+++ b/packages/eas-cli/scripts/readme-header.md
@@ -1,8 +1,10 @@
 <!-- Everything above the "# Commands" section is generated from packages/eas-cli/scripts/readme-header.md. Edit that file, not README.md; `yarn version` regenerates README.md and overwrites this content. -->
 
+<!-- The logo src is an absolute URL on purpose: this file is also the repository root README (README.md is a symlink to it), so it renders at two different depths and no single relative path resolves in both. -->
+
 <p align="center">
   <a href="https://expo.dev/services">
-    <img alt="EAS" height="96" src="../../.github/resources/eas.svg">
+    <img alt="EAS" height="96" src="https://raw.githubusercontent.com/expo/eas-cli/main/.github/resources/eas.svg">
   </a>
 </p>
 


### PR DESCRIPTION
# Why

The EAS logo added in #3844 renders on [packages/eas-cli](https://github.com/expo/eas-cli/tree/main/packages/eas-cli) but is broken on the [repository landing page](https://github.com/expo/eas-cli).

`README.md` at the repository root is a symlink to `packages/eas-cli/README.md`, so GitHub renders the same file at two different depths, and rewrites the relative `../../.github/resources/eas.svg` src differently in each:

| Page | Rendered `src` | Result |
| --- | --- | --- |
| `/packages/eas-cli` | `/expo/eas-cli/raw/main/.github/resources/eas.svg` | 200 `image/svg+xml` |
| repository root | `/expo/eas-cli/.github/resources/eas.svg` | 404 |

At the root, `../../` walks above the repository root, so GitHub clamps the path and drops the `raw/main` segment, leaving a URL that points at a non-existent repository page instead of the raw file.

No single relative path can satisfy both depths, which is why the `expo/expo` pattern this was modeled on does not hit the problem: there, the root README and `packages/expo/README.md` are two separate files, each with its own correct relative path.

# How

Point the logo at an absolute raw URL (`https://raw.githubusercontent.com/expo/eas-cli/main/.github/resources/eas.svg`), which resolves identically from both depths and on npm. Added an HTML comment above it recording why it is absolute, so it does not get "fixed" back to a relative path.

Also regenerated `packages/eas-cli/README.md` from `scripts/readme-header.md` via `scripts/patch-readme.js`, as usual.

`raw.githubusercontent.com` is used rather than `github.com/expo/eas-cli/raw/main/...` because it returns the SVG directly, while the `github.com` form 302s to it. GitHub serves it through camo, which already handles the SVG shields.io badges in this same header.

# Test Plan

- `node packages/eas-cli/scripts/patch-readme.js` regenerates the README with only the header changed; the generated command reference is untouched.
- Verified the URLs behind both rendered pages:
  - `https://github.com/expo/eas-cli/.github/resources/eas.svg` (what the root page requests today) → `404`
  - `https://raw.githubusercontent.com/expo/eas-cli/main/.github/resources/eas.svg` (new src) → `200 image/svg+xml`, no redirect
- `yarn fmt:check` and `git diff --check` are clean.
- After merge, the logo should be verified on both https://github.com/expo/eas-cli and https://github.com/expo/eas-cli/tree/main/packages/eas-cli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)