### PR TITLE
[eas-cli] clean up error handling in local builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] clean up error handling in local builds. ([#4105](https://github.com/expo/eas-cli/pull/4105) by [@douglowder](https://github.com/douglowder))
+
 ### 🧹 Chores
 
 ## [21.4.0](https://github.com/expo/eas-cli/releases/tag/v21.4.0) - 2026-07-28

--- a/packages/eas-cli/src/build/__tests__/local-test.ts
+++ b/packages/eas-cli/src/build/__tests__/local-test.ts
@@ -1,0 +1,52 @@
+import { Job, Metadata } from '@expo/eas-build-job';
+import spawnAsync from '@expo/spawn-async';
+
+import { runLocalBuildAsync } from '../local';
+
+jest.mock('@expo/spawn-async');
+
+const mockSpawnAsync = jest.mocked(spawnAsync);
+
+function decodeInput(base64: string): unknown {
+  return JSON.parse(Buffer.from(base64, 'base64').toString('utf8'));
+}
+
+describe(runLocalBuildAsync, () => {
+  const job = { type: 'test-job', secrets: { buildCredentials: 'super-secret' } } as unknown as Job;
+  const metadata = { appName: 'test' } as unknown as Metadata;
+
+  const originalPluginPath = process.env.EAS_LOCAL_BUILD_PLUGIN_PATH;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Use the plugin-path branch so the test doesn't shell out to `npm --version`.
+    process.env.EAS_LOCAL_BUILD_PLUGIN_PATH = '/path/to/plugin';
+    mockSpawnAsync.mockReturnValue(
+      Object.assign(Promise.resolve({} as any), { child: {} }) as any
+    );
+  });
+
+  afterAll(() => {
+    if (originalPluginPath === undefined) {
+      delete process.env.EAS_LOCAL_BUILD_PLUGIN_PATH;
+    } else {
+      process.env.EAS_LOCAL_BUILD_PLUGIN_PATH = originalPluginPath;
+    }
+  });
+
+  it('passes the job/metadata via EAS_LOCAL_BUILD_PLUGIN_INPUT, never as a command-line argument', async () => {
+    await runLocalBuildAsync(job, metadata, { verbose: true }, {});
+
+    expect(mockSpawnAsync).toHaveBeenCalledTimes(1);
+    const [command, args, spawnOptions] = mockSpawnAsync.mock.calls[0];
+
+    expect(command).toBe('/path/to/plugin');
+    // The credentials-bearing payload must not appear in argv.
+    expect(args).toEqual([]);
+    expect(JSON.stringify(args)).not.toContain('super-secret');
+
+    const input = (spawnOptions?.env as Record<string, string>).EAS_LOCAL_BUILD_PLUGIN_INPUT;
+    expect(input).toBeDefined();
+    expect(decodeInput(input)).toEqual({ job, metadata });
+  });
+});

--- a/packages/eas-cli/src/build/__tests__/local-test.ts
+++ b/packages/eas-cli/src/build/__tests__/local-test.ts
@@ -1,6 +1,7 @@
 import { Job, Metadata } from '@expo/eas-build-job';
 import spawnAsync from '@expo/spawn-async';
 
+import Log from '../../log';
 import { runLocalBuildAsync } from '../local';
 
 jest.mock('@expo/spawn-async');
@@ -48,5 +49,47 @@ describe(runLocalBuildAsync, () => {
     const input = (spawnOptions?.env as Record<string, string>).EAS_LOCAL_BUILD_PLUGIN_INPUT;
     expect(input).toBeDefined();
     expect(decodeInput(input)).toEqual({ job, metadata });
+  });
+
+  it('logs a non-secret build context summary and re-throws on failure', async () => {
+    const richJob = {
+      type: 'managed',
+      platform: 'ios',
+      projectRootDirectory: 'apps/mobile',
+      secrets: { buildCredentials: 'super-secret' },
+    } as unknown as Job;
+    const richMetadata = {
+      buildProfile: 'production',
+      cliVersion: '21.2.0',
+      sdkVersion: '57.0.0',
+      gitCommitHash: '2c9137d8',
+      isGitWorkingTreeDirty: true,
+      requiredPackageManager: 'pnpm',
+      trackingContext: { tracking_id: 'track-123', project_id: 'proj-456' },
+    } as unknown as Metadata;
+
+    const buildError = new Error('build failed');
+    const rejected = Promise.reject(buildError);
+    rejected.catch(() => {}); // avoid an unhandled-rejection warning before it's awaited
+    mockSpawnAsync.mockReturnValue(Object.assign(rejected, { child: {} }) as any);
+
+    const logSpy = jest.spyOn(Log, 'log').mockImplementation(() => {});
+
+    await expect(runLocalBuildAsync(richJob, richMetadata, { verbose: true }, {})).rejects.toBe(
+      buildError
+    );
+
+    const output = logSpy.mock.calls.flat().join('\n');
+    // Useful debugging context is surfaced...
+    expect(output).toContain('ios');
+    expect(output).toContain('production');
+    expect(output).toContain('apps/mobile');
+    expect(output).toContain('pnpm');
+    expect(output).toContain('2c9137d8');
+    expect(output).toContain('track-123');
+    // ...but secrets are never included.
+    expect(output).not.toContain('super-secret');
+
+    logSpy.mockRestore();
   });
 });

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -44,7 +44,12 @@ export async function runLocalBuildAsync(
   options: LocalBuildOptions,
   env: Env
 ): Promise<void> {
-  const { command, args } = await getCommandAndArgsAsync(job, metadata);
+  const { command, args } = await getCommandAndArgsAsync();
+  // The job carries build credentials, so it is passed to the plugin via an
+  // environment variable rather than a command-line argument. Otherwise it
+  // would be exposed in the process list and, on failure, in the spawn error
+  // message (which includes the command line) printed to stderr.
+  const pluginInput = Buffer.from(JSON.stringify({ job, metadata })).toString('base64');
   let spinner;
   if (!options.verbose) {
     spinner = ora().start(options.skipNativeBuild ? 'Preparing project' : 'Building project');
@@ -60,6 +65,7 @@ export async function runLocalBuildAsync(
     const mergedEnv = {
       ...env,
       ...process.env,
+      EAS_LOCAL_BUILD_PLUGIN_INPUT: pluginInput,
       EAS_LOCAL_BUILD_WORKINGDIR: options.workingdir ?? process.env.EAS_LOCAL_BUILD_WORKINGDIR,
       __API_SERVER_URL: getExpoApiBaseUrl(),
       ...(options.skipCleanup || options.skipNativeBuild
@@ -69,11 +75,12 @@ export async function runLocalBuildAsync(
       ...(options.artifactsDir ? { EAS_LOCAL_BUILD_ARTIFACTS_DIR: options.artifactsDir } : {}),
       ...(options.artifactPath ? { EAS_LOCAL_BUILD_ARTIFACT_PATH: options.artifactPath } : {}),
     };
-    // log command execution to assist in debugging local builds
+    // log command execution to assist in debugging local builds; redact the job
+    // input since it contains build credentials.
     Log.debug('Running local build, using local-build-plugin', {
       command,
       args,
-      env: mergedEnv,
+      env: { ...mergedEnv, EAS_LOCAL_BUILD_PLUGIN_INPUT: '[redacted]' },
     });
     const spawnPromise = spawnAsync(command, args, {
       stdio: options.verbose ? 'inherit' : 'pipe',
@@ -87,18 +94,16 @@ export async function runLocalBuildAsync(
   }
 }
 
-async function getCommandAndArgsAsync(
-  job: Job,
-  metadata: Metadata
-): Promise<{ command: string; args: string[] }> {
-  const jobAndMetadataBase64 = Buffer.from(JSON.stringify({ job, metadata })).toString('base64');
+async function getCommandAndArgsAsync(): Promise<{ command: string; args: string[] }> {
+  // The job/metadata payload is passed to the plugin via the
+  // EAS_LOCAL_BUILD_PLUGIN_INPUT environment variable, not as an argument.
   if (process.env.EAS_LOCAL_BUILD_PLUGIN_PATH) {
     return {
       command: process.env.EAS_LOCAL_BUILD_PLUGIN_PATH,
-      args: [jobAndMetadataBase64],
+      args: [],
     };
   } else {
-    const args = [`${PLUGIN_PACKAGE_NAME}@${PLUGIN_PACKAGE_VERSION}`, jobAndMetadataBase64];
+    const args = [`${PLUGIN_PACKAGE_NAME}@${PLUGIN_PACKAGE_VERSION}`];
     if (await isAtLeastNpm7Async()) {
       // npx shipped with npm >= 7.0.0 requires the "-y" flag to run commands without
       // prompting the user to install a package that is used for the first time

--- a/packages/eas-cli/src/build/local.ts
+++ b/packages/eas-cli/src/build/local.ts
@@ -1,5 +1,6 @@
 import { Env, Job, Metadata, version } from '@expo/eas-build-job';
 import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
 import { ChildProcess } from 'child_process';
 import semver from 'semver';
 
@@ -88,10 +89,61 @@ export async function runLocalBuildAsync(
     });
     childProcess = spawnPromise.child;
     await spawnPromise;
+  } catch (error) {
+    // The plugin's build output is already streamed to the terminal; add a
+    // concise context summary to help debug the failure. Never dump the raw
+    // job/metadata, which contains build credentials.
+    spinner?.stop();
+    logLocalBuildDebugInfo(job, metadata);
+    throw error;
   } finally {
     process.removeListener('SIGINT', interruptHandler);
     spinner?.stop();
   }
+}
+
+/**
+ * Logs an allowlisted, non-secret summary of the build's job/metadata to help
+ * a user debug a failed local build. Only known-safe fields are included —
+ * never the raw job/metadata (which carries credentials and other secrets).
+ */
+function logLocalBuildDebugInfo(job: Job, metadata: Metadata): void {
+  // `platform` and `projectRootDirectory` live on the platform-specific job
+  // variants; read them defensively since this is best-effort logging.
+  const jobFields = job as { platform?: string; projectRootDirectory?: string };
+  const trackingContext = metadata.trackingContext ?? {};
+
+  const fields: [string, string | number | boolean | undefined][] = [
+    ['Platform', jobFields.platform],
+    ['Build profile', metadata.buildProfile],
+    ['Workflow', metadata.workflow],
+    ['Distribution', metadata.distribution],
+    ['Credentials source', metadata.credentialsSource],
+    ['Project root directory', jobFields.projectRootDirectory],
+    ['Required package manager', metadata.requiredPackageManager],
+    ['eas-cli version', metadata.cliVersion],
+    ['SDK version', metadata.sdkVersion],
+    ['Runtime version', metadata.runtimeVersion],
+    ['React Native version', metadata.reactNativeVersion],
+    ['Expo package version', metadata.expoPackageVersion],
+    ['App version', metadata.appVersion],
+    ['Fingerprint hash', metadata.fingerprintHash],
+    ['Git commit', metadata.gitCommitHash],
+    ['Git working tree dirty', metadata.isGitWorkingTreeDirty],
+    ['Build tracking ID', trackingContext.tracking_id],
+    ['Project ID', trackingContext.project_id],
+  ];
+
+  const lines = fields
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([label, value]) => `  ${label}: ${String(value)}`);
+  if (lines.length === 0) {
+    return;
+  }
+
+  Log.newLine();
+  Log.log(chalk.bold('Build context (for debugging this failed local build):'));
+  Log.log(chalk.dim(lines.join('\n')));
 }
 
 async function getCommandAndArgsAsync(): Promise<{ command: string; args: string[] }> {

--- a/packages/local-build-plugin/src/parseInput.ts
+++ b/packages/local-build-plugin/src/parseInput.ts
@@ -28,7 +28,10 @@ export async function parseInputAsync(): Promise<Params> {
     console.log(packageJson.version);
     process.exit(0);
   }
-  const rawInput = process.argv[2];
+  const rawInput = process.env.EAS_LOCAL_BUILD_PLUGIN_INPUT;
+  // The input carries build credentials. Remove it from the environment right
+  // away so it is not inherited by the build subprocesses spawned below.
+  delete process.env.EAS_LOCAL_BUILD_PLUGIN_INPUT;
 
   if (!rawInput) {
     displayHelp();
@@ -38,7 +41,9 @@ export async function parseInputAsync(): Promise<Params> {
   try {
     parsedParams = JSON.parse(Buffer.from(rawInput, 'base64').toString('utf8'));
   } catch (err) {
-    console.error(`${chalk.red('The input passed as a argument is not base64 encoded json.')}`);
+    console.error(
+      `${chalk.red('The EAS_LOCAL_BUILD_PLUGIN_INPUT environment variable is not base64 encoded json.')}`
+    );
     throw err;
   }
   const params = validateParams(parsedParams);


### PR DESCRIPTION
# Why

Because all parameters were being passed to a local build as arguments, any error would cause all the parameters to be written to stderr as a large base64 string. This led to usability (error message awkward to read) and security (leaked credentials) issues.

# How

- Pass the build input parameters in the environment instead of arguments
- After extract them in the build function, remove them from the environment so they are not inherited by spawned subprocesses
- If an error occurs, surface an allowed list of known values in the input, to help with debugging

# Test Plan

- Tested locally in an EAS project
- New unit tests added
