### PR TITLE
[build-tools] Publish device run session events in real time

### DIFF
--- a/packages/build-tools/src/steps/utils/__tests__/agentDeviceEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/agentDeviceEvents.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { type CustomBuildContext } from '../../../customBuildContext';
+import HttpLogStream from '../../../logging/HttpLogStream';
 import RemoteLoggerStream from '../../../logging/RemoteLoggerStream';
 import { Sentry } from '../../../sentry';
 import { startAgentDeviceEventCollectionAsync } from '../agentDeviceEvents';
@@ -13,7 +14,15 @@ const mockEventLogStream = {
   write: jest.fn(),
   cleanUp: jest.fn(async () => undefined),
 };
+const mockRealtimeLogStream = {
+  write: jest.fn(),
+  cleanUp: jest.fn(async () => undefined),
+};
 
+jest.mock('../../../logging/HttpLogStream', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockRealtimeLogStream),
+}));
 jest.mock('../../../logging/RemoteLoggerStream', () => ({
   __esModule: true,
   default: jest.fn(() => mockEventLogStream),
@@ -42,7 +51,7 @@ describe(startAgentDeviceEventCollectionAsync, () => {
         summary: 'Started tap',
       })}\n`
     );
-    const ctx = createContext();
+    const ctx = createContext({ realtimeLogs: true });
     const logger = createLogger();
     const collection = await startAgentDeviceEventCollectionAsync({
       ctx,
@@ -97,9 +106,34 @@ describe(startAgentDeviceEventCollectionAsync, () => {
     });
     expect(mockEventLogStream.init).toHaveBeenCalledTimes(1);
     expect(mockEventLogStream.cleanUp).toHaveBeenCalledTimes(1);
+    expect(HttpLogStream).toHaveBeenCalledWith({
+      url: 'https://staging-logs.expo.dev/logs/job-run-id/session-events',
+      headers: { Authorization: 'Bearer robot-access-token' },
+      logger,
+      bufferRetentionMs: 30_000,
+    });
+    expect(mockRealtimeLogStream.cleanUp).toHaveBeenCalledTimes(1);
     expect(mockEventLogStream.write).toHaveBeenNthCalledWith(2, {
       v: 1,
       eventId: 'agent-device:session-id:default:2',
+      ts: '2026-07-10T12:00:01.000Z',
+      producer: 'agent-device',
+      type: 'operation.completed',
+      operationId: 'request-1',
+      outcome: 'success',
+      durationMs: 25,
+      summary: 'Finished tap',
+      data: {
+        session: 'default',
+        sourceVersion: 1,
+        sourceStatus: 'ok',
+        durationMs: 25,
+      },
+    });
+    expect(mockRealtimeLogStream.write).toHaveBeenNthCalledWith(2, {
+      v: 1,
+      eventId: 'agent-device:session-id:default:2',
+      logId: 'agent-device:session-id:default:2',
       ts: '2026-07-10T12:00:01.000Z',
       producer: 'agent-device',
       type: 'operation.completed',
@@ -470,8 +504,15 @@ describe(startAgentDeviceEventCollectionAsync, () => {
   });
 
   it('does not fail the session when event log setup fails', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-events-'));
+    const eventsDir = path.join(stateDir, 'sessions', 'default');
+    await fs.promises.mkdir(eventsDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(eventsDir, 'events.ndjson'),
+      `${JSON.stringify(createAgentDeviceEvent())}\n`
+    );
     const error = new Error('WWW unavailable');
-    const ctx = createContext();
+    const ctx = createContext({ realtimeLogs: true });
     jest.mocked(ctx.graphqlClient.mutation).mockReturnValueOnce({
       toPromise: async () => ({ error }),
     } as unknown as ReturnType<CustomBuildContext['graphqlClient']['mutation']>);
@@ -480,11 +521,16 @@ describe(startAgentDeviceEventCollectionAsync, () => {
     const collection = await startAgentDeviceEventCollectionAsync({
       ctx,
       deviceRunSessionId: 'session-id',
-      stateDir: '/does/not/matter',
+      stateDir,
       logger,
       pollIntervalMs: 10,
     });
-    await collection.stopAsync();
+    try {
+      await waitForAsync(() => expect(mockRealtimeLogStream.write).toHaveBeenCalledTimes(1));
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
 
     expect(logger.warn).toHaveBeenCalledWith(
       {
@@ -493,7 +539,7 @@ describe(startAgentDeviceEventCollectionAsync, () => {
           cause: error,
         }),
       },
-      'Could not start device run session event collection.'
+      'Could not persist device run session events to the artifact.'
     );
     expect(Sentry.capture).toHaveBeenCalledWith(
       'Could not persist device run session events',
@@ -512,10 +558,101 @@ describe(startAgentDeviceEventCollectionAsync, () => {
       }
     );
     expect(mockEventLogStream.init).not.toHaveBeenCalled();
+    expect(mockRealtimeLogStream.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventId: 'agent-device:session-id:default:1',
+        logId: 'agent-device:session-id:default:1',
+      })
+    );
+    expect(mockRealtimeLogStream.cleanUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues persisting the artifact when real-time log setup fails', async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-events-'));
+    const eventsDir = path.join(stateDir, 'sessions', 'default');
+    await fs.promises.mkdir(eventsDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(eventsDir, 'events.ndjson'),
+      `${JSON.stringify(createAgentDeviceEvent())}\n`
+    );
+    const error = new Error('EAS Logs unavailable');
+    jest.mocked(HttpLogStream).mockImplementationOnce(() => {
+      throw error;
+    });
+    const logger = createLogger();
+
+    const collection = await startAgentDeviceEventCollectionAsync({
+      ctx: createContext({ realtimeLogs: true }),
+      deviceRunSessionId: 'session-id',
+      stateDir,
+      logger,
+      pollIntervalMs: 10,
+    });
+    try {
+      await waitForAsync(() => expect(mockEventLogStream.write).toHaveBeenCalledTimes(1));
+    } finally {
+      await collection.stopAsync();
+      await fs.promises.rm(stateDir, { recursive: true, force: true });
+    }
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: error },
+      'Could not start publishing device run session events in real time.'
+    );
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Could not publish device run session events in real time',
+      error,
+      {
+        level: 'warning',
+        tags: {
+          phase: 'device-run-session-event-collection',
+          operation: 'setup',
+          producer: 'agent-device',
+        },
+        extras: { deviceRunSessionId: 'session-id' },
+      }
+    );
+    expect(mockEventLogStream.cleanUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fail the session when real-time log cleanup fails', async () => {
+    const error = new Error('EAS Logs unavailable');
+    mockRealtimeLogStream.cleanUp.mockRejectedValueOnce(error);
+    const logger = createLogger();
+    const collection = await startAgentDeviceEventCollectionAsync({
+      ctx: createContext({ realtimeLogs: true }),
+      deviceRunSessionId: 'session-id',
+      stateDir: '/does/not/matter',
+      logger,
+      pollIntervalMs: 60_000,
+    });
+
+    await expect(collection.stopAsync()).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: error },
+      'Could not finish publishing device run session events in real time.'
+    );
+    expect(Sentry.capture).toHaveBeenCalledWith(
+      'Could not publish device run session events in real time',
+      error,
+      {
+        level: 'warning',
+        tags: {
+          phase: 'device-run-session-event-collection',
+          operation: 'cleanup',
+          producer: 'agent-device',
+        },
+        extras: { deviceRunSessionId: 'session-id' },
+      }
+    );
+    expect(mockEventLogStream.cleanUp).toHaveBeenCalledTimes(1);
   });
 });
 
-function createContext(): CustomBuildContext {
+function createContext({
+  realtimeLogs = false,
+}: { realtimeLogs?: boolean } = {}): CustomBuildContext {
   const mutation = jest.fn().mockReturnValue({
     toPromise: async () => ({
       data: {
@@ -533,7 +670,13 @@ function createContext(): CustomBuildContext {
       },
     }),
   });
-  return { graphqlClient: { mutation } } as unknown as CustomBuildContext;
+  return {
+    graphqlClient: { mutation },
+    env: realtimeLogs ? { EXPO_STAGING: '1', EAS_BUILD_ID: 'job-run-id' } : {},
+    job: {
+      secrets: realtimeLogs ? { robotAccessToken: 'robot-access-token' } : {},
+    },
+  } as unknown as CustomBuildContext;
 }
 
 function createLogger(): bunyan {

--- a/packages/build-tools/src/steps/utils/__tests__/agentDeviceEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/agentDeviceEvents.test.ts
@@ -504,13 +504,6 @@ describe(startAgentDeviceEventCollectionAsync, () => {
   });
 
   it('does not fail the session when event log setup fails', async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-device-events-'));
-    const eventsDir = path.join(stateDir, 'sessions', 'default');
-    await fs.promises.mkdir(eventsDir, { recursive: true });
-    await fs.promises.writeFile(
-      path.join(eventsDir, 'events.ndjson'),
-      `${JSON.stringify(createAgentDeviceEvent())}\n`
-    );
     const error = new Error('WWW unavailable');
     const ctx = createContext({ realtimeLogs: true });
     jest.mocked(ctx.graphqlClient.mutation).mockReturnValueOnce({
@@ -521,16 +514,11 @@ describe(startAgentDeviceEventCollectionAsync, () => {
     const collection = await startAgentDeviceEventCollectionAsync({
       ctx,
       deviceRunSessionId: 'session-id',
-      stateDir,
+      stateDir: '/does/not/matter',
       logger,
       pollIntervalMs: 10,
     });
-    try {
-      await waitForAsync(() => expect(mockRealtimeLogStream.write).toHaveBeenCalledTimes(1));
-    } finally {
-      await collection.stopAsync();
-      await fs.promises.rm(stateDir, { recursive: true, force: true });
-    }
+    await collection.stopAsync();
 
     expect(logger.warn).toHaveBeenCalledWith(
       {
@@ -558,13 +546,7 @@ describe(startAgentDeviceEventCollectionAsync, () => {
       }
     );
     expect(mockEventLogStream.init).not.toHaveBeenCalled();
-    expect(mockRealtimeLogStream.write).toHaveBeenCalledWith(
-      expect.objectContaining({
-        eventId: 'agent-device:session-id:default:1',
-        logId: 'agent-device:session-id:default:1',
-      })
-    );
-    expect(mockRealtimeLogStream.cleanUp).toHaveBeenCalledTimes(1);
+    expect(HttpLogStream).not.toHaveBeenCalled();
   });
 
   it('continues persisting the artifact when real-time log setup fails', async () => {

--- a/packages/build-tools/src/steps/utils/__tests__/argentEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/argentEvents.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { type CustomBuildContext } from '../../../customBuildContext';
+import HttpLogStream from '../../../logging/HttpLogStream';
 import RemoteLoggerStream from '../../../logging/RemoteLoggerStream';
 import { Sentry } from '../../../sentry';
 import { startArgentEventCollectionAsync } from '../argentEvents';
@@ -13,7 +14,15 @@ const mockEventLogStream = {
   write: jest.fn(),
   cleanUp: jest.fn(async () => undefined),
 };
+const mockRealtimeLogStream = {
+  write: jest.fn(),
+  cleanUp: jest.fn(async () => undefined),
+};
 
+jest.mock('../../../logging/HttpLogStream', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockRealtimeLogStream),
+}));
 jest.mock('../../../logging/RemoteLoggerStream', () => ({
   __esModule: true,
   default: jest.fn(() => mockEventLogStream),
@@ -43,7 +52,7 @@ describe(startArgentEventCollectionAsync, () => {
         })
       )}\n`
     );
-    const ctx = createContext();
+    const ctx = createContext({ realtimeLogs: true });
     const logger = createLogger();
     const collection = await startArgentEventCollectionAsync({
       ctx,
@@ -90,6 +99,13 @@ describe(startArgentEventCollectionAsync, () => {
     });
     expect(mockEventLogStream.init).toHaveBeenCalledTimes(1);
     expect(mockEventLogStream.cleanUp).toHaveBeenCalledTimes(1);
+    expect(HttpLogStream).toHaveBeenCalledWith({
+      url: 'https://staging-logs.expo.dev/logs/job-run-id/session-events',
+      headers: { Authorization: 'Bearer robot-access-token' },
+      logger,
+      bufferRetentionMs: 30_000,
+    });
+    expect(mockRealtimeLogStream.cleanUp).toHaveBeenCalledTimes(1);
     expect(mockEventLogStream.write).toHaveBeenNthCalledWith(1, {
       v: 1,
       eventId: 'argent:session-id:tool-server-events:1',
@@ -103,6 +119,19 @@ describe(startArgentEventCollectionAsync, () => {
     expect(mockEventLogStream.write).toHaveBeenNthCalledWith(2, {
       v: 1,
       eventId: 'argent:session-id:tool-server-events:2',
+      ts: '2026-07-10T12:00:01.000Z',
+      producer: 'argent',
+      type: 'operation.completed',
+      operationId: 'call-1',
+      outcome: 'success',
+      durationMs: 12.34,
+      summary: 'Captured screenshot.',
+      data: { toolId: 'screenshot', sourceType: 'tool.completed', sourceLevel: 30 },
+    });
+    expect(mockRealtimeLogStream.write).toHaveBeenNthCalledWith(2, {
+      v: 1,
+      eventId: 'argent:session-id:tool-server-events:2',
+      logId: 'argent:session-id:tool-server-events:2',
       ts: '2026-07-10T12:00:01.000Z',
       producer: 'argent',
       type: 'operation.completed',
@@ -286,7 +315,9 @@ function bunyanRecord(fields: Record<string, unknown>): Record<string, unknown> 
   };
 }
 
-function createContext(): CustomBuildContext {
+function createContext({
+  realtimeLogs = false,
+}: { realtimeLogs?: boolean } = {}): CustomBuildContext {
   const mutation = jest.fn().mockReturnValue({
     toPromise: async () => ({
       data: {
@@ -301,7 +332,13 @@ function createContext(): CustomBuildContext {
       },
     }),
   });
-  return { graphqlClient: { mutation } } as unknown as CustomBuildContext;
+  return {
+    graphqlClient: { mutation },
+    env: realtimeLogs ? { EXPO_STAGING: '1', EAS_BUILD_ID: 'job-run-id' } : {},
+    job: {
+      secrets: realtimeLogs ? { robotAccessToken: 'robot-access-token' } : {},
+    },
+  } as unknown as CustomBuildContext;
 }
 
 function createLogger(): bunyan {

--- a/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
+++ b/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
@@ -6,12 +6,15 @@ import { StringDecoder } from 'node:string_decoder';
 import { setTimeout as setTimeoutAsync } from 'node:timers/promises';
 
 import { type CustomBuildContext } from '../../customBuildContext';
+import HttpLogStream from '../../logging/HttpLogStream';
 import RemoteLoggerStream from '../../logging/RemoteLoggerStream';
 import { Sentry } from '../../sentry';
 import { type SignedUrl } from '../../storage/uploadWithSignedUrl';
 
 const POLL_INTERVAL_MS = 1_000;
 const UPLOAD_INTERVAL_MS = 5_000;
+const EAS_LOGS_THREAD = 'session-events';
+const EAS_LOGS_BUFFER_RETENTION_MS = 30_000;
 
 const CREATE_DEVICE_RUN_SESSION_EVENT_LOG_UPLOAD_SESSION_MUTATION = graphql(`
   mutation CreateDeviceRunSessionEventLogUploadSession($deviceRunSessionId: ID!) {
@@ -118,21 +121,50 @@ export async function startDeviceRunSessionEventCollectionAsync({
     });
   };
 
-  let eventLogStream: RemoteLoggerStream;
+  let eventLogStream: RemoteLoggerStream | undefined;
   try {
     const uploadSession = await createEventLogUploadSessionAsync(ctx, deviceRunSessionId);
-    eventLogStream = new RemoteLoggerStream({
+    const stream = new RemoteLoggerStream({
       logger,
       uploadMethod: { signedUrl: uploadSession },
       options: {
         uploadIntervalMs: UPLOAD_INTERVAL_MS,
       },
     });
-    await eventLogStream.init();
+    await stream.init();
+    eventLogStream = stream;
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
-    logger.warn({ err: error }, 'Could not start device run session event collection.');
+    logger.warn({ err: error }, 'Could not persist device run session events to the artifact.');
     reportEventLogFailure(error, 'setup');
+  }
+
+  let didReportRealtimeLogFailure = false;
+  const reportRealtimeLogFailure = (error: Error, operation: 'setup' | 'cleanup'): void => {
+    if (didReportRealtimeLogFailure) {
+      return;
+    }
+    didReportRealtimeLogFailure = true;
+    Sentry.capture('Could not publish device run session events in real time', error, {
+      level: 'warning',
+      tags: { phase: 'device-run-session-event-collection', operation, producer },
+      extras: { deviceRunSessionId },
+    });
+  };
+
+  let realtimeLogStream: HttpLogStream | undefined;
+  try {
+    realtimeLogStream = createRealtimeLogStream(ctx, logger, Boolean(eventLogStream));
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.warn(
+      { err: error },
+      'Could not start publishing device run session events in real time.'
+    );
+    reportRealtimeLogFailure(error, 'setup');
+  }
+
+  if (!eventLogStream && !realtimeLogStream) {
     return { stopAsync: async () => {} };
   }
 
@@ -161,7 +193,10 @@ export async function startDeviceRunSessionEventCollectionAsync({
           state,
           source,
           deviceRunSessionId,
-          writeEvent: event => eventLogStream.write(event),
+          writeEvent: event => {
+            eventLogStream?.write(event);
+            realtimeLogStream?.write({ ...event, logId: event.eventId });
+          },
           onParseFailure: ({ failure, lineNumber }) => {
             parseFailureCount += 1;
             parseFailureCounts[failure] += 1;
@@ -243,15 +278,56 @@ export async function startDeviceRunSessionEventCollectionAsync({
           extras: { deviceRunSessionId, parseFailureCount, parseFailureCounts },
         });
       }
-      try {
-        await eventLogStream.cleanUp();
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err));
-        logger.warn({ err: error }, 'Could not finish device run session event collection.');
-        reportEventLogFailure(error, 'cleanup');
-      }
+      await Promise.all([cleanUpEventLogStreamAsync(), cleanUpRealtimeLogStreamAsync()]);
     },
   };
+
+  async function cleanUpEventLogStreamAsync(): Promise<void> {
+    try {
+      await eventLogStream?.cleanUp();
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      logger.warn({ err: error }, 'Could not finish persisting device run session events.');
+      reportEventLogFailure(error, 'cleanup');
+    }
+  }
+
+  async function cleanUpRealtimeLogStreamAsync(): Promise<void> {
+    try {
+      await realtimeLogStream?.cleanUp();
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      logger.warn(
+        { err: error },
+        'Could not finish publishing device run session events in real time.'
+      );
+      reportRealtimeLogFailure(error, 'cleanup');
+    }
+  }
+}
+
+function createRealtimeLogStream(
+  ctx: CustomBuildContext,
+  logger: bunyan,
+  hasDurableEventLog: boolean
+): HttpLogStream | undefined {
+  const baseUrl = ctx.env.EXPO_LOCAL
+    ? 'http://localhost:4999/logs/'
+    : ctx.env.EXPO_STAGING
+      ? 'https://staging-logs.expo.dev/logs/'
+      : undefined;
+  const jobRunId = ctx.env.EAS_BUILD_ID;
+  const robotAccessToken = ctx.job.secrets?.robotAccessToken;
+  if (!baseUrl || !jobRunId || !robotAccessToken) {
+    return undefined;
+  }
+
+  return new HttpLogStream({
+    url: new URL(`${jobRunId}/${EAS_LOGS_THREAD}`, baseUrl).toString(),
+    headers: { Authorization: `Bearer ${robotAccessToken}` },
+    logger,
+    bufferRetentionMs: hasDurableEventLog ? EAS_LOGS_BUFFER_RETENTION_MS : null,
+  });
 }
 
 async function createEventLogUploadSessionAsync(

--- a/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
+++ b/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
@@ -121,22 +121,22 @@ export async function startDeviceRunSessionEventCollectionAsync({
     });
   };
 
-  let eventLogStream: RemoteLoggerStream | undefined;
+  let eventLogStream: RemoteLoggerStream;
   try {
     const uploadSession = await createEventLogUploadSessionAsync(ctx, deviceRunSessionId);
-    const stream = new RemoteLoggerStream({
+    eventLogStream = new RemoteLoggerStream({
       logger,
       uploadMethod: { signedUrl: uploadSession },
       options: {
         uploadIntervalMs: UPLOAD_INTERVAL_MS,
       },
     });
-    await stream.init();
-    eventLogStream = stream;
+    await eventLogStream.init();
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
     logger.warn({ err: error }, 'Could not persist device run session events to the artifact.');
     reportEventLogFailure(error, 'setup');
+    return { stopAsync: async () => {} };
   }
 
   let didReportRealtimeLogFailure = false;
@@ -154,7 +154,7 @@ export async function startDeviceRunSessionEventCollectionAsync({
 
   let realtimeLogStream: HttpLogStream | undefined;
   try {
-    realtimeLogStream = createRealtimeLogStream(ctx, logger, Boolean(eventLogStream));
+    realtimeLogStream = createRealtimeLogStream(ctx, logger);
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
     logger.warn(
@@ -162,10 +162,6 @@ export async function startDeviceRunSessionEventCollectionAsync({
       'Could not start publishing device run session events in real time.'
     );
     reportRealtimeLogFailure(error, 'setup');
-  }
-
-  if (!eventLogStream && !realtimeLogStream) {
-    return { stopAsync: async () => {} };
   }
 
   const states = new Map<string, EventFileState>();
@@ -194,7 +190,7 @@ export async function startDeviceRunSessionEventCollectionAsync({
           source,
           deviceRunSessionId,
           writeEvent: event => {
-            eventLogStream?.write(event);
+            eventLogStream.write(event);
             realtimeLogStream?.write({ ...event, logId: event.eventId });
           },
           onParseFailure: ({ failure, lineNumber }) => {
@@ -284,7 +280,7 @@ export async function startDeviceRunSessionEventCollectionAsync({
 
   async function cleanUpEventLogStreamAsync(): Promise<void> {
     try {
-      await eventLogStream?.cleanUp();
+      await eventLogStream.cleanUp();
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       logger.warn({ err: error }, 'Could not finish persisting device run session events.');
@@ -308,8 +304,7 @@ export async function startDeviceRunSessionEventCollectionAsync({
 
 function createRealtimeLogStream(
   ctx: CustomBuildContext,
-  logger: bunyan,
-  hasDurableEventLog: boolean
+  logger: bunyan
 ): HttpLogStream | undefined {
   const baseUrl = ctx.env.EXPO_LOCAL
     ? 'http://localhost:4999/logs/'
@@ -326,7 +321,7 @@ function createRealtimeLogStream(
     url: new URL(`${jobRunId}/${EAS_LOGS_THREAD}`, baseUrl).toString(),
     headers: { Authorization: `Bearer ${robotAccessToken}` },
     logger,
-    bufferRetentionMs: hasDurableEventLog ? EAS_LOGS_BUFFER_RETENTION_MS : null,
+    bufferRetentionMs: EAS_LOGS_BUFFER_RETENTION_MS,
   });
 }
 


### PR DESCRIPTION
## Why

We want to deliver logs faster than every 5 seconds.

## How

Same way we publish logs in worker to `HttpLogStream`, publish them when collecting device run session logs. Whenever we see an event, we write to both loggers.

## Test Plan

CI should pass. Only applies in development and staging.