### PR TITLE
[reviewer] Migrate reviews from GPT to Claude (sonnet 5, opus for security)

### DIFF
--- a/.expo-code-review/agents/security.md
+++ b/.expo-code-review/agents/security.md
@@ -1,10 +1,9 @@
 ---
 description: Security and secrets. Injection, credential or secret leakage, unsafe shell/child-process use, missing validation at trust boundaries.
 alwaysRun: true
-# No model override: security runs on the config default (gpt-5.5, on the
-# subscription). To give it a stronger model, use the metered openai-api alias
-# from the mixed auth.providers setup (see the @expo/code-review-cli README) —
-# pro-tier models are excluded from the subscription.
+# Security is the highest-stakes agent, so it runs on the Opus tier (mirrors
+# the expo/code-review-cli repo's own roster).
+model: anthropic/claude-opus-5
 ---
 
 # Security & secrets

--- a/.expo-code-review/config.jsonc
+++ b/.expo-code-review/config.jsonc
@@ -1,9 +1,11 @@
 {
-  // Default model for every pass — served by the ChatGPT/Codex subscription (see
-  // auth below), so reviews have no marginal cost. Per-agent frontmatter can
-  // override this. Override everything at runtime with REVIEWER_MODEL
-  // (e.g. REVIEWER_MODEL=openai/gpt-5.4-mini for a cheaper local run).
-  "model": "openai/gpt-5.5",
+  // Default model for every pass. Anthropic models run through the Claude Code
+  // CLI engine (`claude -p`), inferred per agent from the model id — see the
+  // auth entry below for the credential. Per-agent frontmatter can override
+  // this (security runs Opus). Override everything at runtime with
+  // REVIEWER_MODEL (e.g. REVIEWER_MODEL=anthropic/claude-haiku-4-5 for a
+  // cheaper local run).
+  "model": "anthropic/claude-sonnet-5",
 
   // Agents are every markdown file in agents/. shared.md (prepended to all) and
   // coordinator.md are reserved. Per-agent overrides go in each file's frontmatter.
@@ -30,17 +32,16 @@
   "breakGlass": { "marker": "/skip-review" },
   "commentTag": "expo-ai-code-reviewer",
 
-  // ChatGPT/Codex subscription (OAuth): tokenEnv holds the ACCESS token from an
-  // `opencode auth login` ChatGPT sign-in (`ecr setup-auth` extracts it) — a
-  // plain bearer with no rotation involvement; re-mint before its ~10-day expiry
-  // (doctor + the run preflight warn first). NEVER use the refresh token here:
-  // it is single-use and dies on first rotation. All models above are on the
-  // subscription's allowlist, so reviews draw no metered spend. (To add pro-tier
-  // models later, see the mixed auth.providers setup in the @expo/code-review-cli
-  // README.)
+  // Anthropic models always run through the Claude Code CLI — the engine is
+  // inferred per agent from the `anthropic/…` model id, so this entry only
+  // supplies the credential. The tokenEnv holds the shared review credential
+  // (an `sk-ant-oat…` token from `claude setup-token`, or an `sk-ant-api…`
+  // Console key — the CLI reads either; the engine classifies by shape).
+  // ECR_EXPECTED_TOKEN_ENV (repo variable / workflow fallback) must equal this
+  // tokenEnv. Locally, an active `claude` login is enough.
   "auth": {
-    "mode": "oauth",
-    "provider": "openai",
-    "tokenEnv": "CODEX_OAUTH_ACCESS_TOKEN"
+    "providers": {
+      "anthropic": { "tokenEnv": "CLAUDE_CODE_REVIEW_SHARED_API_TOKEN" }
+    }
   }
 }

--- a/.expo-code-review/coordinator.md
+++ b/.expo-code-review/coordinator.md
@@ -1,7 +1,7 @@
 ---
-# No model override: the coordinator runs on the config default (gpt-5.5, on the
-# subscription). It only consolidates text (no repo tools), so the default is
-# plenty; override here if consolidation quality ever needs a stronger model.
+# No model override: the coordinator runs on the config default
+# (claude-sonnet-5). It only consolidates text (no repo tools), so the default
+# is plenty; override here if consolidation quality ever needs a stronger model.
 ---
 
 # Coordinator — consolidation & decision

--- a/.github/workflows/expo-code-review-command.yml
+++ b/.github/workflows/expo-code-review-command.yml
@@ -19,7 +19,7 @@ permissions:
 
 env:
   # Published reviewer run via npx (override with repo variable ECR_VERSION).
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.6.0' }}
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.9.2' }}
 
 concurrency:
   group: ai-code-review-cmd-${{ github.event.issue.number }}
@@ -116,13 +116,20 @@ jobs:
           curl -fsSL https://getunblocked.com/install.sh | bash
           echo "$HOME/.unblocked/bin" >> "$GITHUB_PATH"
 
+      # The anthropic/… models run through the Claude Code CLI (claude-code
+      # engine). Pinned exactly — see expo-code-review.yml.
+      - name: Install Claude Code CLI
+        if: steps.cmd.outputs.run == 'true'
+        run: npm install -g @anthropic-ai/claude-code@2.1.212
+
       - name: Run AI review
         if: steps.cmd.outputs.run == 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CODEX_OAUTH_ACCESS_TOKEN: ${{ secrets.CODEX_OAUTH_ACCESS_TOKEN }}
-          ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CODEX_OAUTH_ACCESS_TOKEN' }}
+          # Shared Anthropic review credential — see expo-code-review.yml.
+          CLAUDE_CODE_REVIEW_SHARED_API_TOKEN: ${{ secrets.CLAUDE_CODE_REVIEW_SHARED_API_TOKEN }}
+          ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CLAUDE_CODE_REVIEW_SHARED_API_TOKEN' }}
           # Unblocked CLI headless auth (PAT or team access token). Absent =>
           # the CLI stays unauthenticated; the review still runs.
           UNBLOCKED_API_TOKEN: ${{ secrets.UNBLOCKED_API_TOKEN }}

--- a/.github/workflows/expo-code-review-dismiss.yml
+++ b/.github/workflows/expo-code-review-dismiss.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   # Published reviewer run via npx (override with repo variable ECR_VERSION).
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.6.0' }}
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.9.2' }}
 
 concurrency:
   group: ai-code-review-dismiss-${{ github.event.issue.number }}

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -13,9 +13,9 @@ permissions:
 env:
   # The reviewer is the published @expo/code-review-cli package, run via npx — the
   # repo only carries the `.expo-code-review/` config, not the engine source.
-  # Override with a repo variable ECR_VERSION to pin/bump; defaults to 0.6.x
-  # (0.6.0 = trusted base-commit configuration + PR-head runtime-config scrub).
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.6.0' }}
+  # Override with a repo variable ECR_VERSION to pin/bump; defaults to 0.9.x
+  # (0.9 = the claude-code engine the anthropic/… models below run on).
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.9.2' }}
 
 concurrency:
   group: ai-code-review-${{ github.event.pull_request.number }}
@@ -125,6 +125,14 @@ jobs:
           curl -fsSL https://getunblocked.com/install.sh | bash
           echo "$HOME/.unblocked/bin" >> "$GITHUB_PATH"
 
+      # The anthropic/… models in .expo-code-review/config.jsonc run through the
+      # Claude Code CLI (the claude-code engine). Pinned exactly — an unpinned
+      # CLI would silently drift on every CI run; bump it deliberately (mirrors
+      # expo/code-review-cli's own workflow).
+      - name: Install Claude Code CLI
+        if: steps.resolve.outputs.run == 'true'
+        run: npm install -g @anthropic-ai/claude-code@2.1.212
+
       # SECURITY: the TRUSTED BASE checkout above includes .expo-code-review/
       # config.jsonc, whose auth.tokenEnv names the env var the CLI forwards as the
       # model credential. `ecr verify-config` is the canonical guard (ships with the
@@ -136,7 +144,7 @@ jobs:
       - name: Guard config tokenEnv (root + routing + all scopes)
         if: steps.resolve.outputs.run == 'true'
         env:
-          ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CODEX_OAUTH_ACCESS_TOKEN' }}
+          ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CLAUDE_CODE_REVIEW_SHARED_API_TOKEN' }}
         run: npx --yes -p "@expo/code-review-cli@$ECR_VERSION" ecr verify-config
 
       - name: Run AI review
@@ -148,14 +156,14 @@ jobs:
         env:
           # GitHub token scoped by the permissions block above (PR comments only).
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # ChatGPT/Codex subscription ACCESS token (auth.mode "oauth" in
-          # .expo-code-review/config.jsonc reads this env var) — used as-is, no
-          # rotation involvement; re-mint before its ~10-day expiry. All reviews
-          # run on the subscription.
-          CODEX_OAUTH_ACCESS_TOKEN: ${{ secrets.CODEX_OAUTH_ACCESS_TOKEN }}
+          # Shared Anthropic review credential (auth.providers.anthropic in
+          # .expo-code-review/config.jsonc reads this env var). The claude-code
+          # engine forwards it to the Claude Code CLI as the only credential —
+          # an `sk-ant-oat…` setup-token or an `sk-ant-api…` Console key both work.
+          CLAUDE_CODE_REVIEW_SHARED_API_TOKEN: ${{ secrets.CLAUDE_CODE_REVIEW_SHARED_API_TOKEN }}
           # Layer-1 runtime auth lock (mirrors the guard step): the CLI refuses to
           # run when the tokenEnv the loaded config honors differs from this.
-          ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CODEX_OAUTH_ACCESS_TOKEN' }}
+          ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CLAUDE_CODE_REVIEW_SHARED_API_TOKEN' }}
           # Unblocked CLI headless auth (PAT or team access token). Absent =>
           # the CLI stays unauthenticated; the review still runs.
           UNBLOCKED_API_TOKEN: ${{ secrets.UNBLOCKED_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [reviewer] Migrate AI code reviews from GPT to Claude models on the claude-code engine (Sonnet 5 by default, Opus 5 for the security agent). ([#4148](https://github.com/expo/eas-cli/pull/4148) by [@brentvatne](https://github.com/brentvatne))
+
 ## [21.5.1](https://github.com/expo/eas-cli/releases/tag/v21.5.1) - 2026-08-03
 
 ## [21.5.0](https://github.com/expo/eas-cli/releases/tag/v21.5.0) - 2026-08-03


### PR DESCRIPTION
## Why

GPT review passes kept stalling and timing out. Reviews move to Anthropic models on the claude-code engine, which `@expo/code-review-cli` infers per agent from the `anthropic/…` model id.

## Changes

- **`.expo-code-review/config.jsonc`**: default model `anthropic/claude-sonnet-5`; auth entry `providers.anthropic` with `tokenEnv: CLAUDE_CODE_REVIEW_SHARED_API_TOKEN` (the engine accepts an `sk-ant-oat…` setup-token or an `sk-ant-api…` Console key — it classifies by shape).
- **`agents/security.md`**: `anthropic/claude-opus-5` — highest-stakes agent gets the Opus tier (mirrors expo/code-review-cli's own roster). Correctness/consistency/coordinator inherit sonnet 5.
- **Workflows**: `ECR_VERSION` fallback `^0.6.0` → `^0.9.2` (latest published; ships the claude-code engine); new step installing the Claude Code CLI pinned to `2.1.212` (unpinned would silently drift per run); credential env + `ECR_EXPECTED_TOKEN_ENV` lock swapped from `CODEX_OAUTH_ACCESS_TOKEN` to `CLAUDE_CODE_REVIEW_SHARED_API_TOKEN` in the review and command workflows.

## Before merging

1. Add the `CLAUDE_CODE_REVIEW_SHARED_API_TOKEN` repo secret (Brent is setting this up).
2. If the `ECR_EXPECTED_TOKEN_ENV` repo **variable** is set, update it to `CLAUDE_CODE_REVIEW_SHARED_API_TOKEN` (the variable overrides the YAML fallbacks).
3. The old `CODEX_OAUTH_ACCESS_TOKEN` secret can be deleted after merge.

Note: `ecr ci` loads config from the PR's trusted base commit, so Claude reviews start for PRs opened after this merges.

## Verification

`ecr verify-config` (published 0.9.2) passes against this config with the new expected token env; no CODEX/gpt references remain in `.expo-code-review/` or the review workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)