### PR TITLE
Revert "[build-tools] Pin the default agent-device version for remote sessions (#4142)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Revert "Pin the default `agent-device` version for remote sessions" now that `agent-device` 0.20.5 fixes the broken release. ([#4144](https://github.com/expo/eas-cli/pull/4144) by [@gwdp](https://github.com/gwdp))
+
 ### 🧹 Chores
 
 ## [21.5.1](https://github.com/expo/eas-cli/releases/tag/v21.5.1) - 2026-08-03

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -31,7 +31,6 @@ import {
 } from '../utils/remoteDeviceRunSession';
 
 const AGENT_DEVICE_PACKAGE_NAME = 'agent-device';
-export const DEFAULT_AGENT_DEVICE_VERSION = '0.20.3';
 const AGENT_DEVICE_REPO_URL = 'https://github.com/callstack/agent-device.git';
 const SRC_DIR = '/tmp/agent-device-src';
 const AGENT_DEVICE_STATE_DIR = path.join(os.homedir(), '.agent-device');
@@ -66,11 +65,10 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
       const ngrokAuthtoken = getNgrokAuthtokenOrThrow(env);
 
-      const packageVersion =
-        (inputs.package_version.value as string | undefined) ?? DEFAULT_AGENT_DEVICE_VERSION;
+      const packageVersion = inputs.package_version.value as string | undefined;
       const { runtimePlatform } = global;
       logger.info(
-        `Starting agent-device remote session (version: ${packageVersion}, runtime: ${runtimePlatform}).`
+        `Starting agent-device remote session (version: ${packageVersion ?? 'latest'}, runtime: ${runtimePlatform}).`
       );
 
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
@@ -188,7 +186,7 @@ async function startAgentDeviceDaemonAsync({
   env,
   logger,
 }: {
-  packageVersion: string;
+  packageVersion: string | undefined;
   env: BuildStepEnv;
   logger: bunyan;
 }): Promise<DetachedProcessHandle> {
@@ -225,7 +223,7 @@ async function startAgentDeviceDaemonAsync({
         },
         extras: {
           packageSpec,
-          packageVersion,
+          packageVersion: packageVersion ?? 'latest',
           bunVersion,
           bunInstallConfigured: Boolean(env.BUN_INSTALL?.trim()),
         },
@@ -243,11 +241,15 @@ async function startAgentDeviceDaemonFromGitAsync({
   env,
   logger,
 }: {
-  packageVersion: string;
+  packageVersion: string | undefined;
   env: BuildStepEnv;
   logger: bunyan;
 }): Promise<DetachedProcessHandle> {
-  logger.info(`Cloning agent-device @ v${packageVersion} into ${SRC_DIR}.`);
+  logger.info(
+    packageVersion
+      ? `Cloning agent-device @ v${packageVersion} into ${SRC_DIR}.`
+      : `Cloning agent-device (latest) into ${SRC_DIR}.`
+  );
   await cloneAgentDeviceAsync({ packageVersion, env, logger });
 
   logger.info('Installing agent-device dependencies.');
@@ -271,11 +273,11 @@ async function cloneAgentDeviceAsync({
   env,
   logger,
 }: {
-  packageVersion: string;
+  packageVersion: string | undefined;
   env: BuildStepEnv;
   logger: bunyan;
 }): Promise<void> {
-  const branchArgs = ['--branch', `v${packageVersion}`];
+  const branchArgs = packageVersion ? ['--branch', `v${packageVersion}`] : [];
   await spawn('git', ['clone', '--depth', '1', ...branchArgs, AGENT_DEVICE_REPO_URL, SRC_DIR], {
     env,
     logger,
@@ -315,8 +317,8 @@ async function getBunVersionForDiagnosticsAsync(env: BuildStepEnv): Promise<stri
   }
 }
 
-function createAgentDevicePackageSpec(packageVersion: string): string {
-  const versionSpec = packageVersion.replace(/^v(?=\d)/, '');
+function createAgentDevicePackageSpec(packageVersion: string | undefined): string {
+  const versionSpec = packageVersion ? packageVersion.replace(/^v(?=\d)/, '') : 'latest';
   return `${AGENT_DEVICE_PACKAGE_NAME}@${versionSpec}`;
 }
 


### PR DESCRIPTION
# Why

`agent-device@0.20.4` shipped a broken tarball. It imported `@agent-device/ad-script`, which was never published to npm. That broke every `--type agent-device` simulator session, and local `npx agent-device` commands too. #4142 pinned the default to `0.20.3` to stop the bleeding.

Callstack has published `0.20.5` with that import gone, so the pin isn't needed anymore.

# How

Straight revert of #4142. The default goes back to `latest`.

# Test Plan

Checked 0.20.5 before reverting onto it:

- Remote session started with `--package-version 0.20.5` reached ready, `agent-device apps` returned normally, stopped cleanly -> https://expo.dev/accounts/gwdp/projects/coin-flip/simulator-sessions/019fc95d-8e80-711b-8f86-6bc2b071f94b
