### PR TITLE
[build-tools] Allow running Maestro tests with `maestro-runner`

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
@@ -592,6 +592,22 @@ describe(parseJUnitTestCases, () => {
     );
   });
 
+  it('excludes skipped testcases instead of counting them as passed', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="passing" time="1.0"/>',
+        '  <testcase name="skipped-flow" time="0"><skipped/></testcase>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+
+    expect(results.map(r => r.name)).toEqual(['passing']);
+  });
+
   it('treats a missing or empty file= attribute as undefined', async () => {
     vol.fromJSON({
       '/junit/report.xml': [

--- a/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
@@ -10,10 +10,91 @@ import {
   parseFailedFlowNamesFromJUnitFile,
   parseFailedFlowsFromFileAttrs,
   parseFailedFlowsFromJUnit,
+  parseFailedFlowsFromMaestroRunnerReport,
   parseJUnitTestCases,
   parseMaestroResults,
   parseMaestroResultsFromFileAttrs,
+  parseMaestroRunnerReport,
 } from '../maestroResultParser';
+
+describe(parseFailedFlowsFromMaestroRunnerReport, () => {
+  it('returns exact sourceFile paths for failed flows', async () => {
+    vol.fromJSON({
+      '/project/flows/pass.yml': '',
+      '/project/flows/nested/fail.yml': '',
+      '/reports/attempt-0/report.json': JSON.stringify({
+        flows: [
+          { name: 'Passing flow', sourceFile: 'flows/pass.yml', status: 'passed' },
+          {
+            name: 'Failing flow',
+            sourceFile: 'flows/nested/fail.yml',
+            status: 'failed',
+          },
+          { status: 'skipped' },
+        ],
+      }),
+    });
+
+    await expect(
+      parseFailedFlowsFromMaestroRunnerReport({
+        reportDirectory: '/reports/attempt-0',
+        workingDirectory: '/project',
+      })
+    ).resolves.toEqual(['flows/nested/fail.yml']);
+    await expect(parseMaestroRunnerReport('/reports/attempt-0')).resolves.toEqual({
+      flows: [
+        { name: 'Passing flow', sourceFile: 'flows/pass.yml', status: 'passed' },
+        {
+          name: 'Failing flow',
+          sourceFile: 'flows/nested/fail.yml',
+          status: 'failed',
+        },
+      ],
+    });
+  });
+
+  it.each([
+    {
+      name: 'incomplete flow',
+      report: {
+        version: '1.0.0',
+        status: 'failed',
+        summary: { total: 1 },
+        flows: [{ name: 'Failing flow', sourceFile: 'flows/fail.yml', status: 'running' }],
+      },
+    },
+  ])('returns null for an $name', async ({ report }) => {
+    vol.fromJSON({
+      '/project/flows/fail.yml': '',
+      '/reports/attempt-0/report.json': JSON.stringify(report),
+    });
+
+    await expect(
+      parseFailedFlowsFromMaestroRunnerReport({
+        reportDirectory: '/reports/attempt-0',
+        workingDirectory: '/project',
+      })
+    ).resolves.toBeNull();
+  });
+
+  it('returns null when a failed sourceFile does not exist', async () => {
+    vol.fromJSON({
+      '/reports/attempt-0/report.json': JSON.stringify({
+        version: '1.0.0',
+        status: 'failed',
+        summary: { total: 1 },
+        flows: [{ name: 'Failing flow', sourceFile: 'flows/missing.yml', status: 'failed' }],
+      }),
+    });
+
+    await expect(
+      parseFailedFlowsFromMaestroRunnerReport({
+        reportDirectory: '/reports/attempt-0',
+        workingDirectory: '/project',
+      })
+    ).resolves.toBeNull();
+  });
+});
 
 describe(parseFailedFlowNamesFromJUnitFile, () => {
   it('returns the names of failed testcases, keeping slashes', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroResultParser.test.ts
@@ -453,6 +453,20 @@ describe('junitFileHasFileAttrs', () => {
     expect(await junitFileHasFileAttrs('/junit/report.xml')).toBe(false);
   });
 
+  it('returns true for a maestro-runner report with a file property', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="a" time="1.0">',
+        '    <properties><property name="file" value="flows/a.yaml"/></properties>',
+        '  </testcase>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+    expect(await junitFileHasFileAttrs('/junit/report.xml')).toBe(true);
+  });
+
   it('returns false when the file cannot be read', async () => {
     expect(await junitFileHasFileAttrs('/missing.xml')).toBe(false);
   });
@@ -476,6 +490,25 @@ describe(parseJUnitTestCases, () => {
     });
     const results = await parseJUnitTestCases('/junit');
     expect(results[0].file).toBe('.maestro/login.yaml');
+  });
+
+  it('parses maestro-runner file properties and standard JUnit pass status', async () => {
+    vol.fromJSON({
+      '/junit/report.xml': [
+        '<?xml version="1.0"?>',
+        '<testsuites><testsuite>',
+        '  <testcase name="login" time="1.0">',
+        '    <properties><property name="file" value="flows/login.yaml"/></properties>',
+        '  </testcase>',
+        '</testsuite></testsuites>',
+      ].join('\n'),
+    });
+
+    const results = await parseJUnitTestCases('/junit');
+
+    expect(results[0]).toEqual(
+      expect.objectContaining({ file: 'flows/login.yaml', status: 'passed' })
+    );
   });
 
   it('treats a missing or empty file= attribute as undefined', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/maestroScreenshots.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroScreenshots.test.ts
@@ -7,9 +7,95 @@ import {
   type HarvestedScreenshot,
   computePureFailureFlowNames,
   harvestFailureScreenshotsAsync,
+  harvestMaestroRunnerFailureScreenshotsAsync,
   parseFailureScreenshotFilename,
   selectFailureScreenshots,
 } from '../maestroScreenshots';
+
+describe(harvestMaestroRunnerFailureScreenshotsAsync, () => {
+  const logger = createMockLogger();
+  let reportDirectory: string;
+
+  beforeEach(async () => {
+    reportDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'maestro-runner-harvest-test-'));
+    await fs.mkdir(path.join(reportDirectory, 'flows'));
+    await fs.mkdir(path.join(reportDirectory, 'assets', 'flow-000'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(reportDirectory, { recursive: true, force: true });
+  });
+
+  it('reads the failed command screenshot from a maestro-runner report bundle', async () => {
+    const capturedSinceMs = Date.now() - 1_000;
+    await fs.writeFile(
+      path.join(reportDirectory, 'report.json'),
+      JSON.stringify({
+        flows: [
+          {
+            name: 'authentication/Login',
+            status: 'failed',
+            dataFile: 'flows/flow-000.json',
+          },
+        ],
+      })
+    );
+    await fs.writeFile(
+      path.join(reportDirectory, 'flows', 'flow-000.json'),
+      JSON.stringify({
+        commands: [
+          {
+            status: 'failed',
+            artifacts: { screenshotAfter: 'assets/flow-000/cmd-001-after.png' },
+          },
+        ],
+      })
+    );
+    const screenshotPath = path.join(reportDirectory, 'assets', 'flow-000', 'cmd-001-after.png');
+    await fs.writeFile(screenshotPath, 'png');
+
+    const shots = await harvestMaestroRunnerFailureScreenshotsAsync({
+      reportDirectory,
+      capturedSinceMs,
+      attemptIndex: 1,
+      logger,
+    });
+
+    expect(shots).toEqual([
+      {
+        fileAbsPath: screenshotPath,
+        displayName: 'Failure Screenshot: authentication_Login (attempt 2)',
+        metadata: {
+          kind: 'maestro-test-screenshot',
+          flowName: 'authentication_Login',
+          attemptIndex: 1,
+          capturedAtMs: expect.any(Number),
+        },
+      },
+    ]);
+  });
+
+  it('ignores passing flows and paths outside the report directory', async () => {
+    await fs.writeFile(
+      path.join(reportDirectory, 'report.json'),
+      JSON.stringify({
+        flows: [
+          { name: 'Passing', status: 'passed', dataFile: 'flows/flow-000.json' },
+          { name: 'Unsafe', status: 'failed', dataFile: '../outside.json' },
+        ],
+      })
+    );
+
+    await expect(
+      harvestMaestroRunnerFailureScreenshotsAsync({
+        reportDirectory,
+        capturedSinceMs: 0,
+        attemptIndex: 0,
+        logger,
+      })
+    ).resolves.toEqual([]);
+  });
+});
 
 describe(parseFailureScreenshotFilename, () => {
   it('parses a plain failure screenshot', () => {

--- a/packages/build-tools/src/steps/functions/__tests__/maestroScreenshots.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroScreenshots.test.ts
@@ -79,6 +79,30 @@ describe(harvestMaestroRunnerFailureScreenshotsAsync, () => {
     ]);
   });
 
+  it('rejects a screenshot path that resolves to the parent directory (exact "..")', async () => {
+    await fs.writeFile(
+      path.join(reportDirectory, 'report.json'),
+      JSON.stringify({
+        flows: [{ name: 'Login', status: 'failed', dataFile: 'flows/flow-000.json' }],
+      })
+    );
+    await fs.writeFile(
+      path.join(reportDirectory, 'flows', 'flow-000.json'),
+      JSON.stringify({
+        commands: [{ status: 'failed', artifacts: { screenshotAfter: '..' } }],
+      })
+    );
+
+    await expect(
+      harvestMaestroRunnerFailureScreenshotsAsync({
+        reportDirectory,
+        capturedSinceMs: 0,
+        attemptIndex: 0,
+        logger,
+      })
+    ).resolves.toEqual([]);
+  });
+
   it('ignores passing flows and paths outside the report directory', async () => {
     await fs.writeFile(
       path.join(reportDirectory, 'report.json'),

--- a/packages/build-tools/src/steps/functions/__tests__/maestroScreenshots.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroScreenshots.test.ts
@@ -95,6 +95,24 @@ describe(harvestMaestroRunnerFailureScreenshotsAsync, () => {
       })
     ).resolves.toEqual([]);
   });
+
+  it.each([
+    ['null', 'null'],
+    ['a non-object flows value', JSON.stringify({ flows: 5 })],
+    ['a null flow entry', JSON.stringify({ flows: [null] })],
+    ['not JSON at all', 'not-json'],
+  ])('returns [] without throwing when report.json is %s', async (_label, contents) => {
+    await fs.writeFile(path.join(reportDirectory, 'report.json'), contents);
+
+    await expect(
+      harvestMaestroRunnerFailureScreenshotsAsync({
+        reportDirectory,
+        capturedSinceMs: 0,
+        attemptIndex: 0,
+        logger,
+      })
+    ).resolves.toEqual([]);
+  });
 });
 
 describe(parseFailureScreenshotFilename, () => {

--- a/packages/build-tools/src/steps/functions/__tests__/maestroScreenshots.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroScreenshots.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 
 import { createMockLogger } from '../../../__tests__/utils/logger';
+import { Sentry } from '../../../sentry';
 import {
   type HarvestedScreenshot,
   computePureFailureFlowNames,
@@ -15,15 +16,18 @@ import {
 describe(harvestMaestroRunnerFailureScreenshotsAsync, () => {
   const logger = createMockLogger();
   let reportDirectory: string;
+  let captureSpy: jest.SpiedFunction<typeof Sentry.capture>;
 
   beforeEach(async () => {
     reportDirectory = await fs.mkdtemp(path.join(os.tmpdir(), 'maestro-runner-harvest-test-'));
     await fs.mkdir(path.join(reportDirectory, 'flows'));
     await fs.mkdir(path.join(reportDirectory, 'assets', 'flow-000'), { recursive: true });
+    captureSpy = jest.spyOn(Sentry, 'capture').mockImplementation(() => {});
   });
 
   afterEach(async () => {
     await fs.rm(reportDirectory, { recursive: true, force: true });
+    captureSpy.mockRestore();
   });
 
   it('reads the failed command screenshot from a maestro-runner report bundle', async () => {
@@ -100,8 +104,7 @@ describe(harvestMaestroRunnerFailureScreenshotsAsync, () => {
     ['null', 'null'],
     ['a non-object flows value', JSON.stringify({ flows: 5 })],
     ['a null flow entry', JSON.stringify({ flows: [null] })],
-    ['not JSON at all', 'not-json'],
-  ])('returns [] without throwing when report.json is %s', async (_label, contents) => {
+  ])('reports to Sentry and returns [] when report.json is %s', async (_label, contents) => {
     await fs.writeFile(path.join(reportDirectory, 'report.json'), contents);
 
     await expect(
@@ -112,6 +115,21 @@ describe(harvestMaestroRunnerFailureScreenshotsAsync, () => {
         logger,
       })
     ).resolves.toEqual([]);
+    expect(captureSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns [] without reporting to Sentry when report.json is not valid JSON', async () => {
+    await fs.writeFile(path.join(reportDirectory, 'report.json'), 'not-json');
+
+    await expect(
+      harvestMaestroRunnerFailureScreenshotsAsync({
+        reportDirectory,
+        capturedSinceMs: 0,
+        attemptIndex: 0,
+        logger,
+      })
+    ).resolves.toEqual([]);
+    expect(captureSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -270,6 +270,20 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(mockedSpawn).not.toHaveBeenCalled();
   });
 
+  it('rejects a non-junit output_format with maestro-runner', async () => {
+    const step = createStep({
+      flow_path: ['flows/a.yaml'],
+      platform: 'android',
+      backend: 'maestro-runner',
+      output_format: 'html',
+    });
+
+    await expect(step.executeAsync()).rejects.toThrow(
+      'maestro-runner only supports the "junit" output_format'
+    );
+    expect(mockedSpawn).not.toHaveBeenCalled();
+  });
+
   it('logs that maestro-runner does not support direct DADB', async () => {
     mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
     jest.spyOn(fs, 'copyFile').mockResolvedValue();
@@ -610,38 +624,35 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(a1Args).not.toContain('flows/c.yaml');
   });
 
-  it.each(['junit', 'html'])(
-    'uses maestro-runner report.json for %s retries',
-    async outputFormat => {
-      mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
-      jest.spyOn(fs, 'copyFile').mockResolvedValue();
-      const runnerReportSpy = jest
-        .spyOn(parser, 'parseFailedFlowsFromMaestroRunnerReport')
-        .mockResolvedValue(['flows/b.yaml']);
-      const junitParseSpy = jest.spyOn(parser, 'parseFailedFlowsFromJUnit');
+  it('uses maestro-runner report.json for junit retries', async () => {
+    mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
+    jest.spyOn(fs, 'copyFile').mockResolvedValue();
+    const runnerReportSpy = jest
+      .spyOn(parser, 'parseFailedFlowsFromMaestroRunnerReport')
+      .mockResolvedValue(['flows/b.yaml']);
+    const junitParseSpy = jest.spyOn(parser, 'parseFailedFlowsFromJUnit');
 
-      const step = createStep({
-        flow_path: ['flows/a.yaml', 'flows/b.yaml'],
-        retries: 1,
-        output_format: outputFormat,
-        platform: 'ios',
-        backend: 'maestro-runner',
-      });
-      await step.executeAsync();
+    const step = createStep({
+      flow_path: ['flows/a.yaml', 'flows/b.yaml'],
+      retries: 1,
+      output_format: 'junit',
+      platform: 'ios',
+      backend: 'maestro-runner',
+    });
+    await step.executeAsync();
 
-      expect(runnerReportSpy).toHaveBeenCalledWith({
-        reportDirectory: '/home/expo/.maestro/tests/ios-maestro-runner-attempt-0',
-        workingDirectory: expect.any(String),
-      });
-      expect(junitParseSpy).not.toHaveBeenCalled();
-      expect(mockedSpawn.mock.calls[0][1]).toEqual(
-        expect.arrayContaining(['flows/a.yaml', 'flows/b.yaml'])
-      );
-      const retryArgs = mockedSpawn.mock.calls[1][1]!;
-      expect(retryArgs).toContain('flows/b.yaml');
-      expect(retryArgs).not.toContain('flows/a.yaml');
-    }
-  );
+    expect(runnerReportSpy).toHaveBeenCalledWith({
+      reportDirectory: '/home/expo/.maestro/tests/ios-maestro-runner-attempt-0',
+      workingDirectory: expect.any(String),
+    });
+    expect(junitParseSpy).not.toHaveBeenCalled();
+    expect(mockedSpawn.mock.calls[0][1]).toEqual(
+      expect.arrayContaining(['flows/a.yaml', 'flows/b.yaml'])
+    );
+    const retryArgs = mockedSpawn.mock.calls[1][1]!;
+    expect(retryArgs).toContain('flows/b.yaml');
+    expect(retryArgs).not.toContain('flows/a.yaml');
+  });
 
   it('retries all flows when parseFailedFlowsFromJUnit returns null', async () => {
     const spawnMock = mockedSpawn

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -27,10 +27,14 @@ jest.mock('../../../utils/retry', () => ({
 jest.mock('../maestroScreenshots', () => ({
   ...jest.requireActual('../maestroScreenshots'),
   harvestFailureScreenshotsAsync: jest.fn(),
+  harvestMaestroRunnerFailureScreenshotsAsync: jest.fn(),
 }));
 
 const mockedSpawn = jest.mocked(spawn);
 const mockedHarvest = jest.mocked(maestroScreenshots.harvestFailureScreenshotsAsync);
+const mockedRunnerHarvest = jest.mocked(
+  maestroScreenshots.harvestMaestroRunnerFailureScreenshotsAsync
+);
 const mockUploadArtifact = jest.fn();
 
 function makeShot(index: number): maestroScreenshots.HarvestedScreenshot {
@@ -89,6 +93,8 @@ describe('createMaestroTestsBuildFunction', () => {
     jest.spyOn(parser, 'mergeJUnitReports').mockResolvedValue();
     mockedHarvest.mockReset();
     mockedHarvest.mockResolvedValue([]);
+    mockedRunnerHarvest.mockReset();
+    mockedRunnerHarvest.mockResolvedValue([]);
     mockUploadArtifact.mockReset();
     mockUploadArtifact.mockResolvedValue({ artifactId: 'artifact-1' });
   });
@@ -135,6 +141,134 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(args).toEqual(expect.arrayContaining(['test', 'flows/a.yaml', 'flows/b.yaml']));
     expect(args).toEqual(expect.arrayContaining(['--format=JUNIT']));
     expect(args!.join(' ')).toMatch(/--output=.*android-maestro-junit-attempt-0\.xml/);
+  });
+
+  it('runs maestro-runner and collects its JUnit report when selected by input', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const copyFileSpy = jest.spyOn(fs, 'copyFile').mockResolvedValue();
+    const step = createStep({
+      flow_path: ['flows/a.yaml', 'flows/b.yaml'],
+      output_format: 'junit',
+      platform: 'ios',
+      backend: 'maestro-runner',
+    });
+
+    await step.executeAsync();
+
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+    const [command, args] = mockedSpawn.mock.calls[0];
+    expect(command).toBe('maestro-runner');
+    expect(args).toEqual([
+      '--platform=ios',
+      'test',
+      '--output=/home/expo/.maestro/tests/ios-maestro-runner-attempt-0',
+      '--flatten',
+      'flows/a.yaml',
+      'flows/b.yaml',
+    ]);
+    expect(copyFileSpy).toHaveBeenCalledWith(
+      '/home/expo/.maestro/tests/ios-maestro-runner-attempt-0/junit-report.xml',
+      '/home/expo/.maestro/tests/junit-reports/ios-maestro-junit-attempt-0.xml'
+    );
+    expect(mockedHarvest).not.toHaveBeenCalled();
+    expect(mockedRunnerHarvest).toHaveBeenCalledWith({
+      reportDirectory: '/home/expo/.maestro/tests/ios-maestro-runner-attempt-0',
+      capturedSinceMs: expect.any(Number),
+      attemptIndex: 0,
+      logger: expect.anything(),
+    });
+  });
+
+  it('selects maestro-runner from EAS_MAESTRO_BACKEND', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    jest.spyOn(fs, 'copyFile').mockResolvedValue();
+    const step = createStep(
+      { flow_path: ['flows/a.yaml'], platform: 'android' },
+      { env: { HOME: '/home/expo', EAS_MAESTRO_BACKEND: 'maestro-runner' } }
+    );
+
+    await step.executeAsync();
+
+    expect(mockedSpawn.mock.calls[0][0]).toBe('maestro-runner');
+  });
+
+  it('prefers the backend input over EAS_MAESTRO_BACKEND', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const step = createStep(
+      { flow_path: ['flows/a.yaml'], platform: 'android', backend: 'maestro' },
+      { env: { HOME: '/home/expo', EAS_MAESTRO_BACKEND: 'maestro-runner' } }
+    );
+
+    await step.executeAsync();
+
+    expect(mockedSpawn.mock.calls[0][0]).toBe('maestro');
+  });
+
+  it('passes tags to maestro-runner', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    jest.spyOn(fs, 'copyFile').mockResolvedValue();
+    const step = createStep({
+      flow_path: ['flows/a.yaml'],
+      platform: 'android',
+      backend: 'maestro-runner',
+      include_tags: 'smoke',
+      exclude_tags: 'slow',
+    });
+
+    await step.executeAsync();
+
+    expect(mockedSpawn.mock.calls[0][1]).toEqual(
+      expect.arrayContaining(['--include-tags=smoke', '--exclude-tags=slow'])
+    );
+  });
+
+  it('rejects invalid backend values', async () => {
+    const step = createStep({
+      flow_path: ['flows/a.yaml'],
+      platform: 'android',
+      backend: 'other',
+    });
+
+    await expect(step.executeAsync()).rejects.toThrow(UserError);
+    expect(mockedSpawn).not.toHaveBeenCalled();
+  });
+
+  it('rejects sharding with maestro-runner', async () => {
+    const step = createStep({
+      flow_path: ['flows/a.yaml'],
+      platform: 'android',
+      backend: 'maestro-runner',
+      shards: 2,
+    });
+
+    await expect(step.executeAsync()).rejects.toThrow(
+      'maestro-runner does not support EAS Maestro test sharding'
+    );
+    expect(mockedSpawn).not.toHaveBeenCalled();
+  });
+
+  it('logs that maestro-runner does not support direct DADB', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    jest.spyOn(fs, 'copyFile').mockResolvedValue();
+    const logger = createMockLogger();
+    jest.mocked(logger.child).mockReturnValue(logger);
+    const step = createStep(
+      {
+        flow_path: ['flows/a.yaml'],
+        platform: 'android',
+        backend: 'maestro-runner',
+        android_connection_mode: 'dadb',
+      },
+      { env: { HOME: '/home/expo', PATH: '/usr/bin' }, logger }
+    );
+
+    await step.executeAsync();
+
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+    expect(mockedSpawn.mock.calls[0][0]).toBe('maestro-runner');
+    expect(logger.info).toHaveBeenCalledWith(
+      'maestro-runner does not support DADB. Using the default ADB connection.'
+    );
   });
 
   it('uses direct DADB when android_connection_mode is dadb without cleanup', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -181,6 +181,27 @@ describe('createMaestroTestsBuildFunction', () => {
     });
   });
 
+  it('clears the deterministic maestro-runner output directory before each attempt', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    jest.spyOn(fs, 'copyFile').mockResolvedValue();
+    const rmSpy = jest.spyOn(fs, 'rm').mockResolvedValue();
+    const step = createStep({
+      flow_path: ['flows/a.yaml'],
+      output_format: 'junit',
+      platform: 'ios',
+      backend: 'maestro-runner',
+    });
+
+    await step.executeAsync();
+
+    expect(rmSpy).toHaveBeenCalledWith('/home/expo/.maestro/tests/ios-maestro-runner-attempt-0', {
+      recursive: true,
+      force: true,
+    });
+    // Cleared before the run, so a crash before fresh output can't resurrect stale results.
+    expect(rmSpy.mock.invocationCallOrder[0]).toBeLessThan(mockedSpawn.mock.invocationCallOrder[0]);
+  });
+
   it('selects maestro-runner from EAS_MAESTRO_BACKEND', async () => {
     mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
     jest.spyOn(fs, 'copyFile').mockResolvedValue();

--- a/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/maestroTests.test.ts
@@ -146,6 +146,7 @@ describe('createMaestroTestsBuildFunction', () => {
   it('runs maestro-runner and collects its JUnit report when selected by input', async () => {
     mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
     const copyFileSpy = jest.spyOn(fs, 'copyFile').mockResolvedValue();
+    const junitFailureNamesSpy = jest.spyOn(parser, 'parseFailedFlowNamesFromJUnitFile');
     const step = createStep({
       flow_path: ['flows/a.yaml', 'flows/b.yaml'],
       output_format: 'junit',
@@ -171,6 +172,7 @@ describe('createMaestroTestsBuildFunction', () => {
       '/home/expo/.maestro/tests/junit-reports/ios-maestro-junit-attempt-0.xml'
     );
     expect(mockedHarvest).not.toHaveBeenCalled();
+    expect(junitFailureNamesSpy).not.toHaveBeenCalled();
     expect(mockedRunnerHarvest).toHaveBeenCalledWith({
       reportDirectory: '/home/expo/.maestro/tests/ios-maestro-runner-attempt-0',
       capturedSinceMs: expect.any(Number),
@@ -586,6 +588,39 @@ describe('createMaestroTestsBuildFunction', () => {
     expect(a1Args).not.toContain('flows/a.yaml');
     expect(a1Args).not.toContain('flows/c.yaml');
   });
+
+  it.each(['junit', 'html'])(
+    'uses maestro-runner report.json for %s retries',
+    async outputFormat => {
+      mockedSpawn.mockRejectedValueOnce(rejectExit1()).mockResolvedValueOnce(SPAWN_SUCCESS);
+      jest.spyOn(fs, 'copyFile').mockResolvedValue();
+      const runnerReportSpy = jest
+        .spyOn(parser, 'parseFailedFlowsFromMaestroRunnerReport')
+        .mockResolvedValue(['flows/b.yaml']);
+      const junitParseSpy = jest.spyOn(parser, 'parseFailedFlowsFromJUnit');
+
+      const step = createStep({
+        flow_path: ['flows/a.yaml', 'flows/b.yaml'],
+        retries: 1,
+        output_format: outputFormat,
+        platform: 'ios',
+        backend: 'maestro-runner',
+      });
+      await step.executeAsync();
+
+      expect(runnerReportSpy).toHaveBeenCalledWith({
+        reportDirectory: '/home/expo/.maestro/tests/ios-maestro-runner-attempt-0',
+        workingDirectory: expect.any(String),
+      });
+      expect(junitParseSpy).not.toHaveBeenCalled();
+      expect(mockedSpawn.mock.calls[0][1]).toEqual(
+        expect.arrayContaining(['flows/a.yaml', 'flows/b.yaml'])
+      );
+      const retryArgs = mockedSpawn.mock.calls[1][1]!;
+      expect(retryArgs).toContain('flows/b.yaml');
+      expect(retryArgs).not.toContain('flows/a.yaml');
+    }
+  );
 
   it('retries all flows when parseFailedFlowsFromJUnit returns null', async () => {
     const spawnMock = mockedSpawn
@@ -1146,6 +1181,29 @@ describe('createMaestroTestsBuildFunction', () => {
         }),
       })
     );
+  });
+
+  it('discovers maestro-runner flow results from the attempt report directory', async () => {
+    mockedSpawn.mockResolvedValue(SPAWN_SUCCESS);
+    const shot = makeShot(0);
+    jest.spyOn(fs, 'copyFile').mockResolvedValue();
+    mockedRunnerHarvest.mockResolvedValue([shot]);
+    const parseFlowResultsSpy = jest.spyOn(parser, 'parseMaestroRunnerReport').mockResolvedValue({
+      flows: [{ name: 'Login', sourceFile: 'a.yaml', status: 'failed' }],
+    });
+
+    const step = createStep({
+      flow_path: ['a.yaml'],
+      platform: 'ios',
+      output_format: 'junit',
+      backend: 'maestro-runner',
+    });
+    await step.executeAsync();
+
+    expect(parseFlowResultsSpy).toHaveBeenCalledWith(
+      '/home/expo/.maestro/tests/ios-maestro-runner-attempt-0'
+    );
+    expect(mockUploadArtifact).toHaveBeenCalledTimes(1);
   });
 
   it('uploads screenshots even when all attempts fail, before throwing ERR_MAESTRO_TESTS_FAILED', async () => {

--- a/packages/build-tools/src/steps/functions/maestroResultParser.ts
+++ b/packages/build-tools/src/steps/functions/maestroResultParser.ts
@@ -2,6 +2,7 @@ import { asyncResult } from '@expo/results';
 import { XMLBuilder, XMLParser, XMLValidator } from 'fast-xml-parser';
 import fs from 'fs/promises';
 import path from 'path';
+import { z } from 'zod';
 
 export interface MaestroFlowResult {
   name: string;
@@ -190,6 +191,69 @@ export async function junitFileHasFileAttrs(junitFile: string): Promise<boolean>
 
 async function fileExists(absPath: string): Promise<boolean> {
   return (await asyncResult(fs.stat(absPath))).ok;
+}
+
+// maestro-runner writes report.json as the source of truth for a run. Use it for runner control
+// flow because sourceFile preserves the exact flow path, while older runner JUnit reports flatten
+// it to a basename. Keep only passed and failed flows so the result matches Maestro JUnit reports,
+// which do not include skipped flows.
+const MaestroRunnerRecordedFlowSchema = z.object({
+  name: z.string().min(1),
+  sourceFile: z.string().min(1),
+  status: z.enum(['passed', 'failed']),
+});
+const MaestroRunnerReportSchema = z.object({
+  flows: z
+    .array(
+      z.discriminatedUnion('status', [
+        MaestroRunnerRecordedFlowSchema,
+        z.object({ status: z.literal('skipped') }),
+      ])
+    )
+    .transform(flows =>
+      flows.filter(
+        (flow): flow is z.infer<typeof MaestroRunnerRecordedFlowSchema> => flow.status !== 'skipped'
+      )
+    ),
+});
+
+type MaestroRunnerReport = z.infer<typeof MaestroRunnerReportSchema>;
+
+export async function parseFailedFlowsFromMaestroRunnerReport(args: {
+  reportDirectory: string;
+  workingDirectory: string;
+}): Promise<string[] | null> {
+  const report = await parseMaestroRunnerReport(args.reportDirectory);
+  if (report === null) {
+    return null;
+  }
+
+  const failedPaths = [
+    ...new Set(report.flows.filter(flow => flow.status === 'failed').map(flow => flow.sourceFile)),
+  ];
+  if (failedPaths.length === 0) {
+    return null;
+  }
+
+  for (const flowPath of failedPaths) {
+    if (!(await fileExists(path.resolve(args.workingDirectory, flowPath)))) {
+      return null;
+    }
+  }
+  return failedPaths;
+}
+
+export async function parseMaestroRunnerReport(
+  reportDirectory: string
+): Promise<MaestroRunnerReport | null> {
+  let report: unknown;
+  try {
+    report = JSON.parse(await fs.readFile(path.join(reportDirectory, 'report.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+  const result = MaestroRunnerReportSchema.safeParse(report);
+  return result.success ? result.data : null;
 }
 
 // Group by `file=` so two same-named flows in different files stay separate.

--- a/packages/build-tools/src/steps/functions/maestroResultParser.ts
+++ b/packages/build-tools/src/steps/functions/maestroResultParser.ts
@@ -34,10 +34,16 @@ const xmlParser = new XMLParser({
   isArray: name => ['testsuite', 'testcase', 'property'].includes(name),
 });
 
-// A `file=` attribute counts as present only when it is a non-empty string.
+// Official Maestro writes the flow path as a `file=` testcase attribute. maestro-runner writes
+// the same value as a `<property name="file" value="..."/>` child.
 function fileAttrOf(tc: any): string | undefined {
   const f = tc?.['@_file'];
-  return typeof f === 'string' && f.length > 0 ? f : undefined;
+  if (typeof f === 'string' && f.length > 0) {
+    return f;
+  }
+  const properties: { '@_name'?: unknown; '@_value'?: unknown }[] = tc?.properties?.property ?? [];
+  const fileProperty = properties.find(property => property['@_name'] === 'file')?.['@_value'];
+  return typeof fileProperty === 'string' && fileProperty.length > 0 ? fileProperty : undefined;
 }
 
 function parseJUnitContent(content: string): JUnitTestCaseResult[] {
@@ -68,7 +74,6 @@ function parseJUnitContent(content: string): JUnitTestCaseResult[] {
         const timeSeconds = timeStr ? parseFloat(timeStr) : 0;
         const duration = Number.isFinite(timeSeconds) ? Math.round(timeSeconds * 1000) : 0;
 
-        const status: 'passed' | 'failed' = tc['@_status'] === 'SUCCESS' ? 'passed' : 'failed';
         const failureText =
           tc.failure != null
             ? typeof tc.failure === 'string'
@@ -82,6 +87,17 @@ function parseJUnitContent(content: string): JUnitTestCaseResult[] {
               : (tc.error?.['#text'] ?? null)
             : null;
         const errorMessage: string | null = failureText ?? errorText ?? null;
+        // Official Maestro uses status="SUCCESS". maestro-runner uses standard JUnit semantics:
+        // a testcase passes when it has no failure or error child.
+        const statusAttribute = tc['@_status'];
+        const status: 'passed' | 'failed' =
+          typeof statusAttribute === 'string'
+            ? statusAttribute === 'SUCCESS'
+              ? 'passed'
+              : 'failed'
+            : tc.failure == null && tc.error == null
+              ? 'passed'
+              : 'failed';
 
         const rawProperties: { '@_name': string; '@_value': string }[] =
           tc.properties?.property ?? [];

--- a/packages/build-tools/src/steps/functions/maestroResultParser.ts
+++ b/packages/build-tools/src/steps/functions/maestroResultParser.ts
@@ -69,6 +69,13 @@ function parseJUnitContent(content: string): JUnitTestCaseResult[] {
           continue;
         }
 
+        // Standard JUnit marks skipped tests with a <skipped/> child (no failure/error). Exclude
+        // them so they aren't miscounted as passed, matching the report.json path which drops
+        // skipped flows.
+        if (tc.skipped != null) {
+          continue;
+        }
+
         const file = fileAttrOf(tc);
 
         const timeStr = tc['@_time'];

--- a/packages/build-tools/src/steps/functions/maestroResultParser.ts
+++ b/packages/build-tools/src/steps/functions/maestroResultParser.ts
@@ -75,17 +75,20 @@ function parseJUnitContent(content: string): JUnitTestCaseResult[] {
         const timeSeconds = timeStr ? parseFloat(timeStr) : 0;
         const duration = Number.isFinite(timeSeconds) ? Math.round(timeSeconds * 1000) : 0;
 
+        // maestro-runner puts the real error in the `message` attribute and the command
+        // label (e.g. `tapOn`) in the body; official Maestro only writes the body. Prefer
+        // `@_message` and fall back to `#text` so both stay correct.
         const failureText =
           tc.failure != null
             ? typeof tc.failure === 'string'
               ? tc.failure
-              : (tc.failure?.['#text'] ?? null)
+              : (tc.failure?.['@_message'] ?? tc.failure?.['#text'] ?? null)
             : null;
         const errorText =
           tc.error != null
             ? typeof tc.error === 'string'
               ? tc.error
-              : (tc.error?.['#text'] ?? null)
+              : (tc.error?.['@_message'] ?? tc.error?.['#text'] ?? null)
             : null;
         const errorMessage: string | null = failureText ?? errorText ?? null;
         // Official Maestro uses status="SUCCESS". maestro-runner uses standard JUnit semantics:

--- a/packages/build-tools/src/steps/functions/maestroScreenshots.ts
+++ b/packages/build-tools/src/steps/functions/maestroScreenshots.ts
@@ -4,6 +4,8 @@ import fs from 'fs/promises';
 import path from 'path';
 import { z } from 'zod';
 
+import { Sentry } from '../../sentry';
+
 export interface ParsedFailureScreenshot {
   flowName: string;
   capturedAtMs: number;
@@ -134,9 +136,6 @@ export async function harvestFailureScreenshotsAsync(args: {
   return [...legacyShots, ...dedupeBundleShotsByFlowName(bundleShots)];
 }
 
-// maestro-runner's per-flow command tree; failed leaves point at their failure screenshots.
-// Recursive via a getter (zod v4). Unknown keys are stripped, so real reports (which carry many
-// more fields) still validate.
 const MaestroRunnerCommandSchema = z.object({
   status: z.string().optional(),
   artifacts: z
@@ -151,14 +150,10 @@ const MaestroRunnerCommandSchema = z.object({
 });
 type MaestroRunnerCommand = z.infer<typeof MaestroRunnerCommandSchema>;
 
-// maestro-runner's per-flow detail file (referenced by `flow.dataFile`).
 const MaestroRunnerFlowDetailSchema = z.object({
   commands: z.array(MaestroRunnerCommandSchema).optional(),
 });
 
-// maestro-runner's report.json, narrowed to what the screenshot harvest needs. Tolerant by
-// design: an unexpected shape (`null`, `{ "flows": 5 }`, `{ "flows": [null] }`) fails safeParse
-// and yields no flows rather than throwing out of this "never throws" harvest.
 const MaestroRunnerScreenshotReportSchema = z.object({
   flows: z
     .array(
@@ -192,7 +187,15 @@ export async function harvestMaestroRunnerFailureScreenshotsAsync(args: {
   }
 
   const parsedReport = MaestroRunnerScreenshotReportSchema.safeParse(report);
-  const flows = parsedReport.success ? (parsedReport.data.flows ?? []) : [];
+  if (!parsedReport.success) {
+    args.logger.warn(
+      { err: parsedReport.error },
+      `Skipping maestro-runner screenshot harvest: unexpected report.json shape in ${args.reportDirectory}.`
+    );
+    Sentry.capture('maestro-runner report.json failed schema validation', parsedReport.error);
+    return [];
+  }
+  const flows = parsedReport.data.flows ?? [];
 
   const shots: HarvestedScreenshot[] = [];
   for (const { name, status, dataFile } of flows) {
@@ -211,10 +214,11 @@ export async function harvestMaestroRunnerFailureScreenshotsAsync(args: {
         JSON.parse(await fs.readFile(flowDataPath, 'utf8'))
       );
       if (!detail.success) {
-        args.logger.info(
+        args.logger.warn(
           { err: detail.error },
           `Skipping malformed maestro-runner flow data ${flowDataPath}.`
         );
+        Sentry.capture('maestro-runner flow data failed schema validation', detail.error);
         continue;
       }
       screenshotPath = findFailedMaestroRunnerScreenshot(detail.data.commands ?? []);

--- a/packages/build-tools/src/steps/functions/maestroScreenshots.ts
+++ b/packages/build-tools/src/steps/functions/maestroScreenshots.ts
@@ -2,6 +2,7 @@ import { bunyan } from '@expo/logger';
 import { type Dirent } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
+import { z } from 'zod';
 
 export interface ParsedFailureScreenshot {
   flowName: string;
@@ -133,14 +134,42 @@ export async function harvestFailureScreenshotsAsync(args: {
   return [...legacyShots, ...dedupeBundleShotsByFlowName(bundleShots)];
 }
 
-interface MaestroRunnerCommand {
-  status?: string;
-  artifacts?: {
-    screenshotBefore?: string;
-    screenshotAfter?: string;
-  };
-  subCommands?: MaestroRunnerCommand[];
-}
+// maestro-runner's per-flow command tree; failed leaves point at their failure screenshots.
+// Recursive via a getter (zod v4). Unknown keys are stripped, so real reports (which carry many
+// more fields) still validate.
+const MaestroRunnerCommandSchema = z.object({
+  status: z.string().optional(),
+  artifacts: z
+    .object({
+      screenshotBefore: z.string().optional(),
+      screenshotAfter: z.string().optional(),
+    })
+    .optional(),
+  get subCommands() {
+    return z.array(MaestroRunnerCommandSchema).optional();
+  },
+});
+type MaestroRunnerCommand = z.infer<typeof MaestroRunnerCommandSchema>;
+
+// maestro-runner's per-flow detail file (referenced by `flow.dataFile`).
+const MaestroRunnerFlowDetailSchema = z.object({
+  commands: z.array(MaestroRunnerCommandSchema).optional(),
+});
+
+// maestro-runner's report.json, narrowed to what the screenshot harvest needs. Tolerant by
+// design: an unexpected shape (`null`, `{ "flows": 5 }`, `{ "flows": [null] }`) fails safeParse
+// and yields no flows rather than throwing out of this "never throws" harvest.
+const MaestroRunnerScreenshotReportSchema = z.object({
+  flows: z
+    .array(
+      z.object({
+        name: z.string().optional(),
+        status: z.string().optional(),
+        dataFile: z.string().optional(),
+      })
+    )
+    .optional(),
+});
 
 // maestro-runner records failure screenshot paths in its report JSON instead of using the
 // official Maestro debug-directory layout. Never throws, so screenshots cannot change the test
@@ -162,23 +191,11 @@ export async function harvestMaestroRunnerFailureScreenshotsAsync(args: {
     return [];
   }
 
-  // Validate the shape before iterating: valid JSON of an unexpected shape (`null`,
-  // `{ "flows": 5 }`, `{ "flows": [null] }`) must not throw out of this "never throws" harvest.
-  const flows =
-    typeof report === 'object' && report !== null && Array.isArray((report as any).flows)
-      ? (report as { flows: unknown[] }).flows
-      : [];
+  const parsedReport = MaestroRunnerScreenshotReportSchema.safeParse(report);
+  const flows = parsedReport.success ? (parsedReport.data.flows ?? []) : [];
 
   const shots: HarvestedScreenshot[] = [];
-  for (const flow of flows) {
-    if (typeof flow !== 'object' || flow === null) {
-      continue;
-    }
-    const { name, status, dataFile } = flow as {
-      name?: string;
-      status?: string;
-      dataFile?: string;
-    };
+  for (const { name, status, dataFile } of flows) {
     if (status !== 'failed' || !name || !dataFile) {
       continue;
     }
@@ -190,10 +207,17 @@ export async function harvestMaestroRunnerFailureScreenshotsAsync(args: {
 
     let screenshotPath: string | undefined;
     try {
-      const detail = JSON.parse(await fs.readFile(flowDataPath, 'utf8')) as {
-        commands?: MaestroRunnerCommand[];
-      };
-      screenshotPath = findFailedMaestroRunnerScreenshot(detail.commands ?? []);
+      const detail = MaestroRunnerFlowDetailSchema.safeParse(
+        JSON.parse(await fs.readFile(flowDataPath, 'utf8'))
+      );
+      if (!detail.success) {
+        args.logger.info(
+          { err: detail.error },
+          `Skipping malformed maestro-runner flow data ${flowDataPath}.`
+        );
+        continue;
+      }
+      screenshotPath = findFailedMaestroRunnerScreenshot(detail.data.commands ?? []);
     } catch (err: any) {
       args.logger.info({ err }, `Skipping unreadable maestro-runner flow data ${flowDataPath}.`);
       continue;

--- a/packages/build-tools/src/steps/functions/maestroScreenshots.ts
+++ b/packages/build-tools/src/steps/functions/maestroScreenshots.ts
@@ -151,9 +151,7 @@ export async function harvestMaestroRunnerFailureScreenshotsAsync(args: {
   attemptIndex: number;
   logger: bunyan;
 }): Promise<HarvestedScreenshot[]> {
-  let report: {
-    flows?: { name?: string; status?: string; dataFile?: string }[];
-  };
+  let report: unknown;
   try {
     report = JSON.parse(await fs.readFile(path.join(args.reportDirectory, 'report.json'), 'utf8'));
   } catch (err: any) {
@@ -164,12 +162,27 @@ export async function harvestMaestroRunnerFailureScreenshotsAsync(args: {
     return [];
   }
 
+  // Validate the shape before iterating: valid JSON of an unexpected shape (`null`,
+  // `{ "flows": 5 }`, `{ "flows": [null] }`) must not throw out of this "never throws" harvest.
+  const flows =
+    typeof report === 'object' && report !== null && Array.isArray((report as any).flows)
+      ? (report as { flows: unknown[] }).flows
+      : [];
+
   const shots: HarvestedScreenshot[] = [];
-  for (const flow of report.flows ?? []) {
-    if (flow.status !== 'failed' || !flow.name || !flow.dataFile) {
+  for (const flow of flows) {
+    if (typeof flow !== 'object' || flow === null) {
       continue;
     }
-    const flowDataPath = resolvePathInsideDirectory(args.reportDirectory, flow.dataFile);
+    const { name, status, dataFile } = flow as {
+      name?: string;
+      status?: string;
+      dataFile?: string;
+    };
+    if (status !== 'failed' || !name || !dataFile) {
+      continue;
+    }
+    const flowDataPath = resolvePathInsideDirectory(args.reportDirectory, dataFile);
     if (!flowDataPath) {
       args.logger.info(`Skipping maestro-runner flow data outside the report directory.`);
       continue;
@@ -205,7 +218,7 @@ export async function harvestMaestroRunnerFailureScreenshotsAsync(args: {
       continue;
     }
 
-    const flowName = normalizeFlowName(flow.name);
+    const flowName = normalizeFlowName(name);
     shots.push({
       fileAbsPath,
       displayName: `Failure Screenshot: ${flowName} (attempt ${args.attemptIndex + 1})`,

--- a/packages/build-tools/src/steps/functions/maestroScreenshots.ts
+++ b/packages/build-tools/src/steps/functions/maestroScreenshots.ts
@@ -281,7 +281,7 @@ function findFailedMaestroRunnerScreenshot(
 function resolvePathInsideDirectory(directory: string, relativePath: string): string | null {
   const candidate = path.resolve(directory, relativePath);
   const relative = path.relative(directory, candidate);
-  return relative === '' || (!relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  return relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)
     ? candidate
     : null;
 }

--- a/packages/build-tools/src/steps/functions/maestroScreenshots.ts
+++ b/packages/build-tools/src/steps/functions/maestroScreenshots.ts
@@ -133,6 +133,118 @@ export async function harvestFailureScreenshotsAsync(args: {
   return [...legacyShots, ...dedupeBundleShotsByFlowName(bundleShots)];
 }
 
+interface MaestroRunnerCommand {
+  status?: string;
+  artifacts?: {
+    screenshotBefore?: string;
+    screenshotAfter?: string;
+  };
+  subCommands?: MaestroRunnerCommand[];
+}
+
+// maestro-runner records failure screenshot paths in its report JSON instead of using the
+// official Maestro debug-directory layout. Never throws, so screenshots cannot change the test
+// result.
+export async function harvestMaestroRunnerFailureScreenshotsAsync(args: {
+  reportDirectory: string;
+  capturedSinceMs: number;
+  attemptIndex: number;
+  logger: bunyan;
+}): Promise<HarvestedScreenshot[]> {
+  let report: {
+    flows?: { name?: string; status?: string; dataFile?: string }[];
+  };
+  try {
+    report = JSON.parse(await fs.readFile(path.join(args.reportDirectory, 'report.json'), 'utf8'));
+  } catch (err: any) {
+    args.logger.info(
+      { err },
+      `Skipping maestro-runner screenshot harvest: cannot read ${args.reportDirectory}.`
+    );
+    return [];
+  }
+
+  const shots: HarvestedScreenshot[] = [];
+  for (const flow of report.flows ?? []) {
+    if (flow.status !== 'failed' || !flow.name || !flow.dataFile) {
+      continue;
+    }
+    const flowDataPath = resolvePathInsideDirectory(args.reportDirectory, flow.dataFile);
+    if (!flowDataPath) {
+      args.logger.info(`Skipping maestro-runner flow data outside the report directory.`);
+      continue;
+    }
+
+    let screenshotPath: string | undefined;
+    try {
+      const detail = JSON.parse(await fs.readFile(flowDataPath, 'utf8')) as {
+        commands?: MaestroRunnerCommand[];
+      };
+      screenshotPath = findFailedMaestroRunnerScreenshot(detail.commands ?? []);
+    } catch (err: any) {
+      args.logger.info({ err }, `Skipping unreadable maestro-runner flow data ${flowDataPath}.`);
+      continue;
+    }
+    if (!screenshotPath) {
+      continue;
+    }
+
+    const fileAbsPath = resolvePathInsideDirectory(args.reportDirectory, screenshotPath);
+    if (!fileAbsPath) {
+      args.logger.info(`Skipping maestro-runner screenshot outside the report directory.`);
+      continue;
+    }
+    let capturedAtMs: number;
+    try {
+      capturedAtMs = Math.round((await fs.stat(fileAbsPath)).mtimeMs);
+    } catch (err: any) {
+      args.logger.info({ err }, `Skipping unreadable screenshot ${fileAbsPath}.`);
+      continue;
+    }
+    if (capturedAtMs < args.capturedSinceMs) {
+      continue;
+    }
+
+    const flowName = normalizeFlowName(flow.name);
+    shots.push({
+      fileAbsPath,
+      displayName: `Failure Screenshot: ${flowName} (attempt ${args.attemptIndex + 1})`,
+      metadata: {
+        kind: 'maestro-test-screenshot',
+        flowName,
+        attemptIndex: args.attemptIndex,
+        capturedAtMs,
+      },
+    });
+  }
+  return shots;
+}
+
+function findFailedMaestroRunnerScreenshot(
+  commands: readonly MaestroRunnerCommand[]
+): string | undefined {
+  for (const command of commands) {
+    if (command.status !== 'failed') {
+      continue;
+    }
+    const nested = findFailedMaestroRunnerScreenshot(command.subCommands ?? []);
+    const screenshot =
+      nested ?? command.artifacts?.screenshotAfter ?? command.artifacts?.screenshotBefore;
+    if (screenshot) {
+      return screenshot;
+    }
+  }
+  return undefined;
+}
+
+function resolvePathInsideDirectory(directory: string, relativePath: string): string | null {
+  const candidate = path.resolve(directory, relativePath);
+  const relative = path.relative(directory, candidate);
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+    ? candidate
+    : null;
+}
+
 // Maestro >= 2.7.0: resolve a bundle dir to its owning failed flow and return that flow's failure
 // screenshot — the highest-numbered step in `screenshots/`. A required failure halts the flow, so
 // the failed step is normally the last (highest-numbered) captured step; earlier warned steps have

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -13,6 +13,7 @@ import os from 'os';
 import path from 'path';
 import { z } from 'zod';
 
+import { MaestroBackend, resolveMaestroBackend } from './maestroBackend';
 import { buildFlowNameToPathMap } from './maestroFlowDiscovery';
 import {
   copyLatestAttemptXml,
@@ -27,6 +28,7 @@ import {
   type HarvestedScreenshot,
   computePureFailureFlowNames,
   harvestFailureScreenshotsAsync,
+  harvestMaestroRunnerFailureScreenshotsAsync,
   selectFailureScreenshots,
 } from './maestroScreenshots';
 import { CustomBuildContext } from '../../customBuildContext';
@@ -62,35 +64,74 @@ function isFilesystemError(err: any): boolean {
   );
 }
 
-// `outputPath: null` means "let maestro pick" (no --output flag). Junit and
-// other declared formats pass an explicit path so downstream upload steps
-// know where to find the result.
-function buildMaestroArgs(args: {
-  flow_path: string[];
+function buildMaestroArgs({
+  backend,
+  platform,
+  flowPaths,
+  outputPath,
+  runnerOutputDirectory,
+  outputFormat,
+  shards,
+  includeTags,
+  excludeTags,
+}: {
+  backend: MaestroBackend;
+  platform: 'ios' | 'android';
+  flowPaths: string[];
   outputPath: string | null;
-  output_format: string | undefined;
+  runnerOutputDirectory: string;
+  outputFormat: string | undefined;
   shards: number | undefined;
-  include_tags: string | undefined;
-  exclude_tags: string | undefined;
-}): string[] {
-  const out: string[] = ['test'];
-  if (args.output_format) {
-    out.push(`--format=${args.output_format.toUpperCase()}`);
+  includeTags: string | undefined;
+  excludeTags: string | undefined;
+}): { executable: MaestroBackend; args: string[] } {
+  switch (backend) {
+    case 'maestro': {
+      const args = ['test'];
+      if (outputFormat) {
+        args.push(`--format=${outputFormat.toUpperCase()}`);
+      }
+      if (outputPath) {
+        args.push(`--output=${outputPath}`);
+      }
+      if (shards !== undefined) {
+        args.push(`--shard-split=${shards}`);
+      }
+      appendTagsAndFlows(args, { includeTags, excludeTags, flowPaths });
+      return { executable: 'maestro', args };
+    }
+    case 'maestro-runner': {
+      const args = [
+        `--platform=${platform}`,
+        'test',
+        `--output=${runnerOutputDirectory}`,
+        '--flatten',
+      ];
+      appendTagsAndFlows(args, { includeTags, excludeTags, flowPaths });
+      return { executable: 'maestro-runner', args };
+    }
   }
-  if (args.outputPath) {
-    out.push(`--output=${args.outputPath}`);
+}
+
+function appendTagsAndFlows(
+  args: string[],
+  {
+    includeTags,
+    excludeTags,
+    flowPaths,
+  }: {
+    includeTags: string | undefined;
+    excludeTags: string | undefined;
+    flowPaths: string[];
   }
-  if (args.shards !== undefined) {
-    out.push(`--shard-split=${args.shards}`);
+): void {
+  if (includeTags) {
+    args.push(`--include-tags=${includeTags}`);
   }
-  if (args.include_tags) {
-    out.push(`--include-tags=${args.include_tags}`);
+  if (excludeTags) {
+    args.push(`--exclude-tags=${excludeTags}`);
   }
-  if (args.exclude_tags) {
-    out.push(`--exclude-tags=${args.exclude_tags}`);
-  }
-  out.push(...args.flow_path);
-  return out;
+  args.push(...flowPaths);
 }
 
 export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildFunction {
@@ -149,6 +190,11 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
+      BuildStepInput.createProvider({
+        id: 'backend',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
     ],
     outputProviders: [
       BuildStepOutput.createProvider({ id: 'junit_report_directory', required: true }),
@@ -161,6 +207,10 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       const outputFormat = (inputs.output_format.value as string | undefined)?.toLowerCase();
       const includeTags = inputs.include_tags.value as string | undefined;
       const excludeTags = inputs.exclude_tags.value as string | undefined;
+      const backend = resolveMaestroBackend({
+        input: inputs.backend.value,
+        env,
+      });
 
       const platform: 'ios' | 'android' =
         platformInput === 'ios' || platformInput === 'android'
@@ -219,6 +269,12 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
           undefined,
         'android_connection_mode and EAS_MAESTRO_ANDROID_CONNECTION_MODE must be either "adb" or "dadb".'
       );
+      if (backend === 'maestro-runner' && shards !== undefined && shards > 1) {
+        throw new UserError(
+          'ERR_MAESTRO_INVALID_INPUT',
+          'maestro-runner does not support EAS Maestro test sharding. Remove shards or set it to 1.'
+        );
+      }
       const retryFailedOnly = inputs.retry_failed_only.value as boolean;
 
       try {
@@ -245,7 +301,14 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       const harvested: HarvestedScreenshot[] = [];
 
       const totalAttempts = retries + 1;
-      if (platform === 'android' && androidConnectionMode === 'dadb') {
+      if (
+        backend === 'maestro-runner' &&
+        platform === 'android' &&
+        androidConnectionMode === 'dadb'
+      ) {
+        logger.info('maestro-runner does not support DADB. Using the default ADB connection.');
+      }
+      if (backend === 'maestro' && platform === 'android' && androidConnectionMode === 'dadb') {
         try {
           const adbOverrideDirectoryPath = await fs.mkdtemp(
             path.join(os.tmpdir(), 'maestro-tests-adb-override-')
@@ -280,29 +343,36 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       }
 
       for (let attempt = 0; attempt <= retries; attempt++) {
+        // maestro-runner writes its JUnit report and screenshot metadata to this directory.
+        const runnerOutputDirectory = path.join(
+          testsDirectory,
+          `${platform}-maestro-runner-attempt-${attempt}`
+        );
         const outputPath =
           outputFormat === 'junit'
             ? path.join(junitReportDirectory, `${platform}-maestro-junit-attempt-${attempt}.xml`)
-            : outputFormat
+            : backend === 'maestro' && outputFormat
               ? path.join(testsDirectory, `${platform}-maestro-${outputFormat}.${outputFormat}`)
               : null;
-
-        const maestroArgs = buildMaestroArgs({
-          flow_path: flowsToRun,
+        const { executable, args: maestroArgs } = buildMaestroArgs({
+          backend,
+          platform,
+          flowPaths: flowsToRun,
           outputPath,
-          output_format: outputFormat,
+          runnerOutputDirectory,
+          outputFormat,
           shards,
-          include_tags: includeTags,
-          exclude_tags: excludeTags,
+          includeTags,
+          excludeTags,
         });
         logger.info(
-          `Running maestro (attempt ${attempt + 1}/${totalAttempts}): maestro ${maestroArgs.join(' ')}`
+          `Running ${executable} (attempt ${attempt + 1}/${totalAttempts}): ${executable} ${maestroArgs.join(' ')}`
         );
 
         const attemptStartedAtMs = Date.now();
 
         try {
-          await spawn('maestro', maestroArgs, {
+          await spawn(executable, maestroArgs, {
             cwd: stepCtx.workingDirectory,
             env: spawnEnv,
             logger,
@@ -311,12 +381,27 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
           lastAttemptExitCode = 0;
         } catch (err: any) {
           if (err && (err.code === 'ENOENT' || err.code === 'EACCES')) {
-            throw new SystemError('Failed to invoke maestro', { cause: err });
+            throw new SystemError(`Failed to invoke ${executable}`, { cause: err });
           }
           if (err && typeof err.status === 'number') {
             lastAttemptExitCode = err.status;
           } else {
-            throw new SystemError('Unexpected spawn failure invoking maestro', { cause: err });
+            throw new SystemError(`Unexpected spawn failure invoking ${executable}`, {
+              cause: err,
+            });
+          }
+        }
+
+        // maestro-runner writes a report directory. Copy its JUnit file into the existing
+        // per-attempt directory so retry parsing and final report merging remain shared.
+        if (backend === 'maestro-runner' && outputPath) {
+          try {
+            await fs.copyFile(path.join(runnerOutputDirectory, 'junit-report.xml'), outputPath);
+          } catch (err: any) {
+            logger.warn(
+              { err },
+              `Failed to collect the maestro-runner JUnit report for attempt ${attempt + 1}.`
+            );
           }
         }
 
@@ -327,15 +412,27 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
           const failedFlowNames = outputPath
             ? await parseFailedFlowNamesFromJUnitFile(outputPath)
             : new Set<string>();
-          harvested.push(
-            ...(await harvestFailureScreenshotsAsync({
-              testsDirectory,
-              capturedSinceMs: attemptStartedAtMs,
-              attemptIndex: attempt,
-              failedFlowNames,
-              logger,
-            }))
-          );
+          let screenshots: HarvestedScreenshot[];
+          switch (backend) {
+            case 'maestro':
+              screenshots = await harvestFailureScreenshotsAsync({
+                testsDirectory,
+                capturedSinceMs: attemptStartedAtMs,
+                attemptIndex: attempt,
+                failedFlowNames,
+                logger,
+              });
+              break;
+            case 'maestro-runner':
+              screenshots = await harvestMaestroRunnerFailureScreenshotsAsync({
+                reportDirectory: runnerOutputDirectory,
+                capturedSinceMs: attemptStartedAtMs,
+                attemptIndex: attempt,
+                logger,
+              });
+              break;
+          }
+          harvested.push(...screenshots);
         }
 
         if (lastAttemptExitCode === 0 || attempt === retries) {
@@ -359,7 +456,10 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
               logger,
             }));
             failed = nameToPath
-              ? await parseFailedFlowsFromJUnit({ junitFile: outputPath, nameToPath })
+              ? await parseFailedFlowsFromJUnit({
+                  junitFile: outputPath,
+                  nameToPath,
+                })
               : null;
           }
           if (failed !== null && failed.length > 0) {

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -193,10 +193,6 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       const outputFormat = (inputs.output_format.value as string | undefined)?.toLowerCase();
       const includeTags = inputs.include_tags.value as string | undefined;
       const excludeTags = inputs.exclude_tags.value as string | undefined;
-      const backend = resolveMaestroBackend({
-        input: inputs.backend.value,
-        env,
-      });
 
       const platform: 'ios' | 'android' =
         platformInput === 'ios' || platformInput === 'android'
@@ -232,6 +228,14 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       if (finalReportPath !== undefined) {
         outputs.final_report_path.set(finalReportPath);
       }
+
+      // Resolved after the output assignments above: an invalid backend input or
+      // EAS_MAESTRO_BACKEND throws, and downstream `if: always()` upload steps still
+      // need the outputs interpolated.
+      const backend = resolveMaestroBackend({
+        input: inputs.backend.value,
+        env,
+      });
 
       const flowPaths = parseInput(
         FlowPathSchema,
@@ -565,7 +569,7 @@ async function uploadFailureScreenshotsAsync({
   // test verdict (the whole step is verdict-neutral for screenshots).
   let selected: HarvestedScreenshot[];
   try {
-    let flowResults: { name: string; status: 'passed' | 'failed' }[] | null;
+    let flowResults: { name: string; status: 'passed' | 'failed' }[];
     switch (backend) {
       case 'maestro':
         flowResults = (
@@ -576,15 +580,12 @@ async function uploadFailureScreenshotsAsync({
         const results = await Promise.all(
           reportDirectories.map(directory => parseMaestroRunnerReport(directory))
         );
-        flowResults = results.some(result => result === null)
-          ? null
-          : results.flatMap(result => result?.flows ?? []);
+        // Use whichever reports parsed. An unreadable report (e.g. a final retry that crashed
+        // before writing report.json) contributes no flows rather than discarding screenshots
+        // harvested from the attempts that did report — mirroring the maestro path above.
+        flowResults = results.flatMap(result => result?.flows ?? []);
         break;
       }
-    }
-    if (flowResults === null) {
-      logger.warn('Failed to classify failure screenshots; skipping upload.');
-      return;
     }
     const pureFailureFlowNames = computePureFailureFlowNames(flowResults);
     selected = selectFailureScreenshots(harvested, pureFailureFlowNames);

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -265,6 +265,12 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
           'maestro-runner does not support EAS Maestro test sharding. Remove shards or set it to 1.'
         );
       }
+      if (backend === 'maestro-runner' && outputFormat !== undefined && outputFormat !== 'junit') {
+        throw new UserError(
+          'ERR_MAESTRO_INVALID_INPUT',
+          `maestro-runner only supports the "junit" output_format, but received "${outputFormat}".`
+        );
+      }
       const retryFailedOnly = inputs.retry_failed_only.value as boolean;
 
       try {

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -22,7 +22,9 @@ import {
   parseFailedFlowNamesFromJUnitFile,
   parseFailedFlowsFromFileAttrs,
   parseFailedFlowsFromJUnit,
+  parseFailedFlowsFromMaestroRunnerReport,
   parseJUnitTestCases,
+  parseMaestroRunnerReport,
 } from './maestroResultParser';
 import {
   type HarvestedScreenshot,
@@ -68,8 +70,7 @@ function buildMaestroArgs({
   backend,
   platform,
   flowPaths,
-  outputPath,
-  runnerOutputDirectory,
+  output,
   outputFormat,
   shards,
   includeTags,
@@ -78,8 +79,7 @@ function buildMaestroArgs({
   backend: MaestroBackend;
   platform: 'ios' | 'android';
   flowPaths: string[];
-  outputPath: string | null;
-  runnerOutputDirectory: string;
+  output: string | null;
   outputFormat: string | undefined;
   shards: number | undefined;
   includeTags: string | undefined;
@@ -91,47 +91,33 @@ function buildMaestroArgs({
       if (outputFormat) {
         args.push(`--format=${outputFormat.toUpperCase()}`);
       }
-      if (outputPath) {
-        args.push(`--output=${outputPath}`);
+      if (output) {
+        args.push(`--output=${output}`);
       }
       if (shards !== undefined) {
         args.push(`--shard-split=${shards}`);
       }
-      appendTagsAndFlows(args, { includeTags, excludeTags, flowPaths });
+      if (includeTags) {
+        args.push(`--include-tags=${includeTags}`);
+      }
+      if (excludeTags) {
+        args.push(`--exclude-tags=${excludeTags}`);
+      }
+      args.push(...flowPaths);
       return { executable: 'maestro', args };
     }
     case 'maestro-runner': {
-      const args = [
-        `--platform=${platform}`,
-        'test',
-        `--output=${runnerOutputDirectory}`,
-        '--flatten',
-      ];
-      appendTagsAndFlows(args, { includeTags, excludeTags, flowPaths });
+      const args = [`--platform=${platform}`, 'test', `--output=${output}`, '--flatten'];
+      if (includeTags) {
+        args.push(`--include-tags=${includeTags}`);
+      }
+      if (excludeTags) {
+        args.push(`--exclude-tags=${excludeTags}`);
+      }
+      args.push(...flowPaths);
       return { executable: 'maestro-runner', args };
     }
   }
-}
-
-function appendTagsAndFlows(
-  args: string[],
-  {
-    includeTags,
-    excludeTags,
-    flowPaths,
-  }: {
-    includeTags: string | undefined;
-    excludeTags: string | undefined;
-    flowPaths: string[];
-  }
-): void {
-  if (includeTags) {
-    args.push(`--include-tags=${includeTags}`);
-  }
-  if (excludeTags) {
-    args.push(`--exclude-tags=${excludeTags}`);
-  }
-  args.push(...flowPaths);
 }
 
 export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildFunction {
@@ -283,7 +269,7 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
         throw new SystemError('Failed to create JUnit report directory', { cause: err });
       }
 
-      // Legacy-only (Maestro < 2.6.0 reports carry no `file=` attribute): the
+      // Official Maestro legacy-only (Maestro < 2.6.0 reports carry no `file=` attribute): the
       // flow scan is built lazily in the retry branch below and memoized so
       // retries share one scan. Never runs when the report has `file=`.
       let nameToPathPromise: Promise<Map<string, string> | null> | undefined;
@@ -293,12 +279,13 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       //   numeric err.status → maestro exited non-zero → retry.
       //   else (signal-only, OOM kill, unknown) → infra → SystemError, never
       //     downgraded to "tests failed".
-      // Retry-failed-only (junit mode): after a failed attempt, subset to the failing
-      // flows. The failed-flow parsers return null when the JUnit cannot be
-      // trusted; we then fall through to dumb retry (re-run everything).
+      // Retry-failed-only: after a failed attempt, subset to the failing flows. The
+      // failed-flow parsers return null when a report cannot be trusted; we then fall
+      // through to dumb retry (re-run everything).
       let flowsToRun: string[] = flowPaths;
       let lastAttemptExitCode: number | null = null;
       const harvested: HarvestedScreenshot[] = [];
+      const reportDirectories = backend === 'maestro' ? [junitReportDirectory] : [];
 
       const totalAttempts = retries + 1;
       if (
@@ -358,8 +345,7 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
           backend,
           platform,
           flowPaths: flowsToRun,
-          outputPath,
-          runnerOutputDirectory,
+          output: backend === 'maestro-runner' ? runnerOutputDirectory : outputPath,
           outputFormat,
           shards,
           includeTags,
@@ -405,16 +391,20 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
           }
         }
 
+        if (backend === 'maestro-runner') {
+          reportDirectories.push(runnerOutputDirectory);
+        }
+
         // Harvest this attempt's failure screenshots before any retry subsetting. Gated on
         // junit: test-case-result rows (and therefore the summary icons) only exist for junit
         // runs, so harvesting other formats would just create orphan artifacts the website hides.
         if (outputFormat === 'junit') {
-          const failedFlowNames = outputPath
-            ? await parseFailedFlowNamesFromJUnitFile(outputPath)
-            : new Set<string>();
           let screenshots: HarvestedScreenshot[];
           switch (backend) {
-            case 'maestro':
+            case 'maestro': {
+              const failedFlowNames = outputPath
+                ? await parseFailedFlowNamesFromJUnitFile(outputPath)
+                : new Set<string>();
               screenshots = await harvestFailureScreenshotsAsync({
                 testsDirectory,
                 capturedSinceMs: attemptStartedAtMs,
@@ -423,6 +413,7 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
                 logger,
               });
               break;
+            }
             case 'maestro-runner':
               screenshots = await harvestMaestroRunnerFailureScreenshotsAsync({
                 reportDirectory: runnerOutputDirectory,
@@ -439,28 +430,45 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
           break;
         }
 
-        if (retryFailedOnly && outputFormat === 'junit' && outputPath) {
+        if (
+          retryFailedOnly &&
+          (backend === 'maestro-runner' || (outputFormat === 'junit' && outputPath))
+        ) {
           let failed: string[] | null;
-          if (await junitFileHasFileAttrs(outputPath)) {
-            failed = await parseFailedFlowsFromFileAttrs({
-              junitFile: outputPath,
-              workingDirectory: stepCtx.workingDirectory,
-            });
-          } else {
-            // Legacy (Maestro < 2.6.0): map failed testcase names back to flow
-            // paths via the flow-file scan. DELETE this arm once the fleet is
-            // on >= 2.6.0.
-            const nameToPath = await (nameToPathPromise ??= buildFlowNameToPathMap({
-              inputFlowPaths: flowPaths,
-              projectRoot: stepCtx.workingDirectory,
-              logger,
-            }));
-            failed = nameToPath
-              ? await parseFailedFlowsFromJUnit({
+          switch (backend) {
+            case 'maestro-runner':
+              failed = await parseFailedFlowsFromMaestroRunnerReport({
+                reportDirectory: runnerOutputDirectory,
+                workingDirectory: stepCtx.workingDirectory,
+              });
+              break;
+            case 'maestro':
+              if (!outputPath) {
+                failed = null;
+                break;
+              }
+              if (await junitFileHasFileAttrs(outputPath)) {
+                failed = await parseFailedFlowsFromFileAttrs({
                   junitFile: outputPath,
-                  nameToPath,
-                })
-              : null;
+                  workingDirectory: stepCtx.workingDirectory,
+                });
+                break;
+              }
+              // Legacy (Maestro < 2.6.0): map failed testcase names back to flow
+              // paths via the flow-file scan. DELETE this arm once the fleet is
+              // on >= 2.6.0.
+              const nameToPath = await (nameToPathPromise ??= buildFlowNameToPathMap({
+                inputFlowPaths: flowPaths,
+                projectRoot: stepCtx.workingDirectory,
+                logger,
+              }));
+              failed = nameToPath
+                ? await parseFailedFlowsFromJUnit({
+                    junitFile: outputPath,
+                    nameToPath,
+                  })
+                : null;
+              break;
           }
           if (failed !== null && failed.length > 0) {
             flowsToRun = failed;
@@ -513,7 +521,13 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
       // Upload before the ERR_MAESTRO_TESTS_FAILED throw below so fully-failed runs (which need
       // screenshots most) still upload. Harvest only ran for junit, so guard the same way.
       if (outputFormat === 'junit') {
-        await uploadFailureScreenshotsAsync({ harvested, junitReportDirectory, ctx, logger });
+        await uploadFailureScreenshotsAsync({
+          harvested,
+          backend,
+          reportDirectories,
+          ctx,
+          logger,
+        });
       }
 
       // The retry loop exits via success (0), numeric status (retryable),
@@ -534,12 +548,14 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
 // the maestro test result. Caller guards on junit (harvest only runs for junit).
 async function uploadFailureScreenshotsAsync({
   harvested,
-  junitReportDirectory,
+  backend,
+  reportDirectories,
   ctx,
   logger,
 }: {
   harvested: HarvestedScreenshot[];
-  junitReportDirectory: string;
+  backend: MaestroBackend;
+  reportDirectories: string[];
   ctx: CustomBuildContext;
   logger: bunyan;
 }): Promise<void> {
@@ -549,9 +565,28 @@ async function uploadFailureScreenshotsAsync({
   // test verdict (the whole step is verdict-neutral for screenshots).
   let selected: HarvestedScreenshot[];
   try {
-    const pureFailureFlowNames = computePureFailureFlowNames(
-      await parseJUnitTestCases(junitReportDirectory)
-    );
+    let flowResults: { name: string; status: 'passed' | 'failed' }[] | null;
+    switch (backend) {
+      case 'maestro':
+        flowResults = (
+          await Promise.all(reportDirectories.map(directory => parseJUnitTestCases(directory)))
+        ).flat();
+        break;
+      case 'maestro-runner': {
+        const results = await Promise.all(
+          reportDirectories.map(directory => parseMaestroRunnerReport(directory))
+        );
+        flowResults = results.some(result => result === null)
+          ? null
+          : results.flatMap(result => result?.flows ?? []);
+        break;
+      }
+    }
+    if (flowResults === null) {
+      logger.warn('Failed to classify failure screenshots; skipping upload.');
+      return;
+    }
+    const pureFailureFlowNames = computePureFailureFlowNames(flowResults);
     selected = selectFailureScreenshots(harvested, pureFailureFlowNames);
   } catch (err: any) {
     logger.warn({ err }, 'Failed to classify failure screenshots; skipping screenshot upload.');

--- a/packages/build-tools/src/steps/functions/maestroTests.ts
+++ b/packages/build-tools/src/steps/functions/maestroTests.ts
@@ -359,6 +359,16 @@ export function createMaestroTestsBuildFunction(ctx: CustomBuildContext): BuildF
           `Running ${executable} (attempt ${attempt + 1}/${totalAttempts}): ${executable} ${maestroArgs.join(' ')}`
         );
 
+        // The runner output directory is deterministic and can survive a prior run; clear it
+        // best-effort so a crash before it writes fresh output can't resurrect stale results.
+        if (backend === 'maestro-runner') {
+          try {
+            await fs.rm(runnerOutputDirectory, { recursive: true, force: true });
+          } catch (err) {
+            logger.warn({ err }, `Failed to clear ${runnerOutputDirectory} before the attempt.`);
+          }
+        }
+
         const attemptStartedAtMs = Date.now();
 
         try {


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`maestro-runner` promises to be faster, more reliable alternative to the official Maestro CLI.

# How

Added support for `EAS_MAESTRO_BACKEND` and/or input to `eas/maestro_tests` which opts in to using `maestro-runner` over `maestro` command.

`maestro-runner` doesn't support DADB, but we don't error if both are enabled.

`maestro-runner` has slightly different screenshots and JUnit format -- both are handled. It also exposes a nicer JSON file that lets us parse failed flows without having to parse JUnit file.

This adds relatively big chunk of code, but it's all guarded by `backend === maestro-runner` so maybe it's not so bad? I considered splitting logic into `MaestroCliUtils` and `MaestroRunnerUtils` and expose similar interfaces from them, but I feel it was too complicated.

# Test Plan

- Xcode 16 mixed-flow proof: https://staging.expo.dev/accounts/expo-services/projects/workflows-testing/workflows/019fffe8-9bd8-74f9-87b6-d7963ee6d941
  - Automatically selected maestro-runner 1.1.15 without a workflow version input.
  - Attempt 1 ran both mixed flows.
  - `report.json` selected only `flows/mixed/fail.yml` for attempt 2.
  - Uploaded the expected failure screenshot, merged JUnit report, and complete results archive.
- Android runner success: https://staging.expo.dev/accounts/expo-services/projects/workflows-testing/workflows/019ffcff-4dcb-724f-8671-51c5644f49e1
- Android official Maestro success: https://staging.expo.dev/accounts/expo-services/projects/workflows-testing/workflows/019ffcf8-ffb2-7c84-bd60-682ffc4a3e7e
- Android mixed expected failure: https://staging.expo.dev/accounts/expo-services/projects/workflows-testing/workflows/019ffcfa-6123-7f50-bbbf-42ab03560617
- iOS runner success on Xcode 26: https://staging.expo.dev/accounts/expo-services/projects/workflows-testing/workflows/019ffd22-da8f-79dc-b9c9-3802c5694f7e
- iOS mixed expected failure on Xcode 26: https://staging.expo.dev/accounts/expo-services/projects/workflows-testing/workflows/019ffd1e-5923-7b3b-b5cb-c8329a357e97
- iOS official Maestro success on Xcode 26: https://staging.expo.dev/accounts/expo-services/projects/workflows-testing/workflows/019ffd2b-4b37-7601-b665-a675d39f1cdc
- Reusable proof workflows: https://github.com/expo/workflows-testing/pull/11
