### PR TITLE
[eas-cli] Non-zero exit on empty build:view/submit:view, JSON output before context setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Exit with a non-zero code when `eas build:view` or `eas submit:view` finds no builds or submissions, and print a single failure message instead of two. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@brentvatne](https://github.com/brentvatne))
+- [eas-cli] Enable JSON output before context setup in `eas build:list` and `eas build:view` so `--json` stdout stays pure JSON. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli] clean up error handling in local builds. ([#4105](https://github.com/expo/eas-cli/pull/4105) by [@douglowder](https://github.com/douglowder))
 - [build-tools] Install ffmpeg when it is missing so Argent screen recording works in EAS Simulator sessions. ([#4110](https://github.com/expo/eas-cli/pull/4110) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Stop simulator job runs when `eas simulator:start` is canceled before the session is ready. ([#4113](https://github.com/expo/eas-cli/pull/4113) by [@sjchmiela](https://github.com/sjchmiela))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- [eas-cli] Exit with a non-zero code when `eas build:view` or `eas submit:view` finds no builds or submissions, and print a single failure message instead of two. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@brentvatne](https://github.com/brentvatne))
-- [eas-cli] Enable JSON output before context setup in `eas build:list` and `eas build:view` so `--json` stdout stays pure JSON. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@brentvatne](https://github.com/brentvatne))
+- [eas-cli] Exit with a non-zero code when `eas build:view` or `eas submit:view` finds no builds or submissions, and print a single failure message instead of two. ([#4135](https://github.com/expo/eas-cli/pull/4135) by [@brentvatne](https://github.com/brentvatne))
+- [eas-cli] Enable JSON output before context setup in `eas build:list` and `eas build:view` so `--json` stdout stays pure JSON. ([#4135](https://github.com/expo/eas-cli/pull/4135) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli] clean up error handling in local builds. ([#4105](https://github.com/expo/eas-cli/pull/4105) by [@douglowder](https://github.com/douglowder))
 - [build-tools] Install ffmpeg when it is missing so Argent screen recording works in EAS Simulator sessions. ([#4110](https://github.com/expo/eas-cli/pull/4110) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Stop simulator job runs when `eas simulator:start` is canceled before the session is ready. ([#4113](https://github.com/expo/eas-cli/pull/4113) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/eas-cli/src/commands/build/list.ts
+++ b/packages/eas-cli/src/commands/build/list.ts
@@ -103,15 +103,17 @@ export default class BuildList extends EasCommand {
       );
       process.exit(1);
     }
+    // Redirect stdout before context setup — resolving the project config can log messages,
+    // and with --json those must go to stderr.
+    if (jsonFlag) {
+      enableJsonOutput();
+    }
     const {
       projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(BuildList, {
       nonInteractive,
     });
-    if (jsonFlag) {
-      enableJsonOutput();
-    }
 
     const platform = toAppPlatform(requestedPlatform);
     const graphqlBuildStatus = toGraphQLBuildStatus(buildStatus);

--- a/packages/eas-cli/src/commands/build/view.ts
+++ b/packages/eas-cli/src/commands/build/view.ts
@@ -9,6 +9,8 @@ import { ora } from '../../ora';
 import { getDisplayNameForProjectIdAsync } from '../../project/projectUtils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
+class NoBuildsFoundError extends Error {}
+
 export default class BuildView extends EasCommand {
   static override description = 'view a build for your project';
 
@@ -31,15 +33,17 @@ export default class BuildView extends EasCommand {
       args: { BUILD_ID: buildId },
       flags,
     } = await this.parse(BuildView);
+    // Redirect stdout before context setup — resolving the project config can log messages,
+    // and with --json those must go to stderr.
+    if (flags.json) {
+      enableJsonOutput();
+    }
     const {
       projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(BuildView, {
       nonInteractive: true,
     });
-    if (flags.json) {
-      enableJsonOutput();
-    }
 
     const displayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);
 
@@ -58,7 +62,8 @@ export default class BuildView extends EasCommand {
         });
         if (builds.length === 0) {
           spinner.fail(`Couldn't find any builds for the project ${displayName}`);
-          return;
+          // Throw so scripts get a non-zero exit code instead of silent success.
+          throw new NoBuildsFoundError(`No builds found for the project ${displayName}`);
         }
         build = builds[0];
       }
@@ -75,12 +80,14 @@ export default class BuildView extends EasCommand {
         Log.log(`\n${formatGraphQLBuild(build)}`);
       }
     } catch (err) {
-      if (buildId) {
-        spinner.fail(`Something went wrong and we couldn't fetch the build with id ${buildId}`);
-      } else {
-        spinner.fail(
-          `Something went wrong and we couldn't fetch the last build for the project ${displayName}`
-        );
+      if (!(err instanceof NoBuildsFoundError)) {
+        if (buildId) {
+          spinner.fail(`Something went wrong and we couldn't fetch the build with id ${buildId}`);
+        } else {
+          spinner.fail(
+            `Something went wrong and we couldn't fetch the last build for the project ${displayName}`
+          );
+        }
       }
 
       throw err;

--- a/packages/eas-cli/src/commands/submit/view.ts
+++ b/packages/eas-cli/src/commands/submit/view.ts
@@ -12,6 +12,8 @@ import { getLatestSubmissionAsync } from '../../submit/queries';
 import { formatGraphQLSubmission } from '../../submit/utils/formatSubmission';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
+class NoSubmissionsFoundError extends Error {}
+
 export default class SubmissionView extends EasCommand {
   static override description = 'view a submission for your project';
 
@@ -72,7 +74,7 @@ export default class SubmissionView extends EasCommand {
         });
         if (!submission) {
           spinner.fail(`Couldn't find any submissions for the project ${displayName}`);
-          throw new Error(`No submissions found for the project ${displayName}`);
+          throw new NoSubmissionsFoundError(`No submissions found for the project ${displayName}`);
         }
       }
 
@@ -88,14 +90,16 @@ export default class SubmissionView extends EasCommand {
         Log.log(`\n${formatGraphQLSubmission(submission)}`);
       }
     } catch (err) {
-      if (submissionId) {
-        spinner.fail(
-          `Something went wrong and we couldn't fetch the submission with id ${submissionId}`
-        );
-      } else {
-        spinner.fail(
-          `Something went wrong and we couldn't fetch the last submission for the project ${displayName}`
-        );
+      if (!(err instanceof NoSubmissionsFoundError)) {
+        if (submissionId) {
+          spinner.fail(
+            `Something went wrong and we couldn't fetch the submission with id ${submissionId}`
+          );
+        } else {
+          spinner.fail(
+            `Something went wrong and we couldn't fetch the last submission for the project ${displayName}`
+          );
+        }
       }
 
       throw err;


### PR DESCRIPTION
Follow-up to #4134. Two of its review findings applied equally to the `build:*` commands the submit commands were modeled on:

- `eas build:view` exits 0 when the project has no builds — a script sees success and, with `--json`, gets no output. History check: this dates to the command's first version (#138, Dec 2020) with no recorded discussion, so it is an original-implementation accident rather than a contract.
- `eas build:list` and `eas build:view` call `enableJsonOutput()` after `getContextAsync`, so project-context messages can leak onto stdout before the JSON.