### PR TITLE
[eas-cli] Point gated accounts at the EAS Simulator waitlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Point accounts without EAS Simulator access at the waitlist: `eas simulator:availability` includes the link (and a `waitlistUrl` field in `--json`), and `eas simulator` now fails early with the same message instead of a generic permission error. ([#4151](https://github.com/expo/eas-cli/pull/4151) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Revert "Pin the default `agent-device` version for remote sessions" now that `agent-device` 0.20.5 fixes the broken release. ([#4144](https://github.com/expo/eas-cli/pull/4144) by [@gwdp](https://github.com/gwdp))
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/simulator/__tests__/availability.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/availability.test.ts
@@ -3,11 +3,18 @@ import { Config } from '@oclif/core';
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { DeviceRunSessionAvailabilityQuery } from '../../../graphql/queries/DeviceRunSessionAvailabilityQuery';
 import Log from '../../../log';
+import { EAS_SIMULATOR_WAITLIST_URL } from '../../../simulator/utils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
 import SimulatorAvailability from '../availability';
 
 jest.mock('../../../graphql/queries/DeviceRunSessionAvailabilityQuery');
-jest.mock('../../../log');
+jest.mock('../../../log', () => ({
+  __esModule: true,
+  default: {
+    log: jest.fn(),
+  },
+  link: jest.fn((url: string) => url),
+}));
 jest.mock('../../../ora', () => ({
   ora: jest.fn(() => {
     const spinner = {
@@ -69,7 +76,7 @@ describe(SimulatorAvailability, () => {
     });
   });
 
-  it('emits JSON with available false when not enabled', async () => {
+  it('emits JSON with available false and the waitlist URL when not enabled', async () => {
     mockByAppIdAsync.mockResolvedValue({ accountName: 'testuser', available: false });
 
     const command = createCommand(['--json']);
@@ -78,10 +85,23 @@ describe(SimulatorAvailability, () => {
     expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
       available: false,
       accountName: 'testuser',
+      waitlistUrl: EAS_SIMULATOR_WAITLIST_URL,
     });
   });
 
-  it('logs a graceful message when not enabled', async () => {
+  it('omits the waitlist URL from JSON when enabled', async () => {
+    mockByAppIdAsync.mockResolvedValue({ accountName: 'testuser', available: true });
+
+    const command = createCommand(['--json']);
+    await command.runAsync();
+
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
+      available: true,
+      accountName: 'testuser',
+    });
+  });
+
+  it('logs a graceful message pointing at the waitlist when not enabled', async () => {
     mockByAppIdAsync.mockResolvedValue({ accountName: 'testuser', available: false });
 
     const command = createCommand([]);
@@ -89,7 +109,8 @@ describe(SimulatorAvailability, () => {
 
     expect(mockByAppIdAsync).toHaveBeenCalledWith(graphqlClient, projectId);
     expect(mockLog).toHaveBeenCalledWith(
-      "EAS Simulator isn't available on testuser yet — it's coming soon."
+      "EAS Simulator isn't available on testuser yet — it's coming soon.\n" +
+        `Join the waitlist to get access: ${EAS_SIMULATOR_WAITLIST_URL}`
     );
     expect(mockPrintJsonOnlyOutput).not.toHaveBeenCalled();
   });

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -11,6 +11,7 @@ import {
   JobRunStatus,
 } from '../../../graphql/generated';
 import { DeviceRunSessionMutation } from '../../../graphql/mutations/DeviceRunSessionMutation';
+import { DeviceRunSessionAvailabilityQuery } from '../../../graphql/queries/DeviceRunSessionAvailabilityQuery';
 import { DeviceRunSessionQuery } from '../../../graphql/queries/DeviceRunSessionQuery';
 import Log from '../../../log';
 import { ora } from '../../../ora';
@@ -26,6 +27,7 @@ import Simulator from '../index';
 
 jest.mock('fs-extra');
 jest.mock('../../../graphql/mutations/DeviceRunSessionMutation');
+jest.mock('../../../graphql/queries/DeviceRunSessionAvailabilityQuery');
 jest.mock('../../../graphql/queries/DeviceRunSessionQuery');
 jest.mock('../../../log', () => ({
   __esModule: true,
@@ -72,6 +74,7 @@ const mockCreateDeviceRunSessionAsync = jest.mocked(
 const mockEnsureDeviceRunSessionStoppedAsync = jest.mocked(
   DeviceRunSessionMutation.ensureDeviceRunSessionStoppedAsync
 );
+const mockAvailabilityByAppIdAsync = jest.mocked(DeviceRunSessionAvailabilityQuery.byAppIdAsync);
 const mockByIdAsync = jest.mocked(DeviceRunSessionQuery.byIdAsync);
 const mockLoadSimulatorEnvAsync = jest.mocked(loadSimulatorEnvAsync);
 const mockResetSimulatorEnvAsync = jest.mocked(resetSimulatorEnvAsync);
@@ -149,6 +152,7 @@ describe(Simulator, () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env[EAS_SIMULATOR_SESSION_ID];
+    mockAvailabilityByAppIdAsync.mockResolvedValue({ accountName: 'testuser', available: true });
     mockCreateDeviceRunSessionAsync.mockResolvedValue(makeCreatedDeviceRunSession());
     mockEnsureDeviceRunSessionStoppedAsync.mockResolvedValue({
       id: 'session-123',
@@ -168,19 +172,48 @@ describe(Simulator, () => {
     }
   });
 
-  function createCommand(argv: string[]): {
+  function createCommand(
+    argv: string[],
+    { isExpoAdmin = false }: { isExpoAdmin?: boolean } = {}
+  ): {
     command: Simulator;
     getContextAsync: jest.SpyInstance;
   } {
     const command = new Simulator(argv, mockConfig);
     // @ts-expect-error getContextAsync is protected
     const getContextAsync = jest.spyOn(command, 'getContextAsync').mockResolvedValue({
-      loggedIn: { graphqlClient },
+      loggedIn: { actor: { isExpoAdmin }, graphqlClient },
       projectDir,
       projectId: 'project-123',
     });
     return { command, getContextAsync };
   }
+
+  it('fails with the waitlist link without creating a session when the account is gated', async () => {
+    mockAvailabilityByAppIdAsync.mockResolvedValue({ accountName: 'testuser', available: false });
+
+    const { command } = createCommand(['--platform', 'ios', '--non-interactive']);
+
+    await expect(command.runAsync()).rejects.toThrow(
+      "EAS Simulator isn't available on testuser yet — it's coming soon.\n" +
+        'Join the waitlist to get access: https://expo.dev/services/simulators'
+    );
+    expect(mockAvailabilityByAppIdAsync).toHaveBeenCalledWith(graphqlClient, 'project-123');
+    expect(mockCreateDeviceRunSessionAsync).not.toHaveBeenCalled();
+    expect(mockPromptAsync).not.toHaveBeenCalled();
+  });
+
+  it('skips the gate check for Expo admins on a gated account', async () => {
+    mockAvailabilityByAppIdAsync.mockResolvedValue({ accountName: 'testuser', available: false });
+
+    const { command } = createCommand(['--platform', 'ios', '--non-interactive'], {
+      isExpoAdmin: true,
+    });
+    await command.runAsync();
+
+    expect(mockAvailabilityByAppIdAsync).not.toHaveBeenCalled();
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalled();
+  });
 
   it('prints environment variables without saving when outputting env', async () => {
     const { command, getContextAsync } = createCommand([

--- a/packages/eas-cli/src/commands/simulator/availability.ts
+++ b/packages/eas-cli/src/commands/simulator/availability.ts
@@ -6,6 +6,10 @@ import {
 import { DeviceRunSessionAvailabilityQuery } from '../../graphql/queries/DeviceRunSessionAvailabilityQuery';
 import Log from '../../log';
 import { ora } from '../../ora';
+import {
+  EAS_SIMULATOR_WAITLIST_URL,
+  formatSimulatorUnavailableMessage,
+} from '../../simulator/utils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class SimulatorAvailability extends EasCommand {
@@ -52,7 +56,12 @@ export default class SimulatorAvailability extends EasCommand {
     }
 
     if (jsonFlag) {
-      printJsonOnlyOutput({ available, accountName });
+      printJsonOnlyOutput({
+        available,
+        accountName,
+        // Only present when gated, so scripts and agents can pass the waitlist link on.
+        ...(available ? {} : { waitlistUrl: EAS_SIMULATOR_WAITLIST_URL }),
+      });
       return;
     }
 
@@ -61,6 +70,6 @@ export default class SimulatorAvailability extends EasCommand {
       return;
     }
 
-    Log.log(`EAS Simulator isn't available on ${accountName} yet — it's coming soon.`);
+    Log.log(formatSimulatorUnavailableMessage(accountName));
   }
 }

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -4,6 +4,7 @@ import nullthrows from 'nullthrows';
 import { getDeviceRunSessionUrl } from '../../build/utils/url';
 import EasCommand from '../../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { EasCommandError } from '../../commandUtils/errors';
 import {
   EasNonInteractiveAndJsonFlags,
   resolveNonInteractiveAndJsonFlags,
@@ -15,6 +16,7 @@ import {
   JobRunStatus,
 } from '../../graphql/generated';
 import { DeviceRunSessionMutation } from '../../graphql/mutations/DeviceRunSessionMutation';
+import { DeviceRunSessionAvailabilityQuery } from '../../graphql/queries/DeviceRunSessionAvailabilityQuery';
 import { DeviceRunSessionQuery } from '../../graphql/queries/DeviceRunSessionQuery';
 import Log, { link } from '../../log';
 import { ora } from '../../ora';
@@ -31,6 +33,7 @@ import {
   DEVICE_RUN_SESSION_TYPE_FLAG_VALUES,
   DeviceRunSessionRemoteConfig,
   formatRemoteSessionInstructions,
+  formatSimulatorUnavailableMessage,
   getRemoteSessionEnvironmentVariables,
 } from '../../simulator/utils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
@@ -110,10 +113,23 @@ export default class Simulator extends EasCommand {
     const {
       projectId,
       projectDir,
-      loggedIn: { graphqlClient },
+      loggedIn: { actor, graphqlClient },
     } = await this.getContextAsync(Simulator, {
       nonInteractive,
     });
+
+    // The server would reject the session anyway, but check the gate first so gated
+    // accounts get the waitlist link instead of a generic permission error. Expo admins
+    // skip the check so they can work on any account and let the server decide.
+    if (!actor.isExpoAdmin) {
+      const { accountName, available } = await DeviceRunSessionAvailabilityQuery.byAppIdAsync(
+        graphqlClient,
+        projectId
+      );
+      if (!available) {
+        throw new EasCommandError(formatSimulatorUnavailableMessage(accountName));
+      }
+    }
 
     // The server rejects blank names, so trim here and treat a whitespace-only
     // --name as if it had been omitted rather than surfacing a validation error.

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -1,7 +1,22 @@
 import { DeviceRunSessionByIdQuery, DeviceRunSessionType } from '../graphql/generated';
+import { link } from '../log';
 
 type DeviceRunSessionByIdResult = DeviceRunSessionByIdQuery['deviceRunSessions']['byId'];
 export type DeviceRunSessionRemoteConfig = NonNullable<DeviceRunSessionByIdResult['remoteConfig']>;
+
+/** Landing page where accounts without access can request it. */
+export const EAS_SIMULATOR_WAITLIST_URL = 'https://expo.dev/services/simulators';
+
+/**
+ * Message shown when EAS Simulator is not enabled for the account. Shared by every
+ * command that can hit the gate so users always get the same waitlist pointer.
+ */
+export function formatSimulatorUnavailableMessage(accountName: string): string {
+  return [
+    `EAS Simulator isn't available on ${accountName} yet — it's coming soon.`,
+    `Join the waitlist to get access: ${link(EAS_SIMULATOR_WAITLIST_URL)}`,
+  ].join('\n');
+}
 
 // Mapping enum -> CLI flag value. Declared as Record<DeviceRunSessionType, string>
 // so adding a new enum value in codegen fails the build until it is wired up here.


### PR DESCRIPTION
# Why

EAS Simulator is behind the `device-run-sessions` account feature gate. Accounts without access got a dead end:

- `eas simulator:availability` said only "it's coming soon", with no way to ask for access.
- `eas simulator` failed with a generic server permission error.

There is a waitlist at https://expo.dev/services/simulators, but nothing in the CLI pointed at it. This PR surfaces it on both paths.

# How

Added a shared message helper in `packages/eas-cli/src/simulator/utils.ts` (`EAS_SIMULATOR_WAITLIST_URL` + `formatSimulatorUnavailableMessage`) so both commands print the same text:

```
EAS Simulator isn't available on <account> yet — it's coming soon.
Join the waitlist to get access: https://expo.dev/services/simulators
```

- **`simulator:availability`**: the `available: false` branch prints that message. `--json` output gains a `waitlistUrl` field, present only when gated, so scripts and agents can pass the link on.
- **`eas simulator`** (`packages/eas-cli/src/commands/simulator/index.ts`): checks the gate with `DeviceRunSessionAvailabilityQuery` right after context resolution, and throws `EasCommandError` with the same message when it is off.

Two decisions worth a look:

**The gate is checked before the create mutation, not by matching the server's error.** The CLI has no coded error to match on for this gate today, so a pre-flight check is the reliable signal. Failing early also means a gated user is never prompted for a platform, and no session or `.env.eas-simulator` file is created. The cost is one extra GraphQL query per run, negligible next to a command that polls for up to 15 minutes.

**Expo admins skip the check entirely.** `actor.isExpoAdmin` already ships on every actor variant via the `LoggedIn` context, so admins keep working against accounts without the gate and the server stays the authority. Wrapping the whole block (rather than extending the `if`) also skips the extra query for them. Note this only removes the *client-side* block — if the API enforces the account gate with no admin override, an admin still gets the server's error, same as before this PR.

`simulator:availability` deliberately still reports the account gate for admins: that command answers "is this account enabled?", which stays true regardless of who asks.

# Test Plan

Automated — `cd packages/eas-cli && yarn test src/commands/simulator src/simulator`: 9 suites, 61 tests pass, including new cases:

- `availability.test.ts`: gated JSON output carries `waitlistUrl`; enabled JSON output omits it; the human-readable message includes the waitlist line.
- `index.test.ts`: a gated account rejects with the waitlist message and reaches neither `createDeviceRunSessionAsync` nor the platform prompt; an Expo admin on a gated account skips the availability query and creates the session.

Also ran `yarn typecheck`, `yarn lint`, and `yarn fmt:check` from the repo root — all clean.

Note on the full `eas-cli` suite: `go-test`, `update/embedded/delete`, and `update/embedded/view` fail intermittently under full-suite parallelism. They fail the same way on the unmodified base commit and the failing set varies per run, so they are pre-existing flakes unrelated to this change.

Not covered: `simulator:list`, `get`, `stop`, `exec`, and `events` still surface the raw server error for gated accounts. The helper is in place if we want to wire them up in a follow-up.
