### PR TITLE
[build-tools] Install ffmpeg for argent screen recording when missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [eas-cli] clean up error handling in local builds. ([#4105](https://github.com/expo/eas-cli/pull/4105) by [@douglowder](https://github.com/douglowder))
+- [build-tools] Install ffmpeg when it is missing so Argent screen recording works in EAS Simulator sessions. ([#4110](https://github.com/expo/eas-cli/pull/4110) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🧹 Chores
 

--- a/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
@@ -40,6 +40,7 @@ jest.mock('../../utils/argentEvents', () => ({
   startArgentEventCollectionAsync: jest.fn(),
 }));
 jest.mock('../../utils/remoteDeviceRunSession', () => ({
+  ensureFfmpegInstalledAsync: jest.fn(),
   getDeviceRunSessionIdOrThrow: jest.fn(),
   getNgrokAuthtokenOrThrow: jest.fn(),
   getNgrokTunnelDomainOrThrow: jest.fn(),

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -20,6 +20,7 @@ import { sleepAsync } from '../../utils/retry';
 import { pollArgentArtifactsForUploadAsync } from '../utils/argentArtifacts';
 import { ARGENT_EVENT_LOG_FILENAME, startArgentEventCollectionAsync } from '../utils/argentEvents';
 import {
+  ensureFfmpegInstalledAsync,
   getDeviceRunSessionIdOrThrow,
   getNgrokAuthtokenOrThrow,
   getNgrokTunnelDomainOrThrow,
@@ -88,6 +89,12 @@ export function createStartArgentRemoteSessionBuildFunction(
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
         await selectXcodeDeveloperDirectoryAsync({ env, logger });
       }
+
+      // Argent shells out to ffmpeg to record the screen. Installing it pulls a
+      // large Homebrew dependency tree, so do not block session readiness on it:
+      // the session comes up at its usual speed and only a recording started in
+      // the first moments misses ffmpeg. Never rejects, so `void` is safe.
+      void ensureFfmpegInstalledAsync({ runtimePlatform, env, logger });
 
       logger.info('Enabling the Argent artifacts list endpoint flag.');
       await spawn(

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -450,8 +450,39 @@ describe(ensureFfmpegInstalledAsync, () => {
     );
   });
 
-  it('warns instead of installing on linux, where Homebrew is unavailable', async () => {
-    spawnMock.mockReturnValueOnce(spawnRejected());
+  it('installs ffmpeg with apt on linux when it is missing', async () => {
+    spawnMock
+      .mockReturnValueOnce(spawnRejected()) // command -v ffmpeg
+      .mockReturnValueOnce(spawnResolved()) // apt-get update
+      .mockReturnValueOnce(spawnResolved()); // apt-get install
+
+    await ensureFfmpegInstalledAsync({
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+      env: createEnvMock(),
+      logger: createLoggerMock(),
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'sudo',
+      ['apt-get', 'update'],
+      expect.objectContaining({
+        env: expect.objectContaining({ DEBIAN_FRONTEND: 'noninteractive' }),
+      })
+    );
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      'sudo',
+      ['apt-get', 'install', '-y', 'ffmpeg'],
+      expect.objectContaining({
+        env: expect.objectContaining({ DEBIAN_FRONTEND: 'noninteractive' }),
+      })
+    );
+  });
+
+  it('still installs on linux when the apt index refresh fails', async () => {
+    spawnMock
+      .mockReturnValueOnce(spawnRejected()) // command -v ffmpeg
+      .mockReturnValueOnce(spawnRejected()) // apt-get update
+      .mockReturnValueOnce(spawnResolved()); // apt-get install
     const logger = createLoggerMock();
 
     await ensureFfmpegInstalledAsync({
@@ -460,8 +491,12 @@ describe(ensureFfmpegInstalledAsync, () => {
       logger,
     });
 
-    expect(spawnMock).toHaveBeenCalledTimes(1);
-    expect(logger.warn).toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      'sudo',
+      ['apt-get', 'install', '-y', 'ffmpeg'],
+      expect.anything()
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it('warns and resolves when the install fails, so the session still starts', async () => {

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -1,6 +1,8 @@
 import { bunyan } from '@expo/logger';
-import { BuildStepEnv } from '@expo/steps';
+import { BuildRuntimePlatform, BuildStepEnv } from '@expo/steps';
+import spawn from '@expo/turtle-spawn';
 import * as ngrok from '@ngrok/ngrok';
+import fs from 'node:fs';
 import { setTimeout as setTimeoutAsync } from 'node:timers/promises';
 
 import { CustomBuildContext } from '../../../customBuildContext';
@@ -9,6 +11,7 @@ import { turtleFetch } from '../../../utils/turtleFetch';
 import { sleepAsync } from '../../../utils/retry';
 import {
   createServeSimArgs,
+  ensureFfmpegInstalledAsync,
   fetchServeSimTurnArgsAsync,
   startNgrokTunnelAsync,
   turnIceServersToServeSimArgs,
@@ -21,6 +24,7 @@ jest.mock('node:timers/promises');
 jest.mock('../../../utils/turtleFetch');
 jest.mock('../../../utils/retry', () => ({ sleepAsync: jest.fn() }));
 jest.mock('../../../sentry');
+jest.mock('@expo/turtle-spawn');
 
 function createLoggerMock(): bunyan {
   return {
@@ -377,5 +381,102 @@ describe(waitForDeviceRunSessionStoppedAsync, () => {
       }),
       { level: 'warning' }
     );
+  });
+});
+
+describe(ensureFfmpegInstalledAsync, () => {
+  const spawnMock = jest.mocked(spawn);
+  let existsSyncSpy: jest.SpyInstance;
+
+  function spawnResolved(): ReturnType<typeof spawn> {
+    return Promise.resolve({}) as unknown as ReturnType<typeof spawn>;
+  }
+
+  function spawnRejected(): ReturnType<typeof spawn> {
+    return Promise.reject(new Error('boom')) as unknown as ReturnType<typeof spawn>;
+  }
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+    jest.mocked(Sentry).capture.mockReset();
+    // Default to "no ffmpeg on any fallback path" so each test opts in.
+    existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    existsSyncSpy.mockRestore();
+  });
+
+  it('does not install when ffmpeg is already on a fallback path', async () => {
+    existsSyncSpy.mockImplementation(path => path === '/opt/homebrew/bin/ffmpeg');
+
+    await ensureFfmpegInstalledAsync({
+      runtimePlatform: BuildRuntimePlatform.DARWIN,
+      env: createEnvMock(),
+      logger: createLoggerMock(),
+    });
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('does not install when ffmpeg is on PATH', async () => {
+    spawnMock.mockReturnValueOnce(spawnResolved());
+
+    await ensureFfmpegInstalledAsync({
+      runtimePlatform: BuildRuntimePlatform.DARWIN,
+      env: createEnvMock(),
+      logger: createLoggerMock(),
+    });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenCalledWith('sh', ['-c', 'command -v ffmpeg'], expect.anything());
+  });
+
+  it('installs ffmpeg with Homebrew on darwin when it is missing', async () => {
+    spawnMock.mockReturnValueOnce(spawnRejected()).mockReturnValueOnce(spawnResolved());
+
+    await ensureFfmpegInstalledAsync({
+      runtimePlatform: BuildRuntimePlatform.DARWIN,
+      env: createEnvMock(),
+      logger: createLoggerMock(),
+    });
+
+    expect(spawnMock).toHaveBeenLastCalledWith(
+      'brew',
+      ['install', 'ffmpeg'],
+      expect.objectContaining({
+        env: expect.objectContaining({ HOMEBREW_NO_AUTO_UPDATE: '1' }),
+      })
+    );
+  });
+
+  it('warns instead of installing on linux, where Homebrew is unavailable', async () => {
+    spawnMock.mockReturnValueOnce(spawnRejected());
+    const logger = createLoggerMock();
+
+    await ensureFfmpegInstalledAsync({
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+      env: createEnvMock(),
+      logger,
+    });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('warns and resolves when the install fails, so the session still starts', async () => {
+    spawnMock.mockReturnValueOnce(spawnRejected()).mockReturnValueOnce(spawnRejected());
+    const logger = createLoggerMock();
+
+    await expect(
+      ensureFfmpegInstalledAsync({
+        runtimePlatform: BuildRuntimePlatform.DARWIN,
+        env: createEnvMock(),
+        logger,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalled();
+    expect(jest.mocked(Sentry).capture).toHaveBeenCalled();
   });
 });

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -409,7 +409,7 @@ describe(ensureFfmpegInstalledAsync, () => {
     });
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
-    expect(spawnMock).toHaveBeenCalledWith('sh', ['-c', 'command -v ffmpeg'], expect.anything());
+    expect(spawnMock).toHaveBeenCalledWith('ffmpeg', ['-version'], expect.anything());
   });
 
   it('installs ffmpeg with Homebrew on darwin when it is missing', async () => {
@@ -432,7 +432,7 @@ describe(ensureFfmpegInstalledAsync, () => {
 
   it('installs ffmpeg with apt on linux when it is missing', async () => {
     spawnMock
-      .mockReturnValueOnce(spawnRejected()) // command -v ffmpeg
+      .mockReturnValueOnce(spawnRejected()) // ffmpeg -version
       .mockReturnValueOnce(spawnResolved()) // apt-get update
       .mockReturnValueOnce(spawnResolved()); // apt-get install
 
@@ -460,7 +460,7 @@ describe(ensureFfmpegInstalledAsync, () => {
 
   it('still installs on linux when the apt index refresh fails', async () => {
     spawnMock
-      .mockReturnValueOnce(spawnRejected()) // command -v ffmpeg
+      .mockReturnValueOnce(spawnRejected()) // ffmpeg -version
       .mockReturnValueOnce(spawnRejected()) // apt-get update
       .mockReturnValueOnce(spawnResolved()); // apt-get install
     const logger = createLoggerMock();

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -2,7 +2,6 @@ import { bunyan } from '@expo/logger';
 import { BuildRuntimePlatform, BuildStepEnv } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
 import * as ngrok from '@ngrok/ngrok';
-import fs from 'node:fs';
 import { setTimeout as setTimeoutAsync } from 'node:timers/promises';
 
 import { CustomBuildContext } from '../../../customBuildContext';
@@ -386,7 +385,6 @@ describe(waitForDeviceRunSessionStoppedAsync, () => {
 
 describe(ensureFfmpegInstalledAsync, () => {
   const spawnMock = jest.mocked(spawn);
-  let existsSyncSpy: jest.SpyInstance;
 
   function spawnResolved(): ReturnType<typeof spawn> {
     return Promise.resolve({}) as unknown as ReturnType<typeof spawn>;
@@ -399,24 +397,6 @@ describe(ensureFfmpegInstalledAsync, () => {
   beforeEach(() => {
     spawnMock.mockReset();
     jest.mocked(Sentry).capture.mockReset();
-    // Default to "no ffmpeg on any fallback path" so each test opts in.
-    existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
-  });
-
-  afterEach(() => {
-    existsSyncSpy.mockRestore();
-  });
-
-  it('does not install when ffmpeg is already on a fallback path', async () => {
-    existsSyncSpy.mockImplementation(path => path === '/opt/homebrew/bin/ffmpeg');
-
-    await ensureFfmpegInstalledAsync({
-      runtimePlatform: BuildRuntimePlatform.DARWIN,
-      env: createEnvMock(),
-      logger: createLoggerMock(),
-    });
-
-    expect(spawnMock).not.toHaveBeenCalled();
   });
 
   it('does not install when ffmpeg is on PATH', async () => {

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -494,4 +494,25 @@ describe(ensureFfmpegInstalledAsync, () => {
     expect(logger.warn).toHaveBeenCalled();
     expect(jest.mocked(Sentry).capture).toHaveBeenCalled();
   });
+
+  // The caller runs this with `void` and the worker installs no unhandledRejection
+  // handler, so a rejection here would crash the process. `spawn` is not async and
+  // can throw synchronously, which `asyncResult` cannot catch.
+  it('resolves when the availability check throws synchronously', async () => {
+    spawnMock.mockImplementationOnce(() => {
+      throw new Error('sync spawn failure');
+    });
+    const logger = createLoggerMock();
+
+    await expect(
+      ensureFfmpegInstalledAsync({
+        runtimePlatform: BuildRuntimePlatform.DARWIN,
+        env: createEnvMock(),
+        logger,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalled();
+    expect(jest.mocked(Sentry).capture).toHaveBeenCalled();
+  });
 });

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -230,8 +230,13 @@ async function installFfmpegWithAptAsync({
  * on PATH" — on macOS (iOS simulators) and Linux (Android emulators) alike.
  *
  * Best-effort by design: screen recording is one optional argent tool, so a
- * failure here is logged and the session continues without it. Never rejects,
- * which is what lets the caller run it in the background.
+ * failure here is logged and the session continues without it.
+ *
+ * The whole body is wrapped because the caller runs this in the background with
+ * `void`. There is no unhandledRejection handler in the worker, so a rejection
+ * escaping here would crash the process and take the live session with it.
+ * `spawn` is not an async function and can throw synchronously, which
+ * `asyncResult` cannot catch — it only wraps an already-created promise.
  */
 export async function ensureFfmpegInstalledAsync({
   runtimePlatform,
@@ -242,31 +247,34 @@ export async function ensureFfmpegInstalledAsync({
   env: BuildStepEnv;
   logger: bunyan;
 }): Promise<void> {
-  if (await isFfmpegAvailableAsync(env)) {
-    logger.info('ffmpeg is already installed.');
-    return;
-  }
+  try {
+    if (await isFfmpegAvailableAsync(env)) {
+      logger.info('ffmpeg is already installed.');
+      return;
+    }
 
-  const isDarwin = runtimePlatform === BuildRuntimePlatform.DARWIN;
-  logger.info(
-    `ffmpeg is not installed, installing it with ${
-      isDarwin ? 'Homebrew' : 'apt'
-    } for argent screen recording.`
-  );
-  const installResult = await asyncResult(
-    isDarwin
-      ? installFfmpegWithHomebrewAsync({ env, logger })
-      : installFfmpegWithAptAsync({ env, logger })
-  );
-  if (!installResult.ok) {
-    Sentry.capture('Could not install ffmpeg for argent screen recording', installResult.reason);
+    const isDarwin = runtimePlatform === BuildRuntimePlatform.DARWIN;
+    logger.info(
+      `ffmpeg is not installed, installing it with ${
+        isDarwin ? 'Homebrew' : 'apt'
+      } for argent screen recording.`
+    );
+    if (isDarwin) {
+      await installFfmpegWithHomebrewAsync({ env, logger });
+    } else {
+      await installFfmpegWithAptAsync({ env, logger });
+    }
+    logger.info('Installed ffmpeg.');
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    Sentry.capture('Could not install ffmpeg for argent screen recording', error, {
+      level: 'warning',
+    });
     logger.warn(
-      { err: installResult.reason },
+      { err: error },
       'Could not install ffmpeg. Argent screen recording will not work in this session.'
     );
-    return;
   }
-  logger.info('Installed ffmpeg.');
 }
 
 const TurnIceServersResponseSchema = z.object({

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -1,6 +1,7 @@
 import { SystemError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
-import { BuildStepEnv, spawnAsync } from '@expo/steps';
+import { asyncResult } from '@expo/results';
+import { BuildRuntimePlatform, BuildStepEnv, spawnAsync } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
 import * as ngrok from '@ngrok/ngrok';
 import { graphql } from 'gql.tada';
@@ -184,6 +185,74 @@ async function sleepUntilAbortedAsync(
       throw err;
     }
   }
+}
+
+// Argent encodes screen recordings by piping simulator frames into `ffmpeg`,
+// which it resolves from PATH and then from these prefixes. Keep the list in
+// sync with argent so we never reinstall a binary it can already find.
+const FFMPEG_FALLBACK_PATHS = [
+  '/opt/homebrew/bin/ffmpeg',
+  '/usr/local/bin/ffmpeg',
+  '/usr/bin/ffmpeg',
+];
+
+async function isFfmpegAvailableAsync(env: BuildStepEnv): Promise<boolean> {
+  if (FFMPEG_FALLBACK_PATHS.some(ffmpegPath => fs.existsSync(ffmpegPath))) {
+    return true;
+  }
+  return (await asyncResult(spawn('sh', ['-c', 'command -v ffmpeg'], { env }))).ok;
+}
+
+/**
+ * Install ffmpeg when the runtime does not already provide it, so argent's
+ * `screen-recording-start` tool can encode a video. The worker image does not
+ * ship ffmpeg yet, so without this the tool fails with "`ffmpeg` was not found
+ * on PATH".
+ *
+ * Best-effort by design: screen recording is one optional argent tool, so a
+ * failure here is logged and the session continues without it. Never rejects,
+ * which is what lets the caller run it in the background.
+ */
+export async function ensureFfmpegInstalledAsync({
+  runtimePlatform,
+  env,
+  logger,
+}: {
+  runtimePlatform: BuildRuntimePlatform;
+  env: BuildStepEnv;
+  logger: bunyan;
+}): Promise<void> {
+  if (await isFfmpegAvailableAsync(env)) {
+    logger.info('ffmpeg is already installed.');
+    return;
+  }
+
+  // Homebrew is only available on the macOS workers. Linux workers would need a
+  // package manager and sudo, so report the gap instead of guessing.
+  if (runtimePlatform !== BuildRuntimePlatform.DARWIN) {
+    logger.warn(
+      `ffmpeg is not installed and EAS only installs it on ${BuildRuntimePlatform.DARWIN} runtimes. ` +
+        'Argent screen recording will not work in this session.'
+    );
+    return;
+  }
+
+  logger.info('ffmpeg is not installed, installing it with Homebrew for argent screen recording.');
+  const installResult = await asyncResult(
+    spawn('brew', ['install', 'ffmpeg'], {
+      env: { ...env, HOMEBREW_NO_AUTO_UPDATE: '1' },
+      logger,
+    })
+  );
+  if (!installResult.ok) {
+    Sentry.capture('Could not install ffmpeg for argent screen recording', installResult.reason);
+    logger.warn(
+      { err: installResult.reason },
+      'Could not install ffmpeg. Argent screen recording will not work in this session.'
+    );
+    return;
+  }
+  logger.info('Installed ffmpeg.');
 }
 
 const TurnIceServersResponseSchema = z.object({

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -188,10 +188,11 @@ async function sleepUntilAbortedAsync(
 }
 
 // Argent encodes screen recordings by piping simulator frames into `ffmpeg`,
-// which it resolves from PATH. It inherits this step's env, so PATH here is the
-// PATH argent will search — no need to probe install prefixes ourselves.
+// which it resolves from PATH. The tool-server inherits this step's env, so
+// spawning ffmpeg resolves against the same PATH argent will search: it rejects
+// with ENOENT when the binary is absent, and running it also proves it works.
 async function isFfmpegAvailableAsync(env: BuildStepEnv): Promise<boolean> {
-  return (await asyncResult(spawn('sh', ['-c', 'command -v ffmpeg'], { env }))).ok;
+  return (await asyncResult(spawn('ffmpeg', ['-version'], { env }))).ok;
 }
 
 async function installFfmpegWithHomebrewAsync({

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -203,11 +203,39 @@ async function isFfmpegAvailableAsync(env: BuildStepEnv): Promise<boolean> {
   return (await asyncResult(spawn('sh', ['-c', 'command -v ffmpeg'], { env }))).ok;
 }
 
+async function installFfmpegWithHomebrewAsync({
+  env,
+  logger,
+}: {
+  env: BuildStepEnv;
+  logger: bunyan;
+}): Promise<void> {
+  await spawn('brew', ['install', 'ffmpeg'], {
+    env: { ...env, HOMEBREW_NO_AUTO_UPDATE: '1' },
+    logger,
+  });
+}
+
+async function installFfmpegWithAptAsync({
+  env,
+  logger,
+}: {
+  env: BuildStepEnv;
+  logger: bunyan;
+}): Promise<void> {
+  const aptEnv = { ...env, DEBIAN_FRONTEND: 'noninteractive' };
+  // The worker's package index can be older than the image it booted from, which
+  // makes the install 404 on a moved package. Refreshing first avoids that; a
+  // failed refresh is not fatal because the existing index may still resolve.
+  await asyncResult(spawn('sudo', ['apt-get', 'update'], { env: aptEnv, logger }));
+  await spawn('sudo', ['apt-get', 'install', '-y', 'ffmpeg'], { env: aptEnv, logger });
+}
+
 /**
  * Install ffmpeg when the runtime does not already provide it, so argent's
- * `screen-recording-start` tool can encode a video. The worker image does not
+ * `screen-recording-start` tool can encode a video. The worker images do not
  * ship ffmpeg yet, so without this the tool fails with "`ffmpeg` was not found
- * on PATH".
+ * on PATH" — on macOS (iOS simulators) and Linux (Android emulators) alike.
  *
  * Best-effort by design: screen recording is one optional argent tool, so a
  * failure here is logged and the session continues without it. Never rejects,
@@ -227,22 +255,16 @@ export async function ensureFfmpegInstalledAsync({
     return;
   }
 
-  // Homebrew is only available on the macOS workers. Linux workers would need a
-  // package manager and sudo, so report the gap instead of guessing.
-  if (runtimePlatform !== BuildRuntimePlatform.DARWIN) {
-    logger.warn(
-      `ffmpeg is not installed and EAS only installs it on ${BuildRuntimePlatform.DARWIN} runtimes. ` +
-        'Argent screen recording will not work in this session.'
-    );
-    return;
-  }
-
-  logger.info('ffmpeg is not installed, installing it with Homebrew for argent screen recording.');
+  const isDarwin = runtimePlatform === BuildRuntimePlatform.DARWIN;
+  logger.info(
+    `ffmpeg is not installed, installing it with ${
+      isDarwin ? 'Homebrew' : 'apt'
+    } for argent screen recording.`
+  );
   const installResult = await asyncResult(
-    spawn('brew', ['install', 'ffmpeg'], {
-      env: { ...env, HOMEBREW_NO_AUTO_UPDATE: '1' },
-      logger,
-    })
+    isDarwin
+      ? installFfmpegWithHomebrewAsync({ env, logger })
+      : installFfmpegWithAptAsync({ env, logger })
   );
   if (!installResult.ok) {
     Sentry.capture('Could not install ffmpeg for argent screen recording', installResult.reason);

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -188,18 +188,9 @@ async function sleepUntilAbortedAsync(
 }
 
 // Argent encodes screen recordings by piping simulator frames into `ffmpeg`,
-// which it resolves from PATH and then from these prefixes. Keep the list in
-// sync with argent so we never reinstall a binary it can already find.
-const FFMPEG_FALLBACK_PATHS = [
-  '/opt/homebrew/bin/ffmpeg',
-  '/usr/local/bin/ffmpeg',
-  '/usr/bin/ffmpeg',
-];
-
+// which it resolves from PATH. It inherits this step's env, so PATH here is the
+// PATH argent will search — no need to probe install prefixes ourselves.
 async function isFfmpegAvailableAsync(env: BuildStepEnv): Promise<boolean> {
-  if (FFMPEG_FALLBACK_PATHS.some(ffmpegPath => fs.existsSync(ffmpegPath))) {
-    return true;
-  }
   return (await asyncResult(spawn('sh', ['-c', 'command -v ffmpeg'], { env }))).ok;
 }
 


### PR DESCRIPTION
# Why

Argent screen recording does not work on EAS Simulator sessions. The failure is a missing `ffmpeg` binary on the worker VMs.

Verified live on session `019fadda-2063-7fbd-a6c6-7176b0de2681` (iOS, `--type argent`):

```
POST /tools/screen-recording-start  →
{"error":"[Tool:screen-recording-start] `ffmpeg` was not found on PATH.
 Install it (e.g. `brew install ffmpeg`) to record the screen."}
```

ffmpeg **is** argent's encoder — it pipes simulator frames into ffmpeg's stdin to produce the mp4. Argent resolves it from `PATH`, then `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`. The worker images ship none of them.

Nothing else is wrong. Argent's `screen-recording-start` checks, in order:

1. platform / tvOS
2. simulator-server frame stream → `SCREEN_RECORDING_STREAM_UNAVAILABLE`
3. `startCapture` → `resolveFfmpeg()` → `SCREEN_RECORDING_FFMPEG_NOT_FOUND`

We hit **3**, which proves **2 passed**: the frame stream already works on the VM. ffmpeg is the only blocker.

Also worth noting: with `--type argent` the tool-server runs **on the EAS VM**, and `list-devices` returned a booted `iPhone 17` with no `remote:` prefix. So argent's "remote simulators are unsupported" gate does not apply. This is a missing binary, not an architecture problem.

## Why this lives in eas-cli and not only in the image

There is a companion infra PR that adds ffmpeg to the worker images: https://github.com/expo/turtle-v2/pull/2598. That change applies to **images built from there on**. It deliberately does not update or backfill existing images.

So this PR is not a stopgap for a short rollout window. It is what makes recording work on every worker running a current image, for as long as those images stay in rotation. Once a worker boots an image that already carries ffmpeg, the check finds it and this does nothing.

# How

`ensureFfmpegInstalledAsync` in `remoteDeviceRunSession.ts`, called from `eas/start_argent_remote_session`.

- **Detection matches argent's own resolution** — `PATH` plus the same three Homebrew prefixes — so we never reinstall a binary argent can already find, and the step is a no-op on images that ship it.
- **Both platforms.** Homebrew on macOS (iOS simulators), apt on Linux (Android emulators). Android is covered because argent's capability is `android: { emulator: true, device: true, unknown: true }`, simulator-server has an `android` subcommand, and nothing on that path bypasses `resolveFfmpeg()`. The Linux workers have passwordless sudo (`%sudo ALL=(ALL) NOPASSWD: ALL`).
- **apt index refreshed first.** The worker's index can be older than the image it booted from, which makes the install 404 on a moved package. A failed refresh is not fatal, since the existing index may still resolve.
- **Runs in the background.** `brew install ffmpeg` pulls a large dependency tree and takes minutes. Awaiting it would delay session readiness by that much. Fired with `void` instead, so the session comes up at its usual speed and only a recording started in the first moments misses ffmpeg. This is the main design decision worth pushback if you disagree.
- **Best-effort, never throws.** Screen recording is one optional argent tool. A failed install is logged and reported to Sentry, and the session continues without it. Never rejecting is also what makes the `void` safe.

# Test Plan

Unit tests in `remoteDeviceRunSession.test.ts` cover six paths: already on a fallback path, already on `PATH`, installs with Homebrew on darwin, installs with apt on linux, still installs when the apt refresh fails, and warns without throwing when the install fails.

```
Test Suites: 99 passed, 99 total
Tests:       931 passed, 931 total
```

`yarn typecheck` (13 projects), `yarn lint` (0 errors), and `yarn fmt:check` all pass.

Not yet verified end-to-end on a live session — this is a draft. To verify, start an argent session on a current image, confirm the build log shows the install, then call `screen-recording-start` and expect a started recording instead of the error above.
