### PR TITLE
[build-tools] Enable real time sessions in production

### DIFF
--- a/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
+++ b/packages/build-tools/src/steps/utils/deviceRunSessionEvents.ts
@@ -310,7 +310,7 @@ function createRealtimeLogStream(
     ? 'http://localhost:4999/logs/'
     : ctx.env.EXPO_STAGING
       ? 'https://staging-logs.expo.dev/logs/'
-      : undefined;
+      : 'https://logs.expo.dev/logs/';
   const jobRunId = ctx.env.EAS_BUILD_ID;
   const robotAccessToken = ctx.job.secrets?.robotAccessToken;
   if (!baseUrl || !jobRunId || !robotAccessToken) {


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We want to stream session events in real-time.

# How

Added necessary config.

# Test Plan

Land after https://github.com/expo/universe/pull/29610 and verify in production. Staging works good.