### PR TITLE
[build-tools] Normalize project archive permissions

### DIFF
--- a/packages/build-tools/src/common/__tests__/projectSources.test.ts
+++ b/packages/build-tools/src/common/__tests__/projectSources.test.ts
@@ -7,6 +7,7 @@ import {
   Workflow,
 } from '@expo/eas-build-job';
 import { randomBytes, randomUUID } from 'crypto';
+import spawn from '@expo/turtle-spawn';
 import { vol } from 'memfs';
 import fetch, { Response } from 'node-fetch';
 import { setTimeout } from 'timers/promises';
@@ -14,7 +15,10 @@ import { setTimeout } from 'timers/promises';
 import { createMockLogger } from '../../__tests__/utils/logger';
 import { BuildContext } from '../../context';
 import { shallowCloneRepositoryAsync } from '../git';
-import { prepareProjectSourcesAsync } from '../projectSources';
+import {
+  downloadAndUnpackProjectFromTarGzAsync,
+  prepareProjectSourcesAsync,
+} from '../projectSources';
 
 jest.mock('@expo/turtle-spawn');
 jest.mock('node-fetch');
@@ -23,6 +27,32 @@ jest.mock('@expo/downloader');
 jest.mock('@urql/core');
 
 describe('projectSources', () => {
+  it('normalizes project archive permissions after extraction', async () => {
+    const logger = createMockLogger();
+    const ctx = {
+      env: { EAS_BUILD_ID: randomUUID() },
+      logger,
+      reportError: jest.fn(),
+      workingdir: '/workingdir',
+    } as unknown as BuildContext<Job>;
+
+    await downloadAndUnpackProjectFromTarGzAsync(
+      ctx,
+      'https://example.com/project.tar.gz',
+      '/workingdir/build'
+    );
+
+    expect(spawn).toHaveBeenNthCalledWith(
+      1,
+      'tar',
+      ['-C', '/workingdir/build', '--strip-components', '1', '-zxf', '/workingdir/project.tar.gz'],
+      { logger }
+    );
+    expect(spawn).toHaveBeenNthCalledWith(2, 'chmod', ['-R', 'u+rwX', '/workingdir/build'], {
+      logger,
+    });
+  });
+
   it('should use the refreshed repository URL', async () => {
     const robotAccessToken = randomUUID();
     const buildId = randomUUID();

--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -122,6 +122,9 @@ async function unpackTarGzAsync({
   await spawn('tar', ['-C', destination, '--strip-components', '1', '-zxf', source], {
     logger,
   });
+  // Archives can preserve modes that make project files unreadable or directories unwritable by
+  // the build user. A build workspace must be readable and writable because later phases modify it.
+  await spawn('chmod', ['-R', 'u+rwX', destination], { logger });
 }
 
 function uploadProjectMetadataAsFireAndForget(


### PR DESCRIPTION
## Why

A regression review found 664 prebuild failures across 227 apps and 221 accounts with `EACCES` errors while reading project assets.

[View the affected logs in Datadog](https://app.datadoghq.com/logs?query=service%3Aeas-build%20status%3Aerror%20build_phase%3Aprebuild%20EACCES&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1786080878908&to_ts=1786685678908&live=false)

Project archives can preserve modes that leave files unreadable or directories unwritable by the build user.

<img width="1160" height="310" alt="Screenshot 2026-08-14 at 12 26 49 PM" src="https://github.com/user-attachments/assets/d9ec2a82-b8d7-49a4-b0f2-85fd98cc65db" />


## How

After extracting the project archive, grant the build user read/write access while preserving executable bits.

## Test Plan

- Added a unit test verifying extraction is followed by `chmod -R u+rwX`.
- Locally archived the app icon with mode `000`; without the fix, Prebuild failed with `EACCES` while reading it.
- Rebuilt the same corrupted archive with the fix enabled; Prebuild and the full iOS build succeeded.
