### PR TITLE
[eas-cli] Support naming simulator sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [build-tools] Collect and upload Argent tool-server session events during remote simulator sessions, mirroring agent-device event collection. ([#4067](https://github.com/expo/eas-cli/pull/4067) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Add `--name` to `eas simulator:start` and show simulator session names in `eas simulator:get` and `eas simulator:list`. ([#4099](https://github.com/expo/eas-cli/pull/4099) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -35059,6 +35059,18 @@
             "deprecationReason": null
           },
           {
+            "name": "name",
+            "description": "Human-readable label for the session, at most 255 characters. If omitted, the\nsession is unnamed and clients fall back to identifying it by id.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "packageVersion",
             "description": "The version of the package backing the device run session (e.g. \"0.1.3-alpha.3\").\nIf omitted, consumers treat the session as pinned to \"latest\".",
             "type": {
@@ -40641,6 +40653,18 @@
             "type": {
               "kind": "INTERFACE",
               "name": "Actor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "Human-readable label chosen by whoever started the session. Null when the\nsession was started without one.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,

--- a/packages/eas-cli/src/commands/simulator/__tests__/get.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/get.test.ts
@@ -9,6 +9,7 @@ import {
   JobRunStatus,
 } from '../../../graphql/generated';
 import { DeviceRunSessionQuery } from '../../../graphql/queries/DeviceRunSessionQuery';
+import Log from '../../../log';
 import {
   EAS_SIMULATOR_SESSION_ID,
   SIMULATOR_DOTENV_FILE_NAME,
@@ -46,6 +47,7 @@ const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
 function makeDeviceRunSession(overrides: Partial<DeviceRunSessionById> = {}): DeviceRunSessionById {
   return {
     id: 'session-123',
+    name: null,
     status: DeviceRunSessionStatus.InProgress,
     type: DeviceRunSessionType.AgentDevice,
     platform: AppPlatform.Ios,
@@ -134,6 +136,7 @@ describe(SimulatorGet, () => {
     expect(mockByIdAsync).toHaveBeenCalledWith(graphqlClient, 'session-123');
     expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
       id: 'session-123',
+      name: undefined,
       type: 'agent-device',
       status: DeviceRunSessionStatus.InProgress,
       platform: AppPlatform.Ios,
@@ -146,6 +149,26 @@ describe(SimulatorGet, () => {
       remoteConfig: session.remoteConfig,
       artifacts: session.artifacts,
     });
+  });
+
+  it('includes the session name in JSON and human output when the session is named', async () => {
+    mockByIdAsync.mockResolvedValue(makeDeviceRunSession({ name: 'Checkout regression' }));
+
+    const { command } = createCommand(['--id', 'session-123', '--json']);
+    await command.runAsync();
+
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Checkout regression' })
+    );
+
+    jest.clearAllMocks();
+    mockLoadSimulatorEnvironmentVariablesAsync.mockResolvedValue();
+    mockByIdAsync.mockResolvedValue(makeDeviceRunSession({ name: 'Checkout regression' }));
+
+    const { command: humanCommand } = createCommand(['--id', 'session-123']);
+    await humanCommand.runAsync();
+
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('Checkout regression'));
   });
 
   it(`uses ${EAS_SIMULATOR_SESSION_ID} from simulator env when --id is not passed`, async () => {

--- a/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
@@ -9,6 +9,7 @@ import {
   JobRunStatus,
 } from '../../../graphql/generated';
 import { DeviceRunSessionQuery } from '../../../graphql/queries/DeviceRunSessionQuery';
+import Log from '../../../log';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
 import SimulatorList from '../list';
 
@@ -40,6 +41,7 @@ const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
 function makeSession(overrides: Partial<DeviceRunSessionNode> = {}): DeviceRunSessionNode {
   return {
     id: 'session-123',
+    name: null,
     status: DeviceRunSessionStatus.InProgress,
     type: DeviceRunSessionType.AgentDevice,
     platform: AppPlatform.Ios,
@@ -129,6 +131,7 @@ describe(SimulatorList, () => {
       sessions: [
         {
           id: 'session-123',
+          name: undefined,
           type: 'agent-device',
           status: DeviceRunSessionStatus.InProgress,
           platform: AppPlatform.Ios,
@@ -178,6 +181,26 @@ describe(SimulatorList, () => {
         platforms: [AppPlatform.Ios],
       },
     });
+  });
+
+  it('prints a name row for every session, named or not', async () => {
+    mockListByAppIdAsync.mockResolvedValue(
+      makeConnection([
+        makeSession({ id: 'session-1', name: 'Checkout regression' }),
+        makeSession({ id: 'session-2' }),
+      ])
+    );
+
+    const { command } = createCommand([]);
+    await command.runAsync();
+
+    const printed = jest
+      .mocked(Log.log)
+      .mock.calls.map(([entry]) => String(entry))
+      .join('\n');
+    expect(printed).toContain('Name:     Checkout regression');
+    expect(printed).toContain('Name:     null');
+    expect(printed.match(/Name:/g)).toHaveLength(2);
   });
 
   it('runs non-interactively without --json', async () => {

--- a/packages/eas-cli/src/commands/simulator/__tests__/start.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/start.test.ts
@@ -345,6 +345,32 @@ describe(SimulatorStart, () => {
     );
   });
 
+  it('trims --name before sending it', async () => {
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      '--name',
+      '  Checkout regression  ',
+    ]);
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ name: 'Checkout regression' })
+    );
+  });
+
+  it('omits a blank --name instead of letting the server reject it', async () => {
+    const { command } = createCommand(['--platform', 'ios', '--non-interactive', '--name', '   ']);
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ name: undefined })
+    );
+  });
+
   it('prompts to select the platform when --platform is omitted', async () => {
     mockPromptAsync.mockResolvedValueOnce({ selectedPlatform: AppPlatform.Android });
     mockByIdAsync

--- a/packages/eas-cli/src/commands/simulator/__tests__/start.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/start.test.ts
@@ -99,6 +99,7 @@ function makeCreatedDeviceRunSession(
 function makeDeviceRunSession(overrides: Partial<DeviceRunSessionById> = {}): DeviceRunSessionById {
   return {
     id: 'session-123',
+    name: null,
     status: DeviceRunSessionStatus.InProgress,
     type: DeviceRunSessionType.AgentDevice,
     platform: AppPlatform.Ios,
@@ -189,6 +190,7 @@ describe(SimulatorStart, () => {
     });
     expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(graphqlClient, {
       appId: 'project-123',
+      name: undefined,
       packageVersion: undefined,
       platform: AppPlatform.Ios,
       type: DeviceRunSessionType.AgentDevice,
@@ -278,6 +280,7 @@ describe(SimulatorStart, () => {
     );
     expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(graphqlClient, {
       appId: 'project-123',
+      name: undefined,
       packageVersion: undefined,
       platform: AppPlatform.Ios,
       type: DeviceRunSessionType.AgentDevice,
@@ -297,6 +300,7 @@ describe(SimulatorStart, () => {
     );
     expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(graphqlClient, {
       appId: 'project-123',
+      name: undefined,
       packageVersion: undefined,
       platform: AppPlatform.Ios,
       type: DeviceRunSessionType.AgentDevice,
@@ -323,6 +327,22 @@ describe(SimulatorStart, () => {
     await command.runAsync();
 
     expect(mockResetSimulatorEnvAsync).toHaveBeenCalledWith(projectDir);
+  });
+
+  it('forwards --name to the create mutation', async () => {
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      '--name',
+      'Checkout regression',
+    ]);
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ name: 'Checkout regression' })
+    );
   });
 
   it('prompts to select the platform when --platform is omitted', async () => {

--- a/packages/eas-cli/src/commands/simulator/get.ts
+++ b/packages/eas-cli/src/commands/simulator/get.ts
@@ -85,6 +85,7 @@ export default class SimulatorGet extends EasCommand {
     if (jsonFlag) {
       printJsonOnlyOutput({
         id: session.id,
+        name: session.name ?? undefined,
         type: deviceRunSessionTypeToFlagValue(session.type),
         status: session.status,
         platform: session.platform,
@@ -120,6 +121,7 @@ export default class SimulatorGet extends EasCommand {
 function formatSessionFields(session: DeviceRunSessionById, deviceRunSessionUrl: string): string {
   return formatFields([
     { label: 'ID', value: session.id },
+    { label: 'Name', value: formatNullable(session.name) },
     { label: 'Type', value: session.type },
     { label: 'Status', value: session.status },
     { label: 'Platform', value: session.platform },

--- a/packages/eas-cli/src/commands/simulator/list.ts
+++ b/packages/eas-cli/src/commands/simulator/list.ts
@@ -131,6 +131,7 @@ export default class SimulatorList extends EasCommand {
       printJsonOnlyOutput({
         sessions: sessions.map(session => ({
           id: session.id,
+          name: session.name ?? undefined,
           type: deviceRunSessionTypeToFlagValue(session.type),
           status: session.status,
           platform: session.platform,
@@ -163,6 +164,7 @@ export default class SimulatorList extends EasCommand {
       );
       const lines = [
         `ID:       ${session.id}`,
+        `Name:     ${session.name ?? 'null'}`,
         `Type:     ${session.type}`,
         `Status:   ${session.status}`,
         `Platform: ${session.platform}`,

--- a/packages/eas-cli/src/commands/simulator/start.ts
+++ b/packages/eas-cli/src/commands/simulator/start.ts
@@ -115,6 +115,10 @@ export default class SimulatorStart extends EasCommand {
       nonInteractive,
     });
 
+    // The server rejects blank names, so trim here and treat a whitespace-only
+    // --name as if it had been omitted rather than surfacing a validation error.
+    const name = flags.name?.trim() || undefined;
+
     await loadSimulatorEnvAsync(projectDir);
     const existingDeviceRunSessionId = process.env[EAS_SIMULATOR_SESSION_ID];
     if (existingDeviceRunSessionId && !flags.force) {
@@ -140,7 +144,7 @@ export default class SimulatorStart extends EasCommand {
     try {
       const session = await DeviceRunSessionMutation.createDeviceRunSessionAsync(graphqlClient, {
         appId: projectId,
-        name: flags.name,
+        name,
         platform,
         type: DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE[flags.type],
         packageVersion: flags['package-version'],
@@ -229,7 +233,7 @@ export default class SimulatorStart extends EasCommand {
     if (jsonFlag) {
       printJsonOnlyOutput({
         id: deviceRunSessionId,
-        name: flags.name,
+        name,
         type: flags.type,
         deviceRunSessionUrl,
         remoteConfig,

--- a/packages/eas-cli/src/commands/simulator/start.ts
+++ b/packages/eas-cli/src/commands/simulator/start.ts
@@ -61,6 +61,10 @@ export default class SimulatorStart extends EasCommand {
       description: 'Device platform',
       options: PLATFORM_FLAG_VALUES,
     })(),
+    name: Flags.string({
+      description:
+        'Human-readable name for the simulator session, shown in eas simulator:list and on expo.dev. Defaults to unnamed.',
+    }),
     type: Flags.option({
       description: 'Type of simulator session to create',
       options: Object.values(DEVICE_RUN_SESSION_TYPE_FLAG_VALUES),
@@ -136,6 +140,7 @@ export default class SimulatorStart extends EasCommand {
     try {
       const session = await DeviceRunSessionMutation.createDeviceRunSessionAsync(graphqlClient, {
         appId: projectId,
+        name: flags.name,
         platform,
         type: DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE[flags.type],
         packageVersion: flags['package-version'],
@@ -224,6 +229,7 @@ export default class SimulatorStart extends EasCommand {
     if (jsonFlag) {
       printJsonOnlyOutput({
         id: deviceRunSessionId,
+        name: flags.name,
         type: flags.type,
         deviceRunSessionUrl,
         remoteConfig,

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -4934,6 +4934,11 @@ export type CreateDeviceRunSessionInput = {
    */
   maxRunTimeMinutes?: InputMaybe<Scalars['Int']['input']>;
   /**
+   * Human-readable label for the session, at most 255 characters. If omitted, the
+   * session is unnamed and clients fall back to identifying it by id.
+   */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /**
    * The version of the package backing the device run session (e.g. "0.1.3-alpha.3").
    * If omitted, consumers treat the session as pinned to "latest".
    */
@@ -5689,6 +5694,11 @@ export type DeviceRunSession = {
   finishedAt?: Maybe<Scalars['DateTime']['output']>;
   id: Scalars['ID']['output'];
   initiatingActor?: Maybe<Actor>;
+  /**
+   * Human-readable label chosen by whoever started the session. Null when the
+   * session was started without one.
+   */
+  name?: Maybe<Scalars['String']['output']>;
   /**
    * The version of the package backing the device run session. Null means the session is
    * pinned to "latest" at the consumer side.
@@ -14420,7 +14430,7 @@ export type DeviceRunSessionByIdQueryVariables = Exact<{
 }>;
 
 
-export type DeviceRunSessionByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, type: DeviceRunSessionType, platform: AppPlatform, createdAt: any, startedAt?: any | null, finishedAt?: any | null, updatedAt: any, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, artifacts: Array<{ __typename?: 'DeviceRunSessionArtifact', id: string, name: string, filename: string, downloadUrl: string, fileSizeBytes?: number | null, metadata?: any | null, createdAt: any, updatedAt: any }>, remoteConfig?:
+export type DeviceRunSessionByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, name?: string | null, status: DeviceRunSessionStatus, type: DeviceRunSessionType, platform: AppPlatform, createdAt: any, startedAt?: any | null, finishedAt?: any | null, updatedAt: any, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, artifacts: Array<{ __typename?: 'DeviceRunSessionArtifact', id: string, name: string, filename: string, downloadUrl: string, fileSizeBytes?: number | null, metadata?: any | null, createdAt: any, updatedAt: any }>, remoteConfig?:
         | { __typename: 'AgentDeviceRunSessionRemoteConfig', agentDeviceRemoteSessionUrl: string, agentDeviceRemoteSessionToken: string, webPreviewUrl?: string | null }
         | { __typename: 'ArgentRunSessionRemoteConfig', toolsUrl: string, toolsAuthToken?: string | null, webPreviewUrl?: string | null }
         | { __typename: 'ServeSimRunSessionRemoteConfig', previewUrl: string }
@@ -14434,7 +14444,7 @@ export type DeviceRunSessionsByAppIdQueryVariables = Exact<{
 }>;
 
 
-export type DeviceRunSessionsByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, deviceRunSessionsPaginated: { __typename?: 'AppDeviceRunSessionsConnection', edges: Array<{ __typename?: 'AppDeviceRunSessionEdge', cursor: string, node: { __typename?: 'DeviceRunSession', id: string, status: DeviceRunSessionStatus, type: DeviceRunSessionType, platform: AppPlatform, createdAt: any, startedAt?: any | null, finishedAt?: any | null, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
+export type DeviceRunSessionsByAppIdQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, deviceRunSessionsPaginated: { __typename?: 'AppDeviceRunSessionsConnection', edges: Array<{ __typename?: 'AppDeviceRunSessionEdge', cursor: string, node: { __typename?: 'DeviceRunSession', id: string, name?: string | null, status: DeviceRunSessionStatus, type: DeviceRunSessionType, platform: AppPlatform, createdAt: any, startedAt?: any | null, finishedAt?: any | null, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type ViewEmbeddedUpdateByIdQueryVariables = Exact<{
   embeddedUpdateId: Scalars['ID']['input'];

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
@@ -23,6 +23,7 @@ export const DeviceRunSessionQuery = {
               deviceRunSessions {
                 byId(deviceRunSessionId: $deviceRunSessionId) {
                   id
+                  name
                   status
                   type
                   platform
@@ -111,6 +112,7 @@ export const DeviceRunSessionQuery = {
                       cursor
                       node {
                         id
+                        name
                         status
                         type
                         platform


### PR DESCRIPTION
# Why

Simulator sessions are only identifiable by a UUID, so juggling several at once means matching ids by hand. Part of ENG-25427, alongside expo/universe#29429 (server) and expo/universe#29430 (dashboard).

Depends on expo/universe#29429 being deployed to production. Until then `verify-graphql-code` fails during codegen document validation with `Cannot query field "name" on type "DeviceRunSession"`, because it introspects `api.expo.dev`. Everything else, including the tests on all three Node versions, passes.

# How

`eas simulator:start --name` forwards the label to `createDeviceRunSession`. `simulator:get` and `simulator:list` both always show a `Name` row, printing `null` when unset to match how those commands already render `Started at`, `Finished at`, and `Metadata`. Both include the name in `--json`, where `printJsonOnlyOutput` drops it when unset.

`generated.ts` and `graphql.schema.json` were produced by running codegen against the committed prod introspection snapshot with the new field injected, so the diff is exactly the `name` additions. They should be a no-op once regenerated against a deployed server.

# Test Plan

CI passes, apart from the GraphQL check noted above, which needs expo/universe#29429 deployed first.
