### PR TITLE
[build-tools] Classify Argent session artifacts by MIME type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [build-tools] Set the artifact kind for Argent session artifacts from the MIME type reported by the tool server, so screenshots and screen recordings are grouped and labelled on the simulator session page instead of appearing in an unclassified file list. ([#4154](https://github.com/expo/eas-cli/pull/4154) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
@@ -135,9 +135,68 @@ describe(uploadArgentArtifactAsync, () => {
       artifactId: 'artifact-id',
       name: 'report.json (artifact-id)',
       filename: 'report.json',
+      kind: undefined,
       size: data.length,
       stream: expect.anything(),
     });
+  });
+
+  async function uploadAsync(artifact: {
+    id: string;
+    filename: string;
+    mimeType: string;
+    isDirectory?: boolean;
+  }): Promise<CustomBuildContext> {
+    const ctx = {} as unknown as CustomBuildContext;
+    jest
+      .mocked(fetch)
+      .mockResolvedValueOnce(new Response(Readable.from([Buffer.from('artifact-data')])));
+    jest
+      .mocked(uploadDeviceRunSessionArtifactAsync)
+      .mockImplementationOnce(async (_ctx, { stream }) => {
+        await readStreamAsync(stream);
+      });
+
+    await uploadArgentArtifactAsync(ctx, {
+      deviceRunSessionId: 'drs-id',
+      toolsUrl: 'http://127.0.0.1:1234',
+      logger: createLoggerMock(),
+      artifact,
+    });
+
+    return ctx;
+  }
+
+  it.each([
+    { mimeType: 'image/png', filename: 'screen.png', kind: 'screenshot' },
+    { mimeType: 'image/jpeg', filename: 'screen.jpg', kind: 'screenshot' },
+    // Media types are case-insensitive and may carry parameters.
+    { mimeType: 'IMAGE/PNG; charset=binary', filename: 'screen.png', kind: 'screenshot' },
+    { mimeType: 'video/mp4', filename: 'session.mp4', kind: 'screen-recording' },
+    { mimeType: 'video/quicktime', filename: 'session.mov', kind: 'screen-recording' },
+    { mimeType: 'application/json', filename: 'report.json', kind: undefined },
+    { mimeType: 'text/plain', filename: 'log.txt', kind: undefined },
+  ])('uploads $mimeType with kind $kind', async ({ mimeType, filename, kind }) => {
+    const ctx = await uploadAsync({ id: 'artifact-id', filename, mimeType });
+
+    expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ filename, kind })
+    );
+  });
+
+  it('leaves directory artifacts unclassified because they are uploaded as a tarball', async () => {
+    const ctx = await uploadAsync({
+      id: 'artifact-id',
+      filename: 'screenshots',
+      mimeType: 'image/png',
+      isDirectory: true,
+    });
+
+    expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ filename: 'screenshots.tar.gz', kind: undefined })
+    );
   });
 });
 

--- a/packages/build-tools/src/steps/utils/argentArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/argentArtifacts.ts
@@ -18,6 +18,18 @@ const ARGENT_ARTIFACT_UPLOAD_POLL_INTERVAL_MS = 5_000;
 const ARGENT_ARTIFACT_UPLOAD_CLEANUP_TIMEOUT_MS = 30_000;
 const ARGENT_ARTIFACT_FETCH_TIMEOUT_MS = 10_000;
 
+// Kinds the EAS dashboard groups device run session artifacts by. Only media types the dashboard
+// renders specially are mapped; anything else stays unclassified and lands in its "Other" group.
+// Note that these kinds only affect grouping and labelling. The dashboard gates its inline video
+// player on the `__eas_screen_recording` metadata flag, which Argent artifacts deliberately do not
+// set, so a `screen-recording` kind here does not add a player to the session page.
+const ARGENT_ARTIFACT_KIND_BY_MIME_TYPE = new Map<string, string>([
+  ['image/png', 'screenshot'],
+  ['image/jpeg', 'screenshot'],
+  ['video/mp4', 'screen-recording'],
+  ['video/quicktime', 'screen-recording'],
+]);
+
 const ArgentArtifactSchema = z.object({
   id: z.string(),
   filename: z.string(),
@@ -29,6 +41,17 @@ const ArgentArtifactsListResponseSchema = z.object({
 });
 
 type ArgentArtifact = z.infer<typeof ArgentArtifactSchema>;
+
+function getArgentArtifactKind(artifact: ArgentArtifact): string | undefined {
+  // Directories are repackaged as a tarball before upload, so the reported media type describes the
+  // contents rather than the file we actually store.
+  if (artifact.isDirectory) {
+    return undefined;
+  }
+  // Media types are case-insensitive and may carry parameters, e.g. `image/png; charset=binary`.
+  const mediaType = artifact.mimeType.split(';')[0].trim().toLowerCase();
+  return ARGENT_ARTIFACT_KIND_BY_MIME_TYPE.get(mediaType);
+}
 
 export async function pollArgentArtifactsForUploadAsync(
   ctx: CustomBuildContext,
@@ -184,7 +207,7 @@ export async function uploadArgentArtifactAsync(
       artifactId: artifact.id,
       name: `${filename} (${artifact.id})`,
       filename,
-      kind: undefined,
+      kind: getArgentArtifactKind(artifact),
       size,
       stream: createReadStream(temporaryArtifactPath),
     });


### PR DESCRIPTION
# Why

Currently all argent screenshots and recordings are classified as `other` type on website

# How

Use mime type of argent artifacts to select correct kind and make it display nicely on website

# Test Plan

Tests
