### PR TITLE
[build-tools] Add maestro-runner installation backend

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
@@ -38,6 +38,7 @@ describe('createInstallMaestroBuildFunction', () => {
     expect(step.getOutputValueByName('maestro_version')).toBe('1.41.0');
     expect(Datadog.distribution).toHaveBeenCalledWith('eas.maestro.install', 1, {
       maestro_version: '1.41.0',
+      maestro_backend: 'maestro',
     });
   });
 
@@ -70,6 +71,7 @@ describe('createInstallMaestroBuildFunction', () => {
     expect(step.getOutputValueByName('maestro_version')).toBe('2.0.10');
     expect(Datadog.distribution).toHaveBeenCalledWith('eas.maestro.install', 1, {
       maestro_version: '2.0.10',
+      maestro_backend: 'maestro',
     });
   });
 
@@ -86,5 +88,142 @@ describe('createInstallMaestroBuildFunction', () => {
     await step.executeAsync();
 
     expect(step.getOutputValueByName('maestro_version')).toBe('2.0.10');
+  });
+
+  it('checks maestro-runner when selected by input', async () => {
+    mockedSpawn.mockImplementation((async (command: string) => ({
+      stdout:
+        command === 'maestro-runner'
+          ? 'maestro-runner 1.2.3\n  Commit:  abc123\n  Built:   2026-08-13\n  Go:      go1.26.5\n  OS/Arch: darwin/arm64\n'
+          : '',
+    })) as any);
+
+    const installMaestro = createInstallMaestroBuildFunction();
+    const globalCtx = createGlobalContextMock();
+    globalCtx.updateEnv({ EAS_BUILD_RUNNER: 'eas-build' });
+    const step = installMaestro.createBuildStepFromFunctionCall(globalCtx, {
+      callInputs: { backend: 'maestro-runner' },
+    });
+
+    await step.executeAsync();
+
+    expect(mockedSpawn).toHaveBeenCalledTimes(2);
+    expect(mockedSpawn.mock.calls.map(([command]) => command)).toEqual([
+      'maestro-runner',
+      'maestro-runner',
+    ]);
+    expect(step.getOutputValueByName('maestro_version')).toBe('1.2.3');
+    expect(Datadog.distribution).toHaveBeenCalledWith('eas.maestro.install', 1, {
+      maestro_version: '1.2.3',
+      maestro_backend: 'maestro-runner',
+    });
+  });
+
+  it('selects maestro-runner from EAS_MAESTRO_BACKEND', async () => {
+    mockedSpawn.mockImplementation((async (command: string) => ({
+      stdout: command === 'maestro-runner' ? 'maestro-runner 1.2.3\n' : '',
+    })) as any);
+
+    const installMaestro = createInstallMaestroBuildFunction();
+    const globalCtx = createGlobalContextMock();
+    globalCtx.updateEnv({
+      EAS_BUILD_RUNNER: 'eas-build',
+      EAS_MAESTRO_BACKEND: 'maestro-runner',
+    });
+    const step = installMaestro.createBuildStepFromFunctionCall(globalCtx, { callInputs: {} });
+
+    await step.executeAsync();
+
+    expect(mockedSpawn.mock.calls.map(([command]) => command)).toEqual([
+      'maestro-runner',
+      'maestro-runner',
+    ]);
+  });
+
+  it('installs the latest maestro-runner version when it is missing', async () => {
+    let versionChecks = 0;
+    mockedSpawn.mockImplementation((async (command: string) => {
+      if (command === 'maestro-runner' && versionChecks++ === 0) {
+        throw Object.assign(new Error('not found'), { code: 'ENOENT' });
+      }
+      return { stdout: command === 'maestro-runner' ? 'maestro-runner 1.2.3\n' : '' };
+    }) as any);
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      text: async () => '#!/bin/sh\n',
+    } as Response);
+    const originalPath = process.env.PATH;
+
+    try {
+      const installMaestro = createInstallMaestroBuildFunction();
+      const globalCtx = createGlobalContextMock();
+      globalCtx.updateEnv({
+        EAS_BUILD_RUNNER: 'eas-build',
+        HOME: '/home/expo',
+        PATH: '/usr/bin',
+      });
+      const step = installMaestro.createBuildStepFromFunctionCall(globalCtx, {
+        callInputs: { backend: 'maestro-runner' },
+      });
+
+      await step.executeAsync();
+
+      expect(fetchSpy).toHaveBeenCalledWith('https://open.devicelab.dev/install/maestro-runner');
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        expect.stringMatching(/install_maestro_runner.*\/install_maestro_runner\.sh$/),
+        [],
+        expect.objectContaining({ env: expect.objectContaining({ HOME: '/home/expo' }) })
+      );
+      expect(mockedSpawn).toHaveBeenLastCalledWith(
+        'maestro-runner',
+        ['--version'],
+        expect.objectContaining({
+          env: expect.objectContaining({
+            PATH: expect.stringMatching(/:\/home\/expo\/\.maestro-runner\/bin$/),
+          }),
+        })
+      );
+    } finally {
+      fetchSpy.mockRestore();
+      process.env.PATH = originalPath;
+    }
+  });
+
+  it('installs the requested maestro-runner version', async () => {
+    let versionChecks = 0;
+    mockedSpawn.mockImplementation((async (command: string) => {
+      if (command === 'maestro-runner' && versionChecks++ === 0) {
+        throw Object.assign(new Error('not found'), { code: 'ENOENT' });
+      }
+      return { stdout: command === 'maestro-runner' ? 'maestro-runner 1.0.9\n' : '' };
+    }) as any);
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      text: async () => '#!/bin/sh\n',
+    } as Response);
+    const originalPath = process.env.PATH;
+
+    try {
+      const installMaestro = createInstallMaestroBuildFunction();
+      const globalCtx = createGlobalContextMock();
+      globalCtx.updateEnv({
+        EAS_BUILD_RUNNER: 'eas-build',
+        HOME: '/home/expo',
+        PATH: '/usr/bin',
+      });
+      const step = installMaestro.createBuildStepFromFunctionCall(globalCtx, {
+        callInputs: { backend: 'maestro-runner', maestro_version: '1.0.9' },
+      });
+
+      await step.executeAsync();
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        expect.stringMatching(/install_maestro_runner.*\/install_maestro_runner\.sh$/),
+        ['--version', '1.0.9'],
+        expect.objectContaining({ env: expect.objectContaining({ HOME: '/home/expo' }) })
+      );
+    } finally {
+      jest.restoreAllMocks();
+      process.env.PATH = originalPath;
+    }
   });
 });

--- a/packages/build-tools/src/steps/functions/installMaestro.ts
+++ b/packages/build-tools/src/steps/functions/installMaestro.ts
@@ -15,6 +15,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
+import { MaestroBackend, resolveMaestroBackend } from './maestroBackend';
 import { Datadog } from '../../datadog';
 
 export function createInstallMaestroBuildFunction(): BuildFunction {
@@ -29,6 +30,11 @@ export function createInstallMaestroBuildFunction(): BuildFunction {
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
+      BuildStepInput.createProvider({
+        id: 'backend',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
     ],
     outputProviders: [
       BuildStepOutput.createProvider({
@@ -37,22 +43,28 @@ export function createInstallMaestroBuildFunction(): BuildFunction {
       }),
     ],
     fn: async ({ logger, global }, { inputs, env, outputs }) => {
-      const requestedMaestroVersion = inputs.maestro_version.value as string | undefined;
-      const { value: currentMaestroVersion } = await asyncResult(getMaestroVersion({ env }));
+      const backend = resolveMaestroBackend({
+        input: inputs.backend.value,
+        env,
+      });
+      const requestedVersion = inputs.maestro_version.value as string | undefined;
+      const { value: currentMaestroVersion } = await asyncResult(
+        getMaestroVersion({ env, backend })
+      );
 
       // When not running in EAS Build VM, do not modify local environment.
       if (env.EAS_BUILD_RUNNER !== 'eas-build') {
-        const currentIsJavaInstalled = await isJavaInstalled({ env });
-        const currentIsIdbInstalled = await isIdbInstalled({ env });
+        const needsToInstallJava = backend === 'maestro' && !(await isJavaInstalled({ env }));
+        const needsToInstallIdb = backend === 'maestro' && !(await isIdbInstalled({ env }));
 
-        if (!currentIsJavaInstalled) {
+        if (needsToInstallJava) {
           logger.warn(
             'It seems Java is not installed. It is required to run Maestro. If the job fails, this may be the reason.'
           );
           logger.info('');
         }
 
-        if (!currentIsIdbInstalled) {
+        if (needsToInstallIdb) {
           logger.warn(
             'It seems IDB is not installed. Maestro requires it to run flows on iOS Simulator. If the job fails, this may be the reason.'
           );
@@ -61,27 +73,32 @@ export function createInstallMaestroBuildFunction(): BuildFunction {
 
         if (!currentMaestroVersion) {
           logger.warn(
-            'It seems Maestro is not installed. Please install Maestro manually and rerun the job.'
+            `It seems ${backend} is not installed. Please install it manually and rerun the job.`
           );
           logger.info('');
         }
 
         // Guide is helpful in these two cases, it doesn't mention Java.
-        if (!currentIsIdbInstalled || !currentMaestroVersion) {
+        if (backend === 'maestro' && (needsToInstallIdb || !currentMaestroVersion)) {
           logger.warn(
             'For more info, check out Maestro installation guide: https://maestro.mobile.dev/getting-started/installing-maestro'
+          );
+        } else if (backend === 'maestro-runner' && !currentMaestroVersion) {
+          logger.warn(
+            'For more info, check out maestro-runner installation guide: https://github.com/devicelab-dev/maestro-runner#install'
           );
         }
 
         if (currentMaestroVersion) {
           outputs.maestro_version.set(currentMaestroVersion);
-          logger.info(`Maestro ${currentMaestroVersion} is ready.`);
+          logger.info(`${backend} ${currentMaestroVersion} is ready.`);
         }
 
         return;
       }
 
-      if (!(await isJavaInstalled({ env }))) {
+      const needsToInstallJava = backend === 'maestro' && !(await isJavaInstalled({ env }));
+      if (needsToInstallJava) {
         if (global.runtimePlatform === BuildRuntimePlatform.DARWIN) {
           logger.info('Installing Java');
           await installJavaFromGcs({ logger, env });
@@ -94,10 +111,11 @@ export function createInstallMaestroBuildFunction(): BuildFunction {
       }
 
       // IDB is only a requirement on macOS.
-      if (
+      const needsToInstallIdb =
+        backend === 'maestro' &&
         global.runtimePlatform === BuildRuntimePlatform.DARWIN &&
-        !(await isIdbInstalled({ env }))
-      ) {
+        !(await isIdbInstalled({ env }));
+      if (needsToInstallIdb) {
         logger.info('Installing IDB');
         await installIdbFromBrew({ logger, env });
       }
@@ -106,43 +124,100 @@ export function createInstallMaestroBuildFunction(): BuildFunction {
       // and it is already installed which happens when developing on a local computer.
       if (
         !currentMaestroVersion ||
-        (requestedMaestroVersion && requestedMaestroVersion !== currentMaestroVersion)
+        (requestedVersion && requestedVersion !== currentMaestroVersion)
       ) {
-        await installMaestro({
-          version: requestedMaestroVersion,
-          global,
-          logger,
-          env,
-        });
+        switch (backend) {
+          case 'maestro':
+            await installMaestro({ version: requestedVersion, global, logger, env });
+            break;
+          case 'maestro-runner':
+            await installMaestroRunner({ version: requestedVersion, global, logger, env });
+            break;
+        }
       }
 
-      const maestroVersionResult = await asyncResult(getMaestroVersion({ env }));
+      const maestroVersionResult = await asyncResult(getMaestroVersion({ env, backend }));
       if (!maestroVersionResult.ok) {
         logger.error(maestroVersionResult.reason, 'Failed to get Maestro version.');
 
-        throw new Error('Failed to ensure Maestro is installed.');
+        throw new Error(`Failed to ensure ${backend} is installed.`);
       }
 
-      logger.info(`Maestro ${maestroVersionResult.value} is ready.`);
+      logger.info(`${backend} ${maestroVersionResult.value} is ready.`);
       outputs.maestro_version.set(maestroVersionResult.value);
 
       Datadog.distribution('eas.maestro.install', 1, {
         maestro_version: maestroVersionResult.value,
+        maestro_backend: backend,
       });
     },
   });
 }
 
-async function getMaestroVersion({ env }: { env: BuildStepEnv }): Promise<string> {
-  const { stdout } = await spawn('maestro', ['--version'], { stdio: 'pipe', env });
-  // `maestro --version` can print an analytics notice to stdout before the version,
-  // e.g. "Anonymous analytics enabled. To opt out, set MAESTRO_CLI_NO_ANALYTICS...\n2.0.10".
-  // Take the last version-looking token: the real version is printed after the notice, so
-  // this stays correct even if the notice itself contains a version-like string. Keeps the
-  // step output and the eas.maestro.install metric tag clean. Best-effort only: fall back to
-  // the raw output if none is found, so we never fail the build over a version string.
-  const versions = stdout.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/g);
-  return versions?.at(-1) ?? stdout.trim();
+async function getMaestroVersion({
+  env,
+  backend,
+}: {
+  env: BuildStepEnv;
+  backend: MaestroBackend;
+}): Promise<string> {
+  switch (backend) {
+    case 'maestro': {
+      const { stdout } = await spawn('maestro', ['--version'], { stdio: 'pipe', env });
+      // `maestro --version` can print an analytics notice to stdout before the version,
+      // e.g. "Anonymous analytics enabled. To opt out, set MAESTRO_CLI_NO_ANALYTICS...\n2.0.10".
+      // Take the last version-looking token: the real version is printed after the notice.
+      const versions = stdout.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/g);
+      return versions?.at(-1) ?? stdout.trim();
+    }
+    case 'maestro-runner': {
+      const { stdout } = await spawn('maestro-runner', ['--version'], { stdio: 'pipe', env });
+      // maestro-runner prints build information after its version. The Go runtime version in
+      // that output is also semver-shaped, so read only the prefixed runner version.
+      return /^maestro-runner\s+(\S+)/m.exec(stdout)?.[1] ?? stdout.trim();
+    }
+  }
+}
+
+async function installMaestroRunner({
+  global,
+  version,
+  logger,
+  env,
+}: {
+  version?: string;
+  logger: bunyan;
+  global: BuildStepGlobalContext;
+  env: BuildStepEnv;
+}): Promise<void> {
+  logger.info('Fetching maestro-runner install script');
+  const tempDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'install_maestro_runner'));
+  try {
+    const installMaestroRunnerScriptResponse = await fetch(
+      'https://open.devicelab.dev/install/maestro-runner'
+    );
+    const installMaestroRunnerScript = await installMaestroRunnerScriptResponse.text();
+    const scriptPath = path.join(tempDirectory, 'install_maestro_runner.sh');
+    await fs.promises.writeFile(scriptPath, installMaestroRunnerScript, { mode: 0o777 });
+    logger.info('Installing maestro-runner');
+    assert(
+      env.HOME,
+      'Failed to infer directory to install maestro-runner in: $HOME environment variable is empty.'
+    );
+    await spawn(scriptPath, version && version !== 'latest' ? ['--version', version] : [], {
+      logger,
+      env,
+    });
+    const binDir = path.join(env.HOME, '.maestro-runner', 'bin');
+    global.updateEnv({
+      ...global.env,
+      PATH: `${global.env.PATH}:${binDir}`,
+    });
+    env.PATH = `${env.PATH}:${binDir}`;
+    process.env.PATH = `${process.env.PATH}:${binDir}`;
+  } finally {
+    await fs.promises.rm(tempDirectory, { force: true, recursive: true });
+  }
 }
 
 async function installMaestro({

--- a/packages/build-tools/src/steps/functions/maestroBackend.ts
+++ b/packages/build-tools/src/steps/functions/maestroBackend.ts
@@ -1,0 +1,25 @@
+import { UserError } from '@expo/eas-build-job';
+import { BuildStepEnv } from '@expo/steps';
+import { z } from 'zod';
+
+export const MaestroBackendSchema = z.enum(['maestro', 'maestro-runner']).default('maestro');
+
+export type MaestroBackend = z.output<typeof MaestroBackendSchema>;
+
+export function resolveMaestroBackend({
+  input,
+  env,
+}: {
+  input: unknown;
+  env: BuildStepEnv;
+}): MaestroBackend {
+  const result = MaestroBackendSchema.safeParse(input || env.EAS_MAESTRO_BACKEND || undefined);
+  if (!result.success) {
+    throw new UserError(
+      'ERR_MAESTRO_INVALID_INPUT',
+      'backend and EAS_MAESTRO_BACKEND must be either "maestro" or "maestro-runner".',
+      { cause: result.error }
+    );
+  }
+  return result.data;
+}


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

I want to try `maestro-runner` as Maestro test runner.

# How

Added support for installation of `maestro-runner` through `eas/install_maestro`.

I can see how icky this is, but I want to allow easy opt-in with `EAS_MAESTRO_BACKEND=maestro-runner` and we won't have easy access to all environment variables in `WorkflowMaestroTestJob.ts`.

# Test Plan

CI should pass. Verified `maestro-runner --version` output.