### PR TITLE
[eas-cli] Set up TestFlight internal group when submitting with an existing ascAppId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Point accounts without EAS Simulator access at the waitlist: `eas simulator:availability` includes the link (and a `waitlistUrl` field in `--json`), and `eas simulator` now fails early with the same message instead of a generic permission error. ([#4151](https://github.com/expo/eas-cli/pull/4151) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Revert "Pin the default `agent-device` version for remote sessions" now that `agent-device` 0.20.5 fixes the broken release. ([#4144](https://github.com/expo/eas-cli/pull/4144) by [@gwdp](https://github.com/gwdp))
-- [eas-cli] Fix the TestFlight group URL printed when adding testers partially fails — it pointed at a hardcoded app id. ([#4136](https://github.com/expo/eas-cli/pull/4136) by [@tchayen](https://github.com/tchayen))
+- [eas-cli] Fix the TestFlight group URL printed when adding testers partially fails. ([#4136](https://github.com/expo/eas-cli/pull/4136) by [@tchayen](https://github.com/tchayen))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [eas-cli] Make the non-interactive "EAS project not configured" error actionable on every path: list the exact `eas init --id` / `eas init --account` commands and the accounts you can create projects in, instead of suggesting bare `eas init`, which fails the same way. ([#4153](https://github.com/expo/eas-cli/pull/4153) by [@williamgrosset](https://github.com/williamgrosset))
+- [eas-cli] Set up the internal TestFlight group and invite admin testers when submitting interactively with an existing `ascAppId`, with `--no-auto-testflight-setup` to disable it, and fix the TestFlight group URL printed when adding testers partially fails. ([#4136](https://github.com/expo/eas-cli/pull/4136) by [@tchayen](https://github.com/tchayen))
 
 ### 🧹 Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] Make `eas simulator` the canonical command and keep `eas simulator:start` as an alias. ([#4112](https://github.com/expo/eas-cli/pull/4112) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Validate local composite functions referenced from workflow job hooks during `eas workflow:validate`. ([#4064](https://github.com/expo/eas-cli/pull/4064) by [@sswrk](https://github.com/sswrk))
 - [eas-cli] Add `eas sim` as a shortcut for `eas simulator` commands, e.g. `eas sim:list` runs `eas simulator:list`. ([#4150](https://github.com/expo/eas-cli/pull/4150) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Set up the internal TestFlight group and invite admin testers when submitting with an existing `ascAppId`, using non-interactive App Store Connect API key auth when available. Previously the automatic TestFlight setup only ran when the CLI created the App Store Connect app itself, so apps created on the App Store Connect website required manual tester configuration before anyone could install builds. ([#4136](https://github.com/expo/eas-cli/pull/4136) by [@tchayen](https://github.com/tchayen))
 
 ### 🐛 Bug fixes
 
 - [eas-cli] Point accounts without EAS Simulator access at the waitlist: `eas simulator:availability` includes the link (and a `waitlistUrl` field in `--json`), and `eas simulator` now fails early with the same message instead of a generic permission error. ([#4151](https://github.com/expo/eas-cli/pull/4151) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Revert "Pin the default `agent-device` version for remote sessions" now that `agent-device` 0.20.5 fixes the broken release. ([#4144](https://github.com/expo/eas-cli/pull/4144) by [@gwdp](https://github.com/gwdp))
+- [eas-cli] Fix the TestFlight group URL printed when adding testers partially fails — it pointed at a hardcoded app id. ([#4136](https://github.com/expo/eas-cli/pull/4136) by [@tchayen](https://github.com/tchayen))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/go.ts
+++ b/packages/eas-cli/src/commands/go.ts
@@ -1,5 +1,5 @@
 import { ExpoConfig, getConfigFilePaths } from '@expo/config';
-import { App, User, UserRole } from '@expo/apple-utils';
+import { App } from '@expo/apple-utils';
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
 import * as fs from 'fs-extra';
@@ -15,6 +15,7 @@ import { SetUpAscApiKey } from '../credentials/ios/actions/SetUpAscApiKey';
 import { SetUpBuildCredentials } from '../credentials/ios/actions/SetUpBuildCredentials';
 import { SetUpPushKey } from '../credentials/ios/actions/SetUpPushKey';
 import { ensureAppExistsAsync } from '../credentials/ios/appstore/ensureAppExists';
+import { ensureTestFlightGroupExistsAsync } from '../credentials/ios/appstore/ensureTestFlightGroup';
 import { Target } from '../credentials/ios/types';
 import {
   WorkflowJobStatus,
@@ -60,62 +61,8 @@ export async function detectProjectSdkVersionAsync(
   }
 }
 
-const TESTFLIGHT_GROUP_NAME = 'Team (Expo)';
-
 async function setupTestFlightAsync(ascApp: App): Promise<void> {
-  let group;
-  for (let attempt = 0; attempt < 10; attempt++) {
-    try {
-      const groups = await ascApp.getBetaGroupsAsync({
-        query: { includes: ['betaTesters'] },
-      });
-
-      group = groups.find(
-        g => g.attributes.isInternalGroup && g.attributes.name === TESTFLIGHT_GROUP_NAME
-      );
-
-      if (!group) {
-        group = await ascApp.createBetaGroupAsync({
-          name: TESTFLIGHT_GROUP_NAME,
-          isInternalGroup: true,
-          hasAccessToAllBuilds: true,
-        });
-      }
-      break;
-    } catch (error: any) {
-      // Apple returns this error when the app isn't ready yet
-      if (error?.data?.errors?.some((e: any) => e.code === 'ENTITY_ERROR.RELATIONSHIP.INVALID')) {
-        if (attempt < 9) {
-          await sleepAsync(10_000);
-          continue;
-        }
-      }
-      throw error;
-    }
-  }
-
-  if (!group) {
-    throw new Error('Failed to create TestFlight group');
-  }
-
-  const users = await User.getAsync(ascApp.context);
-  const admins = users.filter(u => u.attributes.roles?.includes(UserRole.ADMIN));
-
-  const existingEmails = new Set(
-    group.attributes.betaTesters?.map((t: any) => t.attributes.email?.toLowerCase()) ?? []
-  );
-
-  const newTesters = admins
-    .filter(u => u.attributes.email && !existingEmails.has(u.attributes.email.toLowerCase()))
-    .map(u => ({
-      email: u.attributes.email!,
-      firstName: u.attributes.firstName ?? '',
-      lastName: u.attributes.lastName ?? '',
-    }));
-
-  if (newTesters.length > 0) {
-    await group.createBulkBetaTesterAssignmentsAsync(newTesters);
-  }
+  await ensureTestFlightGroupExistsAsync(ascApp);
 }
 
 /* eslint-disable no-console */

--- a/packages/eas-cli/src/commands/submit.ts
+++ b/packages/eas-cli/src/commands/submit.ts
@@ -34,6 +34,7 @@ interface RawCommandFlags {
   verbose: boolean;
   wait: boolean;
   'non-interactive': boolean;
+  'auto-testflight-setup': boolean;
   'verbose-fastlane': boolean;
   groups?: string[];
 }
@@ -46,6 +47,7 @@ interface CommandFlags {
   verbose: boolean;
   wait: boolean;
   nonInteractive: boolean;
+  autoTestFlightSetup: boolean;
   isVerboseFastlaneEnabled: boolean;
   groups?: string[];
 }
@@ -106,6 +108,11 @@ export default class Submit extends EasCommand {
       default: false,
       description: 'Run command in non-interactive mode',
     }),
+    'auto-testflight-setup': Flags.boolean({
+      default: true,
+      allowNo: true,
+      description: 'Set up an internal TestFlight group for the app (iOS only)',
+    }),
   };
 
   static override contextDefinition = {
@@ -152,6 +159,7 @@ export default class Submit extends EasCommand {
         profile: submissionProfile.profile,
         archiveFlags: flagsWithPlatform.archiveFlags,
         nonInteractive: flagsWithPlatform.nonInteractive,
+        autoTestFlightSetup: flagsWithPlatform.autoTestFlightSetup,
         isVerboseFastlaneEnabled: flagsWithPlatform.isVerboseFastlaneEnabled,
         groups: flagsWithPlatform.groups,
         actor,
@@ -198,6 +206,7 @@ export default class Submit extends EasCommand {
       wait,
       profile,
       'non-interactive': nonInteractive,
+      'auto-testflight-setup': autoTestFlightSetup,
       'verbose-fastlane': isVerboseFastlaneEnabled,
       groups,
       'what-to-test': whatToTest,
@@ -221,6 +230,7 @@ export default class Submit extends EasCommand {
       wait,
       profile,
       nonInteractive,
+      autoTestFlightSetup,
       whatToTest,
       isVerboseFastlaneEnabled,
       groups,

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/ensureTestFlightGroup-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/ensureTestFlightGroup-test.ts
@@ -1,0 +1,115 @@
+import { App, BetaGroup, User } from '@expo/apple-utils';
+
+import { ensureTestFlightGroupExistsAsync } from '../ensureTestFlightGroup';
+import { confirmAsync } from '../../../../prompts';
+
+jest.mock('../../../../ora');
+jest.mock('../../../../prompts', () => ({
+  confirmAsync: jest.fn(),
+}));
+jest.mock('@expo/apple-utils', () => ({
+  ...jest.requireActual('@expo/apple-utils'),
+  User: { getAsync: jest.fn() },
+  BetaGroup: { deleteAsync: jest.fn() },
+}));
+
+function mockApp({
+  groups,
+  createdGroup,
+}: {
+  groups: Partial<BetaGroup>[];
+  createdGroup?: Partial<BetaGroup>;
+}): App {
+  return {
+    id: '1234567890',
+    context: {},
+    getBetaGroupsAsync: jest.fn().mockResolvedValue(groups),
+    createBetaGroupAsync: jest.fn().mockResolvedValue(createdGroup),
+  } as unknown as App;
+}
+
+function mockGroup({
+  hasAccessToAllBuilds,
+}: {
+  hasAccessToAllBuilds: boolean;
+}): Partial<BetaGroup> {
+  return {
+    id: 'group-id',
+    context: {} as BetaGroup['context'],
+    attributes: {
+      name: 'Team (Expo)',
+      isInternalGroup: true,
+      hasAccessToAllBuilds,
+      betaTesters: [],
+    } as unknown as BetaGroup['attributes'],
+    createBulkBetaTesterAssignmentsAsync: jest.fn(),
+  };
+}
+
+beforeEach(() => {
+  jest.mocked(confirmAsync).mockReset();
+  jest.mocked(User.getAsync).mockReset().mockResolvedValue([]);
+  jest.mocked(BetaGroup.deleteAsync).mockReset();
+  delete process.env.EAS_NO_AUTO_TESTFLIGHT_SETUP;
+});
+
+describe(ensureTestFlightGroupExistsAsync, () => {
+  it('skips setup when the app already has beta groups', async () => {
+    const app = mockApp({ groups: [mockGroup({ hasAccessToAllBuilds: true })] });
+
+    await ensureTestFlightGroupExistsAsync(app, { nonInteractive: true });
+
+    expect(app.createBetaGroupAsync).not.toHaveBeenCalled();
+    expect(User.getAsync).not.toHaveBeenCalled();
+  });
+
+  it('creates a group and adds admins without prompting in non-interactive mode', async () => {
+    const app = mockApp({
+      groups: [],
+      createdGroup: mockGroup({ hasAccessToAllBuilds: true }),
+    });
+
+    await ensureTestFlightGroupExistsAsync(app, { nonInteractive: true });
+
+    expect(app.createBetaGroupAsync).toHaveBeenCalledWith({
+      name: 'Team (Expo)',
+      isInternalGroup: true,
+      hasAccessToAllBuilds: true,
+    });
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt or delete the group in non-interactive mode when it lacks access to all builds', async () => {
+    const app = mockApp({
+      groups: [],
+      createdGroup: mockGroup({ hasAccessToAllBuilds: false }),
+    });
+
+    await ensureTestFlightGroupExistsAsync(app, { nonInteractive: true });
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(BetaGroup.deleteAsync).not.toHaveBeenCalled();
+  });
+
+  it('prompts to regenerate the group in interactive mode when it lacks access to all builds', async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+    const app = mockApp({
+      groups: [],
+      createdGroup: mockGroup({ hasAccessToAllBuilds: false }),
+    });
+
+    await ensureTestFlightGroupExistsAsync(app, { nonInteractive: false });
+
+    expect(confirmAsync).toHaveBeenCalled();
+    expect(BetaGroup.deleteAsync).not.toHaveBeenCalled();
+  });
+
+  it('skips setup entirely when EAS_NO_AUTO_TESTFLIGHT_SETUP is set', async () => {
+    process.env.EAS_NO_AUTO_TESTFLIGHT_SETUP = '1';
+    const app = mockApp({ groups: [] });
+
+    await ensureTestFlightGroupExistsAsync(app, { nonInteractive: true });
+
+    expect(app.getBetaGroupsAsync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/ensureTestFlightGroup-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/ensureTestFlightGroup-test.ts
@@ -1,0 +1,105 @@
+import { App, BetaGroup, User } from '@expo/apple-utils';
+
+import { ensureTestFlightGroupExistsAsync } from '../ensureTestFlightGroup';
+import { confirmAsync } from '../../../../prompts';
+
+jest.mock('../../../../ora');
+jest.mock('../../../../prompts', () => ({
+  confirmAsync: jest.fn(),
+}));
+jest.mock('@expo/apple-utils', () => ({
+  ...jest.requireActual('@expo/apple-utils'),
+  User: { getAsync: jest.fn() },
+  BetaGroup: { deleteAsync: jest.fn() },
+}));
+
+function mockApp({
+  groups,
+  createdGroup,
+}: {
+  groups: Partial<BetaGroup>[];
+  createdGroup?: Partial<BetaGroup>;
+}): App {
+  return {
+    id: '1234567890',
+    context: {},
+    getBetaGroupsAsync: jest.fn().mockResolvedValue(groups),
+    createBetaGroupAsync: jest.fn().mockResolvedValue(createdGroup),
+  } as unknown as App;
+}
+
+function mockGroup({
+  hasAccessToAllBuilds,
+}: {
+  hasAccessToAllBuilds: boolean;
+}): Partial<BetaGroup> {
+  return {
+    id: 'group-id',
+    context: {} as BetaGroup['context'],
+    attributes: {
+      name: 'Team (Expo)',
+      isInternalGroup: true,
+      hasAccessToAllBuilds,
+      betaTesters: [],
+    } as unknown as BetaGroup['attributes'],
+    createBulkBetaTesterAssignmentsAsync: jest.fn(),
+  };
+}
+
+beforeEach(() => {
+  jest.mocked(confirmAsync).mockReset();
+  jest.mocked(User.getAsync).mockReset().mockResolvedValue([]);
+  jest.mocked(BetaGroup.deleteAsync).mockReset();
+});
+
+describe(ensureTestFlightGroupExistsAsync, () => {
+  it('skips setup when the app already has beta groups', async () => {
+    const app = mockApp({ groups: [mockGroup({ hasAccessToAllBuilds: true })] });
+
+    await ensureTestFlightGroupExistsAsync(app, { nonInteractive: true });
+
+    expect(app.createBetaGroupAsync).not.toHaveBeenCalled();
+    expect(User.getAsync).not.toHaveBeenCalled();
+  });
+
+  it('creates a group and adds admins without prompting in non-interactive mode', async () => {
+    const app = mockApp({
+      groups: [],
+      createdGroup: mockGroup({ hasAccessToAllBuilds: true }),
+    });
+
+    await ensureTestFlightGroupExistsAsync(app, { nonInteractive: true });
+
+    expect(app.createBetaGroupAsync).toHaveBeenCalledWith({
+      name: 'Team (Expo)',
+      isInternalGroup: true,
+      hasAccessToAllBuilds: true,
+    });
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt or delete the group in non-interactive mode when it lacks access to all builds', async () => {
+    const app = mockApp({
+      groups: [],
+      createdGroup: mockGroup({ hasAccessToAllBuilds: false }),
+    });
+
+    await ensureTestFlightGroupExistsAsync(app, { nonInteractive: true });
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(BetaGroup.deleteAsync).not.toHaveBeenCalled();
+  });
+
+  it('prompts to regenerate the group in interactive mode when it lacks access to all builds', async () => {
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+    const app = mockApp({
+      groups: [],
+      createdGroup: mockGroup({ hasAccessToAllBuilds: false }),
+    });
+
+    await ensureTestFlightGroupExistsAsync(app, { nonInteractive: false });
+
+    expect(confirmAsync).toHaveBeenCalled();
+    expect(BetaGroup.deleteAsync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureTestFlightGroup.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureTestFlightGroup.ts
@@ -12,12 +12,10 @@ const AUTO_GROUP_NAME = 'Team (Expo)';
  * Ensure a TestFlight internal group with access to all builds exists for the app and has all admin users invited to it.
  * This allows users to instantly access their builds from TestFlight after it finishes processing.
  */
-export async function ensureTestFlightGroupExistsAsync(app: App): Promise<void> {
-  if (process.env.EAS_NO_AUTO_TESTFLIGHT_SETUP) {
-    Log.debug('EAS_NO_AUTO_TESTFLIGHT_SETUP is set, skipping TestFlight setup');
-    return;
-  }
-
+export async function ensureTestFlightGroupExistsAsync(
+  app: App,
+  { nonInteractive = false }: { nonInteractive?: boolean } = {}
+): Promise<void> {
   const groups = await app.getBetaGroupsAsync({
     query: {
       includes: ['betaTesters'],
@@ -33,19 +31,22 @@ export async function ensureTestFlightGroupExistsAsync(app: App): Promise<void> 
   const group = await ensureInternalGroupAsync({
     app,
     groups,
+    nonInteractive,
   });
   const users = await User.getAsync(app.context);
   const admins = users.filter(user => user.attributes.roles?.includes(UserRole.ADMIN));
 
-  await addAllUsersToInternalGroupAsync(group, admins);
+  await addAllUsersToInternalGroupAsync(group, admins, app);
 }
 
 async function ensureInternalGroupAsync({
   groups,
   app,
+  nonInteractive,
 }: {
   groups: BetaGroup[];
   app: App;
+  nonInteractive: boolean;
 }): Promise<BetaGroup> {
   let betaGroup = groups.find(group => group.attributes.name === AUTO_GROUP_NAME);
   if (!betaGroup) {
@@ -88,6 +89,13 @@ async function ensureInternalGroupAsync({
 
   // `hasAccessToAllBuilds` is a newer feature that allows the group to automatically have access to all builds. This cannot be patched so we need to recreate the group.
   if (!betaGroup.attributes.hasAccessToAllBuilds) {
+    if (nonInteractive) {
+      // Deleting a group is destructive, so it needs explicit confirmation.
+      Log.warn(
+        `TestFlight group "${AUTO_GROUP_NAME}" does not have automatic access to new builds. Re-run in interactive mode to regenerate it, or recreate it in App Store Connect.`
+      );
+      return betaGroup;
+    }
     if (
       await confirmAsync({
         message: 'Regenerate internal TestFlight group to allow automatic access to all builds?',
@@ -101,6 +109,7 @@ async function ensureInternalGroupAsync({
             includes: ['betaTesters'],
           },
         }),
+        nonInteractive,
       });
     }
   }
@@ -108,7 +117,11 @@ async function ensureInternalGroupAsync({
   return betaGroup;
 }
 
-async function addAllUsersToInternalGroupAsync(group: BetaGroup, users: User[]): Promise<void> {
+async function addAllUsersToInternalGroupAsync(
+  group: BetaGroup,
+  users: User[],
+  app: App
+): Promise<void> {
   let emails = users
     .filter(user => user.attributes.email)
     .map(user => ({
@@ -162,7 +175,7 @@ async function addAllUsersToInternalGroupAsync(group: BetaGroup, users: User[]):
   });
 
   if (!success) {
-    const groupUrl = await getTestFlightGroupUrlAsync(group);
+    const groupUrl = await getTestFlightGroupUrlAsync(group, app);
 
     Log.error(
       `Unable to add all admins to TestFlight group "${
@@ -181,12 +194,12 @@ async function addAllUsersToInternalGroupAsync(group: BetaGroup, users: User[]):
   }
 }
 
-async function getTestFlightGroupUrlAsync(group: BetaGroup): Promise<string | null> {
+async function getTestFlightGroupUrlAsync(group: BetaGroup, app: App): Promise<string | null> {
   if (group.context.providerId) {
     try {
       const session = await Session.getSessionForProviderIdAsync(group.context.providerId);
 
-      return `https://appstoreconnect.apple.com/teams/${session.provider.publicProviderId}/apps/6741088859/testflight/groups/${group.id}`;
+      return `https://appstoreconnect.apple.com/teams/${session.provider.publicProviderId}/apps/${app.id}/testflight/groups/${group.id}`;
     } catch (error) {
       // Avoid crashing if we can't get the session.
       Log.debug('Failed to get session for provider ID', error);

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureTestFlightGroup.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureTestFlightGroup.ts
@@ -12,7 +12,10 @@ const AUTO_GROUP_NAME = 'Team (Expo)';
  * Ensure a TestFlight internal group with access to all builds exists for the app and has all admin users invited to it.
  * This allows users to instantly access their builds from TestFlight after it finishes processing.
  */
-export async function ensureTestFlightGroupExistsAsync(app: App): Promise<void> {
+export async function ensureTestFlightGroupExistsAsync(
+  app: App,
+  { nonInteractive = false }: { nonInteractive?: boolean } = {}
+): Promise<void> {
   if (process.env.EAS_NO_AUTO_TESTFLIGHT_SETUP) {
     Log.debug('EAS_NO_AUTO_TESTFLIGHT_SETUP is set, skipping TestFlight setup');
     return;
@@ -33,19 +36,22 @@ export async function ensureTestFlightGroupExistsAsync(app: App): Promise<void> 
   const group = await ensureInternalGroupAsync({
     app,
     groups,
+    nonInteractive,
   });
   const users = await User.getAsync(app.context);
   const admins = users.filter(user => user.attributes.roles?.includes(UserRole.ADMIN));
 
-  await addAllUsersToInternalGroupAsync(group, admins);
+  await addAllUsersToInternalGroupAsync(group, admins, app);
 }
 
 async function ensureInternalGroupAsync({
   groups,
   app,
+  nonInteractive,
 }: {
   groups: BetaGroup[];
   app: App;
+  nonInteractive: boolean;
 }): Promise<BetaGroup> {
   let betaGroup = groups.find(group => group.attributes.name === AUTO_GROUP_NAME);
   if (!betaGroup) {
@@ -88,6 +94,13 @@ async function ensureInternalGroupAsync({
 
   // `hasAccessToAllBuilds` is a newer feature that allows the group to automatically have access to all builds. This cannot be patched so we need to recreate the group.
   if (!betaGroup.attributes.hasAccessToAllBuilds) {
+    if (nonInteractive) {
+      // Deleting a group is destructive, so it needs explicit confirmation.
+      Log.warn(
+        `TestFlight group "${AUTO_GROUP_NAME}" does not have automatic access to new builds. Re-run in interactive mode to regenerate it, or recreate it in App Store Connect.`
+      );
+      return betaGroup;
+    }
     if (
       await confirmAsync({
         message: 'Regenerate internal TestFlight group to allow automatic access to all builds?',
@@ -101,6 +114,7 @@ async function ensureInternalGroupAsync({
             includes: ['betaTesters'],
           },
         }),
+        nonInteractive,
       });
     }
   }
@@ -108,7 +122,11 @@ async function ensureInternalGroupAsync({
   return betaGroup;
 }
 
-async function addAllUsersToInternalGroupAsync(group: BetaGroup, users: User[]): Promise<void> {
+async function addAllUsersToInternalGroupAsync(
+  group: BetaGroup,
+  users: User[],
+  app: App
+): Promise<void> {
   let emails = users
     .filter(user => user.attributes.email)
     .map(user => ({
@@ -162,7 +180,7 @@ async function addAllUsersToInternalGroupAsync(group: BetaGroup, users: User[]):
   });
 
   if (!success) {
-    const groupUrl = await getTestFlightGroupUrlAsync(group);
+    const groupUrl = await getTestFlightGroupUrlAsync(group, app);
 
     Log.error(
       `Unable to add all admins to TestFlight group "${
@@ -181,12 +199,12 @@ async function addAllUsersToInternalGroupAsync(group: BetaGroup, users: User[]):
   }
 }
 
-async function getTestFlightGroupUrlAsync(group: BetaGroup): Promise<string | null> {
+async function getTestFlightGroupUrlAsync(group: BetaGroup, app: App): Promise<string | null> {
   if (group.context.providerId) {
     try {
       const session = await Session.getSessionForProviderIdAsync(group.context.providerId);
 
-      return `https://appstoreconnect.apple.com/teams/${session.provider.publicProviderId}/apps/6741088859/testflight/groups/${group.id}`;
+      return `https://appstoreconnect.apple.com/teams/${session.provider.publicProviderId}/apps/${app.id}/testflight/groups/${group.id}`;
     } catch (error) {
       // Avoid crashing if we can't get the session.
       Log.debug('Failed to get session for provider ID', error);

--- a/packages/eas-cli/src/submit/context.ts
+++ b/packages/eas-cli/src/submit/context.ts
@@ -21,6 +21,7 @@ export interface SubmissionContext<T extends Platform> {
   analyticsEventProperties: AnalyticsEventProperties;
   exp: ExpoConfig;
   nonInteractive: boolean;
+  autoTestFlightSetup: boolean;
   isVerboseFastlaneEnabled: boolean;
   groups: T extends Platform.IOS ? string[] : undefined;
   platform: T;
@@ -49,6 +50,7 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
   credentialsCtx?: CredentialsContext;
   env?: Env;
   nonInteractive: boolean;
+  autoTestFlightSetup?: boolean;
   isVerboseFastlaneEnabled: boolean;
   groups: string[] | undefined;
   platform: T;
@@ -116,6 +118,7 @@ export async function createSubmissionContextAsync<T extends Platform>(params: {
 
   return {
     ...rest,
+    autoTestFlightSetup: params.autoTestFlightSetup ?? true,
     accountName: account.name,
     credentialsCtx,
     groups,

--- a/packages/eas-cli/src/submit/ios/AppProduce.ts
+++ b/packages/eas-cli/src/submit/ios/AppProduce.ts
@@ -94,7 +94,7 @@ async function createAppStoreConnectAppAsync(
   });
 
   try {
-    await ensureTestFlightGroupExistsAsync(app);
+    await ensureTestFlightGroupExistsAsync(app, { nonInteractive: ctx.nonInteractive });
   } catch (error: any) {
     // This process is not critical to the app submission so we shouldn't let it fail the entire process.
     Log.error(

--- a/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
@@ -11,6 +11,7 @@ import {
 } from './AppSpecificPasswordSource';
 import { AscApiKeySource, AscApiKeySourceType } from './AscApiKeySource';
 import IosSubmitter, { IosSubmissionOptions } from './IosSubmitter';
+import { ensureTestFlightSetupForExistingAppAsync } from './ensureTestFlightSetup';
 import { MissingCredentialsError } from '../../credentials/errors';
 import Log, { learnMore } from '../../log';
 import { ArchiveSource, ArchiveSourceType, getArchiveAsync } from '../ArchiveSource';
@@ -171,6 +172,7 @@ export default class IosSubmitCommand {
   private async resolveAscAppIdentifierAsync(): Promise<Result<string>> {
     const { ascAppId } = this.ctx.profile;
     if (ascAppId) {
+      await ensureTestFlightSetupForExistingAppAsync(this.ctx, ascAppId);
       return result(ascAppId);
     } else if (this.ctx.nonInteractive) {
       return result(

--- a/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
@@ -172,9 +172,6 @@ export default class IosSubmitCommand {
   private async resolveAscAppIdentifierAsync(): Promise<Result<string>> {
     const { ascAppId } = this.ctx.profile;
     if (ascAppId) {
-      // The automatic TestFlight setup otherwise only runs when the ASC app is
-      // created by the CLI; apps created on the App Store Connect website
-      // would never get an internal group.
       await ensureTestFlightSetupForExistingAppAsync(this.ctx, ascAppId);
       return result(ascAppId);
     } else if (this.ctx.nonInteractive) {

--- a/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
@@ -11,6 +11,7 @@ import {
 } from './AppSpecificPasswordSource';
 import { AscApiKeySource, AscApiKeySourceType } from './AscApiKeySource';
 import IosSubmitter, { IosSubmissionOptions } from './IosSubmitter';
+import { ensureTestFlightSetupForExistingAppAsync } from './ensureTestFlightSetup';
 import { MissingCredentialsError } from '../../credentials/errors';
 import Log, { learnMore } from '../../log';
 import { ArchiveSource, ArchiveSourceType, getArchiveAsync } from '../ArchiveSource';
@@ -171,6 +172,10 @@ export default class IosSubmitCommand {
   private async resolveAscAppIdentifierAsync(): Promise<Result<string>> {
     const { ascAppId } = this.ctx.profile;
     if (ascAppId) {
+      // The automatic TestFlight setup otherwise only runs when the ASC app is
+      // created by the CLI; apps created on the App Store Connect website
+      // would never get an internal group.
+      await ensureTestFlightSetupForExistingAppAsync(this.ctx, ascAppId);
       return result(ascAppId);
     } else if (this.ctx.nonInteractive) {
       return result(

--- a/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
@@ -23,6 +23,7 @@ import {
 import { refreshContextSubmitProfileAsync } from '../../commons';
 import { SubmissionContext, createSubmissionContextAsync } from '../../context';
 import IosSubmitCommand from '../IosSubmitCommand';
+import { ensureTestFlightSetupForExistingAppAsync } from '../ensureTestFlightSetup';
 
 jest.mock('fs');
 jest.mock('../../../ora');
@@ -52,6 +53,9 @@ jest.mock('../../commons', () => {
     refreshContextSubmitProfileAsync: jest.fn(),
   };
 });
+jest.mock('../ensureTestFlightSetup', () => ({
+  ensureTestFlightSetupForExistingAppAsync: jest.fn(),
+}));
 
 const vcsClient = resolveVcsClient();
 
@@ -202,6 +206,11 @@ describe(IosSubmitCommand, () => {
         },
         submittedBuildId: undefined,
       });
+
+      expect(ensureTestFlightSetupForExistingAppAsync).toHaveBeenCalledWith(
+        expect.anything(),
+        '12345678'
+      );
 
       delete process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD;
     });

--- a/packages/eas-cli/src/submit/ios/__tests__/ensureTestFlightSetup-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/ensureTestFlightSetup-test.ts
@@ -1,0 +1,153 @@
+import { App } from '@expo/apple-utils';
+import { Platform } from '@expo/eas-build-job';
+
+import { resolveAscApiKeyForAppCredentialsAsync } from '../../../credentials/ios/actions/AscApiKeyUtils';
+import { AuthenticationMode } from '../../../credentials/ios/appstore/authenticateTypes';
+import { ensureTestFlightGroupExistsAsync } from '../../../credentials/ios/appstore/ensureTestFlightGroup';
+import { hasAscEnvVars } from '../../../credentials/ios/appstore/resolveCredentials';
+import { SubmissionContext } from '../../context';
+import { ensureTestFlightSetupForExistingAppAsync } from '../ensureTestFlightSetup';
+
+jest.mock('@expo/apple-utils', () => ({
+  ...jest.requireActual('@expo/apple-utils'),
+  App: { infoAsync: jest.fn() },
+}));
+jest.mock('../../../credentials/ios/actions/AscApiKeyUtils', () => ({
+  resolveAscApiKeyForAppCredentialsAsync: jest.fn(),
+}));
+jest.mock('../../../credentials/ios/appstore/ensureTestFlightGroup', () => ({
+  ensureTestFlightGroupExistsAsync: jest.fn(),
+}));
+jest.mock('../../../credentials/ios/appstore/resolveCredentials', () => ({
+  ...jest.requireActual('../../../credentials/ios/appstore/resolveCredentials'),
+  hasAscEnvVars: jest.fn(),
+}));
+
+function createContext({
+  nonInteractive = false,
+  autoTestFlightSetup = true,
+}: {
+  nonInteractive?: boolean;
+  autoTestFlightSetup?: boolean;
+}): {
+  ctx: SubmissionContext<Platform.IOS>;
+  ensureAuthenticatedAsync: jest.Mock;
+} {
+  const authCtx = {
+    team: { id: 'team-id' },
+    ascApiKey: { keyP8: 'key', keyId: 'key-id', issuerId: 'issuer-id' },
+    authState: { context: {} },
+  };
+  const appStore: any = { authCtx: undefined };
+  const ensureAuthenticatedAsync = jest.fn(async () => {
+    appStore.authCtx = authCtx;
+    return authCtx;
+  });
+  appStore.ensureAuthenticatedAsync = ensureAuthenticatedAsync;
+
+  return {
+    ctx: {
+      nonInteractive,
+      autoTestFlightSetup,
+      applicationIdentifierOverride: 'com.example.app',
+      profile: {},
+      user: { accounts: [{ name: 'account' }] },
+      accountName: 'account',
+      projectName: 'project',
+      credentialsCtx: { appStore },
+      graphqlClient: {},
+    } as SubmissionContext<Platform.IOS>,
+    ensureAuthenticatedAsync,
+  };
+}
+
+describe(ensureTestFlightSetupForExistingAppAsync, () => {
+  beforeEach(() => {
+    delete process.env.EXPO_ASC_API_KEY_PATH;
+    delete process.env.EXPO_ASC_KEY_ID;
+    delete process.env.EXPO_ASC_ISSUER_ID;
+    delete process.env.EXPO_APPLE_TEAM_ID;
+    jest.mocked(hasAscEnvVars).mockReset().mockReturnValue(false);
+    jest.mocked(resolveAscApiKeyForAppCredentialsAsync).mockReset().mockResolvedValue(null);
+    jest
+      .mocked(App.infoAsync)
+      .mockReset()
+      .mockResolvedValue({ id: '12345678' } as App);
+    jest.mocked(ensureTestFlightGroupExistsAsync).mockReset();
+  });
+
+  it('sets up TestFlight in non-interactive mode when stored credentials are complete', async () => {
+    jest.mocked(resolveAscApiKeyForAppCredentialsAsync).mockResolvedValue({
+      ascApiKey: { keyP8: 'key', keyId: 'key-id', issuerId: 'issuer-id' },
+      teamId: 'team-id',
+      teamName: 'Team',
+    });
+    const { ctx, ensureAuthenticatedAsync } = createContext({ nonInteractive: true });
+
+    await ensureTestFlightSetupForExistingAppAsync(ctx, '12345678');
+
+    expect(ensureAuthenticatedAsync).toHaveBeenCalledWith({
+      mode: AuthenticationMode.API_KEY,
+      ascApiKey: { keyP8: 'key', keyId: 'key-id', issuerId: 'issuer-id' },
+      teamId: 'team-id',
+      teamName: 'Team',
+      teamType: expect.any(String),
+    });
+    expect(ensureTestFlightGroupExistsAsync).toHaveBeenCalledWith(expect.anything(), {
+      nonInteractive: true,
+    });
+  });
+
+  it('sets up TestFlight in non-interactive mode when environment credentials are complete', async () => {
+    jest.mocked(hasAscEnvVars).mockReturnValue(true);
+    process.env.EXPO_ASC_API_KEY_PATH = '/path/to/key.p8';
+    process.env.EXPO_ASC_KEY_ID = 'key-id';
+    process.env.EXPO_ASC_ISSUER_ID = 'issuer-id';
+    process.env.EXPO_APPLE_TEAM_ID = 'team-id';
+    const { ctx, ensureAuthenticatedAsync } = createContext({ nonInteractive: true });
+
+    await ensureTestFlightSetupForExistingAppAsync(ctx, '12345678');
+
+    expect(ensureAuthenticatedAsync).toHaveBeenCalledWith({
+      mode: AuthenticationMode.API_KEY,
+      teamId: 'team-id',
+      teamType: expect.any(String),
+    });
+    expect(ensureTestFlightGroupExistsAsync).toHaveBeenCalledWith(expect.anything(), {
+      nonInteractive: true,
+    });
+  });
+
+  it('skips setup when environment credentials are incomplete', async () => {
+    jest.mocked(hasAscEnvVars).mockReturnValue(true);
+    process.env.EXPO_ASC_KEY_ID = 'key-id';
+    const { ctx, ensureAuthenticatedAsync } = createContext({ nonInteractive: true });
+
+    await ensureTestFlightSetupForExistingAppAsync(ctx, '12345678');
+
+    expect(ensureAuthenticatedAsync).not.toHaveBeenCalled();
+    expect(resolveAscApiKeyForAppCredentialsAsync).not.toHaveBeenCalled();
+    expect(ensureTestFlightGroupExistsAsync).not.toHaveBeenCalled();
+  });
+
+  it('skips setup when stored credentials have no Apple Team ID', async () => {
+    jest.mocked(resolveAscApiKeyForAppCredentialsAsync).mockResolvedValue({
+      ascApiKey: { keyP8: 'key', keyId: 'key-id', issuerId: 'issuer-id' },
+    });
+    const { ctx, ensureAuthenticatedAsync } = createContext({ nonInteractive: true });
+
+    await ensureTestFlightSetupForExistingAppAsync(ctx, '12345678');
+
+    expect(ensureAuthenticatedAsync).not.toHaveBeenCalled();
+    expect(ensureTestFlightGroupExistsAsync).not.toHaveBeenCalled();
+  });
+
+  it('skips setup when automatic setup is disabled', async () => {
+    const { ctx, ensureAuthenticatedAsync } = createContext({ autoTestFlightSetup: false });
+
+    await ensureTestFlightSetupForExistingAppAsync(ctx, '12345678');
+
+    expect(ensureAuthenticatedAsync).not.toHaveBeenCalled();
+    expect(resolveAscApiKeyForAppCredentialsAsync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/submit/ios/ensureTestFlightSetup.ts
+++ b/packages/eas-cli/src/submit/ios/ensureTestFlightSetup.ts
@@ -1,0 +1,100 @@
+import { App } from '@expo/apple-utils';
+import { Platform } from '@expo/eas-build-job';
+import nullthrows from 'nullthrows';
+
+import {
+  AppleTeamType,
+  AuthenticationMode,
+} from '../../credentials/ios/appstore/authenticateTypes';
+import { getRequestContext } from '../../credentials/ios/appstore/authenticate';
+import { ensureTestFlightGroupExistsAsync } from '../../credentials/ios/appstore/ensureTestFlightGroup';
+import {
+  hasAscEnvVars,
+  resolveAppleTeamTypeFromEnvironment,
+} from '../../credentials/ios/appstore/resolveCredentials';
+import { resolveAscApiKeyForAppCredentialsAsync } from '../../credentials/ios/actions/AscApiKeyUtils';
+import Log from '../../log';
+import { getBundleIdentifierAsync } from '../../project/ios/bundleIdentifier';
+import { SubmissionContext } from '../context';
+
+/**
+ * Best-effort TestFlight internal group setup for an App Store Connect app
+ * that already exists with `ascAppId` provided.
+ */
+export async function ensureTestFlightSetupForExistingAppAsync(
+  ctx: SubmissionContext<Platform.IOS>,
+  ascAppIdentifier: string
+): Promise<void> {
+  if (!ctx.autoTestFlightSetup) {
+    return;
+  }
+
+  try {
+    const bundleIdentifier =
+      ctx.applicationIdentifierOverride ??
+      ctx.profile.bundleIdentifier ??
+      (await getBundleIdentifierAsync(ctx.projectDir, ctx.exp, ctx.vcsClient));
+
+    const appLookupParams = {
+      account: nullthrows(
+        ctx.user.accounts.find(a => a.name === ctx.accountName),
+        `You do not have access to account: ${ctx.accountName}`
+      ),
+      projectName: ctx.projectName,
+      bundleIdentifier,
+    };
+
+    if (!ctx.credentialsCtx.appStore.authCtx) {
+      const teamType =
+        resolveAppleTeamTypeFromEnvironment() ?? AppleTeamType.COMPANY_OR_ORGANIZATION;
+      if (hasAscEnvVars()) {
+        const teamId = process.env.EXPO_APPLE_TEAM_ID;
+        if (
+          !process.env.EXPO_ASC_API_KEY_PATH ||
+          !process.env.EXPO_ASC_KEY_ID ||
+          !process.env.EXPO_ASC_ISSUER_ID ||
+          !teamId
+        ) {
+          Log.log('App Store Connect credentials are incomplete, skipping TestFlight setup');
+          return;
+        }
+        await ctx.credentialsCtx.appStore.ensureAuthenticatedAsync({
+          mode: AuthenticationMode.API_KEY,
+          teamId,
+          teamType,
+        });
+      } else {
+        const resolvedKey = await resolveAscApiKeyForAppCredentialsAsync({
+          graphqlClient: ctx.graphqlClient,
+          app: appLookupParams,
+        });
+        const teamId = resolvedKey?.teamId ?? process.env.EXPO_APPLE_TEAM_ID;
+        if (!resolvedKey || !teamId) {
+          Log.log('No complete App Store Connect credentials, skipping TestFlight setup');
+          return;
+        }
+        Log.log('Using App Store Connect API Key from EAS credentials service.');
+        await ctx.credentialsCtx.appStore.ensureAuthenticatedAsync({
+          mode: AuthenticationMode.API_KEY,
+          ascApiKey: resolvedKey.ascApiKey,
+          teamId,
+          teamName: resolvedKey.teamName,
+          teamType,
+        });
+      }
+    }
+
+    const authCtx = ctx.credentialsCtx.appStore.authCtx;
+    if (!authCtx) {
+      Log.debug('No App Store Connect API key available, skipping TestFlight setup');
+      return;
+    }
+
+    const app = await App.infoAsync(getRequestContext(authCtx), { id: ascAppIdentifier });
+    await ensureTestFlightGroupExistsAsync(app, { nonInteractive: ctx.nonInteractive });
+  } catch (error: any) {
+    // Group setup is a convenience on top of the submission and must never
+    // block it.
+    Log.warn('Skipping TestFlight group setup:', error);
+  }
+}

--- a/packages/eas-cli/src/submit/ios/ensureTestFlightSetup.ts
+++ b/packages/eas-cli/src/submit/ios/ensureTestFlightSetup.ts
@@ -1,0 +1,69 @@
+import { App } from '@expo/apple-utils';
+import { Platform } from '@expo/eas-build-job';
+import nullthrows from 'nullthrows';
+
+import { AppleTeamType } from '../../credentials/ios/appstore/authenticateTypes';
+import { getRequestContext } from '../../credentials/ios/appstore/authenticate';
+import { ensureTestFlightGroupExistsAsync } from '../../credentials/ios/appstore/ensureTestFlightGroup';
+import { resolveAppleTeamTypeFromEnvironment } from '../../credentials/ios/appstore/resolveCredentials';
+import { tryAuthenticateAppStoreWithEasAscApiKeyAsync } from '../../credentials/ios/actions/AscApiKeyUtils';
+import Log from '../../log';
+import { getBundleIdentifierAsync } from '../../project/ios/bundleIdentifier';
+import { SubmissionContext } from '../context';
+
+/**
+ * Best-effort TestFlight internal group setup for an App Store Connect app
+ * that already exists (`ascAppId` provided in the submit profile). Without
+ * this, the automatic group creation only ever runs on the interactive path
+ * that creates the ASC app, so apps created in the App Store Connect website
+ * are never set up and builds sit in TestFlight with no one able to install
+ * them.
+ *
+ * Authentication is strictly non-interactive: an ASC API key from the
+ * environment or the EAS credentials service. When neither is available the
+ * setup is skipped silently — it must never add prompts or failures to
+ * `eas submit`.
+ */
+export async function ensureTestFlightSetupForExistingAppAsync(
+  ctx: SubmissionContext<Platform.IOS>,
+  ascAppIdentifier: string
+): Promise<void> {
+  if (process.env.EAS_NO_AUTO_TESTFLIGHT_SETUP) {
+    Log.debug('EAS_NO_AUTO_TESTFLIGHT_SETUP is set, skipping TestFlight setup');
+    return;
+  }
+
+  try {
+    const bundleIdentifier =
+      ctx.applicationIdentifierOverride ??
+      ctx.profile.bundleIdentifier ??
+      (await getBundleIdentifierAsync(ctx.projectDir, ctx.exp, ctx.vcsClient));
+
+    const appLookupParams = {
+      account: nullthrows(
+        ctx.user.accounts.find(a => a.name === ctx.accountName),
+        `You do not have access to account: ${ctx.accountName}`
+      ),
+      projectName: ctx.projectName,
+      bundleIdentifier,
+    };
+
+    const authenticated = await tryAuthenticateAppStoreWithEasAscApiKeyAsync(
+      ctx.credentialsCtx,
+      appLookupParams,
+      resolveAppleTeamTypeFromEnvironment() ?? AppleTeamType.COMPANY_OR_ORGANIZATION
+    );
+    const authCtx = ctx.credentialsCtx.appStore.authCtx;
+    if (!authenticated || !authCtx) {
+      Log.debug('No App Store Connect API key available, skipping TestFlight setup');
+      return;
+    }
+
+    const app = await App.infoAsync(getRequestContext(authCtx), { id: ascAppIdentifier });
+    await ensureTestFlightGroupExistsAsync(app, { nonInteractive: ctx.nonInteractive });
+  } catch (error: any) {
+    // Group setup is a convenience on top of the submission and must never
+    // block it.
+    Log.debug('Skipping TestFlight group setup:', error);
+  }
+}


### PR DESCRIPTION
## Why

I noticed that in some cases when creating apps with CLI I end up in situation where I have to manually go to ASC and add myself as a tester.

## How

When running submit, the CLI looks for tester groups. If there are none, it adds the admins. If there are existing groups - it doesn't do anything.

Also changes Expo Go command to use the same path.

## Test plan

CI passes.