### PR TITLE
[eas-cli] improve wording for additional usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Refresh README as an EAS product landing page. ([#3844](https://github.com/expo/eas-cli/pull/3844) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Fix the EAS logo not rendering in the repository root README. ([#4093](https://github.com/expo/eas-cli/pull/4093) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Improve wording for usage printouts. ([#4094](https://github.com/expo/eas-cli/pull/4094) by [@kadikraman](https://github.com/kadikraman))
 
 ## [21.3.0](https://github.com/expo/eas-cli/releases/tag/v21.3.0) - 2026-07-27
 

--- a/packages/eas-cli/src/commands/account/__tests__/usage.test.ts
+++ b/packages/eas-cli/src/commands/account/__tests__/usage.test.ts
@@ -13,9 +13,12 @@ import { displayUsage } from '../usage';
 
 jest.mock('../../../graphql/queries/AccountQuery');
 jest.mock('../../../log', () => ({
+  __esModule: true,
   ...jest.requireActual('../../../log'),
-  log: jest.fn(),
-  newLine: jest.fn(),
+  default: {
+    log: jest.fn(),
+    newLine: jest.fn(),
+  },
   link: jest.fn((url: string, opts?: { text?: string }) => opts?.text ?? url),
 }));
 

--- a/packages/eas-cli/src/commands/account/__tests__/usage.test.ts
+++ b/packages/eas-cli/src/commands/account/__tests__/usage.test.ts
@@ -1,4 +1,5 @@
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { extractUsageData } from '../../../commandUtils/usageUtils';
 import {
   AccountFullUsageQuery as AccountFullUsageQueryType,
   EasService,
@@ -6,9 +7,17 @@ import {
   UsageMetricType,
 } from '../../../graphql/generated';
 import { AccountQuery } from '../../../graphql/queries/AccountQuery';
+import Log from '../../../log';
 import { calculatePercentUsed, createProgressBar } from '../../../utils/usage/checkForOverages';
+import { displayUsage } from '../usage';
 
 jest.mock('../../../graphql/queries/AccountQuery');
+jest.mock('../../../log', () => ({
+  ...jest.requireActual('../../../log'),
+  log: jest.fn(),
+  newLine: jest.fn(),
+  link: jest.fn((url: string, opts?: { text?: string }) => opts?.text ?? url),
+}));
 
 function createMockFullUsageData(
   overrides: Partial<{
@@ -203,6 +212,39 @@ describe('AccountQuery', () => {
       expect.any(Date)
     );
     expect(result.name).toBe('test-account');
+  });
+});
+
+describe('displayUsage', () => {
+  const mockLog = jest.mocked(Log.log);
+
+  beforeEach(() => {
+    mockLog.mockClear();
+  });
+
+  it('labels usage beyond included credits as "additional usage"', () => {
+    const usageData = createMockFullUsageData({
+      buildValue: 55,
+      buildLimit: 50,
+      mauValue: 3500,
+      mauLimit: 3000,
+      buildOverageCost: 1500,
+      updateOverageCost: 250,
+    });
+    const displayData = extractUsageData(usageData);
+
+    displayUsage(displayData, usageData);
+
+    // eslint-disable-next-line no-control-regex
+    const output = mockLog.mock.calls
+      .flat()
+      .join('\n')
+      .replace(/\u001b\[\d+m/g, '');
+    expect(output).toContain('Unique Updaters (additional usage): 500 users ($2.50)');
+    expect(output).toContain('Additional usage: $17.50');
+    expect(output).toContain('Builds: $15.00');
+    expect(output).toContain('Updates: $2.50');
+    expect(output.toLowerCase()).not.toContain('overage');
   });
 });
 

--- a/packages/eas-cli/src/commands/account/usage.ts
+++ b/packages/eas-cli/src/commands/account/usage.ts
@@ -95,7 +95,7 @@ function billingUrl(accountName: string): string {
   return `https://expo.dev/accounts/${accountName}/settings/billing`;
 }
 
-function displayUsage(data: UsageDisplayData, usageData: AccountFullUsageData): void {
+export function displayUsage(data: UsageDisplayData, usageData: AccountFullUsageData): void {
   const subscription = usageData.subscription;
 
   Log.newLine();

--- a/packages/eas-cli/src/commands/account/usage.ts
+++ b/packages/eas-cli/src/commands/account/usage.ts
@@ -58,7 +58,7 @@ function displayBandwidthMetric(metric: UsageMetricDisplay, indent: string = '  
 
   if (metric.overageValue > 0) {
     Log.log(
-      `${indent}${metric.name} (overage): ${chalk.red(
+      `${indent}${metric.name} (additional usage): ${chalk.red(
         formatBytesDisplay(metric.overageValue)
       )} (${formatCurrency(metric.overageCost)})`
     );
@@ -84,7 +84,7 @@ function displayMetric(metric: UsageMetricDisplay, indent: string = '  '): void 
 
   if (metric.overageValue > 0) {
     Log.log(
-      `${indent}${metric.name} (overage): ${chalk.red(
+      `${indent}${metric.name} (additional usage): ${chalk.red(
         `${formatNumber(metric.overageValue)} ${metric.unit ?? ''}`
       )} (${formatCurrency(metric.overageCost)})`
     );
@@ -172,9 +172,9 @@ function displayUsage(data: UsageDisplayData, usageData: AccountFullUsageData): 
     }
 
     if (data.totalOverageCostCents > 0) {
-      Log.log(`  Current overages: ${chalk.yellow(formatCurrency(data.totalOverageCostCents))}`);
+      Log.log(`  Additional usage: ${chalk.yellow(formatCurrency(data.totalOverageCostCents))}`);
       if (data.builds.overageCostCents > 0) {
-        Log.log(`    Build overages: ${formatCurrency(data.builds.overageCostCents)}`);
+        Log.log(`    Builds: ${formatCurrency(data.builds.overageCostCents)}`);
         // Show breakdown by worker size
         for (const overage of data.builds.overagesByWorkerSize) {
           const platformName = overage.platform === AppPlatform.Ios ? 'iOS' : 'Android';
@@ -188,7 +188,7 @@ function displayUsage(data: UsageDisplayData, usageData: AccountFullUsageData): 
         }
       }
       if (data.updates.overageCostCents > 0) {
-        Log.log(`    Update overages: ${formatCurrency(data.updates.overageCostCents)}`);
+        Log.log(`    Updates: ${formatCurrency(data.updates.overageCostCents)}`);
       }
     }
 

--- a/packages/eas-cli/src/utils/usage/__tests__/checkForOverages-test.ts
+++ b/packages/eas-cli/src/utils/usage/__tests__/checkForOverages-test.ts
@@ -245,7 +245,7 @@ describe('maybeWarnAboutUsageOveragesAsync', () => {
 
     expect(mockWarn).toHaveBeenCalledWith(
       expect.stringContaining(
-        "You've used 10 builds beyond your included credits this billing period ($15.00 in overages so far)."
+        "You've used 10 builds beyond your included credits this billing period ($15.00 in additional usage so far)."
       )
     );
     expect(mockWarn).toHaveBeenCalledWith(
@@ -289,7 +289,7 @@ describe('maybeWarnAboutUsageOveragesAsync', () => {
 
     expect(mockWarn).toHaveBeenCalledWith(
       expect.stringContaining(
-        "You've used 3 builds beyond your included credits this billing period ($4.50 in overages so far)."
+        "You've used 3 builds beyond your included credits this billing period ($4.50 in additional usage so far)."
       )
     );
   });
@@ -558,7 +558,7 @@ describe('displayOverageWarning', () => {
 
     expect(mockWarn).toHaveBeenCalledWith(
       expect.stringContaining(
-        "You've used 10 builds beyond your included credits this billing period ($15.00 in overages so far)."
+        "You've used 10 builds beyond your included credits this billing period ($15.00 in additional usage so far)."
       )
     );
     expect(mockWarn).toHaveBeenCalledWith(
@@ -579,7 +579,7 @@ describe('displayOverageWarning', () => {
 
     expect(mockWarn).toHaveBeenCalledWith(
       expect.stringContaining(
-        "You've used 1 build beyond your included credits this billing period ($1.50 in overages so far)."
+        "You've used 1 build beyond your included credits this billing period ($1.50 in additional usage so far)."
       )
     );
   });

--- a/packages/eas-cli/src/utils/usage/checkForOverages.ts
+++ b/packages/eas-cli/src/utils/usage/checkForOverages.ts
@@ -173,7 +173,7 @@ export function displayOverageWarning({
   // tier === 'over' && paid plan
   Log.warn(
     chalk.bold(
-      `You've used ${overageCount} build${overageCount === 1 ? '' : 's'} beyond your included credits this billing period (${formatCents(overageCostCents)} in overages so far).`
+      `You've used ${overageCount} build${overageCount === 1 ? '' : 's'} beyond your included credits this billing period (${formatCents(overageCostCents)} in additional usage so far).`
     )
   );
   Log.warn(


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Currently we print our information about extra use as "overages" which is misleading.

https://exponent-internal.slack.com/archives/C02123T524U/p1784989673512749

# How

Replace "overages" -> "extra use" in the usage command and in the pre-build usage printout.

### `eas build` (warning shown before starting a build, when over included credits)

**Before**

```
You've used 3 builds beyond your included credits this billing period ($4.50 in overages so far).
Additional builds continue at pay-as-you-go rates. See usage in billing.
```

**After**

```
You've used 3 builds beyond your included credits this billing period ($4.50 in additional usage so far).
Additional builds continue at pay-as-you-go rates. See usage in billing.
```
----
### `eas account:usage`

**Before**

```
EAS Build
  Builds (plan): 50/50
  ████████████████████ 100%
  Builds (overage): 5 builds ($15.00)

EAS Update
  Unique Updaters (plan): 3,500/3,000 users
  ████████████████████ 100%
  Unique Updaters (overage): 500 users ($2.50)

Billing
  Base subscription: $19.00
  Current overages: $17.50
    Build overages: $15.00
      iOS large: 2 builds ($10.00)
    Update overages: $2.50
  Estimated bill: $36.50
```

**After**

```
EAS Build
  Builds (plan): 50/50
  ████████████████████ 100%
  Builds (additional usage): 5 builds ($15.00)

EAS Update
  Unique Updaters (plan): 3,500/3,000 users
  ████████████████████ 100%
  Unique Updaters (additional usage): 500 users ($2.50)

Billing
  Base subscription: $19.00
  Additional usage: $17.50
    Builds: $15.00
      iOS large: 2 builds ($10.00)
    Updates: $2.50
  Estimated bill: $36.50
```

# Test Plan

Updated / added tests.