### PR TITLE
[build-tools] Capture Android emulator process output

### DIFF
--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import { z } from 'zod';
 
+import { Sentry } from '../sentry';
 import { retryAsync } from './retry';
 
 /** Android Virtual Device is the device we run. */
@@ -358,10 +359,24 @@ export namespace AndroidEmulatorUtils {
       }
     );
     const emulatorOutputStream = fs.createWriteStream(emulatorOutputPath, { flags: 'a' });
+    let reportedEmulatorOutputError = false;
     emulatorOutputStream.on('error', err => {
       process.stderr.write(
         `Failed to write Android emulator output to ${emulatorOutputPath}: ${err}\n`
       );
+      if (!reportedEmulatorOutputError) {
+        reportedEmulatorOutputError = true;
+        Sentry.capture('Failed to write Android emulator process output', err, {
+          level: 'warning',
+          tags: {
+            errorCode: (err as NodeJS.ErrnoException).code ?? 'unknown',
+          },
+          extras: {
+            deviceName,
+            emulatorOutputPath,
+          },
+        });
+      }
     });
     emulatorPromise.child.stdout?.pipe(process.stdout, { end: false });
     emulatorPromise.child.stdout?.pipe(emulatorOutputStream, { end: false });

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -379,9 +379,8 @@ export namespace AndroidEmulatorUtils {
         });
       }
     });
-    emulatorPromise.child.stdout?.pipe(process.stdout, { end: false });
+    // Only into the log file -- this process' stdout/stderr is not watched or uploaded.
     emulatorPromise.child.stdout?.pipe(emulatorOutputStream, { end: false });
-    emulatorPromise.child.stderr?.pipe(process.stderr, { end: false });
     emulatorPromise.child.stderr?.pipe(emulatorOutputStream, { end: false });
     emulatorPromise.child.once('close', () => {
       emulatorOutputStream.end();

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -6,6 +6,7 @@ import assert from 'assert';
 import FastGlob from 'fast-glob';
 import { randomBytes } from 'node:crypto';
 import fs from 'node:fs';
+import { Socket } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
@@ -385,6 +386,13 @@ export namespace AndroidEmulatorUtils {
     emulatorPromise.child.once('close', () => {
       emulatorOutputStream.end();
     });
+    // Piped stdio creates socket handles in this process which, unlike inherited
+    // file descriptors, keep the event loop alive for as long as the emulator runs.
+    // We never stop the emulator explicitly, so without unref-ing these the process
+    // would never exit on its own -- defeating the `detached` + `unref()` below.
+    // Output is still captured for as long as this process lives.
+    (emulatorPromise.child.stdout as unknown as Socket | undefined)?.unref();
+    (emulatorPromise.child.stderr as unknown as Socket | undefined)?.unref();
     // If emulator fails to start, throw its error.
     if (!emulatorPromise.child.pid) {
       await emulatorPromise;

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -390,8 +390,12 @@ export namespace AndroidEmulatorUtils {
     // We never stop the emulator explicitly, so without unref-ing these the process
     // would never exit on its own -- defeating the `detached` + `unref()` below.
     // Output is still captured for as long as this process lives.
-    (emulatorPromise.child.stdout as unknown as Socket | undefined)?.unref();
-    (emulatorPromise.child.stderr as unknown as Socket | undefined)?.unref();
+    if (emulatorPromise.child.stdout instanceof Socket) {
+      emulatorPromise.child.stdout.unref();
+    }
+    if (emulatorPromise.child.stderr instanceof Socket) {
+      emulatorPromise.child.stderr.unref();
+    }
     // If emulator fails to start, throw its error.
     if (!emulatorPromise.child.pid) {
       await emulatorPromise;

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -305,21 +305,23 @@ export namespace AndroidEmulatorUtils {
     emulatorPromise: SpawnPromise<SpawnResult>;
     serialId: AndroidDeviceSerialId;
     logcatOutputPath: string;
+    emulatorOutputPath: string;
   }> {
     let logcatOutputPath: string;
+    let emulatorOutputPath: string;
     try {
       await fs.promises.mkdir(logcatDirectory, { recursive: true });
       const safeDeviceName = deviceName.replace(/[^a-zA-Z0-9_.-]/g, '_');
       const timestamp = Math.floor(Date.now() / 1000)
         .toString(16)
         .padStart(8, '0');
-      logcatOutputPath = path.join(
-        logcatDirectory,
-        `${safeDeviceName}-${timestamp}-${randomBytes(2).toString('hex')}.log`
-      );
+      const outputName = `${safeDeviceName}-${timestamp}-${randomBytes(2).toString('hex')}`;
+      logcatOutputPath = path.join(logcatDirectory, `${outputName}-logcat.log`);
+      emulatorOutputPath = path.join(logcatDirectory, `${outputName}-emulator.log`);
       await fs.promises.writeFile(logcatOutputPath, '');
+      await fs.promises.writeFile(emulatorOutputPath, '');
     } catch (err) {
-      throw new SystemError(`Failed to prepare Android emulator logcat output for ${deviceName}.`, {
+      throw new SystemError(`Failed to prepare Android emulator output for ${deviceName}.`, {
         cause: err,
       });
     }
@@ -346,7 +348,8 @@ export namespace AndroidEmulatorUtils {
       ],
       {
         detached: true,
-        stdio: 'inherit',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        ignoreStdio: true,
         env: {
           ...env,
           // We don't need to wait for emulator to exit gracefully.
@@ -354,6 +357,19 @@ export namespace AndroidEmulatorUtils {
         },
       }
     );
+    const emulatorOutputStream = fs.createWriteStream(emulatorOutputPath, { flags: 'a' });
+    emulatorOutputStream.on('error', err => {
+      process.stderr.write(
+        `Failed to write Android emulator output to ${emulatorOutputPath}: ${err}\n`
+      );
+    });
+    emulatorPromise.child.stdout?.pipe(process.stdout, { end: false });
+    emulatorPromise.child.stdout?.pipe(emulatorOutputStream, { end: false });
+    emulatorPromise.child.stderr?.pipe(process.stderr, { end: false });
+    emulatorPromise.child.stderr?.pipe(emulatorOutputStream, { end: false });
+    emulatorPromise.child.once('close', () => {
+      emulatorOutputStream.end();
+    });
     // If emulator fails to start, throw its error.
     if (!emulatorPromise.child.pid) {
       await emulatorPromise;
@@ -382,7 +398,7 @@ export namespace AndroidEmulatorUtils {
 
     // We don't want to await the SpawnPromise here.
     // eslint-disable-next-line @typescript-eslint/return-await
-    return { emulatorPromise, serialId, logcatOutputPath };
+    return { emulatorPromise, serialId, logcatOutputPath, emulatorOutputPath };
   }
 
   export async function waitForReadyAsync({

--- a/packages/build-tools/src/utils/__integration-tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__integration-tests__/AndroidEmulatorUtils.test.ts
@@ -273,7 +273,7 @@ describe('AndroidEmulatorUtils', () => {
     expect(attemptCounter).toBe(2);
   }, 360_000);
 
-  it('captures native logcat output across an ADB server restart', async () => {
+  it('captures emulator and native logcat output across an ADB server restart', async () => {
     const testLogcatDirectory = await fs.promises.mkdtemp(
       path.join(os.tmpdir(), 'android-emulator-logcat-e2e-')
     );
@@ -302,6 +302,21 @@ describe('AndroidEmulatorUtils', () => {
       emulatorPromise = asyncResult(startResult.emulatorPromise);
 
       await AndroidEmulatorUtils.waitForReadyAsync({ serialId, env: process.env });
+      await retryAsync(
+        async () => {
+          const contents = await fs.promises.readFile(startResult.emulatorOutputPath, 'utf-8');
+          if (!contents.includes('Android emulator version')) {
+            throw new Error('Did not find the emulator version in emulator process output yet.');
+          }
+        },
+        {
+          logger,
+          retryOptions: {
+            retries: 10,
+            retryIntervalMs: 1_000,
+          },
+        }
+      );
       await spawn('adb', ['kill-server'], { env: process.env });
       await spawn('adb', ['start-server'], { env: process.env });
       await spawn('adb', ['-s', serialId, 'shell', 'log', '-t', 'EAS_CLI_TEST', marker], {

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -50,11 +50,12 @@ describe('AndroidEmulatorUtils', () => {
 
   describe(AndroidEmulatorUtils.startAsync, () => {
     function mockSuccessfulStart(deviceName: AndroidVirtualDeviceName) {
+      // Under `stdio: 'pipe'` these are net.Sockets, so they carry `unref()`.
       const child = Object.assign(new EventEmitter(), {
         pid: 1234,
         unref: jest.fn(),
-        stdout: new PassThrough(),
-        stderr: new PassThrough(),
+        stdout: Object.assign(new PassThrough(), { unref: jest.fn() }),
+        stderr: Object.assign(new PassThrough(), { unref: jest.fn() }),
       });
       const spawnPromise = Promise.resolve({ stdout: '', stderr: '' }) as any;
       spawnPromise.child = child;
@@ -109,6 +110,10 @@ describe('AndroidEmulatorUtils', () => {
         expect.anything()
       );
       expect(child.unref).toHaveBeenCalled();
+      // Piped stdio would otherwise keep this process' event loop alive
+      // for as long as the emulator runs.
+      expect(child.stdout.unref).toHaveBeenCalled();
+      expect(child.stderr.unref).toHaveBeenCalled();
       const emulatorOutputStream = createWriteStreamSpy.mock.results[0].value;
       const stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
       const writeError = Object.assign(new Error('disk full'), { code: 'ENOSPC' });

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -2,9 +2,9 @@ import { SystemError } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 import { EventEmitter, once } from 'node:events';
 import fs from 'node:fs';
+import { Socket } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
-import { PassThrough } from 'node:stream';
 
 import { createMockLogger } from '../../__tests__/utils/logger';
 import { Sentry } from '../../sentry';
@@ -50,12 +50,17 @@ describe('AndroidEmulatorUtils', () => {
 
   describe(AndroidEmulatorUtils.startAsync, () => {
     function mockSuccessfulStart(deviceName: AndroidVirtualDeviceName) {
-      // Under `stdio: 'pipe'` these are net.Sockets, so they carry `unref()`.
+      // Under `stdio: 'pipe'` these are net.Sockets, which is what startAsync
+      // narrows on before unref-ing them.
+      const stdout = new Socket();
+      const stderr = new Socket();
+      jest.spyOn(stdout, 'unref').mockReturnValue(stdout);
+      jest.spyOn(stderr, 'unref').mockReturnValue(stderr);
       const child = Object.assign(new EventEmitter(), {
         pid: 1234,
         unref: jest.fn(),
-        stdout: Object.assign(new PassThrough(), { unref: jest.fn() }),
-        stderr: Object.assign(new PassThrough(), { unref: jest.fn() }),
+        stdout,
+        stderr,
       });
       const spawnPromise = Promise.resolve({ stdout: '', stderr: '' }) as any;
       spawnPromise.child = child;

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -1,8 +1,10 @@
 import { SystemError } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
+import { EventEmitter, once } from 'node:events';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { PassThrough } from 'node:stream';
 
 import { createMockLogger } from '../../__tests__/utils/logger';
 import { AndroidEmulatorUtils, AndroidVirtualDeviceName } from '../AndroidEmulatorUtils';
@@ -30,6 +32,7 @@ describe('AndroidEmulatorUtils', () => {
   });
 
   afterEach(async () => {
+    jest.restoreAllMocks();
     await Promise.all(
       temporaryDirectories.map(async temporaryDirectory => {
         await fs.promises.rm(temporaryDirectory, { force: true, recursive: true });
@@ -39,7 +42,12 @@ describe('AndroidEmulatorUtils', () => {
 
   describe(AndroidEmulatorUtils.startAsync, () => {
     function mockSuccessfulStart(deviceName: AndroidVirtualDeviceName) {
-      const child = { pid: 1234, unref: jest.fn() };
+      const child = Object.assign(new EventEmitter(), {
+        pid: 1234,
+        unref: jest.fn(),
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+      });
       const spawnPromise = Promise.resolve({ stdout: '', stderr: '' }) as any;
       spawnPromise.child = child;
       mockedSpawn.mockImplementation(((command: string, args: string[]) => {
@@ -57,11 +65,12 @@ describe('AndroidEmulatorUtils', () => {
       return { child };
     }
 
-    it('captures logcat through the emulator process', async () => {
+    it('captures logcat and emulator process output', async () => {
       const outputDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'logcat-staging-'));
       temporaryDirectories.push(outputDir);
       const deviceName = 'eas-simulator' as AndroidVirtualDeviceName;
       const { child } = mockSuccessfulStart(deviceName);
+      const createWriteStreamSpy = jest.spyOn(fs, 'createWriteStream');
 
       const result = await AndroidEmulatorUtils.startAsync({
         deviceName,
@@ -70,13 +79,21 @@ describe('AndroidEmulatorUtils', () => {
       });
 
       expect(result.logcatOutputPath).toMatch(
-        new RegExp(`^${outputDir}/eas-simulator-[a-f0-9]{8}-[a-f0-9]{4}\\.log$`)
+        new RegExp(`^${outputDir}/eas-simulator-[a-f0-9]{8}-[a-f0-9]{4}-logcat\\.log$`)
+      );
+      expect(result.emulatorOutputPath).toMatch(
+        new RegExp(`^${outputDir}/eas-simulator-[a-f0-9]{8}-[a-f0-9]{4}-emulator\\.log$`)
       );
       await expect(fs.promises.access(result.logcatOutputPath)).resolves.toBeUndefined();
+      await expect(fs.promises.access(result.emulatorOutputPath)).resolves.toBeUndefined();
       expect(mockedSpawn).toHaveBeenCalledWith(
         expect.stringMatching(/\/emulator\/emulator$/),
         expect.arrayContaining(['-logcat', '*:v', '-logcat-output', result.logcatOutputPath]),
-        expect.objectContaining({ detached: true, stdio: 'inherit' })
+        expect.objectContaining({
+          detached: true,
+          stdio: ['ignore', 'pipe', 'pipe'],
+          ignoreStdio: true,
+        })
       );
       expect(mockedSpawn).not.toHaveBeenCalledWith(
         'adb',
@@ -84,6 +101,10 @@ describe('AndroidEmulatorUtils', () => {
         expect.anything()
       );
       expect(child.unref).toHaveBeenCalled();
+      const emulatorOutputStream = createWriteStreamSpy.mock.results[0].value;
+      const emulatorOutputStreamClosed = once(emulatorOutputStream, 'close');
+      child.emit('close');
+      await emulatorOutputStreamClosed;
     });
 
     it('throws a SystemError when the staging directory cannot be prepared', async () => {
@@ -100,7 +121,7 @@ describe('AndroidEmulatorUtils', () => {
             logcatDirectory: outputDir,
           })
         ).rejects.toEqual(
-          new SystemError('Failed to prepare Android emulator logcat output for eas-simulator.', {
+          new SystemError('Failed to prepare Android emulator output for eas-simulator.', {
             cause: mkdirError,
           })
         );

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { PassThrough } from 'node:stream';
 
 import { createMockLogger } from '../../__tests__/utils/logger';
+import { Sentry } from '../../sentry';
 import { AndroidEmulatorUtils, AndroidVirtualDeviceName } from '../AndroidEmulatorUtils';
 import { retryAsync } from '../retry';
 
@@ -19,6 +20,12 @@ jest.mock('../retry', () => ({
   retryAsync: jest.fn(async fn => await fn(0)),
 }));
 
+jest.mock('../../sentry', () => ({
+  Sentry: {
+    capture: jest.fn(),
+  },
+}));
+
 const mockedSpawn = jest.mocked(spawn);
 const mockedRetryAsync = jest.mocked(retryAsync);
 
@@ -27,6 +34,7 @@ describe('AndroidEmulatorUtils', () => {
 
   beforeEach(() => {
     temporaryDirectories = [];
+    jest.mocked(Sentry.capture).mockReset();
     mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
     mockedRetryAsync.mockImplementation(async fn => await fn(0));
   });
@@ -102,6 +110,24 @@ describe('AndroidEmulatorUtils', () => {
       );
       expect(child.unref).toHaveBeenCalled();
       const emulatorOutputStream = createWriteStreamSpy.mock.results[0].value;
+      const stderrWriteSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const writeError = Object.assign(new Error('disk full'), { code: 'ENOSPC' });
+      emulatorOutputStream.emit('error', writeError);
+      emulatorOutputStream.emit('error', writeError);
+      expect(stderrWriteSpy).toHaveBeenCalledTimes(2);
+      expect(Sentry.capture).toHaveBeenCalledTimes(1);
+      expect(Sentry.capture).toHaveBeenCalledWith(
+        'Failed to write Android emulator process output',
+        writeError,
+        {
+          level: 'warning',
+          tags: { errorCode: 'ENOSPC' },
+          extras: {
+            deviceName,
+            emulatorOutputPath: result.emulatorOutputPath,
+          },
+        }
+      );
       const emulatorOutputStreamClosed = once(emulatorOutputStream, 'close');
       child.emit('close');
       await emulatorOutputStreamClosed;


### PR DESCRIPTION
## Why

We now provide nice logcat output, but we never supported `emulator` output.

## How

Added piping of the `emulator` command to a new `.log` file in the same directory we put logcat files.

## Test plan

Tested locally.