### PR TITLE
[eas-cli] Validate legacy command/path local functions referenced from workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Set the artifact kind for Argent session artifacts from the MIME type reported by the tool server, so screenshots and screen recordings are grouped and labelled on the simulator session page instead of appearing in an unclassified file list. ([#4154](https://github.com/expo/eas-cli/pull/4154) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Load local functions declaring `command` or `path`, so custom build functions moved from `.eas/build` configs into `.eas/functions` can be called from workflows. ([#4096](https://github.com/expo/eas-cli/pull/4096) by [@sswrk](https://github.com/sswrk))
+- [eas-cli] Validate local functions declaring `command` or `path` referenced from workflows, including that the module directory of a `path` function exists. ([#4098](https://github.com/expo/eas-cli/pull/4098) by [@sswrk](https://github.com/sswrk))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commandUtils/workflow/__tests__/localFunctions-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/__tests__/localFunctions-test.ts
@@ -271,4 +271,24 @@ describe(validateWorkflowLocalFunctionsAsync, () => {
       validateWorkflowLocalFunctionsAsync(workflow, projectDir)
     ).resolves.toBeUndefined();
   });
+
+  it('validates a referenced single-step command function', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-workflow-functions-command-'));
+    await makeProjectWithCompositeFunctionAsync(
+      projectRoot,
+      'say-hi',
+      ['inputs:', '  - name', 'command: echo "Hi, ${ inputs.name }!"'].join('\n')
+    );
+    const workflow = {
+      jobs: {
+        job: {
+          steps: [{ uses: './.eas/functions/say-hi', with: { name: 'World' } }],
+        },
+      },
+    };
+
+    await expect(
+      validateWorkflowLocalFunctionsAsync(workflow, projectRoot)
+    ).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

# How

# Test Plan
