### PR TITLE
[eas-cli] respect Expo admins in simulator availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Report EAS Simulator as available to Expo admins in `eas simulator:availability`, even when the project account's feature gate is disabled. ([#4181](https://github.com/expo/eas-cli/pull/4181) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Make the non-interactive "EAS project not configured" error actionable on every path: list the exact `eas init --id` / `eas init --account` commands and the accounts you can create projects in, instead of suggesting bare `eas init`, which fails the same way. ([#4153](https://github.com/expo/eas-cli/pull/4153) by [@williamgrosset](https://github.com/williamgrosset))
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/simulator/__tests__/availability.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/availability.test.ts
@@ -52,12 +52,15 @@ describe(SimulatorAvailability, () => {
     jest.clearAllMocks();
   });
 
-  function createCommand(argv: string[]): SimulatorAvailability {
+  function createCommand(
+    argv: string[],
+    { isExpoAdmin = false }: { isExpoAdmin?: boolean } = {}
+  ): SimulatorAvailability {
     const command = new SimulatorAvailability(argv, mockConfig);
     // @ts-expect-error getContextAsync is protected
     jest.spyOn(command, 'getContextAsync').mockResolvedValue({
       projectId,
-      loggedIn: { graphqlClient },
+      loggedIn: { actor: { isExpoAdmin }, graphqlClient },
     });
     return command;
   }
@@ -95,6 +98,19 @@ describe(SimulatorAvailability, () => {
     const command = createCommand(['--json']);
     await command.runAsync();
 
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
+      available: true,
+      accountName: 'testuser',
+    });
+  });
+
+  it('emits JSON with available true for Expo admins when the account is gated', async () => {
+    mockByAppIdAsync.mockResolvedValue({ accountName: 'testuser', available: false });
+
+    const command = createCommand(['--json'], { isExpoAdmin: true });
+    await command.runAsync();
+
+    expect(mockByAppIdAsync).toHaveBeenCalledWith(graphqlClient, projectId);
     expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
       available: true,
       accountName: 'testuser',

--- a/packages/eas-cli/src/commands/simulator/availability.ts
+++ b/packages/eas-cli/src/commands/simulator/availability.ts
@@ -37,7 +37,7 @@ export default class SimulatorAvailability extends EasCommand {
 
     const {
       projectId,
-      loggedIn: { graphqlClient },
+      loggedIn: { actor, graphqlClient },
     } = await this.getContextAsync(SimulatorAvailability, {
       nonInteractive,
     });
@@ -50,6 +50,7 @@ export default class SimulatorAvailability extends EasCommand {
         graphqlClient,
         projectId
       ));
+      available ||= actor.isExpoAdmin;
       fetchSpinner?.stop();
     } catch (err) {
       fetchSpinner?.fail('Failed to check EAS Simulator availability');


### PR DESCRIPTION
## Summary

Ensure `eas simulator:availability` returns `true` for expo admins

## Why

If user is expo admin return true

## Validation

CI