### PR TITLE
[eas-cli] Fix `eas login` redirect URI when running in GitHub Codespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] clean up error handling in local builds. ([#4105](https://github.com/expo/eas-cli/pull/4105) by [@douglowder](https://github.com/douglowder))
 - [build-tools] Install ffmpeg when it is missing so Argent screen recording works in EAS Simulator sessions. ([#4110](https://github.com/expo/eas-cli/pull/4110) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Stop simulator job runs when `eas simulator:start` is canceled before the session is ready. ([#4113](https://github.com/expo/eas-cli/pull/4113) by [@sjchmiela](https://github.com/sjchmiela))
-- [eas-cli] Fix `eas login` redirect URI to use the forwarded port URL when running in GitHub Codespaces. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@Ignigena](https://github.com/Ignigena))
+- [eas-cli] Fix `eas login` redirect URI to use the forwarded port URL when running in GitHub Codespaces. ([#4129](https://github.com/expo/eas-cli/pull/4129) by [@Ignigena](https://github.com/Ignigena))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] clean up error handling in local builds. ([#4105](https://github.com/expo/eas-cli/pull/4105) by [@douglowder](https://github.com/douglowder))
 - [build-tools] Install ffmpeg when it is missing so Argent screen recording works in EAS Simulator sessions. ([#4110](https://github.com/expo/eas-cli/pull/4110) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Stop simulator job runs when `eas simulator:start` is canceled before the session is ready. ([#4113](https://github.com/expo/eas-cli/pull/4113) by [@sjchmiela](https://github.com/sjchmiela))
+- [eas-cli] Fix `eas login` redirect URI to use the forwarded port URL when running in GitHub Codespaces. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@Ignigena](https://github.com/Ignigena))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/user/expoBrowserAuthFlowLauncher.ts
+++ b/packages/eas-cli/src/user/expoBrowserAuthFlowLauncher.ts
@@ -22,6 +22,16 @@ function generateState(): string {
   return crypto.randomBytes(32).toString('base64url');
 }
 
+function getRedirectBaseUrl(port: number): string {
+  if (process.env.CODESPACES === 'true') {
+    // In GitHub Codespaces, `localhost` is not reachable from the browser used to complete the
+    // OAuth flow, so the redirect must point at the forwarded port's public URL instead.
+    const { CODESPACE_NAME, GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN } = process.env;
+    return `https://${CODESPACE_NAME}-${port}.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`;
+  }
+  return `http://localhost:${port}`;
+}
+
 async function exchangeCodeForSessionSecretAsync({
   code,
   codeVerifier,
@@ -55,7 +65,6 @@ async function exchangeCodeForSessionSecretAsync({
 }
 
 export async function getSessionUsingBrowserAuthFlowAsync({ sso = false }): Promise<string> {
-  const scheme = 'http';
   const hostname = 'localhost';
   const callbackPath = '/auth/callback';
 
@@ -66,7 +75,7 @@ export async function getSessionUsingBrowserAuthFlowAsync({ sso = false }): Prom
   const state = generateState();
 
   const buildRedirectUri = (port: number): string =>
-    `${scheme}://${hostname}:${port}${callbackPath}`;
+    new URL(callbackPath, getRedirectBaseUrl(port)).toString();
 
   const buildExpoLoginUrl = (port: number, sso: boolean): string => {
     // Note: we avoid URLSearchParams here because better-opn calls encodeURI()


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Our team relies heavily on GitHub Codespaces for development, especially for smaller changes that don't require a full local Native development environment. Codespaces lets contributors jump into the codebase from a browser or a lightweight setup without provisioning all of that tooling locally.

However, `eas login` doesn't work from within GitHub Codespaces. The CLI starts a local callback server and sends `expo.dev` a hardcoded `redirect_uri` of `http://localhost:<port>/auth/callback`, but inside a Codespace the browser completing the login can only reach the forwarded port's public URL (e.g. `https://<codespace-name>-<port>.app.github.dev`), not `localhost`. This leaves the login flow unable to complete when developing inside a Codespace without awkardly copying the correct hostname into the resulting 404 redirect in the browser.

Everything else about the flow already works correctly in Codespaces: the callback HTTP server starts, listens, and Codespaces automatically forwards/exposes the port, so a redirect to that port does reach the running server. The only problem is that the URL handed to `expo.dev` as `redirect_uri` needs to use the forwarded hostname instead of `localhost` for the browser to be able to follow it.

> [!NOTE]
> With this change the CLI sends the correct `*.app.github.dev` `redirect_uri`, but the login flow still doesn't complete end-to-end yet, since `expo.dev`/the auth API currently appears to only redirect back to `localhost` redirect URIs and silently drops non-`localhost` ones. To fully fix this for Codespaces users, the server side will also need to allowlist `*.app.github.dev` as a valid redirect host. This should be low risk: even if someone's forwarded port were made public, Codespaces already shows an interstitial warning page to any unauthenticated visitor before they reach the forwarded service.

# How

- Added `getRedirectBaseUrl(port)` in [expoBrowserAuthFlowLauncher.ts](packages/eas-cli/src/user/expoBrowserAuthFlowLauncher.ts), which returns the Codespaces forwarded-port URL (built from the `CODESPACES`, `CODESPACE_NAME`, and `GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN` environment variables) when running in a Codespace, falling back to `http://localhost:<port>` otherwise.
- `buildRedirectUri` now builds the full redirect URI from that base URL using the `URL` constructor instead of hardcoding the `localhost` scheme/host.
- The callback server itself still binds to `localhost`, since Codespaces port forwarding proxies external requests back to `localhost` inside the container, so only the URL handed to `expo.dev` needed to change.

# Test Plan

- Ran `eas login` inside a GitHub Codespace and confirmed the printed login URL and the `redirect_uri` query param now point at the Codespace's forwarded-port URL (`https://<codespace-name>-<port>.app.github.dev/auth/callback`) instead of `localhost`.
- Completed the login in the browser and confirmed the request reaches `expo.dev` with the correct `redirect_uri`, but `expo.dev` does not redirect back to the `*.app.github.dev` URL, so the callback server never receives the code (see note above — needs a server-side allowlist change to close the loop).
- Ran `eas login` outside of Codespaces (`CODESPACES` unset) and confirmed the redirect URI is unchanged (`http://localhost:<port>/auth/callback`) and login still completes as before.
