### PR TITLE
[eas-cli] Protect simulator environment cleanup

### DIFF
--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -366,7 +366,7 @@ describe(Simulator, () => {
     const { command } = createCommand(['--platform', 'ios']);
     await command.runAsync();
 
-    expect(mockResetSimulatorEnvAsync).toHaveBeenCalledWith(projectDir);
+    expect(mockResetSimulatorEnvAsync).toHaveBeenCalledWith(projectDir, 'session-123');
   });
 
   it('forwards --name to the create mutation', async () => {
@@ -484,7 +484,7 @@ describe(Simulator, () => {
       graphqlClient,
       'session-123'
     );
-    expect(mockResetSimulatorEnvAsync).toHaveBeenCalledWith(projectDir);
+    expect(mockResetSimulatorEnvAsync).toHaveBeenCalledWith(projectDir, 'session-123');
     expect(process.listeners('SIGINT')).toEqual([...existingSigintListeners]);
     processExitSpy.mockRestore();
   });

--- a/packages/eas-cli/src/commands/simulator/__tests__/stop.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/stop.test.ts
@@ -10,6 +10,7 @@ import {
   EAS_SIMULATOR_SESSION_ID,
   SIMULATOR_DOTENV_FILE_NAME,
   loadSimulatorEnvAsync,
+  resetSimulatorEnvAsync,
 } from '../../../simulator/env';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
 import SimulatorStop from '../stop';
@@ -18,6 +19,7 @@ jest.mock('../../../graphql/mutations/DeviceRunSessionMutation');
 jest.mock('../../../simulator/env', () => ({
   ...jest.requireActual('../../../simulator/env'),
   loadSimulatorEnvAsync: jest.fn(),
+  resetSimulatorEnvAsync: jest.fn(),
 }));
 jest.mock('../../../ora', () => ({
   ora: jest.fn(() => {
@@ -40,6 +42,7 @@ const mockEnsureDeviceRunSessionStoppedAsync = jest.mocked(
 );
 const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
 const mockLoadSimulatorEnvironmentVariablesAsync = jest.mocked(loadSimulatorEnvAsync);
+const mockResetSimulatorEnvAsync = jest.mocked(resetSimulatorEnvAsync);
 const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
 
 function makeStoppedDeviceRunSession(
@@ -70,6 +73,7 @@ describe(SimulatorStop, () => {
     jest.clearAllMocks();
     mockEnsureDeviceRunSessionStoppedAsync.mockResolvedValue(makeStoppedDeviceRunSession());
     mockLoadSimulatorEnvironmentVariablesAsync.mockResolvedValue();
+    mockResetSimulatorEnvAsync.mockResolvedValue();
   });
 
   function createCommand(argv: string[]): {
@@ -98,6 +102,7 @@ describe(SimulatorStop, () => {
       graphqlClient,
       'session-123'
     );
+    expect(mockResetSimulatorEnvAsync).toHaveBeenCalledWith(projectDir, 'session-123');
     expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
       id: 'session-123',
       status: DeviceRunSessionStatus.Stopped,
@@ -120,6 +125,7 @@ describe(SimulatorStop, () => {
         graphqlClient,
         'session-from-env'
       );
+      expect(mockResetSimulatorEnvAsync).toHaveBeenCalledWith(projectDir, 'session-from-env');
     } finally {
       if (previousDeviceRunSessionId === undefined) {
         delete process.env[EAS_SIMULATOR_SESSION_ID];

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -406,7 +406,7 @@ async function waitForSessionEndOrInterruptAsync({
         jobRunStatus === JobRunStatus.Finished
       ) {
         spinner.succeed(`Simulator session ended. ${link(deviceRunSessionUrl)}`);
-        await resetSimulatorEnvVerboseAsync(projectDir);
+        await resetSimulatorEnvVerboseAsync(projectDir, deviceRunSessionId);
         return;
       }
 
@@ -420,7 +420,7 @@ async function waitForSessionEndOrInterruptAsync({
     );
     if (stopped) {
       spinner.succeed('Simulator session stopped');
-      await resetSimulatorEnvVerboseAsync(projectDir);
+      await resetSimulatorEnvVerboseAsync(projectDir, deviceRunSessionId);
     } else {
       spinner.fail(
         `Could not confirm the simulator session was stopped. Run \`eas simulator:stop --id ${deviceRunSessionId}\` to terminate it and avoid unexpected charges.`
@@ -490,7 +490,7 @@ async function stopDeviceRunSessionAfterInterruptAsync({
     );
     if (stopped) {
       spinner.succeed('Simulator session stopped');
-      await resetSimulatorEnvVerboseAsync(projectDir);
+      await resetSimulatorEnvVerboseAsync(projectDir, deviceRunSessionId);
     } else {
       spinner.fail(
         `Could not confirm the simulator session was stopped. Run \`eas simulator:stop --id ${deviceRunSessionId}\` to terminate it and avoid unexpected charges.`
@@ -502,9 +502,12 @@ async function stopDeviceRunSessionAfterInterruptAsync({
   process.exit(130);
 }
 
-async function resetSimulatorEnvVerboseAsync(projectDir: string): Promise<void> {
+async function resetSimulatorEnvVerboseAsync(
+  projectDir: string,
+  deviceRunSessionId: string
+): Promise<void> {
   try {
-    await resetSimulatorEnvAsync(projectDir);
+    await resetSimulatorEnvAsync(projectDir, deviceRunSessionId);
   } catch (err) {
     Log.error(`Failed to clean up ${SIMULATOR_DOTENV_FILE_NAME}`);
     throw err;

--- a/packages/eas-cli/src/commands/simulator/stop.ts
+++ b/packages/eas-cli/src/commands/simulator/stop.ts
@@ -11,6 +11,7 @@ import {
   EAS_SIMULATOR_SESSION_ID,
   SIMULATOR_DOTENV_FILE_NAME,
   loadSimulatorEnvAsync,
+  resetSimulatorEnvAsync,
 } from '../../simulator/env';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
@@ -67,6 +68,8 @@ export default class SimulatorStop extends EasCommand {
       stopSpinner.fail(`Failed to stop simulator session ${flagId}`);
       throw err;
     }
+
+    await resetSimulatorEnvAsync(projectDir, flagId);
 
     if (jsonFlag) {
       printJsonOnlyOutput({ id: session.id, status: session.status });

--- a/packages/eas-cli/src/simulator/__tests__/env.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/env.test.ts
@@ -16,12 +16,15 @@ describe(resetSimulatorEnvAsync, () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest
+      .mocked(fs.readFile)
+      .mockResolvedValue(`${EAS_SIMULATOR_SESSION_ID}="session-123"\n` as never);
     jest.mocked(fs.writeFile).mockResolvedValue(undefined as never);
     jest.mocked(fs.truncate).mockResolvedValue(undefined as never);
   });
 
   it('overwrites the simulator dotenv file with the header only', async () => {
-    await resetSimulatorEnvAsync(projectDir);
+    await resetSimulatorEnvAsync(projectDir, 'session-123');
 
     expect(fs.writeFile).toHaveBeenCalledWith(simulatorDotenvPath, SIMULATOR_DOTENV_FILE_HEADER, {
       flag: 'r+',
@@ -34,18 +37,28 @@ describe(resetSimulatorEnvAsync, () => {
 
   it('ignores a missing simulator dotenv file', async () => {
     const err = Object.assign(new Error('missing file'), { code: 'ENOENT' });
-    jest.mocked(fs.writeFile).mockRejectedValue(err as never);
+    jest.mocked(fs.readFile).mockRejectedValue(err as never);
 
-    await expect(resetSimulatorEnvAsync(projectDir)).resolves.toBeUndefined();
+    await expect(resetSimulatorEnvAsync(projectDir, 'session-123')).resolves.toBeUndefined();
 
+    expect(fs.writeFile).not.toHaveBeenCalled();
+    expect(fs.truncate).not.toHaveBeenCalled();
+  });
+
+  it('does not overwrite a simulator dotenv file for a different session', async () => {
+    await resetSimulatorEnvAsync(projectDir, 'different-session');
+
+    expect(fs.writeFile).not.toHaveBeenCalled();
     expect(fs.truncate).not.toHaveBeenCalled();
   });
 
   it('rethrows non-missing-file errors', async () => {
     const err = Object.assign(new Error('permission denied'), { code: 'EACCES' });
-    jest.mocked(fs.writeFile).mockRejectedValue(err as never);
+    jest.mocked(fs.readFile).mockRejectedValue(err as never);
 
-    await expect(resetSimulatorEnvAsync(projectDir)).rejects.toThrow('permission denied');
+    await expect(resetSimulatorEnvAsync(projectDir, 'session-123')).rejects.toThrow(
+      'permission denied'
+    );
   });
 });
 

--- a/packages/eas-cli/src/simulator/env.ts
+++ b/packages/eas-cli/src/simulator/env.ts
@@ -1,4 +1,5 @@
 import { loadEnvFiles, loadProjectEnv } from '@expo/env';
+import { parse as parseDotenv } from 'dotenv';
 import * as fs from 'fs-extra';
 import path from 'path';
 
@@ -33,10 +34,17 @@ export async function writeSimulatorEnvAsync(
   await fs.writeFile(simulatorDotenvFilePath, simulatorDotenvContent);
 }
 
-export async function resetSimulatorEnvAsync(projectDir: string): Promise<void> {
+export async function resetSimulatorEnvAsync(
+  projectDir: string,
+  expectedDeviceRunSessionId: string
+): Promise<void> {
   const simulatorDotenvFilePath = getSimulatorEnvFilePath(projectDir);
 
   try {
+    const currentEnv = parseDotenv(await fs.readFile(simulatorDotenvFilePath, 'utf8'));
+    if (currentEnv[EAS_SIMULATOR_SESSION_ID] !== expectedDeviceRunSessionId) {
+      return;
+    }
     await fs.writeFile(simulatorDotenvFilePath, SIMULATOR_DOTENV_FILE_HEADER, { flag: 'r+' });
     await fs.truncate(simulatorDotenvFilePath, Buffer.byteLength(SIMULATOR_DOTENV_FILE_HEADER));
   } catch (err) {

--- a/packages/eas-cli/src/simulator/env.ts
+++ b/packages/eas-cli/src/simulator/env.ts
@@ -3,6 +3,8 @@ import { parse as parseDotenv } from 'dotenv';
 import * as fs from 'fs-extra';
 import path from 'path';
 
+import Log from '../log';
+
 export const SIMULATOR_DOTENV_FILE_NAME = '.env.eas-simulator';
 export const EAS_SIMULATOR_SESSION_ID = 'EAS_SIMULATOR_SESSION_ID';
 export const SIMULATOR_DOTENV_FILE_HEADER =
@@ -43,6 +45,14 @@ export async function resetSimulatorEnvAsync(
   try {
     const currentEnv = parseDotenv(await fs.readFile(simulatorDotenvFilePath, 'utf8'));
     if (currentEnv[EAS_SIMULATOR_SESSION_ID] !== expectedDeviceRunSessionId) {
+      // The file was overwritten by a newer simulator session, so it is no longer
+      // ours to reset. This is expected when sessions overlap; log at debug level
+      // for troubleshooting without surfacing noise during normal use.
+      Log.debug(
+        `Skipping ${SIMULATOR_DOTENV_FILE_NAME} reset: it belongs to simulator session ${
+          currentEnv[EAS_SIMULATOR_SESSION_ID] ?? '(unknown)'
+        }, not ${expectedDeviceRunSessionId}.`
+      );
       return;
     }
     await fs.writeFile(simulatorDotenvFilePath, SIMULATOR_DOTENV_FILE_HEADER, { flag: 'r+' });


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Codex insists we should clean the environment up when stopping the simulator. I think we should also guard the cleanup with ID check.

# How

Added reset to the stop command and an ID guard.

# Test Plan

CI should pass.
