### PR TITLE
[build-tools] Move HTTP log stream from worker

### DIFF
--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -1,7 +1,8 @@
 import * as Builders from './builders';
+import HttpLogStream from './logging/HttpLogStream';
 import RemoteLoggerStream from './logging/RemoteLoggerStream';
 
-export { Builders, RemoteLoggerStream };
+export { Builders, HttpLogStream, RemoteLoggerStream };
 export { uploadWithSignedUrl } from './storage/uploadWithSignedUrl';
 export type { SignedUrl, UploadWithSignedUrlParams } from './storage/uploadWithSignedUrl';
 

--- a/packages/build-tools/src/logging/HttpLogStream.ts
+++ b/packages/build-tools/src/logging/HttpLogStream.ts
@@ -3,7 +3,7 @@ import { asyncResult } from '@expo/results';
 import fetch from 'node-fetch';
 import { Writable } from 'stream';
 
-import { retry } from './retry';
+import { retryAsync } from '../utils/retry';
 
 const MAX_BATCH_BYTES = 200_000;
 
@@ -152,7 +152,7 @@ export default class HttpLogStream extends Writable {
   }
 
   private async sendBatch(logs: BufferedLogEntry[]): Promise<void> {
-    await retry(
+    await retryAsync(
       async () => {
         const response = await fetch(this.url, {
           method: 'POST',

--- a/packages/build-tools/src/logging/__tests__/HttpLogStream.test.ts
+++ b/packages/build-tools/src/logging/__tests__/HttpLogStream.test.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@expo/logger';
 import { Response } from 'node-fetch';
 import fetch from 'node-fetch';
 
-import HttpLogStream from '../utils/HttpLogStream';
+import HttpLogStream from '../HttpLogStream';
 
 jest.mock('node-fetch', () => {
   const actual = jest.requireActual('node-fetch');
@@ -12,8 +12,8 @@ jest.mock('node-fetch', () => {
     default: jest.fn(),
   };
 });
-jest.mock('../utils/retry', () => ({
-  retry: jest.fn(async (fn: (attemptCount: number) => Promise<unknown>) => await fn(0)),
+jest.mock('../../utils/retry', () => ({
+  retryAsync: jest.fn(async (fn: (attemptCount: number) => Promise<unknown>) => await fn(0)),
 }));
 
 const fetchMock = jest.mocked(fetch);
@@ -150,5 +150,40 @@ describe(HttpLogStream.name, () => {
     const [firstRequestLogs, secondRequestLogs] = parseRequestLogs();
     expect(firstRequestLogs.map(log => log.logId)).toEqual(['first']);
     expect(secondRequestLogs.map(log => log.logId)).toEqual(['second', 'third']);
+  });
+
+  it('keeps a failed batch buffered and resends the same entries', async () => {
+    fetchMock
+      .mockResolvedValueOnce(createResponse(500, 'upload failed'))
+      .mockResolvedValueOnce(createResponse());
+    const stream = new HttpLogStream({
+      url: 'https://logs.expo.test/build-id',
+      headers: { Authorization: 'Bearer token' },
+      logger: createLogger({ name: 'test' }),
+    });
+
+    stream.write({ logId: 'stable-id', msg: 'Retry me' });
+    await stream.cleanUp();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [firstAttemptLogs, secondAttemptLogs] = parseRequestLogs();
+    expect(firstAttemptLogs).toEqual([{ logId: 'stable-id', msg: 'Retry me' }]);
+    expect(secondAttemptLogs).toEqual(firstAttemptLogs);
+  });
+
+  it('does one final best-effort flush during cleanup without looping indefinitely', async () => {
+    fetchMock.mockResolvedValue(createResponse(500, 'upload failed'));
+    const stream = new HttpLogStream({
+      url: 'https://logs.expo.test/build-id',
+      headers: { Authorization: 'Bearer token' },
+      logger: createLogger({ name: 'test' }),
+    });
+
+    stream.write({ logId: 'stable-id', msg: 'Do not hang' });
+    await stream.cleanUp();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [firstAttemptLogs, secondAttemptLogs] = parseRequestLogs();
+    expect(secondAttemptLogs).toEqual(firstAttemptLogs);
   });
 });

--- a/packages/worker/src/__unit__/logger.test.ts
+++ b/packages/worker/src/__unit__/logger.test.ts
@@ -1,7 +1,5 @@
 import { TransformCallback, Writable } from 'node:stream';
 import { EnvironmentSecretType } from '@expo/eas-build-job';
-import { Response } from 'node-fetch';
-import fetch from 'node-fetch';
 import z from 'zod';
 
 jest.mock('@expo/build-tools', () => {
@@ -36,9 +34,32 @@ jest.mock('@expo/build-tools', () => {
     }
   }
 
+  class MockHttpLogStream extends Writable {
+    public static readonly instances: MockHttpLogStream[] = [];
+
+    public readonly writes: any[] = [];
+
+    constructor(public readonly config: Record<string, unknown>) {
+      super({ objectMode: true });
+      MockHttpLogStream.instances.push(this);
+    }
+
+    public async cleanUp(): Promise<void> {}
+
+    public _write(
+      chunk: unknown,
+      _encoding: BufferEncoding,
+      callback: (error?: Error | null) => void
+    ): void {
+      this.writes.push(chunk);
+      callback(null);
+    }
+  }
+
   return {
     ...actual,
     uploadWithSignedUrl: jest.fn(),
+    HttpLogStream: MockHttpLogStream,
     RemoteLoggerStream: MockRemoteLoggerStream,
   };
 });
@@ -46,24 +67,17 @@ jest.mock('@expo/build-tools', () => {
 import config from '../config';
 import { createBuildLoggerWithSecretsFilter } from '../logger';
 
-jest.mock('node-fetch', () => {
-  const actual = jest.requireActual('node-fetch');
-  return {
-    __esModule: true,
-    ...actual,
-    default: jest.fn(),
-  };
-});
-jest.mock('../utils/retry', () => ({
-  retry: jest.fn(async (fn: (attemptCount: number) => Promise<unknown>) => await fn(0)),
-}));
-
 async function waitForStreamFlush(): Promise<void> {
   await new Promise(resolve => setImmediate(resolve));
 }
 
-const fetchMock = jest.mocked(fetch);
-const { RemoteLoggerStream } = jest.requireMock('@expo/build-tools') as {
+const { HttpLogStream, RemoteLoggerStream } = jest.requireMock('@expo/build-tools') as {
+  HttpLogStream: {
+    instances: Array<{
+      config: Record<string, unknown>;
+      writes: any[];
+    }>;
+  };
   RemoteLoggerStream: {
     instances: Array<{
       writes: any[];
@@ -77,8 +91,7 @@ describe('logger', () => {
   const originalGcsSignedUploadUrlForLogs = config.loggers.gcs.signedUploadUrlForLogs;
 
   beforeEach(() => {
-    fetchMock.mockReset();
-    fetchMock.mockResolvedValue(new Response('', { status: 200, statusText: 'OK' }));
+    HttpLogStream.instances.length = 0;
     RemoteLoggerStream.instances.length = 0;
   });
 
@@ -176,136 +189,15 @@ describe('logger', () => {
     await cleanUp();
 
     expect(logs).toHaveLength(1);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://logs.expo.test/logs/build-id',
-      expect.objectContaining({
-        method: 'POST',
-        headers: expect.objectContaining({
-          Authorization: 'Bearer robot-token',
-          'Content-Type': 'application/x-ndjson',
-        }),
-      })
-    );
-
-    const [, requestInit] = fetchMock.mock.calls[0];
-    const [serializedLog] = String(requestInit?.body).split('\n');
-    const uploadedLog = JSON.parse(serializedLog);
-
-    expect(uploadedLog.logId).toBe(logs[0].logId);
-  });
-
-  it('keeps failed HTTP logs buffered and resends them with the same logId', async () => {
-    config.loggers.http.baseUrl = 'https://logs.expo.test/logs/';
-    config.buildId = 'build-id';
-    fetchMock
-      .mockResolvedValueOnce(
-        new Response('upload failed', { status: 500, statusText: 'Internal Server Error' })
-      )
-      .mockResolvedValueOnce(new Response('', { status: 200, statusText: 'OK' }));
-
-    const { logger, outputStream, cleanUp } = await createBuildLoggerWithSecretsFilter({
-      robotAccessToken: 'robot-token',
+    expect(HttpLogStream.instances).toHaveLength(1);
+    expect(HttpLogStream.instances[0].config).toEqual({
+      url: 'https://logs.expo.test/logs/build-id',
+      headers: { Authorization: 'Bearer robot-token' },
+      bufferRetentionMs: null,
+      logger: expect.anything(),
     });
-
-    const logs: any[] = [];
-    const writable = new Writable({
-      objectMode: true,
-      write(chunk: any, _encoding: BufferEncoding, callback: TransformCallback) {
-        logs.push(chunk);
-        callback(null, chunk);
-      },
-    });
-
-    outputStream.pipe(writable);
-    logger.info('Retry me');
-
-    await waitForStreamFlush();
-    await cleanUp();
-
-    const originalLog = logs.find(log => log.msg === 'Retry me');
-
-    expect(originalLog).toBeDefined();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-
-    const [firstAttemptLogs, secondAttemptLogs] = fetchMock.mock.calls.map(([, requestInit]) =>
-      String(requestInit?.body)
-        .split('\n')
-        .filter(Boolean)
-        .map(serializedLog => JSON.parse(serializedLog))
-    );
-    const firstAttemptOriginalLog = firstAttemptLogs.find(log => log.msg === 'Retry me');
-    const secondAttemptOriginalLog = secondAttemptLogs.find(log => log.msg === 'Retry me');
-
-    expect(firstAttemptOriginalLog.logId).toBe(originalLog.logId);
-    expect(secondAttemptOriginalLog.logId).toBe(originalLog.logId);
-    expect(secondAttemptOriginalLog).toEqual(firstAttemptOriginalLog);
-  });
-
-  it('does one final best-effort HTTP flush during cleanup without looping indefinitely', async () => {
-    config.loggers.http.baseUrl = 'https://logs.expo.test/logs/';
-    config.buildId = 'build-id';
-    fetchMock.mockResolvedValue(
-      new Response('upload failed', { status: 500, statusText: 'Internal Server Error' })
-    );
-
-    const { logger, cleanUp } = await createBuildLoggerWithSecretsFilter({
-      robotAccessToken: 'robot-token',
-    });
-
-    logger.info('Do not hang on cleanup');
-    await cleanUp();
-
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-
-    const [firstAttemptLogs, secondAttemptLogs] = fetchMock.mock.calls.map(([, requestInit]) =>
-      String(requestInit?.body)
-        .split('\n')
-        .filter(Boolean)
-        .map(serializedLog => JSON.parse(serializedLog))
-    );
-    const firstAttemptOriginalLog = firstAttemptLogs.find(
-      log => log.msg === 'Do not hang on cleanup'
-    );
-    const secondAttemptOriginalLog = secondAttemptLogs.find(
-      log => log.msg === 'Do not hang on cleanup'
-    );
-
-    expect(firstAttemptOriginalLog).toBeDefined();
-    expect(secondAttemptOriginalLog).toBeDefined();
-    expect(secondAttemptOriginalLog).toEqual(firstAttemptOriginalLog);
-  });
-
-  it('does not forward HTTP upload failures to the GCS build log stream', async () => {
-    config.loggers.http.baseUrl = 'https://logs.expo.test/logs/';
-    config.loggers.gcs.signedUploadUrlForLogs = {
-      url: 'https://gcs.expo.test/logs',
-      headers: {},
-    };
-    config.buildId = 'build-id';
-    fetchMock.mockResolvedValue(
-      new Response('upload failed', { status: 500, statusText: 'Internal Server Error' })
-    );
-
-    const { logger, cleanUp } = await createBuildLoggerWithSecretsFilter({
-      robotAccessToken: 'robot-token',
-    });
-
-    logger.info('Actual build log');
-    await cleanUp();
-
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(RemoteLoggerStream.instances).toHaveLength(1);
-
-    const remoteLogs = RemoteLoggerStream.instances[0].writes;
-    expect(remoteLogs).toEqual(
-      expect.arrayContaining([expect.objectContaining({ msg: 'Actual build log' })])
-    );
-    expect(remoteLogs).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ msg: 'Failed to send logs batch over HTTP' }),
-      ])
-    );
+    expect(HttpLogStream.instances[0].writes).toHaveLength(1);
+    expect(HttpLogStream.instances[0].writes[0].logId).toBe(logs[0].logId);
   });
 
   it('drains transformed logs even without explicit output consumer', async () => {

--- a/packages/worker/src/logger.ts
+++ b/packages/worker/src/logger.ts
@@ -1,4 +1,4 @@
-import { LogBuffer, RemoteLoggerStream } from '@expo/build-tools';
+import { HttpLogStream, LogBuffer, RemoteLoggerStream } from '@expo/build-tools';
 import { BuildPhase, EnvironmentSecret, Job } from '@expo/eas-build-job';
 import { LoggerLevel, bunyan, createLogger } from '@expo/logger';
 import { Readable, Transform, TransformCallback, Writable } from 'stream';
@@ -6,7 +6,6 @@ import { Readable, Transform, TransformCallback, Writable } from 'stream';
 import config from './config';
 import { maybeStringBase64Decode, simpleSecretsWhitelist } from './secrets';
 import { uuidv7 } from 'uuidv7';
-import HttpLogStream from './utils/HttpLogStream';
 
 const defaultLogger = createLogger({
   name: config.loggers.base.name,


### PR DESCRIPTION
## Why

I want to reuse `HttpLogStream` in `build-tools` logging.

## How

Moved `HttpLogStream` and its tests to `build-tools`.

## Test plan

CI should pass.