### PR TITLE
[eas-cli] Add Appium simulator session support

### DIFF
--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -6526,61 +6526,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "AppiumRunSessionRemoteConfig",
-        "description": null,
-        "fields": [
-          {
-            "name": "appiumUrl",
-            "description": "Authenticated Appium server URL. Treat this value as a secret.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "capabilities",
-            "description": "W3C capabilities for the device that backs this session.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "JSONObject",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "webPreviewUrl",
-            "description": "URL of the web preview surface for the session. Null when web previews are\nnot available for the platform (e.g. Android).",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "AndroidAppBuildCredentials",
         "description": null,
         "fields": [
@@ -14901,6 +14846,39 @@
             "deprecationReason": null
           },
           {
+            "name": "overviewStability",
+            "description": "Crash-free rates with previous-period comparison for the Overview stability tiles.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveOverviewStabilityInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverviewStability",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "overviewUpdateComparison",
             "description": "Per-update comparison within one app version: the embedded bundle plus each OTA update.",
             "args": [
@@ -16157,6 +16135,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "symbolicationBuild",
+            "description": "Build whose uploaded source map symbolicated exceptionStacktrace; null when the stack trace is shown as reported.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Build",
               "ofType": null
             },
             "isDeprecated": false,
@@ -17885,6 +17875,145 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveErrorPlatformStats",
+        "description": "AppObserveErrorStats for one platform; iOS includes iPadOS and tvOS.",
+        "fields": [
+          {
+            "name": "affectedSessions",
+            "description": "Distinct sessions on this platform that hit any exception.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "affectedUsers",
+            "description": "Distinct users on this platform that hit any exception.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "crashFreeSessions",
+            "description": "Fraction (0..1) of this platform's active sessions without a fatal error.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "crashFreeUsers",
+            "description": "Fraction (0..1) of this platform's active users without a fatal error.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fatalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nonFatalCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObservePlatform",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalErrors",
+            "description": "Total exception events in range on this platform.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -19777,7 +19906,7 @@
         "fields": [
           {
             "name": "metrics",
-            "description": "One entry per (metric, platform) with data in range; iOS includes tvOS and iPadOS.",
+            "description": "One entry per (metric, platform) with data in range; one entry per exact device platform.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -20059,8 +20188,8 @@
         "description": null,
         "fields": [
           {
-            "name": "affectedUsers",
-            "description": null,
+            "name": "crashCount",
+            "description": "Fatal exception events in range.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -20107,7 +20236,162 @@
             "deprecationReason": null
           },
           {
+            "name": "crashedUsers",
+            "description": "Distinct users that hit a fatal error in range.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "previousPeriodCrashCount",
+            "description": "Fatal exception events in the equal-length window before startTime.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "previousPeriodCrashFreeSessions",
+            "description": "Same fractions for the equal-length window before startTime; null when it had no activity.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "previousPeriodCrashFreeUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "previousPeriodCrashedUsers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "series",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveOverviewStabilityBucket",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "totalErrors",
+            "description": "All exception events in range, for distinguishing quiet apps from crash-free ones.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverviewStabilityBucket",
+        "description": null,
+        "fields": [
+          {
+            "name": "affectedUsers",
+            "description": "Approximate unique users that hit any exception in this bucket. Not summable across buckets.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bucketStart",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "crashCount",
             "description": null,
             "args": [],
             "type": {
@@ -20125,6 +20409,85 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveOverviewStabilityInput",
+        "description": "Stability-tile filters. No release filters: the tiles always span all versions.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "bucketIntervalMinutes",
+            "description": "Series bucket size. Defaults to one day.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObservePlatform",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -20279,15 +20642,23 @@
           },
           {
             "name": "stability",
-            "description": null,
+            "description": "Error stats for this update, one entry per platform with activity; iOS includes iPadOS and tvOS.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "AppObserveOverviewStability",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveErrorPlatformStats",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -20614,7 +20985,7 @@
           },
           {
             "name": "metrics",
-            "description": "One entry per (metric, platform) with data in range; iOS includes tvOS and iPadOS.",
+            "description": "One entry per (metric, platform) with data in range; each device OS (iOS, iPadOS, tvOS, macOS, Android) is a separate platform.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -20638,15 +21009,23 @@
           },
           {
             "name": "stability",
-            "description": "Error stats for this version, all platforms combined.",
+            "description": "Error stats for this version, one entry per platform with activity; iOS includes iPadOS and tvOS.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "AppObserveOverviewStability",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveErrorPlatformStats",
+                    "ofType": null
+                  }
+                }
               }
             },
             "isDeprecated": false,
@@ -20994,6 +21373,24 @@
           },
           {
             "name": "IOS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IPADOS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MACOS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TVOS",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -25358,6 +25755,61 @@
                 "name": "WorkflowsInsightsWorkflowConnection",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppiumRunSessionRemoteConfig",
+        "description": null,
+        "fields": [
+          {
+            "name": "appiumUrl",
+            "description": "Appium server URL for the remote device.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "capabilities",
+            "description": "W3C capabilities for the device that backs this session.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webPreviewUrl",
+            "description": "URL of the web preview surface for the session. Null when web previews are\nnot available for the platform (e.g. Android).",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -36773,7 +37225,7 @@
           },
           {
             "name": "maxIdleTimeMinutes",
-            "description": "Stop the session automatically after this many minutes without observed\nsession activity. Must be positive and smaller than the session's maximum\nduration (2 hours, or maxRunTimeMinutes when set). Only supported for\nagent-device and argent sessions. If omitted, the session has no idle\ntimeout.",
+            "description": "Stop the session automatically after this many minutes without observed\nsession activity. Must be positive and smaller than the session's maximum\nduration (2 hours, or maxRunTimeMinutes when set). Only supported for\nagent-device, argent, and Appium sessions. If omitted, the session has no idle\ntimeout.",
             "type": {
               "kind": "SCALAR",
               "name": "Int",
@@ -36785,7 +37237,7 @@
           },
           {
             "name": "maxRunTimeMinutes",
-            "description": "Override for the underlying turtle job run's max run time, in minutes. Must\nbe non-negative and smaller than 120 (2 hours). Only customizable on paid\nplans. If omitted, the default is derived based on the job run's priority.",
+            "description": "Maximum usable session duration, in minutes, starting when the remote session\nis ready. Must be non-negative and no greater than 40 for normal-priority\naccounts or 115 for high-priority accounts. The backing job receives an\nadditional five minutes for cleanup.",
             "type": {
               "kind": "SCALAR",
               "name": "Int",

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -6526,6 +6526,61 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AppiumRunSessionRemoteConfig",
+        "description": null,
+        "fields": [
+          {
+            "name": "appiumUrl",
+            "description": "Authenticated Appium server URL. Treat this value as a secret.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "capabilities",
+            "description": "W3C capabilities for the device that backs this session.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "webPreviewUrl",
+            "description": "URL of the web preview surface for the session. Null when web previews are\nnot available for the platform (e.g. Android).",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AndroidAppBuildCredentials",
         "description": null,
         "fields": [
@@ -43122,6 +43177,11 @@
           },
           {
             "kind": "OBJECT",
+            "name": "AppiumRunSessionRemoteConfig",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "ArgentRunSessionRemoteConfig",
             "ofType": null
           },
@@ -43177,6 +43237,12 @@
         "enumValues": [
           {
             "name": "AGENT_DEVICE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "APPIUM",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -252,15 +252,15 @@ describe(Simulator, () => {
     expect(fs.writeFile).toHaveBeenNthCalledWith(
       1,
       simulatorDotenvPath,
-      SIMULATOR_DOTENV_FILE_HEADER + `${EAS_SIMULATOR_SESSION_ID}="session-123"\n`
+      SIMULATOR_DOTENV_FILE_HEADER + `${EAS_SIMULATOR_SESSION_ID}='session-123'\n`
     );
     expect(fs.writeFile).toHaveBeenNthCalledWith(
       2,
       simulatorDotenvPath,
       SIMULATOR_DOTENV_FILE_HEADER +
-        'AGENT_DEVICE_DAEMON_BASE_URL="https://agent.example.com"\n' +
-        'AGENT_DEVICE_DAEMON_AUTH_TOKEN="token-123"\n' +
-        `${EAS_SIMULATOR_SESSION_ID}="session-123"\n`
+        "AGENT_DEVICE_DAEMON_BASE_URL='https://agent.example.com'\n" +
+        "AGENT_DEVICE_DAEMON_AUTH_TOKEN='token-123'\n" +
+        `${EAS_SIMULATOR_SESSION_ID}='session-123'\n`
     );
     expect(jest.mocked(fs.writeFile).mock.invocationCallOrder[0]).toBeLessThan(
       mockByIdAsync.mock.invocationCallOrder[0]
@@ -282,6 +282,51 @@ describe(Simulator, () => {
     );
   });
 
+  it('writes the Appium environment and capabilities to the simulator dotenv', async () => {
+    mockByIdAsync.mockResolvedValue(
+      makeDeviceRunSession({
+        type: DeviceRunSessionType.Appium,
+        platform: AppPlatform.Ios,
+        remoteConfig: {
+          __typename: 'AppiumRunSessionRemoteConfig',
+          appiumUrl: 'https://appium.example.test',
+          capabilities: {
+            platformName: 'iOS',
+            'appium:automationName': 'XCUITest',
+            'appium:udid': 'simulator-id',
+          },
+          webPreviewUrl: 'https://preview.example.test',
+        },
+      })
+    );
+
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--type',
+      'appium',
+      '--non-interactive',
+    ]);
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ type: DeviceRunSessionType.Appium })
+    );
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      simulatorDotenvPath,
+      expect.stringContaining(
+        `APPIUM_CAPS='{"platformName":"iOS","appium:automationName":"XCUITest","appium:udid":"simulator-id"}'`
+      )
+    );
+    expect(Log.log).toHaveBeenCalledWith(
+      expect.stringContaining('eas simulator:exec <appium-client> [args...]')
+    );
+    expect(Log.log).not.toHaveBeenCalledWith(
+      expect.stringContaining('https://appium.example.test')
+    );
+  });
+
   it('overwrites .env.eas-simulator when outputting dotenv and the file exists', async () => {
     const { command } = createCommand([
       '--platform',
@@ -295,15 +340,15 @@ describe(Simulator, () => {
     expect(fs.writeFile).toHaveBeenNthCalledWith(
       1,
       simulatorDotenvPath,
-      SIMULATOR_DOTENV_FILE_HEADER + `${EAS_SIMULATOR_SESSION_ID}="session-123"\n`
+      SIMULATOR_DOTENV_FILE_HEADER + `${EAS_SIMULATOR_SESSION_ID}='session-123'\n`
     );
     expect(fs.writeFile).toHaveBeenNthCalledWith(
       2,
       simulatorDotenvPath,
       SIMULATOR_DOTENV_FILE_HEADER +
-        'AGENT_DEVICE_DAEMON_BASE_URL="https://agent.example.com"\n' +
-        'AGENT_DEVICE_DAEMON_AUTH_TOKEN="token-123"\n' +
-        `${EAS_SIMULATOR_SESSION_ID}="session-123"\n`
+        "AGENT_DEVICE_DAEMON_BASE_URL='https://agent.example.com'\n" +
+        "AGENT_DEVICE_DAEMON_AUTH_TOKEN='token-123'\n" +
+        `${EAS_SIMULATOR_SESSION_ID}='session-123'\n`
     );
   });
 

--- a/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
@@ -161,7 +161,7 @@ describe(SimulatorList, () => {
       '--status',
       'new',
       '--type',
-      'argent',
+      'appium',
       '--platform',
       'ios',
       '--name',
@@ -179,7 +179,7 @@ describe(SimulatorList, () => {
       after: 'page-cursor',
       filter: {
         statuses: [DeviceRunSessionStatus.InProgress, DeviceRunSessionStatus.New],
-        types: [DeviceRunSessionType.Argent],
+        types: [DeviceRunSessionType.Appium],
         platforms: [AppPlatform.Ios],
         name: 'checkout',
       },

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1078,19 +1078,6 @@ export type AgentDeviceRunSessionRemoteConfig = {
   webPreviewUrl?: Maybe<Scalars['String']['output']>;
 };
 
-export type AppiumRunSessionRemoteConfig = {
-  __typename?: 'AppiumRunSessionRemoteConfig';
-  /** Authenticated Appium server URL. Treat this value as a secret. */
-  appiumUrl: Scalars['String']['output'];
-  /** W3C capabilities for the device that backs this session. */
-  capabilities: Scalars['JSONObject']['output'];
-  /**
-   * URL of the web preview surface for the session. Null when web previews are
-   * not available for the platform (e.g. Android).
-   */
-  webPreviewUrl?: Maybe<Scalars['String']['output']>;
-};
-
 export type AndroidAppBuildCredentials = {
   __typename?: 'AndroidAppBuildCredentials';
   androidKeystore?: Maybe<AndroidKeystore>;
@@ -2204,6 +2191,8 @@ export type AppObserve = {
   navigationRoutes: AppObserveNavigationRoutesConnection;
   /** Active users and sessions for the Overview engagement band, across all versions. */
   overviewEngagement: AppObserveOverviewEngagement;
+  /** Crash-free rates with previous-period comparison for the Overview stability tiles. */
+  overviewStability: AppObserveOverviewStability;
   /** Per-update comparison within one app version: the embedded bundle plus each OTA update. */
   overviewUpdateComparison: AppObserveOverviewUpdateComparison;
   /** Per-version, per-platform metric summaries for the Overview version-comparison matrix. */
@@ -2306,6 +2295,11 @@ export type AppObserveNavigationRoutesArgs = {
 
 export type AppObserveOverviewEngagementArgs = {
   input: AppObserveOverviewEngagementInput;
+};
+
+
+export type AppObserveOverviewStabilityArgs = {
+  input: AppObserveOverviewStabilityInput;
 };
 
 
@@ -2458,6 +2452,8 @@ export type AppObserveCustomEvent = {
   sessionId?: Maybe<Scalars['String']['output']>;
   severityNumber?: Maybe<Scalars['Int']['output']>;
   severityText?: Maybe<Scalars['String']['output']>;
+  /** Build whose uploaded source map symbolicated exceptionStacktrace; null when the stack trace is shown as reported. */
+  symbolicationBuild?: Maybe<Build>;
   timestamp: Scalars['DateTime']['output'];
 };
 
@@ -2664,6 +2660,24 @@ export enum AppObserveErrorGroupsOrderBy {
   MostFrequent = 'MOST_FREQUENT',
   MostUsers = 'MOST_USERS'
 }
+
+/** AppObserveErrorStats for one platform; iOS includes iPadOS and tvOS. */
+export type AppObserveErrorPlatformStats = {
+  __typename?: 'AppObserveErrorPlatformStats';
+  /** Distinct sessions on this platform that hit any exception. */
+  affectedSessions: Scalars['Int']['output'];
+  /** Distinct users on this platform that hit any exception. */
+  affectedUsers: Scalars['Int']['output'];
+  /** Fraction (0..1) of this platform's active sessions without a fatal error. */
+  crashFreeSessions: Scalars['Float']['output'];
+  /** Fraction (0..1) of this platform's active users without a fatal error. */
+  crashFreeUsers: Scalars['Float']['output'];
+  fatalCount: Scalars['Int']['output'];
+  nonFatalCount: Scalars['Int']['output'];
+  platform: AppObservePlatform;
+  /** Total exception events in range on this platform. */
+  totalErrors: Scalars['Int']['output'];
+};
 
 export enum AppObserveErrorSeverity {
   Error = 'ERROR',
@@ -2886,7 +2900,7 @@ export type AppObserveNavigationStat = {
 
 export type AppObserveOverviewAllReleases = {
   __typename?: 'AppObserveOverviewAllReleases';
-  /** One entry per (metric, platform) with data in range; iOS includes tvOS and iPadOS. */
+  /** One entry per (metric, platform) with data in range; one entry per exact device platform. */
   metrics: Array<AppObserveOverviewVersionMetric>;
   uniqueUserCount: Scalars['Int']['output'];
 };
@@ -2923,12 +2937,41 @@ export type AppObserveOverviewEngagementStat = {
 
 export type AppObserveOverviewStability = {
   __typename?: 'AppObserveOverviewStability';
-  affectedUsers: Scalars['Int']['output'];
+  /** Fatal exception events in range. */
+  crashCount: Scalars['Int']['output'];
   /** Fraction (0..1) of active sessions without a fatal error. */
   crashFreeSessions: Scalars['Float']['output'];
   /** Fraction (0..1) of active users without a fatal error. */
   crashFreeUsers: Scalars['Float']['output'];
+  /** Distinct users that hit a fatal error in range. */
+  crashedUsers: Scalars['Int']['output'];
+  /** Fatal exception events in the equal-length window before startTime. */
+  previousPeriodCrashCount: Scalars['Int']['output'];
+  /** Same fractions for the equal-length window before startTime; null when it had no activity. */
+  previousPeriodCrashFreeSessions?: Maybe<Scalars['Float']['output']>;
+  previousPeriodCrashFreeUsers?: Maybe<Scalars['Float']['output']>;
+  previousPeriodCrashedUsers: Scalars['Int']['output'];
+  series: Array<AppObserveOverviewStabilityBucket>;
+  /** All exception events in range, for distinguishing quiet apps from crash-free ones. */
   totalErrors: Scalars['Int']['output'];
+};
+
+export type AppObserveOverviewStabilityBucket = {
+  __typename?: 'AppObserveOverviewStabilityBucket';
+  /** Approximate unique users that hit any exception in this bucket. Not summable across buckets. */
+  affectedUsers: Scalars['Int']['output'];
+  bucketStart: Scalars['DateTime']['output'];
+  crashCount: Scalars['Int']['output'];
+};
+
+/** Stability-tile filters. No release filters: the tiles always span all versions. */
+export type AppObserveOverviewStabilityInput = {
+  /** Series bucket size. Defaults to one day. */
+  bucketIntervalMinutes?: InputMaybe<Scalars['Int']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  platform?: InputMaybe<AppObservePlatform>;
+  startTime: Scalars['DateTime']['input'];
 };
 
 export type AppObserveOverviewUpdate = {
@@ -2948,7 +2991,8 @@ export type AppObserveOverviewUpdate = {
   metrics: Array<AppObserveOverviewUpdateMetric>;
   /** When the update was published; null for the embedded bundle. */
   publishedAt?: Maybe<Scalars['DateTime']['output']>;
-  stability: AppObserveOverviewStability;
+  /** Error stats for this update, one entry per platform with activity; iOS includes iPadOS and tvOS. */
+  stability: Array<AppObserveErrorPlatformStats>;
   uniqueUserCount: Scalars['Int']['output'];
 };
 
@@ -2986,10 +3030,10 @@ export type AppObserveOverviewVersion = {
   __typename?: 'AppObserveOverviewVersion';
   appVersion: Scalars['String']['output'];
   firstSeenAt: Scalars['DateTime']['output'];
-  /** One entry per (metric, platform) with data in range; iOS includes tvOS and iPadOS. */
+  /** One entry per (metric, platform) with data in range; each device OS (iOS, iPadOS, tvOS, macOS, Android) is a separate platform. */
   metrics: Array<AppObserveOverviewVersionMetric>;
-  /** Error stats for this version, all platforms combined. */
-  stability: AppObserveOverviewStability;
+  /** Error stats for this version, one entry per platform with activity; iOS includes iPadOS and tvOS. */
+  stability: Array<AppObserveErrorPlatformStats>;
   uniqueUserCount: Scalars['Int']['output'];
 };
 
@@ -3030,7 +3074,10 @@ export type AppObserveOverviewVersionSummary = {
 
 export enum AppObservePlatform {
   Android = 'ANDROID',
-  Ios = 'IOS'
+  Ios = 'IOS',
+  Ipados = 'IPADOS',
+  Macos = 'MACOS',
+  Tvos = 'TVOS'
 }
 
 export enum AppObservePropertyType {
@@ -3619,6 +3666,19 @@ export type AppWorkflowsInsightsWorkflowsArgs = {
   filters?: InputMaybe<WorkflowsInsightsFiltersInput>;
   first: Scalars['Int']['input'];
   timespan: WorkflowsInsightsTimespanInput;
+};
+
+export type AppiumRunSessionRemoteConfig = {
+  __typename?: 'AppiumRunSessionRemoteConfig';
+  /** Appium server URL for the remote device. */
+  appiumUrl: Scalars['String']['output'];
+  /** W3C capabilities for the device that backs this session. */
+  capabilities: Scalars['JSONObject']['output'];
+  /**
+   * URL of the web preview surface for the session. Null when web previews are
+   * not available for the platform (e.g. Android).
+   */
+  webPreviewUrl?: Maybe<Scalars['String']['output']>;
 };
 
 export type AppleAppIdentifier = {
@@ -5185,14 +5245,15 @@ export type CreateDeviceRunSessionInput = {
    * Stop the session automatically after this many minutes without observed
    * session activity. Must be positive and smaller than the session's maximum
    * duration (2 hours, or maxRunTimeMinutes when set). Only supported for
-   * agent-device and argent sessions. If omitted, the session has no idle
+   * agent-device, argent, and Appium sessions. If omitted, the session has no idle
    * timeout.
    */
   maxIdleTimeMinutes?: InputMaybe<Scalars['Int']['input']>;
   /**
-   * Override for the underlying turtle job run's max run time, in minutes. Must
-   * be non-negative and smaller than 120 (2 hours). Only customizable on paid
-   * plans. If omitted, the default is derived based on the job run's priority.
+   * Maximum usable session duration, in minutes, starting when the remote session
+   * is ready. Must be non-negative and no greater than 40 for normal-priority
+   * accounts or 115 for high-priority accounts. The backing job receives an
+   * additional five minutes for cleanup.
    */
   maxRunTimeMinutes?: InputMaybe<Scalars['Int']['input']>;
   /**

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1078,6 +1078,19 @@ export type AgentDeviceRunSessionRemoteConfig = {
   webPreviewUrl?: Maybe<Scalars['String']['output']>;
 };
 
+export type AppiumRunSessionRemoteConfig = {
+  __typename?: 'AppiumRunSessionRemoteConfig';
+  /** Authenticated Appium server URL. Treat this value as a secret. */
+  appiumUrl: Scalars['String']['output'];
+  /** W3C capabilities for the device that backs this session. */
+  capabilities: Scalars['JSONObject']['output'];
+  /**
+   * URL of the web preview surface for the session. Null when web previews are
+   * not available for the platform (e.g. Android).
+   */
+  webPreviewUrl?: Maybe<Scalars['String']['output']>;
+};
+
 export type AndroidAppBuildCredentials = {
   __typename?: 'AndroidAppBuildCredentials';
   androidKeystore?: Maybe<AndroidKeystore>;
@@ -6069,7 +6082,7 @@ export type DeviceRunSessionQueryByIdArgs = {
   deviceRunSessionId: Scalars['ID']['input'];
 };
 
-export type DeviceRunSessionRemoteConfig = AgentDeviceRunSessionRemoteConfig | ArgentRunSessionRemoteConfig | ServeSimRunSessionRemoteConfig;
+export type DeviceRunSessionRemoteConfig = AgentDeviceRunSessionRemoteConfig | AppiumRunSessionRemoteConfig | ArgentRunSessionRemoteConfig | ServeSimRunSessionRemoteConfig;
 
 export enum DeviceRunSessionStatus {
   Errored = 'ERRORED',
@@ -6080,6 +6093,7 @@ export enum DeviceRunSessionStatus {
 
 export enum DeviceRunSessionType {
   AgentDevice = 'AGENT_DEVICE',
+  Appium = 'APPIUM',
   Argent = 'ARGENT',
   ServeSim = 'SERVE_SIM'
 }
@@ -14917,6 +14931,7 @@ export type DeviceRunSessionByIdQueryVariables = Exact<{
 
 export type DeviceRunSessionByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, name?: string | null, status: DeviceRunSessionStatus, type: DeviceRunSessionType, platform: AppPlatform, createdAt: any, startedAt?: any | null, finishedAt?: any | null, updatedAt: any, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, artifacts: Array<{ __typename?: 'DeviceRunSessionArtifact', id: string, name: string, filename: string, downloadUrl: string, fileSizeBytes?: number | null, metadata?: any | null, createdAt: any, updatedAt: any }>, remoteConfig?:
         | { __typename: 'AgentDeviceRunSessionRemoteConfig', agentDeviceRemoteSessionUrl: string, agentDeviceRemoteSessionToken: string, webPreviewUrl?: string | null }
+        | { __typename: 'AppiumRunSessionRemoteConfig', appiumUrl: string, capabilities: any, webPreviewUrl?: string | null }
         | { __typename: 'ArgentRunSessionRemoteConfig', toolsUrl: string, toolsAuthToken?: string | null, webPreviewUrl?: string | null }
         | { __typename: 'ServeSimRunSessionRemoteConfig', previewUrl: string }
        | null, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } } };

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
@@ -92,6 +92,11 @@ export const DeviceRunSessionQuery = {
                       toolsAuthToken
                       webPreviewUrl
                     }
+                    ... on AppiumRunSessionRemoteConfig {
+                      appiumUrl
+                      capabilities
+                      webPreviewUrl
+                    }
                     ... on ServeSimRunSessionRemoteConfig {
                       previewUrl
                     }

--- a/packages/eas-cli/src/simulator/__tests__/env.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/env.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs-extra';
+import { parse as parseDotenv } from 'dotenv';
 
 import {
   EAS_SIMULATOR_SESSION_ID,
@@ -18,7 +19,7 @@ describe(resetSimulatorEnvAsync, () => {
     jest.clearAllMocks();
     jest
       .mocked(fs.readFile)
-      .mockResolvedValue(`${EAS_SIMULATOR_SESSION_ID}="session-123"\n` as never);
+      .mockResolvedValue(`${EAS_SIMULATOR_SESSION_ID}='session-123'\n` as never);
     jest.mocked(fs.writeFile).mockResolvedValue(undefined as never);
     jest.mocked(fs.truncate).mockResolvedValue(undefined as never);
   });
@@ -81,9 +82,21 @@ describe(writeSimulatorEnvAsync, () => {
     expect(fs.writeFile).toHaveBeenCalledWith(
       simulatorDotenvPath,
       SIMULATOR_DOTENV_FILE_HEADER +
-        'AGENT_DEVICE_DAEMON_BASE_URL="https://agent.example.com"\n' +
-        'AGENT_DEVICE_DAEMON_AUTH_TOKEN="token-123"\n' +
-        `${EAS_SIMULATOR_SESSION_ID}="session-123"\n`
+        "AGENT_DEVICE_DAEMON_BASE_URL='https://agent.example.com'\n" +
+        "AGENT_DEVICE_DAEMON_AUTH_TOKEN='token-123'\n" +
+        `${EAS_SIMULATOR_SESSION_ID}='session-123'\n`
     );
+  });
+
+  it('preserves serialized Appium capabilities as one dotenv value', async () => {
+    const capabilities = JSON.stringify({
+      platformName: 'iOS',
+      note: `It's important to preserve "quotes" and \\slashes`,
+    });
+
+    await writeSimulatorEnvAsync(projectDir, { APPIUM_CAPS: capabilities });
+
+    const writtenContent = jest.mocked(fs.writeFile).mock.calls[0][1];
+    expect(parseDotenv(String(writtenContent)).APPIUM_CAPS).toBe(capabilities);
   });
 });

--- a/packages/eas-cli/src/simulator/__tests__/utils.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/utils.test.ts
@@ -1,0 +1,39 @@
+import { DeviceRunSessionType } from '../../graphql/generated';
+import {
+  DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE,
+  formatRemoteSessionInstructions,
+  getRemoteSessionEnvironmentVariables,
+} from '../utils';
+
+const iosAppiumConfig = {
+  __typename: 'AppiumRunSessionRemoteConfig' as const,
+  appiumUrl: 'https://appium.example.test',
+  capabilities: {
+    platformName: 'iOS',
+    'appium:automationName': 'XCUITest',
+    'appium:udid': 'simulator-id',
+  },
+  webPreviewUrl: 'https://preview.example.test',
+};
+
+describe('Appium simulator configuration', () => {
+  it('maps the appium CLI value to the GraphQL enum', () => {
+    expect(DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE.appium).toBe(DeviceRunSessionType.Appium);
+  });
+
+  it('creates the Appium client environment', () => {
+    expect(getRemoteSessionEnvironmentVariables(iosAppiumConfig)).toEqual({
+      APPIUM_URL: 'https://appium.example.test',
+      APPIUM_CAPS:
+        '{"platformName":"iOS","appium:automationName":"XCUITest","appium:udid":"simulator-id"}',
+    });
+  });
+
+  it('does not print the URL in managed dotenv instructions', () => {
+    const instructions = formatRemoteSessionInstructions(iosAppiumConfig, 'dotenv');
+
+    expect(instructions).toContain('eas simulator:exec <appium-client> [args...]');
+    expect(instructions).toContain('https://preview.example.test');
+    expect(instructions).not.toContain('https://appium.example.test');
+  });
+});

--- a/packages/eas-cli/src/simulator/env.ts
+++ b/packages/eas-cli/src/simulator/env.ts
@@ -29,7 +29,7 @@ export async function writeSimulatorEnvAsync(
   const simulatorDotenvContent =
     SIMULATOR_DOTENV_FILE_HEADER +
     Object.entries(environmentVariables)
-      .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
+      .map(([key, value]) => `${key}='${value}'`)
       .join('\n') +
     '\n';
 

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -22,6 +22,7 @@ export function formatSimulatorUnavailableMessage(accountName: string): string {
 // so adding a new enum value in codegen fails the build until it is wired up here.
 export const DEVICE_RUN_SESSION_TYPE_FLAG_VALUES: Record<DeviceRunSessionType, string> = {
   [DeviceRunSessionType.AgentDevice]: 'agent-device',
+  [DeviceRunSessionType.Appium]: 'appium',
   [DeviceRunSessionType.Argent]: 'argent',
   [DeviceRunSessionType.ServeSim]: 'serve-sim',
 };
@@ -49,6 +50,11 @@ export function getRemoteSessionEnvironmentVariables(
       return {
         ARGENT_TOOLS_URL: remoteConfig.toolsUrl,
         ...(remoteConfig.toolsAuthToken ? { ARGENT_AUTH_TOKEN: remoteConfig.toolsAuthToken } : {}),
+      };
+    case 'AppiumRunSessionRemoteConfig':
+      return {
+        APPIUM_URL: remoteConfig.appiumUrl,
+        APPIUM_CAPS: JSON.stringify(remoteConfig.capabilities),
       };
     case 'ServeSimRunSessionRemoteConfig':
       return {};
@@ -123,6 +129,29 @@ export function formatRemoteSessionInstructions(
           '',
           remoteConfig.webPreviewUrl
         );
+      }
+      return lines.join('\n');
+    }
+    case 'AppiumRunSessionRemoteConfig': {
+      const environmentVariables = getRemoteSessionEnvironmentVariables(remoteConfig);
+      const lines =
+        configType === 'dotenv'
+          ? [
+              'Run an Appium client with the simulator session environment:',
+              '',
+              'eas simulator:exec <appium-client> [args...]',
+            ]
+          : [
+              'Run the following in your shell to attach an Appium client to this session:',
+              '',
+              ...Object.entries(environmentVariables).map(
+                ([key, value]) => `export ${key}='${value}'`
+              ),
+              '',
+              '<appium-client> [args...]',
+            ];
+      if (remoteConfig.webPreviewUrl) {
+        lines.push('', 'Open the iOS simulator preview:', '', remoteConfig.webPreviewUrl);
       }
       return lines.join('\n');
     }


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Now that we support Appium sessions, eas-cli needs to support it too.

# How

Added spread on GraphQL fetch, special instructions for printing and env file.

# Test Plan

CI should pass. Also ran a local e2e test.