### PR TITLE
[build-tools] Proxy React Native Maven artifacts

### DIFF
--- a/packages/build-tools/src/ios/__tests__/pod.test.ts
+++ b/packages/build-tools/src/ios/__tests__/pod.test.ts
@@ -27,11 +27,13 @@ function makeIosBuildContext({
   cocoapodsCacheUrl,
   usePrecompiledModules = true,
   expoUsePrecompiledModules,
+  enterpriseRepository,
 }: {
   expoVersion?: string;
   cocoapodsCacheUrl?: string;
   usePrecompiledModules?: boolean;
   expoUsePrecompiledModules?: string;
+  enterpriseRepository?: string;
 }): BuildContext<Ios.Job> {
   vol.fromJSON({
     [path.join(IOS_DIR, '.keep')]: '',
@@ -63,6 +65,7 @@ function makeIosBuildContext({
         ? { EXPO_USE_PRECOMPILED_MODULES: expoUsePrecompiledModules }
         : {}),
       ...(cocoapodsCacheUrl ? { EAS_BUILD_COCOAPODS_CACHE_URL: cocoapodsCacheUrl } : {}),
+      ...(enterpriseRepository ? { ENTERPRISE_REPOSITORY: enterpriseRepository } : {}),
     },
     uploadArtifact: jest.fn(),
   });
@@ -128,6 +131,47 @@ describe(installPods, () => {
     expect(ctx.logger.info).toHaveBeenCalledWith(
       'Detected expo=999.0.0; enabling precompiled modules use. Installing pods with additional environment variables.\nEXPO_USE_PRECOMPILED_MODULES=1\nEXPO_PRECOMPILED_MODULES_BASE_URL=https://cocoapods-cache.expo.test/storage.googleapis.com/eas-build-precompiled-modules/\nPrecompiled modules pod install environment is configured.'
     );
+  });
+
+  it('configures the React Native enterprise repository through the CocoaPods cache', async () => {
+    const ctx = makeIosBuildContext({
+      usePrecompiledModules: false,
+      cocoapodsCacheUrl: 'https://cocoapods-cache.expo.test/',
+    });
+
+    await installPods(ctx, {});
+
+    expect((spawn as jest.Mock).mock.calls[0][2].env).toEqual(
+      expect.objectContaining({
+        EAS_BUILD_COCOAPODS_CACHE_URL: 'https://cocoapods-cache.expo.test/',
+        ENTERPRISE_REPOSITORY: 'https://cocoapods-cache.expo.test/repo1.maven.org/maven2',
+      })
+    );
+  });
+
+  it('does not override a user-provided React Native enterprise repository', async () => {
+    const ctx = makeIosBuildContext({
+      usePrecompiledModules: false,
+      cocoapodsCacheUrl: 'https://cocoapods-cache.expo.test/',
+      enterpriseRepository: 'https://maven.corporate.test/maven2',
+    });
+
+    await installPods(ctx, {});
+
+    expect((spawn as jest.Mock).mock.calls[0][2].env).toEqual(
+      expect.objectContaining({
+        EAS_BUILD_COCOAPODS_CACHE_URL: 'https://cocoapods-cache.expo.test/',
+        ENTERPRISE_REPOSITORY: 'https://maven.corporate.test/maven2',
+      })
+    );
+  });
+
+  it('does not configure the React Native enterprise repository without the CocoaPods cache', async () => {
+    const ctx = makeIosBuildContext({ usePrecompiledModules: false });
+
+    await installPods(ctx, {});
+
+    expect((spawn as jest.Mock).mock.calls[0][2].env.ENTERPRISE_REPOSITORY).toBeUndefined();
   });
 
   it('does not add precompiled modules env vars below the minimum Expo version', async () => {

--- a/packages/build-tools/src/ios/pod.ts
+++ b/packages/build-tools/src/ios/pod.ts
@@ -8,6 +8,7 @@ import { BuildContext } from '../context';
 const MIN_PRECOMPILED_MODULES_EXPO_VERSION = '55.0.26';
 const PRECOMPILED_MODULES_BASE_URL =
   'https://storage.googleapis.com/eas-build-precompiled-modules/';
+const MAVEN_CENTRAL_BASE_URL = 'https://repo1.maven.org/maven2';
 
 export async function installPods<TJob extends Ios.Job>(
   ctx: BuildContext<TJob>,
@@ -18,6 +19,7 @@ export async function installPods<TJob extends Ios.Job>(
   const verboseFlag = ctx.env['EAS_VERBOSE'] === '1' ? ['--verbose'] : [];
   const cocoapodsDeploymentFlag = ctx.env['POD_INSTALL_DEPLOYMENT'] === '1' ? ['--deployment'] : [];
   const precompiledModulesEnv = await resolvePrecompiledModulesPodInstallEnvAsync(ctx);
+  const enterpriseRepositoryEnv = resolveEnterpriseRepositoryPodInstallEnv(ctx);
 
   return {
     spawnPromise: spawn('pod', ['install', ...verboseFlag, ...cocoapodsDeploymentFlag], {
@@ -27,6 +29,7 @@ export async function installPods<TJob extends Ios.Job>(
         ...ctx.env,
         LANG: 'en_US.UTF-8',
         ...precompiledModulesEnv,
+        ...enterpriseRepositoryEnv,
       },
       lineTransformer: (line?: string) => {
         if (
@@ -40,6 +43,22 @@ export async function installPods<TJob extends Ios.Job>(
       },
       infoCallbackFn,
     }),
+  };
+}
+
+function resolveEnterpriseRepositoryPodInstallEnv<TJob extends Ios.Job>(
+  ctx: BuildContext<TJob>
+): Env {
+  if (ctx.env.ENTERPRISE_REPOSITORY || !ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL) {
+    return {};
+  }
+
+  const parsedUrl = new URL(MAVEN_CENTRAL_BASE_URL);
+  return {
+    ENTERPRISE_REPOSITORY: MAVEN_CENTRAL_BASE_URL.replace(
+      `${parsedUrl.protocol}//${parsedUrl.host}`,
+      `${ctx.env.EAS_BUILD_COCOAPODS_CACHE_URL.replace(/\/$/, '')}/${parsedUrl.host}`
+    ),
   };
 }
 

--- a/packages/expo-cocoapods-proxy/lib/expo_cocoapods_proxy/proxy.rb
+++ b/packages/expo-cocoapods-proxy/lib/expo_cocoapods_proxy/proxy.rb
@@ -38,12 +38,24 @@ module Pod
       end
 
       def download_file(full_filename)
+        return download_already_proxied_maven_file(full_filename) if already_proxied_maven?
         return orig_download_file(full_filename) unless should_proxy?
 
         download_file_via_proxy(full_filename)
       end
 
       private
+
+      def download_already_proxied_maven_file(full_filename)
+        orig_download_file(full_filename)
+      rescue ::StandardError
+        @url = url.sub("#{normalized_proxy}/repo1.maven.org", 'https://repo1.maven.org')
+        orig_download_file(full_filename)
+      end
+
+      def already_proxied_maven?
+        proxy && url.start_with?("#{normalized_proxy}/repo1.maven.org/")
+      end
 
       def should_proxy?
         return false unless proxy
@@ -69,6 +81,10 @@ module Pod
 
       def proxy
         ENV['EAS_BUILD_COCOAPODS_CACHE_URL']
+      end
+
+      def normalized_proxy
+        proxy.chomp('/')
       end
 
       def parsed_url

--- a/packages/expo-cocoapods-proxy/spec/expo_cocoapods_proxy/proxy_spec.rb
+++ b/packages/expo-cocoapods-proxy/spec/expo_cocoapods_proxy/proxy_spec.rb
@@ -165,6 +165,20 @@ RSpec.describe ExpoCocoaPodsProxy do
       expect(downloader).to have_attributes(url: url)
     end
 
+    it 'falls back to Maven Central when an already proxied Maven download fails' do
+      path = Pathname.new('some/fake/path')
+      url = 'http://localhost:9001/repo1.maven.org/maven2/com/facebook/react/react-native.tar.gz'
+      downloader = Pod::Downloader::Http.new(path, url, {})
+
+      expect(downloader).to receive(:orig_download_file).once.and_raise
+      expect(downloader).to receive(:orig_download_file).once {}
+
+      downloader.download_file(path.to_s)
+      expect(downloader).to have_attributes(
+        url: 'https://repo1.maven.org/maven2/com/facebook/react/react-native.tar.gz'
+      )
+    end
+
     it 'does not proxy when curlrc is present in home directory' do
       path = Pathname.new('some/fake/path')
       url = 'https://github.com/expo/test-repo/archive/main.tar.gz'

--- a/packages/expo-cocoapods-proxy/spec/expo_cocoapods_proxy/proxy_spec.rb
+++ b/packages/expo-cocoapods-proxy/spec/expo_cocoapods_proxy/proxy_spec.rb
@@ -153,6 +153,18 @@ RSpec.describe ExpoCocoaPodsProxy do
       downloader.download_file(path.to_s)
     end
 
+    it 'does not proxy a Maven URL that already points to the CocoaPods cache' do
+      path = Pathname.new('some/fake/path')
+      url = 'http://localhost:9001/repo1.maven.org/maven2/com/facebook/react/react-native.tar.gz'
+      downloader = Pod::Downloader::Http.new(path, url, {})
+
+      expect(downloader).to receive(:orig_download_file).once {}
+      expect(downloader).not_to receive(:download_file_via_proxy)
+
+      downloader.download_file(path.to_s)
+      expect(downloader).to have_attributes(url: url)
+    end
+
     it 'does not proxy when curlrc is present in home directory' do
       path = Pathname.new('some/fake/path')
       url = 'https://github.com/expo/test-repo/archive/main.tar.gz'


### PR DESCRIPTION
# Why

React Native 0.81 and newer support `ENTERPRISE_REPOSITORY` for stable Hermes, React Native Core, and React Native Dependencies artifacts. React Native 0.87 also reads this setting in its experimental Swift Package Manager artifact downloader.

Set a system fallback so React Native downloads during `pod install` use the existing EAS CocoaPods cache without replacing a repository configured by the user.

React Native source: https://github.com/facebook/react-native/blob/v0.87.0/packages/react-native/scripts/cocoapods/rncore.rb

# How

During `pod install`, set `ENTERPRISE_REPOSITORY` to `<EAS_BUILD_COCOAPODS_CACHE_URL>/repo1.maven.org/maven2` only when the user did not set it.

The existing proxy mechanisms remain active:

- `EAS_BUILD_COCOAPODS_CACHE_URL` stays set, so the CocoaPods plug-in handles all other supported hosts.
- An already proxied Maven URL is not proxied a second time.
- If that cache download fails, the CocoaPods plug-in reconstructs the Maven Central URL and retries it directly. This preserves the existing origin fallback.
- The curl wrapper leaves the already proxied URL unchanged because it only rewrites URLs that start with `https://repo1.maven.org/maven2`.

This change does not remove the CocoaPods plug-in or curl wrapper.

# Test Plan

- Added build-tools tests for the system fallback, user precedence, and disabled-cache behavior.
- Added expo-cocoapods-proxy tests for an already proxied Maven URL and its direct-origin fallback.
- `yarn workspace @expo/build-tools test pod.test.ts --runInBand`
- `bundle exec rspec spec/expo_cocoapods_proxy/proxy_spec.rb`
- `yarn build`
- `yarn fmt:check`
- `yarn lint` (0 errors; existing unrelated warnings remain)