### PR TITLE
Exclude locally ignored files from build archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] clean up error handling in local builds. ([#4105](https://github.com/expo/eas-cli/pull/4105) by [@douglowder](https://github.com/douglowder))
 - [build-tools] Install ffmpeg when it is missing so Argent screen recording works in EAS Simulator sessions. ([#4110](https://github.com/expo/eas-cli/pull/4110) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Stop simulator job runs when `eas simulator:start` is canceled before the session is ready. ([#4113](https://github.com/expo/eas-cli/pull/4113) by [@sjchmiela](https://github.com/sjchmiela))
+- [eas-cli] Exclude files ignored via `$GIT_DIR/info/exclude` and `core.excludesFile` from the project archive. ([#4123](https://github.com/expo/eas-cli/pull/4123) by [@Nezz](https://github.com/Nezz))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/vcs/__tests__/local-test.ts
+++ b/packages/eas-cli/src/vcs/__tests__/local-test.ts
@@ -1,6 +1,6 @@
 import { vol } from 'memfs';
 
-import { Ignore } from '../local';
+import { Ignore, IgnoredPathsFilter } from '../local';
 
 jest.mock('fs');
 
@@ -110,5 +110,30 @@ describe(Ignore, () => {
 
     const ignore = await Ignore.createForCopyingAsync('/root');
     expect(() => ignore.ignores('dir/test')).not.toThrowError();
+  });
+});
+
+describe(IgnoredPathsFilter, () => {
+  it('ignores the listed files', () => {
+    const filter = new IgnoredPathsFilter(['secret.txt', 'dir/other.txt']);
+    expect(filter.ignores('secret.txt')).toBe(true);
+    expect(filter.ignores('dir/other.txt')).toBe(true);
+    expect(filter.ignores('other.txt')).toBe(false);
+    expect(filter.ignores('dir/secret.txt')).toBe(false);
+  });
+
+  it('ignores the content of the listed directories', () => {
+    const filter = new IgnoredPathsFilter(['worktrees/']);
+    expect(filter.ignores('worktrees')).toBe(true);
+    expect(filter.ignores('worktrees/a/b.txt')).toBe(true);
+    expect(filter.ignores('worktrees-2')).toBe(false);
+  });
+
+  it('always ignores .git and node_modules', () => {
+    const filter = new IgnoredPathsFilter([]);
+    expect(filter.ignores('.git')).toBe(true);
+    expect(filter.ignores('.git/config')).toBe(true);
+    expect(filter.ignores('node_modules')).toBe(true);
+    expect(filter.ignores('packages/app/node_modules')).toBe(true);
   });
 });

--- a/packages/eas-cli/src/vcs/clients/__tests__/git.test.ts
+++ b/packages/eas-cli/src/vcs/clients/__tests__/git.test.ts
@@ -243,6 +243,112 @@ describe('git', () => {
     ).resolves.not.toThrow();
   });
 
+  it('does not include files ignored in $GIT_DIR/info/exclude', async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+    await spawnAsync('git', ['init'], { cwd: repoRoot });
+    const vcs = new GitClient({
+      requireCommit: false,
+      maybeCwdOverride: repoRoot,
+    });
+
+    await fs.writeFile(`${repoRoot}/committed-file.txt`, 'file');
+    await spawnAsync('git', ['add', '.'], { cwd: repoRoot });
+    await spawnAsync('git', ['commit', '-m', 'add file'], { cwd: repoRoot });
+
+    await fs.mkdir(`${repoRoot}/locally-excluded-dir`);
+    await fs.writeFile(`${repoRoot}/locally-excluded-dir/file.txt`, 'file');
+    await fs.writeFile(`${repoRoot}/locally-excluded-file.txt`, 'file');
+    await fs.writeFile(
+      `${repoRoot}/.git/info/exclude`,
+      'locally-excluded-dir/\nlocally-excluded-file.txt\n'
+    );
+
+    const repoClone = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+    await expect(vcs.makeShallowCopyAsync(repoClone)).resolves.not.toThrow();
+    await expect(fs.stat(path.join(repoClone, 'locally-excluded-dir'))).rejects.toThrow('ENOENT');
+    await expect(fs.stat(path.join(repoClone, 'locally-excluded-file.txt'))).rejects.toThrow(
+      'ENOENT'
+    );
+    await expect(fs.stat(path.join(repoClone, 'committed-file.txt'))).resolves.not.toThrow();
+  });
+
+  it('does not include files ignored in core.excludesFile', async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+    await spawnAsync('git', ['init'], { cwd: repoRoot });
+    const vcs = new GitClient({
+      requireCommit: false,
+      maybeCwdOverride: repoRoot,
+    });
+
+    const globalExcludesFile = path.join(repoRoot, '..', `${path.basename(repoRoot)}-excludes`);
+    await fs.writeFile(globalExcludesFile, 'globally-excluded-file.txt\n');
+    await spawnAsync('git', ['config', 'core.excludesFile', globalExcludesFile], { cwd: repoRoot });
+
+    await fs.writeFile(`${repoRoot}/committed-file.txt`, 'file');
+    await spawnAsync('git', ['add', 'committed-file.txt'], { cwd: repoRoot });
+    await spawnAsync('git', ['commit', '-m', 'add file'], { cwd: repoRoot });
+    await fs.writeFile(`${repoRoot}/globally-excluded-file.txt`, 'file');
+
+    const repoClone = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+    await expect(vcs.makeShallowCopyAsync(repoClone)).resolves.not.toThrow();
+    await expect(fs.stat(path.join(repoClone, 'globally-excluded-file.txt'))).rejects.toThrow(
+      'ENOENT'
+    );
+    await expect(fs.stat(path.join(repoClone, 'committed-file.txt'))).resolves.not.toThrow();
+  });
+
+  it('does not include files ignored inside a submodule', async () => {
+    const submoduleRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+    await spawnAsync('git', ['init'], { cwd: submoduleRoot });
+    await fs.writeFile(`${submoduleRoot}/.gitignore`, 'build/\n');
+    await fs.writeFile(`${submoduleRoot}/source.txt`, 'file');
+    await spawnAsync('git', ['add', '.'], { cwd: submoduleRoot });
+    await spawnAsync('git', ['commit', '-m', 'add source'], { cwd: submoduleRoot });
+
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+    await spawnAsync('git', ['init'], { cwd: repoRoot });
+    const vcs = new GitClient({
+      requireCommit: false,
+      maybeCwdOverride: repoRoot,
+    });
+
+    await spawnAsync(
+      'git',
+      // Local submodules are refused unless the file protocol is allowed.
+      ['-c', 'protocol.file.allow=always', 'submodule', 'add', submoduleRoot, 'submodule'],
+      { cwd: repoRoot }
+    );
+    await spawnAsync('git', ['commit', '-m', 'add submodule'], { cwd: repoRoot });
+
+    await fs.mkdir(`${repoRoot}/submodule/build`);
+    await fs.writeFile(`${repoRoot}/submodule/build/artifact.txt`, 'file');
+
+    const repoClone = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+    await expect(vcs.makeShallowCopyAsync(repoClone)).resolves.not.toThrow();
+    await expect(fs.stat(path.join(repoClone, 'submodule/build'))).rejects.toThrow('ENOENT');
+    await expect(fs.stat(path.join(repoClone, 'submodule/source.txt'))).resolves.not.toThrow();
+  });
+
+  it('includes tracked files that match a .gitignore rule', async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+    await spawnAsync('git', ['init'], { cwd: repoRoot });
+    const vcs = new GitClient({
+      requireCommit: false,
+      maybeCwdOverride: repoRoot,
+    });
+
+    await fs.writeFile(`${repoRoot}/.gitignore`, '*.env\n');
+    await fs.writeFile(`${repoRoot}/tracked.env`, 'file');
+    await fs.writeFile(`${repoRoot}/untracked.env`, 'file');
+    await spawnAsync('git', ['add', '--force', '.gitignore', 'tracked.env'], { cwd: repoRoot });
+    await spawnAsync('git', ['commit', '-m', 'add files'], { cwd: repoRoot });
+
+    const repoClone = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));
+    await expect(vcs.makeShallowCopyAsync(repoClone)).resolves.not.toThrow();
+    await expect(fs.stat(path.join(repoClone, 'tracked.env'))).resolves.not.toThrow();
+    await expect(fs.stat(path.join(repoClone, 'untracked.env'))).rejects.toThrow('ENOENT');
+  });
+
   describe('when requireCommit is true', () => {
     it('adheres to .easignore', async () => {
       const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-git-test-'));

--- a/packages/eas-cli/src/vcs/clients/git.ts
+++ b/packages/eas-cli/src/vcs/clients/git.ts
@@ -12,11 +12,18 @@ import { confirmAsync, promptAsync } from '../../prompts';
 import {
   doesGitRepoExistAsync,
   getGitDiffOutputAsync,
+  getIgnoredPathsAsync,
   gitDiffAsync,
   gitStatusAsync,
   isGitInstalledAsync,
 } from '../git';
-import { EASIGNORE_FILENAME, Ignore, makeShallowCopyAsync } from '../local';
+import {
+  EASIGNORE_FILENAME,
+  Ignore,
+  IgnoredPathsFilter,
+  makeShallowCopyAsync,
+  PathFilter,
+} from '../local';
 import { Client } from '../vcs';
 
 let hasWarnedAboutEasignoreInRequireCommit = false;
@@ -274,7 +281,11 @@ export default class GitClient extends Client {
       //
       // We only do this if `requireCommit` is false because `requireCommit: true`
       // setups expect no changes in files (e.g. locked files should remain locked).
-      await makeShallowCopyAsync(rootPath, destinationPath);
+      await makeShallowCopyAsync(
+        rootPath,
+        destinationPath,
+        await this.createCopyFilterAsync(rootPath, { doesEasignoreExist })
+      );
     } else {
       Log.debug('not making shallow copy', { requireCommit: this.requireCommit });
     }
@@ -390,6 +401,23 @@ export default class GitClient extends Client {
 
   public override canGetLastCommitMessage(): boolean {
     return true;
+  }
+
+  private async createCopyFilterAsync(
+    rootPath: string,
+    { doesEasignoreExist }: { doesEasignoreExist: boolean }
+  ): Promise<PathFilter> {
+    if (doesEasignoreExist) {
+      // `.easignore` replaces the Git ignore rules entirely.
+      return await Ignore.createForCopyingAsync(rootPath);
+    }
+
+    // Ask Git which paths are ignored rather than reimplementing its ignore
+    // rules, so that the copy stays consistent with `isFileIgnoredAsync()` and
+    // with what the user sees in `git status`.
+    const ignoredPaths = await getIgnoredPathsAsync(rootPath);
+    Log.debug('paths ignored by git', { ignoredPaths });
+    return new IgnoredPathsFilter(ignoredPaths);
   }
 
   private async ensureGitConfiguredAsync({

--- a/packages/eas-cli/src/vcs/git.ts
+++ b/packages/eas-cli/src/vcs/git.ts
@@ -1,4 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
+import path from 'path';
 
 export async function isGitInstalledAsync(): Promise<boolean> {
   try {
@@ -34,6 +35,45 @@ export async function gitStatusAsync({ showUntracked, cwd }: GitStatusOptions): 
       cwd,
     })
   ).stdout;
+}
+
+/**
+ * Lists the paths Git considers ignored, following all of the standard exclude
+ * sources: `.gitignore` files, `$GIT_DIR/info/exclude` and `core.excludesFile`.
+ *
+ * Directories that are ignored as a whole are returned as a single entry with a
+ * trailing slash, so Git does not have to walk their contents.
+ */
+export async function getIgnoredPathsAsync(cwd: string): Promise<string[]> {
+  const ignoredPaths = await listIgnoredPathsAsync(cwd);
+
+  // `git ls-files` does not descend into submodules, so each one has to be
+  // asked separately for the paths it ignores.
+  for (const submodulePath of await getSubmodulePathsAsync(cwd)) {
+    const submoduleIgnoredPaths = await listIgnoredPathsAsync(path.join(cwd, submodulePath));
+    ignoredPaths.push(...submoduleIgnoredPaths.map(entry => `${submodulePath}/${entry}`));
+  }
+
+  return ignoredPaths;
+}
+
+async function listIgnoredPathsAsync(cwd: string): Promise<string[]> {
+  const { stdout } = await spawnAsync(
+    'git',
+    ['ls-files', '--others', '--ignored', '--exclude-standard', '--directory', '-z'],
+    { cwd }
+  );
+  return stdout.split('\0').filter(entry => entry !== '');
+}
+
+/** Paths of the initialized submodules, relative to `cwd`, nested ones included. */
+async function getSubmodulePathsAsync(cwd: string): Promise<string[]> {
+  const { stdout } = await spawnAsync(
+    'git',
+    ['submodule', 'foreach', '--recursive', '--quiet', 'echo "$displaypath"'],
+    { cwd }
+  );
+  return stdout.split('\n').filter(entry => entry !== '');
 }
 
 export async function getGitDiffOutputAsync(cwd: string | undefined): Promise<string> {

--- a/packages/eas-cli/src/vcs/local.ts
+++ b/packages/eas-cli/src/vcs/local.ts
@@ -8,6 +8,48 @@ import Log from '../log';
 
 export const EASIGNORE_FILENAME = '.easignore';
 const GITIGNORE_FILENAME = '.gitignore';
+const ALWAYS_IGNORED = `
+.git
+node_modules
+`;
+
+/** Decides which paths are left out of the copy of the project. */
+export interface PathFilter {
+  ignores(relativePath: string): boolean;
+}
+
+/**
+ * Ignores an explicit list of paths, as opposed to a list of patterns. Paths are
+ * relative to the copied directory and separated with forward slashes, and a
+ * trailing slash marks a directory, whose whole content is ignored.
+ *
+ * `GitClient` builds this from the paths Git reports as ignored, so that the
+ * copy matches what `git status` shows instead of a reimplementation of Git's
+ * ignore rules.
+ */
+export class IgnoredPathsFilter implements PathFilter {
+  private readonly ignoredFiles: Set<string>;
+  private readonly ignoredDirectories: string[];
+  private readonly alwaysIgnored = createIgnore().add(ALWAYS_IGNORED);
+
+  constructor(ignoredPaths: string[]) {
+    this.ignoredFiles = new Set(ignoredPaths.filter(entry => !entry.endsWith('/')));
+    this.ignoredDirectories = ignoredPaths.filter(entry => entry.endsWith('/'));
+  }
+
+  public ignores(relativePath: string): boolean {
+    const posixPath = relativePath.split(path.sep).join('/');
+    if (this.alwaysIgnored.ignores(posixPath)) {
+      return true;
+    }
+    if (this.ignoredFiles.has(posixPath)) {
+      return true;
+    }
+    return this.ignoredDirectories.some(
+      directory => posixPath === directory.slice(0, -1) || posixPath.startsWith(directory)
+    );
+  }
+}
 
 /**
  * Ignore wraps the 'ignore' package to support multiple .gitignore files
@@ -17,9 +59,13 @@ const GITIGNORE_FILENAME = '.gitignore';
  * - if parent .gitignore has ignore rule and child has exception to that rule,
  *   file will still be ignored,
  * - node_modules is always ignored,
- * - if .easignore exists, .gitignore files are not used.
+ * - if .easignore exists, .gitignore files are not used,
+ * - local exclude files ($GIT_DIR/info/exclude, core.excludesFile) are not read.
+ *
+ * `GitClient` only uses this for projects with an .easignore; otherwise it asks
+ * Git for the ignored paths and uses `IgnoredPathsFilter`.
  */
-export class Ignore {
+export class Ignore implements PathFilter {
   public ignoreMapping: (readonly [string, SingleFileIgnore])[] = [];
 
   private constructor(private readonly rootDir: string) {}
@@ -27,10 +73,7 @@ export class Ignore {
   static async createForCopyingAsync(rootDir: string): Promise<Ignore> {
     const ignore = new Ignore(rootDir);
     await ignore.initIgnoreAsync({
-      defaultIgnore: `
-.git
-node_modules
-`,
+      defaultIgnore: ALWAYS_IGNORED,
     });
     return ignore;
   }
@@ -93,7 +136,11 @@ node_modules
   }
 }
 
-export async function makeShallowCopyAsync(_src: string, dst: string): Promise<void> {
+export async function makeShallowCopyAsync(
+  _src: string,
+  dst: string,
+  filter?: PathFilter
+): Promise<void> {
   // `node:fs` on Windows adds a namespace prefix (e.g. `\\?\`) to the path provided
   // to the `filter` function in `fs.cp`. We need to ensure that we compare the right paths
   // (both with prefix), otherwise the `relativePath` ends up being wrong and causes no files
@@ -101,8 +148,8 @@ export async function makeShallowCopyAsync(_src: string, dst: string): Promise<v
   const src = path.toNamespacedPath(path.normalize(_src));
 
   Log.debug('makeShallowCopyAsync', { src, dst });
-  const ignore = await Ignore.createForCopyingAsync(src);
-  Log.debug('makeShallowCopyAsync ignoreMapping', { ignoreMapping: ignore.ignoreMapping });
+  const ignore = filter ?? (await Ignore.createForCopyingAsync(src));
+  Log.debug('makeShallowCopyAsync filter', { filter: ignore });
 
   await fs.cp(src, dst, {
     recursive: true,


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Fixes #4122

# How

`GitClient` now asks git which paths are ignored instead of grabbing git's ignore rules from `.gitignore` files only. That covers `$GIT_DIR/info/exclude` and `core.excludesFile`, and makes the copy consistent with `isFileIgnoredAsync()`, which already used `git check-ignore`. Projects with an `.easignore` keep the existing behaviour.

# Test Plan

7 new tests, each failing on `main`: `info/exclude`, `core.excludesFile`, ignores inside a submodule, and tracked files matching a `.gitignore` rule. `yarn test`, `yarn typecheck`, `yarn lint` and `yarn fmt:check` are clean.

Reproduces with `eas build:inspect -p ios -s archive -o /tmp/inspect` on a blank project with a 100 MB directory listed in `.git/info/exclude`, where `git status` stays clean:

```
before  100M /tmp/inspect
after   132K /tmp/inspect
```
