### PR TITLE
[build-tools] Add Appium remote simulator sessions

### DIFF
--- a/packages/build-tools/src/steps/easFunctions.ts
+++ b/packages/build-tools/src/steps/easFunctions.ts
@@ -45,6 +45,7 @@ import { createSendSlackMessageFunction } from './functions/sendSlackMessage';
 import { createStartAgentDeviceRemoteSessionBuildFunction } from './functions/startAgentDeviceRemoteSession';
 import { createStartAndroidEmulatorBuildFunction } from './functions/startAndroidEmulator';
 import { createStartArgentRemoteSessionBuildFunction } from './functions/startArgentRemoteSession';
+import { createStartAppiumRemoteSessionBuildFunction } from './functions/startAppiumRemoteSession';
 import { createStartCuttlefishDeviceBuildFunction } from './functions/startCuttlefishDevice';
 import { createStartIosSimulatorBuildFunction } from './functions/startIosSimulator';
 import { createStartIosSimulatorRecordingsBuildFunction } from './functions/startIosSimulatorRecordings';
@@ -94,6 +95,7 @@ export function getEasFunctions(ctx: CustomBuildContext): BuildFunction[] {
     parseXcactivitylogFunction(),
     createStartAgentDeviceRemoteSessionBuildFunction(ctx),
     createStartArgentRemoteSessionBuildFunction(ctx),
+    createStartAppiumRemoteSessionBuildFunction(ctx),
     createStartAndroidEmulatorBuildFunction(),
     createStartCuttlefishDeviceBuildFunction(),
     createStartIosSimulatorBuildFunction(),

--- a/packages/build-tools/src/steps/functions/__tests__/startAppiumRemoteSession.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startAppiumRemoteSession.test.ts
@@ -1,0 +1,86 @@
+import { BuildRuntimePlatform } from '@expo/steps';
+
+import { AndroidEmulatorUtils } from '../../../utils/AndroidEmulatorUtils';
+import { IosSimulatorUtils } from '../../../utils/IosSimulatorUtils';
+import { selectXcodeDeveloperDirectoryAsync } from '../../utils/remoteDeviceRunSession';
+
+import { resolveAppium3VersionSpec, resolveAppiumDeviceAsync } from '../startAppiumRemoteSession';
+
+jest.mock('../../../utils/AndroidEmulatorUtils', () => ({
+  AndroidEmulatorUtils: { getAttachedDevicesAsync: jest.fn() },
+}));
+jest.mock('../../../utils/IosSimulatorUtils', () => ({
+  IosSimulatorUtils: { getAvailableDevicesAsync: jest.fn() },
+}));
+jest.mock('../../utils/remoteDeviceRunSession', () => ({
+  selectXcodeDeveloperDirectoryAsync: jest.fn(),
+}));
+
+const logger = { info: jest.fn(), warn: jest.fn() } as never;
+
+describe(resolveAppium3VersionSpec, () => {
+  it('uses the worker-supported Appium 3 version by default', () => {
+    expect(resolveAppium3VersionSpec(undefined)).toBe('^3');
+  });
+
+  it.each(['3', '^3', '3.x', '3.5.0', '>=3 <4'])('accepts Appium 3 version %s', version => {
+    expect(resolveAppium3VersionSpec(version)).toBe(version);
+  });
+
+  it.each(['2', '2.19.0', 'latest', '4.0.0', '>=3'])('rejects version %s', version => {
+    expect(() => resolveAppium3VersionSpec(version)).toThrow(
+      `Appium 3 is required for EAS Simulator sessions. Received package version "${version}".`
+    );
+  });
+});
+
+describe(resolveAppiumDeviceAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns XCUITest capabilities for the booted iOS simulator', async () => {
+    jest
+      .mocked(IosSimulatorUtils.getAvailableDevicesAsync)
+      .mockResolvedValue([{ udid: 'ios-simulator-id' } as never]);
+
+    await expect(
+      resolveAppiumDeviceAsync({
+        runtimePlatform: BuildRuntimePlatform.DARWIN,
+        env: {},
+        logger,
+      })
+    ).resolves.toEqual({
+      platformName: 'iOS',
+      automationName: 'XCUITest',
+      driverName: 'xcuitest',
+      udid: 'ios-simulator-id',
+    });
+    expect(selectXcodeDeveloperDirectoryAsync).toHaveBeenCalledWith({ env: {}, logger });
+    expect(IosSimulatorUtils.getAvailableDevicesAsync).toHaveBeenCalledWith({
+      env: {},
+      filter: 'booted',
+    });
+  });
+
+  it('returns UiAutomator2 capabilities for the booted Android emulator', async () => {
+    jest
+      .mocked(AndroidEmulatorUtils.getAttachedDevicesAsync)
+      .mockResolvedValue([{ serialId: 'emulator-5554', state: 'device' } as never]);
+
+    await expect(
+      resolveAppiumDeviceAsync({
+        runtimePlatform: BuildRuntimePlatform.LINUX,
+        env: {},
+        logger,
+      })
+    ).resolves.toEqual({
+      platformName: 'Android',
+      automationName: 'UiAutomator2',
+      driverName: 'uiautomator2',
+      udid: 'emulator-5554',
+    });
+    expect(AndroidEmulatorUtils.getAttachedDevicesAsync).toHaveBeenCalledWith({ env: {} });
+    expect(selectXcodeDeveloperDirectoryAsync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/build-tools/src/steps/functions/startAppiumRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAppiumRemoteSession.ts
@@ -1,0 +1,283 @@
+import { SystemError } from '@expo/eas-build-job';
+import { type bunyan } from '@expo/logger';
+import {
+  BuildFunction,
+  BuildRuntimePlatform,
+  type BuildStepEnv,
+  BuildStepInput,
+  BuildStepInputValueTypeName,
+} from '@expo/steps';
+import spawn from '@expo/turtle-spawn';
+import semver from 'semver';
+import { z } from 'zod';
+
+import { type CustomBuildContext } from '../../customBuildContext';
+import { AndroidEmulatorUtils } from '../../utils/AndroidEmulatorUtils';
+import { IosSimulatorUtils } from '../../utils/IosSimulatorUtils';
+import { sleepAsync } from '../../utils/retry';
+import { turtleFetch } from '../../utils/turtleFetch';
+import { startAppiumEventCollectionAsync } from '../utils/appiumEvents';
+import {
+  getDeviceRunSessionIdOrThrow,
+  getNgrokAuthtokenOrThrow,
+  getNgrokTunnelDomainOrThrow,
+  selectXcodeDeveloperDirectoryAsync,
+  spawnDetached,
+  startNgrokTunnelAsync,
+  startServeSimWithTunnelAsync,
+  uploadRemoteSessionConfigAsync,
+  waitForDeviceRunSessionStoppedAsync,
+} from '../utils/remoteDeviceRunSession';
+
+const APPIUM_HOST = '127.0.0.1';
+const APPIUM_PORT = 4723;
+const APPIUM_STARTUP_TIMEOUT_MS = 120_000;
+const DEFAULT_APPIUM_VERSION = '^3';
+
+const AppiumInstalledDriversSchema = z.record(
+  z.string(),
+  z.object({ installed: z.boolean().optional() }).passthrough()
+);
+
+export function createStartAppiumRemoteSessionBuildFunction(
+  ctx: CustomBuildContext
+): BuildFunction {
+  return new BuildFunction({
+    namespace: 'eas',
+    id: 'start_appium_remote_session',
+    name: 'Start Appium remote session',
+    __metricsId: 'eas/start_appium_remote_session',
+    inputProviders: [
+      BuildStepInput.createProvider({
+        id: 'package_version',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
+      BuildStepInput.createProvider({
+        id: 'max_idle_time_minutes',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
+      }),
+    ],
+    fn: async ({ logger, global }, { inputs, env, signal }) => {
+      const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
+      const ngrokTunnelDomain = getNgrokTunnelDomainOrThrow(env);
+      const ngrokAuthtoken = getNgrokAuthtokenOrThrow(env);
+      const packageVersion = inputs.package_version.value as string | undefined;
+      const maxIdleTimeMinutes = inputs.max_idle_time_minutes.value as number | undefined;
+      const { runtimePlatform } = global;
+      const versionSpec = resolveAppium3VersionSpec(packageVersion);
+
+      logger.info(
+        `Starting Appium remote session (version: ${versionSpec}, runtime: ${runtimePlatform}).`
+      );
+      const device = await resolveAppiumDeviceAsync({ runtimePlatform, env, logger });
+      await installAppiumAsync({ versionSpec, driverName: device.driverName, env, logger });
+
+      const appiumProcess = spawnDetached({
+        command: 'appium',
+        args: [
+          '--address',
+          APPIUM_HOST,
+          '--port',
+          String(APPIUM_PORT),
+          '--base-path',
+          '/',
+          '--log-level',
+          'error',
+        ],
+        env,
+      });
+      try {
+        await waitForAppiumReadyAsync({ appiumProcess, logger });
+      } catch (error) {
+        await appiumProcess.stopAsync();
+        throw error;
+      }
+
+      const eventCollection = await startAppiumEventCollectionAsync({
+        ctx,
+        deviceRunSessionId,
+        appiumUrl: `http://${APPIUM_HOST}:${APPIUM_PORT}/`,
+        logger,
+      });
+      let appiumTunnel: Awaited<ReturnType<typeof startNgrokTunnelAsync>> | undefined;
+      let serveSim: Awaited<ReturnType<typeof startServeSimWithTunnelAsync>> | undefined;
+      try {
+        appiumTunnel = await startNgrokTunnelAsync({
+          port: APPIUM_PORT,
+          subdomainPrefix: 'appium',
+          baseDomain: ngrokTunnelDomain,
+          authtoken: ngrokAuthtoken,
+          logger,
+        });
+
+        switch (runtimePlatform) {
+          case BuildRuntimePlatform.DARWIN:
+            serveSim = await startServeSimWithTunnelAsync(ctx, {
+              baseDomain: ngrokTunnelDomain,
+              env,
+              logger,
+              timeoutMs: APPIUM_STARTUP_TIMEOUT_MS,
+            });
+            break;
+          case BuildRuntimePlatform.LINUX:
+            break;
+        }
+
+        await uploadRemoteSessionConfigAsync({
+          ctx,
+          deviceRunSessionId,
+          remoteConfig: {
+            appiumUrl: appiumTunnel.url,
+            capabilities: {
+              platformName: device.platformName,
+              'appium:automationName': device.automationName,
+              'appium:udid': device.udid,
+              'appium:eventTimings': true,
+            },
+            ...(serveSim ? { webPreviewUrl: serveSim.previewUrl } : {}),
+          },
+          logger,
+        });
+
+        await waitForDeviceRunSessionStoppedAsync({
+          ctx,
+          deviceRunSessionId,
+          logger,
+          signal,
+          idleTimeout:
+            maxIdleTimeMinutes !== undefined && maxIdleTimeMinutes > 0
+              ? {
+                  maxIdleTimeMinutes,
+                  getLastEventObservedAt: eventCollection.getLastEventObservedAt,
+                }
+              : undefined,
+        });
+      } finally {
+        if (serveSim) {
+          await serveSim.stopAsync();
+        }
+        if (appiumTunnel) {
+          await appiumTunnel.stopAsync();
+        }
+        await eventCollection.stopAsync();
+        await appiumProcess.stopAsync();
+      }
+    },
+  });
+}
+
+export function resolveAppium3VersionSpec(packageVersion: string | undefined): string {
+  const versionSpec = packageVersion ?? DEFAULT_APPIUM_VERSION;
+  const range = semver.validRange(versionSpec);
+  if (!range || !semver.subset(range, '>=3.0.0 <4.0.0-0')) {
+    throw new SystemError(
+      `Appium 3 is required for EAS Simulator sessions. Received package version "${versionSpec}".`
+    );
+  }
+  return versionSpec;
+}
+
+type AppiumDevice = {
+  platformName: 'iOS' | 'Android';
+  automationName: 'XCUITest' | 'UiAutomator2';
+  driverName: 'xcuitest' | 'uiautomator2';
+  udid: string;
+};
+
+export async function resolveAppiumDeviceAsync({
+  runtimePlatform,
+  env,
+  logger,
+}: {
+  runtimePlatform: BuildRuntimePlatform;
+  env: BuildStepEnv;
+  logger: bunyan;
+}): Promise<AppiumDevice> {
+  switch (runtimePlatform) {
+    case BuildRuntimePlatform.DARWIN: {
+      await selectXcodeDeveloperDirectoryAsync({ env, logger });
+      const [bootedDevice] = await IosSimulatorUtils.getAvailableDevicesAsync({
+        env,
+        filter: 'booted',
+      });
+      if (!bootedDevice) {
+        throw new SystemError('Could not find a booted iOS simulator for the Appium session.');
+      }
+      return {
+        platformName: 'iOS',
+        automationName: 'XCUITest',
+        driverName: 'xcuitest',
+        udid: bootedDevice.udid,
+      };
+    }
+    case BuildRuntimePlatform.LINUX: {
+      const attachedDevices = await AndroidEmulatorUtils.getAttachedDevicesAsync({ env });
+      const bootedDevice = attachedDevices.find(device => device.state === 'device');
+      if (!bootedDevice) {
+        throw new SystemError('Could not find a booted Android emulator for the Appium session.');
+      }
+      return {
+        platformName: 'Android',
+        automationName: 'UiAutomator2',
+        driverName: 'uiautomator2',
+        udid: bootedDevice.serialId,
+      };
+    }
+  }
+}
+
+async function installAppiumAsync({
+  versionSpec,
+  driverName,
+  env,
+  logger,
+}: {
+  versionSpec: string;
+  driverName: AppiumDevice['driverName'];
+  env: BuildStepEnv;
+  logger: bunyan;
+}): Promise<void> {
+  logger.info(`Installing appium@${versionSpec}.`);
+  await spawn('npm', ['install', '--global', `appium@${versionSpec}`], { env, logger });
+  const { stdout } = await spawn('appium', ['driver', 'list', '--installed', '--json'], {
+    env,
+    stdio: 'pipe',
+  });
+  const installedDrivers = AppiumInstalledDriversSchema.parse(JSON.parse(stdout));
+  if (installedDrivers[driverName]?.installed) {
+    logger.info(`Updating the installed Appium ${driverName} driver.`);
+    await spawn('appium', ['driver', 'update', driverName], { env, logger });
+  } else {
+    logger.info(`Installing the Appium ${driverName} driver.`);
+    await spawn('appium', ['driver', 'install', driverName], { env, logger });
+  }
+}
+
+async function waitForAppiumReadyAsync({
+  appiumProcess,
+  logger,
+}: {
+  appiumProcess: { getOutput: () => string };
+  logger: bunyan;
+}): Promise<void> {
+  const deadline = Date.now() + APPIUM_STARTUP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const response = await turtleFetch(`http://${APPIUM_HOST}:${APPIUM_PORT}/status`, 'GET', {
+        timeout: 2_000,
+        retries: 0,
+        logger,
+      });
+      if (response.ok) {
+        return;
+      }
+    } catch {}
+    await sleepAsync(1_000);
+  }
+  const output = appiumProcess.getOutput();
+  throw new SystemError(
+    `Timed out waiting for Appium to become ready.${output ? `\nAppium output:\n${output}` : ''}`
+  );
+}

--- a/packages/build-tools/src/steps/functions/startAppiumRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAppiumRemoteSession.ts
@@ -8,6 +8,9 @@ import {
   BuildStepInputValueTypeName,
 } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import semver from 'semver';
 import { z } from 'zod';
 
@@ -72,10 +75,15 @@ export function createStartAppiumRemoteSessionBuildFunction(
         `Starting Appium remote session (version: ${versionSpec}, runtime: ${runtimePlatform}).`
       );
       const device = await resolveAppiumDeviceAsync({ runtimePlatform, env, logger });
-      await installAppiumAsync({ versionSpec, driverName: device.driverName, env, logger });
+      const { appiumHome, appiumBinPath, appiumEnv } = await installAppiumAsync({
+        versionSpec,
+        driverName: device.driverName,
+        env,
+        logger,
+      });
 
       const appiumProcess = spawnDetached({
-        command: 'appium',
+        command: appiumBinPath,
         args: [
           '--address',
           APPIUM_HOST,
@@ -91,12 +99,13 @@ export function createStartAppiumRemoteSessionBuildFunction(
           '--allow-insecure',
           '*:session_discovery',
         ],
-        env,
+        env: appiumEnv,
       });
       try {
         await waitForAppiumReadyAsync({ appiumProcess, logger });
       } catch (error) {
         await appiumProcess.stopAsync();
+        await fs.promises.rm(appiumHome, { recursive: true, force: true });
         throw error;
       }
 
@@ -168,6 +177,7 @@ export function createStartAppiumRemoteSessionBuildFunction(
         }
         await eventCollection.stopAsync();
         await appiumProcess.stopAsync();
+        await fs.promises.rm(appiumHome, { recursive: true, force: true });
       }
     },
   });
@@ -243,21 +253,33 @@ async function installAppiumAsync({
   driverName: AppiumDevice['driverName'];
   env: BuildStepEnv;
   logger: bunyan;
-}): Promise<void> {
+}): Promise<{ appiumHome: string; appiumBinPath: string; appiumEnv: BuildStepEnv }> {
+  const appiumHome = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'eas-appium-home-'));
+  await fs.promises.writeFile(
+    path.join(appiumHome, 'package.json'),
+    `${JSON.stringify({ name: 'eas-appium-home', private: true })}\n`
+  );
+  const appiumEnv: BuildStepEnv = { ...env, APPIUM_HOME: appiumHome };
+  const appiumBinPath = path.join(appiumHome, 'node_modules', '.bin', 'appium');
+
   logger.info(`Installing appium@${versionSpec}.`);
-  await spawn('npm', ['install', '--global', `appium@${versionSpec}`], { env, logger });
-  const { stdout } = await spawn('appium', ['driver', 'list', '--installed', '--json'], {
-    env,
+  await spawn('npm', ['install', '--prefix', appiumHome, `appium@${versionSpec}`], {
+    env: appiumEnv,
+    logger,
+  });
+  const { stdout } = await spawn(appiumBinPath, ['driver', 'list', '--installed', '--json'], {
+    env: appiumEnv,
     stdio: 'pipe',
   });
   const installedDrivers = AppiumInstalledDriversSchema.parse(JSON.parse(stdout));
   if (installedDrivers[driverName]?.installed) {
     logger.info(`Updating the installed Appium ${driverName} driver.`);
-    await spawn('appium', ['driver', 'update', driverName], { env, logger });
+    await spawn(appiumBinPath, ['driver', 'update', driverName], { env: appiumEnv, logger });
   } else {
     logger.info(`Installing the Appium ${driverName} driver.`);
-    await spawn('appium', ['driver', 'install', driverName], { env, logger });
+    await spawn(appiumBinPath, ['driver', 'install', driverName], { env: appiumEnv, logger });
   }
+  return { appiumHome, appiumBinPath, appiumEnv };
 }
 
 async function waitForAppiumReadyAsync({

--- a/packages/build-tools/src/steps/functions/startAppiumRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAppiumRemoteSession.ts
@@ -85,6 +85,11 @@ export function createStartAppiumRemoteSessionBuildFunction(
           '/',
           '--log-level',
           'error',
+          // Appium 3 gates session listing (GET /appium/sessions) behind the
+          // session_discovery insecure feature. We rely on it to poll for
+          // Appium Event Timings, so enable it for all drivers.
+          '--allow-insecure',
+          '*:session_discovery',
         ],
         env,
       });

--- a/packages/build-tools/src/steps/utils/__tests__/appiumEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/appiumEvents.test.ts
@@ -62,6 +62,18 @@ describe(startAppiumEventCollectionAsync, () => {
       },
     });
 
+    // Appium 3 removed GET /sessions; session discovery must use /appium/sessions.
+    expect(turtleFetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:4723/appium/sessions',
+      'GET',
+      expect.anything()
+    );
+    expect(turtleFetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:4723/session/appium-session-id/appium/events',
+      'POST',
+      expect.anything()
+    );
+
     await collection.stopAsync();
   });
 });

--- a/packages/build-tools/src/steps/utils/__tests__/appiumEvents.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/appiumEvents.test.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+
+import { turtleFetch } from '../../../utils/turtleFetch';
+import { startAppiumEventCollectionAsync } from '../appiumEvents';
+import { startDeviceRunSessionEventCollectionAsync } from '../deviceRunSessionEvents';
+
+jest.mock('../../../utils/turtleFetch');
+jest.mock('../deviceRunSessionEvents', () => ({
+  startDeviceRunSessionEventCollectionAsync: jest.fn(async () => ({
+    getLastEventObservedAt: () => undefined,
+    stopAsync: async () => undefined,
+  })),
+}));
+
+describe(startAppiumEventCollectionAsync, () => {
+  it('writes new Appium Event Timings commands to a normal event file', async () => {
+    jest
+      .mocked(turtleFetch)
+      .mockResolvedValueOnce(response({ value: [{ id: 'appium-session-id' }] }))
+      .mockResolvedValueOnce(
+        response({
+          value: {
+            commands: [
+              { cmd: 'getOrientation', startTime: 1_786_693_000_000, endTime: 1_786_693_000_025 },
+              { cmd: 'getLogEvents', startTime: 1_786_693_000_026, endTime: 1_786_693_000_027 },
+            ],
+          },
+        })
+      )
+      .mockResolvedValueOnce(response({ value: [] }));
+
+    const collection = await startAppiumEventCollectionAsync({
+      ctx: {} as never,
+      deviceRunSessionId: 'device-session-id',
+      appiumUrl: 'http://127.0.0.1:4723/',
+      logger: { warn: jest.fn() } as never,
+      pollIntervalMs: 60_000,
+    });
+    const source = jest.mocked(startDeviceRunSessionEventCollectionAsync).mock.calls[0][0].source;
+    const [eventFile] = await source.findEventFilesAsync();
+    let contents = '';
+    await waitForAsync(async () => {
+      contents = await fs.promises.readFile(eventFile, 'utf8');
+      expect(contents).toContain('getOrientation');
+    });
+    const lines = contents.trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const [line] = lines;
+    expect(
+      source.parseLine({
+        line,
+        sourceKey: source.sourceKeyForFile(eventFile),
+        sequenceNumber: 1,
+        deviceRunSessionId: 'device-session-id',
+      })
+    ).toMatchObject({
+      event: {
+        producer: 'appium',
+        type: 'operation.completed',
+        durationMs: 25,
+        summary: 'getOrientation',
+      },
+    });
+
+    await collection.stopAsync();
+  });
+});
+
+async function waitForAsync(assertion: () => Promise<void>): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      await assertion();
+      return;
+    } catch {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+  }
+  await assertion();
+}
+
+function response(value: unknown): Awaited<ReturnType<typeof turtleFetch>> {
+  return { json: async () => value } as never;
+}

--- a/packages/build-tools/src/steps/utils/appiumEvents.ts
+++ b/packages/build-tools/src/steps/utils/appiumEvents.ts
@@ -1,0 +1,216 @@
+import { type bunyan } from '@expo/logger';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as setTimeoutAsync } from 'node:timers/promises';
+import { z } from 'zod';
+
+import { type CustomBuildContext } from '../../customBuildContext';
+import { turtleFetch } from '../../utils/turtleFetch';
+import {
+  type DeviceRunSessionEventCollection,
+  type DeviceRunSessionEventSource,
+  startDeviceRunSessionEventCollectionAsync,
+} from './deviceRunSessionEvents';
+
+const APPIUM_REQUEST_TIMEOUT_MS = 10_000;
+const POLL_INTERVAL_MS = 1_000;
+const GET_LOG_EVENTS_COMMAND = 'getLogEvents';
+
+const AppiumSessionsResponseSchema = z.object({
+  value: z.array(z.object({ id: z.string() }).passthrough()),
+});
+
+const AppiumCommandSchema = z.object({
+  appiumSessionId: z.string(),
+  cmd: z.string(),
+  startTime: z.number(),
+  endTime: z.number(),
+});
+
+const AppiumEventsResponseSchema = z.object({
+  value: z.object({
+    commands: z.array(AppiumCommandSchema.omit({ appiumSessionId: true })),
+  }),
+});
+
+type AppiumCommand = z.infer<typeof AppiumCommandSchema>;
+
+export async function startAppiumEventCollectionAsync({
+  ctx,
+  deviceRunSessionId,
+  appiumUrl,
+  logger,
+  pollIntervalMs = POLL_INTERVAL_MS,
+}: {
+  ctx: CustomBuildContext;
+  deviceRunSessionId: string;
+  appiumUrl: string;
+  logger: bunyan;
+  pollIntervalMs?: number;
+}): Promise<DeviceRunSessionEventCollection> {
+  const eventDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'eas-appium-events-'));
+  const eventFile = path.join(eventDirectory, 'commands.ndjson');
+  await fs.promises.writeFile(eventFile, '');
+
+  let eventCollection: DeviceRunSessionEventCollection;
+  try {
+    eventCollection = await startDeviceRunSessionEventCollectionAsync({
+      ctx,
+      deviceRunSessionId,
+      logger,
+      pollIntervalMs,
+      source: createAppiumEventSource(eventFile),
+    });
+  } catch (error) {
+    await fs.promises.rm(eventDirectory, { recursive: true, force: true });
+    throw error;
+  }
+
+  const observedCommandKeys = new Set<string>();
+  const controller = new AbortController();
+  let didReportCollectionFailure = false;
+  const collectSafelyAsync = async (): Promise<void> => {
+    try {
+      await collectAppiumCommandsAsync({
+        appiumUrl,
+        eventFile,
+        observedCommandKeys,
+        logger,
+      });
+      didReportCollectionFailure = false;
+    } catch (error) {
+      if (!didReportCollectionFailure) {
+        didReportCollectionFailure = true;
+        logger.warn({ err: error }, 'Could not collect Appium events.');
+      }
+    }
+  };
+  const pollingPromise = (async () => {
+    while (!controller.signal.aborted) {
+      await collectSafelyAsync();
+      try {
+        await setTimeoutAsync(pollIntervalMs, undefined, { signal: controller.signal });
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          throw error;
+        }
+      }
+    }
+  })().catch(error => {
+    logger.warn({ err: error }, 'Appium event collection poller failed.');
+  });
+
+  return {
+    getLastEventObservedAt: eventCollection.getLastEventObservedAt,
+    stopAsync: async () => {
+      controller.abort();
+      await pollingPromise;
+      await collectSafelyAsync();
+      try {
+        await eventCollection.stopAsync();
+      } finally {
+        await fs.promises.rm(eventDirectory, { recursive: true, force: true });
+      }
+    },
+  };
+}
+
+function createAppiumEventSource(eventFile: string): DeviceRunSessionEventSource {
+  return {
+    producer: 'appium',
+    findEventFilesAsync: async () => [eventFile],
+    sourceKeyForFile: file => path.basename(file, path.extname(file)),
+    parseLine: ({ line, sourceKey, sequenceNumber, deviceRunSessionId }) => {
+      if (!line.trim()) {
+        return {};
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        return { failure: 'invalid-json' };
+      }
+      const result = AppiumCommandSchema.safeParse(parsed);
+      if (!result.success) {
+        return { failure: 'invalid-event' };
+      }
+      const command = result.data;
+      const operationId = `${sourceKey}:${sequenceNumber}`;
+      return {
+        event: {
+          v: 1,
+          eventId: `appium:${deviceRunSessionId}:${operationId}`,
+          ts: new Date(command.endTime).toISOString(),
+          producer: 'appium',
+          type: 'operation.completed',
+          operationId,
+          durationMs: Math.max(0, command.endTime - command.startTime),
+          summary: command.cmd,
+          data: {
+            command: command.cmd,
+            appiumSessionId: command.appiumSessionId,
+          },
+        },
+      };
+    },
+  };
+}
+
+async function collectAppiumCommandsAsync({
+  appiumUrl,
+  eventFile,
+  observedCommandKeys,
+  logger,
+}: {
+  appiumUrl: string;
+  eventFile: string;
+  observedCommandKeys: Set<string>;
+  logger: bunyan;
+}): Promise<void> {
+  const response = await turtleFetch(new URL('sessions', appiumUrl).toString(), 'GET', {
+    timeout: APPIUM_REQUEST_TIMEOUT_MS,
+    retries: 0,
+    logger,
+  });
+  const sessions = AppiumSessionsResponseSchema.parse(await response.json()).value;
+  const newCommands: { key: string; command: AppiumCommand }[] = [];
+  const pendingCommandKeys = new Set<string>();
+
+  for (const { id: appiumSessionId } of sessions) {
+    const eventsResponse = await turtleFetch(
+      new URL(`session/${encodeURIComponent(appiumSessionId)}/appium/events`, appiumUrl).toString(),
+      'POST',
+      {
+        json: {},
+        timeout: APPIUM_REQUEST_TIMEOUT_MS,
+        retries: 0,
+        logger,
+      }
+    );
+    const commands = AppiumEventsResponseSchema.parse(await eventsResponse.json()).value.commands;
+    for (const command of commands) {
+      const key = [appiumSessionId, command.cmd, command.startTime, command.endTime].join(':');
+      if (
+        command.cmd === GET_LOG_EVENTS_COMMAND ||
+        observedCommandKeys.has(key) ||
+        pendingCommandKeys.has(key)
+      ) {
+        continue;
+      }
+      pendingCommandKeys.add(key);
+      newCommands.push({ key, command: { appiumSessionId, ...command } });
+    }
+  }
+
+  if (newCommands.length === 0) {
+    return;
+  }
+  await fs.promises.appendFile(
+    eventFile,
+    `${newCommands.map(({ command }) => JSON.stringify(command)).join('\n')}\n`
+  );
+  for (const { key } of newCommands) {
+    observedCommandKeys.add(key);
+  }
+}

--- a/packages/build-tools/src/steps/utils/appiumEvents.ts
+++ b/packages/build-tools/src/steps/utils/appiumEvents.ts
@@ -168,7 +168,7 @@ async function collectAppiumCommandsAsync({
   observedCommandKeys: Set<string>;
   logger: bunyan;
 }): Promise<void> {
-  const response = await turtleFetch(new URL('sessions', appiumUrl).toString(), 'GET', {
+  const response = await turtleFetch(new URL('appium/sessions', appiumUrl).toString(), 'GET', {
     timeout: APPIUM_REQUEST_TIMEOUT_MS,
     retries: 0,
     logger,


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Appium is one of the industry standards when it comes to interacting with local and remote mobile devices. I think it may be nice to add support for it to EAS Simulator.

# How

Added a new EAS function that installs Appium v3, necessary plugin, starts it and exposes its endpoint through ngrok.

The event collection is a bit wonky since we're repeatedly calling Appium endpoint for events, but maybe it's ok. Alternatively we could extend session event collection mechanism to support `getEventsAsync`, but decided not to do that (see [diff](https://github.com/expo/eas-cli/compare/8c1e165899c495981ba6bfd506bcd1444cf0c5e8..25c685b5709f66f28341d7f09cc2999d7b0885be)).

# Test Plan

Tested manually locally. A remote test is going to be better!