### PR TITLE
[build-tools] Add direct DADB mode for Maestro tests

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -266,15 +266,34 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(mockedSpawn).not.toHaveBeenCalled();
   });
 
-  it('rejects direct DADB mode on iOS', async () => {
+  it('ignores direct DADB input mode on iOS', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
     const step = createStep({
       flow_path: ['flows/a.yaml'],
       platform: 'ios',
       android_connection_mode: 'dadb',
     });
 
-    await expect(step.executeAsync()).rejects.toThrow(UserError);
-    expect(mockedSpawn).not.toHaveBeenCalled();
+    await step.executeAsync();
+
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+    expect(mockedSpawn.mock.calls[0][0]).toBe('maestro');
+  });
+
+  it('ignores direct DADB environment mode on iOS', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const step = createStep(
+      {
+        flow_path: ['flows/a.yaml'],
+        platform: 'ios',
+      },
+      { env: { HOME: '/home/expo', EAS_MAESTRO_ANDROID_CONNECTION_MODE: 'dadb' } }
+    );
+
+    await step.executeAsync();
+
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+    expect(mockedSpawn.mock.calls[0][0]).toBe('maestro');
   });
 
   it('does not clean up direct DADB mode when Maestro fails', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -134,6 +134,116 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(args!.join(' ')).toMatch(/--output=.*android-maestro-junit-attempt-0\.xml/);
   });
 
+  it('uses direct DADB when android_connection_mode is dadb and restores ADB', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const writeFileSpy = jest.spyOn(fs, 'writeFile');
+    const rmSpy = jest.spyOn(fs, 'rm');
+    const step = createStep(
+      {
+        flow_path: ['flows/a.yaml'],
+        platform: 'android',
+        android_connection_mode: 'dadb',
+      },
+      { env: { HOME: '/home/expo', PATH: '/usr/bin' } }
+    );
+
+    await step.executeAsync();
+
+    expect(mockedSpawn).toHaveBeenCalledTimes(3);
+    expect(mockedSpawn.mock.calls[0].slice(0, 2)).toEqual(['adb', ['kill-server']]);
+    expect(mockedSpawn.mock.calls[1][0]).toBe('maestro');
+    expect(mockedSpawn.mock.calls[2].slice(0, 2)).toEqual(['adb', ['start-server']]);
+
+    const maestroEnv = mockedSpawn.mock.calls[1][2]?.env;
+    expect(maestroEnv?.PATH).toMatch(
+      new RegExp(`^${os.tmpdir()}/maestro-tests-adb-override-.+${path.delimiter}/usr/bin$`)
+    );
+    expect(mockedSpawn.mock.calls[2][2]?.env?.PATH).toBe(mockedSpawn.mock.calls[0][2]?.env?.PATH);
+    expect(mockedSpawn.mock.calls[2][2]?.env?.PATH).not.toContain('maestro-tests-adb-override-');
+
+    expect(writeFileSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/maestro-tests-adb-override-.+\/adb$/),
+      '#!/bin/sh\nexit 1\n',
+      { mode: 0o755 }
+    );
+    expect(rmSpy).toHaveBeenCalledWith(expect.stringMatching(/maestro-tests-adb-override-/), {
+      force: true,
+      recursive: true,
+    });
+  });
+
+  it('uses the same direct DADB environment for all retries', async () => {
+    let maestroAttempt = 0;
+    mockedSpawn.mockImplementation((async (command: string) => {
+      if (command === 'maestro' && maestroAttempt++ === 0) {
+        throw rejectExit1();
+      }
+      return SPAWN_SUCCESS;
+    }) as any);
+    jest.spyOn(parser, 'parseFailedFlowsFromJUnit').mockResolvedValue(null);
+    const step = createStep(
+      {
+        flow_path: ['flows/a.yaml'],
+        retries: 1,
+        platform: 'android',
+        android_connection_mode: 'dadb',
+      },
+      { env: { HOME: '/home/expo', PATH: '/usr/bin' } }
+    );
+
+    await step.executeAsync();
+
+    const maestroCalls = mockedSpawn.mock.calls.filter(([command]) => command === 'maestro');
+    expect(maestroCalls).toHaveLength(2);
+    expect(maestroCalls[0][2]?.env?.PATH).toBe(maestroCalls[1][2]?.env?.PATH);
+    expect(mockedSpawn.mock.calls.filter(([command]) => command === 'adb')).toHaveLength(2);
+  });
+
+  it('rejects invalid android_connection_mode values', async () => {
+    const step = createStep({
+      flow_path: ['flows/a.yaml'],
+      platform: 'android',
+      android_connection_mode: 'automatic',
+    });
+
+    await expect(step.executeAsync()).rejects.toThrow(UserError);
+    expect(mockedSpawn).not.toHaveBeenCalled();
+  });
+
+  it('rejects direct DADB mode on iOS', async () => {
+    const step = createStep({
+      flow_path: ['flows/a.yaml'],
+      platform: 'ios',
+      android_connection_mode: 'dadb',
+    });
+
+    await expect(step.executeAsync()).rejects.toThrow(UserError);
+    expect(mockedSpawn).not.toHaveBeenCalled();
+  });
+
+  it('restores ADB without masking a Maestro failure', async () => {
+    mockedSpawn.mockImplementation((async (command: string, args: string[]) => {
+      if (command === 'maestro') {
+        throw new Error('maestro crashed');
+      }
+      if (command === 'adb' && args?.[0] === 'start-server') {
+        throw new Error('adb failed to restart');
+      }
+      return SPAWN_SUCCESS;
+    }) as any);
+    const step = createStep(
+      {
+        flow_path: ['flows/a.yaml'],
+        platform: 'android',
+        android_connection_mode: 'dadb',
+      },
+      { env: { HOME: '/home/expo', PATH: '/usr/bin' } }
+    );
+
+    await expect(step.executeAsync()).rejects.toThrow('Unexpected spawn failure invoking maestro');
+    expect(mockedSpawn.mock.calls.at(-1)?.slice(0, 2)).toEqual(['adb', ['start-server']]);
+  });
+
   it('throws SystemError when spawn fails with ENOENT (binary missing)', async () => {
     mockedSpawn.mockRejectedValue(Object.assign(new Error('not found'), { code: 'ENOENT' }));
     const step = createStep({ flow_path: ['a.yaml'], platform: 'android' });

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -134,14 +134,8 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(args!.join(' ')).toMatch(/--output=.*android-maestro-junit-attempt-0\.xml/);
   });
 
-  it('uses direct DADB when android_connection_mode is dadb and restores ADB', async () => {
-    let maestroPathDuringRun: string | undefined;
-    mockedSpawn.mockImplementation((async (command: string, _args: string[], options: any) => {
-      if (command === 'maestro') {
-        maestroPathDuringRun = options.env.PATH;
-      }
-      return SPAWN_SUCCESS;
-    }) as any);
+  it('uses direct DADB when android_connection_mode is dadb without cleanup', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
     const writeFileSpy = jest.spyOn(fs, 'writeFile');
     const rmSpy = jest.spyOn(fs, 'rm');
     const step = createStep(
@@ -155,28 +149,25 @@ describe('createMaestroTestsBuildFunction', () => {
 
     await step.executeAsync();
 
-    expect(mockedSpawn).toHaveBeenCalledTimes(3);
+    expect(mockedSpawn).toHaveBeenCalledTimes(2);
     expect(mockedSpawn.mock.calls[0].slice(0, 2)).toEqual(['adb', ['kill-server']]);
     expect(mockedSpawn.mock.calls[1][0]).toBe('maestro');
-    expect(mockedSpawn.mock.calls[2].slice(0, 2)).toEqual(['adb', ['start-server']]);
 
-    expect(maestroPathDuringRun).toMatch(
+    const maestroEnv = mockedSpawn.mock.calls[1][2]?.env;
+    expect(maestroEnv?.PATH).toMatch(
       new RegExp(`^${os.tmpdir()}/maestro-tests-adb-override-.+${path.delimiter}/usr/bin$`)
     );
-    const maestroEnv = mockedSpawn.mock.calls[1][2]?.env;
-    expect(maestroEnv?.PATH).toBe(mockedSpawn.mock.calls[0][2]?.env?.PATH);
-    expect(mockedSpawn.mock.calls[2][2]?.env?.PATH).toBe(mockedSpawn.mock.calls[0][2]?.env?.PATH);
-    expect(mockedSpawn.mock.calls[2][2]?.env?.PATH).not.toContain('maestro-tests-adb-override-');
+    expect(mockedSpawn.mock.calls[0][2]?.env?.PATH).not.toContain('maestro-tests-adb-override-');
 
     expect(writeFileSpy).toHaveBeenCalledWith(
       expect.stringMatching(/maestro-tests-adb-override-.+\/adb$/),
       '#!/bin/sh\nexit 1\n',
       { mode: 0o755 }
     );
-    expect(rmSpy).toHaveBeenCalledWith(expect.stringMatching(/maestro-tests-adb-override-/), {
-      force: true,
-      recursive: true,
-    });
+    expect(rmSpy).not.toHaveBeenCalledWith(
+      expect.stringMatching(/maestro-tests-adb-override-/),
+      expect.anything()
+    );
   });
 
   it('uses the same direct DADB environment for all retries', async () => {
@@ -203,7 +194,7 @@ describe('createMaestroTestsBuildFunction', () => {
     const maestroCalls = mockedSpawn.mock.calls.filter(([command]) => command === 'maestro');
     expect(maestroCalls).toHaveLength(2);
     expect(maestroCalls[0][2]?.env?.PATH).toBe(maestroCalls[1][2]?.env?.PATH);
-    expect(mockedSpawn.mock.calls.filter(([command]) => command === 'adb')).toHaveLength(2);
+    expect(mockedSpawn.mock.calls.filter(([command]) => command === 'adb')).toHaveLength(1);
   });
 
   it('rejects invalid android_connection_mode values', async () => {
@@ -228,16 +219,14 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(mockedSpawn).not.toHaveBeenCalled();
   });
 
-  it('restores ADB without masking a Maestro failure', async () => {
-    mockedSpawn.mockImplementation((async (command: string, args: string[]) => {
+  it('does not clean up direct DADB mode when Maestro fails', async () => {
+    mockedSpawn.mockImplementation((async (command: string) => {
       if (command === 'maestro') {
         throw new Error('maestro crashed');
       }
-      if (command === 'adb' && args?.[0] === 'start-server') {
-        throw new Error('adb failed to restart');
-      }
       return SPAWN_SUCCESS;
     }) as any);
+    const rmSpy = jest.spyOn(fs, 'rm');
     const step = createStep(
       {
         flow_path: ['flows/a.yaml'],
@@ -248,7 +237,11 @@ describe('createMaestroTestsBuildFunction', () => {
     );
 
     await expect(step.executeAsync()).rejects.toThrow('Unexpected spawn failure invoking maestro');
-    expect(mockedSpawn.mock.calls.at(-1)?.slice(0, 2)).toEqual(['adb', ['start-server']]);
+    expect(mockedSpawn.mock.calls.filter(([command]) => command === 'adb')).toHaveLength(1);
+    expect(rmSpy).not.toHaveBeenCalledWith(
+      expect.stringMatching(/maestro-tests-adb-override-/),
+      expect.anything()
+    );
   });
 
   it('throws SystemError when spawn fails with ENOENT (binary missing)', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -135,7 +135,13 @@ describe('createMaestroTestsBuildFunction', () => {
   });
 
   it('uses direct DADB when android_connection_mode is dadb and restores ADB', async () => {
-    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    let maestroPathDuringRun: string | undefined;
+    mockedSpawn.mockImplementation((async (command: string, _args: string[], options: any) => {
+      if (command === 'maestro') {
+        maestroPathDuringRun = options.env.PATH;
+      }
+      return SPAWN_SUCCESS;
+    }) as any);
     const writeFileSpy = jest.spyOn(fs, 'writeFile');
     const rmSpy = jest.spyOn(fs, 'rm');
     const step = createStep(
@@ -154,10 +160,11 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(mockedSpawn.mock.calls[1][0]).toBe('maestro');
     expect(mockedSpawn.mock.calls[2].slice(0, 2)).toEqual(['adb', ['start-server']]);
 
-    const maestroEnv = mockedSpawn.mock.calls[1][2]?.env;
-    expect(maestroEnv?.PATH).toMatch(
+    expect(maestroPathDuringRun).toMatch(
       new RegExp(`^${os.tmpdir()}/maestro-tests-adb-override-.+${path.delimiter}/usr/bin$`)
     );
+    const maestroEnv = mockedSpawn.mock.calls[1][2]?.env;
+    expect(maestroEnv?.PATH).toBe(mockedSpawn.mock.calls[0][2]?.env?.PATH);
     expect(mockedSpawn.mock.calls[2][2]?.env?.PATH).toBe(mockedSpawn.mock.calls[0][2]?.env?.PATH);
     expect(mockedSpawn.mock.calls[2][2]?.env?.PATH).not.toContain('maestro-tests-adb-override-');
 

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -170,6 +170,51 @@ describe('createMaestroTestsBuildFunction', () => {
     );
   });
 
+  it('uses direct DADB when EAS_MAESTRO_ANDROID_CONNECTION_MODE is dadb', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const step = createStep(
+      {
+        flow_path: ['flows/a.yaml'],
+        platform: 'android',
+      },
+      {
+        env: {
+          HOME: '/home/expo',
+          PATH: '/usr/bin',
+          EAS_MAESTRO_ANDROID_CONNECTION_MODE: 'dadb',
+        },
+      }
+    );
+
+    await step.executeAsync();
+
+    expect(mockedSpawn.mock.calls[0].slice(0, 2)).toEqual(['adb', ['kill-server']]);
+    expect(mockedSpawn.mock.calls[1][0]).toBe('maestro');
+  });
+
+  it('prefers android_connection_mode over EAS_MAESTRO_ANDROID_CONNECTION_MODE', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const step = createStep(
+      {
+        flow_path: ['flows/a.yaml'],
+        platform: 'android',
+        android_connection_mode: 'adb',
+      },
+      {
+        env: {
+          HOME: '/home/expo',
+          PATH: '/usr/bin',
+          EAS_MAESTRO_ANDROID_CONNECTION_MODE: 'dadb',
+        },
+      }
+    );
+
+    await step.executeAsync();
+
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+    expect(mockedSpawn.mock.calls[0][0]).toBe('maestro');
+  });
+
   it('uses the same direct DADB environment for all retries', async () => {
     let maestroAttempt = 0;
     mockedSpawn.mockImplementation((async (command: string) => {
@@ -203,6 +248,19 @@ describe('createMaestroTestsBuildFunction', () => {
       platform: 'android',
       android_connection_mode: 'automatic',
     });
+
+    await expect(step.executeAsync()).rejects.toThrow(UserError);
+    expect(mockedSpawn).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid EAS_MAESTRO_ANDROID_CONNECTION_MODE values', async () => {
+    const step = createStep(
+      {
+        flow_path: ['flows/a.yaml'],
+        platform: 'android',
+      },
+      { env: { HOME: '/home/expo', EAS_MAESTRO_ANDROID_CONNECTION_MODE: 'automatic' } }
+    );
 
     await expect(step.executeAsync()).rejects.toThrow(UserError);
     expect(mockedSpawn).not.toHaveBeenCalled();

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -63,11 +63,14 @@ const rejectExit1 = (): Error => {
 
 function createStep(
   callInputs?: Record<string, unknown>,
-  options: { env?: Record<string, string | undefined> } = {}
+  options: {
+    env?: Record<string, string | undefined>;
+    logger?: ReturnType<typeof createMockLogger>;
+  } = {}
 ): ReturnType<
   ReturnType<typeof createMaestroTestsBuildFunction>['createBuildStepFromFunctionCall']
 > {
-  const logger = createMockLogger();
+  const logger = options.logger ?? createMockLogger();
   const ctx = {
     runtimeApi: { uploadArtifact: mockUploadArtifact },
   } as unknown as CustomBuildContext;
@@ -152,6 +155,7 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(mockedSpawn).toHaveBeenCalledTimes(2);
     expect(mockedSpawn.mock.calls[0].slice(0, 2)).toEqual(['adb', ['kill-server']]);
     expect(mockedSpawn.mock.calls[1][0]).toBe('maestro');
+    expect(mockedSpawn.mock.calls[0][2]?.signal).toBe(mockedSpawn.mock.calls[1][2]?.signal);
 
     const maestroEnv = mockedSpawn.mock.calls[1][2]?.env;
     expect(maestroEnv?.PATH).toMatch(
@@ -167,6 +171,34 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(rmSpy).not.toHaveBeenCalledWith(
       expect.stringMatching(/maestro-tests-adb-override-/),
       expect.anything()
+    );
+  });
+
+  it('continues with direct DADB and warns when adb kill-server fails', async () => {
+    const killServerError = new Error('ADB server is unavailable');
+    mockedSpawn.mockImplementation((async (command: string) => {
+      if (command === 'adb') {
+        throw killServerError;
+      }
+      return SPAWN_SUCCESS;
+    }) as any);
+    const logger = createMockLogger();
+    jest.mocked(logger.child).mockReturnValue(logger);
+    const step = createStep(
+      {
+        flow_path: ['flows/a.yaml'],
+        platform: 'android',
+        android_connection_mode: 'dadb',
+      },
+      { env: { HOME: '/home/expo', PATH: '/usr/bin' }, logger }
+    );
+
+    await step.executeAsync();
+
+    expect(mockedSpawn.mock.calls.map(([command]) => command)).toEqual(['adb', 'maestro']);
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: killServerError },
+      'Failed to stop the ADB server before Maestro tests; continuing.'
     );
   });
 

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -141,13 +141,15 @@ describe('createMaestroTestsBuildFunction', () => {
     mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
     const writeFileSpy = jest.spyOn(fs, 'writeFile');
     const rmSpy = jest.spyOn(fs, 'rm');
+    const logger = createMockLogger();
+    jest.mocked(logger.child).mockReturnValue(logger);
     const step = createStep(
       {
         flow_path: ['flows/a.yaml'],
         platform: 'android',
         android_connection_mode: 'dadb',
       },
-      { env: { HOME: '/home/expo', PATH: '/usr/bin' } }
+      { env: { HOME: '/home/expo', PATH: '/usr/bin' }, logger }
     );
 
     await step.executeAsync();
@@ -162,6 +164,9 @@ describe('createMaestroTestsBuildFunction', () => {
       new RegExp(`^${os.tmpdir()}/maestro-tests-adb-override-.+${path.delimiter}/usr/bin$`)
     );
     expect(mockedSpawn.mock.calls[0][2]?.env?.PATH).not.toContain('maestro-tests-adb-override-');
+    expect(logger.info).toHaveBeenCalledWith(
+      'Using a direct DADB connection for Android Maestro tests after stopping the ADB server.'
+    );
 
     expect(writeFileSpy).toHaveBeenCalledWith(
       expect.stringMatching(/maestro-tests-adb-override-.+\/adb$/),
@@ -198,8 +203,34 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(mockedSpawn.mock.calls.map(([command]) => command)).toEqual(['adb', 'maestro']);
     expect(logger.warn).toHaveBeenCalledWith(
       { err: killServerError },
-      'Failed to stop the ADB server before Maestro tests; continuing.'
+      'Using a direct DADB connection for Android Maestro tests, but failed to stop the ADB server.'
     );
+  });
+
+  it.each([
+    {
+      source: 'omitted',
+      callInputs: { flow_path: ['flows/a.yaml'], platform: 'android' },
+      env: { HOME: '/home/expo' },
+    },
+    {
+      source: 'empty input',
+      callInputs: { flow_path: ['flows/a.yaml'], platform: 'android', android_connection_mode: '' },
+      env: { HOME: '/home/expo' },
+    },
+    {
+      source: 'empty environment variable',
+      callInputs: { flow_path: ['flows/a.yaml'], platform: 'android' },
+      env: { HOME: '/home/expo', EAS_MAESTRO_ANDROID_CONNECTION_MODE: '' },
+    },
+  ])('treats an $source connection mode value as adb', async ({ callInputs, env }) => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const step = createStep(callInputs, { env });
+
+    await step.executeAsync();
+
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+    expect(mockedSpawn.mock.calls[0][0]).toBe('maestro');
   });
 
   it('uses direct DADB when EAS_MAESTRO_ANDROID_CONNECTION_MODE is dadb', async () => {

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -187,7 +187,7 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       // Public docs (EAS workflows pre-packaged-jobs) document
       // `${MAESTRO_TESTS_DIR}` for users to save screenshots/recordings into
       // the uploaded dir.
-      const spawnEnv = { ...env, MAESTRO_TESTS_DIR: testsDirectory };
+      const spawnEnv: NodeJS.ProcessEnv = { ...env, MAESTRO_TESTS_DIR: testsDirectory };
 
       // Outputs are published BEFORE any throw below so downstream
       // `if: always()` upload steps still see populated values when this
@@ -249,13 +249,45 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       let lastAttemptExitCode: number | null = null;
       const harvested: HarvestedScreenshot[] = [];
 
-      const restoreAndroidConnectionMode =
-        androidConnectionMode === 'dadb'
-          ? await enableDirectDadbConnectionAsync({ mutatingSpawnEnv: spawnEnv, logger })
-          : null;
-
+      const adbEnv = { ...spawnEnv };
+      const originalSpawnPath = spawnEnv.PATH;
+      let adbOverrideDirectoryPath: string | undefined;
+      let directDadbEnabled = false;
       const totalAttempts = retries + 1;
       try {
+        if (androidConnectionMode === 'dadb') {
+          try {
+            adbOverrideDirectoryPath = await fs.mkdtemp(
+              path.join(os.tmpdir(), 'maestro-tests-adb-override-')
+            );
+            await fs.writeFile(path.join(adbOverrideDirectoryPath, 'adb'), '#!/bin/sh\nexit 1\n', {
+              mode: 0o755,
+            });
+
+            // DADB starts an ADB server when it can find an adb binary. Stop the existing
+            // server first, then make only the Maestro process find the failing shim.
+            await spawn('adb', ['kill-server'], { env: adbEnv, logger });
+            spawnEnv.PATH = `${adbOverrideDirectoryPath}${path.delimiter}${originalSpawnPath ?? ''}`;
+            logger.info('Using a direct DADB connection for Android Maestro tests.');
+            directDadbEnabled = true;
+          } catch (err) {
+            spawnEnv.PATH = originalSpawnPath;
+            if (adbOverrideDirectoryPath) {
+              try {
+                await fs.rm(adbOverrideDirectoryPath, { force: true, recursive: true });
+              } catch (cleanupErr) {
+                logger.warn(
+                  { err: cleanupErr },
+                  'Failed to remove the temporary Maestro adb override.'
+                );
+              }
+            }
+            throw new SystemError('Failed to enable direct DADB connection for Maestro', {
+              cause: err,
+            });
+          }
+        }
+
         for (let attempt = 0; attempt <= retries; attempt++) {
           const outputPath =
             outputFormat === 'junit'
@@ -356,7 +388,24 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
           await sleepAsync(2000);
         }
       } finally {
-        await restoreAndroidConnectionMode?.();
+        if (directDadbEnabled) {
+          spawnEnv.PATH = originalSpawnPath;
+          if (adbOverrideDirectoryPath) {
+            try {
+              await fs.rm(adbOverrideDirectoryPath, { force: true, recursive: true });
+            } catch (err) {
+              logger.warn({ err }, 'Failed to remove the temporary Maestro adb override.');
+            }
+          }
+
+          try {
+            await spawn('adb', ['start-server'], { env: adbEnv, logger });
+          } catch (err) {
+            // Restoration supports later best-effort recording and log collection. It
+            // must not replace the Maestro test result with a cleanup failure.
+            logger.warn({ err }, 'Failed to restart the ADB server after Maestro tests.');
+          }
+        }
       }
 
       // Smart merge first; on data errors (bad XML, missing input) fall back
@@ -407,65 +456,6 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       }
     },
   });
-}
-
-async function enableDirectDadbConnectionAsync({
-  mutatingSpawnEnv,
-  logger,
-}: {
-  mutatingSpawnEnv: NodeJS.ProcessEnv;
-  logger: bunyan;
-}): Promise<() => Promise<void>> {
-  const adbEnv = { ...mutatingSpawnEnv };
-  const originalPath = mutatingSpawnEnv.PATH;
-  const hadOriginalPath = Object.hasOwn(mutatingSpawnEnv, 'PATH');
-  const restoreSpawnEnv = (): void => {
-    if (hadOriginalPath) {
-      mutatingSpawnEnv.PATH = originalPath;
-    } else {
-      delete mutatingSpawnEnv.PATH;
-    }
-  };
-  const adbOverrideDirectoryPath = await fs.mkdtemp(
-    path.join(os.tmpdir(), 'maestro-tests-adb-override-')
-  );
-
-  try {
-    await fs.writeFile(path.join(adbOverrideDirectoryPath, 'adb'), '#!/bin/sh\nexit 1\n', {
-      mode: 0o755,
-    });
-
-    // DADB starts an ADB server when it can find an adb binary. Stop the existing
-    // server first, then make only the Maestro process find the failing shim.
-    await spawn('adb', ['kill-server'], { env: adbEnv, logger });
-    mutatingSpawnEnv.PATH = `${adbOverrideDirectoryPath}${path.delimiter}${originalPath ?? ''}`;
-    logger.info('Using a direct DADB connection for Android Maestro tests.');
-  } catch (err) {
-    restoreSpawnEnv();
-    try {
-      await fs.rm(adbOverrideDirectoryPath, { force: true, recursive: true });
-    } catch (cleanupErr) {
-      logger.warn({ err: cleanupErr }, 'Failed to remove the temporary Maestro adb override.');
-    }
-    throw new SystemError('Failed to enable direct DADB connection for Maestro', { cause: err });
-  }
-
-  return async () => {
-    restoreSpawnEnv();
-    try {
-      await fs.rm(adbOverrideDirectoryPath, { force: true, recursive: true });
-    } catch (err) {
-      logger.warn({ err }, 'Failed to remove the temporary Maestro adb override.');
-    }
-
-    try {
-      await spawn('adb', ['start-server'], { env: adbEnv, logger });
-    } catch (err) {
-      // Restoration supports later best-effort recording and log collection. It
-      // must not replace the Maestro test result with a cleanup failure.
-      logger.warn({ err }, 'Failed to restart the ADB server after Maestro tests.');
-    }
-  };
 }
 
 // Reduce harvested failure screenshots to what's worth uploading, then upload them as workflow

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -147,7 +147,6 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       BuildStepInput.createProvider({
         id: 'android_connection_mode',
         required: false,
-        defaultValue: 'adb',
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
     ],
@@ -215,8 +214,8 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       );
       const androidConnectionMode = parseInput(
         AndroidConnectionModeSchema,
-        inputs.android_connection_mode.value,
-        'android_connection_mode must be either "adb" or "dadb".'
+        inputs.android_connection_mode.value ?? env.EAS_MAESTRO_ANDROID_CONNECTION_MODE,
+        'android_connection_mode and EAS_MAESTRO_ANDROID_CONNECTION_MODE must be either "adb" or "dadb".'
       );
       if (androidConnectionMode === 'dadb' && platform !== 'android') {
         throw new UserError(

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -35,6 +35,7 @@ import { sleepAsync } from '../../utils/retry';
 const FlowPathSchema = z.array(z.string().min(1)).min(1);
 const RetriesSchema = z.number().int().min(0).default(0);
 const ShardsSchema = z.number().int().min(1).optional();
+const AndroidConnectionModeSchema = z.enum(['adb', 'dadb']).default('adb');
 
 function parseInput<S extends z.ZodTypeAny>(
   schema: S,
@@ -143,6 +144,12 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
+      BuildStepInput.createProvider({
+        id: 'android_connection_mode',
+        required: false,
+        defaultValue: 'adb',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
     ],
     outputProviders: [
       BuildStepOutput.createProvider({ id: 'junit_report_directory', required: true }),
@@ -206,6 +213,17 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
         inputs.shards.value,
         'shards must be a positive integer.'
       );
+      const androidConnectionMode = parseInput(
+        AndroidConnectionModeSchema,
+        inputs.android_connection_mode.value,
+        'android_connection_mode must be either "adb" or "dadb".'
+      );
+      if (androidConnectionMode === 'dadb' && platform !== 'android') {
+        throw new UserError(
+          'ERR_MAESTRO_INVALID_INPUT',
+          'android_connection_mode "dadb" can only be used with the Android platform.'
+        );
+      }
       const retryFailedOnly = inputs.retry_failed_only.value as boolean;
 
       try {
@@ -231,105 +249,114 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       let lastAttemptExitCode: number | null = null;
       const harvested: HarvestedScreenshot[] = [];
 
+      const restoreAndroidConnectionMode =
+        androidConnectionMode === 'dadb'
+          ? await enableDirectDadbConnectionAsync({ spawnEnv, logger })
+          : null;
+
       const totalAttempts = retries + 1;
-      for (let attempt = 0; attempt <= retries; attempt++) {
-        const outputPath =
-          outputFormat === 'junit'
-            ? path.join(junitReportDirectory, `${platform}-maestro-junit-attempt-${attempt}.xml`)
-            : outputFormat
-              ? path.join(testsDirectory, `${platform}-maestro-${outputFormat}.${outputFormat}`)
-              : null;
+      try {
+        for (let attempt = 0; attempt <= retries; attempt++) {
+          const outputPath =
+            outputFormat === 'junit'
+              ? path.join(junitReportDirectory, `${platform}-maestro-junit-attempt-${attempt}.xml`)
+              : outputFormat
+                ? path.join(testsDirectory, `${platform}-maestro-${outputFormat}.${outputFormat}`)
+                : null;
 
-        const maestroArgs = buildMaestroArgs({
-          flow_path: flowsToRun,
-          outputPath,
-          output_format: outputFormat,
-          shards,
-          include_tags: includeTags,
-          exclude_tags: excludeTags,
-        });
-        logger.info(
-          `Running maestro (attempt ${attempt + 1}/${totalAttempts}): maestro ${maestroArgs.join(' ')}`
-        );
-
-        const attemptStartedAtMs = Date.now();
-
-        try {
-          await spawn('maestro', maestroArgs, {
-            cwd: stepCtx.workingDirectory,
-            env: spawnEnv,
-            logger,
-            signal,
+          const maestroArgs = buildMaestroArgs({
+            flow_path: flowsToRun,
+            outputPath,
+            output_format: outputFormat,
+            shards,
+            include_tags: includeTags,
+            exclude_tags: excludeTags,
           });
-          lastAttemptExitCode = 0;
-        } catch (err: any) {
-          if (err && (err.code === 'ENOENT' || err.code === 'EACCES')) {
-            throw new SystemError('Failed to invoke maestro', { cause: err });
-          }
-          if (err && typeof err.status === 'number') {
-            lastAttemptExitCode = err.status;
-          } else {
-            throw new SystemError('Unexpected spawn failure invoking maestro', { cause: err });
-          }
-        }
-
-        // Harvest this attempt's failure screenshots before any retry subsetting. Gated on
-        // junit: test-case-result rows (and therefore the summary icons) only exist for junit
-        // runs, so harvesting other formats would just create orphan artifacts the website hides.
-        if (outputFormat === 'junit') {
-          const failedFlowNames = outputPath
-            ? await parseFailedFlowNamesFromJUnitFile(outputPath)
-            : new Set<string>();
-          harvested.push(
-            ...(await harvestFailureScreenshotsAsync({
-              testsDirectory,
-              capturedSinceMs: attemptStartedAtMs,
-              attemptIndex: attempt,
-              failedFlowNames,
-              logger,
-            }))
+          logger.info(
+            `Running maestro (attempt ${attempt + 1}/${totalAttempts}): maestro ${maestroArgs.join(' ')}`
           );
-        }
 
-        if (lastAttemptExitCode === 0 || attempt === retries) {
-          break;
-        }
+          const attemptStartedAtMs = Date.now();
 
-        if (retryFailedOnly && outputFormat === 'junit' && outputPath) {
-          let failed: string[] | null;
-          if (await junitFileHasFileAttrs(outputPath)) {
-            failed = await parseFailedFlowsFromFileAttrs({
-              junitFile: outputPath,
-              workingDirectory: stepCtx.workingDirectory,
-            });
-          } else {
-            // Legacy (Maestro < 2.6.0): map failed testcase names back to flow
-            // paths via the flow-file scan. DELETE this arm once the fleet is
-            // on >= 2.6.0.
-            const nameToPath = await (nameToPathPromise ??= buildFlowNameToPathMap({
-              inputFlowPaths: flowPaths,
-              projectRoot: stepCtx.workingDirectory,
+          try {
+            await spawn('maestro', maestroArgs, {
+              cwd: stepCtx.workingDirectory,
+              env: spawnEnv,
               logger,
-            }));
-            failed = nameToPath
-              ? await parseFailedFlowsFromJUnit({ junitFile: outputPath, nameToPath })
-              : null;
+              signal,
+            });
+            lastAttemptExitCode = 0;
+          } catch (err: any) {
+            if (err && (err.code === 'ENOENT' || err.code === 'EACCES')) {
+              throw new SystemError('Failed to invoke maestro', { cause: err });
+            }
+            if (err && typeof err.status === 'number') {
+              lastAttemptExitCode = err.status;
+            } else {
+              throw new SystemError('Unexpected spawn failure invoking maestro', { cause: err });
+            }
           }
-          if (failed !== null && failed.length > 0) {
-            flowsToRun = failed;
-            logger.info(
-              `Test failed; retrying ${failed.length} failed flow(s): ${failed.join(', ')}`
+
+          // Harvest this attempt's failure screenshots before any retry subsetting. Gated on
+          // junit: test-case-result rows (and therefore the summary icons) only exist for junit
+          // runs, so harvesting other formats would just create orphan artifacts the website hides.
+          if (outputFormat === 'junit') {
+            const failedFlowNames = outputPath
+              ? await parseFailedFlowNamesFromJUnitFile(outputPath)
+              : new Set<string>();
+            harvested.push(
+              ...(await harvestFailureScreenshotsAsync({
+                testsDirectory,
+                capturedSinceMs: attemptStartedAtMs,
+                attemptIndex: attempt,
+                failedFlowNames,
+                logger,
+              }))
             );
+          }
+
+          if (lastAttemptExitCode === 0 || attempt === retries) {
+            break;
+          }
+
+          if (retryFailedOnly && outputFormat === 'junit' && outputPath) {
+            let failed: string[] | null;
+            if (await junitFileHasFileAttrs(outputPath)) {
+              failed = await parseFailedFlowsFromFileAttrs({
+                junitFile: outputPath,
+                workingDirectory: stepCtx.workingDirectory,
+              });
+            } else {
+              // Legacy (Maestro < 2.6.0): map failed testcase names back to flow
+              // paths via the flow-file scan. DELETE this arm once the fleet is
+              // on >= 2.6.0.
+              const nameToPath = await (nameToPathPromise ??= buildFlowNameToPathMap({
+                inputFlowPaths: flowPaths,
+                projectRoot: stepCtx.workingDirectory,
+                logger,
+              }));
+              failed = nameToPath
+                ? await parseFailedFlowsFromJUnit({ junitFile: outputPath, nameToPath })
+                : null;
+            }
+            if (failed !== null && failed.length > 0) {
+              flowsToRun = failed;
+              logger.info(
+                `Test failed; retrying ${failed.length} failed flow(s): ${failed.join(', ')}`
+              );
+            } else {
+              flowsToRun = flowPaths;
+              logger.info('Test failed; could not determine failed subset, retrying all flows');
+            }
           } else {
             flowsToRun = flowPaths;
-            logger.info('Test failed; could not determine failed subset, retrying all flows');
+            logger.info('Test failed, retrying all flows');
           }
-        } else {
-          flowsToRun = flowPaths;
-          logger.info('Test failed, retrying all flows');
-        }
 
-        await sleepAsync(2000);
+          await sleepAsync(2000);
+        }
+      } finally {
+        await restoreAndroidConnectionMode?.();
       }
 
       // Smart merge first; on data errors (bad XML, missing input) fall back
@@ -380,6 +407,54 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       }
     },
   });
+}
+
+async function enableDirectDadbConnectionAsync({
+  spawnEnv,
+  logger,
+}: {
+  spawnEnv: NodeJS.ProcessEnv;
+  logger: bunyan;
+}): Promise<() => Promise<void>> {
+  const adbEnv = { ...spawnEnv };
+  const adbOverrideDirectoryPath = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'maestro-tests-adb-override-')
+  );
+
+  try {
+    await fs.writeFile(path.join(adbOverrideDirectoryPath, 'adb'), '#!/bin/sh\nexit 1\n', {
+      mode: 0o755,
+    });
+
+    // DADB starts an ADB server when it can find an adb binary. Stop the existing
+    // server first, then make only the Maestro process find the failing shim.
+    await spawn('adb', ['kill-server'], { env: adbEnv, logger });
+    spawnEnv.PATH = `${adbOverrideDirectoryPath}${path.delimiter}${spawnEnv.PATH ?? ''}`;
+    logger.info('Using a direct DADB connection for Android Maestro tests.');
+  } catch (err) {
+    try {
+      await fs.rm(adbOverrideDirectoryPath, { force: true, recursive: true });
+    } catch (cleanupErr) {
+      logger.warn({ err: cleanupErr }, 'Failed to remove the temporary Maestro adb override.');
+    }
+    throw new SystemError('Failed to enable direct DADB connection for Maestro', { cause: err });
+  }
+
+  return async () => {
+    try {
+      await fs.rm(adbOverrideDirectoryPath, { force: true, recursive: true });
+    } catch (err) {
+      logger.warn({ err }, 'Failed to remove the temporary Maestro adb override.');
+    }
+
+    try {
+      await spawn('adb', ['start-server'], { env: adbEnv, logger });
+    } catch (err) {
+      // Restoration supports later best-effort recording and log collection. It
+      // must not replace the Maestro test result with a cleanup failure.
+      logger.warn({ err }, 'Failed to restart the ADB server after Maestro tests.');
+    }
+  };
 }
 
 // Reduce harvested failure screenshots to what's worth uploading, then upload them as workflow

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -214,7 +214,9 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       );
       const androidConnectionMode = parseInput(
         AndroidConnectionModeSchema,
-        inputs.android_connection_mode.value ?? env.EAS_MAESTRO_ANDROID_CONNECTION_MODE,
+        inputs.android_connection_mode.value ||
+          env.EAS_MAESTRO_ANDROID_CONNECTION_MODE ||
+          undefined,
         'android_connection_mode and EAS_MAESTRO_ANDROID_CONNECTION_MODE must be either "adb" or "dadb".'
       );
       const retryFailedOnly = inputs.retry_failed_only.value as boolean;
@@ -256,13 +258,18 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
           // server first, then make only the Maestro process find the failing shim.
           try {
             await spawn('adb', ['kill-server'], { env: { ...spawnEnv }, logger, signal });
+            logger.info(
+              'Using a direct DADB connection for Android Maestro tests after stopping the ADB server.'
+            );
           } catch (err) {
-            logger.warn({ err }, 'Failed to stop the ADB server before Maestro tests; continuing.');
+            logger.warn(
+              { err },
+              'Using a direct DADB connection for Android Maestro tests, but failed to stop the ADB server.'
+            );
           }
           spawnEnv.PATH = spawnEnv.PATH
             ? `${adbOverrideDirectoryPath}${path.delimiter}${spawnEnv.PATH}`
             : adbOverrideDirectoryPath;
-          logger.info('Using a direct DADB connection for Android Maestro tests.');
         } catch (err) {
           // Intentionally skip cleanup because the worker is disposable.
           throw new SystemError('Failed to enable direct DADB connection for Maestro', {

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -254,8 +254,14 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
 
           // DADB starts an ADB server when it can find an adb binary. Stop the existing
           // server first, then make only the Maestro process find the failing shim.
-          await spawn('adb', ['kill-server'], { env: { ...spawnEnv }, logger });
-          spawnEnv.PATH = `${adbOverrideDirectoryPath}${path.delimiter}${spawnEnv.PATH ?? ''}`;
+          try {
+            await spawn('adb', ['kill-server'], { env: { ...spawnEnv }, logger, signal });
+          } catch (err) {
+            logger.warn({ err }, 'Failed to stop the ADB server before Maestro tests; continuing.');
+          }
+          spawnEnv.PATH = spawnEnv.PATH
+            ? `${adbOverrideDirectoryPath}${path.delimiter}${spawnEnv.PATH}`
+            : adbOverrideDirectoryPath;
           logger.info('Using a direct DADB connection for Android Maestro tests.');
         } catch (err) {
           // Intentionally skip cleanup because the worker is disposable.

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -251,7 +251,7 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
 
       const restoreAndroidConnectionMode =
         androidConnectionMode === 'dadb'
-          ? await enableDirectDadbConnectionAsync({ spawnEnv, logger })
+          ? await enableDirectDadbConnectionAsync({ mutatingSpawnEnv: spawnEnv, logger })
           : null;
 
       const totalAttempts = retries + 1;
@@ -410,13 +410,22 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
 }
 
 async function enableDirectDadbConnectionAsync({
-  spawnEnv,
+  mutatingSpawnEnv,
   logger,
 }: {
-  spawnEnv: NodeJS.ProcessEnv;
+  mutatingSpawnEnv: NodeJS.ProcessEnv;
   logger: bunyan;
 }): Promise<() => Promise<void>> {
-  const adbEnv = { ...spawnEnv };
+  const adbEnv = { ...mutatingSpawnEnv };
+  const originalPath = mutatingSpawnEnv.PATH;
+  const hadOriginalPath = Object.hasOwn(mutatingSpawnEnv, 'PATH');
+  const restoreSpawnEnv = (): void => {
+    if (hadOriginalPath) {
+      mutatingSpawnEnv.PATH = originalPath;
+    } else {
+      delete mutatingSpawnEnv.PATH;
+    }
+  };
   const adbOverrideDirectoryPath = await fs.mkdtemp(
     path.join(os.tmpdir(), 'maestro-tests-adb-override-')
   );
@@ -429,9 +438,10 @@ async function enableDirectDadbConnectionAsync({
     // DADB starts an ADB server when it can find an adb binary. Stop the existing
     // server first, then make only the Maestro process find the failing shim.
     await spawn('adb', ['kill-server'], { env: adbEnv, logger });
-    spawnEnv.PATH = `${adbOverrideDirectoryPath}${path.delimiter}${spawnEnv.PATH ?? ''}`;
+    mutatingSpawnEnv.PATH = `${adbOverrideDirectoryPath}${path.delimiter}${originalPath ?? ''}`;
     logger.info('Using a direct DADB connection for Android Maestro tests.');
   } catch (err) {
+    restoreSpawnEnv();
     try {
       await fs.rm(adbOverrideDirectoryPath, { force: true, recursive: true });
     } catch (cleanupErr) {
@@ -441,6 +451,7 @@ async function enableDirectDadbConnectionAsync({
   }
 
   return async () => {
+    restoreSpawnEnv();
     try {
       await fs.rm(adbOverrideDirectoryPath, { force: true, recursive: true });
     } catch (err) {

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -249,163 +249,128 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       let lastAttemptExitCode: number | null = null;
       const harvested: HarvestedScreenshot[] = [];
 
-      const adbEnv = { ...spawnEnv };
-      const originalSpawnPath = spawnEnv.PATH;
-      let adbOverrideDirectoryPath: string | undefined;
-      let directDadbEnabled = false;
       const totalAttempts = retries + 1;
-      try {
-        if (androidConnectionMode === 'dadb') {
-          try {
-            adbOverrideDirectoryPath = await fs.mkdtemp(
-              path.join(os.tmpdir(), 'maestro-tests-adb-override-')
-            );
-            await fs.writeFile(path.join(adbOverrideDirectoryPath, 'adb'), '#!/bin/sh\nexit 1\n', {
-              mode: 0o755,
-            });
+      if (androidConnectionMode === 'dadb') {
+        try {
+          const adbOverrideDirectoryPath = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'maestro-tests-adb-override-')
+          );
+          await fs.writeFile(path.join(adbOverrideDirectoryPath, 'adb'), '#!/bin/sh\nexit 1\n', {
+            mode: 0o755,
+          });
 
-            // DADB starts an ADB server when it can find an adb binary. Stop the existing
-            // server first, then make only the Maestro process find the failing shim.
-            await spawn('adb', ['kill-server'], { env: adbEnv, logger });
-            spawnEnv.PATH = `${adbOverrideDirectoryPath}${path.delimiter}${originalSpawnPath ?? ''}`;
-            logger.info('Using a direct DADB connection for Android Maestro tests.');
-            directDadbEnabled = true;
-          } catch (err) {
-            spawnEnv.PATH = originalSpawnPath;
-            if (adbOverrideDirectoryPath) {
-              try {
-                await fs.rm(adbOverrideDirectoryPath, { force: true, recursive: true });
-              } catch (cleanupErr) {
-                logger.warn(
-                  { err: cleanupErr },
-                  'Failed to remove the temporary Maestro adb override.'
-                );
-              }
-            }
-            throw new SystemError('Failed to enable direct DADB connection for Maestro', {
-              cause: err,
-            });
+          // DADB starts an ADB server when it can find an adb binary. Stop the existing
+          // server first, then make only the Maestro process find the failing shim.
+          await spawn('adb', ['kill-server'], { env: { ...spawnEnv }, logger });
+          spawnEnv.PATH = `${adbOverrideDirectoryPath}${path.delimiter}${spawnEnv.PATH ?? ''}`;
+          logger.info('Using a direct DADB connection for Android Maestro tests.');
+        } catch (err) {
+          // Intentionally skip cleanup because the worker is disposable.
+          throw new SystemError('Failed to enable direct DADB connection for Maestro', {
+            cause: err,
+          });
+        }
+        // Do not restart ADB or remove the override. This keeps Maestro in direct DADB mode.
+      }
+
+      for (let attempt = 0; attempt <= retries; attempt++) {
+        const outputPath =
+          outputFormat === 'junit'
+            ? path.join(junitReportDirectory, `${platform}-maestro-junit-attempt-${attempt}.xml`)
+            : outputFormat
+              ? path.join(testsDirectory, `${platform}-maestro-${outputFormat}.${outputFormat}`)
+              : null;
+
+        const maestroArgs = buildMaestroArgs({
+          flow_path: flowsToRun,
+          outputPath,
+          output_format: outputFormat,
+          shards,
+          include_tags: includeTags,
+          exclude_tags: excludeTags,
+        });
+        logger.info(
+          `Running maestro (attempt ${attempt + 1}/${totalAttempts}): maestro ${maestroArgs.join(' ')}`
+        );
+
+        const attemptStartedAtMs = Date.now();
+
+        try {
+          await spawn('maestro', maestroArgs, {
+            cwd: stepCtx.workingDirectory,
+            env: spawnEnv,
+            logger,
+            signal,
+          });
+          lastAttemptExitCode = 0;
+        } catch (err: any) {
+          if (err && (err.code === 'ENOENT' || err.code === 'EACCES')) {
+            throw new SystemError('Failed to invoke maestro', { cause: err });
+          }
+          if (err && typeof err.status === 'number') {
+            lastAttemptExitCode = err.status;
+          } else {
+            throw new SystemError('Unexpected spawn failure invoking maestro', { cause: err });
           }
         }
 
-        for (let attempt = 0; attempt <= retries; attempt++) {
-          const outputPath =
-            outputFormat === 'junit'
-              ? path.join(junitReportDirectory, `${platform}-maestro-junit-attempt-${attempt}.xml`)
-              : outputFormat
-                ? path.join(testsDirectory, `${platform}-maestro-${outputFormat}.${outputFormat}`)
-                : null;
-
-          const maestroArgs = buildMaestroArgs({
-            flow_path: flowsToRun,
-            outputPath,
-            output_format: outputFormat,
-            shards,
-            include_tags: includeTags,
-            exclude_tags: excludeTags,
-          });
-          logger.info(
-            `Running maestro (attempt ${attempt + 1}/${totalAttempts}): maestro ${maestroArgs.join(' ')}`
-          );
-
-          const attemptStartedAtMs = Date.now();
-
-          try {
-            await spawn('maestro', maestroArgs, {
-              cwd: stepCtx.workingDirectory,
-              env: spawnEnv,
+        // Harvest this attempt's failure screenshots before any retry subsetting. Gated on
+        // junit: test-case-result rows (and therefore the summary icons) only exist for junit
+        // runs, so harvesting other formats would just create orphan artifacts the website hides.
+        if (outputFormat === 'junit') {
+          const failedFlowNames = outputPath
+            ? await parseFailedFlowNamesFromJUnitFile(outputPath)
+            : new Set<string>();
+          harvested.push(
+            ...(await harvestFailureScreenshotsAsync({
+              testsDirectory,
+              capturedSinceMs: attemptStartedAtMs,
+              attemptIndex: attempt,
+              failedFlowNames,
               logger,
-              signal,
+            }))
+          );
+        }
+
+        if (lastAttemptExitCode === 0 || attempt === retries) {
+          break;
+        }
+
+        if (retryFailedOnly && outputFormat === 'junit' && outputPath) {
+          let failed: string[] | null;
+          if (await junitFileHasFileAttrs(outputPath)) {
+            failed = await parseFailedFlowsFromFileAttrs({
+              junitFile: outputPath,
+              workingDirectory: stepCtx.workingDirectory,
             });
-            lastAttemptExitCode = 0;
-          } catch (err: any) {
-            if (err && (err.code === 'ENOENT' || err.code === 'EACCES')) {
-              throw new SystemError('Failed to invoke maestro', { cause: err });
-            }
-            if (err && typeof err.status === 'number') {
-              lastAttemptExitCode = err.status;
-            } else {
-              throw new SystemError('Unexpected spawn failure invoking maestro', { cause: err });
-            }
+          } else {
+            // Legacy (Maestro < 2.6.0): map failed testcase names back to flow
+            // paths via the flow-file scan. DELETE this arm once the fleet is
+            // on >= 2.6.0.
+            const nameToPath = await (nameToPathPromise ??= buildFlowNameToPathMap({
+              inputFlowPaths: flowPaths,
+              projectRoot: stepCtx.workingDirectory,
+              logger,
+            }));
+            failed = nameToPath
+              ? await parseFailedFlowsFromJUnit({ junitFile: outputPath, nameToPath })
+              : null;
           }
-
-          // Harvest this attempt's failure screenshots before any retry subsetting. Gated on
-          // junit: test-case-result rows (and therefore the summary icons) only exist for junit
-          // runs, so harvesting other formats would just create orphan artifacts the website hides.
-          if (outputFormat === 'junit') {
-            const failedFlowNames = outputPath
-              ? await parseFailedFlowNamesFromJUnitFile(outputPath)
-              : new Set<string>();
-            harvested.push(
-              ...(await harvestFailureScreenshotsAsync({
-                testsDirectory,
-                capturedSinceMs: attemptStartedAtMs,
-                attemptIndex: attempt,
-                failedFlowNames,
-                logger,
-              }))
+          if (failed !== null && failed.length > 0) {
+            flowsToRun = failed;
+            logger.info(
+              `Test failed; retrying ${failed.length} failed flow(s): ${failed.join(', ')}`
             );
-          }
-
-          if (lastAttemptExitCode === 0 || attempt === retries) {
-            break;
-          }
-
-          if (retryFailedOnly && outputFormat === 'junit' && outputPath) {
-            let failed: string[] | null;
-            if (await junitFileHasFileAttrs(outputPath)) {
-              failed = await parseFailedFlowsFromFileAttrs({
-                junitFile: outputPath,
-                workingDirectory: stepCtx.workingDirectory,
-              });
-            } else {
-              // Legacy (Maestro < 2.6.0): map failed testcase names back to flow
-              // paths via the flow-file scan. DELETE this arm once the fleet is
-              // on >= 2.6.0.
-              const nameToPath = await (nameToPathPromise ??= buildFlowNameToPathMap({
-                inputFlowPaths: flowPaths,
-                projectRoot: stepCtx.workingDirectory,
-                logger,
-              }));
-              failed = nameToPath
-                ? await parseFailedFlowsFromJUnit({ junitFile: outputPath, nameToPath })
-                : null;
-            }
-            if (failed !== null && failed.length > 0) {
-              flowsToRun = failed;
-              logger.info(
-                `Test failed; retrying ${failed.length} failed flow(s): ${failed.join(', ')}`
-              );
-            } else {
-              flowsToRun = flowPaths;
-              logger.info('Test failed; could not determine failed subset, retrying all flows');
-            }
           } else {
             flowsToRun = flowPaths;
-            logger.info('Test failed, retrying all flows');
+            logger.info('Test failed; could not determine failed subset, retrying all flows');
           }
-
-          await sleepAsync(2000);
+        } else {
+          flowsToRun = flowPaths;
+          logger.info('Test failed, retrying all flows');
         }
-      } finally {
-        if (directDadbEnabled) {
-          spawnEnv.PATH = originalSpawnPath;
-          if (adbOverrideDirectoryPath) {
-            try {
-              await fs.rm(adbOverrideDirectoryPath, { force: true, recursive: true });
-            } catch (err) {
-              logger.warn({ err }, 'Failed to remove the temporary Maestro adb override.');
-            }
-          }
 
-          try {
-            await spawn('adb', ['start-server'], { env: adbEnv, logger });
-          } catch (err) {
-            // Restoration supports later best-effort recording and log collection. It
-            // must not replace the Maestro test result with a cleanup failure.
-            logger.warn({ err }, 'Failed to restart the ADB server after Maestro tests.');
-          }
-        }
+        await sleepAsync(2000);
       }
 
       // Smart merge first; on data errors (bad XML, missing input) fall back

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -217,12 +217,6 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
         inputs.android_connection_mode.value ?? env.EAS_MAESTRO_ANDROID_CONNECTION_MODE,
         'android_connection_mode and EAS_MAESTRO_ANDROID_CONNECTION_MODE must be either "adb" or "dadb".'
       );
-      if (androidConnectionMode === 'dadb' && platform !== 'android') {
-        throw new UserError(
-          'ERR_MAESTRO_INVALID_INPUT',
-          'android_connection_mode "dadb" can only be used with the Android platform.'
-        );
-      }
       const retryFailedOnly = inputs.retry_failed_only.value as boolean;
 
       try {
@@ -249,7 +243,7 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       const harvested: HarvestedScreenshot[] = [];
 
       const totalAttempts = retries + 1;
-      if (androidConnectionMode === 'dadb') {
+      if (platform === 'android' && androidConnectionMode === 'dadb') {
         try {
           const adbOverrideDirectoryPath = await fs.mkdtemp(
             path.join(os.tmpdir(), 'maestro-tests-adb-override-')


### PR DESCRIPTION
## Why

ADB server is sometimes flaky.

## How

Allow opting in to [DADB](https://github.com/mobile-dev-inc/dadb) for Maestro-Android emulator connections.

DADB mode can be enabled with either:

- the `android_connection_mode: dadb` step input
- the `EAS_MAESTRO_ANDROID_CONNECTION_MODE=dadb` environment variable

The explicit step input has priority over the environment variable. The default remains `adb`. On iOS, `dadb` is accepted and ignored, so the environment variable can be set for the whole project.

## Test plan

I tested this before with a client. I want to allow another client to easily opt in. This is a no-op unless it is enabled on Android.

Unit tests cover input opt-in, environment opt-in, input precedence, invalid values, iOS behavior, retries, and failure behavior.