### PR TITLE
Revert "[build-tools] Pin the default agent-device version for remote sessions (#4142)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Revert pinning the default `agent-device` version for remote sessions, so sessions install `latest` again when no `package_version` input is set. ([#4145](https://github.com/expo/eas-cli/pull/4145) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [21.5.1](https://github.com/expo/eas-cli/releases/tag/v21.5.1) - 2026-08-03

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -31,7 +31,6 @@ import {
 } from '../utils/remoteDeviceRunSession';
 
 const AGENT_DEVICE_PACKAGE_NAME = 'agent-device';
-export const DEFAULT_AGENT_DEVICE_VERSION = '0.20.3';
 const AGENT_DEVICE_REPO_URL = 'https://github.com/callstack/agent-device.git';
 const SRC_DIR = '/tmp/agent-device-src';
 const AGENT_DEVICE_STATE_DIR = path.join(os.homedir(), '.agent-device');
@@ -66,11 +65,10 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
       const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
       const ngrokAuthtoken = getNgrokAuthtokenOrThrow(env);
 
-      const packageVersion =
-        (inputs.package_version.value as string | undefined) ?? DEFAULT_AGENT_DEVICE_VERSION;
+      const packageVersion = inputs.package_version.value as string | undefined;
       const { runtimePlatform } = global;
       logger.info(
-        `Starting agent-device remote session (version: ${packageVersion}, runtime: ${runtimePlatform}).`
+        `Starting agent-device remote session (version: ${packageVersion ?? 'latest'}, runtime: ${runtimePlatform}).`
       );
 
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
@@ -188,7 +186,7 @@ async function startAgentDeviceDaemonAsync({
   env,
   logger,
 }: {
-  packageVersion: string;
+  packageVersion: string | undefined;
   env: BuildStepEnv;
   logger: bunyan;
 }): Promise<DetachedProcessHandle> {
@@ -225,7 +223,7 @@ async function startAgentDeviceDaemonAsync({
         },
         extras: {
           packageSpec,
-          packageVersion,
+          packageVersion: packageVersion ?? 'latest',
           bunVersion,
           bunInstallConfigured: Boolean(env.BUN_INSTALL?.trim()),
         },
@@ -243,11 +241,15 @@ async function startAgentDeviceDaemonFromGitAsync({
   env,
   logger,
 }: {
-  packageVersion: string;
+  packageVersion: string | undefined;
   env: BuildStepEnv;
   logger: bunyan;
 }): Promise<DetachedProcessHandle> {
-  logger.info(`Cloning agent-device @ v${packageVersion} into ${SRC_DIR}.`);
+  logger.info(
+    packageVersion
+      ? `Cloning agent-device @ v${packageVersion} into ${SRC_DIR}.`
+      : `Cloning agent-device (latest) into ${SRC_DIR}.`
+  );
   await cloneAgentDeviceAsync({ packageVersion, env, logger });
 
   logger.info('Installing agent-device dependencies.');
@@ -271,11 +273,11 @@ async function cloneAgentDeviceAsync({
   env,
   logger,
 }: {
-  packageVersion: string;
+  packageVersion: string | undefined;
   env: BuildStepEnv;
   logger: bunyan;
 }): Promise<void> {
-  const branchArgs = ['--branch', `v${packageVersion}`];
+  const branchArgs = packageVersion ? ['--branch', `v${packageVersion}`] : [];
   await spawn('git', ['clone', '--depth', '1', ...branchArgs, AGENT_DEVICE_REPO_URL, SRC_DIR], {
     env,
     logger,
@@ -315,8 +317,8 @@ async function getBunVersionForDiagnosticsAsync(env: BuildStepEnv): Promise<stri
   }
 }
 
-function createAgentDevicePackageSpec(packageVersion: string): string {
-  const versionSpec = packageVersion.replace(/^v(?=\d)/, '');
+function createAgentDevicePackageSpec(packageVersion: string | undefined): string {
+  const versionSpec = packageVersion ? packageVersion.replace(/^v(?=\d)/, '') : 'latest';
   return `${AGENT_DEVICE_PACKAGE_NAME}@${versionSpec}`;
 }
 


### PR DESCRIPTION
# Why

Reverts [#4142](https://github.com/expo/eas-cli/pull/4142) ("[build-tools] Pin the default `agent-device` version for remote sessions").

# How

`git revert` of commit f56c054be4adde4dec2730bd5aafa26050afcdcb. The default `agent-device` version for remote sessions goes back to `latest` when the `package_version` input is not set:

- `DEFAULT_AGENT_DEVICE_VERSION` is removed.
- `packageVersion` is `string | undefined` again in `startAgentDeviceDaemonAsync`, `startAgentDeviceDaemonFromGitAsync`, `cloneAgentDeviceAsync`, and `createAgentDevicePackageSpec`.
- The npm package spec falls back to `agent-device@latest`, and the git clone omits `--branch` when no version is given.

The CHANGELOG entry for #4142 stays in the `21.5.0` section because that change already shipped in `@expo/build-tools@21.5.1`. A new entry under `## main` records the revert.

# Test Plan

- `yarn typecheck` — passes.
- `yarn lint` — passes (0 errors).
- `yarn fmt:check` — passes.
- `yarn lint-changelog` — passes.
- `cd packages/build-tools && yarn test` — 104 of 105 suites pass. The one failure is `steps/functions/__tests__/repack.test.ts`, which fails the same way on the base commit `d003bffa` (`spawn yarn ENOENT` in the local sandbox) and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
