### PR TITLE
[eas-cli] Enforce uploaded file integrity with GCS MD5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [eas-cli] Disallow 0-length uploads. ([#4192](https://github.com/expo/eas-cli/pull/4192) by [@wschurman](https://github.com/wschurman))
+- [eas-cli] Send the expected `Content-MD5` checksum with GCS signed URL uploads so GCS rejects corrupted uploads. ([#4208](https://github.com/expo/eas-cli/pull/4208) by [@wschurman](https://github.com/wschurman))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/__tests__/uploads-test.ts
+++ b/packages/eas-cli/src/__tests__/uploads-test.ts
@@ -1,0 +1,37 @@
+import crypto from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+
+import fs from 'fs-extra';
+
+import { computeFileMd5Base64Async } from '../uploads';
+
+describe(computeFileMd5Base64Async, () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'eas-cli-uploads-test-'));
+  });
+
+  afterAll(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  it('computes the base64 MD5 checksum of a small file', async () => {
+    const file = path.join(tmpDir, 'small.txt');
+    await fs.writeFile(file, 'abc');
+    // md5("abc") = 900150983cd24fb0d6963f7d28e17f72
+    expect(await computeFileMd5Base64Async(file)).toBe('kAFQmDzST7DWlj99KOF/cg==');
+  });
+
+  it('computes the same checksum as a one-shot hash for a file larger than one stream chunk', async () => {
+    const file = path.join(tmpDir, 'large.bin');
+    const data = Buffer.alloc(256 * 1024);
+    for (let i = 0; i < data.length; i++) {
+      data[i] = i % 251;
+    }
+    await fs.writeFile(file, data);
+    const expected = crypto.createHash('md5').update(data).digest('base64');
+    expect(await computeFileMd5Base64Async(file)).toBe(expected);
+  });
+});

--- a/packages/eas-cli/src/uploads.ts
+++ b/packages/eas-cli/src/uploads.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+
 import FormData from 'form-data';
 import fs from 'fs-extra';
 import { Response } from 'node-fetch';
@@ -154,6 +156,8 @@ async function uploadWithSignedUrlWithProgressAsync(
     );
   }
 
+  const contentMd5 = await computeFileMd5Base64Async(file);
+
   const readStream = fs.createReadStream(file);
   const uploadPromise = fetch(signedUrl.url, {
     method: 'PUT',
@@ -161,6 +165,7 @@ async function uploadWithSignedUrlWithProgressAsync(
     headers: {
       ...signedUrl.headers,
       'Content-Length': String(fileSize), // make GCS reject the request if the file size changes during the upload
+      'Content-MD5': contentMd5, // make GCS reject the request if the uploaded bytes do not match this checksum
     },
   });
 
@@ -188,4 +193,16 @@ async function uploadWithSignedUrlWithProgressAsync(
     handleProgressEvent({ isComplete: true, error });
     throw error;
   }
+}
+
+/**
+ * Computes the base64-encoded MD5 checksum of a file, the format GCS expects
+ * in the `Content-MD5` request header.
+ */
+export async function computeFileMd5Base64Async(file: string): Promise<string> {
+  const hash = crypto.createHash('md5');
+  for await (const chunk of fs.createReadStream(file)) {
+    hash.update(chunk as Buffer);
+  }
+  return hash.digest('base64');
 }


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

https://github.com/expo/eas-cli/pull/4192#discussion_r3786148180

We want to rule out client upload issues from corrupted fingerprints (and other uploads). The previous PR verified the file size. This PR goes one step further and does file hash verification.

# How

Compute MD5, put in header that google checks.

# Test Plan

1. `EXPO_STAGING=1 neas fingerprint:generate --platform android`
2. Navigate to new fingerprint permalink (ensure it is a new one), see sources are uploaded.