### PR TITLE
[eas-cli] Add --device flag to eas simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add `--device` flag to `eas simulator` for selecting the virtual device to start. ([#4172](https://github.com/expo/eas-cli/pull/4172) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🐛 Bug fixes
 
 - [eas-cli] Disallow 0-length uploads. ([#4192](https://github.com/expo/eas-cli/pull/4192) by [@wschurman](https://github.com/wschurman))

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -10455,6 +10455,22 @@
             "deprecationReason": null
           },
           {
+            "name": "isEligibleForObserveNotice",
+            "description": "Tells you if the project can show the Observe promotional notification. This field is part of\nthe observe-notification experiment.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "This field is deprecated from its first release. It supplies data for the observe-notification promotion on the project page. It will be removed when the promotion ends. Do not rely on it."
+          },
+          {
             "name": "lastDeletionAttemptTime",
             "description": null,
             "args": [],
@@ -24164,6 +24180,30 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "unavailableServiceUsageMetrics",
+            "description": "Services whose estimates could not be computed and are omitted from the other fields.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "UnavailableServiceUsageMetric",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -36659,6 +36699,18 @@
                 "name": "ID",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceIdentifier",
+            "description": "Identifier of the virtual device to start for the session. On iOS this is a\nSimulator device name or UDID (e.g. \"iPhone 16 Pro\"). On Android this is an\nAVD hardware profile id (e.g. \"pixel_7\"). If omitted, the runner picks a\ndefault device.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -74488,6 +74540,49 @@
       },
       {
         "kind": "OBJECT",
+        "name": "UnavailableServiceUsageMetric",
+        "description": null,
+        "fields": [
+          {
+            "name": "message",
+            "description": "User-displayable explanation of why the service's estimate is missing.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "service",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EASService",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "UniqueUsersOverTimeData",
         "description": null,
         "fields": [
@@ -79568,6 +79663,30 @@
                 "kind": "SCALAR",
                 "name": "Float",
                 "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unavailableServiceUsageMetrics",
+            "description": "Services whose estimates could not be computed and are omitted from the other fields.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "UnavailableServiceUsageMetric",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -411,6 +411,48 @@ describe(Simulator, () => {
     );
   });
 
+  it('forwards --device to the create mutation as deviceIdentifier', async () => {
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      '--device',
+      'iPhone 16 Pro',
+    ]);
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ deviceIdentifier: 'iPhone 16 Pro' })
+    );
+  });
+
+  it('trims --device before sending it', async () => {
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      '--device',
+      '  iPhone 16 Pro  ',
+    ]);
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ deviceIdentifier: 'iPhone 16 Pro' })
+    );
+  });
+
+  it('omits a blank --device', async () => {
+    const { command } = createCommand(['--platform', 'ios', '--non-interactive', '--device', '  ']);
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ deviceIdentifier: undefined })
+    );
+  });
+
   it('stops the simulator session when interrupted before the session is ready', async () => {
     const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(code => {
       throw new Error(`process.exit(${code})`);

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -68,6 +68,10 @@ export default class Simulator extends EasCommand {
       description:
         'Human-readable name for the simulator session, shown in eas simulator:list and on expo.dev. Defaults to unnamed.',
     }),
+    device: Flags.string({
+      description:
+        'Virtual device to start for the session. On iOS, a Simulator device name or UDID (e.g. "iPhone 16 Pro"). On Android, an AVD hardware profile id (e.g. "pixel_7"). Defaults to a device chosen by the runner.',
+    }),
     type: Flags.option({
       description: 'Type of simulator session to create',
       options: Object.values(DEVICE_RUN_SESSION_TYPE_FLAG_VALUES),
@@ -134,6 +138,7 @@ export default class Simulator extends EasCommand {
     // The server rejects blank names, so trim here and treat a whitespace-only
     // --name as if it had been omitted rather than surfacing a validation error.
     const name = flags.name?.trim() || undefined;
+    const deviceIdentifier = flags.device?.trim() || undefined;
 
     await loadSimulatorEnvAsync(projectDir);
     const existingDeviceRunSessionId = process.env[EAS_SIMULATOR_SESSION_ID];
@@ -165,6 +170,7 @@ export default class Simulator extends EasCommand {
         platform,
         type: DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE[flags.type],
         packageVersion: flags['package-version'],
+        deviceIdentifier,
         maxRunTimeMinutes: flags['max-duration-minutes'],
       });
       deviceRunSessionId = session.id;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1472,6 +1472,12 @@ export type App = Project & {
   internalDistributionBuildPrivacy: AppInternalDistributionBuildPrivacy;
   /** iOS app credentials for the project */
   iosAppCredentials: Array<IosAppCredentials>;
+  /**
+   * Tells you if the project can show the Observe promotional notification. This field is part of
+   * the observe-notification experiment.
+   * @deprecated This field is deprecated from its first release. It supplies data for the observe-notification promotion on the project page. It will be removed when the promotion ends. Do not rely on it.
+   */
+  isEligibleForObserveNotice: Scalars['Boolean']['output'];
   lastDeletionAttemptTime?: Maybe<Scalars['DateTime']['output']>;
   /** Time of the last user activity (update, branch, submission). */
   latestActivity: Scalars['DateTime']['output'];
@@ -3438,6 +3444,8 @@ export type AppUsageMetricTotal = {
   planMetrics: Array<EstimatedUsage>;
   /** Total cost of overages, in cents */
   totalCost: Scalars['Float']['output'];
+  /** Services whose estimates could not be computed and are omitted from the other fields. */
+  unavailableServiceUsageMetrics: Array<UnavailableServiceUsageMetric>;
 };
 
 export type AppUsageMetrics = {
@@ -10547,6 +10555,13 @@ export enum TurtleSshTransportType {
   UptermV1 = 'UPTERM_V1'
 }
 
+export type UnavailableServiceUsageMetric = {
+  __typename?: 'UnavailableServiceUsageMetric';
+  /** User-displayable explanation of why the service's estimate is missing. */
+  message: Scalars['String']['output'];
+  service: EasService;
+};
+
 export type UniqueUsersOverTimeData = {
   __typename?: 'UniqueUsersOverTimeData';
   data: LineChartData;
@@ -11225,6 +11240,8 @@ export type UsageMetricTotal = {
   planMetrics: Array<EstimatedUsage>;
   /** Total cost of overages, in cents */
   totalCost: Scalars['Float']['output'];
+  /** Services whose estimates could not be computed and are omitted from the other fields. */
+  unavailableServiceUsageMetrics: Array<UnavailableServiceUsageMetric>;
 };
 
 export enum UsageMetricType {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -5154,6 +5154,13 @@ export type CreateDeviceRunSessionEventLogUploadSessionResult = {
 export type CreateDeviceRunSessionInput = {
   appId: Scalars['ID']['input'];
   /**
+   * Identifier of the virtual device to start for the session. On iOS this is a
+   * Simulator device name or UDID (e.g. "iPhone 16 Pro"). On Android this is an
+   * AVD hardware profile id (e.g. "pixel_7"). If omitted, the runner picks a
+   * default device.
+   */
+  deviceIdentifier?: InputMaybe<Scalars['String']['input']>;
+  /**
    * Stop the session automatically after this many minutes without observed
    * session activity. Must be positive and smaller than the session's maximum
    * duration (2 hours, or maxRunTimeMinutes when set). Only supported for


### PR DESCRIPTION
# Why

Companion to https://github.com/expo/universe/pull/29910

Allow controlling device we boot by default

# How

Add a --device flag to eas simulator command

# Test Plan

Tests