### PR TITLE
[build-tools][worker] Enable production EAS Logs

### DIFF
--- a/packages/build-tools/src/logging/HttpLogStream.ts
+++ b/packages/build-tools/src/logging/HttpLogStream.ts
@@ -6,6 +6,7 @@ import { Writable } from 'stream';
 import { retryAsync } from '../utils/retry';
 
 const MAX_BATCH_BYTES = 200_000;
+const REQUEST_TIMEOUT_MS = 10_000;
 
 interface BufferedLogEntry {
   enqueuedAt: number;
@@ -161,6 +162,7 @@ export default class HttpLogStream extends Writable {
             'Content-Type': 'application/x-ndjson',
           },
           body: logs.map(log => log.serialized).join('\n'),
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
         });
 
         if (!response.ok) {

--- a/packages/build-tools/src/logging/__tests__/HttpLogStream.test.ts
+++ b/packages/build-tools/src/logging/__tests__/HttpLogStream.test.ts
@@ -186,4 +186,21 @@ describe(HttpLogStream.name, () => {
     const [firstAttemptLogs, secondAttemptLogs] = parseRequestLogs();
     expect(secondAttemptLogs).toEqual(firstAttemptLogs);
   });
+
+  it('sets a ten-second timeout on HTTP uploads', async () => {
+    fetchMock.mockResolvedValue(createResponse());
+    const abortSignalTimeoutSpy = jest.spyOn(AbortSignal, 'timeout');
+    const stream = new HttpLogStream({
+      url: 'https://logs.expo.test/build-id',
+      headers: { Authorization: 'Bearer token' },
+      logger: createLogger({ name: 'test' }),
+    });
+
+    stream.write({ logId: 'stable-id', msg: 'Do not hang' });
+    await stream.cleanUp();
+
+    expect(abortSignalTimeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(fetchMock.mock.calls[0][1]?.signal).toBeInstanceOf(AbortSignal);
+    abortSignalTimeoutSpy.mockRestore();
+  });
 });

--- a/packages/worker/src/__unit__/config.test.ts
+++ b/packages/worker/src/__unit__/config.test.ts
@@ -1,0 +1,24 @@
+import { Environment } from '../constants';
+
+describe('config', () => {
+  const originalEnvironment = process.env.ENVIRONMENT;
+
+  afterEach(() => {
+    process.env.ENVIRONMENT = originalEnvironment;
+    jest.resetModules();
+  });
+
+  it.each([
+    [Environment.DEVELOPMENT, 'http://localhost:4999/logs/'],
+    [Environment.STAGING, 'https://staging-logs.expo.dev/logs/'],
+    [Environment.PRODUCTION, 'https://logs.expo.dev/logs/'],
+    [Environment.TEST, null],
+  ])('uses the expected EAS Logs URL in %s', (environment, expectedBaseUrl) => {
+    process.env.ENVIRONMENT = environment;
+
+    jest.isolateModules(() => {
+      const config = require('../config').default;
+      expect(config.loggers.http.baseUrl).toBe(expectedBaseUrl);
+    });
+  });
+});

--- a/packages/worker/src/config.ts
+++ b/packages/worker/src/config.ts
@@ -50,7 +50,9 @@ export default {
           ? 'http://localhost:4999/logs/'
           : process.env.ENVIRONMENT === 'staging'
             ? 'https://staging-logs.expo.dev/logs/'
-            : null,
+            : process.env.ENVIRONMENT === 'production'
+              ? 'https://logs.expo.dev/logs/'
+              : null,
     },
   },
   buildCache: {


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I want to see how the architecture works under full logs pressure.

# How

Enabled pushing logs to logs.expo.dev in production too.

# Test Plan

Staging works, let's see it in production.