### PR TITLE
[eas-cli] Add --name filter to simulator:list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Pass a metrics CORS origin to serve-sim so the dashboard can read a session's live CPU/memory stream cross-origin. ([#3990](https://github.com/expo/eas-cli/pull/3990) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Collect each iOS session's serve-sim CPU/memory `/metrics` to a file and upload it as a device run session artifact at teardown. ([#3995](https://github.com/expo/eas-cli/pull/3995) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Load local composite function catalogs for hook steps, in both steps-based and native builds. ([#4063](https://github.com/expo/eas-cli/pull/4063) by [@sswrk](https://github.com/sswrk))
+- [eas-cli] Add `--name` filter to `eas simulator:list`. ([#4118](https://github.com/expo/eas-cli/pull/4118) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
@@ -164,6 +164,8 @@ describe(SimulatorList, () => {
       'argent',
       '--platform',
       'ios',
+      '--name',
+      'checkout',
       '--limit',
       '25',
       '--after',
@@ -179,6 +181,7 @@ describe(SimulatorList, () => {
         statuses: [DeviceRunSessionStatus.InProgress, DeviceRunSessionStatus.New],
         types: [DeviceRunSessionType.Argent],
         platforms: [AppPlatform.Ios],
+        name: 'checkout',
       },
     });
   });

--- a/packages/eas-cli/src/commands/simulator/list.ts
+++ b/packages/eas-cli/src/commands/simulator/list.ts
@@ -69,6 +69,9 @@ export default class SimulatorList extends EasCommand {
       options: Object.values(PLATFORM_FLAG_VALUES),
       multiple: true,
     })(),
+    name: Flags.string({
+      description: 'Filter by session name (case-insensitive prefix match)',
+    }),
     limit: getLimitFlagWithCustomValues({ defaultTo: DEFAULT_LIMIT, limit: MAX_LIMIT }),
     after: Flags.string({
       description:
@@ -106,6 +109,9 @@ export default class SimulatorList extends EasCommand {
     }
     if (flags.platform && flags.platform.length > 0) {
       filter.platforms = flags.platform.map(value => PLATFORM_BY_FLAG_VALUE[value]);
+    }
+    if (flags.name) {
+      filter.name = flags.name;
     }
 
     const limit = flags.limit ?? DEFAULT_LIMIT;


### PR DESCRIPTION
# Why

Lets you filter `eas simulator:list` results by session name, next to the existing `--status`, `--type`, and `--platform` filters.

# How

`--name` maps to the `DeviceRunSessionFilterInput.name` field added in expo/universe#29550, which does a case-insensitive prefix match server side. That change is deployed, so the regenerated schema picks the field up from production.

# Test Plan

CI passes.

```
➜  testapp-staging git:(master) ✗ EXPO_STAGING=1 easd simulator:list --name szym --platform ios --type agent-device --status stopped
✔ Fetched 2 simulator session(s)

ID:       019fb30a-e913-72db-a3fc-7e864b3d81a5
Name:     Szymon's test
Type:     AGENT_DEVICE
Status:   STOPPED
Platform: IOS
Created:  4 days ago
URL:      https://staging.expo.dev/accounts/expo-services/projects/testapp-staging/simulator-sessions/019fb30a-e913-72db-a3fc-7e864b3d81a5

———

ID:       019fa856-b182-7f6b-805a-7e6ef00c4291
Name:     Szymon's test
Type:     AGENT_DEVICE
Status:   STOPPED
Platform: IOS
Created:  6 days ago
URL:      https://staging.expo.dev/accounts/expo-services/projects/testapp-staging/simulator-sessions/019fa856-b182-7f6b-805a-7e6ef00c4291
```
