### PR TITLE
[eas-cli] Add `eas sim` as a shortcut for `eas simulator` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Make `eas simulator` the canonical command and keep `eas simulator:start` as an alias. ([#4112](https://github.com/expo/eas-cli/pull/4112) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Validate local composite functions referenced from workflow job hooks during `eas workflow:validate`. ([#4064](https://github.com/expo/eas-cli/pull/4064) by [@sswrk](https://github.com/sswrk))
+- [eas-cli] Add `eas sim` as a shortcut for `eas simulator` commands, e.g. `eas sim:list` runs `eas simulator:list`. ([#4150](https://github.com/expo/eas-cli/pull/4150) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/simulator/availability.ts
+++ b/packages/eas-cli/src/commands/simulator/availability.ts
@@ -10,6 +10,7 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class SimulatorAvailability extends EasCommand {
   static override hidden = true;
+  static override aliases = ['sim:availability'];
   static override description =
     '[EXPERIMENTAL] check whether EAS Simulator is enabled for the current project account';
 

--- a/packages/eas-cli/src/commands/simulator/events.ts
+++ b/packages/eas-cli/src/commands/simulator/events.ts
@@ -30,6 +30,7 @@ const POST_STOP_REFRESH_COUNT = 2;
 
 export default class SimulatorEvents extends EasCommand {
   static override hidden = true;
+  static override aliases = ['sim:events'];
   static override description =
     '[EXPERIMENTAL] show activity events from a remote simulator session';
 

--- a/packages/eas-cli/src/commands/simulator/exec.ts
+++ b/packages/eas-cli/src/commands/simulator/exec.ts
@@ -5,6 +5,7 @@ import { SIMULATOR_DOTENV_FILE_NAME, loadSimulatorEnvAsync } from '../../simulat
 
 export default class SimulatorExec extends EasCommand {
   static override hidden = true;
+  static override aliases = ['sim:exec'];
   static override description = `[EXPERIMENTAL] execute a simulator command with ${SIMULATOR_DOTENV_FILE_NAME} environment loaded`;
   static override strict = false;
 

--- a/packages/eas-cli/src/commands/simulator/get.ts
+++ b/packages/eas-cli/src/commands/simulator/get.ts
@@ -28,6 +28,7 @@ type DeviceRunSessionArtifact = DeviceRunSessionById['artifacts'][number];
 
 export default class SimulatorGet extends EasCommand {
   static override hidden = true;
+  static override aliases = ['sim:get'];
   static override description =
     '[EXPERIMENTAL] get info about a remote simulator session on EAS by its simulator session ID';
 

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -51,7 +51,7 @@ const APP_PLATFORM_BY_FLAG_VALUE: Record<PlatformFlagValue, AppPlatform> = {
 
 export default class Simulator extends EasCommand {
   static override hidden = true;
-  static override aliases = ['simulator:start'];
+  static override aliases = ['simulator:start', 'sim', 'sim:start'];
   static override description =
     '[EXPERIMENTAL] start a remote simulator session on EAS and get instructions to connect to it';
 

--- a/packages/eas-cli/src/commands/simulator/list.ts
+++ b/packages/eas-cli/src/commands/simulator/list.ts
@@ -50,6 +50,7 @@ const PLATFORM_BY_FLAG_VALUE = Object.fromEntries(
 
 export default class SimulatorList extends EasCommand {
   static override hidden = true;
+  static override aliases = ['sim:list'];
   static override description =
     '[EXPERIMENTAL] list remote simulator sessions for the current project';
 

--- a/packages/eas-cli/src/commands/simulator/stop.ts
+++ b/packages/eas-cli/src/commands/simulator/stop.ts
@@ -16,6 +16,7 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class SimulatorStop extends EasCommand {
   static override hidden = true;
+  static override aliases = ['sim:stop'];
   static override description =
     '[EXPERIMENTAL] stop a remote simulator session on EAS by its simulator session ID';
 


### PR DESCRIPTION
# Why

Add `eas sim` as shorter alias to `eas simulator`

# How

Add `eas sim` as shorter alias to `eas simulator`

# Test Plan

```
$ for c in sim sim:start sim:list sim:get sim:stop sim:exec sim:events sim:availability; do ./bin/run $c --help | head -1; done
[EXPERIMENTAL] start a remote simulator session on EAS and get instructions to connect to it
[EXPERIMENTAL] start a remote simulator session on EAS and get instructions to connect to it
[EXPERIMENTAL] list remote simulator sessions for the current project
[EXPERIMENTAL] get info about a remote simulator session on EAS by its simulator session ID
[EXPERIMENTAL] stop a remote simulator session on EAS by its simulator session ID
[EXPERIMENTAL] execute a simulator command with .env.eas-simulator environment loaded
[EXPERIMENTAL] show activity events from a remote simulator session
[EXPERIMENTAL] check whether EAS Simulator is enabled for the current project account
```