### PR TITLE
[eas-cli] Check non-interactive mode before fetching context in submit:cancel and submit:retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Check non-interactive mode before fetching context in `eas submit:cancel` and `eas submit:retry`, so a missing submission ID fails fast without network requests. ([#4141](https://github.com/expo/eas-cli/pull/4141) by [@brentvatne](https://github.com/brentvatne))
 - [build-tools] Run EAS Simulator previews with the official `@expo/serve-sim` package under EAS-owned supervision. ([#4114](https://github.com/expo/eas-cli/pull/4114) by [@szdziedzic](https://github.com/szdziedzic))
 - [reviewer] Report each AI review finding with a confidence and shipping-impact signal, and open the review summary with an overall PR risk rating. ([#4128](https://github.com/expo/eas-cli/pull/4128) by [@brentvatne](https://github.com/brentvatne))
 

--- a/packages/eas-cli/src/commands/submit/cancel.ts
+++ b/packages/eas-cli/src/commands/submit/cancel.ts
@@ -96,6 +96,10 @@ export default class SubmissionCancel extends EasCommand {
       );
     }
 
+    if (!submissionIdFromArg && nonInteractive) {
+      throw new Error('Submission ID must be provided in non-interactive mode');
+    }
+
     const {
       projectId,
       loggedIn: { graphqlClient },
@@ -103,13 +107,9 @@ export default class SubmissionCancel extends EasCommand {
       nonInteractive,
     });
 
-    const displayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);
-
     let submissionId: string | null = submissionIdFromArg ?? null;
     if (!submissionId) {
-      if (nonInteractive) {
-        throw new Error('Submission ID must be provided in non-interactive mode');
-      }
+      const displayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);
 
       submissionId = await selectSubmissionToCancelAsync(
         graphqlClient,

--- a/packages/eas-cli/src/commands/submit/retry.ts
+++ b/packages/eas-cli/src/commands/submit/retry.ts
@@ -95,6 +95,10 @@ export default class SubmissionRetry extends EasCommand {
       );
     }
 
+    if (!submissionIdFromArg && nonInteractive) {
+      throw new Error('Submission ID must be provided in non-interactive mode');
+    }
+
     if (jsonFlag) {
       enableJsonOutput();
     }
@@ -105,13 +109,9 @@ export default class SubmissionRetry extends EasCommand {
       nonInteractive,
     });
 
-    const displayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);
-
     let submissionId: string | null = submissionIdFromArg ?? null;
     if (!submissionId) {
-      if (nonInteractive) {
-        throw new Error('Submission ID must be provided in non-interactive mode');
-      }
+      const displayName = await getDisplayNameForProjectIdAsync(graphqlClient, projectId);
 
       submissionId = await selectSubmissionToRetryAsync(
         graphqlClient,


### PR DESCRIPTION
# Why

Follow-up to #4134, addressing @douglowder's review feedback: the "Submission ID must be provided in non-interactive mode" check ran after `getContextAsync` and `getDisplayNameForProjectIdAsync`. The command did network work before it failed on invalid input.

# How

In `submit:cancel` and `submit:retry`, the non-interactive check now runs immediately after flag validation, before any context or project lookups. The `getDisplayNameForProjectIdAsync` call moved inside the interactive branch, since only the interactive submission picker uses the display name.

# Test Plan

- `yarn typecheck`, `yarn lint`, and `yarn fmt:check` pass.
- `eas submit:cancel --non-interactive` and `eas submit:retry --non-interactive` (no submission ID) fail immediately with "Submission ID must be provided in non-interactive mode".
- Interactive `eas submit:cancel` and `eas submit:retry` still list submissions with the project display name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)