### PR TITLE
[build-tools] Restore maestro-runner WDA cache

### DIFF
--- a/packages/build-tools/src/ios/__tests__/xcode.test.ts
+++ b/packages/build-tools/src/ios/__tests__/xcode.test.ts
@@ -1,3 +1,4 @@
+import { SystemError } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 
 import { getXcodeVersionAsync } from '../xcode';
@@ -28,5 +29,18 @@ describe(getXcodeVersionAsync, () => {
     await expect(getXcodeVersionAsync({ env: process.env })).rejects.toThrow(
       'Failed to determine Xcode version'
     );
+  });
+
+  it('wraps errors from xcodebuild in a SystemError', async () => {
+    const cause = new Error('xcode-select: error: invalid developer directory');
+    mockedSpawn.mockRejectedValue(cause);
+
+    const promise = getXcodeVersionAsync({ env: process.env });
+
+    await expect(promise).rejects.toBeInstanceOf(SystemError);
+    await expect(promise).rejects.toMatchObject({
+      message: 'Failed to get Xcode version',
+      cause,
+    });
   });
 });

--- a/packages/build-tools/src/ios/__tests__/xcode.test.ts
+++ b/packages/build-tools/src/ios/__tests__/xcode.test.ts
@@ -1,0 +1,32 @@
+import spawn from '@expo/turtle-spawn';
+
+import { getXcodeVersionAsync } from '../xcode';
+
+jest.mock('@expo/turtle-spawn', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockedSpawn = jest.mocked(spawn);
+
+describe(getXcodeVersionAsync, () => {
+  it('returns the Xcode version', async () => {
+    mockedSpawn.mockResolvedValue({
+      stdout: 'Xcode 26.0\nBuild version 17A324\n',
+    } as any);
+
+    await expect(getXcodeVersionAsync({ env: process.env })).resolves.toBe('26.0');
+    expect(mockedSpawn).toHaveBeenCalledWith('xcodebuild', ['-version'], {
+      stdio: 'pipe',
+      env: process.env,
+    });
+  });
+
+  it('throws when the Xcode version cannot be parsed', async () => {
+    mockedSpawn.mockResolvedValue({ stdout: 'unexpected output' } as any);
+
+    await expect(getXcodeVersionAsync({ env: process.env })).rejects.toThrow(
+      'Failed to determine Xcode version'
+    );
+  });
+});

--- a/packages/build-tools/src/ios/xcode.ts
+++ b/packages/build-tools/src/ios/xcode.ts
@@ -1,0 +1,11 @@
+import { SystemError } from '@expo/eas-build-job';
+import spawn from '@expo/turtle-spawn';
+
+export async function getXcodeVersionAsync({ env }: { env: NodeJS.ProcessEnv }): Promise<string> {
+  const { stdout } = await spawn('xcodebuild', ['-version'], { stdio: 'pipe', env });
+  const version = /^Xcode\s+(\d+(?:\.\d+)*)$/m.exec(stdout)?.[1];
+  if (!version) {
+    throw new SystemError(`Failed to determine Xcode version from: ${stdout.trim()}`);
+  }
+  return version;
+}

--- a/packages/build-tools/src/ios/xcode.ts
+++ b/packages/build-tools/src/ios/xcode.ts
@@ -2,7 +2,12 @@ import { SystemError } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 
 export async function getXcodeVersionAsync({ env }: { env: NodeJS.ProcessEnv }): Promise<string> {
-  const { stdout } = await spawn('xcodebuild', ['-version'], { stdio: 'pipe', env });
+  let stdout: string;
+  try {
+    ({ stdout } = await spawn('xcodebuild', ['-version'], { stdio: 'pipe', env }));
+  } catch (error) {
+    throw new SystemError('Failed to get Xcode version', { cause: error });
+  }
   const version = /^Xcode\s+(\d+(?:\.\d+)*)$/m.exec(stdout)?.[1];
   if (!version) {
     throw new SystemError(`Failed to determine Xcode version from: ${stdout.trim()}`);

--- a/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
@@ -1,6 +1,9 @@
 import { SystemError, UserError } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 import { BuildRuntimePlatform } from '@expo/steps';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { Datadog } from '../../../datadog';
@@ -18,6 +21,18 @@ jest.mock('../../../datadog', () => ({
 }));
 
 const mockedSpawn = jest.mocked(spawn);
+
+async function writeInstalledWdaVersion(homeDirectory: string, version: string): Promise<void> {
+  const wdaDirectory = path.join(
+    homeDirectory,
+    '.maestro-runner',
+    'drivers',
+    'ios',
+    'WebDriverAgent'
+  );
+  await fs.promises.mkdir(wdaDirectory, { recursive: true });
+  await fs.promises.writeFile(path.join(wdaDirectory, 'package.json'), JSON.stringify({ version }));
+}
 
 describe('createInstallMaestroBuildFunction', () => {
   beforeEach(() => {
@@ -437,6 +452,177 @@ describe('createInstallMaestroBuildFunction', () => {
     } finally {
       jest.restoreAllMocks();
       process.env.PATH = originalPath;
+    }
+  });
+
+  it('installs the prebuilt WDA cache for each available iOS runtime', async () => {
+    const homeDirectory = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'install-maestro-test-')
+    );
+    mockedSpawn.mockImplementation((async (command: string, args: string[]) => {
+      if (command === 'maestro-runner') {
+        return { stdout: 'maestro-runner 1.2.3\n' };
+      }
+      if (command === 'xcrun') {
+        return {
+          stdout: JSON.stringify({
+            runtimes: [
+              {
+                identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-3',
+                isAvailable: true,
+                version: '18.3',
+              },
+              {
+                identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-0',
+                isAvailable: true,
+                version: '26.0',
+              },
+              {
+                identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-17-5',
+                isAvailable: false,
+                version: '17.5',
+              },
+            ],
+          }),
+        };
+      }
+      if (command === 'xcodebuild') {
+        return { stdout: 'Xcode 26.0\nBuild version 17A324\n' };
+      }
+      if (command === 'tar') {
+        const maestroRunnerHome = args[args.indexOf('-C') + 1];
+        const productsDirectory = path.join(
+          maestroRunnerHome,
+          'cache',
+          'wda-builds',
+          'generic',
+          'DerivedData',
+          'Build',
+          'Products'
+        );
+        await fs.promises.mkdir(productsDirectory, { recursive: true });
+        await fs.promises.writeFile(
+          path.join(productsDirectory, 'WebDriverAgentRunner.xctestrun'),
+          'cached'
+        );
+      }
+      return { stdout: '' };
+    }) as any);
+
+    try {
+      await writeInstalledWdaVersion(homeDirectory, '11.1.3');
+      const installMaestro = createInstallMaestroBuildFunction();
+      const globalCtx = createGlobalContextMock({
+        runtimePlatform: BuildRuntimePlatform.DARWIN,
+      });
+      globalCtx.updateEnv({
+        EAS_BUILD_RUNNER: 'eas-build',
+        HOME: homeDirectory,
+      });
+      const step = installMaestro.createBuildStepFromFunctionCall(globalCtx, {
+        callInputs: { backend: 'maestro-runner' },
+      });
+
+      await step.executeAsync();
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        'curl',
+        expect.arrayContaining([
+          'https://storage.googleapis.com/turtle-v2/maestro-runner-wda-cache/xcode-26.0-wda-11.1.3.tar.gz',
+        ]),
+        expect.objectContaining({ env: expect.objectContaining({ HOME: homeDirectory }) })
+      );
+      for (const runtimeVersion of ['18.3', '26.0']) {
+        await expect(
+          fs.promises.readFile(
+            path.join(
+              homeDirectory,
+              '.maestro-runner',
+              'cache',
+              'wda-builds',
+              `sim-ios${runtimeVersion}-iphone`,
+              'DerivedData',
+              'Build',
+              'Products',
+              'WebDriverAgentRunner.xctestrun'
+            ),
+            'utf8'
+          )
+        ).resolves.toBe('cached');
+      }
+      await expect(
+        fs.promises.access(
+          path.join(homeDirectory, '.maestro-runner', 'cache', 'wda-builds', 'sim-ios17.5-iphone')
+        )
+      ).rejects.toThrow();
+    } finally {
+      await fs.promises.rm(homeDirectory, { force: true, recursive: true });
+    }
+  });
+
+  it('does not download the WDA cache when the installed WDA version is unknown', async () => {
+    mockedSpawn.mockResolvedValue({ stdout: 'maestro-runner 1.2.3\n' } as any);
+    const installMaestro = createInstallMaestroBuildFunction();
+    const globalCtx = createGlobalContextMock({
+      runtimePlatform: BuildRuntimePlatform.DARWIN,
+    });
+    globalCtx.updateEnv({ EAS_BUILD_RUNNER: 'eas-build', HOME: '/home/expo' });
+    const step = installMaestro.createBuildStepFromFunctionCall(globalCtx, {
+      callInputs: { backend: 'maestro-runner' },
+    });
+
+    await step.executeAsync();
+
+    expect(mockedSpawn.mock.calls.map(([command]) => command)).toEqual([
+      'maestro-runner',
+      'maestro-runner',
+    ]);
+  });
+
+  it('continues when the prebuilt WDA cache is not available', async () => {
+    mockedSpawn.mockImplementation((async (command: string) => {
+      switch (command) {
+        case 'maestro-runner':
+          return { stdout: 'maestro-runner 1.2.3\n' };
+        case 'xcodebuild':
+          return { stdout: 'Xcode 26.5\nBuild version 17F90\n' };
+        case 'xcrun':
+          return {
+            stdout: JSON.stringify({
+              runtimes: [
+                {
+                  identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-5',
+                  isAvailable: true,
+                  version: '26.5',
+                },
+              ],
+            }),
+          };
+        case 'curl':
+          throw new Error('HTTP 404');
+        default:
+          return { stdout: '' };
+      }
+    }) as any);
+    const homeDirectory = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'install-maestro-test-')
+    );
+
+    try {
+      await writeInstalledWdaVersion(homeDirectory, '11.1.3');
+      const installMaestro = createInstallMaestroBuildFunction();
+      const globalCtx = createGlobalContextMock({
+        runtimePlatform: BuildRuntimePlatform.DARWIN,
+      });
+      globalCtx.updateEnv({ EAS_BUILD_RUNNER: 'eas-build', HOME: homeDirectory });
+      const step = installMaestro.createBuildStepFromFunctionCall(globalCtx, {
+        callInputs: { backend: 'maestro-runner' },
+      });
+
+      await expect(step.executeAsync()).resolves.toBeUndefined();
+      expect(step.getOutputValueByName('maestro_version')).toBe('1.2.3');
+    } finally {
+      await fs.promises.rm(homeDirectory, { force: true, recursive: true });
     }
   });
 });

--- a/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
@@ -478,7 +478,7 @@ describe('createInstallMaestroBuildFunction', () => {
               {
                 identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-3',
                 isAvailable: true,
-                version: '18.3',
+                version: '18.3.1',
               },
               {
                 identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-26-0',
@@ -537,7 +537,7 @@ describe('createInstallMaestroBuildFunction', () => {
       expect(mockedDownloadFile).toHaveBeenCalledWith(
         'https://cache.example.com/storage.googleapis.com/turtle-v2/maestro-runner-wda-cache/xcode-26.0-wda-11.1.3.tar.gz',
         expect.stringMatching(/install_maestro_runner_wda_cache.*\/wda-cache\.tar\.gz$/),
-        { retry: 3 }
+        { retry: 3, timeout: 20_000 }
       );
       for (const runtimeVersion of ['18.3', '26.0']) {
         await expect(

--- a/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
@@ -1,3 +1,4 @@
+import downloadFile from '@expo/downloader';
 import { SystemError, UserError } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 import { BuildRuntimePlatform } from '@expo/steps';
@@ -14,6 +15,11 @@ jest.mock('@expo/turtle-spawn', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('@expo/downloader', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 jest.mock('../../../datadog', () => ({
   Datadog: {
     distribution: jest.fn(),
@@ -21,6 +27,7 @@ jest.mock('../../../datadog', () => ({
 }));
 
 const mockedSpawn = jest.mocked(spawn);
+const mockedDownloadFile = jest.mocked(downloadFile);
 
 async function writeInstalledWdaVersion(homeDirectory: string, version: string): Promise<void> {
   const wdaDirectory = path.join(
@@ -37,6 +44,7 @@ async function writeInstalledWdaVersion(homeDirectory: string, version: string):
 describe('createInstallMaestroBuildFunction', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedDownloadFile.mockResolvedValue(undefined);
     // `maestro --version` reports an installed version; `java -version` succeeds.
     // With no requested version and Maestro present, the step skips installation.
     mockedSpawn.mockImplementation((async (command: string) => ({
@@ -525,12 +533,10 @@ describe('createInstallMaestroBuildFunction', () => {
 
       await step.executeAsync();
 
-      expect(mockedSpawn).toHaveBeenCalledWith(
-        'curl',
-        expect.arrayContaining([
-          'https://storage.googleapis.com/turtle-v2/maestro-runner-wda-cache/xcode-26.0-wda-11.1.3.tar.gz',
-        ]),
-        expect.objectContaining({ env: expect.objectContaining({ HOME: homeDirectory }) })
+      expect(mockedDownloadFile).toHaveBeenCalledWith(
+        'https://storage.googleapis.com/turtle-v2/maestro-runner-wda-cache/xcode-26.0-wda-11.1.3.tar.gz',
+        expect.stringMatching(/install_maestro_runner_wda_cache.*\/wda-cache\.tar\.gz$/),
+        { retry: 3 }
       );
       for (const runtimeVersion of ['18.3', '26.0']) {
         await expect(
@@ -598,12 +604,11 @@ describe('createInstallMaestroBuildFunction', () => {
               ],
             }),
           };
-        case 'curl':
-          throw new Error('HTTP 404');
         default:
           return { stdout: '' };
       }
     }) as any);
+    mockedDownloadFile.mockRejectedValue(new Error('HTTP 404'));
     const homeDirectory = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), 'install-maestro-test-')
     );

--- a/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/installMaestro.test.ts
@@ -525,6 +525,7 @@ describe('createInstallMaestroBuildFunction', () => {
       });
       globalCtx.updateEnv({
         EAS_BUILD_RUNNER: 'eas-build',
+        EAS_BUILD_COCOAPODS_CACHE_URL: 'https://cache.example.com',
         HOME: homeDirectory,
       });
       const step = installMaestro.createBuildStepFromFunctionCall(globalCtx, {
@@ -534,7 +535,7 @@ describe('createInstallMaestroBuildFunction', () => {
       await step.executeAsync();
 
       expect(mockedDownloadFile).toHaveBeenCalledWith(
-        'https://storage.googleapis.com/turtle-v2/maestro-runner-wda-cache/xcode-26.0-wda-11.1.3.tar.gz',
+        'https://cache.example.com/storage.googleapis.com/turtle-v2/maestro-runner-wda-cache/xcode-26.0-wda-11.1.3.tar.gz',
         expect.stringMatching(/install_maestro_runner_wda_cache.*\/wda-cache\.tar\.gz$/),
         { retry: 3 }
       );
@@ -567,7 +568,10 @@ describe('createInstallMaestroBuildFunction', () => {
   });
 
   it('does not download the WDA cache when the installed WDA version is unknown', async () => {
-    mockedSpawn.mockResolvedValue({ stdout: 'maestro-runner 1.2.3\n' } as any);
+    mockedSpawn.mockImplementation((async (command: string) => ({
+      stdout:
+        command === 'xcodebuild' ? 'Xcode 26.5\nBuild version 17F90\n' : 'maestro-runner 1.2.3\n',
+    })) as any);
     const installMaestro = createInstallMaestroBuildFunction();
     const globalCtx = createGlobalContextMock({
       runtimePlatform: BuildRuntimePlatform.DARWIN,
@@ -579,10 +583,10 @@ describe('createInstallMaestroBuildFunction', () => {
 
     await step.executeAsync();
 
-    expect(mockedSpawn.mock.calls.map(([command]) => command)).toEqual([
-      'maestro-runner',
-      'maestro-runner',
-    ]);
+    // The installed WDA version is unknown (no package.json under $HOME), so the
+    // cache download is skipped before resolving the Xcode/runtime versions.
+    expect(mockedDownloadFile).not.toHaveBeenCalled();
+    expect(mockedSpawn.mock.calls.map(([command]) => command)).not.toContain('xcrun');
   });
 
   it('continues when the prebuilt WDA cache is not available', async () => {
@@ -619,13 +623,21 @@ describe('createInstallMaestroBuildFunction', () => {
       const globalCtx = createGlobalContextMock({
         runtimePlatform: BuildRuntimePlatform.DARWIN,
       });
-      globalCtx.updateEnv({ EAS_BUILD_RUNNER: 'eas-build', HOME: homeDirectory });
+      globalCtx.updateEnv({
+        EAS_BUILD_RUNNER: 'eas-build',
+        EAS_BUILD_COCOAPODS_CACHE_URL: 'https://cache.example.com',
+        HOME: homeDirectory,
+      });
       const step = installMaestro.createBuildStepFromFunctionCall(globalCtx, {
         callInputs: { backend: 'maestro-runner' },
       });
 
       await expect(step.executeAsync()).resolves.toBeUndefined();
       expect(step.getOutputValueByName('maestro_version')).toBe('1.2.3');
+      expect(mockedDownloadFile.mock.calls.map(([url]) => url)).toEqual([
+        'https://cache.example.com/storage.googleapis.com/turtle-v2/maestro-runner-wda-cache/xcode-26.5-wda-11.1.3.tar.gz',
+        'https://storage.googleapis.com/turtle-v2/maestro-runner-wda-cache/xcode-26.5-wda-11.1.3.tar.gz',
+      ]);
     } finally {
       await fs.promises.rm(homeDirectory, { force: true, recursive: true });
     }

--- a/packages/build-tools/src/steps/functions/installMaestro.ts
+++ b/packages/build-tools/src/steps/functions/installMaestro.ts
@@ -24,6 +24,8 @@ import { getXcodeVersionAsync } from '../../ios/xcode';
 import { IosSimulatorUtils } from '../../utils/IosSimulatorUtils';
 import { getProxiedDownloadUrl } from '../../utils/download';
 
+const MAESTRO_RUNNER_WDA_CACHE_DOWNLOAD_TIMEOUT_MS = 20_000;
+
 export function createInstallMaestroBuildFunction(): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
@@ -262,16 +264,25 @@ async function installMaestroRunnerWdaCache({
       logger.info(`Downloading the prebuilt WebDriverAgent cache for Xcode ${xcodeVersion}`);
       if (proxiedArchiveUrl) {
         try {
-          await downloadFile(proxiedArchiveUrl, archivePath, { retry: 3 });
+          await downloadFile(proxiedArchiveUrl, archivePath, {
+            retry: 3,
+            timeout: MAESTRO_RUNNER_WDA_CACHE_DOWNLOAD_TIMEOUT_MS,
+          });
         } catch (err) {
           logger.debug(
             { err },
             'Failed to download the prebuilt WebDriverAgent cache via the proxy; falling back to the direct URL.'
           );
-          await downloadFile(directArchiveUrl, archivePath, { retry: 3 });
+          await downloadFile(directArchiveUrl, archivePath, {
+            retry: 3,
+            timeout: MAESTRO_RUNNER_WDA_CACHE_DOWNLOAD_TIMEOUT_MS,
+          });
         }
       } else {
-        await downloadFile(directArchiveUrl, archivePath, { retry: 3 });
+        await downloadFile(directArchiveUrl, archivePath, {
+          retry: 3,
+          timeout: MAESTRO_RUNNER_WDA_CACHE_DOWNLOAD_TIMEOUT_MS,
+        });
       }
       await fs.promises.mkdir(maestroRunnerHome, { recursive: true });
       await spawn('tar', ['-xzf', archivePath, '-C', maestroRunnerHome], { logger, env });

--- a/packages/build-tools/src/steps/functions/installMaestro.ts
+++ b/packages/build-tools/src/steps/functions/installMaestro.ts
@@ -22,9 +22,7 @@ import { MaestroBackend, resolveMaestroBackend } from './maestroBackend';
 import { Datadog } from '../../datadog';
 import { getXcodeVersionAsync } from '../../ios/xcode';
 import { IosSimulatorUtils } from '../../utils/IosSimulatorUtils';
-
-const MAESTRO_RUNNER_WDA_CACHE_URL =
-  'https://storage.googleapis.com/turtle-v2/maestro-runner-wda-cache';
+import { getProxiedDownloadUrl } from '../../utils/download';
 
 export function createInstallMaestroBuildFunction(): BuildFunction {
   return new BuildFunction({
@@ -154,11 +152,13 @@ export function createInstallMaestroBuildFunction(): BuildFunction {
               (requestedVersion === undefined &&
                 (!currentMaestroRunnerVersion || semver.gt(currentMaestroRunnerVersion, '1.1.15'))))
           ) {
-            const xcodeVersion = await getXcodeVersion({ env });
+            // `getXcodeVersionAsync` returns the raw version (e.g. "16.4"), which
+            // `semver.coerce` normalizes (e.g. "16.4.0") for comparison and display.
+            const xcodeVersion = semver.coerce(await getXcodeVersionAsync({ env }));
 
             // maestro-runner 1.1.16 added `arch` to its xcodebuild destination. Xcode versions
             // below 26 reject that option, so use the last compatible maestro-runner version.
-            if (semver.lt(xcodeVersion, '26.0.0')) {
+            if (xcodeVersion && semver.lt(xcodeVersion, '26.0.0')) {
               if (requestedMaestroRunnerVersion) {
                 throw new UserError(
                   'ERR_MAESTRO_INVALID_INPUT',
@@ -214,21 +214,6 @@ export function createInstallMaestroBuildFunction(): BuildFunction {
   });
 }
 
-async function getXcodeVersion({ env }: { env: BuildStepEnv }): Promise<string> {
-  let stdout: string;
-  try {
-    ({ stdout } = await spawn('xcodebuild', ['-version'], { stdio: 'pipe', env }));
-  } catch (error) {
-    throw new SystemError('Failed to get Xcode version', { cause: error });
-  }
-
-  const xcodeVersion = semver.coerce(/^Xcode\s+(\S+)/m.exec(stdout)?.[1])?.version;
-  if (!xcodeVersion) {
-    throw new SystemError(`Failed to parse Xcode version from xcodebuild output: ${stdout.trim()}`);
-  }
-  return xcodeVersion;
-}
-
 async function installMaestroRunnerWdaCache({
   logger,
   env,
@@ -266,12 +251,28 @@ async function installMaestroRunnerWdaCache({
     );
     try {
       const archivePath = path.join(tempDirectory, 'wda-cache.tar.gz');
-      const archiveUrl = `${MAESTRO_RUNNER_WDA_CACHE_URL}/xcode-${encodeURIComponent(
-        xcodeVersion
-      )}-wda-${encodeURIComponent(wdaVersion)}.tar.gz`;
+      const directArchiveUrl =
+        `https://storage.googleapis.com/turtle-v2/maestro-runner-wda-cache/` +
+        `xcode-${encodeURIComponent(xcodeVersion)}-wda-${encodeURIComponent(wdaVersion)}.tar.gz`;
+      const proxiedArchiveUrl = getProxiedDownloadUrl({
+        directUrl: directArchiveUrl,
+        proxyBaseUrl: env.EAS_BUILD_COCOAPODS_CACHE_URL,
+      });
 
       logger.info(`Downloading the prebuilt WebDriverAgent cache for Xcode ${xcodeVersion}`);
-      await downloadFile(archiveUrl, archivePath, { retry: 3 });
+      if (proxiedArchiveUrl) {
+        try {
+          await downloadFile(proxiedArchiveUrl, archivePath, { retry: 3 });
+        } catch (err) {
+          logger.debug(
+            { err },
+            'Failed to download the prebuilt WebDriverAgent cache via the proxy; falling back to the direct URL.'
+          );
+          await downloadFile(directArchiveUrl, archivePath, { retry: 3 });
+        }
+      } else {
+        await downloadFile(directArchiveUrl, archivePath, { retry: 3 });
+      }
       await fs.promises.mkdir(maestroRunnerHome, { recursive: true });
       await spawn('tar', ['-xzf', archivePath, '-C', maestroRunnerHome], { logger, env });
 

--- a/packages/build-tools/src/steps/functions/installMaestro.ts
+++ b/packages/build-tools/src/steps/functions/installMaestro.ts
@@ -1,3 +1,4 @@
+import downloadFile from '@expo/downloader';
 import { SystemError, UserError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
@@ -19,6 +20,8 @@ import semver from 'semver';
 
 import { MaestroBackend, resolveMaestroBackend } from './maestroBackend';
 import { Datadog } from '../../datadog';
+import { getXcodeVersionAsync } from '../../ios/xcode';
+import { IosSimulatorUtils } from '../../utils/IosSimulatorUtils';
 
 const MAESTRO_RUNNER_WDA_CACHE_URL =
   'https://storage.googleapis.com/turtle-v2/maestro-runner-wda-cache';
@@ -233,14 +236,13 @@ async function installMaestroRunnerWdaCache({
   logger: bunyan;
   env: BuildStepEnv;
 }): Promise<void> {
-  const maestroRunnerHome =
-    env.MAESTRO_RUNNER_HOME ?? (env.HOME ? path.join(env.HOME, '.maestro-runner') : undefined);
-  if (!maestroRunnerHome) {
+  if (!env.HOME) {
     logger.warn(
       'Skipping the prebuilt WebDriverAgent cache because the $HOME environment variable is empty.'
     );
     return;
   }
+  const maestroRunnerHome = path.join(env.HOME, '.maestro-runner');
 
   try {
     const wdaVersion = await getMaestroRunnerWdaVersion({ maestroRunnerHome });
@@ -250,8 +252,8 @@ async function installMaestroRunnerWdaCache({
       );
       return;
     }
-    const xcodeVersion = await getXcodeVersion({ env });
-    const iosRuntimeVersions = await getAvailableIosRuntimeVersions({ env });
+    const xcodeVersion = await getXcodeVersionAsync({ env });
+    const iosRuntimeVersions = await IosSimulatorUtils.getAvailableRuntimeVersionsAsync({ env });
     if (iosRuntimeVersions.length === 0) {
       logger.info(
         'Skipping the prebuilt WebDriverAgent cache because no iOS runtime is available.'
@@ -263,16 +265,13 @@ async function installMaestroRunnerWdaCache({
       path.join(os.tmpdir(), 'install_maestro_runner_wda_cache')
     );
     try {
-      const archiveName = `xcode-${xcodeVersion}-wda-${wdaVersion}.tar.gz`;
-      const archivePath = path.join(tempDirectory, archiveName);
-      const archiveUrl = `${MAESTRO_RUNNER_WDA_CACHE_URL}/${archiveName}`;
+      const archivePath = path.join(tempDirectory, 'wda-cache.tar.gz');
+      const archiveUrl = `${MAESTRO_RUNNER_WDA_CACHE_URL}/xcode-${encodeURIComponent(
+        xcodeVersion
+      )}-wda-${encodeURIComponent(wdaVersion)}.tar.gz`;
 
       logger.info(`Downloading the prebuilt WebDriverAgent cache for Xcode ${xcodeVersion}`);
-      await spawn(
-        'curl',
-        ['--fail', '--location', '--silent', '--show-error', archiveUrl, '--output', archivePath],
-        { logger, env }
-      );
+      await downloadFile(archiveUrl, archivePath, { retry: 3 });
       await fs.promises.mkdir(maestroRunnerHome, { recursive: true });
       await spawn('tar', ['-xzf', archivePath, '-C', maestroRunnerHome], { logger, env });
 
@@ -324,37 +323,10 @@ async function getMaestroRunnerWdaVersion({
         'utf8'
       )
     );
-    return typeof packageJson.version === 'string' && packageJson.version.match(/^\d+\.\d+\.\d+$/)
-      ? packageJson.version
-      : null;
+    return typeof packageJson.version === 'string' ? packageJson.version : null;
   } catch {
     return null;
   }
-}
-
-async function getAvailableIosRuntimeVersions({ env }: { env: BuildStepEnv }): Promise<string[]> {
-  const { stdout } = await spawn('xcrun', ['simctl', 'list', 'runtimes', '--json'], {
-    stdio: 'pipe',
-    env,
-  });
-  const runtimes = JSON.parse(stdout).runtimes as {
-    identifier?: string;
-    isAvailable?: boolean;
-    version?: string;
-  }[];
-
-  return [
-    ...new Set(
-      runtimes
-        .filter(
-          runtime =>
-            runtime.isAvailable !== false &&
-            runtime.identifier?.startsWith('com.apple.CoreSimulator.SimRuntime.iOS-') &&
-            runtime.version?.match(/^\d+(?:\.\d+)*$/)
-        )
-        .map(runtime => runtime.version as string)
-    ),
-  ];
 }
 
 async function getMaestroVersion({

--- a/packages/build-tools/src/steps/functions/installMaestro.ts
+++ b/packages/build-tools/src/steps/functions/installMaestro.ts
@@ -240,7 +240,18 @@ async function installMaestroRunnerWdaCache({
       return;
     }
     const xcodeVersion = await getXcodeVersionAsync({ env });
-    const iosRuntimeVersions = await IosSimulatorUtils.getAvailableRuntimeVersionsAsync({ env });
+    const iosRuntimes = await IosSimulatorUtils.getAvailableRuntimesAsync({ env });
+    const iosRuntimeIdentifierPrefix = 'com.apple.CoreSimulator.SimRuntime.iOS-';
+    // maestro-runner derives its WDA cache key from the runtime identifier, not from the runtime
+    // version. These values can differ for patched runtimes, for example the iOS-26-3 identifier
+    // can report version 26.3.1.
+    const iosRuntimeVersions = [
+      ...new Set(
+        iosRuntimes.map(runtime =>
+          runtime.identifier.slice(iosRuntimeIdentifierPrefix.length).replaceAll('-', '.')
+        )
+      ),
+    ];
     if (iosRuntimeVersions.length === 0) {
       logger.info(
         'Skipping the prebuilt WebDriverAgent cache because no iOS runtime is available.'

--- a/packages/build-tools/src/steps/functions/installMaestro.ts
+++ b/packages/build-tools/src/steps/functions/installMaestro.ts
@@ -20,6 +20,9 @@ import semver from 'semver';
 import { MaestroBackend, resolveMaestroBackend } from './maestroBackend';
 import { Datadog } from '../../datadog';
 
+const MAESTRO_RUNNER_WDA_CACHE_URL =
+  'https://storage.googleapis.com/turtle-v2/maestro-runner-wda-cache';
+
 export function createInstallMaestroBuildFunction(): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
@@ -190,6 +193,13 @@ export function createInstallMaestroBuildFunction(): BuildFunction {
         throw new Error(`Failed to ensure ${backend} is installed.`);
       }
 
+      if (backend === 'maestro-runner' && global.runtimePlatform === BuildRuntimePlatform.DARWIN) {
+        await installMaestroRunnerWdaCache({
+          logger,
+          env,
+        });
+      }
+
       logger.info(`${backend} ${maestroVersionResult.value} is ready.`);
       outputs.maestro_version.set(maestroVersionResult.value);
 
@@ -214,6 +224,137 @@ async function getXcodeVersion({ env }: { env: BuildStepEnv }): Promise<string> 
     throw new SystemError(`Failed to parse Xcode version from xcodebuild output: ${stdout.trim()}`);
   }
   return xcodeVersion;
+}
+
+async function installMaestroRunnerWdaCache({
+  logger,
+  env,
+}: {
+  logger: bunyan;
+  env: BuildStepEnv;
+}): Promise<void> {
+  const maestroRunnerHome =
+    env.MAESTRO_RUNNER_HOME ?? (env.HOME ? path.join(env.HOME, '.maestro-runner') : undefined);
+  if (!maestroRunnerHome) {
+    logger.warn(
+      'Skipping the prebuilt WebDriverAgent cache because the $HOME environment variable is empty.'
+    );
+    return;
+  }
+
+  try {
+    const wdaVersion = await getMaestroRunnerWdaVersion({ maestroRunnerHome });
+    if (!wdaVersion) {
+      logger.info(
+        'Skipping the prebuilt WebDriverAgent cache because the installed WDA version is unknown.'
+      );
+      return;
+    }
+    const xcodeVersion = await getXcodeVersion({ env });
+    const iosRuntimeVersions = await getAvailableIosRuntimeVersions({ env });
+    if (iosRuntimeVersions.length === 0) {
+      logger.info(
+        'Skipping the prebuilt WebDriverAgent cache because no iOS runtime is available.'
+      );
+      return;
+    }
+
+    const tempDirectory = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'install_maestro_runner_wda_cache')
+    );
+    try {
+      const archiveName = `xcode-${xcodeVersion}-wda-${wdaVersion}.tar.gz`;
+      const archivePath = path.join(tempDirectory, archiveName);
+      const archiveUrl = `${MAESTRO_RUNNER_WDA_CACHE_URL}/${archiveName}`;
+
+      logger.info(`Downloading the prebuilt WebDriverAgent cache for Xcode ${xcodeVersion}`);
+      await spawn(
+        'curl',
+        ['--fail', '--location', '--silent', '--show-error', archiveUrl, '--output', archivePath],
+        { logger, env }
+      );
+      await fs.promises.mkdir(maestroRunnerHome, { recursive: true });
+      await spawn('tar', ['-xzf', archivePath, '-C', maestroRunnerHome], { logger, env });
+
+      const genericProductsDirectory = path.join(
+        maestroRunnerHome,
+        'cache',
+        'wda-builds',
+        'generic',
+        'DerivedData',
+        'Build',
+        'Products'
+      );
+      for (const runtimeVersion of iosRuntimeVersions) {
+        const productsDirectory = path.join(
+          maestroRunnerHome,
+          'cache',
+          'wda-builds',
+          `sim-ios${runtimeVersion}-iphone`,
+          'DerivedData',
+          'Build',
+          'Products'
+        );
+        await fs.promises.cp(genericProductsDirectory, productsDirectory, { recursive: true });
+      }
+
+      logger.info(
+        `Installed the prebuilt WebDriverAgent cache for iOS ${iosRuntimeVersions.join(', ')}.`
+      );
+    } finally {
+      await fs.promises.rm(tempDirectory, { force: true, recursive: true });
+    }
+  } catch (err: any) {
+    logger.warn(
+      { err },
+      'Failed to install the prebuilt WebDriverAgent cache. maestro-runner will build WebDriverAgent when it is needed.'
+    );
+  }
+}
+
+async function getMaestroRunnerWdaVersion({
+  maestroRunnerHome,
+}: {
+  maestroRunnerHome: string;
+}): Promise<string | null> {
+  try {
+    const packageJson = JSON.parse(
+      await fs.promises.readFile(
+        path.join(maestroRunnerHome, 'drivers', 'ios', 'WebDriverAgent', 'package.json'),
+        'utf8'
+      )
+    );
+    return typeof packageJson.version === 'string' && packageJson.version.match(/^\d+\.\d+\.\d+$/)
+      ? packageJson.version
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function getAvailableIosRuntimeVersions({ env }: { env: BuildStepEnv }): Promise<string[]> {
+  const { stdout } = await spawn('xcrun', ['simctl', 'list', 'runtimes', '--json'], {
+    stdio: 'pipe',
+    env,
+  });
+  const runtimes = JSON.parse(stdout).runtimes as {
+    identifier?: string;
+    isAvailable?: boolean;
+    version?: string;
+  }[];
+
+  return [
+    ...new Set(
+      runtimes
+        .filter(
+          runtime =>
+            runtime.isAvailable !== false &&
+            runtime.identifier?.startsWith('com.apple.CoreSimulator.SimRuntime.iOS-') &&
+            runtime.version?.match(/^\d+(?:\.\d+)*$/)
+        )
+        .map(runtime => runtime.version as string)
+    ),
+  ];
 }
 
 async function getMaestroVersion({

--- a/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
+++ b/packages/build-tools/src/steps/utils/ios/xcactivitylog.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import { z } from 'zod';
 
 import { Sentry } from '../../../sentry';
+import { getProxiedDownloadUrl } from '../../../utils/download';
 
 const DEFAULT_XCLOGPARSER_VERSION = 'v0.2.47';
 const XCLOGPARSER_DOWNLOAD_URL = 'https://storage.googleapis.com/turtle-v2/xclogparser';
@@ -292,24 +293,6 @@ const COMPILE_SIGNATURE_PREFIXES = ['SwiftCompile ', 'SwiftGeneratePch '];
 
 function getXclogparserZipName(version: string): string {
   return `XCLogParser-macOS-x86-64-arm64-${version}.zip`;
-}
-
-function getProxiedDownloadUrl({
-  directUrl,
-  proxyBaseUrl,
-}: {
-  directUrl: string;
-  proxyBaseUrl?: string;
-}): string | null {
-  if (!proxyBaseUrl) {
-    return null;
-  }
-
-  const parsedUrl = new URL(directUrl);
-  return directUrl.replace(
-    `${parsedUrl.protocol}//${parsedUrl.host}`,
-    `${proxyBaseUrl}/${parsedUrl.host}`
-  );
 }
 
 export function isCompileStep(step: Partial<XcactivitylogStep>): boolean {

--- a/packages/build-tools/src/utils/IosSimulatorUtils.ts
+++ b/packages/build-tools/src/utils/IosSimulatorUtils.ts
@@ -44,6 +44,35 @@ export namespace IosSimulatorUtils {
     };
   };
 
+  type XcrunSimctlListRuntimesJsonOutput = {
+    runtimes: {
+      identifier?: string;
+      isAvailable?: boolean;
+      version?: string;
+    }[];
+  };
+
+  export async function getAvailableRuntimeVersionsAsync({
+    env,
+  }: {
+    env: NodeJS.ProcessEnv;
+  }): Promise<string[]> {
+    const { stdout } = await spawn('xcrun', ['simctl', 'list', 'runtimes', '--json'], { env });
+    const { runtimes } = JSON.parse(stdout) as XcrunSimctlListRuntimesJsonOutput;
+
+    return [
+      ...new Set(
+        runtimes.flatMap(runtime =>
+          runtime.isAvailable !== false &&
+          runtime.identifier?.startsWith('com.apple.CoreSimulator.SimRuntime.iOS-') &&
+          typeof runtime.version === 'string'
+            ? [runtime.version]
+            : []
+        )
+      ),
+    ];
+  }
+
   export async function getAvailableDevicesAsync({
     env,
     filter,

--- a/packages/build-tools/src/utils/IosSimulatorUtils.ts
+++ b/packages/build-tools/src/utils/IosSimulatorUtils.ts
@@ -44,36 +44,30 @@ export namespace IosSimulatorUtils {
     };
   };
 
-  type XcrunSimctlListRuntimesJsonOutput = {
-    runtimes: {
-      identifier?: string;
-      isAvailable?: boolean;
-    }[];
+  export type IosSimulatorRuntime = {
+    identifier: string;
+    isAvailable?: boolean;
+    version?: string;
   };
 
-  export async function getAvailableRuntimeVersionsAsync({
+  type XcrunSimctlListRuntimesJsonOutput = {
+    runtimes: (Omit<IosSimulatorRuntime, 'identifier'> & { identifier?: string })[];
+  };
+
+  export async function getAvailableRuntimesAsync({
     env,
   }: {
     env: NodeJS.ProcessEnv;
-  }): Promise<string[]> {
+  }): Promise<IosSimulatorRuntime[]> {
     const { stdout } = await spawn('xcrun', ['simctl', 'list', 'runtimes', '--json'], { env });
     const { runtimes } = JSON.parse(stdout) as XcrunSimctlListRuntimesJsonOutput;
 
-    return [
-      ...new Set(
-        runtimes.flatMap(runtime => {
-          const identifierPrefix = 'com.apple.CoreSimulator.SimRuntime.iOS-';
-          if (runtime.isAvailable === false || !runtime.identifier?.startsWith(identifierPrefix)) {
-            return [];
-          }
-
-          // maestro-runner derives its WDA cache key from the runtime identifier, not from the
-          // runtime version. These values can differ for patched runtimes, for example the
-          // iOS-26-3 identifier can report version 26.3.1.
-          return [runtime.identifier.slice(identifierPrefix.length).replaceAll('-', '.')];
-        })
-      ),
-    ];
+    return runtimes.flatMap(runtime =>
+      runtime.isAvailable !== false &&
+      runtime.identifier?.startsWith('com.apple.CoreSimulator.SimRuntime.iOS-')
+        ? [{ ...runtime, identifier: runtime.identifier }]
+        : []
+    );
   }
 
   export async function getAvailableDevicesAsync({

--- a/packages/build-tools/src/utils/IosSimulatorUtils.ts
+++ b/packages/build-tools/src/utils/IosSimulatorUtils.ts
@@ -48,7 +48,6 @@ export namespace IosSimulatorUtils {
     runtimes: {
       identifier?: string;
       isAvailable?: boolean;
-      version?: string;
     }[];
   };
 
@@ -62,13 +61,17 @@ export namespace IosSimulatorUtils {
 
     return [
       ...new Set(
-        runtimes.flatMap(runtime =>
-          runtime.isAvailable !== false &&
-          runtime.identifier?.startsWith('com.apple.CoreSimulator.SimRuntime.iOS-') &&
-          typeof runtime.version === 'string'
-            ? [runtime.version]
-            : []
-        )
+        runtimes.flatMap(runtime => {
+          const identifierPrefix = 'com.apple.CoreSimulator.SimRuntime.iOS-';
+          if (runtime.isAvailable === false || !runtime.identifier?.startsWith(identifierPrefix)) {
+            return [];
+          }
+
+          // maestro-runner derives its WDA cache key from the runtime identifier, not from the
+          // runtime version. These values can differ for patched runtimes, for example the
+          // iOS-26-3 identifier can report version 26.3.1.
+          return [runtime.identifier.slice(identifierPrefix.length).replaceAll('-', '.')];
+        })
       ),
     ];
   }

--- a/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
@@ -23,8 +23,8 @@ describe('IosSimulatorUtils', () => {
     mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
   });
 
-  describe(IosSimulatorUtils.getAvailableRuntimeVersionsAsync, () => {
-    it('returns unique available iOS runtime versions', async () => {
+  describe(IosSimulatorUtils.getAvailableRuntimesAsync, () => {
+    it('returns available iOS runtimes', async () => {
       mockedSpawn.mockResolvedValue({
         stdout: JSON.stringify({
           runtimes: [
@@ -32,11 +32,6 @@ describe('IosSimulatorUtils', () => {
               identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-3',
               isAvailable: true,
               version: '18.3.1',
-            },
-            {
-              identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-3',
-              isAvailable: true,
-              version: '18.3',
             },
             {
               identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-17-5',
@@ -49,8 +44,14 @@ describe('IosSimulatorUtils', () => {
       } as any);
 
       await expect(
-        IosSimulatorUtils.getAvailableRuntimeVersionsAsync({ env: process.env })
-      ).resolves.toEqual(['18.3']);
+        IosSimulatorUtils.getAvailableRuntimesAsync({ env: process.env })
+      ).resolves.toEqual([
+        {
+          identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-3',
+          isAvailable: true,
+          version: '18.3.1',
+        },
+      ]);
       expect(mockedSpawn).toHaveBeenCalledWith('xcrun', ['simctl', 'list', 'runtimes', '--json'], {
         env: process.env,
       });

--- a/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
@@ -23,6 +23,40 @@ describe('IosSimulatorUtils', () => {
     mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
   });
 
+  describe(IosSimulatorUtils.getAvailableRuntimeVersionsAsync, () => {
+    it('returns unique available iOS runtime versions', async () => {
+      mockedSpawn.mockResolvedValue({
+        stdout: JSON.stringify({
+          runtimes: [
+            {
+              identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-3',
+              isAvailable: true,
+              version: '18.3',
+            },
+            {
+              identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-3',
+              isAvailable: true,
+              version: '18.3',
+            },
+            {
+              identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-17-5',
+              isAvailable: false,
+              version: '17.5',
+            },
+          ],
+        }),
+        stderr: '',
+      } as any);
+
+      await expect(
+        IosSimulatorUtils.getAvailableRuntimeVersionsAsync({ env: process.env })
+      ).resolves.toEqual(['18.3']);
+      expect(mockedSpawn).toHaveBeenCalledWith('xcrun', ['simctl', 'list', 'runtimes', '--json'], {
+        env: process.env,
+      });
+    });
+  });
+
   describe(IosSimulatorUtils.getAvailableDevicesAsync, () => {
     it('adds a human-readable runtime display name', async () => {
       mockedSpawn.mockResolvedValue({

--- a/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
@@ -31,7 +31,7 @@ describe('IosSimulatorUtils', () => {
             {
               identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-3',
               isAvailable: true,
-              version: '18.3',
+              version: '18.3.1',
             },
             {
               identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-3',

--- a/packages/build-tools/src/utils/__tests__/download.test.ts
+++ b/packages/build-tools/src/utils/__tests__/download.test.ts
@@ -1,0 +1,27 @@
+import { getProxiedDownloadUrl } from '../download';
+
+describe(getProxiedDownloadUrl, () => {
+  it('returns null when no proxy base URL is set', () => {
+    expect(
+      getProxiedDownloadUrl({ directUrl: 'https://storage.googleapis.com/bucket/object' })
+    ).toBeNull();
+  });
+
+  it('rewrites the origin to the proxy base URL', () => {
+    expect(
+      getProxiedDownloadUrl({
+        directUrl: 'https://storage.googleapis.com/bucket/object',
+        proxyBaseUrl: 'https://cache.example.com',
+      })
+    ).toBe('https://cache.example.com/storage.googleapis.com/bucket/object');
+  });
+
+  it('normalizes a proxy base URL with a trailing slash', () => {
+    expect(
+      getProxiedDownloadUrl({
+        directUrl: 'https://storage.googleapis.com/bucket/object',
+        proxyBaseUrl: 'https://cache.example.com/',
+      })
+    ).toBe('https://cache.example.com/storage.googleapis.com/bucket/object');
+  });
+});

--- a/packages/build-tools/src/utils/download.ts
+++ b/packages/build-tools/src/utils/download.ts
@@ -1,0 +1,17 @@
+export function getProxiedDownloadUrl({
+  directUrl,
+  proxyBaseUrl,
+}: {
+  directUrl: string;
+  proxyBaseUrl?: string;
+}): string | null {
+  if (!proxyBaseUrl) {
+    return null;
+  }
+
+  const parsedUrl = new URL(directUrl);
+  return directUrl.replace(
+    `${parsedUrl.protocol}//${parsedUrl.host}`,
+    `${proxyBaseUrl.replace(/\/$/, '')}/${parsedUrl.host}`
+  );
+}


### PR DESCRIPTION
## Why

`maestro-runner` needs WDA driver to run tests. By default it compiles it on first run which takes a minute.

## How

Compiled WDA on all images, uploaded to `turtle-v2` GCS and added optimistic download to `eas/install_maestro`. See https://github.com/expo/turtle-v2/pull/2603.

## Test plan

https://staging.expo.dev/accounts/expo-services/projects/workflows-testing/workflows/01a0009e-b171-7497-9335-af1fc470a8d5