### PR TITLE
[eas-cli] Disallow 0-length uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Disallow 0-length uploads. ([#4192](https://github.com/expo/eas-cli/pull/4192) by [@wschurman](https://github.com/wschurman))
+
 ### 🧹 Chores
 
 ## [22.0.0](https://github.com/expo/eas-cli/releases/tag/v22.0.0) - 2026-08-14

--- a/packages/eas-cli/src/uploads.ts
+++ b/packages/eas-cli/src/uploads.ts
@@ -148,6 +148,11 @@ async function uploadWithSignedUrlWithProgressAsync(
 ): Promise<Response> {
   const fileStat = await fs.stat(file);
   const fileSize = fileStat.size;
+  if (fileSize === 0) {
+    throw new Error(
+      `Failed to upload ${file}: the file is empty. It may not have been written correctly. Retry the command, and report this issue if it persists.`
+    );
+  }
 
   const readStream = fs.createReadStream(file);
   const uploadPromise = fetch(signedUrl.url, {
@@ -155,6 +160,7 @@ async function uploadWithSignedUrlWithProgressAsync(
     body: readStream,
     headers: {
       ...signedUrl.headers,
+      'Content-Length': String(fileSize), // make GCS reject the request if the file size changes during the upload
     },
   });
 
@@ -171,6 +177,11 @@ async function uploadWithSignedUrlWithProgressAsync(
   });
   try {
     const response = await uploadPromise;
+    if (currentSize !== fileSize) {
+      throw new Error(
+        `Failed to upload ${file}: sent ${currentSize} of ${fileSize} bytes. The file may have changed during the upload. Retry the command, and report this issue if it persists.`
+      );
+    }
     handleProgressEvent({ isComplete: true });
     return response;
   } catch (error: any) {


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Some fingerprint source uploads are ending up 0-sized. We're not sure why. The goal of this PR is to help isolate the issue by preventing 0-length uploads to begin with so we can trace the "why".

Ref ENG-25965.

# How

Disallow 0-length uploads by checking length ahead of upload, validating uploaded length using `content-length` header, and checking length post-upload.

# Test Plan

1. `EXPO_STAGING=1 neas fingerprint:generate --platform android`
2. Navigate to fingerprint permalink, see sources are uploaded.
