### PR TITLE
[reviewer] Bump AI code review to @expo/code-review-cli 0.10.0

### DIFF
--- a/.github/workflows/expo-code-review-command.yml
+++ b/.github/workflows/expo-code-review-command.yml
@@ -19,7 +19,7 @@ permissions:
 
 env:
   # Published reviewer run via npx (override with repo variable ECR_VERSION).
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.9.2' }}
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.10.0' }}
 
 concurrency:
   group: ai-code-review-cmd-${{ github.event.issue.number }}

--- a/.github/workflows/expo-code-review-dismiss.yml
+++ b/.github/workflows/expo-code-review-dismiss.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   # Published reviewer run via npx (override with repo variable ECR_VERSION).
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.9.2' }}
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.10.0' }}
 
 concurrency:
   group: ai-code-review-dismiss-${{ github.event.issue.number }}

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -13,9 +13,9 @@ permissions:
 env:
   # The reviewer is the published @expo/code-review-cli package, run via npx — the
   # repo only carries the `.expo-code-review/` config, not the engine source.
-  # Override with a repo variable ECR_VERSION to pin/bump; defaults to 0.9.x
-  # (0.9 = the claude-code engine the anthropic/… models below run on).
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.9.2' }}
+  # Override with a repo variable ECR_VERSION to pin/bump; defaults to 0.10.x
+  # (the claude-code engine the anthropic/… models below run on).
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.10.0' }}
 
 concurrency:
   group: ai-code-review-${{ github.event.pull_request.number }}


### PR DESCRIPTION
# Why

The AI code review workflows pin `@expo/code-review-cli` to `^0.9.2`. 0.10.0 is now published, and it brings two changes worth having here:

- **Streamed Claude agent activity** — each agent's progress lands in the run log as it happens, instead of appearing only when the pass finishes.
- **Reuse of unchanged review results** — files that have not changed since the last run are not re-reviewed, which cuts both cost and wall-clock on pushes to an open PR.

# How

Bumped the `ECR_VERSION` default in all three reviewer workflows:

- `.github/workflows/expo-code-review.yml`
- `.github/workflows/expo-code-review-command.yml`
- `.github/workflows/expo-code-review-dismiss.yml`

```diff
-  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.9.2' }}
+  ECR_VERSION: ${{ vars.ECR_VERSION || '^0.10.0' }}
```

The `vars.ECR_VERSION` repo-variable override still wins, so this only moves the default. No config changes were needed: this repo already has the Claude Code wiring 0.10.0 expects (the pinned `@anthropic-ai/claude-code` install step and the `CLAUDE_CODE_REVIEW_SHARED_API_TOKEN` env), added when reviews migrated to Claude in #4148.

# Test Plan

`ecr verify-config` was run against this repo's checked-in config using the published 0.10.0, confirming the config validates unchanged on the new version:

```
$ ECR_EXPECTED_TOKEN_ENV=CLAUDE_CODE_REVIEW_SHARED_API_TOKEN \
    npx --yes -p @expo/code-review-cli@0.10.0 ecr verify-config
verify-config: OK — tokenEnv locked to "CLAUDE_CODE_REVIEW_SHARED_API_TOKEN"; no non-root config declares root-locked keys.
```

The reviewer workflow runs on this PR, so the end-to-end check is the review that 0.10.0 posts here. Watch for the streamed per-agent activity in the run log — that is the visible 0.10.0 behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)