### PR TITLE
[steps][build-tools][eas-cli] Expand legacy command/path local functions to a single build step; rename references in the consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Label serve-sim metrics artifacts with the sim's device name (from the metrics meta) instead of the raw udid. ([#4127](https://github.com/expo/eas-cli/pull/4127) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Set the artifact kind for Argent session artifacts from the MIME type reported by the tool server, so screenshots and screen recordings are grouped and labelled on the simulator session page instead of appearing in an unclassified file list. ([#4154](https://github.com/expo/eas-cli/pull/4154) by [@szdziedzic](https://github.com/szdziedzic))
+- [build-tools] Load local functions declaring `command` or `path`, so custom build functions moved from `.eas/build` configs into `.eas/functions` can be called from workflows. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Label serve-sim metrics artifacts with the sim's device name (from the metrics meta) instead of the raw udid. ([#4127](https://github.com/expo/eas-cli/pull/4127) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Set the artifact kind for Argent session artifacts from the MIME type reported by the tool server, so screenshots and screen recordings are grouped and labelled on the simulator session page instead of appearing in an unclassified file list. ([#4154](https://github.com/expo/eas-cli/pull/4154) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Load local functions declaring `command` or `path`, so custom build functions moved from `.eas/build` configs into `.eas/functions` can be called from workflows. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
+- [eas-cli] Validate local functions declaring `command` or `path` referenced from workflows, including that the module directory of a `path` function exists. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Label serve-sim metrics artifacts with the sim's device name (from the metrics meta) instead of the raw udid. ([#4127](https://github.com/expo/eas-cli/pull/4127) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Set the artifact kind for Argent session artifacts from the MIME type reported by the tool server, so screenshots and screen recordings are grouped and labelled on the simulator session page instead of appearing in an unclassified file list. ([#4154](https://github.com/expo/eas-cli/pull/4154) by [@szdziedzic](https://github.com/szdziedzic))
-- [build-tools] Load local functions declaring `command` or `path`, so custom build functions moved from `.eas/build` configs into `.eas/functions` can be called from workflows. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
+- [build-tools] Load local functions declaring `command` or `path`, so custom build functions moved out of `.eas/build` configs into local `function.yml` files can be called from workflows. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
 - [eas-cli] Validate local functions declaring `command` or `path` referenced from workflows, including that the module directory of a `path` function exists. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [build-tools] Set the artifact kind for Argent session artifacts from the MIME type reported by the tool server, so screenshots and screen recordings are grouped and labelled on the simulator session page instead of appearing in an unclassified file list. ([#4154](https://github.com/expo/eas-cli/pull/4154) by [@szdziedzic](https://github.com/szdziedzic))
-- [build-tools] Load local functions declaring `command` or `path`, so custom build functions moved from `.eas/build` configs into `.eas/functions` can be called from workflows. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
+- [build-tools] Load local functions declaring `command` or `path`, so custom build functions moved out of `.eas/build` configs into local `function.yml` files can be called from workflows. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
 - [eas-cli] Validate local functions declaring `command` or `path` referenced from workflows, including that the module directory of a `path` function exists. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Set the artifact kind for Argent session artifacts from the MIME type reported by the tool server, so screenshots and screen recordings are grouped and labelled on the simulator session page instead of appearing in an unclassified file list. ([#4154](https://github.com/expo/eas-cli/pull/4154) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Load local functions declaring `command` or `path`, so custom build functions moved from `.eas/build` configs into `.eas/functions` can be called from workflows. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
+- [eas-cli] Validate local functions declaring `command` or `path` referenced from workflows, including that the module directory of a `path` function exists. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [build-tools] Set the artifact kind for Argent session artifacts from the MIME type reported by the tool server, so screenshots and screen recordings are grouped and labelled on the simulator session page instead of appearing in an unclassified file list. ([#4154](https://github.com/expo/eas-cli/pull/4154) by [@szdziedzic](https://github.com/szdziedzic))
+- [build-tools] Load local functions declaring `command` or `path`, so custom build functions moved from `.eas/build` configs into `.eas/functions` can be called from workflows. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [build-tools] Load local functions declaring `command` or `path`, so custom build functions moved out of `.eas/build` configs into local `function.yml` files can be called from workflows. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
+- [eas-cli] Validate local functions declaring `command` or `path` referenced from workflows, including that the module directory of a `path` function exists. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
+
 ### 🐛 Bug fixes
 
 - [eas-cli] Make the non-interactive "EAS project not configured" error actionable on every path: list the exact `eas init --id` / `eas init --account` commands and the accounts you can create projects in, instead of suggesting bare `eas init`, which fails the same way. ([#4153](https://github.com/expo/eas-cli/pull/4153) by [@williamgrosset](https://github.com/williamgrosset))
@@ -31,8 +34,6 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Label serve-sim metrics artifacts with the sim's device name (from the metrics meta) instead of the raw udid. ([#4127](https://github.com/expo/eas-cli/pull/4127) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Set the artifact kind for Argent session artifacts from the MIME type reported by the tool server, so screenshots and screen recordings are grouped and labelled on the simulator session page instead of appearing in an unclassified file list. ([#4154](https://github.com/expo/eas-cli/pull/4154) by [@szdziedzic](https://github.com/szdziedzic))
-- [build-tools] Load local functions declaring `command` or `path`, so custom build functions moved out of `.eas/build` configs into local `function.yml` files can be called from workflows. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
-- [eas-cli] Validate local functions declaring `command` or `path` referenced from workflows, including that the module directory of a `path` function exists. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
 
 ### 🐛 Bug fixes
 

--- a/packages/build-tools/src/builders/custom.ts
+++ b/packages/build-tools/src/builders/custom.ts
@@ -4,8 +4,8 @@ import {
   BuildStepGlobalContext,
   BuildWorkflow,
   StepsConfigParser,
-  buildLocalCompositeFunctionCatalogAsync,
-  createLocalCompositeFunctionLoader,
+  buildLocalFunctionCatalogAsync,
+  createLocalFunctionLoader,
   errors,
 } from '@expo/steps';
 import assert from 'assert';
@@ -70,11 +70,11 @@ export async function runCustomBuildAsync(ctx: BuildContext<BuildJob>): Promise<
             steps: ctx.job.steps,
             hooks: ctx.job.hooks,
             // Eager for job steps (always run), lazy loader for hooks (running anchors only).
-            compositeFunctionCatalog: await buildLocalCompositeFunctionCatalogAsync(projectRoot, {
+            localFunctionCatalog: await buildLocalFunctionCatalogAsync(projectRoot, {
               rootSteps: ctx.job.steps,
               logger: ctx.logger,
             }),
-            loadCompositeFunction: createLocalCompositeFunctionLoader(projectRoot, {
+            loadLocalFunction: createLocalFunctionLoader(projectRoot, {
               logger: ctx.logger,
             }),
           })

--- a/packages/build-tools/src/common/__tests__/jobHooks.test.ts
+++ b/packages/build-tools/src/common/__tests__/jobHooks.test.ts
@@ -173,17 +173,24 @@ describe(parseJobHooksAsync, () => {
     );
     const result = parseJobHooksAsync(ctx, INSTALL);
     await expect(result).rejects.toThrow(
-      'Failed to parse hooks.before_install_node_modules: Local composite function "./.eas/functions/missing" was referenced by a step but no such composite function exists'
+      'Failed to parse hooks.before_install_node_modules: Local function "./.eas/functions/missing" was referenced by a step but no such local function exists'
     );
     await expect(result).rejects.toMatchObject({ errorCode: ErrorCode.HOOKS_ERROR });
   });
 
   it('reports the hook key when a composite function call sets working_directory', async () => {
-    const { ctx } = createCtx({
-      before_install_node_modules: [
-        { uses: './.eas/functions/setup', working_directory: 'subdir' },
-      ],
-    });
+    const workingdir = await makeWorkingdirWithCompositeFunctionAsync(
+      'setup',
+      ['runs:', '  steps:', '    - run: echo setup'].join('\n')
+    );
+    const { ctx } = createCtx(
+      {
+        before_install_node_modules: [
+          { uses: './.eas/functions/setup', working_directory: 'subdir' },
+        ],
+      },
+      { workingdir }
+    );
     const result = parseJobHooksAsync(ctx, INSTALL);
     await expect(result).rejects.toThrow(
       'Failed to parse hooks.before_install_node_modules: "working_directory" is not supported'

--- a/packages/build-tools/src/common/jobHooks.ts
+++ b/packages/build-tools/src/common/jobHooks.ts
@@ -13,8 +13,8 @@ import {
   BuildStepGlobalContext,
   HookEntry,
   constructHookEntriesAsync,
-  createLocalCompositeFunctionLoader,
-  extendCompositeFunctionCatalogFromStepsAsync,
+  createLocalFunctionLoader,
+  extendLocalFunctionCatalogFromStepsAsync,
   validateHookStepsAsync,
 } from '@expo/steps';
 
@@ -98,11 +98,10 @@ export async function parseJobHooksAsync<TJob extends BuildJob>(
   // outputs accumulate across keys.
   const hookEntriesByKey: Partial<Record<HookKey, HookEntry[]>> = {};
   const orderedSteps: BuildStep[] = [];
-  const compositeFunctionCatalog: LocalFunctionCatalog = {};
-  const loadCompositeFunction = createLocalCompositeFunctionLoader(
-    ctx.getReactNativeProjectDirectory(),
-    { logger: ctx.logger }
-  );
+  const localFunctionCatalog: LocalFunctionCatalog = {};
+  const loadLocalFunction = createLocalFunctionLoader(ctx.getReactNativeProjectDirectory(), {
+    logger: ctx.logger,
+  });
   for (const anchor of wrappedAnchors) {
     for (const side of ['before', 'after'] as const) {
       const key: HookKey = `${side}_${anchor}`;
@@ -113,15 +112,15 @@ export async function parseJobHooksAsync<TJob extends BuildJob>(
       let entries: HookEntry[];
       try {
         // Extended per key so a bad `uses:` path is attributed to that hook key.
-        await extendCompositeFunctionCatalogFromStepsAsync({
-          catalog: compositeFunctionCatalog,
+        await extendLocalFunctionCatalogFromStepsAsync({
+          catalog: localFunctionCatalog,
           rootSteps: steps,
-          loadCompositeFunction,
+          loadLocalFunction,
         });
         entries = await constructHookEntriesAsync(globalContext, steps, {
           externalFunctions,
           externalFunctionGroups,
-          compositeFunctionCatalog,
+          localFunctionCatalog,
         });
       } catch (err) {
         throw new UserError(

--- a/packages/build-tools/src/generic.ts
+++ b/packages/build-tools/src/generic.ts
@@ -4,8 +4,8 @@ import {
   BuildStepGlobalContext,
   BuildWorkflow,
   StepsConfigParser,
-  buildLocalCompositeFunctionCatalogAsync,
-  createLocalCompositeFunctionLoader,
+  buildLocalFunctionCatalogAsync,
+  createLocalFunctionLoader,
   errors,
 } from '@expo/steps';
 import fs from 'fs/promises';
@@ -54,7 +54,7 @@ export async function runGenericJobAsync(
     try {
       const projectRoot = ctx.getReactNativeProjectDirectory(customBuildCtx.projectSourceDirectory);
       // Eager for job steps (always run), lazy loader for hooks (running anchors only).
-      const compositeFunctionCatalog = await buildLocalCompositeFunctionCatalogAsync(projectRoot, {
+      const localFunctionCatalog = await buildLocalFunctionCatalogAsync(projectRoot, {
         rootSteps: ctx.job.steps,
         logger: ctx.logger,
       });
@@ -64,8 +64,8 @@ export async function runGenericJobAsync(
         externalFunctionGroups: getEasFunctionGroups(customBuildCtx),
         steps: ctx.job.steps,
         hooks: ctx.job.hooks,
-        compositeFunctionCatalog,
-        loadCompositeFunction: createLocalCompositeFunctionLoader(projectRoot, {
+        localFunctionCatalog,
+        loadLocalFunction: createLocalFunctionLoader(projectRoot, {
           logger: ctx.logger,
         }),
       });

--- a/packages/eas-build-job/src/compositeFunction.ts
+++ b/packages/eas-build-job/src/compositeFunction.ts
@@ -8,6 +8,10 @@ import { StepZ } from './step';
 
 const CompositeFunctionInputValueTypeNameZ = z.enum(['string', 'boolean', 'number', 'json']);
 
+export type CompositeFunctionInputValueTypeName = z.infer<
+  typeof CompositeFunctionInputValueTypeNameZ
+>;
+
 const CompositeFunctionInputValueZ = z.union([
   z.string(),
   z.boolean(),

--- a/packages/eas-cli/src/commandUtils/workflow/__tests__/localFunctions-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/__tests__/localFunctions-test.ts
@@ -46,7 +46,7 @@ describe(validateWorkflowLocalFunctionsAsync, () => {
     };
 
     await expect(validateWorkflowLocalFunctionsAsync(workflow, projectRoot)).rejects.toThrow(
-      /Local composite function "\.\/\.eas\/functions\/setup" was referenced by a step but no such composite function exists/
+      /Local function "\.\/\.eas\/functions\/setup" was referenced by a step but no such local function exists/
     );
   });
 
@@ -104,7 +104,7 @@ describe(validateWorkflowLocalFunctionsAsync, () => {
     };
 
     await expect(validateWorkflowLocalFunctionsAsync(workflow, projectRoot)).rejects.toThrow(
-      /Local composite function "\.\/\.eas\/functions\/setup" was referenced by a step but no such composite function exists/
+      /Local function "\.\/\.eas\/functions\/setup" was referenced by a step but no such local function exists/
     );
   });
 
@@ -176,7 +176,7 @@ describe(validateWorkflowLocalFunctionsAsync, () => {
     };
 
     await expect(validateWorkflowLocalFunctionsAsync(workflow, projectRoot)).rejects.toThrow(
-      /Local composite function "\.\/\.eas\/functions\/setup" was referenced by a step but no such composite function exists/
+      /Local function "\.\/\.eas\/functions\/setup" was referenced by a step but no such local function exists/
     );
   });
 
@@ -244,7 +244,7 @@ describe(validateWorkflowLocalFunctionsAsync, () => {
     };
 
     await expect(validateWorkflowLocalFunctionsAsync(workflow, projectDir)).rejects.toThrow(
-      /Local composite function "\.\/\.eas\/functions\/notify" was referenced by a step but no such composite function exists/
+      /Local function "\.\/\.eas\/functions\/notify" was referenced by a step but no such local function exists/
     );
   });
 

--- a/packages/eas-cli/src/commandUtils/workflow/__tests__/localFunctions-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/__tests__/localFunctions-test.ts
@@ -271,4 +271,24 @@ describe(validateWorkflowLocalFunctionsAsync, () => {
       validateWorkflowLocalFunctionsAsync(workflow, projectDir)
     ).resolves.toBeUndefined();
   });
+
+  it('validates a referenced single-step command function', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-workflow-functions-command-'));
+    await makeProjectWithCompositeFunctionAsync(
+      projectRoot,
+      'say-hi',
+      ['inputs:', '  - name', 'command: echo "Hi, ${ inputs.name }!"'].join('\n')
+    );
+    const workflow = {
+      jobs: {
+        job: {
+          steps: [{ uses: './.eas/functions/say-hi', with: { name: 'World' } }],
+        },
+      },
+    };
+
+    await expect(
+      validateWorkflowLocalFunctionsAsync(workflow, projectRoot)
+    ).resolves.toBeUndefined();
+  });
 });

--- a/packages/eas-cli/src/commandUtils/workflow/__tests__/localFunctions-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/__tests__/localFunctions-test.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { validateWorkflowLocalCompositeFunctionsAsync } from '../compositeFunctions';
+import { validateWorkflowLocalFunctionsAsync } from '../localFunctions';
 
 async function makeProjectWithCompositeFunctionAsync(
   projectRoot: string,
@@ -14,7 +14,7 @@ async function makeProjectWithCompositeFunctionAsync(
   await fs.writeFile(path.join(functionDir, 'function.yml'), contents, 'utf-8');
 }
 
-describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
+describe(validateWorkflowLocalFunctionsAsync, () => {
   it('validates referenced local composite functions', async () => {
     const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-workflow-functions-test-'));
     await makeProjectWithCompositeFunctionAsync(
@@ -31,7 +31,7 @@ describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
     };
 
     await expect(
-      validateWorkflowLocalCompositeFunctionsAsync(workflow, projectRoot)
+      validateWorkflowLocalFunctionsAsync(workflow, projectRoot)
     ).resolves.toBeUndefined();
   });
 
@@ -45,9 +45,7 @@ describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
       },
     };
 
-    await expect(
-      validateWorkflowLocalCompositeFunctionsAsync(workflow, projectRoot)
-    ).rejects.toThrow(
+    await expect(validateWorkflowLocalFunctionsAsync(workflow, projectRoot)).rejects.toThrow(
       /Local composite function "\.\/\.eas\/functions\/setup" was referenced by a step but no such composite function exists/
     );
   });
@@ -64,9 +62,9 @@ describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
       },
     };
 
-    await expect(
-      validateWorkflowLocalCompositeFunctionsAsync(workflow, projectRoot)
-    ).rejects.toThrow(/must not contain interpolation/);
+    await expect(validateWorkflowLocalFunctionsAsync(workflow, projectRoot)).rejects.toThrow(
+      /must not contain interpolation/
+    );
   });
 
   it('validates local composite functions referenced from job hooks', async () => {
@@ -88,7 +86,7 @@ describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
     };
 
     await expect(
-      validateWorkflowLocalCompositeFunctionsAsync(workflow, projectRoot)
+      validateWorkflowLocalFunctionsAsync(workflow, projectRoot)
     ).resolves.toBeUndefined();
   });
 
@@ -105,9 +103,7 @@ describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
       },
     };
 
-    await expect(
-      validateWorkflowLocalCompositeFunctionsAsync(workflow, projectRoot)
-    ).rejects.toThrow(
+    await expect(validateWorkflowLocalFunctionsAsync(workflow, projectRoot)).rejects.toThrow(
       /Local composite function "\.\/\.eas\/functions\/setup" was referenced by a step but no such composite function exists/
     );
   });
@@ -131,7 +127,7 @@ describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
     };
 
     await expect(
-      validateWorkflowLocalCompositeFunctionsAsync(workflow, projectRoot)
+      validateWorkflowLocalFunctionsAsync(workflow, projectRoot)
     ).resolves.toBeUndefined();
   });
 
@@ -158,7 +154,7 @@ describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
     };
 
     await expect(
-      validateWorkflowLocalCompositeFunctionsAsync(workflow, projectRoot)
+      validateWorkflowLocalFunctionsAsync(workflow, projectRoot)
     ).resolves.toBeUndefined();
   });
 
@@ -179,9 +175,7 @@ describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
       },
     };
 
-    await expect(
-      validateWorkflowLocalCompositeFunctionsAsync(workflow, projectRoot)
-    ).rejects.toThrow(
+    await expect(validateWorkflowLocalFunctionsAsync(workflow, projectRoot)).rejects.toThrow(
       /Local composite function "\.\/\.eas\/functions\/setup" was referenced by a step but no such composite function exists/
     );
   });
@@ -197,13 +191,10 @@ describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
     };
 
     await expect(
-      validateWorkflowLocalCompositeFunctionsAsync({ defaults: 'garbage', jobs }, projectRoot)
+      validateWorkflowLocalFunctionsAsync({ defaults: 'garbage', jobs }, projectRoot)
     ).resolves.toBeUndefined();
     await expect(
-      validateWorkflowLocalCompositeFunctionsAsync(
-        { defaults: { hooks: 'garbage' }, jobs },
-        projectRoot
-      )
+      validateWorkflowLocalFunctionsAsync({ defaults: { hooks: 'garbage' }, jobs }, projectRoot)
     ).resolves.toBeUndefined();
   });
 
@@ -229,7 +220,7 @@ describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
     };
 
     await expect(
-      validateWorkflowLocalCompositeFunctionsAsync(workflow, projectDir)
+      validateWorkflowLocalFunctionsAsync(workflow, projectDir)
     ).resolves.toBeUndefined();
   });
 
@@ -252,9 +243,7 @@ describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
       },
     };
 
-    await expect(
-      validateWorkflowLocalCompositeFunctionsAsync(workflow, projectDir)
-    ).rejects.toThrow(
+    await expect(validateWorkflowLocalFunctionsAsync(workflow, projectDir)).rejects.toThrow(
       /Local composite function "\.\/\.eas\/functions\/notify" was referenced by a step but no such composite function exists/
     );
   });
@@ -279,7 +268,7 @@ describe(validateWorkflowLocalCompositeFunctionsAsync, () => {
     };
 
     await expect(
-      validateWorkflowLocalCompositeFunctionsAsync(workflow, projectDir)
+      validateWorkflowLocalFunctionsAsync(workflow, projectDir)
     ).resolves.toBeUndefined();
   });
 });

--- a/packages/eas-cli/src/commandUtils/workflow/__tests__/localFunctions-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/__tests__/localFunctions-test.ts
@@ -291,4 +291,60 @@ describe(validateWorkflowLocalFunctionsAsync, () => {
       validateWorkflowLocalFunctionsAsync(workflow, projectRoot)
     ).resolves.toBeUndefined();
   });
+
+  it('accepts a single-step function with a quoted scalar default', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-workflow-functions-coerce-'));
+    await makeProjectWithCompositeFunctionAsync(
+      projectRoot,
+      'say-hi',
+      [
+        'inputs:',
+        '  - name: count',
+        '    type: number',
+        '    default_value: "42"',
+        '    required: false',
+        'command: echo hi',
+      ].join('\n')
+    );
+    const workflow = {
+      jobs: {
+        job: {
+          steps: [{ uses: './.eas/functions/say-hi' }],
+        },
+      },
+    };
+
+    await expect(
+      validateWorkflowLocalFunctionsAsync(workflow, projectRoot)
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects a single-step function with a mistyped default at validate time', async () => {
+    const projectRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'eas-workflow-functions-mistyped-')
+    );
+    await makeProjectWithCompositeFunctionAsync(
+      projectRoot,
+      'say-hi',
+      [
+        'inputs:',
+        '  - name: count',
+        '    type: number',
+        '    default_value: abc',
+        '    required: false',
+        'command: echo hi',
+      ].join('\n')
+    );
+    const workflow = {
+      jobs: {
+        job: {
+          steps: [{ uses: './.eas/functions/say-hi' }],
+        },
+      },
+    };
+
+    await expect(validateWorkflowLocalFunctionsAsync(workflow, projectRoot)).rejects.toThrow(
+      'Invalid local function "./.eas/functions/say-hi": "default_value" of input "count" is set to "abc" which is not of type "number" or a step or context reference.'
+    );
+  });
 });

--- a/packages/eas-cli/src/commandUtils/workflow/localFunctions.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/localFunctions.ts
@@ -1,12 +1,12 @@
-import { buildLocalCompositeFunctionCatalogAsync } from '@expo/steps';
+import { buildLocalFunctionCatalogAsync } from '@expo/steps';
 
 import Log from '../../log';
 
-export async function validateWorkflowLocalCompositeFunctionsAsync(
+export async function validateWorkflowLocalFunctionsAsync(
   parsedYaml: any,
   projectDir: string
 ): Promise<void> {
-  await buildLocalCompositeFunctionCatalogAsync(projectDir, {
+  await buildLocalFunctionCatalogAsync(projectDir, {
     rootSteps: stepsFromWorkflow(parsedYaml),
     logger: {
       debug: message => {

--- a/packages/eas-cli/src/commandUtils/workflow/validation.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/validation.ts
@@ -4,7 +4,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import * as YAML from 'yaml';
 
-import { validateWorkflowLocalCompositeFunctionsAsync } from './compositeFunctions';
+import { validateWorkflowLocalFunctionsAsync } from './localFunctions';
 import { buildProfileNamesFromProjectAsync } from './buildProfileUtils';
 import { getExpoApiWorkflowSchemaURL } from '../../api';
 import { WorkflowRevisionMutation } from '../../graphql/mutations/WorkflowRevisionMutation';
@@ -47,8 +47,8 @@ export async function validateWorkflowFileAsync(
   Log.debug(`Validating workflow structure...`);
   validateWorkflowStructure(parsedYaml, workflowSchema);
 
-  Log.debug(`Validating workflow local composite functions...`);
-  await validateWorkflowLocalCompositeFunctionsAsync(parsedYaml, projectDir);
+  Log.debug(`Validating workflow local functions...`);
+  await validateWorkflowLocalFunctionsAsync(parsedYaml, projectDir);
 
   // Check for other errors using the server-side validation
   Log.debug(`Validating workflow on server...`);

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -8,7 +8,7 @@ import { BuildRuntimePlatform } from './BuildRuntimePlatform';
 import { BuildStepEnv } from './BuildStepEnv';
 import { BuildStepInputValueType, BuildStepInputValueTypeName } from './BuildStepInput';
 import { BuildConfigError, BuildWorkflowError } from './errors';
-import { isLocalCompositeFunctionPath } from './utils/localCompositeFunctions';
+import { isLocalFunctionPath } from './utils/localCompositeFunctions';
 import { BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX } from './utils/template';
 
 export type BuildFunctions = Record<string, BuildFunctionConfig>;
@@ -439,16 +439,14 @@ export function validateAllFunctionsExist(
     }
   }
   const calledFunctionsOrFunctionGroup = Array.from(calledFunctionsOrFunctionGroupsSet);
-  const compositeFunctionPaths = calledFunctionsOrFunctionGroup.filter(
-    isLocalCompositeFunctionPath
-  );
-  if (compositeFunctionPaths.length > 0) {
+  const localFunctionPaths = calledFunctionsOrFunctionGroup.filter(isLocalFunctionPath);
+  if (localFunctionPaths.length > 0) {
     throw new BuildConfigError(
-      `Local composite functions (${compositeFunctionPaths
-        .map(compositeFunctionPath => `"${compositeFunctionPath}"`)
+      `Local functions (${localFunctionPaths
+        .map(localFunctionPath => `"${localFunctionPath}"`)
         .join(
           ', '
-        )}) are not supported in ".eas/build/*.yml" custom builds. Local composite functions can only be used in EAS workflows (".eas/workflows/*.yml").`
+        )}) are not supported in ".eas/build/*.yml" custom builds. Local functions can only be used in EAS workflows (".eas/workflows/*.yml").`
     );
   }
   const externalFunctionIdsSet = new Set(externalFunctionIds);

--- a/packages/steps/src/BuildConfig.ts
+++ b/packages/steps/src/BuildConfig.ts
@@ -8,7 +8,7 @@ import { BuildRuntimePlatform } from './BuildRuntimePlatform';
 import { BuildStepEnv } from './BuildStepEnv';
 import { BuildStepInputValueType, BuildStepInputValueTypeName } from './BuildStepInput';
 import { BuildConfigError, BuildWorkflowError } from './errors';
-import { isLocalFunctionPath } from './utils/localCompositeFunctions';
+import { isLocalFunctionPath } from './utils/localFunctions';
 import { BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX } from './utils/template';
 
 export type BuildFunctions = Record<string, BuildFunctionConfig>;

--- a/packages/steps/src/BuildConfigParser.ts
+++ b/packages/steps/src/BuildConfigParser.ts
@@ -31,7 +31,11 @@ import {
   BuildStepInputProvider,
   BuildStepInputValueTypeName,
 } from './BuildStepInput';
-import { BuildStepOutput, BuildStepOutputProvider } from './BuildStepOutput';
+import {
+  BuildStepOutput,
+  BuildStepOutputProvider,
+  createBuildStepOutputProviderFromDefinition,
+} from './BuildStepOutput';
 import { BuildConfigError } from './errors';
 import { AnchorHooks } from './hooks';
 
@@ -362,11 +366,7 @@ export class BuildConfigParser extends AbstractConfigParser {
   private createBuildStepOutputProvidersFromBuildFunctionOutputs(
     buildFunctionOutputs: BuildFunctionOutputs
   ): BuildStepOutputProvider[] {
-    return buildFunctionOutputs.map(entry =>
-      typeof entry === 'string'
-        ? BuildStepOutput.createProvider({ id: entry, required: true })
-        : BuildStepOutput.createProvider({ id: entry.name, required: entry.required ?? true })
-    );
+    return buildFunctionOutputs.map(createBuildStepOutputProviderFromDefinition);
   }
 
   private mergeBuildFunctionsWithExternal(

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -1,4 +1,4 @@
-import { JobInterpolationContext } from '@expo/eas-build-job';
+import { CompositeFunctionInputValueTypeName, JobInterpolationContext } from '@expo/eas-build-job';
 import assert from 'assert';
 
 import { BuildStepGlobalContext } from './BuildStepContext';
@@ -25,6 +25,12 @@ export type BuildStepInputValueType<
     : T extends BuildStepInputValueTypeName.NUMBER
       ? number
       : Record<string, unknown>;
+
+export function parseBuildStepInputValueTypeName(
+  type: CompositeFunctionInputValueTypeName
+): BuildStepInputValueTypeName {
+  return type satisfies `${BuildStepInputValueTypeName}` as BuildStepInputValueTypeName;
+}
 
 export type BuildStepInputById = Record<string, BuildStepInput>;
 export type BuildStepInputProvider = (

--- a/packages/steps/src/BuildStepInput.ts
+++ b/packages/steps/src/BuildStepInput.ts
@@ -1,5 +1,6 @@
 import { CompositeFunctionInputValueTypeName, JobInterpolationContext } from '@expo/eas-build-job';
 import assert from 'assert';
+import { isDeepStrictEqual } from 'util';
 
 import { BuildStepGlobalContext } from './BuildStepContext';
 import { BuildStepRuntimeError } from './errors';
@@ -164,7 +165,7 @@ export class BuildStepInput<
     if (this.allowedValues === undefined || value === undefined) {
       return true;
     }
-    return this.allowedValues.includes(value);
+    return this.allowedValues.some(allowedValue => isDeepStrictEqual(allowedValue, value));
   }
 
   public isRawValueStepOrContextReference(): boolean {

--- a/packages/steps/src/BuildStepOutput.ts
+++ b/packages/steps/src/BuildStepOutput.ts
@@ -92,6 +92,14 @@ export class BuildStepOutput<R extends boolean = boolean> {
   }
 }
 
+export function createBuildStepOutputProviderFromDefinition(
+  entry: string | { name: string; required?: boolean }
+): BuildStepOutputProvider {
+  return typeof entry === 'string'
+    ? BuildStepOutput.createProvider({ id: entry, required: true })
+    : BuildStepOutput.createProvider({ id: entry.name, required: entry.required ?? true });
+}
+
 export function makeBuildStepOutputByIdMap(outputs?: BuildStepOutput[]): BuildStepOutputById {
   if (outputs === undefined) {
     return {};

--- a/packages/steps/src/LocalFunctionExpander.ts
+++ b/packages/steps/src/LocalFunctionExpander.ts
@@ -1,16 +1,18 @@
 /**
- * Expands local composite functions (`uses: ./path/to/function`) into a
- * {@link CompositeBuildStep} tree at parse time.
+ * Expands local functions (`uses: ./path/to/function`) into build steps at parse time.
  *
- * Each call becomes a node with prefixed child ids (`caller__inner`); the parser
- * flattens the tree into the workflow. Expanded steps carry a
- * {@link BuildStepCompositeFunctionScope} so `${{ steps.* }}` and `${{ inputs.* }}`
- * resolve against composite-function-local names.
+ * A composite function call becomes a {@link CompositeBuildStep} node with prefixed child ids
+ * (`caller__inner`); the parser flattens the tree into the workflow. Expanded steps carry a
+ * {@link BuildStepCompositeFunctionScope} so `${{ steps.* }}` and `${{ inputs.* }}` resolve
+ * against composite-function-local names. A single-step (`command`/`path`) function call becomes
+ * one ordinary build step keeping the caller's own id.
  */
 import {
   CompositeFunctionConfig,
   FunctionStep,
+  LegacyFunctionConfig,
   LocalFunctionCatalog,
+  LocalFunctionConfig,
   ShellStep,
   Step,
   isLegacyFunctionConfig,
@@ -32,6 +34,7 @@ import {
 import { CompositeBuildStep } from './CompositeBuildStep';
 import { BuildConfigError } from './errors';
 import { duplicates } from './utils/expodash/duplicates';
+import { createBuildFunctionFromLegacyFunctionConfig } from './utils/legacyFunction';
 import {
   getLocalFunctionCallWorkingDirectoryError,
   isLocalFunctionPath,
@@ -48,14 +51,16 @@ export type FunctionMaps = {
 
 type LocalFunctionCall = {
   functionPath: string;
-  /** Caller-assigned id used as prefix for all inner step ids. */
+  /** Caller-assigned id; for a composite function also the prefix of all inner step ids. */
   syntheticStepId: string;
   name?: string;
-  /** Caller-provided input values, consumed when composite function inputs are interpolated. */
+  /** Caller-provided input values, consumed when function inputs are interpolated. */
   callWith?: Record<string, unknown>;
   callIf?: string;
   parentScope?: BuildStepCompositeFunctionScope;
   inheritedEnv?: BuildStepEnv;
+  /** Rejected for composite calls. */
+  workingDirectory?: string;
 };
 
 type StepOverrides = {
@@ -83,9 +88,8 @@ export class LocalFunctionExpander {
     step: FunctionStep,
     functionPath: string,
     syntheticStepId: string
-  ): CompositeBuildStep {
-    this.rejectLocalFunctionCallWorkingDirectory(step);
-    return this.expand(
+  ): BuildStep[] {
+    const expanded = this.expandCall(
       {
         functionPath,
         syntheticStepId,
@@ -93,24 +97,55 @@ export class LocalFunctionExpander {
         callWith: step.with,
         callIf: step.if,
         inheritedEnv: step.env,
+        workingDirectory: step.working_directory,
       },
       new Set<string>()
     );
+    return expanded instanceof CompositeBuildStep ? expanded.getFlattenedSteps() : [expanded];
   }
 
-  // The call step expands away; `working_directory` on it would never apply.
-  private rejectLocalFunctionCallWorkingDirectory(step: FunctionStep): void {
-    if (step.working_directory !== undefined) {
-      throw new BuildConfigError(getLocalFunctionCallWorkingDirectoryError(step.uses));
+  private expandCall(call: LocalFunctionCall, visited: ReadonlySet<string>): BuildStep {
+    const localFunction = this.lookupLocalFunction(call.functionPath);
+    if (isLegacyFunctionConfig(localFunction)) {
+      return this.createLegacyFunctionStep(call, localFunction);
     }
+    return this.expand(call, localFunction, visited);
+  }
+
+  // Keeps the caller's id and if:. No expansion scope to hang the condition on.
+  private createLegacyFunctionStep(
+    call: LocalFunctionCall,
+    config: LegacyFunctionConfig
+  ): BuildStep {
+    const { functionPath } = call;
+    // One BuildFunction per path. Relative ./../ keys cannot collide with registered ids.
+    const buildFunction = (this.functionMaps.buildFunctionById[functionPath] ??=
+      createBuildFunctionFromLegacyFunctionConfig(functionPath, config));
+    return buildFunction.createBuildStepFromFunctionCall(this.ctx, {
+      id: call.syntheticStepId,
+      name: call.name ?? config.name ?? functionPath,
+      callInputs: call.callWith,
+      workingDirectory: call.workingDirectory,
+      shell: config.shell,
+      env: call.inheritedEnv,
+      ifCondition: call.callIf,
+      compositeFunctionScope: call.parentScope,
+    });
   }
 
   // `visited.size` is the current composite function nesting depth.
-  private expand(call: LocalFunctionCall, visited: ReadonlySet<string>): CompositeBuildStep {
+  private expand(
+    call: LocalFunctionCall,
+    compositeFunction: CompositeFunctionConfig,
+    visited: ReadonlySet<string>
+  ): CompositeBuildStep {
     const { functionPath: compositeFunctionPath, syntheticStepId } = call;
+    // The call step expands away; `working_directory` on it would never apply.
+    if (call.workingDirectory !== undefined) {
+      throw new BuildConfigError(getLocalFunctionCallWorkingDirectoryError(compositeFunctionPath));
+    }
     this.guardAgainstRunawayRecursion(compositeFunctionPath, visited);
 
-    const compositeFunction = this.lookupLocalFunction(compositeFunctionPath);
     const compositeFunctionDisplayName =
       call.name ?? compositeFunction.name ?? compositeFunctionPath;
     const innerSteps = compositeFunction.runs.steps;
@@ -185,23 +220,14 @@ export class LocalFunctionExpander {
     }
   }
 
-  private lookupLocalFunction(compositeFunctionPath: string): CompositeFunctionConfig {
-    // The catalog can hold either shape, but this expander does not dispatch on legacy
-    // functions yet, so a lookup here is always the composite shape.
-    const compositeFunction = this.localFunctionCatalog[compositeFunctionPath] as
-      | CompositeFunctionConfig
-      | undefined;
-    if (!compositeFunction) {
+  private lookupLocalFunction(functionPath: string): LocalFunctionConfig {
+    const localFunction = this.localFunctionCatalog[functionPath];
+    if (!localFunction) {
       throw new BuildConfigError(
-        `Local composite function "${compositeFunctionPath}" does not exist. Expected a "function.yml" (or "function.yaml") file at "${compositeFunctionPath}" relative to the EAS project root (convention: ".eas/functions/<name>").`
+        `Local function "${functionPath}" does not exist. Expected a "function.yml" (or "function.yaml") file at "${functionPath}" relative to the EAS project root (convention: ".eas/functions/<name>").`
       );
     }
-    if (isLegacyFunctionConfig(compositeFunction)) {
-      throw new BuildConfigError(
-        `Local function "${compositeFunctionPath}" uses the legacy command/path shape, which this expander does not support yet.`
-      );
-    }
-    return compositeFunction;
+    return localFunction;
   }
 
   private expandInnerStep(
@@ -221,7 +247,6 @@ export class LocalFunctionExpander {
 
     if (isStepFunctionStep(innerStep)) {
       if (isLocalFunctionPath(innerStep.uses)) {
-        this.rejectLocalFunctionCallWorkingDirectory(innerStep);
         return this.expandNestedLocalFunctionCall(innerStep, {
           functionPath: parseLocalFunctionPath(innerStep.uses),
           newId,
@@ -268,8 +293,8 @@ export class LocalFunctionExpander {
       scope: BuildStepCompositeFunctionScope;
       visited: ReadonlySet<string>;
     }
-  ): CompositeBuildStep {
-    return this.expand(
+  ): BuildStep {
+    return this.expandCall(
       {
         functionPath,
         syntheticStepId: newId,
@@ -278,6 +303,7 @@ export class LocalFunctionExpander {
         callIf: overrides.ifCondition,
         parentScope: scope,
         inheritedEnv: overrides.env,
+        workingDirectory: overrides.workingDirectory,
       },
       visited
     );

--- a/packages/steps/src/LocalFunctionExpander.ts
+++ b/packages/steps/src/LocalFunctionExpander.ts
@@ -39,7 +39,7 @@ import {
   getLocalFunctionCallWorkingDirectoryError,
   isLocalFunctionPath,
   parseLocalFunctionPath,
-} from './utils/localCompositeFunctions';
+} from './utils/localFunctions';
 import { createBuildStepOutputsFromDefinition, getShellStepDisplayName } from './utils/step';
 
 const MAX_COMPOSITE_FUNCTION_NESTING_DEPTH = 10;

--- a/packages/steps/src/LocalFunctionExpander.ts
+++ b/packages/steps/src/LocalFunctionExpander.ts
@@ -33,9 +33,9 @@ import { CompositeBuildStep } from './CompositeBuildStep';
 import { BuildConfigError } from './errors';
 import { duplicates } from './utils/expodash/duplicates';
 import {
-  getLocalCompositeFunctionCallWorkingDirectoryError,
-  isLocalCompositeFunctionPath,
-  parseLocalCompositeFunctionPath,
+  getLocalFunctionCallWorkingDirectoryError,
+  isLocalFunctionPath,
+  parseLocalFunctionPath,
 } from './utils/localCompositeFunctions';
 import { createBuildStepOutputsFromDefinition, getShellStepDisplayName } from './utils/step';
 
@@ -46,8 +46,8 @@ export type FunctionMaps = {
   buildFunctionGroupById: BuildFunctionGroupById;
 };
 
-type CompositeFunctionCall = {
-  compositeFunctionPath: string;
+type LocalFunctionCall = {
+  functionPath: string;
   /** Caller-assigned id used as prefix for all inner step ids. */
   syntheticStepId: string;
   name?: string;
@@ -64,10 +64,10 @@ type StepOverrides = {
   ifCondition?: string;
 };
 
-export class CompositeFunctionExpander {
+export class LocalFunctionExpander {
   constructor(
     private readonly ctx: BuildStepGlobalContext,
-    private readonly compositeFunctionCatalog: LocalFunctionCatalog,
+    private readonly localFunctionCatalog: LocalFunctionCatalog,
     private readonly functionMaps: FunctionMaps
   ) {}
 
@@ -79,15 +79,15 @@ export class CompositeFunctionExpander {
     return this.functionMaps.buildFunctionGroupById;
   }
 
-  public expandCompositeFunctionStep(
+  public expandLocalFunctionStep(
     step: FunctionStep,
-    compositeFunctionPath: string,
+    functionPath: string,
     syntheticStepId: string
   ): CompositeBuildStep {
-    this.rejectCompositeFunctionCallWorkingDirectory(step);
+    this.rejectLocalFunctionCallWorkingDirectory(step);
     return this.expand(
       {
-        compositeFunctionPath,
+        functionPath,
         syntheticStepId,
         name: step.name,
         callWith: step.with,
@@ -99,18 +99,18 @@ export class CompositeFunctionExpander {
   }
 
   // The call step expands away; `working_directory` on it would never apply.
-  private rejectCompositeFunctionCallWorkingDirectory(step: FunctionStep): void {
+  private rejectLocalFunctionCallWorkingDirectory(step: FunctionStep): void {
     if (step.working_directory !== undefined) {
-      throw new BuildConfigError(getLocalCompositeFunctionCallWorkingDirectoryError(step.uses));
+      throw new BuildConfigError(getLocalFunctionCallWorkingDirectoryError(step.uses));
     }
   }
 
   // `visited.size` is the current composite function nesting depth.
-  private expand(call: CompositeFunctionCall, visited: ReadonlySet<string>): CompositeBuildStep {
-    const { compositeFunctionPath, syntheticStepId } = call;
+  private expand(call: LocalFunctionCall, visited: ReadonlySet<string>): CompositeBuildStep {
+    const { functionPath: compositeFunctionPath, syntheticStepId } = call;
     this.guardAgainstRunawayRecursion(compositeFunctionPath, visited);
 
-    const compositeFunction = this.lookupCompositeFunction(compositeFunctionPath);
+    const compositeFunction = this.lookupLocalFunction(compositeFunctionPath);
     const compositeFunctionDisplayName =
       call.name ?? compositeFunction.name ?? compositeFunctionPath;
     const innerSteps = compositeFunction.runs.steps;
@@ -185,8 +185,12 @@ export class CompositeFunctionExpander {
     }
   }
 
-  private lookupCompositeFunction(compositeFunctionPath: string): CompositeFunctionConfig {
-    const compositeFunction = this.compositeFunctionCatalog[compositeFunctionPath];
+  private lookupLocalFunction(compositeFunctionPath: string): CompositeFunctionConfig {
+    // The catalog can hold either shape, but this expander does not dispatch on legacy
+    // functions yet, so a lookup here is always the composite shape.
+    const compositeFunction = this.localFunctionCatalog[compositeFunctionPath] as
+      | CompositeFunctionConfig
+      | undefined;
     if (!compositeFunction) {
       throw new BuildConfigError(
         `Local composite function "${compositeFunctionPath}" does not exist. Expected a "function.yml" (or "function.yaml") file at "${compositeFunctionPath}" relative to the EAS project root (convention: ".eas/functions/<name>").`
@@ -216,10 +220,10 @@ export class CompositeFunctionExpander {
     const overrides = this.resolveStepOverrides(innerStep);
 
     if (isStepFunctionStep(innerStep)) {
-      if (isLocalCompositeFunctionPath(innerStep.uses)) {
-        this.rejectCompositeFunctionCallWorkingDirectory(innerStep);
-        return this.expandNestedCompositeFunctionCall(innerStep, {
-          compositeFunctionPath: parseLocalCompositeFunctionPath(innerStep.uses),
+      if (isLocalFunctionPath(innerStep.uses)) {
+        this.rejectLocalFunctionCallWorkingDirectory(innerStep);
+        return this.expandNestedLocalFunctionCall(innerStep, {
+          functionPath: parseLocalFunctionPath(innerStep.uses),
           newId,
           overrides,
           scope,
@@ -249,16 +253,16 @@ export class CompositeFunctionExpander {
     };
   }
 
-  private expandNestedCompositeFunctionCall(
+  private expandNestedLocalFunctionCall(
     innerStep: FunctionStep,
     {
-      compositeFunctionPath,
+      functionPath,
       newId,
       overrides,
       scope,
       visited,
     }: {
-      compositeFunctionPath: string;
+      functionPath: string;
       newId: string;
       overrides: StepOverrides;
       scope: BuildStepCompositeFunctionScope;
@@ -267,7 +271,7 @@ export class CompositeFunctionExpander {
   ): CompositeBuildStep {
     return this.expand(
       {
-        compositeFunctionPath,
+        functionPath,
         syntheticStepId: newId,
         name: innerStep.name,
         callWith: innerStep.with,

--- a/packages/steps/src/LocalFunctionExpander.ts
+++ b/packages/steps/src/LocalFunctionExpander.ts
@@ -26,8 +26,8 @@ import { BuildStepGlobalContext } from './BuildStepContext';
 import { BuildStepEnv } from './BuildStepEnv';
 import {
   BuildStepInput,
-  BuildStepInputValueTypeName,
   getDisallowedInputValueError,
+  parseBuildStepInputValueTypeName,
 } from './BuildStepInput';
 import { CompositeBuildStep } from './CompositeBuildStep';
 import { BuildConfigError } from './errors';
@@ -401,7 +401,7 @@ export class LocalFunctionExpander {
         typeof declared === 'string'
           ? {
               name: declared,
-              type: 'string',
+              type: 'string' as const,
               required: false,
               allowedValues: undefined as unknown[] | undefined,
               defaultValue: undefined as unknown,
@@ -419,11 +419,7 @@ export class LocalFunctionExpander {
         defaultValue: definition.defaultValue,
         required: definition.required,
         allowedValues: definition.allowedValues,
-        allowedValueTypeName: this.toInputValueTypeName(
-          definition.type,
-          compositeFunctionPath,
-          definition.name
-        ),
+        allowedValueTypeName: parseBuildStepInputValueTypeName(definition.type),
       });
       if (callWith && Object.prototype.hasOwnProperty.call(callWith, definition.name)) {
         const value = callWith[definition.name];
@@ -446,21 +442,5 @@ export class LocalFunctionExpander {
       inputs.set(definition.name, input);
     }
     return { inputs, providedInputKeys };
-  }
-
-  private toInputValueTypeName(
-    type: string,
-    compositeFunctionPath: string,
-    inputName: string
-  ): BuildStepInputValueTypeName {
-    const supported = Object.values(BuildStepInputValueTypeName) as string[];
-    if (!supported.includes(type)) {
-      throw new BuildConfigError(
-        `Composite function "${compositeFunctionPath}" input "${inputName}" has unsupported type "${type}". Supported types: ${supported.join(
-          ', '
-        )}.`
-      );
-    }
-    return type as BuildStepInputValueTypeName;
   }
 }

--- a/packages/steps/src/StepsConfigParser.ts
+++ b/packages/steps/src/StepsConfigParser.ts
@@ -1,4 +1,5 @@
 import {
+  CompositeFunctionConfig,
   FunctionStep,
   HookAnchorId,
   HookKey,
@@ -56,6 +57,8 @@ export class StepsConfigParser extends AbstractConfigParser {
       externalFunctionGroups,
       localFunctionCatalog,
       loadLocalFunction,
+      compositeFunctionCatalog,
+      loadCompositeFunction,
     }: {
       steps: Step[];
       // Required (not `hooks?:`) so a call site cannot silently forget to pass
@@ -66,6 +69,10 @@ export class StepsConfigParser extends AbstractConfigParser {
       localFunctionCatalog?: LocalFunctionCatalog;
       /** Loads a hook local function missing from the catalog. When omitted, missing entries fail as unknown. */
       loadLocalFunction?: (functionPath: string) => Promise<LocalFunctionConfig>;
+      /** @deprecated Use `localFunctionCatalog`. */
+      compositeFunctionCatalog?: LocalFunctionCatalog;
+      /** @deprecated Use `loadLocalFunction`. */
+      loadCompositeFunction?: (functionPath: string) => Promise<CompositeFunctionConfig>;
     }
   ) {
     super(ctx, {
@@ -76,8 +83,8 @@ export class StepsConfigParser extends AbstractConfigParser {
     this.steps = steps;
     this.hooks = hooks ?? {};
     // Shallow copy so lazy loading never mutates a caller-owned catalog.
-    this.localFunctionCatalog = { ...(localFunctionCatalog ?? {}) };
-    this.loadLocalFunction = loadLocalFunction;
+    this.localFunctionCatalog = { ...(localFunctionCatalog ?? compositeFunctionCatalog ?? {}) };
+    this.loadLocalFunction = loadLocalFunction ?? loadCompositeFunction;
   }
 
   protected async parseConfigToBuildStepsAndBuildFunctionByIdMappingAsync(): Promise<{

--- a/packages/steps/src/StepsConfigParser.ts
+++ b/packages/steps/src/StepsConfigParser.ts
@@ -1,10 +1,10 @@
 import {
-  CompositeFunctionConfig,
   FunctionStep,
   HookAnchorId,
   HookKey,
   Hooks,
   LocalFunctionCatalog,
+  LocalFunctionConfig,
   Step,
   isHookAnchorId,
   isStepFunctionStep,
@@ -36,7 +36,7 @@ import {
   extendLocalFunctionCatalogFromStepsAsync,
   isLocalFunctionPath,
   parseLocalFunctionPath,
-} from './utils/localCompositeFunctions';
+} from './utils/localFunctions';
 
 type ValidatedHooks = ReadonlyMap<HookKey, { anchorId: HookAnchorId; steps: Step[] }>;
 
@@ -45,7 +45,7 @@ export class StepsConfigParser extends AbstractConfigParser {
   private readonly hooks: Hooks;
   /** Pre-loaded local function configs keyed by normalized path (e.g. `./.eas/functions/setup`). */
   private readonly localFunctionCatalog: LocalFunctionCatalog;
-  private readonly loadLocalFunction?: (functionPath: string) => Promise<CompositeFunctionConfig>;
+  private readonly loadLocalFunction?: (functionPath: string) => Promise<LocalFunctionConfig>;
 
   constructor(
     ctx: BuildStepGlobalContext,
@@ -65,7 +65,7 @@ export class StepsConfigParser extends AbstractConfigParser {
       externalFunctionGroups?: BuildFunctionGroup[];
       localFunctionCatalog?: LocalFunctionCatalog;
       /** Loads a hook local function missing from the catalog. When omitted, missing entries fail as unknown. */
-      loadLocalFunction?: (functionPath: string) => Promise<CompositeFunctionConfig>;
+      loadLocalFunction?: (functionPath: string) => Promise<LocalFunctionConfig>;
     }
   ) {
     super(ctx, {

--- a/packages/steps/src/StepsConfigParser.ts
+++ b/packages/steps/src/StepsConfigParser.ts
@@ -149,11 +149,12 @@ export class StepsConfigParser extends AbstractConfigParser {
         );
         continue;
       }
-      // Rejected regardless of expansion size: the anchor would land on an
-      // expanded inner step, and hooks never fire inside a composite function.
+      // For composite functions the anchor would land on an expanded inner step. Single-step
+      // functions keep the same restriction so anchor support does not depend on the function's
+      // shape.
       if (isStepFunctionStep(stepConfig) && isLocalFunctionPath(stepConfig.uses)) {
         throw new BuildConfigError(
-          'Hook anchors are not supported on local composite function steps.'
+          'Hook anchors are not supported on steps that call a local function.'
         );
       }
       seenAnchorIds.add(anchorId);
@@ -347,13 +348,11 @@ export class StepsConfigParser extends AbstractConfigParser {
     localFunctionExpander: LocalFunctionExpander
   ): BuildStep[] {
     if (isLocalFunctionPath(step.uses)) {
-      return localFunctionExpander
-        .expandLocalFunctionStep(
-          step,
-          parseLocalFunctionPath(step.uses),
-          BuildStep.getNewId(step.id)
-        )
-        .getFlattenedSteps();
+      return localFunctionExpander.expandLocalFunctionStep(
+        step,
+        parseLocalFunctionPath(step.uses),
+        BuildStep.getNewId(step.id)
+      );
     }
 
     const buildFunction = localFunctionExpander.buildFunctionById[step.uses];

--- a/packages/steps/src/StepsConfigParser.ts
+++ b/packages/steps/src/StepsConfigParser.ts
@@ -15,7 +15,7 @@ import {
 import assert from 'node:assert';
 
 import { AbstractConfigParser } from './AbstractConfigParser';
-import { CompositeFunctionExpander } from './CompositeFunctionExpander';
+import { LocalFunctionExpander } from './LocalFunctionExpander';
 import { BuildFunction, BuildFunctionById, createBuildFunctionByIdMapping } from './BuildFunction';
 import {
   BuildFunctionGroup,
@@ -33,9 +33,9 @@ import {
   validateAllStepFunctionsExist,
 } from './hooks';
 import {
-  extendCompositeFunctionCatalogFromStepsAsync,
-  isLocalCompositeFunctionPath,
-  parseLocalCompositeFunctionPath,
+  extendLocalFunctionCatalogFromStepsAsync,
+  isLocalFunctionPath,
+  parseLocalFunctionPath,
 } from './utils/localCompositeFunctions';
 
 type ValidatedHooks = ReadonlyMap<HookKey, { anchorId: HookAnchorId; steps: Step[] }>;
@@ -43,11 +43,9 @@ type ValidatedHooks = ReadonlyMap<HookKey, { anchorId: HookAnchorId; steps: Step
 export class StepsConfigParser extends AbstractConfigParser {
   private readonly steps: Step[];
   private readonly hooks: Hooks;
-  /** Pre-loaded composite function configs keyed by normalized path (e.g. `./.eas/functions/setup`). */
-  private readonly compositeFunctionCatalog: LocalFunctionCatalog;
-  private readonly loadCompositeFunction?: (
-    compositeFunctionPath: string
-  ) => Promise<CompositeFunctionConfig>;
+  /** Pre-loaded local function configs keyed by normalized path (e.g. `./.eas/functions/setup`). */
+  private readonly localFunctionCatalog: LocalFunctionCatalog;
+  private readonly loadLocalFunction?: (functionPath: string) => Promise<CompositeFunctionConfig>;
 
   constructor(
     ctx: BuildStepGlobalContext,
@@ -56,8 +54,8 @@ export class StepsConfigParser extends AbstractConfigParser {
       hooks,
       externalFunctions,
       externalFunctionGroups,
-      compositeFunctionCatalog,
-      loadCompositeFunction,
+      localFunctionCatalog,
+      loadLocalFunction,
     }: {
       steps: Step[];
       // Required (not `hooks?:`) so a call site cannot silently forget to pass
@@ -65,9 +63,9 @@ export class StepsConfigParser extends AbstractConfigParser {
       hooks: Hooks | undefined;
       externalFunctions?: BuildFunction[];
       externalFunctionGroups?: BuildFunctionGroup[];
-      compositeFunctionCatalog?: LocalFunctionCatalog;
-      /** Loads a hook composite missing from the catalog. When omitted, missing entries fail as unknown. */
-      loadCompositeFunction?: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
+      localFunctionCatalog?: LocalFunctionCatalog;
+      /** Loads a hook local function missing from the catalog. When omitted, missing entries fail as unknown. */
+      loadLocalFunction?: (functionPath: string) => Promise<CompositeFunctionConfig>;
     }
   ) {
     super(ctx, {
@@ -78,8 +76,8 @@ export class StepsConfigParser extends AbstractConfigParser {
     this.steps = steps;
     this.hooks = hooks ?? {};
     // Shallow copy so lazy loading never mutates a caller-owned catalog.
-    this.compositeFunctionCatalog = { ...(compositeFunctionCatalog ?? {}) };
-    this.loadCompositeFunction = loadCompositeFunction;
+    this.localFunctionCatalog = { ...(localFunctionCatalog ?? {}) };
+    this.loadLocalFunction = loadLocalFunction;
   }
 
   protected async parseConfigToBuildStepsAndBuildFunctionByIdMappingAsync(): Promise<{
@@ -99,14 +97,10 @@ export class StepsConfigParser extends AbstractConfigParser {
       this.externalFunctionGroups ?? []
     );
     // Expander shares this catalog by reference; it grows as hook composites load.
-    const compositeFunctionExpander = new CompositeFunctionExpander(
-      this.ctx,
-      this.compositeFunctionCatalog,
-      {
-        buildFunctionById,
-        buildFunctionGroupById,
-      }
-    );
+    const localFunctionExpander = new LocalFunctionExpander(this.ctx, this.localFunctionCatalog, {
+      buildFunctionById,
+      buildFunctionGroupById,
+    });
 
     // Only the job's own steps are scanned — steps constructed from hooks are
     // never treated as anchors (no nesting). Construction order (before →
@@ -118,7 +112,7 @@ export class StepsConfigParser extends AbstractConfigParser {
 
     for (const stepConfig of validatedSteps) {
       const maybeFunctionGroup =
-        isStepFunctionStep(stepConfig) && !isLocalCompositeFunctionPath(stepConfig.uses)
+        isStepFunctionStep(stepConfig) && !isLocalFunctionPath(stepConfig.uses)
           ? buildFunctionGroupById[stepConfig.uses]
           : undefined;
       if (maybeFunctionGroup !== undefined) {
@@ -139,7 +133,7 @@ export class StepsConfigParser extends AbstractConfigParser {
           const anchorHooks = await this.constructAnchorHooksAsync(
             anchorId,
             validatedHooks,
-            compositeFunctionExpander
+            localFunctionExpander
           );
           if (anchorHooks !== undefined) {
             hooksByAnchorStep.set(expandedStep, anchorHooks);
@@ -151,13 +145,13 @@ export class StepsConfigParser extends AbstractConfigParser {
       const anchorId = StepsConfigParser.resolveStepAnchor(stepConfig, buildFunctionById);
       if (anchorId === undefined) {
         buildSteps.push(
-          ...this.createBuildStepsFromNonGroupStepConfig(stepConfig, compositeFunctionExpander)
+          ...this.createBuildStepsFromNonGroupStepConfig(stepConfig, localFunctionExpander)
         );
         continue;
       }
       // Rejected regardless of expansion size: the anchor would land on an
       // expanded inner step, and hooks never fire inside a composite function.
-      if (isStepFunctionStep(stepConfig) && isLocalCompositeFunctionPath(stepConfig.uses)) {
+      if (isStepFunctionStep(stepConfig) && isLocalFunctionPath(stepConfig.uses)) {
         throw new BuildConfigError(
           'Hook anchors are not supported on local composite function steps.'
         );
@@ -167,11 +161,11 @@ export class StepsConfigParser extends AbstractConfigParser {
         anchorId,
         'before',
         validatedHooks,
-        compositeFunctionExpander
+        localFunctionExpander
       );
       const createdSteps = this.createBuildStepsFromNonGroupStepConfig(
         stepConfig,
-        compositeFunctionExpander
+        localFunctionExpander
       );
       assert(
         createdSteps.length === 1,
@@ -183,7 +177,7 @@ export class StepsConfigParser extends AbstractConfigParser {
         anchorId,
         'after',
         validatedHooks,
-        compositeFunctionExpander
+        localFunctionExpander
       );
       if (before.length > 0 || after.length > 0) {
         hooksByAnchorStep.set(anchorStep, { anchor: anchorId, before, after });
@@ -260,19 +254,19 @@ export class StepsConfigParser extends AbstractConfigParser {
   private async constructAnchorHooksAsync(
     anchorId: HookAnchorId,
     validatedHooks: ValidatedHooks,
-    compositeFunctionExpander: CompositeFunctionExpander
+    localFunctionExpander: LocalFunctionExpander
   ): Promise<AnchorHooks | undefined> {
     const before = await this.constructHookSideEntriesAsync(
       anchorId,
       'before',
       validatedHooks,
-      compositeFunctionExpander
+      localFunctionExpander
     );
     const after = await this.constructHookSideEntriesAsync(
       anchorId,
       'after',
       validatedHooks,
-      compositeFunctionExpander
+      localFunctionExpander
     );
     if (before.length === 0 && after.length === 0) {
       return undefined;
@@ -284,7 +278,7 @@ export class StepsConfigParser extends AbstractConfigParser {
     anchorId: HookAnchorId,
     side: 'before' | 'after',
     validatedHooks: ValidatedHooks,
-    compositeFunctionExpander: CompositeFunctionExpander
+    localFunctionExpander: LocalFunctionExpander
   ): Promise<HookEntry[]> {
     const hookSteps = validatedHooks.get(`${side}_${anchorId}`)?.steps;
     if (hookSteps === undefined) {
@@ -302,13 +296,13 @@ export class StepsConfigParser extends AbstractConfigParser {
         }`
       );
     }
-    if (this.loadCompositeFunction !== undefined) {
+    if (this.loadLocalFunction !== undefined) {
       // Load only once the anchor runs, so unused anchors do not fail on missing composites.
       try {
-        await extendCompositeFunctionCatalogFromStepsAsync({
-          catalog: this.compositeFunctionCatalog,
+        await extendLocalFunctionCatalogFromStepsAsync({
+          catalog: this.localFunctionCatalog,
           rootSteps: hookSteps,
-          loadCompositeFunction: this.loadCompositeFunction,
+          loadLocalFunction: this.loadLocalFunction,
         });
       } catch (err) {
         if (err instanceof BuildConfigError) {
@@ -317,14 +311,14 @@ export class StepsConfigParser extends AbstractConfigParser {
           );
         }
         throw new BuildConfigError(
-          `Failed to load a local composite function referenced from "hooks.${side}_${anchorId}": ${
+          `Failed to load a local function referenced from "hooks.${side}_${anchorId}": ${
             err instanceof Error ? err.message : String(err)
           }`
         );
       }
     }
     try {
-      return constructHookEntriesFromValidatedSteps(this.ctx, hookSteps, compositeFunctionExpander);
+      return constructHookEntriesFromValidatedSteps(this.ctx, hookSteps, localFunctionExpander);
     } catch (err) {
       if (err instanceof BuildConfigError) {
         throw new BuildConfigError(`Invalid steps in "hooks.${side}_${anchorId}": ${err.message}`);
@@ -335,13 +329,13 @@ export class StepsConfigParser extends AbstractConfigParser {
 
   private createBuildStepsFromNonGroupStepConfig(
     stepConfig: Step,
-    compositeFunctionExpander: CompositeFunctionExpander
+    localFunctionExpander: LocalFunctionExpander
   ): BuildStep[] {
     if (isStepShellStep(stepConfig)) {
       return [createBuildStepFromShellStep(this.ctx, stepConfig)];
     }
     if (isStepFunctionStep(stepConfig)) {
-      return this.createBuildStepsFromFunctionStepConfig(stepConfig, compositeFunctionExpander);
+      return this.createBuildStepsFromFunctionStepConfig(stepConfig, localFunctionExpander);
     }
     throw new BuildConfigError(
       'Invalid job step configuration detected. Step must be shell or function step'
@@ -350,19 +344,19 @@ export class StepsConfigParser extends AbstractConfigParser {
 
   private createBuildStepsFromFunctionStepConfig(
     step: FunctionStep,
-    compositeFunctionExpander: CompositeFunctionExpander
+    localFunctionExpander: LocalFunctionExpander
   ): BuildStep[] {
-    if (isLocalCompositeFunctionPath(step.uses)) {
-      return compositeFunctionExpander
-        .expandCompositeFunctionStep(
+    if (isLocalFunctionPath(step.uses)) {
+      return localFunctionExpander
+        .expandLocalFunctionStep(
           step,
-          parseLocalCompositeFunctionPath(step.uses),
+          parseLocalFunctionPath(step.uses),
           BuildStep.getNewId(step.id)
         )
         .getFlattenedSteps();
     }
 
-    const buildFunction = compositeFunctionExpander.buildFunctionById[step.uses];
+    const buildFunction = localFunctionExpander.buildFunctionById[step.uses];
     assert(buildFunction, 'function ID must be ID of function or function group');
 
     return [

--- a/packages/steps/src/__tests__/BuildConfig-test.ts
+++ b/packages/steps/src/__tests__/BuildConfig-test.ts
@@ -1052,7 +1052,7 @@ describe(validateAllFunctionsExist, () => {
     expect(() => {
       validateAllFunctionsExist(buildConfig, { externalFunctionIds: [] });
     }).toThrowError(
-      /Local composite functions \("\.\/\.eas\/functions\/my-function"\) are not supported in "\.eas\/build\/\*\.yml" custom builds\. Local composite functions can only be used in EAS workflows \("\.eas\/workflows\/\*\.yml"\)\./
+      /Local functions \("\.\/\.eas\/functions\/my-function"\) are not supported in "\.eas\/build\/\*\.yml" custom builds\. Local functions can only be used in EAS workflows \("\.eas\/workflows\/\*\.yml"\)\./
     );
   });
   test('rejects object-form local composite function references with a dedicated error', () => {
@@ -1073,7 +1073,7 @@ describe(validateAllFunctionsExist, () => {
     expect(() => {
       validateAllFunctionsExist(buildConfig, { externalFunctionIds: [] });
     }).toThrow(
-      /Local composite functions \("\.\/\.eas\/functions\/my-function"\) are not supported in "\.eas\/build\/\*\.yml" custom builds\. Local composite functions can only be used in EAS workflows \("\.eas\/workflows\/\*\.yml"\)\./
+      /Local functions \("\.\/\.eas\/functions\/my-function"\) are not supported in "\.eas\/build\/\*\.yml" custom builds\. Local functions can only be used in EAS workflows \("\.eas\/workflows\/\*\.yml"\)\./
     );
   });
   test('non-existent namespaced functions with skipNamespacedFunctionsOrFunctionGroupsCheck = false', () => {

--- a/packages/steps/src/__tests__/BuildStepInput-test.ts
+++ b/packages/steps/src/__tests__/BuildStepInput-test.ts
@@ -5,6 +5,7 @@ import { BuildStep } from '../BuildStep';
 import {
   BuildStepInput,
   BuildStepInputValueTypeName,
+  getDisallowedInputValueError,
   makeBuildStepInputByIdMap,
 } from '../BuildStepInput';
 import { BuildStepRuntimeError } from '../errors';
@@ -938,6 +939,36 @@ describe(BuildStepInput, () => {
       i.set(undefined);
     }).toThrowError(
       new BuildStepRuntimeError('Input parameter "foo" for step "test1" is required.')
+    );
+  });
+
+  test('accepts a json value structurally equal to an allowed value', () => {
+    const ctx = createGlobalContextMock();
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: 'test1',
+      required: true,
+      allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+      allowedValues: [{ a: 1 }, { b: 2 }],
+    });
+    i.set({ a: 1 });
+    expect(i.isRawValueOneOfAllowedValues()).toBe(true);
+    expect(getDisallowedInputValueError(i, 'test1')).toBeUndefined();
+  });
+
+  test('rejects a json value not among the allowed values', () => {
+    const ctx = createGlobalContextMock();
+    const i = new BuildStepInput(ctx, {
+      id: 'foo',
+      stepDisplayName: 'test1',
+      required: true,
+      allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+      allowedValues: [{ a: 1 }],
+    });
+    i.set({ a: 2 });
+    expect(i.isRawValueOneOfAllowedValues()).toBe(false);
+    expect(getDisallowedInputValueError(i, 'test1')).toBe(
+      'Input parameter "foo" for step "test1" is set to "{"a":2}" which is not one of the allowed values: {"a":1}.'
     );
   });
 });

--- a/packages/steps/src/__tests__/BuildWorkflow-hooks-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-hooks-test.ts
@@ -121,7 +121,7 @@ describe('BuildWorkflow hook execution', () => {
       hooks,
       externalFunctions,
       externalFunctionGroups,
-      compositeFunctionCatalog: compositeFunctionCatalog
+      localFunctionCatalog: compositeFunctionCatalog
         ? makeCatalog(compositeFunctionCatalog)
         : undefined,
     });

--- a/packages/steps/src/__tests__/StepsConfigParser-composite-functions-expansion-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-composite-functions-expansion-test.ts
@@ -163,7 +163,7 @@ describe('StepsConfigParser local composite functions', () => {
         parseCompositeFunctions({
           steps: [{ uses: './.eas/functions/missing', id: 'x' }],
         })
-      ).rejects.toThrow(/Local composite function ".\/.eas\/functions\/missing"/);
+      ).rejects.toThrow(/Local function ".\/.eas\/functions\/missing" does not exist/);
     });
 
     it.each([

--- a/packages/steps/src/__tests__/StepsConfigParser-composite-functions-scoping-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-composite-functions-scoping-test.ts
@@ -620,7 +620,7 @@ describe('StepsConfigParser local composite functions', () => {
       const parser = new StepsConfigParser(ctx, {
         steps: [{ uses: SETUP, id: 'setup', if: "${{ env.DEPLOY == 'true' }}" }],
         hooks: undefined,
-        compositeFunctionCatalog: makeCatalog({
+        localFunctionCatalog: makeCatalog({
           [SETUP]: {
             runs: { steps: [{ id: 'inner', uses: 'eas/echo', env: { DEPLOY: 'false' } }] },
           },
@@ -780,7 +780,7 @@ describe('StepsConfigParser local composite functions', () => {
       const parser = new StepsConfigParser(ctx, {
         steps: [{ uses: SETUP, id: 'setup', with: { msg: '${{ env.SECRET }}' } }],
         hooks: undefined,
-        compositeFunctionCatalog: makeCatalog({
+        localFunctionCatalog: makeCatalog({
           [SETUP]: {
             inputs: [{ name: 'msg', type: 'string', required: false }],
             runs: {
@@ -823,7 +823,7 @@ describe('StepsConfigParser local composite functions', () => {
       const parser = new StepsConfigParser(ctx, {
         steps: [{ uses: SETUP, id: 'setup' }],
         hooks: undefined,
-        compositeFunctionCatalog: makeCatalog({
+        localFunctionCatalog: makeCatalog({
           [SETUP]: {
             inputs: [{ name: 'label', type: 'string', default_value: '${{ env.NAME }}' }],
             runs: {

--- a/packages/steps/src/__tests__/StepsConfigParser-composite-functions-test-utils.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-composite-functions-test-utils.ts
@@ -1,4 +1,4 @@
-import { CompositeFunctionConfigZ, LocalFunctionCatalog, Step } from '@expo/eas-build-job';
+import { LocalFunctionCatalog, LocalFunctionConfigZ, Step } from '@expo/eas-build-job';
 
 import { createGlobalContextMock } from './utils/context';
 import { BuildFunction } from '../BuildFunction';
@@ -13,7 +13,7 @@ export const SETUP = './.eas/functions/setup';
 export function makeCatalog(entries: Record<string, unknown>): LocalFunctionCatalog {
   const catalog: LocalFunctionCatalog = {};
   for (const [compositeFunctionPath, raw] of Object.entries(entries)) {
-    catalog[compositeFunctionPath] = CompositeFunctionConfigZ.parse(raw);
+    catalog[compositeFunctionPath] = LocalFunctionConfigZ.parse(raw);
   }
   return catalog;
 }

--- a/packages/steps/src/__tests__/StepsConfigParser-composite-functions-test-utils.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-composite-functions-test-utils.ts
@@ -28,7 +28,7 @@ export async function parseCompositeFunctions(options: {
   const parser = new StepsConfigParser(ctx, {
     steps: options.steps,
     hooks: undefined,
-    compositeFunctionCatalog: makeCatalog(options.catalog ?? {}),
+    localFunctionCatalog: makeCatalog(options.catalog ?? {}),
     externalFunctions: options.externalFunctions,
     externalFunctionGroups: options.externalFunctionGroups,
   });

--- a/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
@@ -595,7 +595,9 @@ describe('StepsConfigParser hooks with composite functions', () => {
       });
     });
     expect(error).toBeInstanceOf(BuildConfigError);
-    expect(error.message).toBe('Hook anchors are not supported on local composite function steps.');
+    expect(error.message).toBe(
+      'Hook anchors are not supported on steps that call a local function.'
+    );
   });
 
   it('rejects a REGISTERED stamp on a composite call that expands into multiple steps', async () => {
@@ -612,7 +614,9 @@ describe('StepsConfigParser hooks with composite functions', () => {
       });
     });
     expect(error).toBeInstanceOf(BuildConfigError);
-    expect(error.message).toBe('Hook anchors are not supported on local composite function steps.');
+    expect(error.message).toBe(
+      'Hook anchors are not supported on steps that call a local function.'
+    );
   });
 
   it('treats an UNREGISTERED-stamped composite call as an inert ordinary step (skew tolerance)', async () => {
@@ -653,6 +657,30 @@ describe('StepsConfigParser hooks with composite functions', () => {
       'setup__composite_function_step_1',
       'setup',
     ]);
+    expect(workflow.buildSteps.map(step => step.displayName)).toEqual(['Install node modules']);
+  });
+
+  it('parses a single-step function hook step into one entry with one step', async () => {
+    const workflow = await parseWorkflowAsync({
+      ctx,
+      steps: [{ uses: 'eas/install_node_modules' }],
+      hooks: {
+        before_install_node_modules: [
+          { uses: './.eas/functions/say-hi', id: 'greet', if: '${{ always() }}' },
+        ],
+      },
+      localFunctionCatalog: makeCatalog({
+        './.eas/functions/say-hi': { name: 'Say hi', command: 'echo hi' },
+      }),
+    });
+    const anchorHooks = [...workflow.hooksByAnchorStep.values()][0];
+    expect(anchorHooks.before).toHaveLength(1);
+    const [hookStep] = anchorHooks.before[0].steps;
+    expect(anchorHooks.before[0].steps).toHaveLength(1);
+    expect(hookStep.id).toBe('greet');
+    expect(hookStep.displayName).toBe('Say hi');
+    expect(hookStep.command).toBe('echo hi');
+    expect(hookStep.ifCondition).toBe('${{ always() }}');
     expect(workflow.buildSteps.map(step => step.displayName)).toEqual(['Install node modules']);
   });
 

--- a/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
@@ -1140,3 +1140,40 @@ describe('StepsConfigParser hook validation view', () => {
     expect((error as BuildWorkflowError).errors[0].message).toMatch(/not allowed on platform/);
   });
 });
+
+describe('deprecated composite function option keys', () => {
+  let ctx: BuildStepGlobalContext;
+
+  beforeEach(() => {
+    ctx = createGlobalContextMock();
+  });
+
+  it('StepsConfigParser accepts compositeFunctionCatalog and loadCompositeFunction', async () => {
+    const parser = new StepsConfigParser(ctx, {
+      steps: [
+        { uses: './.eas/functions/setup', id: 'setup' },
+        { uses: 'eas/install_node_modules' },
+      ],
+      hooks: { before_install_node_modules: [{ uses: './.eas/functions/hook-fn' }] },
+      externalFunctions: [createInstallNodeModulesFunction()],
+      compositeFunctionCatalog: makeCatalog({
+        './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
+      }),
+      loadCompositeFunction: async () =>
+        CompositeFunctionConfigZ.parse({ runs: { steps: [{ run: 'echo hook' }] } }),
+    });
+    const workflow = await parser.parseAsync();
+    expect(workflow.buildSteps).toHaveLength(2);
+    expect(workflow.hooksByAnchorStep.size).toBe(1);
+  });
+
+  it('constructHookEntriesAsync accepts compositeFunctionCatalog', async () => {
+    const entries = await constructHookEntriesAsync(ctx, [{ uses: './.eas/functions/setup' }], {
+      compositeFunctionCatalog: makeCatalog({
+        './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
+      }),
+    });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].steps).toHaveLength(1);
+  });
+});

--- a/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-hooks-test.ts
@@ -45,16 +45,16 @@ async function parseWorkflowAsync({
   hooks,
   externalFunctions,
   externalFunctionGroups,
-  compositeFunctionCatalog,
-  loadCompositeFunction,
+  localFunctionCatalog,
+  loadLocalFunction,
 }: {
   ctx: BuildStepGlobalContext;
   steps: Step[];
   hooks: Hooks | undefined;
   externalFunctions?: BuildFunction[];
   externalFunctionGroups?: BuildFunctionGroup[];
-  compositeFunctionCatalog?: LocalFunctionCatalog;
-  loadCompositeFunction?: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
+  localFunctionCatalog?: LocalFunctionCatalog;
+  loadLocalFunction?: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
 }): Promise<BuildWorkflow> {
   const parser = new StepsConfigParser(ctx, {
     steps,
@@ -64,8 +64,8 @@ async function parseWorkflowAsync({
       createCheckoutFunction(),
     ],
     externalFunctionGroups,
-    compositeFunctionCatalog,
-    loadCompositeFunction,
+    localFunctionCatalog,
+    loadLocalFunction,
   });
   return await parser.parseAsync();
 }
@@ -541,7 +541,7 @@ describe('StepsConfigParser hooks with composite functions', () => {
         before_install_node_modules: [{ run: 'echo never' }],
         after_install_node_modules: [{ run: 'echo never' }],
       },
-      compositeFunctionCatalog: makeCatalog({
+      localFunctionCatalog: makeCatalog({
         './.eas/functions/setup': {
           runs: { steps: [{ uses: 'eas/install_node_modules' }] },
         },
@@ -566,7 +566,7 @@ describe('StepsConfigParser hooks with composite functions', () => {
         before_install_node_modules: [{ run: 'echo before', id: 'before-hook' }],
         after_install_node_modules: [{ run: 'echo after', id: 'after-hook' }],
       },
-      compositeFunctionCatalog: makeCatalog({
+      localFunctionCatalog: makeCatalog({
         './.eas/functions/setup': {
           runs: { steps: [{ uses: 'eas/install_node_modules' }] },
         },
@@ -587,7 +587,7 @@ describe('StepsConfigParser hooks with composite functions', () => {
         ctx,
         steps: [{ uses: './.eas/functions/setup', id: 'setup', __hook_id: 'install_node_modules' }],
         hooks: { before_install_node_modules: [{ run: 'echo never' }] },
-        compositeFunctionCatalog: makeCatalog({
+        localFunctionCatalog: makeCatalog({
           './.eas/functions/setup': {
             runs: { steps: [{ run: 'echo setup' }] },
           },
@@ -604,7 +604,7 @@ describe('StepsConfigParser hooks with composite functions', () => {
         ctx,
         steps: [{ uses: './.eas/functions/setup', id: 'setup', __hook_id: 'install_node_modules' }],
         hooks: { before_install_node_modules: [{ run: 'echo never' }] },
-        compositeFunctionCatalog: makeCatalog({
+        localFunctionCatalog: makeCatalog({
           './.eas/functions/setup': {
             runs: { steps: [{ run: 'echo one' }, { run: 'echo two' }] },
           },
@@ -620,7 +620,7 @@ describe('StepsConfigParser hooks with composite functions', () => {
       ctx,
       steps: [{ uses: './.eas/functions/setup', id: 'setup', __hook_id: 'some_future_anchor' }],
       hooks: { before_install_node_modules: [{ run: 'echo never' }] },
-      compositeFunctionCatalog: makeCatalog({
+      localFunctionCatalog: makeCatalog({
         './.eas/functions/setup': {
           runs: { steps: [{ uses: 'eas/install_node_modules' }] },
         },
@@ -637,7 +637,7 @@ describe('StepsConfigParser hooks with composite functions', () => {
       hooks: {
         before_install_node_modules: [{ uses: './.eas/functions/setup', id: 'setup' }],
       },
-      compositeFunctionCatalog: makeCatalog({
+      localFunctionCatalog: makeCatalog({
         './.eas/functions/setup': {
           outputs: { version: { value: '${{ steps.read.outputs.version }}' } },
           runs: {
@@ -666,7 +666,7 @@ describe('StepsConfigParser hooks with composite functions', () => {
           { uses: './.eas/functions/setup', id: 'setup', if: '${{ failure() }}' },
         ],
       },
-      compositeFunctionCatalog: makeCatalog({
+      localFunctionCatalog: makeCatalog({
         './.eas/functions/setup': {
           runs: { steps: [{ run: 'echo hi' }] },
         },
@@ -687,7 +687,7 @@ describe('StepsConfigParser hooks with composite functions', () => {
             { uses: './.eas/functions/setup', id: 'setup', working_directory: 'app' },
           ],
         },
-        compositeFunctionCatalog: makeCatalog({
+        localFunctionCatalog: makeCatalog({
           './.eas/functions/setup': {
             runs: { steps: [{ run: 'echo hi' }] },
           },
@@ -706,7 +706,7 @@ describe('StepsConfigParser hooks with composite functions', () => {
         hooks: {
           before_install_node_modules: [{ uses: './.eas/functions/notify', id: 'notify' }],
         },
-        compositeFunctionCatalog: makeCatalog({
+        localFunctionCatalog: makeCatalog({
           './.eas/functions/notify': {
             inputs: [{ name: 'message', type: 'string', required: true }],
             runs: { steps: [{ run: 'echo hi' }] },
@@ -727,7 +727,7 @@ describe('StepsConfigParser hooks with composite functions', () => {
       hooks: {
         before_install_node_modules: [{ uses: './.eas/functions/outer', id: 'top' }],
       },
-      compositeFunctionCatalog: makeCatalog({
+      localFunctionCatalog: makeCatalog({
         './.eas/functions/outer': {
           runs: {
             steps: [{ uses: './.eas/functions/inner', id: 'mid' }, { run: 'echo done' }],
@@ -755,7 +755,7 @@ describe('StepsConfigParser hooks with composite functions', () => {
         before_install_node_modules: [{ uses: './.eas/functions/setup', id: 'setup' }],
         after_install_node_modules: [{ uses: './.eas/functions/teardown', id: 'teardown' }],
       },
-      compositeFunctionCatalog: makeCatalog({
+      localFunctionCatalog: makeCatalog({
         './.eas/functions/setup': {
           runs: { steps: [{ id: 'prepare', run: 'echo prepare' }] },
         },
@@ -779,7 +779,7 @@ describe('StepsConfigParser hooks with composite functions', () => {
         hooks: {
           before_install_node_modules: [{ uses: './.eas/functions/setup', id: 'setup' }],
         },
-        compositeFunctionCatalog: makeCatalog({
+        localFunctionCatalog: makeCatalog({
           './.eas/functions/setup': {
             // Outputs node reuses the call id, forcing the collision with the job step.
             outputs: { version: { value: '${{ steps.read.outputs.version }}' } },
@@ -800,13 +800,13 @@ describe('StepsConfigParser lazy hook composite loading', () => {
   });
 
   function createLoader(entries: Record<string, unknown>): {
-    loadCompositeFunction: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
+    loadLocalFunction: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
     loadedPaths: string[];
   } {
     const loadedPaths: string[] = [];
     return {
       loadedPaths,
-      loadCompositeFunction: async compositeFunctionPath => {
+      loadLocalFunction: async compositeFunctionPath => {
         loadedPaths.push(compositeFunctionPath);
         const raw = entries[compositeFunctionPath];
         if (raw === undefined) {
@@ -824,7 +824,7 @@ describe('StepsConfigParser lazy hook composite loading', () => {
   }
 
   it('loads a hook composite through the loader (normalized path) when the anchor is present', async () => {
-    const { loadCompositeFunction, loadedPaths } = createLoader({
+    const { loadLocalFunction, loadedPaths } = createLoader({
       './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
     });
     const workflow = await parseWorkflowAsync({
@@ -834,7 +834,7 @@ describe('StepsConfigParser lazy hook composite loading', () => {
         // Trailing slash must normalize before the loader is called.
         before_install_node_modules: [{ uses: './.eas/functions/setup/', id: 'setup' }],
       },
-      loadCompositeFunction,
+      loadLocalFunction,
     });
     expect(loadedPaths).toEqual(['./.eas/functions/setup']);
     const anchorHooks = [...workflow.hooksByAnchorStep.values()][0];
@@ -853,7 +853,7 @@ describe('StepsConfigParser lazy hook composite loading', () => {
       hooks: {
         before_install_node_modules: [{ uses: './.eas/functions/only-elsewhere' }],
       },
-      loadCompositeFunction: rejectingLoader(),
+      loadLocalFunction: rejectingLoader(),
     });
     expect(orderedDisplayNames(workflow)).toEqual(['Checkout']);
   });
@@ -886,7 +886,7 @@ describe('StepsConfigParser lazy hook composite loading', () => {
         ctx,
         steps: [{ uses: 'eas/install_node_modules' }],
         hooks: { before_install_node_modules: [{ uses: './.eas/functions/missing' }] },
-        loadCompositeFunction: createLoader({}).loadCompositeFunction,
+        loadLocalFunction: createLoader({}).loadLocalFunction,
       });
     });
     expect(error).toBeInstanceOf(BuildConfigError);
@@ -900,7 +900,7 @@ describe('StepsConfigParser lazy hook composite loading', () => {
         ctx,
         steps: [{ uses: 'eas/install_node_modules' }],
         hooks: { after_install_node_modules: [{ uses: './.eas/functions/missing' }] },
-        loadCompositeFunction: createLoader({}).loadCompositeFunction,
+        loadLocalFunction: createLoader({}).loadLocalFunction,
       });
     });
     expect(error).toBeInstanceOf(BuildConfigError);
@@ -917,9 +917,9 @@ describe('StepsConfigParser lazy hook composite loading', () => {
             { uses: './.eas/functions/setup', id: 'setup', working_directory: 'app' },
           ],
         },
-        loadCompositeFunction: createLoader({
+        loadLocalFunction: createLoader({
           './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
-        }).loadCompositeFunction,
+        }).loadLocalFunction,
       });
     });
     expect(error).toBeInstanceOf(BuildConfigError);
@@ -929,14 +929,14 @@ describe('StepsConfigParser lazy hook composite loading', () => {
   });
 
   it('calls the loader once per composite across repeated occurrences of the same anchor', async () => {
-    const { loadCompositeFunction, loadedPaths } = createLoader({
+    const { loadLocalFunction, loadedPaths } = createLoader({
       './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
     });
     await parseWorkflowAsync({
       ctx,
       steps: [{ uses: 'eas/install_node_modules' }, { uses: 'eas/install_node_modules' }],
       hooks: { before_install_node_modules: [{ uses: './.eas/functions/setup' }] },
-      loadCompositeFunction,
+      loadLocalFunction,
     });
     expect(loadedPaths).toEqual(['./.eas/functions/setup']);
   });
@@ -946,16 +946,16 @@ describe('StepsConfigParser lazy hook composite loading', () => {
       ctx,
       steps: [{ uses: 'eas/install_node_modules' }],
       hooks: { before_install_node_modules: [{ uses: './.eas/functions/setup' }] },
-      compositeFunctionCatalog: makeCatalog({
+      localFunctionCatalog: makeCatalog({
         './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
       }),
-      loadCompositeFunction: rejectingLoader(),
+      loadLocalFunction: rejectingLoader(),
     });
     expect(workflow.hooksByAnchorStep.size).toBe(1);
   });
 
   it('loads composites transitively referenced by a hook composite', async () => {
-    const { loadCompositeFunction, loadedPaths } = createLoader({
+    const { loadLocalFunction, loadedPaths } = createLoader({
       './.eas/functions/outer': {
         runs: { steps: [{ uses: './.eas/functions/inner', id: 'mid' }] },
       },
@@ -965,7 +965,7 @@ describe('StepsConfigParser lazy hook composite loading', () => {
       ctx,
       steps: [{ uses: 'eas/install_node_modules' }],
       hooks: { before_install_node_modules: [{ uses: './.eas/functions/outer', id: 'top' }] },
-      loadCompositeFunction,
+      loadLocalFunction,
     });
     expect(loadedPaths.sort()).toEqual(['./.eas/functions/inner', './.eas/functions/outer']);
     const anchorHooks = [...workflow.hooksByAnchorStep.values()][0];
@@ -985,7 +985,7 @@ describe('StepsConfigParser lazy hook composite loading', () => {
         installFunction.createBuildStepFromFunctionCall(globalCtx),
       ],
     });
-    const { loadCompositeFunction, loadedPaths } = createLoader({
+    const { loadLocalFunction, loadedPaths } = createLoader({
       './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
     });
     const workflow = await parseWorkflowAsync({
@@ -994,7 +994,7 @@ describe('StepsConfigParser lazy hook composite loading', () => {
       hooks: { before_install_node_modules: [{ uses: './.eas/functions/setup', id: 'setup' }] },
       externalFunctions: [checkoutFunction, installFunction],
       externalFunctionGroups: [group],
-      loadCompositeFunction,
+      loadLocalFunction,
     });
     expect(loadedPaths).toEqual(['./.eas/functions/setup']);
     expect(workflow.hooksByAnchorStep.size).toBe(1);
@@ -1006,10 +1006,10 @@ describe('StepsConfigParser lazy hook composite loading', () => {
       ctx,
       steps: [{ uses: 'eas/install_node_modules' }],
       hooks: { before_install_node_modules: [{ uses: './.eas/functions/setup' }] },
-      compositeFunctionCatalog: callerCatalog,
-      loadCompositeFunction: createLoader({
+      localFunctionCatalog: callerCatalog,
+      loadLocalFunction: createLoader({
         './.eas/functions/setup': { runs: { steps: [{ run: 'echo setup' }] } },
-      }).loadCompositeFunction,
+      }).loadLocalFunction,
     });
     expect(Object.keys(callerCatalog)).toEqual([]);
   });

--- a/packages/steps/src/__tests__/StepsConfigParser-legacy-functions-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-legacy-functions-test.ts
@@ -1,0 +1,376 @@
+import fs from 'fs/promises';
+import assert from 'node:assert';
+import path from 'node:path';
+
+import { parseCompositeFunctions } from './StepsConfigParser-composite-functions-test-utils';
+import { getErrorAsync } from './utils/error';
+import { BuildWorkflow } from '../BuildWorkflow';
+import { BuildWorkflowError } from '../errors';
+
+const SAY_HI = './.eas/functions/say-hi';
+
+const createdDirectories: string[] = [];
+
+async function executeWorkflowAsync(workflow: BuildWorkflow): Promise<void> {
+  const globalCtx = workflow.buildSteps[0].ctx.global;
+  for (const directory of [
+    globalCtx.defaultWorkingDirectory,
+    globalCtx.stepsInternalBuildDirectory,
+  ]) {
+    await fs.mkdir(directory, { recursive: true });
+    createdDirectories.push(directory);
+  }
+  await workflow.executeAsync();
+}
+
+afterEach(async () => {
+  await Promise.all(
+    createdDirectories.map(directory => fs.rm(directory, { recursive: true, force: true }))
+  );
+  createdDirectories.length = 0;
+});
+
+describe('StepsConfigParser local single-step functions', () => {
+  describe('expansion', () => {
+    it('expands a command function into one step keeping the caller id', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: { [SAY_HI]: { name: 'Say hi', command: 'echo hi' } },
+        steps: [
+          {
+            uses: SAY_HI,
+            id: 'greet',
+            name: 'Greet the world',
+            env: { GREETING: 'Hi' },
+            if: '${{ always() }}',
+          },
+        ],
+      });
+
+      expect(workflow.buildSteps).toHaveLength(1);
+      const [step] = workflow.buildSteps;
+      expect(step.id).toBe('greet');
+      expect(step.displayName).toBe('Greet the world');
+      expect(step.command).toBe('echo hi');
+      expect(step.fn).toBeUndefined();
+      expect(step.ifCondition).toBe('${{ always() }}');
+      expect(step.stepEnvOverrides).toEqual({ GREETING: 'Hi' });
+    });
+
+    it('falls back to the function name and then to the function path for the display name', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          [SAY_HI]: { name: 'Say hi', command: 'echo hi' },
+          './.eas/functions/anonymous': { command: 'echo anonymous' },
+        },
+        steps: [
+          { uses: SAY_HI, id: 'greet' },
+          { uses: './.eas/functions/anonymous', id: 'anonymous' },
+        ],
+      });
+
+      expect(workflow.buildSteps.map(step => step.displayName)).toEqual([
+        'Say hi',
+        './.eas/functions/anonymous',
+      ]);
+    });
+
+    it('generates a step id when the caller has none', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: { [SAY_HI]: { command: 'echo hi' } },
+        steps: [{ uses: SAY_HI }],
+      });
+
+      expect(workflow.buildSteps[0].id).toMatch(/^step-\d{3,}$/);
+    });
+
+    it('expands repeated calls to the same function into separate steps', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: { [SAY_HI]: { command: 'echo hi' } },
+        steps: [
+          { uses: SAY_HI, id: 'first' },
+          { uses: SAY_HI, id: 'second' },
+        ],
+      });
+
+      expect(workflow.buildSteps.map(step => step.id)).toEqual(['first', 'second']);
+    });
+
+    it('forwards the function-level shell to the step', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: { [SAY_HI]: { command: 'echo hi', shell: 'sh' } },
+        steps: [{ uses: SAY_HI, id: 'greet' }],
+      });
+
+      expect(workflow.buildSteps[0].shell).toBe('sh');
+    });
+
+    it('expands a path function into a step calling the module', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          [SAY_HI]: { path: path.resolve(__dirname, './fixtures/my-custom-ts-function') },
+        },
+        steps: [{ uses: SAY_HI, id: 'greet' }],
+      });
+
+      const [step] = workflow.buildSteps;
+      expect(step.command).toBeUndefined();
+      expect(step.fn).toBeDefined();
+    });
+
+    it('registers the expanded function in workflow.buildFunctions keyed by its path', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: { [SAY_HI]: { command: 'echo hi' } },
+        steps: [{ uses: SAY_HI, id: 'greet' }],
+      });
+
+      expect(workflow.buildFunctions[SAY_HI]).toBeDefined();
+      expect(workflow.buildFunctions[SAY_HI].command).toBe('echo hi');
+    });
+
+    it('forwards working_directory from the caller to the step', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: { [SAY_HI]: { command: 'echo hi' } },
+        steps: [{ uses: SAY_HI, id: 'greet', working_directory: 'packages/app' }],
+      });
+
+      expect(workflow.buildSteps[0].ctx.relativeWorkingDirectory).toBe('packages/app');
+    });
+
+    it('throws a clear error for a function missing from the catalog', async () => {
+      await expect(
+        parseCompositeFunctions({ steps: [{ uses: SAY_HI, id: 'greet' }] })
+      ).rejects.toThrow(/Local function ".\/.eas\/functions\/say-hi" does not exist/);
+    });
+  });
+
+  describe('inputs', () => {
+    it('passes caller values to the function inputs', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          [SAY_HI]: {
+            inputs: ['name'],
+            outputs: ['greeting'],
+            command: 'set-output greeting "Hi, ${ inputs.name }!"',
+          },
+        },
+        steps: [{ uses: SAY_HI, id: 'greet', with: { name: 'World' } }],
+      });
+      await executeWorkflowAsync(workflow);
+
+      expect(workflow.buildSteps[0].getOutputValueByName('greeting')).toBe('Hi, World!');
+    });
+
+    it('applies the declared default when the caller omits a value', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          [SAY_HI]: {
+            inputs: [{ name: 'name', type: 'string', default_value: 'World', required: false }],
+            outputs: ['greeting'],
+            command: 'set-output greeting "Hi, ${ inputs.name }!"',
+          },
+        },
+        steps: [{ uses: SAY_HI, id: 'greet' }],
+      });
+      await executeWorkflowAsync(workflow);
+
+      expect(workflow.buildSteps[0].getOutputValueByName('greeting')).toBe('Hi, World!');
+    });
+
+    it('treats shorthand inputs as required, unlike composite function inputs', async () => {
+      const error = await getErrorAsync<BuildWorkflowError>(() =>
+        parseCompositeFunctions({
+          catalog: { [SAY_HI]: { inputs: ['name'], command: 'echo hi' } },
+          steps: [{ uses: SAY_HI, id: 'greet' }],
+        })
+      );
+
+      expect(error).toBeInstanceOf(BuildWorkflowError);
+      assert(error instanceof BuildWorkflowError);
+      expect(error.errors[0].message).toBe(
+        'Input parameter "name" for step "./.eas/functions/say-hi" is required but it was not set.'
+      );
+    });
+
+    it('accepts an input declared as not required', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          [SAY_HI]: {
+            inputs: [{ name: 'name', type: 'string', required: false }],
+            command: 'echo hi',
+          },
+        },
+        steps: [{ uses: SAY_HI, id: 'greet' }],
+      });
+
+      expect(workflow.buildSteps).toHaveLength(1);
+    });
+
+    it('rejects a value outside the declared allowed values', async () => {
+      const error = await getErrorAsync<BuildWorkflowError>(() =>
+        parseCompositeFunctions({
+          catalog: {
+            [SAY_HI]: {
+              inputs: [
+                {
+                  name: 'platform',
+                  type: 'string',
+                  default_value: 'ios',
+                  allowed_values: ['ios', 'android'],
+                },
+              ],
+              command: 'echo hi',
+            },
+          },
+          steps: [{ uses: SAY_HI, id: 'greet', with: { platform: 'web' } }],
+        })
+      );
+
+      expect(error).toBeInstanceOf(BuildWorkflowError);
+      assert(error instanceof BuildWorkflowError);
+      expect(error.errors[0].message).toBe(
+        'Input parameter "platform" for step "./.eas/functions/say-hi" is set to "web" which is not one of the allowed values: "ios", "android".'
+      );
+    });
+  });
+
+  describe('outputs', () => {
+    it('exposes declared outputs to later steps', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          [SAY_HI]: { outputs: ['version'], command: 'set-output version "1.0.0"' },
+        },
+        steps: [
+          { uses: SAY_HI, id: 'read' },
+          {
+            id: 'copy',
+            run: 'set-output copied "${{ steps.read.outputs.version }}"',
+            outputs: [{ name: 'copied', required: true }],
+          },
+        ],
+      });
+      await executeWorkflowAsync(workflow);
+
+      expect(workflow.buildSteps[0].getOutputValueByName('version')).toBe('1.0.0');
+      expect(workflow.buildSteps[1].getOutputValueByName('copied')).toBe('1.0.0');
+    });
+
+    it('treats shorthand outputs as required', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: { [SAY_HI]: { outputs: ['version'], command: 'echo hi' } },
+        steps: [{ uses: SAY_HI, id: 'read' }],
+      });
+
+      await expect(executeWorkflowAsync(workflow)).rejects.toThrow(
+        /Some required outputs have not been set: "version"/
+      );
+    });
+
+    it('accepts an output declared as not required', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          [SAY_HI]: { outputs: [{ name: 'version', required: false }], command: 'echo hi' },
+        },
+        steps: [{ uses: SAY_HI, id: 'read' }],
+      });
+
+      await expect(executeWorkflowAsync(workflow)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('supported platforms', () => {
+    it('rejects a function that does not support the runtime platform', async () => {
+      const error = await getErrorAsync<BuildWorkflowError>(() =>
+        parseCompositeFunctions({
+          catalog: { [SAY_HI]: { command: 'echo hi', supported_platforms: ['darwin'] } },
+          steps: [{ uses: SAY_HI, id: 'greet' }],
+        })
+      );
+
+      expect(error).toBeInstanceOf(BuildWorkflowError);
+      assert(error instanceof BuildWorkflowError);
+      expect(error.errors[0].message).toBe(
+        'Step "./.eas/functions/say-hi" is not allowed on platform "linux". Allowed platforms for this step are: "darwin".'
+      );
+    });
+
+    it('accepts a function that supports the runtime platform', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: { [SAY_HI]: { command: 'echo hi', supported_platforms: ['linux'] } },
+        steps: [{ uses: SAY_HI, id: 'greet' }],
+      });
+
+      expect(workflow.buildSteps).toHaveLength(1);
+    });
+  });
+
+  describe('inside a composite function', () => {
+    it('expands a single-step function called from a composite function', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          './.eas/functions/outer': {
+            inputs: [{ name: 'name', type: 'string', default_value: 'World' }],
+            outputs: { greeting: { value: '${{ steps.inner.outputs.greeting }}' } },
+            runs: {
+              steps: [{ id: 'inner', uses: SAY_HI, with: { name: '${{ inputs.name }}' } }],
+            },
+          },
+          [SAY_HI]: {
+            inputs: ['name'],
+            outputs: ['greeting'],
+            command: 'set-output greeting "Hi, ${ inputs.name }!"',
+          },
+        },
+        steps: [{ uses: './.eas/functions/outer', id: 'outer', with: { name: 'Expo' } }],
+      });
+      await executeWorkflowAsync(workflow);
+
+      const [innerStep, outputsStep] = workflow.buildSteps;
+      expect(innerStep.id).toBe('outer__inner');
+      expect(innerStep.getOutputValueByName('greeting')).toBe('Hi, Expo!');
+      expect(outputsStep.id).toBe('outer');
+      expect(outputsStep.getOutputValueByName('greeting')).toBe('Hi, Expo!');
+    });
+
+    it('exposes the outputs of a nested single-step function to its siblings', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          './.eas/functions/outer': {
+            runs: {
+              steps: [
+                { id: 'inner', uses: SAY_HI },
+                {
+                  id: 'copy',
+                  run: 'set-output copied "${{ steps.inner.outputs.version }}"',
+                  outputs: [{ name: 'copied', required: true }],
+                },
+              ],
+            },
+          },
+          [SAY_HI]: { outputs: ['version'], command: 'set-output version "1.0.0"' },
+        },
+        steps: [{ uses: './.eas/functions/outer', id: 'outer' }],
+      });
+      await executeWorkflowAsync(workflow);
+
+      expect(workflow.buildSteps.map(step => step.id)).toEqual(['outer__inner', 'outer__copy']);
+      expect(workflow.buildSteps[1].getOutputValueByName('copied')).toBe('1.0.0');
+    });
+
+    it('forwards working_directory from a nested call to the step', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          './.eas/functions/outer': {
+            runs: {
+              steps: [{ id: 'inner', uses: SAY_HI, working_directory: 'packages/app' }],
+            },
+          },
+          [SAY_HI]: { command: 'echo hi' },
+        },
+        steps: [{ uses: './.eas/functions/outer', id: 'outer' }],
+      });
+
+      expect(workflow.buildSteps[0].id).toBe('outer__inner');
+      expect(workflow.buildSteps[0].ctx.relativeWorkingDirectory).toBe('packages/app');
+    });
+  });
+});

--- a/packages/steps/src/__tests__/StepsConfigParser-legacy-functions-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-legacy-functions-test.ts
@@ -239,6 +239,7 @@ describe('StepsConfigParser local single-step functions', () => {
             inputs: [
               { name: 'count', type: 'number', default_value: '42', required: false },
               { name: 'verbose', type: 'boolean', default_value: 'true', required: false },
+              { name: 'clean', type: 'boolean', default_value: 'True', required: false },
             ],
             command: 'echo hi',
           },
@@ -249,6 +250,7 @@ describe('StepsConfigParser local single-step functions', () => {
       const [step] = workflow.buildSteps;
       expect(step.inputs?.find(input => input.id === 'count')?.rawValue).toBe(42);
       expect(step.inputs?.find(input => input.id === 'verbose')?.rawValue).toBe(true);
+      expect(step.inputs?.find(input => input.id === 'clean')?.rawValue).toBe(true);
     });
 
     it('coerces quoted allowed values and accepts a quoted default among them', async () => {

--- a/packages/steps/src/__tests__/StepsConfigParser-legacy-functions-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-legacy-functions-test.ts
@@ -231,6 +231,96 @@ describe('StepsConfigParser local single-step functions', () => {
         'Input parameter "platform" for step "./.eas/functions/say-hi" is set to "web" which is not one of the allowed values: "ios", "android".'
       );
     });
+
+    it('coerces quoted number and boolean defaults like the custom build schema', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          [SAY_HI]: {
+            inputs: [
+              { name: 'count', type: 'number', default_value: '42', required: false },
+              { name: 'verbose', type: 'boolean', default_value: 'true', required: false },
+            ],
+            command: 'echo hi',
+          },
+        },
+        steps: [{ uses: SAY_HI, id: 'greet' }],
+      });
+
+      const [step] = workflow.buildSteps;
+      expect(step.inputs?.find(input => input.id === 'count')?.rawValue).toBe(42);
+      expect(step.inputs?.find(input => input.id === 'verbose')?.rawValue).toBe(true);
+    });
+
+    it('coerces quoted allowed values and accepts a quoted default among them', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          [SAY_HI]: {
+            inputs: [
+              {
+                name: 'count',
+                type: 'number',
+                default_value: '1',
+                allowed_values: ['1', '2'],
+                required: false,
+              },
+            ],
+            command: 'echo hi',
+          },
+        },
+        steps: [{ uses: SAY_HI, id: 'greet' }],
+      });
+
+      const input = workflow.buildSteps[0].inputs?.find(i => i.id === 'count');
+      expect(input?.rawValue).toBe(1);
+      expect(input?.allowedValues).toEqual([1, 2]);
+    });
+
+    it('accepts a caller json value structurally equal to an allowed value', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          [SAY_HI]: {
+            inputs: [
+              {
+                name: 'payload',
+                type: 'json',
+                allowed_values: [{ a: 1 }, { b: 2 }],
+                required: false,
+              },
+            ],
+            command: 'echo hi',
+          },
+        },
+        steps: [{ uses: SAY_HI, id: 'greet', with: { payload: { a: 1 } } }],
+      });
+
+      expect(workflow.buildSteps[0].inputs?.find(i => i.id === 'payload')?.rawValue).toEqual({
+        a: 1,
+      });
+    });
+
+    it('accepts a json default structurally equal to an allowed value', async () => {
+      const workflow = await parseCompositeFunctions({
+        catalog: {
+          [SAY_HI]: {
+            inputs: [
+              {
+                name: 'payload',
+                type: 'json',
+                default_value: { a: 1 },
+                allowed_values: [{ a: 1 }],
+                required: false,
+              },
+            ],
+            command: 'echo hi',
+          },
+        },
+        steps: [{ uses: SAY_HI, id: 'greet' }],
+      });
+
+      expect(workflow.buildSteps[0].inputs?.find(i => i.id === 'payload')?.rawValue).toEqual({
+        a: 1,
+      });
+    });
   });
 
   describe('outputs', () => {

--- a/packages/steps/src/hooks.ts
+++ b/packages/steps/src/hooks.ts
@@ -13,12 +13,9 @@ import { BuildFunctionGroup, createBuildFunctionGroupByIdMapping } from './Build
 import { BuildStep } from './BuildStep';
 import { BuildStepGlobalContext } from './BuildStepContext';
 import { collectAggregateStepErrors } from './BuildWorkflowValidator';
-import { CompositeFunctionExpander } from './CompositeFunctionExpander';
+import { LocalFunctionExpander } from './LocalFunctionExpander';
 import { BuildConfigError, BuildWorkflowError } from './errors';
-import {
-  isLocalCompositeFunctionPath,
-  parseLocalCompositeFunctionPath,
-} from './utils/localCompositeFunctions';
+import { isLocalFunctionPath, parseLocalFunctionPath } from './utils/localCompositeFunctions';
 import { createBuildStepOutputsFromDefinition, getShellStepDisplayName } from './utils/step';
 
 /**
@@ -73,12 +70,12 @@ export async function constructHookEntriesAsync(
   {
     externalFunctions,
     externalFunctionGroups,
-    compositeFunctionCatalog,
+    localFunctionCatalog,
   }: {
     externalFunctions?: BuildFunction[];
     externalFunctionGroups?: BuildFunctionGroup[];
-    /** When omitted, composite `uses:` fail as missing from an empty catalog. */
-    compositeFunctionCatalog?: LocalFunctionCatalog;
+    /** When omitted, local `uses:` paths fail as missing from an empty catalog. */
+    localFunctionCatalog?: LocalFunctionCatalog;
   }
 ): Promise<HookEntry[]> {
   // An empty array is a valid no-op (e.g. opting out of a default hook);
@@ -98,7 +95,7 @@ export async function constructHookEntriesAsync(
   return constructHookEntriesFromValidatedSteps(
     ctx,
     validatedSteps,
-    new CompositeFunctionExpander(ctx, compositeFunctionCatalog ?? {}, {
+    new LocalFunctionExpander(ctx, localFunctionCatalog ?? {}, {
       buildFunctionById,
       buildFunctionGroupById,
     })
@@ -126,7 +123,7 @@ export async function validateHookStepsAsync(
 export function constructHookEntriesFromValidatedSteps(
   ctx: BuildStepGlobalContext,
   validatedSteps: Step[],
-  compositeFunctionExpander: CompositeFunctionExpander
+  localFunctionExpander: LocalFunctionExpander
 ): HookEntry[] {
   const entries: HookEntry[] = [];
   for (const step of validatedSteps) {
@@ -136,19 +133,19 @@ export function constructHookEntriesFromValidatedSteps(
       });
       continue;
     }
-    if (isLocalCompositeFunctionPath(step.uses)) {
+    if (isLocalFunctionPath(step.uses)) {
       entries.push({
-        steps: compositeFunctionExpander
-          .expandCompositeFunctionStep(
+        steps: localFunctionExpander
+          .expandLocalFunctionStep(
             step,
-            parseLocalCompositeFunctionPath(step.uses),
+            parseLocalFunctionPath(step.uses),
             BuildStep.getNewId(step.id)
           )
           .getFlattenedSteps(),
       });
       continue;
     }
-    const maybeFunctionGroup = compositeFunctionExpander.buildFunctionGroupById[step.uses];
+    const maybeFunctionGroup = localFunctionExpander.buildFunctionGroupById[step.uses];
     if (maybeFunctionGroup !== undefined) {
       entries.push({
         steps: maybeFunctionGroup.createBuildStepsFromFunctionGroupCall(ctx, {
@@ -158,7 +155,7 @@ export function constructHookEntriesFromValidatedSteps(
       });
       continue;
     }
-    const buildFunction = compositeFunctionExpander.buildFunctionById[step.uses];
+    const buildFunction = localFunctionExpander.buildFunctionById[step.uses];
     assert(buildFunction, 'function ID must be ID of function or function group');
     entries.push({
       steps: [
@@ -211,7 +208,7 @@ export function validateAllStepFunctionsExist(
 ): void {
   const calledFunctionsOrFunctionGroupsSet = new Set<string>();
   for (const step of steps) {
-    if (step.uses && !isLocalCompositeFunctionPath(step.uses)) {
+    if (step.uses && !isLocalFunctionPath(step.uses)) {
       calledFunctionsOrFunctionGroupsSet.add(step.uses);
     }
   }

--- a/packages/steps/src/hooks.ts
+++ b/packages/steps/src/hooks.ts
@@ -135,13 +135,11 @@ export function constructHookEntriesFromValidatedSteps(
     }
     if (isLocalFunctionPath(step.uses)) {
       entries.push({
-        steps: localFunctionExpander
-          .expandLocalFunctionStep(
-            step,
-            parseLocalFunctionPath(step.uses),
-            BuildStep.getNewId(step.id)
-          )
-          .getFlattenedSteps(),
+        steps: localFunctionExpander.expandLocalFunctionStep(
+          step,
+          parseLocalFunctionPath(step.uses),
+          BuildStep.getNewId(step.id)
+        ),
       });
       continue;
     }

--- a/packages/steps/src/hooks.ts
+++ b/packages/steps/src/hooks.ts
@@ -71,11 +71,14 @@ export async function constructHookEntriesAsync(
     externalFunctions,
     externalFunctionGroups,
     localFunctionCatalog,
+    compositeFunctionCatalog,
   }: {
     externalFunctions?: BuildFunction[];
     externalFunctionGroups?: BuildFunctionGroup[];
     /** When omitted, local `uses:` paths fail as missing from an empty catalog. */
     localFunctionCatalog?: LocalFunctionCatalog;
+    /** @deprecated Use `localFunctionCatalog`. */
+    compositeFunctionCatalog?: LocalFunctionCatalog;
   }
 ): Promise<HookEntry[]> {
   // An empty array is a valid no-op (e.g. opting out of a default hook);
@@ -95,7 +98,7 @@ export async function constructHookEntriesAsync(
   return constructHookEntriesFromValidatedSteps(
     ctx,
     validatedSteps,
-    new LocalFunctionExpander(ctx, localFunctionCatalog ?? {}, {
+    new LocalFunctionExpander(ctx, localFunctionCatalog ?? compositeFunctionCatalog ?? {}, {
       buildFunctionById,
       buildFunctionGroupById,
     })

--- a/packages/steps/src/hooks.ts
+++ b/packages/steps/src/hooks.ts
@@ -15,7 +15,7 @@ import { BuildStepGlobalContext } from './BuildStepContext';
 import { collectAggregateStepErrors } from './BuildWorkflowValidator';
 import { LocalFunctionExpander } from './LocalFunctionExpander';
 import { BuildConfigError, BuildWorkflowError } from './errors';
-import { isLocalFunctionPath, parseLocalFunctionPath } from './utils/localCompositeFunctions';
+import { isLocalFunctionPath, parseLocalFunctionPath } from './utils/localFunctions';
 import { createBuildStepOutputsFromDefinition, getShellStepDisplayName } from './utils/step';
 
 /**

--- a/packages/steps/src/index.ts
+++ b/packages/steps/src/index.ts
@@ -17,5 +17,5 @@ export * from './interpolation';
 export * from './utils/shell/spawn';
 export * from './utils/jsepEval';
 export * from './utils/hashFiles';
-export * from './utils/localCompositeFunctions';
+export * from './utils/localFunctions';
 export { StepMetric, StepMetricResult, WorkflowHookMetric } from './StepMetrics';

--- a/packages/steps/src/utils/__tests__/localCompositeFunctions-test.ts
+++ b/packages/steps/src/utils/__tests__/localCompositeFunctions-test.ts
@@ -4,14 +4,14 @@ import os from 'os';
 import path from 'path';
 
 import {
-  buildCompositeFunctionCatalogFromStepsAsync,
-  buildLocalCompositeFunctionCatalogAsync,
-  createLocalCompositeFunctionLoader,
-  extendCompositeFunctionCatalogFromStepsAsync,
-  isLocalCompositeFunctionPath,
-  loadLocalCompositeFunctionConfigAsync,
-  parseLocalCompositeFunctionPath,
-  resolveLocalCompositeFunctionPath,
+  buildLocalFunctionCatalogAsync,
+  buildLocalFunctionCatalogFromStepsAsync,
+  createLocalFunctionLoader,
+  extendLocalFunctionCatalogFromStepsAsync,
+  isLocalFunctionPath,
+  loadLocalFunctionConfigAsync,
+  parseLocalFunctionPath,
+  resolveLocalFunctionPath,
 } from '../localCompositeFunctions';
 
 async function makeCompositeFunctionAsync(
@@ -25,88 +25,80 @@ async function makeCompositeFunctionAsync(
   await fs.writeFile(path.join(functionDir, fileName), contents, 'utf-8');
 }
 
-describe(isLocalCompositeFunctionPath, () => {
+describe(isLocalFunctionPath, () => {
   it('recognizes relative paths as local composite function paths', () => {
-    expect(isLocalCompositeFunctionPath('./.eas/functions/setup')).toBe(true);
-    expect(isLocalCompositeFunctionPath('../../shared/actions/setup')).toBe(true);
-    expect(isLocalCompositeFunctionPath('  ./.eas/functions/setup/  ')).toBe(true);
+    expect(isLocalFunctionPath('./.eas/functions/setup')).toBe(true);
+    expect(isLocalFunctionPath('../../shared/actions/setup')).toBe(true);
+    expect(isLocalFunctionPath('  ./.eas/functions/setup/  ')).toBe(true);
   });
 
   it('rejects function ids and absolute or backslash-prefixed paths', () => {
-    expect(isLocalCompositeFunctionPath('eas/build')).toBe(false);
-    expect(isLocalCompositeFunctionPath('/actions/setup')).toBe(false);
-    expect(isLocalCompositeFunctionPath('..\\actions\\setup')).toBe(false);
+    expect(isLocalFunctionPath('eas/build')).toBe(false);
+    expect(isLocalFunctionPath('/actions/setup')).toBe(false);
+    expect(isLocalFunctionPath('..\\actions\\setup')).toBe(false);
   });
 });
 
-describe(parseLocalCompositeFunctionPath, () => {
+describe(parseLocalFunctionPath, () => {
   it('parses local composite function paths', () => {
-    expect(parseLocalCompositeFunctionPath('./.eas/functions/setup')).toBe(
-      './.eas/functions/setup'
-    );
-    expect(parseLocalCompositeFunctionPath('../../shared/actions/setup')).toBe(
-      '../../shared/actions/setup'
-    );
+    expect(parseLocalFunctionPath('./.eas/functions/setup')).toBe('./.eas/functions/setup');
+    expect(parseLocalFunctionPath('../../shared/actions/setup')).toBe('../../shared/actions/setup');
   });
 
   it('normalizes local composite function paths', () => {
-    expect(parseLocalCompositeFunctionPath('  ./.eas/functions/setup/  ')).toBe(
-      './.eas/functions/setup'
-    );
+    expect(parseLocalFunctionPath('  ./.eas/functions/setup/  ')).toBe('./.eas/functions/setup');
   });
 
   it('collapses equivalent paths to the same canonical path', () => {
-    expect(parseLocalCompositeFunctionPath('././.eas/functions/setup')).toBe(
+    expect(parseLocalFunctionPath('././.eas/functions/setup')).toBe('./.eas/functions/setup');
+    expect(parseLocalFunctionPath('./.eas/functions/other/../setup')).toBe(
       './.eas/functions/setup'
     );
-    expect(parseLocalCompositeFunctionPath('./.eas/functions/other/../setup')).toBe(
-      './.eas/functions/setup'
-    );
-    expect(parseLocalCompositeFunctionPath('../shared/other/../functions/setup')).toBe(
+    expect(parseLocalFunctionPath('../shared/other/../functions/setup')).toBe(
       '../shared/functions/setup'
     );
   });
 
   it('keeps the "./" prefix for under-root directories whose name starts with ".."', () => {
-    expect(parseLocalCompositeFunctionPath('./..actions/setup')).toBe('./..actions/setup');
+    expect(parseLocalFunctionPath('./..actions/setup')).toBe('./..actions/setup');
   });
 
   it('canonicalizes paths pointing at the project root or its parent', () => {
-    expect(parseLocalCompositeFunctionPath('./')).toBe('./.');
-    expect(parseLocalCompositeFunctionPath('  ./  ')).toBe('./.');
-    expect(parseLocalCompositeFunctionPath('../')).toBe('..');
-    expect(parseLocalCompositeFunctionPath('./..')).toBe('..');
+    expect(parseLocalFunctionPath('./')).toBe('./.');
+    expect(parseLocalFunctionPath('  ./  ')).toBe('./.');
+    expect(parseLocalFunctionPath('../')).toBe('..');
+    expect(parseLocalFunctionPath('./..')).toBe('..');
   });
 
   it('is stable when re-parsing its own canonical output', () => {
-    expect(parseLocalCompositeFunctionPath('./.')).toBe('./.');
-    expect(parseLocalCompositeFunctionPath('../.')).toBe('..');
+    expect(parseLocalFunctionPath('./.')).toBe('./.');
+    expect(parseLocalFunctionPath('../.')).toBe('..');
   });
 
   it('throws for backslash-based paths', () => {
-    expect(() => parseLocalCompositeFunctionPath('./compositeFunctions\\setup')).toThrow(
+    expect(() => parseLocalFunctionPath('./compositeFunctions\\setup')).toThrow(
       /must not contain backslashes/
     );
   });
 
   it('throws for interpolated local composite function paths', () => {
-    expect(() => parseLocalCompositeFunctionPath('./.eas/functions/${{ inputs.name }}')).toThrow(
+    expect(() => parseLocalFunctionPath('./.eas/functions/${{ inputs.name }}')).toThrow(
       /must not contain interpolation/
     );
   });
 
   it('parses local composite function paths that contain }}${{ as literal characters', () => {
-    expect(parseLocalCompositeFunctionPath('./.eas/functions/weird}}${{name')).toBe(
+    expect(parseLocalFunctionPath('./.eas/functions/weird}}${{name')).toBe(
       './.eas/functions/weird}}${{name'
     );
   });
 });
 
-describe(buildCompositeFunctionCatalogFromStepsAsync, () => {
+describe(buildLocalFunctionCatalogFromStepsAsync, () => {
   it('loads referenced composite functions transitively', async () => {
-    const catalog = await buildCompositeFunctionCatalogFromStepsAsync({
+    const catalog = await buildLocalFunctionCatalogFromStepsAsync({
       rootSteps: [{ uses: './.eas/functions/outer', id: 'outer' }],
-      loadCompositeFunction: async compositeFunctionPath => {
+      loadLocalFunction: async compositeFunctionPath => {
         if (compositeFunctionPath === './.eas/functions/outer') {
           return CompositeFunctionConfigZ.parse({
             runs: { steps: [{ uses: './.eas/functions/inner' }] },
@@ -128,9 +120,9 @@ describe(buildCompositeFunctionCatalogFromStepsAsync, () => {
   });
 
   it('loads each action once even when references are cyclic (cycles are reported at expansion time)', async () => {
-    const catalog = await buildCompositeFunctionCatalogFromStepsAsync({
+    const catalog = await buildLocalFunctionCatalogFromStepsAsync({
       rootSteps: [{ uses: './.eas/functions/a', id: 'a' }],
-      loadCompositeFunction: async compositeFunctionPath => {
+      loadLocalFunction: async compositeFunctionPath => {
         if (compositeFunctionPath === './.eas/functions/a') {
           return CompositeFunctionConfigZ.parse({
             runs: { steps: [{ uses: './.eas/functions/b' }] },
@@ -152,9 +144,9 @@ describe(buildCompositeFunctionCatalogFromStepsAsync, () => {
     const chainLength = 10;
     const paths = Array.from({ length: chainLength }, (_, index) => `./.eas/functions/a${index}`);
 
-    const catalog = await buildCompositeFunctionCatalogFromStepsAsync({
+    const catalog = await buildLocalFunctionCatalogFromStepsAsync({
       rootSteps: [{ uses: paths[0], id: 'root' }],
-      loadCompositeFunction: async compositeFunctionPath => {
+      loadLocalFunction: async compositeFunctionPath => {
         const index = paths.indexOf(compositeFunctionPath);
         if (index === -1) {
           throw new Error(`missing ${compositeFunctionPath}`);
@@ -173,9 +165,9 @@ describe(buildCompositeFunctionCatalogFromStepsAsync, () => {
 
   it('collects normalized action paths from steps', async () => {
     const loadedPaths: string[] = [];
-    await buildCompositeFunctionCatalogFromStepsAsync({
+    await buildLocalFunctionCatalogFromStepsAsync({
       rootSteps: [{ uses: './.eas/functions/setup/' }, { uses: 'eas/build' }, { run: 'echo hi' }],
-      loadCompositeFunction: async compositeFunctionPath => {
+      loadLocalFunction: async compositeFunctionPath => {
         loadedPaths.push(compositeFunctionPath);
         return CompositeFunctionConfigZ.parse({ runs: { steps: [{ run: 'echo setup' }] } });
       },
@@ -185,9 +177,9 @@ describe(buildCompositeFunctionCatalogFromStepsAsync, () => {
 
   it('rejects interpolated local composite function paths', async () => {
     await expect(
-      buildCompositeFunctionCatalogFromStepsAsync({
+      buildLocalFunctionCatalogFromStepsAsync({
         rootSteps: [{ uses: './.eas/functions/${{ inputs.name }}' }],
-        loadCompositeFunction: async () =>
+        loadLocalFunction: async () =>
           CompositeFunctionConfigZ.parse({ runs: { steps: [{ run: 'echo setup' }] } }),
       })
     ).rejects.toThrow(/must not contain interpolation/);
@@ -195,9 +187,9 @@ describe(buildCompositeFunctionCatalogFromStepsAsync, () => {
 
   it('rejects working_directory on a root step that calls a local composite function', async () => {
     await expect(
-      buildCompositeFunctionCatalogFromStepsAsync({
+      buildLocalFunctionCatalogFromStepsAsync({
         rootSteps: [{ uses: './.eas/functions/setup', working_directory: 'packages/app' }],
-        loadCompositeFunction: async () =>
+        loadLocalFunction: async () =>
           CompositeFunctionConfigZ.parse({ runs: { steps: [{ run: 'echo setup' }] } }),
       })
     ).rejects.toThrow(/"working_directory" is not supported on a step that calls/);
@@ -205,9 +197,9 @@ describe(buildCompositeFunctionCatalogFromStepsAsync, () => {
 
   it('rejects working_directory on a nested step that calls a local composite function', async () => {
     await expect(
-      buildCompositeFunctionCatalogFromStepsAsync({
+      buildLocalFunctionCatalogFromStepsAsync({
         rootSteps: [{ uses: './.eas/functions/outer' }],
-        loadCompositeFunction: async compositeFunctionPath => {
+        loadLocalFunction: async compositeFunctionPath => {
           if (compositeFunctionPath === './.eas/functions/outer') {
             return CompositeFunctionConfigZ.parse({
               runs: {
@@ -222,26 +214,26 @@ describe(buildCompositeFunctionCatalogFromStepsAsync, () => {
   });
 
   it('allows working_directory on a step that calls a function, not a local composite function', async () => {
-    const catalog = await buildCompositeFunctionCatalogFromStepsAsync({
+    const catalog = await buildLocalFunctionCatalogFromStepsAsync({
       rootSteps: [{ uses: 'eas/build', working_directory: 'packages/app' }],
-      loadCompositeFunction: async () =>
+      loadLocalFunction: async () =>
         CompositeFunctionConfigZ.parse({ runs: { steps: [{ run: 'echo setup' }] } }),
     });
     expect(Object.keys(catalog)).toEqual([]);
   });
 });
 
-describe(extendCompositeFunctionCatalogFromStepsAsync, () => {
+describe(extendLocalFunctionCatalogFromStepsAsync, () => {
   it('extends the given catalog in place', async () => {
     const catalog = {
       './.eas/functions/existing': CompositeFunctionConfigZ.parse({
         runs: { steps: [{ run: 'echo existing' }] },
       }),
     };
-    await extendCompositeFunctionCatalogFromStepsAsync({
+    await extendLocalFunctionCatalogFromStepsAsync({
       catalog,
       rootSteps: [{ uses: './.eas/functions/setup' }],
-      loadCompositeFunction: async () =>
+      loadLocalFunction: async () =>
         CompositeFunctionConfigZ.parse({ runs: { steps: [{ run: 'echo setup' }] } }),
     });
     expect(Object.keys(catalog).sort()).toEqual([
@@ -257,10 +249,10 @@ describe(extendCompositeFunctionCatalogFromStepsAsync, () => {
         runs: { steps: [{ run: 'echo setup' }] },
       }),
     };
-    await extendCompositeFunctionCatalogFromStepsAsync({
+    await extendLocalFunctionCatalogFromStepsAsync({
       catalog,
       rootSteps: [{ uses: './.eas/functions/setup' }],
-      loadCompositeFunction: async compositeFunctionPath => {
+      loadLocalFunction: async compositeFunctionPath => {
         loadedPaths.push(compositeFunctionPath);
         throw new Error(`must not be called: ${compositeFunctionPath}`);
       },
@@ -271,10 +263,10 @@ describe(extendCompositeFunctionCatalogFromStepsAsync, () => {
 
   it('recurses into nested references', async () => {
     const catalog = {};
-    await extendCompositeFunctionCatalogFromStepsAsync({
+    await extendLocalFunctionCatalogFromStepsAsync({
       catalog,
       rootSteps: [{ uses: './.eas/functions/outer' }],
-      loadCompositeFunction: async compositeFunctionPath => {
+      loadLocalFunction: async compositeFunctionPath => {
         if (compositeFunctionPath === './.eas/functions/outer') {
           return CompositeFunctionConfigZ.parse({
             runs: { steps: [{ uses: './.eas/functions/inner' }] },
@@ -290,29 +282,29 @@ describe(extendCompositeFunctionCatalogFromStepsAsync, () => {
   });
 });
 
-describe(resolveLocalCompositeFunctionPath, () => {
+describe(resolveLocalFunctionPath, () => {
   const projectRoot = path.resolve('/tmp/project');
 
   it('resolves a path under the conventional .eas/functions directory', () => {
-    expect(resolveLocalCompositeFunctionPath(projectRoot, './.eas/functions/setup')).toBe(
+    expect(resolveLocalFunctionPath(projectRoot, './.eas/functions/setup')).toBe(
       path.join(projectRoot, '.eas', 'functions', 'setup')
     );
   });
 
   it('resolves an arbitrary arbitrary path style path within the project', () => {
-    expect(resolveLocalCompositeFunctionPath(projectRoot, './internal-actions/deploy')).toBe(
+    expect(resolveLocalFunctionPath(projectRoot, './internal-actions/deploy')).toBe(
       path.join(projectRoot, 'internal-actions', 'deploy')
     );
   });
 
   it('resolves a composite function above the EAS project root', () => {
-    expect(resolveLocalCompositeFunctionPath(projectRoot, '../shared-actions/deploy')).toBe(
+    expect(resolveLocalFunctionPath(projectRoot, '../shared-actions/deploy')).toBe(
       path.resolve(projectRoot, '../shared-actions/deploy')
     );
   });
 });
 
-describe(loadLocalCompositeFunctionConfigAsync, () => {
+describe(loadLocalFunctionConfigAsync, () => {
   it('loads and validates a function.yml file', async () => {
     const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-test-'));
     await makeCompositeFunctionAsync(
@@ -321,10 +313,7 @@ describe(loadLocalCompositeFunctionConfigAsync, () => {
       ['name: Setup', 'runs:', '  steps:', '    - run: echo setup'].join('\n')
     );
 
-    const config = await loadLocalCompositeFunctionConfigAsync(
-      projectRoot,
-      './.eas/functions/setup'
-    );
+    const config = await loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/setup');
 
     expect(config.name).toBe('Setup');
     expect(config.runs.steps).toHaveLength(1);
@@ -339,10 +328,7 @@ describe(loadLocalCompositeFunctionConfigAsync, () => {
       { fileName: 'function.yaml' }
     );
 
-    const config = await loadLocalCompositeFunctionConfigAsync(
-      projectRoot,
-      './.eas/functions/setup'
-    );
+    const config = await loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/setup');
 
     expect(config.runs.steps).toHaveLength(1);
   });
@@ -361,10 +347,7 @@ describe(loadLocalCompositeFunctionConfigAsync, () => {
       { fileName: 'function.yaml' }
     );
 
-    const config = await loadLocalCompositeFunctionConfigAsync(
-      projectRoot,
-      './.eas/functions/setup'
-    );
+    const config = await loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/setup');
 
     expect(config.name).toBe('FromYml');
   });
@@ -373,7 +356,7 @@ describe(loadLocalCompositeFunctionConfigAsync, () => {
     const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-test-'));
 
     await expect(
-      loadLocalCompositeFunctionConfigAsync(projectRoot, './.eas/functions/missing')
+      loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/missing')
     ).rejects.toThrow(
       /Local composite function "\.\/\.eas\/functions\/missing" was referenced by a step but no such composite function exists/
     );
@@ -383,12 +366,12 @@ describe(loadLocalCompositeFunctionConfigAsync, () => {
     const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-test-'));
     await makeCompositeFunctionAsync(projectRoot, 'broken', 'runs: [unclosed');
 
-    const error: Error = await loadLocalCompositeFunctionConfigAsync(
+    const error: Error = await loadLocalFunctionConfigAsync(
       projectRoot,
       './.eas/functions/broken'
     ).then(
       () => {
-        throw new Error('expected loadLocalCompositeFunctionConfigAsync to throw');
+        throw new Error('expected loadLocalFunctionConfigAsync to throw');
       },
       err => err
     );
@@ -408,7 +391,7 @@ describe(loadLocalCompositeFunctionConfigAsync, () => {
     );
 
     await expect(
-      loadLocalCompositeFunctionConfigAsync(projectRoot, './.eas/functions/broken')
+      loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/broken')
     ).rejects.toThrow(
       /Invalid composite function "\.\/\.eas\/functions\/broken": .*must declare at least one step under "runs\.steps"/s
     );
@@ -421,12 +404,12 @@ describe(loadLocalCompositeFunctionConfigAsync, () => {
       recursive: true,
     });
 
-    const error: Error = await loadLocalCompositeFunctionConfigAsync(
+    const error: Error = await loadLocalFunctionConfigAsync(
       projectRoot,
       './.eas/functions/setup'
     ).then(
       () => {
-        throw new Error('expected loadLocalCompositeFunctionConfigAsync to throw');
+        throw new Error('expected loadLocalFunctionConfigAsync to throw');
       },
       err => err
     );
@@ -453,11 +436,8 @@ describe(loadLocalCompositeFunctionConfigAsync, () => {
       'utf-8'
     );
 
-    const underRoot = await loadLocalCompositeFunctionConfigAsync(
-      projectRoot,
-      './.eas/functions/setup'
-    );
-    const aboveRoot = await loadLocalCompositeFunctionConfigAsync(
+    const underRoot = await loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/setup');
+    const aboveRoot = await loadLocalFunctionConfigAsync(
       projectRoot,
       '../../shared/functions/deploy'
     );
@@ -475,7 +455,7 @@ describe(loadLocalCompositeFunctionConfigAsync, () => {
     );
     const logger = { debug: jest.fn() };
 
-    await loadLocalCompositeFunctionConfigAsync(projectRoot, './.eas/functions/setup', { logger });
+    await loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/setup', { logger });
 
     expect(logger.debug).toHaveBeenCalledWith(
       `Loaded local composite function "./.eas/functions/setup" from ${path.join(
@@ -488,7 +468,7 @@ describe(loadLocalCompositeFunctionConfigAsync, () => {
   });
 });
 
-describe(createLocalCompositeFunctionLoader, () => {
+describe(createLocalFunctionLoader, () => {
   it('loads function.yml from disk for a normalized path', async () => {
     const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-loader-'));
     await makeCompositeFunctionAsync(
@@ -497,7 +477,7 @@ describe(createLocalCompositeFunctionLoader, () => {
       ['name: Setup', 'runs:', '  steps:', '    - run: echo setup'].join('\n')
     );
 
-    const loader = createLocalCompositeFunctionLoader(projectRoot);
+    const loader = createLocalFunctionLoader(projectRoot);
     const config = await loader('./.eas/functions/setup');
 
     expect(config.name).toBe('Setup');
@@ -507,7 +487,7 @@ describe(createLocalCompositeFunctionLoader, () => {
   it('rejects for a path with no composite function on disk', async () => {
     const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-loader-'));
 
-    const loader = createLocalCompositeFunctionLoader(projectRoot);
+    const loader = createLocalFunctionLoader(projectRoot);
 
     await expect(loader('./.eas/functions/missing')).rejects.toThrow(
       /no such composite function exists/
@@ -515,7 +495,7 @@ describe(createLocalCompositeFunctionLoader, () => {
   });
 });
 
-describe(buildLocalCompositeFunctionCatalogAsync, () => {
+describe(buildLocalFunctionCatalogAsync, () => {
   it('builds a catalog keyed by normalized ref, loading transitively nested functions from disk', async () => {
     const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-catalog-'));
     await makeCompositeFunctionAsync(
@@ -529,7 +509,7 @@ describe(buildLocalCompositeFunctionCatalogAsync, () => {
       ['runs:', '  steps:', '    - run: echo inner'].join('\n')
     );
 
-    const catalog = await buildLocalCompositeFunctionCatalogAsync(projectRoot, {
+    const catalog = await buildLocalFunctionCatalogAsync(projectRoot, {
       rootSteps: [{ uses: './.eas/functions/outer/', id: 'outer' }],
     });
 
@@ -549,7 +529,7 @@ describe(buildLocalCompositeFunctionCatalogAsync, () => {
       'utf-8'
     );
 
-    const catalog = await buildLocalCompositeFunctionCatalogAsync(projectRoot, {
+    const catalog = await buildLocalFunctionCatalogAsync(projectRoot, {
       rootSteps: [{ uses: './internal-functions/deploy' }],
     });
 
@@ -564,7 +544,7 @@ describe(buildLocalCompositeFunctionCatalogAsync, () => {
       ['runs:', '  steps:', '    - uses: ./.eas/functions/loop'].join('\n')
     );
 
-    const catalog = await buildLocalCompositeFunctionCatalogAsync(projectRoot, {
+    const catalog = await buildLocalFunctionCatalogAsync(projectRoot, {
       rootSteps: [{ uses: './.eas/functions/loop' }],
     });
 
@@ -589,7 +569,7 @@ describe(buildLocalCompositeFunctionCatalogAsync, () => {
       ['runs:', '  steps:', '    - uses: ./.eas/functions/shared'].join('\n')
     );
 
-    const catalog = await buildLocalCompositeFunctionCatalogAsync(projectRoot, {
+    const catalog = await buildLocalFunctionCatalogAsync(projectRoot, {
       rootSteps: [{ uses: './.eas/functions/left' }, { uses: './.eas/functions/right' }],
     });
 
@@ -608,7 +588,7 @@ describe(buildLocalCompositeFunctionCatalogAsync, () => {
       ['name: Broken', 'runs:', '  steps: []'].join('\n')
     );
 
-    const catalog = await buildLocalCompositeFunctionCatalogAsync(projectRoot, {
+    const catalog = await buildLocalFunctionCatalogAsync(projectRoot, {
       rootSteps: [{ run: 'echo hi' }],
     });
 

--- a/packages/steps/src/utils/__tests__/localCompositeFunctions-test.ts
+++ b/packages/steps/src/utils/__tests__/localCompositeFunctions-test.ts
@@ -1,4 +1,4 @@
-import { CompositeFunctionConfigZ } from '@expo/eas-build-job';
+import { CompositeFunctionConfigZ, LocalFunctionConfigZ } from '@expo/eas-build-job';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -11,6 +11,7 @@ import {
   isLocalFunctionPath,
   loadLocalFunctionConfigAsync,
   parseLocalFunctionPath,
+  resolveLegacyFunctionModulePath,
   resolveLocalFunctionPath,
 } from '../localCompositeFunctions';
 
@@ -161,6 +162,39 @@ describe(buildLocalFunctionCatalogFromStepsAsync, () => {
     });
 
     expect(Object.keys(catalog).sort()).toEqual(paths.sort());
+  });
+
+  it('loads a single-step function without recursing into it', async () => {
+    const loadedPaths: string[] = [];
+    const catalog = await buildLocalFunctionCatalogFromStepsAsync({
+      rootSteps: [{ uses: './.eas/functions/say-hi' }],
+      loadLocalFunction: async compositeFunctionPath => {
+        loadedPaths.push(compositeFunctionPath);
+        return LocalFunctionConfigZ.parse({ command: 'echo hi' });
+      },
+    });
+
+    expect(loadedPaths).toEqual(['./.eas/functions/say-hi']);
+    expect(Object.keys(catalog)).toEqual(['./.eas/functions/say-hi']);
+  });
+
+  it('loads a single-step function referenced from inside a composite function', async () => {
+    const catalog = await buildLocalFunctionCatalogFromStepsAsync({
+      rootSteps: [{ uses: './.eas/functions/outer' }],
+      loadLocalFunction: async compositeFunctionPath => {
+        if (compositeFunctionPath === './.eas/functions/outer') {
+          return LocalFunctionConfigZ.parse({
+            runs: { steps: [{ uses: './.eas/functions/say-hi' }] },
+          });
+        }
+        return LocalFunctionConfigZ.parse({ command: 'echo hi' });
+      },
+    });
+
+    expect(Object.keys(catalog).sort()).toEqual([
+      './.eas/functions/outer',
+      './.eas/functions/say-hi',
+    ]);
   });
 
   it('collects normalized action paths from steps', async () => {
@@ -593,5 +627,40 @@ describe(buildLocalFunctionCatalogAsync, () => {
     });
 
     expect(catalog).toEqual({});
+  });
+});
+
+describe(resolveLegacyFunctionModulePath, () => {
+  const projectRoot = path.resolve('/tmp/project');
+
+  it('resolves a relative module path against the function directory', () => {
+    expect(
+      resolveLegacyFunctionModulePath({
+        projectRoot,
+        functionPath: './.eas/functions/say-hi',
+        modulePath: './my-function',
+      })
+    ).toBe(path.join(projectRoot, '.eas', 'functions', 'say-hi', 'my-function'));
+  });
+
+  it('resolves a module path pointing outside the function directory', () => {
+    expect(
+      resolveLegacyFunctionModulePath({
+        projectRoot,
+        functionPath: './.eas/functions/say-hi',
+        modulePath: '../shared/my-function',
+      })
+    ).toBe(path.join(projectRoot, '.eas', 'functions', 'shared', 'my-function'));
+  });
+
+  it('passes an absolute module path through', () => {
+    const absolutePath = path.resolve('/opt/functions/say-hi');
+    expect(
+      resolveLegacyFunctionModulePath({
+        projectRoot,
+        functionPath: './.eas/functions/say-hi',
+        modulePath: absolutePath,
+      })
+    ).toBe(absolutePath);
   });
 });

--- a/packages/steps/src/utils/__tests__/localFunctions-test.ts
+++ b/packages/steps/src/utils/__tests__/localFunctions-test.ts
@@ -9,13 +9,23 @@ import os from 'os';
 import path from 'path';
 
 import {
+  buildCompositeFunctionCatalogFromStepsAsync,
+  buildLocalCompositeFunctionCatalogAsync,
   buildLocalFunctionCatalogAsync,
   buildLocalFunctionCatalogFromStepsAsync,
+  createLocalCompositeFunctionLoader,
   createLocalFunctionLoader,
+  extendCompositeFunctionCatalogFromStepsAsync,
   extendLocalFunctionCatalogFromStepsAsync,
+  getLocalCompositeFunctionCallWorkingDirectoryError,
+  getLocalFunctionCallWorkingDirectoryError,
+  isLocalCompositeFunctionPath,
   isLocalFunctionPath,
+  loadLocalCompositeFunctionConfigAsync,
   loadLocalFunctionConfigAsync,
+  parseLocalCompositeFunctionPath,
   parseLocalFunctionPath,
+  resolveLocalCompositeFunctionPath,
   resolveLocalFunctionPath,
 } from '../localFunctions';
 
@@ -759,5 +769,114 @@ describe(buildLocalFunctionCatalogAsync, () => {
         rootSteps: [{ uses: './.eas/functions/say-hi', id: 'greet' }],
       })
     ).rejects.toThrow(/does not contain a package.json file/);
+  });
+});
+
+describe('deprecated local composite function aliases', () => {
+  it('keeps the pre-rename names as aliases of the renamed functions', () => {
+    expect(parseLocalCompositeFunctionPath).toBe(parseLocalFunctionPath);
+    expect(isLocalCompositeFunctionPath).toBe(isLocalFunctionPath);
+    expect(getLocalCompositeFunctionCallWorkingDirectoryError).toBe(
+      getLocalFunctionCallWorkingDirectoryError
+    );
+    expect(resolveLocalCompositeFunctionPath).toBe(resolveLocalFunctionPath);
+  });
+
+  it('loadLocalCompositeFunctionConfigAsync loads a composite function', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-deprecated-'));
+    await makeCompositeFunctionAsync(
+      projectRoot,
+      'setup',
+      ['name: Setup', 'runs:', '  steps:', '    - run: echo setup'].join('\n')
+    );
+
+    const config = await loadLocalCompositeFunctionConfigAsync(
+      projectRoot,
+      './.eas/functions/setup'
+    );
+
+    expect(config.name).toBe('Setup');
+    expect(config.runs.steps).toHaveLength(1);
+  });
+
+  it('loadLocalCompositeFunctionConfigAsync rejects a legacy command function', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-deprecated-'));
+    await makeCompositeFunctionAsync(projectRoot, 'say-hi', 'command: echo hi');
+
+    await expect(
+      loadLocalCompositeFunctionConfigAsync(projectRoot, './.eas/functions/say-hi')
+    ).rejects.toThrow(/declares "command" or "path"/);
+  });
+
+  it('buildLocalCompositeFunctionCatalogAsync builds a composite-only catalog', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-deprecated-'));
+    await makeCompositeFunctionAsync(
+      projectRoot,
+      'setup',
+      ['runs:', '  steps:', '    - run: echo setup'].join('\n')
+    );
+
+    const catalog = await buildLocalCompositeFunctionCatalogAsync(projectRoot, {
+      rootSteps: [{ uses: './.eas/functions/setup' }],
+    });
+
+    expect(catalog['./.eas/functions/setup'].runs.steps).toHaveLength(1);
+  });
+
+  it('buildLocalCompositeFunctionCatalogAsync rejects a referenced legacy function', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-deprecated-'));
+    await makeCompositeFunctionAsync(projectRoot, 'say-hi', 'command: echo hi');
+
+    await expect(
+      buildLocalCompositeFunctionCatalogAsync(projectRoot, {
+        rootSteps: [{ uses: './.eas/functions/say-hi' }],
+      })
+    ).rejects.toThrow(/declares "command" or "path"/);
+  });
+
+  it('createLocalCompositeFunctionLoader loads composite and rejects legacy functions', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-deprecated-'));
+    await makeCompositeFunctionAsync(
+      projectRoot,
+      'setup',
+      ['runs:', '  steps:', '    - run: echo setup'].join('\n')
+    );
+    await makeCompositeFunctionAsync(projectRoot, 'say-hi', 'command: echo hi');
+
+    const loader = createLocalCompositeFunctionLoader(projectRoot);
+
+    const config = await loader('./.eas/functions/setup');
+    expect(config.runs.steps).toHaveLength(1);
+    await expect(loader('./.eas/functions/say-hi')).rejects.toThrow(/declares "command" or "path"/);
+  });
+
+  it('buildCompositeFunctionCatalogFromStepsAsync accepts the loadCompositeFunction key', async () => {
+    const catalog = await buildCompositeFunctionCatalogFromStepsAsync({
+      rootSteps: [{ uses: './.eas/functions/setup' }],
+      loadCompositeFunction: async () =>
+        CompositeFunctionConfigZ.parse({ runs: { steps: [{ run: 'echo setup' }] } }),
+    });
+
+    expect(catalog['./.eas/functions/setup'].runs.steps).toHaveLength(1);
+  });
+
+  it('extendCompositeFunctionCatalogFromStepsAsync accepts the loadCompositeFunction key', async () => {
+    const catalog = {
+      './.eas/functions/existing': CompositeFunctionConfigZ.parse({
+        runs: { steps: [{ run: 'echo existing' }] },
+      }),
+    };
+
+    await extendCompositeFunctionCatalogFromStepsAsync({
+      catalog,
+      rootSteps: [{ uses: './.eas/functions/setup' }],
+      loadCompositeFunction: async () =>
+        CompositeFunctionConfigZ.parse({ runs: { steps: [{ run: 'echo setup' }] } }),
+    });
+
+    expect(Object.keys(catalog).sort()).toEqual([
+      './.eas/functions/existing',
+      './.eas/functions/setup',
+    ]);
   });
 });

--- a/packages/steps/src/utils/__tests__/localFunctions-test.ts
+++ b/packages/steps/src/utils/__tests__/localFunctions-test.ts
@@ -1,4 +1,9 @@
-import { CompositeFunctionConfigZ, LocalFunctionConfigZ } from '@expo/eas-build-job';
+import {
+  CompositeFunctionConfigZ,
+  LocalFunctionConfigZ,
+  isLegacyFunctionConfig,
+} from '@expo/eas-build-job';
+import assert from 'assert';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -11,9 +16,8 @@ import {
   isLocalFunctionPath,
   loadLocalFunctionConfigAsync,
   parseLocalFunctionPath,
-  resolveLegacyFunctionModulePath,
   resolveLocalFunctionPath,
-} from '../localCompositeFunctions';
+} from '../localFunctions';
 
 async function makeCompositeFunctionAsync(
   projectRoot: string,
@@ -247,6 +251,14 @@ describe(buildLocalFunctionCatalogFromStepsAsync, () => {
     ).rejects.toThrow(/"working_directory" is not supported on a step that calls/);
   });
 
+  it('allows working_directory on a step that calls a single-step function', async () => {
+    const catalog = await buildLocalFunctionCatalogFromStepsAsync({
+      rootSteps: [{ uses: './.eas/functions/say-hi', working_directory: 'packages/app' }],
+      loadLocalFunction: async () => LocalFunctionConfigZ.parse({ command: 'echo hi' }),
+    });
+    expect(Object.keys(catalog)).toEqual(['./.eas/functions/say-hi']);
+  });
+
   it('allows working_directory on a step that calls a function, not a local composite function', async () => {
     const catalog = await buildLocalFunctionCatalogFromStepsAsync({
       rootSteps: [{ uses: 'eas/build', working_directory: 'packages/app' }],
@@ -349,6 +361,7 @@ describe(loadLocalFunctionConfigAsync, () => {
 
     const config = await loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/setup');
 
+    assert(!isLegacyFunctionConfig(config));
     expect(config.name).toBe('Setup');
     expect(config.runs.steps).toHaveLength(1);
   });
@@ -364,6 +377,7 @@ describe(loadLocalFunctionConfigAsync, () => {
 
     const config = await loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/setup');
 
+    assert(!isLegacyFunctionConfig(config));
     expect(config.runs.steps).toHaveLength(1);
   });
 
@@ -392,7 +406,7 @@ describe(loadLocalFunctionConfigAsync, () => {
     await expect(
       loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/missing')
     ).rejects.toThrow(
-      /Local composite function "\.\/\.eas\/functions\/missing" was referenced by a step but no such composite function exists/
+      /Local function "\.\/\.eas\/functions\/missing" was referenced by a step but no such local function exists/
     );
   });
 
@@ -411,7 +425,7 @@ describe(loadLocalFunctionConfigAsync, () => {
     );
 
     expect(error.message).toMatch(
-      /Failed to parse local composite function "\.\/\.eas\/functions\/broken" YAML at /
+      /Failed to parse local function "\.\/\.eas\/functions\/broken" YAML at /
     );
     expect(error.cause).toBeInstanceOf(Error);
   });
@@ -427,7 +441,7 @@ describe(loadLocalFunctionConfigAsync, () => {
     await expect(
       loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/broken')
     ).rejects.toThrow(
-      /Invalid composite function "\.\/\.eas\/functions\/broken": .*must declare at least one step under "runs\.steps"/s
+      /Invalid local function "\.\/\.eas\/functions\/broken": .*must declare at least one step under "runs\.steps"/s
     );
   });
 
@@ -449,7 +463,7 @@ describe(loadLocalFunctionConfigAsync, () => {
     );
 
     expect(error.message).toMatch(
-      /Failed to read local composite function "\.\/\.eas\/functions\/setup" from /
+      /Failed to read local function "\.\/\.eas\/functions\/setup" from /
     );
     expect((error.cause as NodeJS.ErrnoException).code).toBe('EISDIR');
   });
@@ -492,7 +506,7 @@ describe(loadLocalFunctionConfigAsync, () => {
     await loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/setup', { logger });
 
     expect(logger.debug).toHaveBeenCalledWith(
-      `Loaded local composite function "./.eas/functions/setup" from ${path.join(
+      `Loaded local function "./.eas/functions/setup" from ${path.join(
         '.eas',
         'functions',
         'setup',
@@ -514,6 +528,7 @@ describe(createLocalFunctionLoader, () => {
     const loader = createLocalFunctionLoader(projectRoot);
     const config = await loader('./.eas/functions/setup');
 
+    assert(!isLegacyFunctionConfig(config));
     expect(config.name).toBe('Setup');
     expect(config.runs.steps).toHaveLength(1);
   });
@@ -524,7 +539,7 @@ describe(createLocalFunctionLoader, () => {
     const loader = createLocalFunctionLoader(projectRoot);
 
     await expect(loader('./.eas/functions/missing')).rejects.toThrow(
-      /no such composite function exists/
+      /no such local function exists/
     );
   });
 });
@@ -628,39 +643,89 @@ describe(buildLocalFunctionCatalogAsync, () => {
 
     expect(catalog).toEqual({});
   });
-});
 
-describe(resolveLegacyFunctionModulePath, () => {
-  const projectRoot = path.resolve('/tmp/project');
+  it('loads a referenced single-step command function', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-catalog-'));
+    await makeCompositeFunctionAsync(
+      projectRoot,
+      'say-hi',
+      [
+        'name: Say hi',
+        'inputs:',
+        '  - name',
+        'outputs:',
+        '  - greeting',
+        'command: set-output greeting "Hi, ${ inputs.name }!"',
+        'shell: sh',
+        'supported_platforms:',
+        '  - linux',
+      ].join('\n')
+    );
 
-  it('resolves a relative module path against the function directory', () => {
-    expect(
-      resolveLegacyFunctionModulePath({
-        projectRoot,
-        functionPath: './.eas/functions/say-hi',
-        modulePath: './my-function',
-      })
-    ).toBe(path.join(projectRoot, '.eas', 'functions', 'say-hi', 'my-function'));
+    const catalog = await buildLocalFunctionCatalogAsync(projectRoot, {
+      rootSteps: [{ uses: './.eas/functions/say-hi', id: 'greet' }],
+    });
+
+    const localFunction = catalog['./.eas/functions/say-hi'];
+    assert(isLegacyFunctionConfig(localFunction));
+    expect(localFunction.name).toBe('Say hi');
+    expect(localFunction.command).toBe('set-output greeting "Hi, ${ inputs.name }!"');
+    expect(localFunction.shell).toBe('sh');
+    expect(localFunction.supported_platforms).toEqual(['linux']);
+    expect(localFunction.inputs).toEqual(['name']);
+    expect(localFunction.outputs).toEqual(['greeting']);
   });
 
-  it('resolves a module path pointing outside the function directory', () => {
-    expect(
-      resolveLegacyFunctionModulePath({
-        projectRoot,
-        functionPath: './.eas/functions/say-hi',
-        modulePath: '../shared/my-function',
-      })
-    ).toBe(path.join(projectRoot, '.eas', 'functions', 'shared', 'my-function'));
+  it('rewrites the "path" of a single-step function to an absolute module path', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-catalog-'));
+    await makeCompositeFunctionAsync(
+      projectRoot,
+      'say-hi',
+      ['name: Say hi', 'path: ./my-function'].join('\n')
+    );
+    const moduleDir = path.join(projectRoot, '.eas', 'functions', 'say-hi', 'my-function');
+    await fs.mkdir(moduleDir, { recursive: true });
+    await fs.writeFile(path.join(moduleDir, 'package.json'), '{}', 'utf-8');
+
+    const catalog = await buildLocalFunctionCatalogAsync(projectRoot, {
+      rootSteps: [{ uses: './.eas/functions/say-hi', id: 'greet' }],
+    });
+
+    const localFunction = catalog['./.eas/functions/say-hi'];
+    assert(isLegacyFunctionConfig(localFunction));
+    expect(localFunction.path).toBe(moduleDir);
   });
 
-  it('passes an absolute module path through', () => {
-    const absolutePath = path.resolve('/opt/functions/say-hi');
-    expect(
-      resolveLegacyFunctionModulePath({
-        projectRoot,
-        functionPath: './.eas/functions/say-hi',
-        modulePath: absolutePath,
+  it('throws when a single-step function points at a module directory that does not exist', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-catalog-'));
+    await makeCompositeFunctionAsync(
+      projectRoot,
+      'say-hi',
+      ['name: Say hi', 'path: ./my-function'].join('\n')
+    );
+
+    await expect(
+      buildLocalFunctionCatalogAsync(projectRoot, {
+        rootSteps: [{ uses: './.eas/functions/say-hi', id: 'greet' }],
       })
-    ).toBe(absolutePath);
+    ).rejects.toThrow(/there is no such directory at /);
+  });
+
+  it('throws when the module directory of a single-step function has no package.json', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-catalog-'));
+    await makeCompositeFunctionAsync(
+      projectRoot,
+      'say-hi',
+      ['name: Say hi', 'path: ./my-function'].join('\n')
+    );
+    await fs.mkdir(path.join(projectRoot, '.eas', 'functions', 'say-hi', 'my-function'), {
+      recursive: true,
+    });
+
+    await expect(
+      buildLocalFunctionCatalogAsync(projectRoot, {
+        rootSteps: [{ uses: './.eas/functions/say-hi', id: 'greet' }],
+      })
+    ).rejects.toThrow(/does not contain a package.json file/);
   });
 });

--- a/packages/steps/src/utils/__tests__/localFunctions-test.ts
+++ b/packages/steps/src/utils/__tests__/localFunctions-test.ts
@@ -676,6 +676,38 @@ describe(buildLocalFunctionCatalogAsync, () => {
     expect(localFunction.outputs).toEqual(['greeting']);
   });
 
+  it('normalizes the camelCase spellings of a single-step function to snake_case', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-catalog-'));
+    await makeCompositeFunctionAsync(
+      projectRoot,
+      'say-hi',
+      [
+        'name: Say hi',
+        'inputs:',
+        '  - name: greeting',
+        '    allowedValueType: string',
+        '    defaultValue: Hi',
+        '    allowedValues:',
+        '      - Hi',
+        '      - Hello',
+        'command: echo "${ inputs.greeting }!"',
+        'supportedRuntimePlatforms:',
+        '  - linux',
+      ].join('\n')
+    );
+
+    const catalog = await buildLocalFunctionCatalogAsync(projectRoot, {
+      rootSteps: [{ uses: './.eas/functions/say-hi', id: 'greet' }],
+    });
+
+    const localFunction = catalog['./.eas/functions/say-hi'];
+    assert(isLegacyFunctionConfig(localFunction));
+    expect(localFunction.supported_platforms).toEqual(['linux']);
+    expect(localFunction.inputs).toEqual([
+      { name: 'greeting', type: 'string', default_value: 'Hi', allowed_values: ['Hi', 'Hello'] },
+    ]);
+  });
+
   it('rewrites the "path" of a single-step function to an absolute module path', async () => {
     const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-catalog-'));
     await makeCompositeFunctionAsync(

--- a/packages/steps/src/utils/__tests__/localFunctions-test.ts
+++ b/packages/steps/src/utils/__tests__/localFunctions-test.ts
@@ -1,5 +1,6 @@
 import {
   CompositeFunctionConfigZ,
+  LocalFunctionConfig,
   LocalFunctionConfigZ,
   isLegacyFunctionConfig,
 } from '@expo/eas-build-job';
@@ -523,6 +524,216 @@ describe(loadLocalFunctionConfigAsync, () => {
         'function.yml'
       )}`
     );
+  });
+
+  describe('legacy input normalization', () => {
+    async function loadLegacyFunctionAsync(lines: string[]): Promise<LocalFunctionConfig> {
+      const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-legacy-inputs-'));
+      await makeCompositeFunctionAsync(projectRoot, 'say-hi', lines.join('\n'));
+      return await loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/say-hi');
+    }
+
+    it('coerces quoted number defaults and allowed values like the custom build schema', async () => {
+      const config = await loadLegacyFunctionAsync([
+        'inputs:',
+        '  - name: count',
+        '    type: number',
+        '    default_value: "2"',
+        '    allowed_values: ["1", "2"]',
+        'command: echo hi',
+      ]);
+
+      assert(isLegacyFunctionConfig(config));
+      expect(config.inputs).toEqual([
+        { name: 'count', type: 'number', default_value: 2, allowed_values: [1, 2] },
+      ]);
+    });
+
+    it('coerces quoted boolean defaults', async () => {
+      const config = await loadLegacyFunctionAsync([
+        'inputs:',
+        '  - name: verbose',
+        '    type: boolean',
+        '    default_value: "true"',
+        '  - name: clean',
+        '    type: boolean',
+        '    default_value: "false"',
+        'command: echo hi',
+      ]);
+
+      assert(isLegacyFunctionConfig(config));
+      expect(config.inputs).toEqual([
+        { name: 'verbose', type: 'boolean', default_value: true },
+        { name: 'clean', type: 'boolean', default_value: false },
+      ]);
+    });
+
+    it('coerces camelCase spellings the same way', async () => {
+      const config = await loadLegacyFunctionAsync([
+        'inputs:',
+        '  - name: count',
+        '    allowedValueType: number',
+        '    defaultValue: "42"',
+        'command: echo hi',
+      ]);
+
+      assert(isLegacyFunctionConfig(config));
+      expect(config.inputs).toEqual([{ name: 'count', type: 'number', default_value: 42 }]);
+    });
+
+    it('keeps a step or context reference default untouched', async () => {
+      const config = await loadLegacyFunctionAsync([
+        'inputs:',
+        '  - name: count',
+        '    type: number',
+        "    default_value: '${ eas.job.version }'",
+        'command: echo hi',
+      ]);
+
+      assert(isLegacyFunctionConfig(config));
+      expect(config.inputs).toEqual([
+        { name: 'count', type: 'number', default_value: '${ eas.job.version }' },
+      ]);
+    });
+
+    it('accepts a json default structurally equal to an allowed value', async () => {
+      const config = await loadLegacyFunctionAsync([
+        'inputs:',
+        '  - name: payload',
+        '    type: json',
+        '    default_value: { a: 1 }',
+        '    allowed_values: [{ a: 1 }, { b: 2 }]',
+        'command: echo hi',
+      ]);
+
+      assert(isLegacyFunctionConfig(config));
+      expect(config.inputs).toEqual([
+        {
+          name: 'payload',
+          type: 'json',
+          default_value: { a: 1 },
+          allowed_values: [{ a: 1 }, { b: 2 }],
+        },
+      ]);
+    });
+
+    it('rejects a number default that does not parse as a number', async () => {
+      await expect(
+        loadLegacyFunctionAsync([
+          'inputs:',
+          '  - name: count',
+          '    type: number',
+          '    default_value: abc',
+          'command: echo hi',
+        ])
+      ).rejects.toThrow(
+        'Invalid local function "./.eas/functions/say-hi": "default_value" of input "count" is set to "abc" which is not of type "number" or a step or context reference.'
+      );
+    });
+
+    it('rejects a non-string default for a string input', async () => {
+      await expect(
+        loadLegacyFunctionAsync([
+          'inputs:',
+          '  - name: label',
+          '    default_value: 42',
+          'command: echo hi',
+        ])
+      ).rejects.toThrow(
+        '"default_value" of input "label" is set to "42" which is not of type "string".'
+      );
+    });
+
+    it('rejects an array or plain string default for a json input', async () => {
+      await expect(
+        loadLegacyFunctionAsync([
+          'inputs:',
+          '  - name: payload',
+          '    type: json',
+          '    default_value: [1, 2]',
+          'command: echo hi',
+        ])
+      ).rejects.toThrow(
+        '"default_value" of input "payload" is set to [1,2] which is not of type "json" or a step or context reference.'
+      );
+
+      await expect(
+        loadLegacyFunctionAsync([
+          'inputs:',
+          '  - name: payload',
+          '    type: json',
+          '    default_value: hello',
+          'command: echo hi',
+        ])
+      ).rejects.toThrow(
+        '"default_value" of input "payload" is set to "hello" which is not of type "json" or a step or context reference.'
+      );
+    });
+
+    it('rejects an allowed value that does not match the declared type', async () => {
+      await expect(
+        loadLegacyFunctionAsync([
+          'inputs:',
+          '  - name: count',
+          '    type: number',
+          '    allowed_values: [1, abc]',
+          'command: echo hi',
+        ])
+      ).rejects.toThrow(
+        '"allowed_values" of input "count" contains "abc" which is not of type "number".'
+      );
+    });
+
+    it('rejects a default outside the allowed values after coercion', async () => {
+      await expect(
+        loadLegacyFunctionAsync([
+          'inputs:',
+          '  - name: count',
+          '    type: number',
+          '    default_value: "3"',
+          '    allowed_values: [1, 2]',
+          'command: echo hi',
+        ])
+      ).rejects.toThrow(
+        '"default_value" of input "count" is set to "3" which is not one of the allowed values: "1", "2".'
+      );
+    });
+
+    it('rejects a reference default when allowed values are declared, like the custom build schema', async () => {
+      await expect(
+        loadLegacyFunctionAsync([
+          'inputs:',
+          '  - name: count',
+          '    type: number',
+          "    default_value: '${ eas.job.version }'",
+          '    allowed_values: [1, 2]',
+          'command: echo hi',
+        ])
+      ).rejects.toThrow(
+        '"default_value" of input "count" is set to "${ eas.job.version }" which is not one of the allowed values: "1", "2".'
+      );
+    });
+
+    it('aggregates issues from multiple inputs into one error', async () => {
+      const error: Error = await loadLegacyFunctionAsync([
+        'inputs:',
+        '  - name: count',
+        '    type: number',
+        '    default_value: abc',
+        '  - name: verbose',
+        '    type: boolean',
+        '    default_value: yes-please',
+        'command: echo hi',
+      ]).then(
+        () => {
+          throw new Error('expected loadLocalFunctionConfigAsync to throw');
+        },
+        err => err
+      );
+
+      expect(error.message).toContain('"default_value" of input "count"');
+      expect(error.message).toContain('"default_value" of input "verbose"');
+    });
   });
 });
 

--- a/packages/steps/src/utils/__tests__/localFunctions-test.ts
+++ b/packages/steps/src/utils/__tests__/localFunctions-test.ts
@@ -456,6 +456,36 @@ describe(loadLocalFunctionConfigAsync, () => {
     );
   });
 
+  it('reports the unrecognized key of a composite function instead of the generic union message', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-test-'));
+    await makeCompositeFunctionAsync(
+      projectRoot,
+      'broken',
+      ['shel: bash', 'runs:', '  steps:', '    - run: echo hi'].join('\n')
+    );
+
+    await expect(
+      loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/broken')
+    ).rejects.toThrow(
+      /Invalid local function "\.\/\.eas\/functions\/broken": .*Unrecognized key: "shel"/s
+    );
+  });
+
+  it('reports the invalid field of a legacy command function instead of the generic union message', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-test-'));
+    await makeCompositeFunctionAsync(
+      projectRoot,
+      'broken',
+      ['command: echo hi', 'supported_platforms: [windows]'].join('\n')
+    );
+
+    await expect(
+      loadLocalFunctionConfigAsync(projectRoot, './.eas/functions/broken')
+    ).rejects.toThrow(
+      /Invalid local function "\.\/\.eas\/functions\/broken": .*expected one of "darwin"\|"linux".*supported_platforms/s
+    );
+  });
+
   it('throws a read error with a cause for a non-ENOENT filesystem error', async () => {
     const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'steps-functions-test-'));
     // A directory named function.yml makes readFile fail with EISDIR instead of ENOENT.

--- a/packages/steps/src/utils/__tests__/localFunctions-test.ts
+++ b/packages/steps/src/utils/__tests__/localFunctions-test.ts
@@ -598,6 +598,26 @@ describe(loadLocalFunctionConfigAsync, () => {
       ]);
     });
 
+    it('coerces mixed-case quoted boolean defaults and allowed values', async () => {
+      const config = await loadLegacyFunctionAsync([
+        'inputs:',
+        '  - name: verbose',
+        '    type: boolean',
+        '    default_value: "True"',
+        '    allowed_values: ["True", "FALSE"]',
+        '  - name: clean',
+        '    type: boolean',
+        '    default_value: "FALSE"',
+        'command: echo hi',
+      ]);
+
+      assert(isLegacyFunctionConfig(config));
+      expect(config.inputs).toEqual([
+        { name: 'verbose', type: 'boolean', default_value: true, allowed_values: [true, false] },
+        { name: 'clean', type: 'boolean', default_value: false },
+      ]);
+    });
+
     it('coerces camelCase spellings the same way', async () => {
       const config = await loadLegacyFunctionAsync([
         'inputs:',

--- a/packages/steps/src/utils/legacyFunction.ts
+++ b/packages/steps/src/utils/legacyFunction.ts
@@ -1,0 +1,56 @@
+/**
+ * Maps a single-step local function config (`command` or `path` in `function.yml`, the shape
+ * custom build functions use in `.eas/build/*.yml`) onto a {@link BuildFunction}, so calling one
+ * from a workflow runs it exactly like a custom build does.
+ *
+ * Legacy semantics are preserved: inputs and outputs are required unless declared otherwise,
+ * which is the opposite of the composite function default.
+ */
+import { LegacyFunctionConfig } from '@expo/eas-build-job';
+
+import { BuildFunction } from '../BuildFunction';
+import { BuildRuntimePlatform } from '../BuildRuntimePlatform';
+import {
+  BuildStepInput,
+  BuildStepInputProvider,
+  BuildStepInputValueTypeName,
+  parseBuildStepInputValueTypeName,
+} from '../BuildStepInput';
+import { createBuildStepOutputProviderFromDefinition } from '../BuildStepOutput';
+
+type LegacyFunctionInput = NonNullable<LegacyFunctionConfig['inputs']>[number];
+
+export function createBuildFunctionFromLegacyFunctionConfig(
+  functionPath: string,
+  config: LegacyFunctionConfig
+): BuildFunction {
+  return new BuildFunction({
+    id: functionPath,
+    name: config.name,
+    command: config.command,
+    customFunctionModulePath: config.path,
+    shell: config.shell,
+    supportedRuntimePlatforms: config.supported_platforms?.map(
+      platform => platform satisfies `${BuildRuntimePlatform}` as BuildRuntimePlatform
+    ),
+    inputProviders: config.inputs?.map(createInputProvider),
+    outputProviders: config.outputs?.map(createBuildStepOutputProviderFromDefinition),
+  });
+}
+
+function createInputProvider(input: LegacyFunctionInput): BuildStepInputProvider {
+  if (typeof input === 'string') {
+    return BuildStepInput.createProvider({
+      id: input,
+      required: true,
+      allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+    });
+  }
+  return BuildStepInput.createProvider({
+    id: input.name,
+    required: input.required ?? true,
+    defaultValue: input.default_value,
+    allowedValues: input.allowed_values,
+    allowedValueTypeName: parseBuildStepInputValueTypeName(input.type),
+  });
+}

--- a/packages/steps/src/utils/legacyFunction.ts
+++ b/packages/steps/src/utils/legacyFunction.ts
@@ -6,6 +6,8 @@
  * Legacy semantics are preserved: inputs and outputs are required unless declared otherwise,
  * which is the opposite of the composite function default.
  */
+import { isDeepStrictEqual } from 'util';
+
 import { LegacyFunctionConfig } from '@expo/eas-build-job';
 
 import { BuildFunction } from '../BuildFunction';
@@ -17,8 +19,11 @@ import {
   parseBuildStepInputValueTypeName,
 } from '../BuildStepInput';
 import { createBuildStepOutputProviderFromDefinition } from '../BuildStepOutput';
+import { BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX } from './template';
 
 type LegacyFunctionInput = NonNullable<LegacyFunctionConfig['inputs']>[number];
+type LegacyFunctionObjectInput = Exclude<LegacyFunctionInput, string>;
+type LegacyFunctionInputValue = LegacyFunctionObjectInput['default_value'];
 
 export function createBuildFunctionFromLegacyFunctionConfig(
   functionPath: string,
@@ -49,8 +54,119 @@ function createInputProvider(input: LegacyFunctionInput): BuildStepInputProvider
   return BuildStepInput.createProvider({
     id: input.name,
     required: input.required ?? true,
-    defaultValue: input.default_value,
-    allowedValues: input.allowed_values,
+    defaultValue: coerceLegacyFunctionInputValue(input.type, input.default_value),
+    allowedValues: input.allowed_values?.map(value =>
+      coerceLegacyFunctionInputValue(input.type, value)
+    ),
     allowedValueTypeName: parseBuildStepInputValueTypeName(input.type),
   });
+}
+
+function isStepOrContextReference(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    (BUILD_STEP_OR_BUILD_GLOBAL_CONTEXT_REFERENCE_REGEX.test(value) ||
+      (value.startsWith('${{') && value.endsWith('}}')))
+  );
+}
+
+// Matches the coercions the custom build Joi schema applies to quoted values
+function coerceLegacyFunctionInputValue<V extends LegacyFunctionInputValue>(
+  type: LegacyFunctionObjectInput['type'],
+  value: V
+): V | number | boolean {
+  if (typeof value !== 'string') {
+    return value;
+  }
+  if (type === 'number' && value.trim() !== '' && Number.isFinite(Number(value))) {
+    return Number(value);
+  }
+  if (type === 'boolean' && (value === 'true' || value === 'false')) {
+    return value === 'true';
+  }
+  return value;
+}
+
+function matchesLegacyFunctionInputType(
+  type: LegacyFunctionObjectInput['type'],
+  value: NonNullable<LegacyFunctionInputValue>,
+  { allowReference }: { allowReference: boolean }
+): boolean {
+  if (type === 'string') {
+    return typeof value === 'string';
+  }
+  if (allowReference && isStepOrContextReference(value)) {
+    return true;
+  }
+  if (type === 'json') {
+    return typeof value === 'object' && !Array.isArray(value);
+  }
+  return typeof value === type;
+}
+
+function renderLegacyFunctionInputValue(value: NonNullable<LegacyFunctionInputValue>): string {
+  return typeof value === 'object' ? JSON.stringify(value) : `"${value}"`;
+}
+
+/**
+ * Coerces quoted `default_value` and `allowed_values` entries to the declared input type,
+ * like the original custom build Joi schema does.
+ */
+export function normalizeLegacyFunctionConfigInputs(
+  functionPath: string,
+  config: LegacyFunctionConfig
+): void {
+  const issues: string[] = [];
+  for (const input of config.inputs ?? []) {
+    if (typeof input === 'string') {
+      continue;
+    }
+    input.default_value = coerceLegacyFunctionInputValue(input.type, input.default_value);
+    input.allowed_values = input.allowed_values?.map(value =>
+      coerceLegacyFunctionInputValue(input.type, value)
+    );
+
+    let typesAreValid = true;
+    for (const value of input.allowed_values ?? []) {
+      if (!matchesLegacyFunctionInputType(input.type, value, { allowReference: false })) {
+        typesAreValid = false;
+        issues.push(
+          `"allowed_values" of input "${input.name}" contains ${renderLegacyFunctionInputValue(
+            value
+          )} which is not of type "${input.type}".`
+        );
+      }
+    }
+    if (
+      input.default_value !== undefined &&
+      !matchesLegacyFunctionInputType(input.type, input.default_value, { allowReference: true })
+    ) {
+      typesAreValid = false;
+      issues.push(
+        `"default_value" of input "${input.name}" is set to ${renderLegacyFunctionInputValue(
+          input.default_value
+        )} which is not of type "${input.type}"${
+          input.type === 'string' ? '' : ' or a step or context reference'
+        }.`
+      );
+    }
+
+    if (
+      typesAreValid &&
+      input.default_value !== undefined &&
+      input.allowed_values !== undefined &&
+      !input.allowed_values.some(value => isDeepStrictEqual(value, input.default_value))
+    ) {
+      issues.push(
+        `"default_value" of input "${input.name}" is set to ${renderLegacyFunctionInputValue(
+          input.default_value
+        )} which is not one of the allowed values: ${input.allowed_values
+          .map(renderLegacyFunctionInputValue)
+          .join(', ')}.`
+      );
+    }
+  }
+  if (issues.length > 0) {
+    throw new Error(`Invalid local function "${functionPath}": ${issues.join('\n')}`);
+  }
 }

--- a/packages/steps/src/utils/legacyFunction.ts
+++ b/packages/steps/src/utils/legacyFunction.ts
@@ -83,8 +83,11 @@ function coerceLegacyFunctionInputValue<V extends LegacyFunctionInputValue>(
   if (type === 'number' && value.trim() !== '' && Number.isFinite(Number(value))) {
     return Number(value);
   }
-  if (type === 'boolean' && (value === 'true' || value === 'false')) {
-    return value === 'true';
+  if (type === 'boolean') {
+    const lowercased = value.toLowerCase();
+    if (lowercased === 'true' || lowercased === 'false') {
+      return lowercased === 'true';
+    }
   }
   return value;
 }

--- a/packages/steps/src/utils/legacyFunction.ts
+++ b/packages/steps/src/utils/legacyFunction.ts
@@ -1,10 +1,12 @@
 /**
  * Maps a single-step local function config (`command` or `path` in `function.yml`, the shape
- * custom build functions use in `.eas/build/*.yml`) onto a {@link BuildFunction}, so calling one
- * from a workflow runs it exactly like a custom build does.
+ * custom build functions use in `.eas/build/*.yml`) onto a {@link BuildFunction}.
  *
  * Legacy semantics are preserved: inputs and outputs are required unless declared otherwise,
  * which is the opposite of the composite function default.
+ *
+ * One difference between the original custom build behavior and the new function is that
+ * function-level `shell:` is honored.
  */
 import { isDeepStrictEqual } from 'util';
 

--- a/packages/steps/src/utils/localCompositeFunctions.ts
+++ b/packages/steps/src/utils/localCompositeFunctions.ts
@@ -3,7 +3,9 @@ import {
   CompositeFunctionConfig,
   CompositeFunctionConfigZ,
   LocalFunctionCatalog,
+  LocalFunctionConfig,
   Step,
+  isLegacyFunctionConfig,
 } from '@expo/eas-build-job';
 import fs from 'fs/promises';
 import path from 'path';
@@ -12,7 +14,7 @@ import { z } from 'zod';
 
 import { BuildConfigError } from '../errors';
 
-// Local composite functions referenced via `uses: ./path` or `uses: ../path` in EAS workflows.
+// Local functions referenced via `uses: ./path` or `uses: ../path` in EAS workflows.
 // Not supported in `.eas/build/*.yml` custom build configs.
 
 const JOB_CONTEXT_INTERPOLATION_REGEXP = /\$\{\{(.+?)\}\}/;
@@ -48,18 +50,18 @@ export function isLocalFunctionPath(uses: string): boolean {
 }
 
 export function getLocalFunctionCallWorkingDirectoryError(uses: string): string {
-  return `"working_directory" is not supported on a step that calls a local composite function ("uses: ${uses.trim()}"). Set "working_directory" on the steps inside the composite function instead.`;
+  return `"working_directory" is not supported on a step that calls a local function ("uses: ${uses.trim()}"). For a composite function, set "working_directory" on the steps inside it; for a single-step "command" function, change directories inside the command.`;
 }
 
-/** Loads only composite functions transitively referenced by `rootSteps`. Unreferenced files are ignored. */
+/** Loads only functions transitively referenced by `rootSteps`. Unreferenced files are ignored. */
 export async function buildLocalFunctionCatalogFromStepsAsync({
   rootSteps,
   loadLocalFunction,
 }: {
   rootSteps: readonly Step[];
-  loadLocalFunction: (functionPath: string) => Promise<CompositeFunctionConfig>;
-}): Promise<CompositeFunctionCatalog> {
-  const catalog: CompositeFunctionCatalog = {};
+  loadLocalFunction: (functionPath: string) => Promise<LocalFunctionConfig>;
+}): Promise<LocalFunctionCatalog> {
+  const catalog: LocalFunctionCatalog = {};
   await extendLocalFunctionCatalogFromStepsAsync({ catalog, rootSteps, loadLocalFunction });
   return catalog;
 }
@@ -72,7 +74,7 @@ export async function extendLocalFunctionCatalogFromStepsAsync({
 }: {
   catalog: LocalFunctionCatalog;
   rootSteps: readonly Step[];
-  loadLocalFunction: (functionPath: string) => Promise<CompositeFunctionConfig>;
+  loadLocalFunction: (functionPath: string) => Promise<LocalFunctionConfig>;
 }): Promise<void> {
   const loadRecursiveAsync = async (functionPath: string): Promise<void> => {
     if (functionPath in catalog) {
@@ -82,6 +84,10 @@ export async function extendLocalFunctionCatalogFromStepsAsync({
     const config = await loadLocalFunction(functionPath);
     catalog[functionPath] = config;
 
+    // Single-step functions are leaves: they have no steps that could reference other functions.
+    if (isLegacyFunctionConfig(config)) {
+      return;
+    }
     for (const nestedPath of collectLocalFunctionPathsFromSteps(config.runs.steps)) {
       await loadRecursiveAsync(nestedPath);
     }
@@ -96,12 +102,32 @@ export function resolveLocalFunctionPath(projectRoot: string, functionPath: stri
   return path.resolve(projectRoot, functionPath);
 }
 
+/**
+ * Resolves the `path` of a single-step local function against the function's own directory, the
+ * way a `.eas/build` config resolves it against the config file. Shared by every loader so the
+ * two cannot drift.
+ */
+export function resolveLegacyFunctionModulePath({
+  projectRoot,
+  functionPath,
+  modulePath,
+}: {
+  projectRoot: string;
+  functionPath: string;
+  modulePath: string;
+}): string {
+  if (path.isAbsolute(modulePath)) {
+    return modulePath;
+  }
+  return path.resolve(resolveLocalFunctionPath(projectRoot, functionPath), modulePath);
+}
+
 export interface LocalFunctionLogger {
   debug(message: string): void;
 }
 
 /**
- * Reads and validates the function.yml (or function.yaml) file of a local composite function.
+ * Reads and validates the function.yml (or function.yaml) file of a local function.
  * `functionPath` is the normalized ref returned by {@link parseLocalFunctionPath}.
  */
 export async function loadLocalFunctionConfigAsync(
@@ -167,7 +193,7 @@ export function createLocalFunctionLoader(
     await loadLocalFunctionConfigAsync(projectRoot, functionPath, { logger });
 }
 
-/** Builds the catalog of composite functions transitively referenced by `rootSteps`, loading each from disk. */
+/** Builds the catalog of local functions transitively referenced by `rootSteps`, loading each from disk. */
 export async function buildLocalFunctionCatalogAsync(
   projectRoot: string,
   { rootSteps, logger }: { rootSteps: readonly Step[]; logger?: LocalFunctionLogger }

--- a/packages/steps/src/utils/localCompositeFunctions.ts
+++ b/packages/steps/src/utils/localCompositeFunctions.ts
@@ -17,15 +17,15 @@ import { BuildConfigError } from '../errors';
 
 const JOB_CONTEXT_INTERPOLATION_REGEXP = /\$\{\{(.+?)\}\}/;
 
-function doesLocalCompositeFunctionPathRequireInterpolation(uses: string): boolean {
+function doesLocalFunctionPathRequireInterpolation(uses: string): boolean {
   return JOB_CONTEXT_INTERPOLATION_REGEXP.test(uses);
 }
 
-export function parseLocalCompositeFunctionPath(uses: string): string {
+export function parseLocalFunctionPath(uses: string): string {
   const trimmed = uses.trim();
-  // The composite function catalog is built before the workflow runs, so a local composite function path must be
+  // The local function catalog is built before the workflow runs, so a local function path must be
   // known statically.
-  if (doesLocalCompositeFunctionPathRequireInterpolation(trimmed)) {
+  if (doesLocalFunctionPathRequireInterpolation(trimmed)) {
     throw new BuildConfigError(
       `Local composite function path "${trimmed}" must not contain interpolation ("\${{ ... }}"). The "uses" path for a local composite function must be a static, literal path.`
     );
@@ -42,77 +42,74 @@ export function parseLocalCompositeFunctionPath(uses: string): string {
   return `./${normalized}`;
 }
 
-export function isLocalCompositeFunctionPath(uses: string): boolean {
+export function isLocalFunctionPath(uses: string): boolean {
   const trimmed = uses.trim();
   return trimmed.startsWith('./') || trimmed.startsWith('../');
 }
 
-export function getLocalCompositeFunctionCallWorkingDirectoryError(uses: string): string {
+export function getLocalFunctionCallWorkingDirectoryError(uses: string): string {
   return `"working_directory" is not supported on a step that calls a local composite function ("uses: ${uses.trim()}"). Set "working_directory" on the steps inside the composite function instead.`;
 }
 
 /** Loads only composite functions transitively referenced by `rootSteps`. Unreferenced files are ignored. */
-export async function buildCompositeFunctionCatalogFromStepsAsync({
+export async function buildLocalFunctionCatalogFromStepsAsync({
   rootSteps,
-  loadCompositeFunction,
+  loadLocalFunction,
 }: {
   rootSteps: readonly Step[];
-  loadCompositeFunction: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
+  loadLocalFunction: (functionPath: string) => Promise<CompositeFunctionConfig>;
 }): Promise<CompositeFunctionCatalog> {
   const catalog: CompositeFunctionCatalog = {};
-  await extendCompositeFunctionCatalogFromStepsAsync({ catalog, rootSteps, loadCompositeFunction });
+  await extendLocalFunctionCatalogFromStepsAsync({ catalog, rootSteps, loadLocalFunction });
   return catalog;
 }
 
 /** Extends `catalog` in place with functions transitively referenced by `rootSteps`. Skips paths already present. */
-export async function extendCompositeFunctionCatalogFromStepsAsync({
+export async function extendLocalFunctionCatalogFromStepsAsync({
   catalog,
   rootSteps,
-  loadCompositeFunction,
+  loadLocalFunction,
 }: {
   catalog: LocalFunctionCatalog;
   rootSteps: readonly Step[];
-  loadCompositeFunction: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
+  loadLocalFunction: (functionPath: string) => Promise<CompositeFunctionConfig>;
 }): Promise<void> {
-  const loadRecursiveAsync = async (compositeFunctionPath: string): Promise<void> => {
-    if (compositeFunctionPath in catalog) {
+  const loadRecursiveAsync = async (functionPath: string): Promise<void> => {
+    if (functionPath in catalog) {
       return;
     }
 
-    const config = await loadCompositeFunction(compositeFunctionPath);
-    catalog[compositeFunctionPath] = config;
+    const config = await loadLocalFunction(functionPath);
+    catalog[functionPath] = config;
 
-    for (const nestedPath of collectLocalCompositeFunctionPathsFromSteps(config.runs.steps)) {
+    for (const nestedPath of collectLocalFunctionPathsFromSteps(config.runs.steps)) {
       await loadRecursiveAsync(nestedPath);
     }
   };
 
-  for (const compositeFunctionPath of collectLocalCompositeFunctionPathsFromSteps(rootSteps)) {
-    await loadRecursiveAsync(compositeFunctionPath);
+  for (const functionPath of collectLocalFunctionPathsFromSteps(rootSteps)) {
+    await loadRecursiveAsync(functionPath);
   }
 }
 
-export function resolveLocalCompositeFunctionPath(
-  projectRoot: string,
-  compositeFunctionPath: string
-): string {
-  return path.resolve(projectRoot, compositeFunctionPath);
+export function resolveLocalFunctionPath(projectRoot: string, functionPath: string): string {
+  return path.resolve(projectRoot, functionPath);
 }
 
-export interface LocalCompositeFunctionLogger {
+export interface LocalFunctionLogger {
   debug(message: string): void;
 }
 
 /**
  * Reads and validates the function.yml (or function.yaml) file of a local composite function.
- * `compositeFunctionPath` is the normalized ref returned by {@link parseLocalCompositeFunctionPath}.
+ * `functionPath` is the normalized ref returned by {@link parseLocalFunctionPath}.
  */
-export async function loadLocalCompositeFunctionConfigAsync(
+export async function loadLocalFunctionConfigAsync(
   projectRoot: string,
-  compositeFunctionPath: string,
-  { logger }: { logger?: LocalCompositeFunctionLogger } = {}
+  functionPath: string,
+  { logger }: { logger?: LocalFunctionLogger } = {}
 ): Promise<CompositeFunctionConfig> {
-  const resolvedPath = resolveLocalCompositeFunctionPath(projectRoot, compositeFunctionPath);
+  const resolvedPath = resolveLocalFunctionPath(projectRoot, functionPath);
 
   for (const ext of ['yml', 'yaml'] as const) {
     const absolutePath = path.join(resolvedPath, `function.${ext}`);
@@ -124,7 +121,7 @@ export async function loadLocalCompositeFunctionConfigAsync(
         continue;
       }
       throw new Error(
-        `Failed to read local composite function "${compositeFunctionPath}" from ${absolutePath}`,
+        `Failed to read local composite function "${functionPath}" from ${absolutePath}`,
         {
           cause: err as Error,
         }
@@ -136,7 +133,7 @@ export async function loadLocalCompositeFunctionConfigAsync(
       parsed = YAML.parse(rawContents);
     } catch (err) {
       throw new Error(
-        `Failed to parse local composite function "${compositeFunctionPath}" YAML at ${absolutePath}`,
+        `Failed to parse local composite function "${functionPath}" YAML at ${absolutePath}`,
         {
           cause: err as Error,
         }
@@ -146,49 +143,49 @@ export async function loadLocalCompositeFunctionConfigAsync(
     const result = CompositeFunctionConfigZ.safeParse(parsed);
     if (!result.success) {
       throw new Error(
-        `Invalid composite function "${compositeFunctionPath}": ${z.prettifyError(result.error)}`
+        `Invalid composite function "${functionPath}": ${z.prettifyError(result.error)}`
       );
     }
 
     logger?.debug(
-      `Loaded local composite function "${compositeFunctionPath}" from ${path.relative(projectRoot, absolutePath)}`
+      `Loaded local composite function "${functionPath}" from ${path.relative(projectRoot, absolutePath)}`
     );
     return result.data;
   }
 
   throw new Error(
-    `Local composite function "${compositeFunctionPath}" was referenced by a step but no such composite function exists. A local composite function is resolved from a "function.yml" (or "function.yaml") file at the referenced path relative to the EAS project root (e.g. "uses: ${compositeFunctionPath}" resolves "${compositeFunctionPath}/function.yml"). The recommended convention is to keep composite functions under ".eas/functions/<name>".`
+    `Local composite function "${functionPath}" was referenced by a step but no such composite function exists. A local composite function is resolved from a "function.yml" (or "function.yaml") file at the referenced path relative to the EAS project root (e.g. "uses: ${functionPath}" resolves "${functionPath}/function.yml"). The recommended convention is to keep composite functions under ".eas/functions/<name>".`
   );
 }
 
 /** Loader for the lazy hook path: bound to a project root, passed to {@link StepsConfigParser}. */
-export function createLocalCompositeFunctionLoader(
+export function createLocalFunctionLoader(
   projectRoot: string,
-  { logger }: { logger?: LocalCompositeFunctionLogger } = {}
-): (compositeFunctionPath: string) => Promise<CompositeFunctionConfig> {
-  return async compositeFunctionPath =>
-    await loadLocalCompositeFunctionConfigAsync(projectRoot, compositeFunctionPath, { logger });
+  { logger }: { logger?: LocalFunctionLogger } = {}
+): (functionPath: string) => Promise<CompositeFunctionConfig> {
+  return async functionPath =>
+    await loadLocalFunctionConfigAsync(projectRoot, functionPath, { logger });
 }
 
 /** Builds the catalog of composite functions transitively referenced by `rootSteps`, loading each from disk. */
-export async function buildLocalCompositeFunctionCatalogAsync(
+export async function buildLocalFunctionCatalogAsync(
   projectRoot: string,
-  { rootSteps, logger }: { rootSteps: readonly Step[]; logger?: LocalCompositeFunctionLogger }
+  { rootSteps, logger }: { rootSteps: readonly Step[]; logger?: LocalFunctionLogger }
 ): Promise<CompositeFunctionCatalog> {
-  return await buildCompositeFunctionCatalogFromStepsAsync({
+  return await buildLocalFunctionCatalogFromStepsAsync({
     rootSteps,
-    loadCompositeFunction: createLocalCompositeFunctionLoader(projectRoot, { logger }),
+    loadLocalFunction: createLocalFunctionLoader(projectRoot, { logger }),
   });
 }
 
-function collectLocalCompositeFunctionPathsFromSteps(steps: readonly Step[]): Set<string> {
+function collectLocalFunctionPathsFromSteps(steps: readonly Step[]): Set<string> {
   const paths = new Set<string>();
   for (const step of steps) {
-    if (step.uses !== undefined && isLocalCompositeFunctionPath(step.uses)) {
+    if (step.uses !== undefined && isLocalFunctionPath(step.uses)) {
       if (step.working_directory !== undefined) {
-        throw new BuildConfigError(getLocalCompositeFunctionCallWorkingDirectoryError(step.uses));
+        throw new BuildConfigError(getLocalFunctionCallWorkingDirectoryError(step.uses));
       }
-      paths.add(parseLocalCompositeFunctionPath(step.uses));
+      paths.add(parseLocalFunctionPath(step.uses));
     }
   }
   return paths;

--- a/packages/steps/src/utils/localCompositeFunctions.ts
+++ b/packages/steps/src/utils/localCompositeFunctions.ts
@@ -16,15 +16,15 @@ import { BuildConfigError } from '../errors';
 
 const JOB_CONTEXT_INTERPOLATION_REGEXP = /\$\{\{(.+?)\}\}/;
 
-function doesLocalCompositeFunctionPathRequireInterpolation(uses: string): boolean {
+function doesLocalFunctionPathRequireInterpolation(uses: string): boolean {
   return JOB_CONTEXT_INTERPOLATION_REGEXP.test(uses);
 }
 
-export function parseLocalCompositeFunctionPath(uses: string): string {
+export function parseLocalFunctionPath(uses: string): string {
   const trimmed = uses.trim();
-  // The composite function catalog is built before the workflow runs, so a local composite function path must be
+  // The local function catalog is built before the workflow runs, so a local function path must be
   // known statically.
-  if (doesLocalCompositeFunctionPathRequireInterpolation(trimmed)) {
+  if (doesLocalFunctionPathRequireInterpolation(trimmed)) {
     throw new BuildConfigError(
       `Local composite function path "${trimmed}" must not contain interpolation ("\${{ ... }}"). The "uses" path for a local composite function must be a static, literal path.`
     );
@@ -41,77 +41,74 @@ export function parseLocalCompositeFunctionPath(uses: string): string {
   return `./${normalized}`;
 }
 
-export function isLocalCompositeFunctionPath(uses: string): boolean {
+export function isLocalFunctionPath(uses: string): boolean {
   const trimmed = uses.trim();
   return trimmed.startsWith('./') || trimmed.startsWith('../');
 }
 
-export function getLocalCompositeFunctionCallWorkingDirectoryError(uses: string): string {
+export function getLocalFunctionCallWorkingDirectoryError(uses: string): string {
   return `"working_directory" is not supported on a step that calls a local composite function ("uses: ${uses.trim()}"). Set "working_directory" on the steps inside the composite function instead.`;
 }
 
 /** Loads only composite functions transitively referenced by `rootSteps`. Unreferenced files are ignored. */
-export async function buildCompositeFunctionCatalogFromStepsAsync({
+export async function buildLocalFunctionCatalogFromStepsAsync({
   rootSteps,
-  loadCompositeFunction,
+  loadLocalFunction,
 }: {
   rootSteps: readonly Step[];
-  loadCompositeFunction: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
+  loadLocalFunction: (functionPath: string) => Promise<CompositeFunctionConfig>;
 }): Promise<LocalFunctionCatalog> {
   const catalog: LocalFunctionCatalog = {};
-  await extendCompositeFunctionCatalogFromStepsAsync({ catalog, rootSteps, loadCompositeFunction });
+  await extendLocalFunctionCatalogFromStepsAsync({ catalog, rootSteps, loadLocalFunction });
   return catalog;
 }
 
 /** Extends `catalog` in place with functions transitively referenced by `rootSteps`. Skips paths already present. */
-export async function extendCompositeFunctionCatalogFromStepsAsync({
+export async function extendLocalFunctionCatalogFromStepsAsync({
   catalog,
   rootSteps,
-  loadCompositeFunction,
+  loadLocalFunction,
 }: {
   catalog: LocalFunctionCatalog;
   rootSteps: readonly Step[];
-  loadCompositeFunction: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
+  loadLocalFunction: (functionPath: string) => Promise<CompositeFunctionConfig>;
 }): Promise<void> {
-  const loadRecursiveAsync = async (compositeFunctionPath: string): Promise<void> => {
-    if (compositeFunctionPath in catalog) {
+  const loadRecursiveAsync = async (functionPath: string): Promise<void> => {
+    if (functionPath in catalog) {
       return;
     }
 
-    const config = await loadCompositeFunction(compositeFunctionPath);
-    catalog[compositeFunctionPath] = config;
+    const config = await loadLocalFunction(functionPath);
+    catalog[functionPath] = config;
 
-    for (const nestedPath of collectLocalCompositeFunctionPathsFromSteps(config.runs.steps)) {
+    for (const nestedPath of collectLocalFunctionPathsFromSteps(config.runs.steps)) {
       await loadRecursiveAsync(nestedPath);
     }
   };
 
-  for (const compositeFunctionPath of collectLocalCompositeFunctionPathsFromSteps(rootSteps)) {
-    await loadRecursiveAsync(compositeFunctionPath);
+  for (const functionPath of collectLocalFunctionPathsFromSteps(rootSteps)) {
+    await loadRecursiveAsync(functionPath);
   }
 }
 
-export function resolveLocalCompositeFunctionPath(
-  projectRoot: string,
-  compositeFunctionPath: string
-): string {
-  return path.resolve(projectRoot, compositeFunctionPath);
+export function resolveLocalFunctionPath(projectRoot: string, functionPath: string): string {
+  return path.resolve(projectRoot, functionPath);
 }
 
-export interface LocalCompositeFunctionLogger {
+export interface LocalFunctionLogger {
   debug(message: string): void;
 }
 
 /**
  * Reads and validates the function.yml (or function.yaml) file of a local composite function.
- * `compositeFunctionPath` is the normalized ref returned by {@link parseLocalCompositeFunctionPath}.
+ * `functionPath` is the normalized ref returned by {@link parseLocalFunctionPath}.
  */
-export async function loadLocalCompositeFunctionConfigAsync(
+export async function loadLocalFunctionConfigAsync(
   projectRoot: string,
-  compositeFunctionPath: string,
-  { logger }: { logger?: LocalCompositeFunctionLogger } = {}
+  functionPath: string,
+  { logger }: { logger?: LocalFunctionLogger } = {}
 ): Promise<CompositeFunctionConfig> {
-  const resolvedPath = resolveLocalCompositeFunctionPath(projectRoot, compositeFunctionPath);
+  const resolvedPath = resolveLocalFunctionPath(projectRoot, functionPath);
 
   for (const ext of ['yml', 'yaml'] as const) {
     const absolutePath = path.join(resolvedPath, `function.${ext}`);
@@ -123,7 +120,7 @@ export async function loadLocalCompositeFunctionConfigAsync(
         continue;
       }
       throw new Error(
-        `Failed to read local composite function "${compositeFunctionPath}" from ${absolutePath}`,
+        `Failed to read local composite function "${functionPath}" from ${absolutePath}`,
         {
           cause: err as Error,
         }
@@ -135,7 +132,7 @@ export async function loadLocalCompositeFunctionConfigAsync(
       parsed = YAML.parse(rawContents);
     } catch (err) {
       throw new Error(
-        `Failed to parse local composite function "${compositeFunctionPath}" YAML at ${absolutePath}`,
+        `Failed to parse local composite function "${functionPath}" YAML at ${absolutePath}`,
         {
           cause: err as Error,
         }
@@ -145,49 +142,49 @@ export async function loadLocalCompositeFunctionConfigAsync(
     const result = CompositeFunctionConfigZ.safeParse(parsed);
     if (!result.success) {
       throw new Error(
-        `Invalid composite function "${compositeFunctionPath}": ${z.prettifyError(result.error)}`
+        `Invalid composite function "${functionPath}": ${z.prettifyError(result.error)}`
       );
     }
 
     logger?.debug(
-      `Loaded local composite function "${compositeFunctionPath}" from ${path.relative(projectRoot, absolutePath)}`
+      `Loaded local composite function "${functionPath}" from ${path.relative(projectRoot, absolutePath)}`
     );
     return result.data;
   }
 
   throw new Error(
-    `Local composite function "${compositeFunctionPath}" was referenced by a step but no such composite function exists. A local composite function is resolved from a "function.yml" (or "function.yaml") file at the referenced path relative to the EAS project root (e.g. "uses: ${compositeFunctionPath}" resolves "${compositeFunctionPath}/function.yml"). The recommended convention is to keep composite functions under ".eas/functions/<name>".`
+    `Local composite function "${functionPath}" was referenced by a step but no such composite function exists. A local composite function is resolved from a "function.yml" (or "function.yaml") file at the referenced path relative to the EAS project root (e.g. "uses: ${functionPath}" resolves "${functionPath}/function.yml"). The recommended convention is to keep composite functions under ".eas/functions/<name>".`
   );
 }
 
 /** Loader for the lazy hook path: bound to a project root, passed to {@link StepsConfigParser}. */
-export function createLocalCompositeFunctionLoader(
+export function createLocalFunctionLoader(
   projectRoot: string,
-  { logger }: { logger?: LocalCompositeFunctionLogger } = {}
-): (compositeFunctionPath: string) => Promise<CompositeFunctionConfig> {
-  return async compositeFunctionPath =>
-    await loadLocalCompositeFunctionConfigAsync(projectRoot, compositeFunctionPath, { logger });
+  { logger }: { logger?: LocalFunctionLogger } = {}
+): (functionPath: string) => Promise<CompositeFunctionConfig> {
+  return async functionPath =>
+    await loadLocalFunctionConfigAsync(projectRoot, functionPath, { logger });
 }
 
 /** Builds the catalog of composite functions transitively referenced by `rootSteps`, loading each from disk. */
-export async function buildLocalCompositeFunctionCatalogAsync(
+export async function buildLocalFunctionCatalogAsync(
   projectRoot: string,
-  { rootSteps, logger }: { rootSteps: readonly Step[]; logger?: LocalCompositeFunctionLogger }
+  { rootSteps, logger }: { rootSteps: readonly Step[]; logger?: LocalFunctionLogger }
 ): Promise<LocalFunctionCatalog> {
-  return await buildCompositeFunctionCatalogFromStepsAsync({
+  return await buildLocalFunctionCatalogFromStepsAsync({
     rootSteps,
-    loadCompositeFunction: createLocalCompositeFunctionLoader(projectRoot, { logger }),
+    loadLocalFunction: createLocalFunctionLoader(projectRoot, { logger }),
   });
 }
 
-function collectLocalCompositeFunctionPathsFromSteps(steps: readonly Step[]): Set<string> {
+function collectLocalFunctionPathsFromSteps(steps: readonly Step[]): Set<string> {
   const paths = new Set<string>();
   for (const step of steps) {
-    if (step.uses !== undefined && isLocalCompositeFunctionPath(step.uses)) {
+    if (step.uses !== undefined && isLocalFunctionPath(step.uses)) {
       if (step.working_directory !== undefined) {
-        throw new BuildConfigError(getLocalCompositeFunctionCallWorkingDirectoryError(step.uses));
+        throw new BuildConfigError(getLocalFunctionCallWorkingDirectoryError(step.uses));
       }
-      paths.add(parseLocalCompositeFunctionPath(step.uses));
+      paths.add(parseLocalFunctionPath(step.uses));
     }
   }
   return paths;

--- a/packages/steps/src/utils/localCompositeFunctions.ts
+++ b/packages/steps/src/utils/localCompositeFunctions.ts
@@ -2,7 +2,9 @@ import {
   CompositeFunctionConfig,
   CompositeFunctionConfigZ,
   LocalFunctionCatalog,
+  LocalFunctionConfig,
   Step,
+  isLegacyFunctionConfig,
 } from '@expo/eas-build-job';
 import fs from 'fs/promises';
 import path from 'path';
@@ -11,7 +13,7 @@ import { z } from 'zod';
 
 import { BuildConfigError } from '../errors';
 
-// Local composite functions referenced via `uses: ./path` or `uses: ../path` in EAS workflows.
+// Local functions referenced via `uses: ./path` or `uses: ../path` in EAS workflows.
 // Not supported in `.eas/build/*.yml` custom build configs.
 
 const JOB_CONTEXT_INTERPOLATION_REGEXP = /\$\{\{(.+?)\}\}/;
@@ -47,16 +49,16 @@ export function isLocalFunctionPath(uses: string): boolean {
 }
 
 export function getLocalFunctionCallWorkingDirectoryError(uses: string): string {
-  return `"working_directory" is not supported on a step that calls a local composite function ("uses: ${uses.trim()}"). Set "working_directory" on the steps inside the composite function instead.`;
+  return `"working_directory" is not supported on a step that calls a local function ("uses: ${uses.trim()}"). For a composite function, set "working_directory" on the steps inside it; for a single-step "command" function, change directories inside the command.`;
 }
 
-/** Loads only composite functions transitively referenced by `rootSteps`. Unreferenced files are ignored. */
+/** Loads only functions transitively referenced by `rootSteps`. Unreferenced files are ignored. */
 export async function buildLocalFunctionCatalogFromStepsAsync({
   rootSteps,
   loadLocalFunction,
 }: {
   rootSteps: readonly Step[];
-  loadLocalFunction: (functionPath: string) => Promise<CompositeFunctionConfig>;
+  loadLocalFunction: (functionPath: string) => Promise<LocalFunctionConfig>;
 }): Promise<LocalFunctionCatalog> {
   const catalog: LocalFunctionCatalog = {};
   await extendLocalFunctionCatalogFromStepsAsync({ catalog, rootSteps, loadLocalFunction });
@@ -71,7 +73,7 @@ export async function extendLocalFunctionCatalogFromStepsAsync({
 }: {
   catalog: LocalFunctionCatalog;
   rootSteps: readonly Step[];
-  loadLocalFunction: (functionPath: string) => Promise<CompositeFunctionConfig>;
+  loadLocalFunction: (functionPath: string) => Promise<LocalFunctionConfig>;
 }): Promise<void> {
   const loadRecursiveAsync = async (functionPath: string): Promise<void> => {
     if (functionPath in catalog) {
@@ -81,6 +83,10 @@ export async function extendLocalFunctionCatalogFromStepsAsync({
     const config = await loadLocalFunction(functionPath);
     catalog[functionPath] = config;
 
+    // Single-step functions are leaves: they have no steps that could reference other functions.
+    if (isLegacyFunctionConfig(config)) {
+      return;
+    }
     for (const nestedPath of collectLocalFunctionPathsFromSteps(config.runs.steps)) {
       await loadRecursiveAsync(nestedPath);
     }
@@ -95,12 +101,32 @@ export function resolveLocalFunctionPath(projectRoot: string, functionPath: stri
   return path.resolve(projectRoot, functionPath);
 }
 
+/**
+ * Resolves the `path` of a single-step local function against the function's own directory, the
+ * way a `.eas/build` config resolves it against the config file. Shared by every loader so the
+ * two cannot drift.
+ */
+export function resolveLegacyFunctionModulePath({
+  projectRoot,
+  functionPath,
+  modulePath,
+}: {
+  projectRoot: string;
+  functionPath: string;
+  modulePath: string;
+}): string {
+  if (path.isAbsolute(modulePath)) {
+    return modulePath;
+  }
+  return path.resolve(resolveLocalFunctionPath(projectRoot, functionPath), modulePath);
+}
+
 export interface LocalFunctionLogger {
   debug(message: string): void;
 }
 
 /**
- * Reads and validates the function.yml (or function.yaml) file of a local composite function.
+ * Reads and validates the function.yml (or function.yaml) file of a local function.
  * `functionPath` is the normalized ref returned by {@link parseLocalFunctionPath}.
  */
 export async function loadLocalFunctionConfigAsync(
@@ -166,7 +192,7 @@ export function createLocalFunctionLoader(
     await loadLocalFunctionConfigAsync(projectRoot, functionPath, { logger });
 }
 
-/** Builds the catalog of composite functions transitively referenced by `rootSteps`, loading each from disk. */
+/** Builds the catalog of local functions transitively referenced by `rootSteps`, loading each from disk. */
 export async function buildLocalFunctionCatalogAsync(
   projectRoot: string,
   { rootSteps, logger }: { rootSteps: readonly Step[]; logger?: LocalFunctionLogger }

--- a/packages/steps/src/utils/localFunctions.ts
+++ b/packages/steps/src/utils/localFunctions.ts
@@ -1,13 +1,11 @@
 import {
-  CompositeFunctionCatalog,
-  CompositeFunctionConfig,
-  CompositeFunctionConfigZ,
   LocalFunctionCatalog,
   LocalFunctionConfig,
+  LocalFunctionConfigZ,
   Step,
   isLegacyFunctionConfig,
 } from '@expo/eas-build-job';
-import fs from 'fs/promises';
+import fs from 'fs-extra';
 import path from 'path';
 import YAML from 'yaml';
 import { z } from 'zod';
@@ -29,12 +27,12 @@ export function parseLocalFunctionPath(uses: string): string {
   // known statically.
   if (doesLocalFunctionPathRequireInterpolation(trimmed)) {
     throw new BuildConfigError(
-      `Local composite function path "${trimmed}" must not contain interpolation ("\${{ ... }}"). The "uses" path for a local composite function must be a static, literal path.`
+      `Local function path "${trimmed}" must not contain interpolation ("\${{ ... }}"). The "uses" path for a local function must be a static, literal path.`
     );
   }
   if (trimmed.includes('\\')) {
     throw new BuildConfigError(
-      `Local composite function path "${trimmed}" must not contain backslashes. Use forward slashes as path separators.`
+      `Local function path "${trimmed}" must not contain backslashes. Use forward slashes as path separators.`
     );
   }
   const normalized = path.posix.normalize(trimmed.replace(/\/+$/, ''));
@@ -50,7 +48,7 @@ export function isLocalFunctionPath(uses: string): boolean {
 }
 
 export function getLocalFunctionCallWorkingDirectoryError(uses: string): string {
-  return `"working_directory" is not supported on a step that calls a local function ("uses: ${uses.trim()}"). For a composite function, set "working_directory" on the steps inside it; for a single-step "command" function, change directories inside the command.`;
+  return `"working_directory" is not supported on a step that calls a local composite function ("uses: ${uses.trim()}"). The call step expands away; set "working_directory" on the steps inside the composite function instead.`;
 }
 
 /** Loads only functions transitively referenced by `rootSteps`. Unreferenced files are ignored. */
@@ -76,25 +74,36 @@ export async function extendLocalFunctionCatalogFromStepsAsync({
   rootSteps: readonly Step[];
   loadLocalFunction: (functionPath: string) => Promise<LocalFunctionConfig>;
 }): Promise<void> {
-  const loadRecursiveAsync = async (functionPath: string): Promise<void> => {
-    if (functionPath in catalog) {
+  const loadRecursiveAsync = async (
+    functionPath: string,
+    calledWithWorkingDirectory: boolean
+  ): Promise<void> => {
+    const alreadyLoaded = functionPath in catalog;
+    const config = alreadyLoaded ? catalog[functionPath] : await loadLocalFunction(functionPath);
+
+    // working_directory is invalid on composite calls. Shape is only known after load.
+    if (calledWithWorkingDirectory && !isLegacyFunctionConfig(config)) {
+      throw new BuildConfigError(getLocalFunctionCallWorkingDirectoryError(functionPath));
+    }
+    if (alreadyLoaded) {
       return;
     }
-
-    const config = await loadLocalFunction(functionPath);
     catalog[functionPath] = config;
 
-    // Single-step functions are leaves: they have no steps that could reference other functions.
     if (isLegacyFunctionConfig(config)) {
       return;
     }
-    for (const nestedPath of collectLocalFunctionPathsFromSteps(config.runs.steps)) {
-      await loadRecursiveAsync(nestedPath);
+    for (const [nestedPath, nestedCalledWithWorkingDirectory] of collectLocalFunctionCallsFromSteps(
+      config.runs.steps
+    )) {
+      await loadRecursiveAsync(nestedPath, nestedCalledWithWorkingDirectory);
     }
   };
 
-  for (const functionPath of collectLocalFunctionPathsFromSteps(rootSteps)) {
-    await loadRecursiveAsync(functionPath);
+  for (const [functionPath, calledWithWorkingDirectory] of collectLocalFunctionCallsFromSteps(
+    rootSteps
+  )) {
+    await loadRecursiveAsync(functionPath, calledWithWorkingDirectory);
   }
 }
 
@@ -102,12 +111,7 @@ export function resolveLocalFunctionPath(projectRoot: string, functionPath: stri
   return path.resolve(projectRoot, functionPath);
 }
 
-/**
- * Resolves the `path` of a single-step local function against the function's own directory, the
- * way a `.eas/build` config resolves it against the config file. Shared by every loader so the
- * two cannot drift.
- */
-export function resolveLegacyFunctionModulePath({
+async function resolveAndValidateLegacyFunctionModulePathAsync({
   projectRoot,
   functionPath,
   modulePath,
@@ -115,11 +119,21 @@ export function resolveLegacyFunctionModulePath({
   projectRoot: string;
   functionPath: string;
   modulePath: string;
-}): string {
-  if (path.isAbsolute(modulePath)) {
-    return modulePath;
+}): Promise<string> {
+  const resolvedModulePath = path.isAbsolute(modulePath)
+    ? modulePath
+    : path.resolve(resolveLocalFunctionPath(projectRoot, functionPath), modulePath);
+  if (!(await fs.pathExists(resolvedModulePath))) {
+    throw new Error(
+      `Local function "${functionPath}" declares "path: ${modulePath}", but there is no such directory at ${resolvedModulePath}.`
+    );
   }
-  return path.resolve(resolveLocalFunctionPath(projectRoot, functionPath), modulePath);
+  if (!(await fs.pathExists(path.join(resolvedModulePath, 'package.json')))) {
+    throw new Error(
+      `Local function "${functionPath}" declares "path: ${modulePath}", but the module directory ${resolvedModulePath} does not contain a package.json file.`
+    );
+  }
+  return resolvedModulePath;
 }
 
 export interface LocalFunctionLogger {
@@ -134,7 +148,7 @@ export async function loadLocalFunctionConfigAsync(
   projectRoot: string,
   functionPath: string,
   { logger }: { logger?: LocalFunctionLogger } = {}
-): Promise<CompositeFunctionConfig> {
+): Promise<LocalFunctionConfig> {
   const resolvedPath = resolveLocalFunctionPath(projectRoot, functionPath);
 
   for (const ext of ['yml', 'yaml'] as const) {
@@ -146,41 +160,43 @@ export async function loadLocalFunctionConfigAsync(
       if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
         continue;
       }
-      throw new Error(
-        `Failed to read local composite function "${functionPath}" from ${absolutePath}`,
-        {
-          cause: err as Error,
-        }
-      );
+      throw new Error(`Failed to read local function "${functionPath}" from ${absolutePath}`, {
+        cause: err as Error,
+      });
     }
 
     let parsed: unknown;
     try {
       parsed = YAML.parse(rawContents);
     } catch (err) {
-      throw new Error(
-        `Failed to parse local composite function "${functionPath}" YAML at ${absolutePath}`,
-        {
-          cause: err as Error,
-        }
-      );
+      throw new Error(`Failed to parse local function "${functionPath}" YAML at ${absolutePath}`, {
+        cause: err as Error,
+      });
     }
 
-    const result = CompositeFunctionConfigZ.safeParse(parsed);
+    const result = LocalFunctionConfigZ.safeParse(parsed);
     if (!result.success) {
-      throw new Error(
-        `Invalid composite function "${functionPath}": ${z.prettifyError(result.error)}`
-      );
+      throw new Error(`Invalid local function "${functionPath}": ${z.prettifyError(result.error)}`);
+    }
+
+    const config = result.data;
+    // Steps parser expects an absolute module path.
+    if (isLegacyFunctionConfig(config) && config.path !== undefined) {
+      config.path = await resolveAndValidateLegacyFunctionModulePathAsync({
+        projectRoot,
+        functionPath,
+        modulePath: config.path,
+      });
     }
 
     logger?.debug(
-      `Loaded local composite function "${functionPath}" from ${path.relative(projectRoot, absolutePath)}`
+      `Loaded local function "${functionPath}" from ${path.relative(projectRoot, absolutePath)}`
     );
-    return result.data;
+    return config;
   }
 
   throw new Error(
-    `Local composite function "${functionPath}" was referenced by a step but no such composite function exists. A local composite function is resolved from a "function.yml" (or "function.yaml") file at the referenced path relative to the EAS project root (e.g. "uses: ${functionPath}" resolves "${functionPath}/function.yml"). The recommended convention is to keep composite functions under ".eas/functions/<name>".`
+    `Local function "${functionPath}" was referenced by a step but no such local function exists. A local function is resolved from a "function.yml" (or "function.yaml") file at the referenced path relative to the EAS project root (e.g. "uses: ${functionPath}" resolves "${functionPath}/function.yml"). The recommended convention is to keep local functions under ".eas/functions/<name>".`
   );
 }
 
@@ -188,7 +204,7 @@ export async function loadLocalFunctionConfigAsync(
 export function createLocalFunctionLoader(
   projectRoot: string,
   { logger }: { logger?: LocalFunctionLogger } = {}
-): (functionPath: string) => Promise<CompositeFunctionConfig> {
+): (functionPath: string) => Promise<LocalFunctionConfig> {
   return async functionPath =>
     await loadLocalFunctionConfigAsync(projectRoot, functionPath, { logger });
 }
@@ -197,22 +213,24 @@ export function createLocalFunctionLoader(
 export async function buildLocalFunctionCatalogAsync(
   projectRoot: string,
   { rootSteps, logger }: { rootSteps: readonly Step[]; logger?: LocalFunctionLogger }
-): Promise<CompositeFunctionCatalog> {
+): Promise<LocalFunctionCatalog> {
   return await buildLocalFunctionCatalogFromStepsAsync({
     rootSteps,
     loadLocalFunction: createLocalFunctionLoader(projectRoot, { logger }),
   });
 }
 
-function collectLocalFunctionPathsFromSteps(steps: readonly Step[]): Set<string> {
-  const paths = new Set<string>();
+function collectLocalFunctionCallsFromSteps(steps: readonly Step[]): Map<string, boolean> {
+  const calledWithWorkingDirectoryByPath = new Map<string, boolean>();
   for (const step of steps) {
     if (step.uses !== undefined && isLocalFunctionPath(step.uses)) {
-      if (step.working_directory !== undefined) {
-        throw new BuildConfigError(getLocalFunctionCallWorkingDirectoryError(step.uses));
-      }
-      paths.add(parseLocalFunctionPath(step.uses));
+      const functionPath = parseLocalFunctionPath(step.uses);
+      calledWithWorkingDirectoryByPath.set(
+        functionPath,
+        (calledWithWorkingDirectoryByPath.get(functionPath) ?? false) ||
+          step.working_directory !== undefined
+      );
     }
   }
-  return paths;
+  return calledWithWorkingDirectoryByPath;
 }

--- a/packages/steps/src/utils/localFunctions.ts
+++ b/packages/steps/src/utils/localFunctions.ts
@@ -1,4 +1,6 @@
 import {
+  CompositeFunctionCatalog,
+  CompositeFunctionConfig,
   LocalFunctionCatalog,
   LocalFunctionConfig,
   LocalFunctionConfigZ,
@@ -217,6 +219,95 @@ export async function buildLocalFunctionCatalogAsync(
   return await buildLocalFunctionCatalogFromStepsAsync({
     rootSteps,
     loadLocalFunction: createLocalFunctionLoader(projectRoot, { logger }),
+  });
+}
+
+// Deprecated aliases for the pre-rename "local composite function" API, published up to v21.8.0.
+// The wrappers keep the composite-only contract of that API: a legacy command/path function fails
+// to load, exactly like it failed CompositeFunctionConfigZ validation before the rename.
+
+/** @deprecated Use `parseLocalFunctionPath`. */
+export const parseLocalCompositeFunctionPath = parseLocalFunctionPath;
+
+/** @deprecated Use `isLocalFunctionPath`. */
+export const isLocalCompositeFunctionPath = isLocalFunctionPath;
+
+/** @deprecated Use `getLocalFunctionCallWorkingDirectoryError`. */
+export const getLocalCompositeFunctionCallWorkingDirectoryError =
+  getLocalFunctionCallWorkingDirectoryError;
+
+/** @deprecated Use `resolveLocalFunctionPath`. */
+export const resolveLocalCompositeFunctionPath = resolveLocalFunctionPath;
+
+/** @deprecated Use `LocalFunctionLogger`. */
+export type LocalCompositeFunctionLogger = LocalFunctionLogger;
+
+/** @deprecated Use `loadLocalFunctionConfigAsync`, which also loads legacy command/path functions. */
+export async function loadLocalCompositeFunctionConfigAsync(
+  projectRoot: string,
+  compositeFunctionPath: string,
+  { logger }: { logger?: LocalCompositeFunctionLogger } = {}
+): Promise<CompositeFunctionConfig> {
+  const config = await loadLocalFunctionConfigAsync(projectRoot, compositeFunctionPath, { logger });
+  if (isLegacyFunctionConfig(config)) {
+    throw new Error(
+      `Local function "${compositeFunctionPath}" declares "command" or "path". Use loadLocalFunctionConfigAsync to load legacy functions.`
+    );
+  }
+  return config;
+}
+
+/** @deprecated Use `createLocalFunctionLoader`, which also loads legacy command/path functions. */
+export function createLocalCompositeFunctionLoader(
+  projectRoot: string,
+  { logger }: { logger?: LocalCompositeFunctionLogger } = {}
+): (compositeFunctionPath: string) => Promise<CompositeFunctionConfig> {
+  return async compositeFunctionPath =>
+    await loadLocalCompositeFunctionConfigAsync(projectRoot, compositeFunctionPath, { logger });
+}
+
+/** @deprecated Use `buildLocalFunctionCatalogFromStepsAsync`. */
+export async function buildCompositeFunctionCatalogFromStepsAsync({
+  rootSteps,
+  loadCompositeFunction,
+}: {
+  rootSteps: readonly Step[];
+  loadCompositeFunction: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
+}): Promise<CompositeFunctionCatalog> {
+  const catalog: CompositeFunctionCatalog = {};
+  await extendLocalFunctionCatalogFromStepsAsync({
+    catalog,
+    rootSteps,
+    loadLocalFunction: loadCompositeFunction,
+  });
+  return catalog;
+}
+
+/** @deprecated Use `extendLocalFunctionCatalogFromStepsAsync`. */
+export async function extendCompositeFunctionCatalogFromStepsAsync({
+  catalog,
+  rootSteps,
+  loadCompositeFunction,
+}: {
+  catalog: CompositeFunctionCatalog;
+  rootSteps: readonly Step[];
+  loadCompositeFunction: (compositeFunctionPath: string) => Promise<CompositeFunctionConfig>;
+}): Promise<void> {
+  await extendLocalFunctionCatalogFromStepsAsync({
+    catalog,
+    rootSteps,
+    loadLocalFunction: loadCompositeFunction,
+  });
+}
+
+/** @deprecated Use `buildLocalFunctionCatalogAsync`, which also loads legacy command/path functions. */
+export async function buildLocalCompositeFunctionCatalogAsync(
+  projectRoot: string,
+  { rootSteps, logger }: { rootSteps: readonly Step[]; logger?: LocalCompositeFunctionLogger }
+): Promise<CompositeFunctionCatalog> {
+  return await buildCompositeFunctionCatalogFromStepsAsync({
+    rootSteps,
+    loadCompositeFunction: createLocalCompositeFunctionLoader(projectRoot, { logger }),
   });
 }
 

--- a/packages/steps/src/utils/localFunctions.ts
+++ b/packages/steps/src/utils/localFunctions.ts
@@ -12,6 +12,7 @@ import path from 'path';
 import YAML from 'yaml';
 import { z } from 'zod';
 
+import { normalizeLegacyFunctionConfigInputs } from './legacyFunction';
 import { BuildConfigError } from '../errors';
 
 // Local functions referenced via `uses: ./path` or `uses: ../path` in EAS workflows.
@@ -182,13 +183,16 @@ export async function loadLocalFunctionConfigAsync(
     }
 
     const config = result.data;
-    // Steps parser expects an absolute module path.
-    if (isLegacyFunctionConfig(config) && config.path !== undefined) {
-      config.path = await resolveAndValidateLegacyFunctionModulePathAsync({
-        projectRoot,
-        functionPath,
-        modulePath: config.path,
-      });
+    if (isLegacyFunctionConfig(config)) {
+      normalizeLegacyFunctionConfigInputs(functionPath, config);
+      // Steps parser expects an absolute module path.
+      if (config.path !== undefined) {
+        config.path = await resolveAndValidateLegacyFunctionModulePathAsync({
+          projectRoot,
+          functionPath,
+          modulePath: config.path,
+        });
+      }
     }
 
     logger?.debug(

--- a/packages/steps/src/utils/localFunctions.ts
+++ b/packages/steps/src/utils/localFunctions.ts
@@ -1,12 +1,11 @@
 import {
-  CompositeFunctionConfig,
-  CompositeFunctionConfigZ,
   LocalFunctionCatalog,
   LocalFunctionConfig,
+  LocalFunctionConfigZ,
   Step,
   isLegacyFunctionConfig,
 } from '@expo/eas-build-job';
-import fs from 'fs/promises';
+import fs from 'fs-extra';
 import path from 'path';
 import YAML from 'yaml';
 import { z } from 'zod';
@@ -28,12 +27,12 @@ export function parseLocalFunctionPath(uses: string): string {
   // known statically.
   if (doesLocalFunctionPathRequireInterpolation(trimmed)) {
     throw new BuildConfigError(
-      `Local composite function path "${trimmed}" must not contain interpolation ("\${{ ... }}"). The "uses" path for a local composite function must be a static, literal path.`
+      `Local function path "${trimmed}" must not contain interpolation ("\${{ ... }}"). The "uses" path for a local function must be a static, literal path.`
     );
   }
   if (trimmed.includes('\\')) {
     throw new BuildConfigError(
-      `Local composite function path "${trimmed}" must not contain backslashes. Use forward slashes as path separators.`
+      `Local function path "${trimmed}" must not contain backslashes. Use forward slashes as path separators.`
     );
   }
   const normalized = path.posix.normalize(trimmed.replace(/\/+$/, ''));
@@ -49,7 +48,7 @@ export function isLocalFunctionPath(uses: string): boolean {
 }
 
 export function getLocalFunctionCallWorkingDirectoryError(uses: string): string {
-  return `"working_directory" is not supported on a step that calls a local function ("uses: ${uses.trim()}"). For a composite function, set "working_directory" on the steps inside it; for a single-step "command" function, change directories inside the command.`;
+  return `"working_directory" is not supported on a step that calls a local composite function ("uses: ${uses.trim()}"). The call step expands away; set "working_directory" on the steps inside the composite function instead.`;
 }
 
 /** Loads only functions transitively referenced by `rootSteps`. Unreferenced files are ignored. */
@@ -75,25 +74,36 @@ export async function extendLocalFunctionCatalogFromStepsAsync({
   rootSteps: readonly Step[];
   loadLocalFunction: (functionPath: string) => Promise<LocalFunctionConfig>;
 }): Promise<void> {
-  const loadRecursiveAsync = async (functionPath: string): Promise<void> => {
-    if (functionPath in catalog) {
+  const loadRecursiveAsync = async (
+    functionPath: string,
+    calledWithWorkingDirectory: boolean
+  ): Promise<void> => {
+    const alreadyLoaded = functionPath in catalog;
+    const config = alreadyLoaded ? catalog[functionPath] : await loadLocalFunction(functionPath);
+
+    // working_directory is invalid on composite calls. Shape is only known after load.
+    if (calledWithWorkingDirectory && !isLegacyFunctionConfig(config)) {
+      throw new BuildConfigError(getLocalFunctionCallWorkingDirectoryError(functionPath));
+    }
+    if (alreadyLoaded) {
       return;
     }
-
-    const config = await loadLocalFunction(functionPath);
     catalog[functionPath] = config;
 
-    // Single-step functions are leaves: they have no steps that could reference other functions.
     if (isLegacyFunctionConfig(config)) {
       return;
     }
-    for (const nestedPath of collectLocalFunctionPathsFromSteps(config.runs.steps)) {
-      await loadRecursiveAsync(nestedPath);
+    for (const [nestedPath, nestedCalledWithWorkingDirectory] of collectLocalFunctionCallsFromSteps(
+      config.runs.steps
+    )) {
+      await loadRecursiveAsync(nestedPath, nestedCalledWithWorkingDirectory);
     }
   };
 
-  for (const functionPath of collectLocalFunctionPathsFromSteps(rootSteps)) {
-    await loadRecursiveAsync(functionPath);
+  for (const [functionPath, calledWithWorkingDirectory] of collectLocalFunctionCallsFromSteps(
+    rootSteps
+  )) {
+    await loadRecursiveAsync(functionPath, calledWithWorkingDirectory);
   }
 }
 
@@ -101,12 +111,7 @@ export function resolveLocalFunctionPath(projectRoot: string, functionPath: stri
   return path.resolve(projectRoot, functionPath);
 }
 
-/**
- * Resolves the `path` of a single-step local function against the function's own directory, the
- * way a `.eas/build` config resolves it against the config file. Shared by every loader so the
- * two cannot drift.
- */
-export function resolveLegacyFunctionModulePath({
+async function resolveAndValidateLegacyFunctionModulePathAsync({
   projectRoot,
   functionPath,
   modulePath,
@@ -114,11 +119,21 @@ export function resolveLegacyFunctionModulePath({
   projectRoot: string;
   functionPath: string;
   modulePath: string;
-}): string {
-  if (path.isAbsolute(modulePath)) {
-    return modulePath;
+}): Promise<string> {
+  const resolvedModulePath = path.isAbsolute(modulePath)
+    ? modulePath
+    : path.resolve(resolveLocalFunctionPath(projectRoot, functionPath), modulePath);
+  if (!(await fs.pathExists(resolvedModulePath))) {
+    throw new Error(
+      `Local function "${functionPath}" declares "path: ${modulePath}", but there is no such directory at ${resolvedModulePath}.`
+    );
   }
-  return path.resolve(resolveLocalFunctionPath(projectRoot, functionPath), modulePath);
+  if (!(await fs.pathExists(path.join(resolvedModulePath, 'package.json')))) {
+    throw new Error(
+      `Local function "${functionPath}" declares "path: ${modulePath}", but the module directory ${resolvedModulePath} does not contain a package.json file.`
+    );
+  }
+  return resolvedModulePath;
 }
 
 export interface LocalFunctionLogger {
@@ -133,7 +148,7 @@ export async function loadLocalFunctionConfigAsync(
   projectRoot: string,
   functionPath: string,
   { logger }: { logger?: LocalFunctionLogger } = {}
-): Promise<CompositeFunctionConfig> {
+): Promise<LocalFunctionConfig> {
   const resolvedPath = resolveLocalFunctionPath(projectRoot, functionPath);
 
   for (const ext of ['yml', 'yaml'] as const) {
@@ -145,41 +160,43 @@ export async function loadLocalFunctionConfigAsync(
       if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
         continue;
       }
-      throw new Error(
-        `Failed to read local composite function "${functionPath}" from ${absolutePath}`,
-        {
-          cause: err as Error,
-        }
-      );
+      throw new Error(`Failed to read local function "${functionPath}" from ${absolutePath}`, {
+        cause: err as Error,
+      });
     }
 
     let parsed: unknown;
     try {
       parsed = YAML.parse(rawContents);
     } catch (err) {
-      throw new Error(
-        `Failed to parse local composite function "${functionPath}" YAML at ${absolutePath}`,
-        {
-          cause: err as Error,
-        }
-      );
+      throw new Error(`Failed to parse local function "${functionPath}" YAML at ${absolutePath}`, {
+        cause: err as Error,
+      });
     }
 
-    const result = CompositeFunctionConfigZ.safeParse(parsed);
+    const result = LocalFunctionConfigZ.safeParse(parsed);
     if (!result.success) {
-      throw new Error(
-        `Invalid composite function "${functionPath}": ${z.prettifyError(result.error)}`
-      );
+      throw new Error(`Invalid local function "${functionPath}": ${z.prettifyError(result.error)}`);
+    }
+
+    const config = result.data;
+    // Steps parser expects an absolute module path.
+    if (isLegacyFunctionConfig(config) && config.path !== undefined) {
+      config.path = await resolveAndValidateLegacyFunctionModulePathAsync({
+        projectRoot,
+        functionPath,
+        modulePath: config.path,
+      });
     }
 
     logger?.debug(
-      `Loaded local composite function "${functionPath}" from ${path.relative(projectRoot, absolutePath)}`
+      `Loaded local function "${functionPath}" from ${path.relative(projectRoot, absolutePath)}`
     );
-    return result.data;
+    return config;
   }
 
   throw new Error(
-    `Local composite function "${functionPath}" was referenced by a step but no such composite function exists. A local composite function is resolved from a "function.yml" (or "function.yaml") file at the referenced path relative to the EAS project root (e.g. "uses: ${functionPath}" resolves "${functionPath}/function.yml"). The recommended convention is to keep composite functions under ".eas/functions/<name>".`
+    `Local function "${functionPath}" was referenced by a step but no such local function exists. A local function is resolved from a "function.yml" (or "function.yaml") file at the referenced path relative to the EAS project root (e.g. "uses: ${functionPath}" resolves "${functionPath}/function.yml"). The recommended convention is to keep local functions under ".eas/functions/<name>".`
   );
 }
 
@@ -187,7 +204,7 @@ export async function loadLocalFunctionConfigAsync(
 export function createLocalFunctionLoader(
   projectRoot: string,
   { logger }: { logger?: LocalFunctionLogger } = {}
-): (functionPath: string) => Promise<CompositeFunctionConfig> {
+): (functionPath: string) => Promise<LocalFunctionConfig> {
   return async functionPath =>
     await loadLocalFunctionConfigAsync(projectRoot, functionPath, { logger });
 }
@@ -203,15 +220,17 @@ export async function buildLocalFunctionCatalogAsync(
   });
 }
 
-function collectLocalFunctionPathsFromSteps(steps: readonly Step[]): Set<string> {
-  const paths = new Set<string>();
+function collectLocalFunctionCallsFromSteps(steps: readonly Step[]): Map<string, boolean> {
+  const calledWithWorkingDirectoryByPath = new Map<string, boolean>();
   for (const step of steps) {
     if (step.uses !== undefined && isLocalFunctionPath(step.uses)) {
-      if (step.working_directory !== undefined) {
-        throw new BuildConfigError(getLocalFunctionCallWorkingDirectoryError(step.uses));
-      }
-      paths.add(parseLocalFunctionPath(step.uses));
+      const functionPath = parseLocalFunctionPath(step.uses);
+      calledWithWorkingDirectoryByPath.set(
+        functionPath,
+        (calledWithWorkingDirectoryByPath.get(functionPath) ?? false) ||
+          step.working_directory !== undefined
+      );
     }
   }
-  return paths;
+  return calledWithWorkingDirectoryByPath;
 }


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We want to grandfather the legacy reusable functions from custom builds (https://docs.expo.dev/custom-builds/functions/) into the new reusable functions that can be used in workflows. This is to make the migration from custom builds to workflows easier.

This PR adds support for parsing the legacy custom build functions into workflow steps.

# How

First, across `steps`, and the consumers (`build-tools` and `eas-cli`):

- Rename “composite local function” occurrences to “local function” in places where we support both composite and legacy functions (this is done in the first commit so I recommend taking a look and then reviewing the rest of the commits to avoid the renaming noise).

The actual feature in `steps`:

- Load legacy functions in the local function catalog (`utils/localFunctions.ts`).
  - Functions that specify `path:` have the `path` resolved in this step.
- Map a legacy config to `BuildFunction` (`utils/legacyFunction.ts`).
  -  Inputs and outputs default to required, which match the legacy functions, but is different from composites.
- Expand a legacy call into a single build step (`LocalFunctionExpander`). `BuildStep` already has the machinery to run such function.
  - Note: unlike composite functions, `working_directory` set by the caller is allowed, because there's just one step.

This affects consumers:

- `build-tools`: legacy functions referenced in workflows, hooks or composite functions used in workflows are now loaded.
- `eas-cli`: `eas workflow:validate` accepts legacy functions.

# Test Plan

Added unit tests.
