### PR TITLE
[eas-cli] Apply --session-id in observe:events summary mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Apply --session-id in observe:events summary mode. ([#4100](https://github.com/expo/eas-cli/pull/4100) by [@douglowder](https://github.com/douglowder))
 - [eas-cli] Suggest running `agent-device` via `npx` in EAS Simulator session instructions. ([#4070](https://github.com/expo/eas-cli/pull/4070) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/observe/__tests__/events.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/events.test.ts
@@ -133,6 +133,17 @@ describe(ObserveEvents, () => {
     expect(options.eventName).toBeUndefined();
   });
 
+  it('routes to fetchObserveCustomEventsAsync with the session filter when --session-id is set with no positional arg', async () => {
+    const command = createCommand(['--session-id', 'session-xyz']);
+    await command.runAsync();
+
+    expect(mockFetchObserveCustomEventsAsync).toHaveBeenCalledTimes(1);
+    expect(mockCustomEventNamesAsync).not.toHaveBeenCalled();
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.eventName).toBeUndefined();
+    expect(options.sessionId).toBe('session-xyz');
+  });
+
   it('throws when both an event name argument and --all-events are provided', async () => {
     const command = createCommand(['my_event', '--all-events']);
     await expect(command.runAsync()).rejects.toThrow(

--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -55,7 +55,8 @@ export default class ObserveEvents extends EasCommand {
     ...ObserveAppVersionFlag,
     ...ObserveUpdateIdFlag,
     'session-id': Flags.string({
-      description: 'Filter by session ID',
+      description:
+        'Filter by session ID. When no event name is given, lists the events in the session instead of the event-name summary.',
     }),
     'all-events': Flags.boolean({
       description:
@@ -101,7 +102,10 @@ export default class ObserveEvents extends EasCommand {
 
     const platform = appObservePlatformFromFlag(flags.platform);
 
-    if (!args.eventName && !flags['all-events']) {
+    // A session ID narrows to a single session, so show that session's events
+    // (like --all-events) instead of the account-wide name+count summary, which
+    // has no session filter.
+    if (!args.eventName && !flags['all-events'] && !flags['session-id']) {
       const { names, isTruncated } = await withObservePlanGateHandlingAsync(() =>
         ObserveQuery.customEventNamesAsync(graphqlClient, {
           appId: projectId,


### PR DESCRIPTION
# Summary

Without an event name, observe:events showed the account-wide event-name summary, which has no session filter, so --session-id was ignored. When a session ID is given, take the events-list path (like --all-events) so the
session's events are shown filtered by the customEventList session filter.

# Test Plan

- New unit tests added
- Manual testing against a production project