### PR TITLE
[eas-cli] update deprecated posthog session replay package with new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Apply --session-id in observe:events summary mode. ([#4100](https://github.com/expo/eas-cli/pull/4100) by [@douglowder](https://github.com/douglowder))
 - [eas-cli] Suggest running `agent-device` via `npx` in EAS Simulator session instructions. ([#4070](https://github.com/expo/eas-cli/pull/4070) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Install `@posthog/react-native-plugin` instead of the deprecated `posthog-react-native-session-replay` package when connecting the PostHog integration. ([#4102](https://github.com/expo/eas-cli/pull/4102) by [@metehandemir](https://github.com/metehandemir))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
@@ -168,7 +168,7 @@ describe(IntegrationsPostHogConnect, () => {
 
     const installArgs = jest.mocked(spawnAsync).mock.calls[0][1];
     expect(installArgs).toContain('posthog-react-native');
-    expect(installArgs).toContain('posthog-react-native-session-replay');
+    expect(installArgs).toContain('@posthog/react-native-plugin');
     expect(createOrModifyExpoConfigAsync).toHaveBeenCalled();
     expect(fs.writeFile).toHaveBeenCalled();
 
@@ -221,7 +221,7 @@ describe(IntegrationsPostHogConnect, () => {
     await createCommand([]).runAsync();
 
     expect(jest.mocked(spawnAsync).mock.calls[0][1]).not.toContain(
-      'posthog-react-native-session-replay'
+      '@posthog/react-native-plugin'
     );
     const createdNames = jest
       .mocked(EnvironmentVariableMutation.createForAppAsync)
@@ -238,7 +238,7 @@ describe(IntegrationsPostHogConnect, () => {
     // The plugin wires native modules replay needs, so it must be added even without analytics.
     expect(createOrModifyExpoConfigAsync).toHaveBeenCalled();
     expect(jest.mocked(spawnAsync).mock.calls[0][1]).toContain(
-      'posthog-react-native-session-replay'
+      '@posthog/react-native-plugin'
     );
     // The public key + host initialize the SDK for any feature, so they're still written.
     const createdNames = jest
@@ -264,7 +264,7 @@ describe(IntegrationsPostHogConnect, () => {
     expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('Skipping error tracking'));
     // Session replay defaults on, so its package is still installed.
     expect(jest.mocked(spawnAsync).mock.calls[0][1]).toContain(
-      'posthog-react-native-session-replay'
+      '@posthog/react-native-plugin'
     );
   });
 
@@ -531,7 +531,7 @@ describe(IntegrationsPostHogConnect, () => {
 
     expect(promptAsync).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'features' }));
     expect(jest.mocked(spawnAsync).mock.calls[0][1]).not.toContain(
-      'posthog-react-native-session-replay'
+      '@posthog/react-native-plugin'
     );
   });
 

--- a/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
@@ -220,9 +220,7 @@ describe(IntegrationsPostHogConnect, () => {
 
     await createCommand([]).runAsync();
 
-    expect(jest.mocked(spawnAsync).mock.calls[0][1]).not.toContain(
-      '@posthog/react-native-plugin'
-    );
+    expect(jest.mocked(spawnAsync).mock.calls[0][1]).not.toContain('@posthog/react-native-plugin');
     const createdNames = jest
       .mocked(EnvironmentVariableMutation.createForAppAsync)
       .mock.calls.map(call => call[1].name);
@@ -237,9 +235,7 @@ describe(IntegrationsPostHogConnect, () => {
 
     // The plugin wires native modules replay needs, so it must be added even without analytics.
     expect(createOrModifyExpoConfigAsync).toHaveBeenCalled();
-    expect(jest.mocked(spawnAsync).mock.calls[0][1]).toContain(
-      '@posthog/react-native-plugin'
-    );
+    expect(jest.mocked(spawnAsync).mock.calls[0][1]).toContain('@posthog/react-native-plugin');
     // The public key + host initialize the SDK for any feature, so they're still written.
     const createdNames = jest
       .mocked(EnvironmentVariableMutation.createForAppAsync)
@@ -263,9 +259,7 @@ describe(IntegrationsPostHogConnect, () => {
     expect(createdNames).not.toContain('POSTHOG_CLI_API_KEY');
     expect(Log.warn).toHaveBeenCalledWith(expect.stringContaining('Skipping error tracking'));
     // Session replay defaults on, so its package is still installed.
-    expect(jest.mocked(spawnAsync).mock.calls[0][1]).toContain(
-      '@posthog/react-native-plugin'
-    );
+    expect(jest.mocked(spawnAsync).mock.calls[0][1]).toContain('@posthog/react-native-plugin');
   });
 
   it('non-interactive --error-tracking without a key fails before any provisioning', async () => {
@@ -530,9 +524,7 @@ describe(IntegrationsPostHogConnect, () => {
     await createCommand(['--no-session-replay']).runAsync();
 
     expect(promptAsync).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'features' }));
-    expect(jest.mocked(spawnAsync).mock.calls[0][1]).not.toContain(
-      '@posthog/react-native-plugin'
-    );
+    expect(jest.mocked(spawnAsync).mock.calls[0][1]).not.toContain('@posthog/react-native-plugin');
   });
 
   it('prompts for a personal API key and validates it', async () => {

--- a/packages/eas-cli/src/commands/integrations/posthog/connect.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/connect.ts
@@ -55,7 +55,7 @@ const SDK_PACKAGES = [
   'expo-device',
   'expo-localization',
 ];
-const SESSION_REPLAY_PACKAGE = 'posthog-react-native-session-replay';
+const SESSION_REPLAY_PACKAGE = '@posthog/react-native-plugin';
 const CONFIG_PLUGIN = 'posthog-react-native/expo';
 
 const EAS_POSTHOG_API_KEY_ENV_VAR_NAME = 'EXPO_PUBLIC_POSTHOG_API_KEY';


### PR DESCRIPTION
# Why

`eas integrations:posthog:connect` currently installs the deprecated `posthog-react-native-session-replay` package.

As of `posthog-react-native` **4.47.0+**, PostHog renamed this plugin to `@posthog/react-native-plugin`, which now provides both Session Replay and native error tracking. The old package is only intended for projects using versions of `posthog-react-native` earlier than `4.47.0`.

This change updates the integration to install the new package for supported versions, aligning the generated project with the current PostHog documentation.

Fixes #4101

# How

Updated the PostHog integration to use `@posthog/react-native-plugin` instead of `posthog-react-native-session-replay`.

The integration now follows the current PostHog package naming introduced in `posthog-react-native` 4.47.0+, avoiding installation of a deprecated dependency for new projects.

# Test Plan

Verified the change by running:

```sh
eas integrations:posthog:connect
```

Before this change:

```text
✔ Installed posthog-react-native-session-replay
```

After this change:

```text
✔ Installed @posthog/react-native-plugin
```

Confirmed that the generated project installs the new plugin successfully and that the PostHog integration continues to configure correctly.
