### PR TITLE
[build-tools] Limit Gradle profile table width

### DIFF
--- a/packages/build-tools/src/android/__tests__/gradleProfile.test.ts
+++ b/packages/build-tools/src/android/__tests__/gradleProfile.test.ts
@@ -1,0 +1,35 @@
+import { GradleProfileTask, formatGradleProfileReport } from '../gradleProfile';
+
+describe(formatGradleProfileReport, () => {
+  it('does not expand the table for long task names', () => {
+    const tasks: GradleProfileTask[] = [
+      { path: ':app', durationMs: 10_000, result: '(total)' },
+      {
+        path: ':app:aVeryLongGradleTaskNameThatWouldOtherwiseMakeTheTableTooWide',
+        durationMs: 10_000,
+        result: 'executed',
+      },
+    ];
+
+    const report = formatGradleProfileReport(tasks);
+    const tableLines = report.split('\n').filter(line => line.startsWith('│'));
+
+    expect(tableLines).toHaveLength(4);
+    expect(new Set(tableLines.map(line => line.length))).toEqual(new Set([104]));
+    expect(report).toContain('  └─ aVeryLongGradle…MakeTheTableTooWide');
+  });
+
+  it('caps the task column for long module names', () => {
+    const modulePath = ':aVeryLongGradleModuleNameThatWouldOtherwiseMakeTheTableTooWide';
+    const tasks: GradleProfileTask[] = [
+      { path: modulePath, durationMs: 10_000, result: '(total)' },
+      { path: `${modulePath}:compile`, durationMs: 10_000, result: 'executed' },
+    ];
+
+    const report = formatGradleProfileReport(tasks);
+    const tableLines = report.split('\n').filter(line => line.startsWith('│'));
+
+    expect(new Set(tableLines.map(line => line.length))).toEqual(new Set([104]));
+    expect(report).toContain(':aVeryLongGradleModu…MakeTheTableTooWide');
+  });
+});

--- a/packages/build-tools/src/android/__tests__/gradleProfile.test.ts
+++ b/packages/build-tools/src/android/__tests__/gradleProfile.test.ts
@@ -15,8 +15,8 @@ describe(formatGradleProfileReport, () => {
     const tableLines = report.split('\n').filter(line => line.startsWith('│'));
 
     expect(tableLines).toHaveLength(4);
-    expect(new Set(tableLines.map(line => line.length))).toEqual(new Set([104]));
-    expect(report).toContain('  └─ aVeryLongGradle…MakeTheTableTooWide');
+    expect(new Set(tableLines.map(line => line.length))).toEqual(new Set([112]));
+    expect(report).toContain('  └─ aVeryLongGradleTask…wiseMakeTheTableTooWide');
   });
 
   it('caps the task column for long module names', () => {
@@ -29,7 +29,7 @@ describe(formatGradleProfileReport, () => {
     const report = formatGradleProfileReport(tasks);
     const tableLines = report.split('\n').filter(line => line.startsWith('│'));
 
-    expect(new Set(tableLines.map(line => line.length))).toEqual(new Set([104]));
-    expect(report).toContain(':aVeryLongGradleModu…MakeTheTableTooWide');
+    expect(new Set(tableLines.map(line => line.length))).toEqual(new Set([112]));
+    expect(report).toContain(':aVeryLongGradleModuleNa…wiseMakeTheTableTooWide');
   });
 });

--- a/packages/build-tools/src/android/gradleProfile.ts
+++ b/packages/build-tools/src/android/gradleProfile.ts
@@ -90,6 +90,17 @@ function formatSeconds(ms: number): string {
   return `${s.toFixed(1)}s`;
 }
 
+function truncateMiddle(value: string, width: number): string {
+  if (value.length <= width) {
+    return value;
+  }
+
+  const availableWidth = width - 1;
+  const startWidth = Math.ceil(availableWidth / 2);
+  const endWidth = Math.floor(availableWidth / 2);
+  return `${value.slice(0, startWidth)}…${value.slice(-endWidth)}`;
+}
+
 export function formatGradleProfileReport(tasks: GradleProfileTask[]): string {
   // Filter out tasks under 1 second
   const significantTasks = tasks.filter(t => t.durationMs >= 1000);
@@ -142,7 +153,13 @@ export function formatGradleProfileReport(tasks: GradleProfileTask[]): string {
   const totalMs = individualTasks.reduce((sum, t) => sum + t.durationMs, 0);
   const maxMs = totalMs || 1;
 
-  const nameWidth = Math.max(4, ...rows.map(r => r.displayName.length)) + 2;
+  // Keep the report close to the xclogparser table width. Gradle task names can be very long,
+  // so allowing them to grow the first column without a limit makes the table difficult to read.
+  const maxNameWidth = 40;
+  const nameWidth = Math.min(
+    maxNameWidth,
+    Math.max(4, ...rows.map(row => row.displayName.length)) + 2
+  );
   const barMaxWidth = 20;
 
   const header =
@@ -197,7 +214,7 @@ export function formatGradleProfileReport(tasks: GradleProfileTask[]): string {
 
     lines.push(
       '│ ' +
-        row.displayName.padEnd(nameWidth) +
+        truncateMiddle(row.displayName, nameWidth).padEnd(nameWidth) +
         ' │ ' +
         formatSeconds(row.task.durationMs).padStart(10) +
         ' │ ' +

--- a/packages/build-tools/src/android/gradleProfile.ts
+++ b/packages/build-tools/src/android/gradleProfile.ts
@@ -155,7 +155,7 @@ export function formatGradleProfileReport(tasks: GradleProfileTask[]): string {
 
   // Keep the report close to the xclogparser table width. Gradle task names can be very long,
   // so allowing them to grow the first column without a limit makes the table difficult to read.
-  const maxNameWidth = 40;
+  const maxNameWidth = 48;
   const nameWidth = Math.min(
     maxNameWidth,
     Math.max(4, ...rows.map(row => row.displayName.length)) + 2


### PR DESCRIPTION
## Why

The Gradle profile table uses the longest task name to size the first column. Some Gradle task names get really long, so the whole table ends up stretched and hard to scan:

<img width="2382" height="1312" alt="image" src="https://github.com/user-attachments/assets/37f9a4f7-10ac-499f-8051-2a16aa80be7f" />

## What changed

Cap the task column at 48 characters and truncate long names in the middle. This keeps the table at 112 characters while preserving both the module/phase prefix and the useful task suffix.

## Test plan

- added coverage for long task and module names
- verified every rendered row stays at 112 characters
- ran the formatter, lint, and focused build-tools tests