### PR TITLE
[eas-cli] Add --auto-configure-update flag to eas build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add `--auto-configure-update` flag to `eas build` to configure EAS Update before the build starts (install expo-updates, set updates.url and runtimeVersion, add channels to build profiles). ([#4139](https://github.com/expo/eas-cli/pull/4139) by [@williamgrosset](https://github.com/williamgrosset))
 - [eas-cli] Add `--link-project-id` flag to `eas build` to link the directory to an existing project before building, like `eas init --id`. ([#4138](https://github.com/expo/eas-cli/pull/4138) by [@williamgrosset](https://github.com/williamgrosset))
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -536,9 +536,9 @@ start a build
 ```
 USAGE
   $ eas build [-p android|ios|all] [-e PROFILE_NAME] [--force --link-project-id PROJECT_ID] [--local]
-    [--output <value>] [--wait] [--clear-cache] [-s | --auto-submit-with-profile PROFILE_NAME] [--what-to-test <value>]
-    [-m <value>] [--build-logger-level trace|debug|info|warn|error|fatal] [--freeze-credentials]
-    [--refresh-ad-hoc-provisioning-profile] [--verbose-logs] [--json] [--non-interactive]
+    [--output <value>] [--wait] [--clear-cache] [--auto-configure-update] [-s | --auto-submit-with-profile PROFILE_NAME]
+    [--what-to-test <value>] [-m <value>] [--build-logger-level trace|debug|info|warn|error|fatal]
+    [--freeze-credentials] [--refresh-ad-hoc-provisioning-profile] [--verbose-logs] [--json] [--non-interactive]
 
 FLAGS
   -e, --profile=PROFILE_NAME                   Name of the build profile from eas.json. Defaults to "production" if
@@ -547,6 +547,9 @@ FLAGS
   -p, --platform=<option>                      <options: android|ios|all>
   -s, --auto-submit                            Submit on build complete using the submit profile with the same name as
                                                the build profile
+      --auto-configure-update                  Configure the project for EAS Update before the build starts (install
+                                               expo-updates, set updates.url and runtimeVersion in app config, add
+                                               channels to build profiles), so the resulting binary can receive updates
       --auto-submit-with-profile=PROFILE_NAME  Submit on build complete using the submit profile with provided name
       --build-logger-level=<option>            The level of logs to output during the build process. Defaults to "info".
                                                <options: trace|debug|info|warn|error|fatal>

--- a/packages/eas-cli/src/build/__tests__/runBuildAndSubmit-test.ts
+++ b/packages/eas-cli/src/build/__tests__/runBuildAndSubmit-test.ts
@@ -1,0 +1,160 @@
+import { EasJsonUtils } from '@expo/eas-json';
+
+import { ensureProjectConfiguredAsync } from '../configure';
+import { BuildFlags, runBuildAndSubmitAsync } from '../runBuildAndSubmit';
+import { reviewAndCommitChangesAsync } from '../utils/repository';
+import { Analytics } from '../../analytics/AnalyticsManager';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { RequestedPlatform } from '../../platform';
+import {
+  ensureEASUpdateIsConfiguredAsync,
+  ensureEASUpdateIsConfiguredInEasJsonAsync,
+} from '../../update/configure';
+import { Actor } from '../../user/User';
+import { getProfilesAsync } from '../../utils/profiles';
+import { Client } from '../../vcs/vcs';
+
+jest.mock('../configure');
+jest.mock('../utils/repository');
+jest.mock('../utils/devClient');
+jest.mock('../utils/printBuildInfo');
+jest.mock('../../update/configure');
+jest.mock('../../utils/profiles');
+jest.mock('../../project/discourageExpoGoForProdAsync');
+jest.mock('../../log');
+jest.mock('@expo/eas-json', () => {
+  const actual = jest.requireActual('@expo/eas-json');
+  return {
+    ...actual,
+    EasJsonAccessor: { fromProjectPath: jest.fn(() => ({})) },
+    EasJsonUtils: { getCliConfigAsync: jest.fn() },
+  };
+});
+
+const projectDir = '/app';
+const projectId = 'e0b6b8fc-1e2b-4b1c-9c7f-2d3a4b5c6d7e';
+const exp = { name: 'test-app', slug: 'test-app' };
+
+function createVcsClient(
+  { isCommitRequired }: { isCommitRequired: boolean } = { isCommitRequired: false }
+): Client {
+  return {
+    ensureRepoExistsAsync: jest.fn(),
+    isCommitRequiredAsync: jest.fn().mockResolvedValue(isCommitRequired),
+  } as unknown as Client;
+}
+
+function createFlags(overrides: Partial<BuildFlags> = {}): BuildFlags {
+  return {
+    requestedPlatform: RequestedPlatform.Android,
+    nonInteractive: false,
+    wait: false,
+    clearCache: false,
+    json: false,
+    autoSubmit: false,
+    localBuildOptions: {},
+    freezeCredentials: false,
+    autoConfigureUpdate: false,
+    ...overrides,
+  };
+}
+
+async function runAsync({
+  flags,
+  vcsClient = createVcsClient(),
+  envOverride,
+}: {
+  flags: BuildFlags;
+  vcsClient?: Client;
+  envOverride?: Record<string, string>;
+}): Promise<void> {
+  await runBuildAndSubmitAsync({
+    graphqlClient: {} as ExpoGraphqlClient,
+    analytics: {} as Analytics,
+    vcsClient,
+    projectDir,
+    flags,
+    actor: {} as Actor,
+    getDynamicPrivateProjectConfigAsync: jest.fn().mockResolvedValue({ exp, projectId }),
+    envOverride,
+  });
+}
+
+describe(runBuildAndSubmitAsync, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mocked(getProfilesAsync).mockResolvedValue([]);
+    jest.mocked(ensureProjectConfiguredAsync).mockResolvedValue(true);
+    jest.mocked(EasJsonUtils.getCliConfigAsync).mockResolvedValue({});
+  });
+
+  describe('--auto-configure-update', () => {
+    it('does not configure EAS Update when the flag is not set', async () => {
+      await runAsync({ flags: createFlags({ autoConfigureUpdate: false }) });
+
+      expect(ensureEASUpdateIsConfiguredAsync).not.toHaveBeenCalled();
+      expect(ensureEASUpdateIsConfiguredInEasJsonAsync).not.toHaveBeenCalled();
+    });
+
+    it('configures EAS Update with the requested platform and env when the flag is set', async () => {
+      const envOverride = { MY_VAR: 'value' };
+      jest
+        .mocked(EasJsonUtils.getCliConfigAsync)
+        .mockResolvedValue({ updateManifestHostOverride: 'https://custom.example.com' });
+
+      await runAsync({
+        flags: createFlags({
+          autoConfigureUpdate: true,
+          requestedPlatform: RequestedPlatform.Ios,
+        }),
+        envOverride,
+      });
+
+      expect(ensureEASUpdateIsConfiguredAsync).toHaveBeenCalledWith({
+        exp,
+        projectId,
+        projectDir,
+        vcsClient: expect.anything(),
+        platform: RequestedPlatform.Ios,
+        env: envOverride,
+        manifestHostOverride: 'https://custom.example.com',
+      });
+    });
+
+    it('passes a null manifestHostOverride when eas.json does not set one', async () => {
+      await runAsync({ flags: createFlags({ autoConfigureUpdate: true }) });
+
+      expect(ensureEASUpdateIsConfiguredAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ manifestHostOverride: null })
+      );
+    });
+
+    it('adds channels to all build profiles regardless of the selected profile', async () => {
+      await runAsync({ flags: createFlags({ autoConfigureUpdate: true, profile: 'preview' }) });
+
+      expect(ensureEASUpdateIsConfiguredInEasJsonAsync).toHaveBeenCalledWith(projectDir);
+    });
+
+    it('commits the changes when the configuration modified the working tree', async () => {
+      await runAsync({
+        flags: createFlags({ autoConfigureUpdate: true, nonInteractive: true }),
+        vcsClient: createVcsClient({ isCommitRequired: true }),
+      });
+
+      expect(reviewAndCommitChangesAsync).toHaveBeenCalledWith(
+        expect.anything(),
+        'Configure EAS Update',
+        { nonInteractive: true }
+      );
+    });
+
+    it('does not commit when the configuration left the working tree unchanged', async () => {
+      await runAsync({
+        flags: createFlags({ autoConfigureUpdate: true }),
+        vcsClient: createVcsClient({ isCommitRequired: false }),
+      });
+
+      expect(reviewAndCommitChangesAsync).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -25,7 +25,7 @@ import { LocalBuildMode, LocalBuildOptions } from './local';
 import { ensureLockfileExistsAsync } from './validateLockfile';
 import { ensureExpoDevClientInstalledForDevClientBuildsAsync } from './utils/devClient';
 import { printBuildResults, printLogsUrls } from './utils/printBuildInfo';
-import { ensureRepoIsCleanAsync } from './utils/repository';
+import { ensureRepoIsCleanAsync, reviewAndCommitChangesAsync } from './utils/repository';
 import { Analytics } from '../analytics/AnalyticsManager';
 import { createAndLinkChannelAsync, doesChannelExistAsync } from '../channel/queries';
 import { DynamicConfigContextFn } from '../commandUtils/context/DynamicProjectConfigContextField';
@@ -75,7 +75,10 @@ import {
   waitToCompleteAsync as waitForSubmissionsToCompleteAsync,
 } from '../submit/submit';
 import { printSubmissionDetailsUrls } from '../submit/utils/urls';
-import { ensureEASUpdateIsConfiguredAsync } from '../update/configure';
+import {
+  ensureEASUpdateIsConfiguredAsync,
+  ensureEASUpdateIsConfiguredInEasJsonAsync,
+} from '../update/configure';
 import { Actor } from '../user/User';
 import { downloadAndMaybeExtractAppAsync } from '../utils/download';
 import { truthy } from '../utils/expodash/filter';
@@ -107,6 +110,7 @@ export interface BuildFlags {
   isVerboseLoggingEnabled?: boolean;
   whatToTest?: string;
   simulator?: SimulatorRunTarget;
+  autoConfigureUpdate: boolean;
 }
 
 export async function runBuildAndSubmitAsync({
@@ -144,6 +148,26 @@ export async function runBuildAndSubmitAsync({
   const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
   const easJsonCliConfig: EasJson['cli'] =
     (await EasJsonUtils.getCliConfigAsync(easJsonAccessor)) ?? {};
+
+  if (flags.autoConfigureUpdate) {
+    const { exp, projectId } = await getDynamicPrivateProjectConfigAsync({ env: envOverride });
+    await ensureEASUpdateIsConfiguredAsync({
+      exp,
+      projectId,
+      projectDir,
+      vcsClient,
+      platform: flags.requestedPlatform,
+      env: envOverride,
+      manifestHostOverride: easJsonCliConfig.updateManifestHostOverride ?? null,
+    });
+    await ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir);
+    if (await vcsClient.isCommitRequiredAsync()) {
+      Log.addNewLineIfNone();
+      await reviewAndCommitChangesAsync(vcsClient, 'Configure EAS Update', {
+        nonInteractive: flags.nonInteractive,
+      });
+    }
+  }
 
   const platforms = toPlatforms(flags.requestedPlatform);
   const buildProfiles = await getProfilesAsync({
@@ -673,7 +697,7 @@ async function validateExpoUpdatesInstalledAsProjectDependencyAsync({
     );
   } else if (nonInteractive) {
     Log.warn(
-      `The build profile "${buildProfile.profileName}" has specified the channel "${buildProfile.profile.channel}", but the "expo-updates" package hasn't been installed. To use channels for your builds, install the "expo-updates" package by running "npx expo install expo-updates" followed by "eas update:configure".`
+      `The build profile "${buildProfile.profileName}" has specified the channel "${buildProfile.profile.channel}", but the "expo-updates" package hasn't been installed. To use channels for your builds, install the "expo-updates" package by running "npx expo install expo-updates" followed by "eas update:configure", or re-run this build with the --auto-configure-update flag.`
     );
   } else {
     Log.warn(

--- a/packages/eas-cli/src/commands/build/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/build/__tests__/index.test.ts
@@ -132,6 +132,47 @@ describe(Build, () => {
     expect(runBuildAndSubmitAsync).not.toHaveBeenCalled();
   });
 
+  it('passes autoConfigureUpdate: true when --auto-configure-update is set', async () => {
+    await createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      '--auto-configure-update',
+    ]).runAsync();
+
+    expect(runBuildAndSubmitAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flags: expect.objectContaining({ autoConfigureUpdate: true }),
+      })
+    );
+  });
+
+  it('passes autoConfigureUpdate: false when --auto-configure-update is not set', async () => {
+    await createCommand(['--platform', 'ios', '--non-interactive']).runAsync();
+
+    expect(runBuildAndSubmitAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flags: expect.objectContaining({ autoConfigureUpdate: false }),
+      })
+    );
+  });
+
+  it('composes --auto-configure-update with --json', async () => {
+    await createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      '--json',
+      '--auto-configure-update',
+    ]).runAsync();
+
+    expect(runBuildAndSubmitAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flags: expect.objectContaining({ autoConfigureUpdate: true, json: true }),
+      })
+    );
+  });
+
   it('works with --json', async () => {
     await createCommand([
       '--platform',

--- a/packages/eas-cli/src/commands/build/dev.ts
+++ b/packages/eas-cli/src/commands/build/dev.ts
@@ -188,6 +188,7 @@ export default class BuildDev extends EasCommand {
         freezeCredentials: false,
         wait: true,
         clearCache: false,
+        autoConfigureUpdate: false,
         json: false,
         autoSubmit: false,
         localBuildOptions: {},

--- a/packages/eas-cli/src/commands/build/index.ts
+++ b/packages/eas-cli/src/commands/build/index.ts
@@ -37,6 +37,7 @@ interface RawBuildFlags {
   output?: string;
   wait: boolean;
   'clear-cache': boolean;
+  'auto-configure-update': boolean;
   json: boolean;
   'auto-submit': boolean;
   'auto-submit-with-profile'?: string;
@@ -96,6 +97,11 @@ export default class Build extends EasCommand {
     'clear-cache': Flags.boolean({
       default: false,
       description: 'Clear cache before the build',
+    }),
+    'auto-configure-update': Flags.boolean({
+      default: false,
+      description:
+        'Configure the project for EAS Update before the build starts (install expo-updates, set updates.url and runtimeVersion in app config, add channels to build profiles), so the resulting binary can receive updates',
     }),
     'auto-submit': Flags.boolean({
       char: 's',
@@ -289,6 +295,7 @@ export default class Build extends EasCommand {
         : {},
       wait: flags['wait'],
       clearCache: flags['clear-cache'],
+      autoConfigureUpdate: flags['auto-configure-update'],
       json,
       autoSubmit,
       submitProfile: flags['auto-submit-with-profile'] ?? profile,

--- a/packages/eas-cli/src/commands/build/inspect.ts
+++ b/packages/eas-cli/src/commands/build/inspect.ts
@@ -109,6 +109,7 @@ export default class BuildInspect extends EasCommand {
             freezeCredentials: false,
             wait: true,
             clearCache: false,
+            autoConfigureUpdate: false,
             json: false,
             autoSubmit: false,
             requestedPlatform: flags.platform,

--- a/packages/eas-cli/src/commands/build/internal.ts
+++ b/packages/eas-cli/src/commands/build/internal.ts
@@ -93,6 +93,7 @@ export default class BuildInternal extends EasCommand {
         refreshAdHocProvisioningProfile: flags['refresh-ad-hoc-provisioning-profile'],
         wait: false,
         clearCache: false,
+        autoConfigureUpdate: false,
         json: true,
         autoSubmit: flags['auto-submit'] || flags['auto-submit-with-profile'] !== undefined,
         localBuildOptions: {

--- a/packages/eas-cli/src/update/__tests__/configure-test.ts
+++ b/packages/eas-cli/src/update/__tests__/configure-test.ts
@@ -1,11 +1,18 @@
 import { Workflow } from '@expo/eas-build-job';
+import { EasJsonAccessor } from '@expo/eas-json';
+import fs from 'fs-extra';
+import { vol } from 'memfs';
 
 import {
   DEFAULT_BARE_RUNTIME_VERSION,
   DEFAULT_MANAGED_RUNTIME_VERSION_GTE_SDK_49,
   DEFAULT_MANAGED_RUNTIME_VERSION_LTE_SDK_48,
+  ensureEASUpdateIsConfiguredInEasJsonAsync,
   getDefaultRuntimeVersion,
 } from '../configure';
+
+jest.mock('fs');
+jest.mock('../../log');
 
 describe(getDefaultRuntimeVersion, () => {
   it('gets the right rtv version/policy', () => {
@@ -48,5 +55,60 @@ describe(getDefaultRuntimeVersion, () => {
     expect(getDefaultRuntimeVersion(Workflow.GENERIC, undefined)).toBe(
       DEFAULT_BARE_RUNTIME_VERSION
     );
+  });
+});
+
+describe(ensureEASUpdateIsConfiguredInEasJsonAsync, () => {
+  const easJsonPath = EasJsonAccessor.formatEasJsonPath('.');
+
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  function volWithEasJson(build: Record<string, object>): void {
+    vol.fromJSON({
+      './eas.json': `${JSON.stringify({ cli: { version: '>= 1.0.0' }, build }, null, 2)}\n`,
+    });
+  }
+
+  async function readBuildProfilesAsync(): Promise<any> {
+    const easJsonAccessor = EasJsonAccessor.fromProjectPath('.');
+    const easJson = await easJsonAccessor.readRawJsonAsync();
+    return easJson.build;
+  }
+
+  it('adds a channel to every profile without one', async () => {
+    volWithEasJson({
+      development: { developmentClient: true, distribution: 'internal' },
+      preview: { distribution: 'internal' },
+      production: { channel: 'custom' },
+    });
+
+    await ensureEASUpdateIsConfiguredInEasJsonAsync('.');
+
+    const build = await readBuildProfilesAsync();
+    expect(build.development.channel).toBe('development');
+    expect(build.preview.channel).toBe('preview');
+    expect(build.production.channel).toBe('custom');
+  });
+
+  it('does not rewrite eas.json when every profile already has a channel', async () => {
+    volWithEasJson({
+      preview: { channel: 'shared' },
+      production: { channel: 'custom' },
+    });
+    const before = await fs.readFile(easJsonPath, 'utf8');
+
+    await ensureEASUpdateIsConfiguredInEasJsonAsync('.');
+
+    const after = await fs.readFile(easJsonPath, 'utf8');
+    expect(after).toBe(before);
+    const build = await readBuildProfilesAsync();
+    expect(build.preview.channel).toBe('shared');
+    expect(build.production.channel).toBe('custom');
+  });
+
+  it('resolves without error when eas.json does not exist', async () => {
+    await expect(ensureEASUpdateIsConfiguredInEasJsonAsync('.')).resolves.toBeUndefined();
   });
 });

--- a/packages/eas-cli/src/update/configure.ts
+++ b/packages/eas-cli/src/update/configure.ts
@@ -315,6 +315,7 @@ export async function ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir: stri
     const easJsonAccessor = EasJsonAccessor.fromProjectPath(projectDir);
     await easJsonAccessor.readRawJsonAsync();
 
+    const patchedProfileNames: string[] = [];
     easJsonAccessor.patch(easJsonRawObject => {
       // If there are no build profiles then we are done.
       if (!easJsonRawObject.build) {
@@ -326,6 +327,7 @@ export async function ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir: stri
           const buildProfile = easJsonRawObject.build[profileNameKey];
           const isNotAlreadyConfigured = !buildProfile.channel;
           if (isNotAlreadyConfigured) {
+            patchedProfileNames.push(profileNameKey);
             return {
               ...acc,
               [profileNameKey]: {
@@ -350,6 +352,10 @@ export async function ensureEASUpdateIsConfiguredInEasJsonAsync(projectDir: stri
         build: easBuildProfilesWithChannels,
       };
     });
+
+    if (patchedProfileNames.length === 0) {
+      return;
+    }
 
     await easJsonAccessor.writeAsync();
     Log.withTick(`Configured ${chalk.bold('eas.json')}.`);


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Users/agents should be able to configure EAS update before a build command runs, so that a user doesn't have to complete a rebuild after.

# How

- Added `--auto-configure-update` to `eas build`: before the build starts, installs `expo-updates`, sets `updates.url` and `runtimeVersion` in the app config, syncs native config, and adds channels to build profiles
- Equivalent to running `eas update:configure` before the build, scoped to the build's `--platform`
- Repeat runs change nothing. `ensureEASUpdateIsConfiguredInEasJsonAsync` (shared with `eas update:configure`) now skips the `eas.json` write when no profile changed

# Test Plan

Manually verified  EAS update is configured and `eas build` continues it's execution:

https://github.com/user-attachments/assets/42c9df6f-69bf-4c4e-82c7-8bbd45e47b83