### PR TITLE
[eas-cli] Fail when --private-key-path is set without codeSigningCertificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and publishing an unsigned update. ([#4161](https://github.com/expo/eas-cli/pull/4161) by [@gwdp](https://github.com/gwdp))
+
 ### 🧹 Chores
 
 ## [21.6.0](https://github.com/expo/eas-cli/releases/tag/v21.6.0) - 2026-08-05

--- a/packages/eas-cli/src/utils/__tests__/code-signing-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/code-signing-test.ts
@@ -50,7 +50,7 @@ describe(getCodeSigningInfoAsync, () => {
         'test'
       )
     ).rejects.toThrow(
-      'Must specify codeSigningCertificate under the "updates" field of your app config file to use EAS code signing'
+      '--private-key-path was specified, but updates.codeSigningCertificate is not set in the resolved app config'
     );
   });
 

--- a/packages/eas-cli/src/utils/__tests__/code-signing-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/code-signing-test.ts
@@ -28,6 +28,32 @@ function generateMultipartBody(stringifiedManifest: string): FormData {
 }
 
 describe(getCodeSigningInfoAsync, () => {
+  it('returns undefined when codeSigningCertificate and private key path are not specified', async () => {
+    await expect(
+      getCodeSigningInfoAsync(
+        {
+          name: 'wat',
+          slug: 'test',
+        },
+        undefined
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws when private key path is specified without codeSigningCertificate', async () => {
+    await expect(
+      getCodeSigningInfoAsync(
+        {
+          name: 'wat',
+          slug: 'test',
+        },
+        'test'
+      )
+    ).rejects.toThrow(
+      'Must specify codeSigningCertificate under the "updates" field of your app config file to use EAS code signing'
+    );
+  });
+
   it('throws when codeSigningMetadata is not specified for EAS', async () => {
     await expect(
       getCodeSigningInfoAsync(

--- a/packages/eas-cli/src/utils/code-signing.ts
+++ b/packages/eas-cli/src/utils/code-signing.ts
@@ -30,6 +30,11 @@ export async function getCodeSigningInfoAsync(
 ): Promise<CodeSigningInfo | undefined> {
   const codeSigningCertificatePath = config.updates?.codeSigningCertificate;
   if (!codeSigningCertificatePath) {
+    if (privateKeyPath) {
+      throw new Error(
+        'Must specify codeSigningCertificate under the "updates" field of your app config file to use EAS code signing'
+      );
+    }
     return undefined;
   }
 

--- a/packages/eas-cli/src/utils/code-signing.ts
+++ b/packages/eas-cli/src/utils/code-signing.ts
@@ -32,7 +32,7 @@ export async function getCodeSigningInfoAsync(
   if (!codeSigningCertificatePath) {
     if (privateKeyPath) {
       throw new Error(
-        'Must specify codeSigningCertificate under the "updates" field of your app config file to use EAS code signing'
+        '--private-key-path was specified, but updates.codeSigningCertificate is not set in the resolved app config. Code signing requires both the certificate in app config and the private key. Ensure codeSigningCertificate (and codeSigningMetadata) are present for this publish, or omit --private-key-path if you do not intend to sign.\nLearn more: https://docs.expo.dev/eas-update/code-signing/'
       );
     }
     return undefined;


### PR DESCRIPTION
## Why
When `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config: that **implies an intent to sign**, but the CLI previously ignored the flag and published unsigned.

## How
- In `getCodeSigningInfoAsync`, throw if a private key path is provided without a certificate path
- Leave the unsigned path alone when neither is set


## Test Plan
- New unit tests for no-cert/no-key → undefined, and no-cert/with-key → throw
- CI