### PR TITLE
[worker] Prewarm Xcode tools in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- [worker] Prewarm Xcode interface and asset build tools in the background to reduce iOS build times. ([#4211](https://github.com/expo/eas-cli/pull/4211) by [@sjchmiela](https://github.com/sjchmiela))
+- [worker] Prewarm Xcode interface and asset build tools in the background for iOS builds. ([#4211](https://github.com/expo/eas-cli/pull/4211) by [@sjchmiela](https://github.com/sjchmiela))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [worker] Prewarm Xcode interface and asset build tools in the background to reduce iOS build times. ([#4211](https://github.com/expo/eas-cli/pull/4211) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🐛 Bug fixes
 
 - [eas-cli] Disallow 0-length uploads. ([#4192](https://github.com/expo/eas-cli/pull/4192) by [@wschurman](https://github.com/wschurman))

--- a/packages/worker/src/__unit__/prewarmXcodeBuildTools.test.ts
+++ b/packages/worker/src/__unit__/prewarmXcodeBuildTools.test.ts
@@ -1,0 +1,122 @@
+import type { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
+
+jest.mock('@expo/turtle-spawn');
+jest.mock('fs-extra');
+
+const spawnResult: SpawnResult = {
+  output: [],
+  status: 0,
+  signal: null,
+  stdout: '',
+  stderr: '',
+};
+
+const logger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+};
+
+function createSpawnPromise(result: Promise<SpawnResult>): SpawnPromise<SpawnResult> {
+  return Object.assign(result, {
+    child: { kill: jest.fn() },
+  }) as unknown as SpawnPromise<SpawnResult>;
+}
+
+function setProcessPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform });
+}
+
+async function loadModule(): Promise<{
+  module: typeof import('../ios/prewarmXcodeBuildTools');
+  spawnMock: jest.MockedFunction<typeof import('@expo/turtle-spawn').default>;
+  fsMock: any;
+}> {
+  jest.resetModules();
+  const spawnMock = jest.mocked((await import('@expo/turtle-spawn')).default);
+  const fsMock = jest.mocked((await import('fs-extra')).default);
+  const module = await import('../ios/prewarmXcodeBuildTools');
+  return { module, spawnMock, fsMock };
+}
+
+function prepareFsMock(fsMock: any): void {
+  fsMock.mkdtemp.mockResolvedValue('/tmp/eas-xcode-build-tool-prewarm-test');
+  fsMock.outputFile.mockResolvedValue(undefined);
+  fsMock.ensureDir.mockResolvedValue(undefined);
+  fsMock.remove.mockResolvedValue(undefined);
+}
+
+describe('Xcode build tool prewarming', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    logger.info.mockReset();
+    logger.warn.mockReset();
+  });
+
+  afterEach(() => {
+    setProcessPlatform(originalPlatform);
+  });
+
+  it('does nothing outside macOS', async () => {
+    setProcessPlatform('linux');
+    const { module, spawnMock } = await loadModule();
+
+    await module.startXcodeBuildToolsPrewarming({ env: process.env, logger: logger as any });
+
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('prewarms ibtool before both actool targets, once, and removes temporary files', async () => {
+    setProcessPlatform('darwin');
+    const { module, spawnMock, fsMock } = await loadModule();
+    prepareFsMock(fsMock);
+    spawnMock.mockImplementation(() => createSpawnPromise(Promise.resolve(spawnResult)));
+
+    await module.startXcodeBuildToolsPrewarming({ env: process.env, logger: logger as any });
+    await module.startXcodeBuildToolsPrewarming({ env: process.env, logger: logger as any });
+
+    expect(spawnMock).toHaveBeenCalledTimes(3);
+    expect(spawnMock).toHaveBeenCalledWith(
+      'xcrun',
+      expect.arrayContaining(['ibtool']),
+      expect.objectContaining({ env: process.env, stdio: 'pipe' })
+    );
+    expect(spawnMock).toHaveBeenCalledWith(
+      'xcrun',
+      expect.arrayContaining(['actool', 'iphonesimulator']),
+      expect.objectContaining({ env: process.env, stdio: 'pipe' })
+    );
+    expect(spawnMock).toHaveBeenCalledWith(
+      'xcrun',
+      expect.arrayContaining(['actool', 'iphoneos']),
+      expect.objectContaining({ env: process.env, stdio: 'pipe' })
+    );
+    expect(spawnMock.mock.invocationCallOrder[0]).toBeLessThan(
+      spawnMock.mock.invocationCallOrder[1]
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('Xcode interface and asset build tools were prewarmed')
+    );
+
+    expect(fsMock.remove).toHaveBeenCalledWith('/tmp/eas-xcode-build-tool-prewarm-test');
+  });
+
+  it('continues when a prewarm command fails', async () => {
+    setProcessPlatform('darwin');
+    const { module, spawnMock, fsMock } = await loadModule();
+    prepareFsMock(fsMock);
+    spawnMock
+      .mockImplementationOnce(() => createSpawnPromise(Promise.reject(new Error('failed'))))
+      .mockImplementation(() => createSpawnPromise(Promise.resolve(spawnResult)));
+
+    await expect(
+      module.startXcodeBuildToolsPrewarming({ env: process.env, logger: logger as any })
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ errors: [expect.any(Error)] }),
+      expect.stringContaining('continuing the build')
+    );
+    expect(spawnMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/worker/src/build.ts
+++ b/packages/worker/src/build.ts
@@ -16,6 +16,7 @@ import omit from 'lodash/omit';
 import config from './config';
 import { displayWorkerRuntimeInfo } from './displayRuntimeInfo';
 import { Analytics, Event, logProjectDependenciesAsync } from './external/analytics';
+import { startXcodeBuildToolsPrewarming } from './ios/prewarmXcodeBuildTools';
 import { prepareRuntimeEnvironment } from './runtimeEnvironment';
 import { cleanUpWorkingdir } from './workingdir';
 
@@ -35,6 +36,7 @@ export async function build({
     await ctx.runBuildPhase(
       BuildPhase.SPIN_UP_BUILDER,
       async () => {
+        await startXcodeBuildToolsPrewarming({ env: ctx.env, logger: ctx.logger });
         displayWorkerRuntimeInfo(ctx);
         ctx.logger.info(
           { job: omit(ctx.job, 'secrets', 'projectArchive') },

--- a/packages/worker/src/build.ts
+++ b/packages/worker/src/build.ts
@@ -37,7 +37,9 @@ export async function build({
       BuildPhase.SPIN_UP_BUILDER,
       async () => {
         displayWorkerRuntimeInfo(ctx);
-        void startXcodeBuildToolsPrewarming({ env: ctx.env, logger: ctx.logger });
+        if (job.platform === Platform.IOS && job.mode === BuildMode.BUILD) {
+          void startXcodeBuildToolsPrewarming({ env: ctx.env, logger: ctx.logger });
+        }
         ctx.logger.info(
           { job: omit(ctx.job, 'secrets', 'projectArchive') },
           'Builder is ready, starting build'

--- a/packages/worker/src/build.ts
+++ b/packages/worker/src/build.ts
@@ -36,8 +36,8 @@ export async function build({
     await ctx.runBuildPhase(
       BuildPhase.SPIN_UP_BUILDER,
       async () => {
-        await startXcodeBuildToolsPrewarming({ env: ctx.env, logger: ctx.logger });
         displayWorkerRuntimeInfo(ctx);
+        void startXcodeBuildToolsPrewarming({ env: ctx.env, logger: ctx.logger });
         ctx.logger.info(
           { job: omit(ctx.job, 'secrets', 'projectArchive') },
           'Builder is ready, starting build'

--- a/packages/worker/src/ios/prewarmXcodeBuildTools.ts
+++ b/packages/worker/src/ios/prewarmXcodeBuildTools.ts
@@ -1,0 +1,236 @@
+import { bunyan } from '@expo/logger';
+import spawn, { SpawnPromise, SpawnResult } from '@expo/turtle-spawn';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+
+const PREWARM_TIMEOUT_MS = 5 * 60 * 1000;
+
+// Keep this fixture compatible with the oldest Xcode version supported by EAS Build.
+const STORYBOARD = `<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="view-controller">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <scene sceneID="scene">
+            <objects>
+                <viewController id="view-controller" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="view">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="first-responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>`;
+
+const ASSET_CATALOG_CONTENTS = JSON.stringify({
+  info: { author: 'expo', version: 1 },
+});
+
+const IMAGE_SET_CONTENTS = JSON.stringify({
+  images: [{ filename: 'Warmup.png', idiom: 'universal', scale: '1x' }],
+  info: { author: 'expo', version: 1 },
+});
+
+const WARMUP_IMAGE = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLkWQAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+const COLOR_SET_CONTENTS = JSON.stringify({
+  colors: [
+    {
+      color: {
+        'color-space': 'srgb',
+        components: { alpha: '1.000', blue: '1.000', green: '1.000', red: '1.000' },
+      },
+      idiom: 'universal',
+    },
+  ],
+  info: { author: 'expo', version: 1 },
+});
+
+let prewarmPromise: Promise<void> | undefined;
+
+/**
+ * The worker starts this promise during process startup. The SPIN_UP_BUILDER phase calls this
+ * function again and waits for the same promise before any project work starts.
+ */
+export function startXcodeBuildToolsPrewarming({
+  env,
+  logger,
+}: {
+  env: NodeJS.ProcessEnv;
+  logger: bunyan;
+}): Promise<void> {
+  if (process.platform !== 'darwin') {
+    return Promise.resolve();
+  }
+
+  prewarmPromise ??= prewarmXcodeBuildToolsAsync({ env, logger }).catch((error: any) => {
+    logger.warn({ err: error }, 'Xcode build tool prewarming failed; continuing the build.');
+  });
+  return prewarmPromise;
+}
+
+async function prewarmXcodeBuildToolsAsync({
+  env,
+  logger,
+}: {
+  env: NodeJS.ProcessEnv;
+  logger: bunyan;
+}): Promise<void> {
+  const startedAt = Date.now();
+  const temporaryDirectory = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'eas-xcode-build-tool-prewarm-')
+  );
+
+  try {
+    const storyboardPath = path.join(temporaryDirectory, 'Warmup.storyboard');
+    const storyboardOutputPath = path.join(temporaryDirectory, 'storyboard-output');
+    const assetCatalogPath = path.join(temporaryDirectory, 'Warmup.xcassets');
+    const colorSetPath = path.join(assetCatalogPath, 'Warmup.colorset');
+    const imageSetPath = path.join(assetCatalogPath, 'Warmup.imageset');
+    const simulatorOutputPath = path.join(temporaryDirectory, 'asset-catalog-simulator-output');
+    const deviceOutputPath = path.join(temporaryDirectory, 'asset-catalog-device-output');
+
+    await Promise.all([
+      fs.outputFile(storyboardPath, STORYBOARD),
+      fs.outputFile(path.join(assetCatalogPath, 'Contents.json'), ASSET_CATALOG_CONTENTS),
+      fs.outputFile(path.join(colorSetPath, 'Contents.json'), COLOR_SET_CONTENTS),
+      fs.outputFile(path.join(imageSetPath, 'Contents.json'), IMAGE_SET_CONTENTS),
+      fs.outputFile(path.join(imageSetPath, 'Warmup.png'), WARMUP_IMAGE),
+      fs.ensureDir(storyboardOutputPath),
+      fs.ensureDir(simulatorOutputPath),
+      fs.ensureDir(deviceOutputPath),
+    ]);
+
+    logger.info('Prewarming Xcode interface and asset build tools during worker startup.');
+
+    // ibtool performs the expensive shared Interface Builder initialization. Start actool only
+    // after it finishes to avoid running two instances of the same initialization concurrently.
+    const results: PromiseSettledResult<SpawnResult>[] = await Promise.allSettled([
+      spawnWithTimeout(
+        'xcrun',
+        [
+          'ibtool',
+          '--errors',
+          '--warnings',
+          '--notices',
+          '--target-device',
+          'iphone',
+          '--target-device',
+          'ipad',
+          '--minimum-deployment-target',
+          '12.0',
+          '--output-format',
+          'human-readable-text',
+          storyboardPath,
+          '--compilation-directory',
+          storyboardOutputPath,
+        ],
+        { env }
+      ),
+    ]);
+
+    results.push(
+      ...(await Promise.allSettled([
+        runActoolAsync({
+          assetCatalogPath,
+          env,
+          outputPath: simulatorOutputPath,
+          platform: 'iphonesimulator',
+        }),
+        runActoolAsync({
+          assetCatalogPath,
+          env,
+          outputPath: deviceOutputPath,
+          platform: 'iphoneos',
+        }),
+      ]))
+    );
+
+    const failedResults = results.filter(result => result.status === 'rejected');
+    if (failedResults.length > 0) {
+      logger.warn(
+        { errors: failedResults.map(result => result.reason) },
+        'Some Xcode build tools could not be prewarmed; continuing the build.'
+      );
+    } else {
+      logger.info(
+        `Xcode interface and asset build tools were prewarmed in ${(
+          (Date.now() - startedAt) /
+          1000
+        ).toFixed(1)} seconds.`
+      );
+    }
+  } finally {
+    await fs.remove(temporaryDirectory);
+  }
+}
+
+async function runActoolAsync({
+  assetCatalogPath,
+  env,
+  outputPath,
+  platform,
+}: {
+  assetCatalogPath: string;
+  env: NodeJS.ProcessEnv;
+  outputPath: string;
+  platform: 'iphoneos' | 'iphonesimulator';
+}): Promise<SpawnResult> {
+  return await spawnWithTimeout(
+    'xcrun',
+    [
+      'actool',
+      assetCatalogPath,
+      '--compile',
+      outputPath,
+      '--output-partial-info-plist',
+      `${outputPath}.plist`,
+      '--output-format',
+      'human-readable-text',
+      '--notices',
+      '--warnings',
+      '--platform',
+      platform,
+      '--minimum-deployment-target',
+      '12.0',
+      '--target-device',
+      'iphone',
+      '--target-device',
+      'ipad',
+    ],
+    { env }
+  );
+}
+
+async function spawnWithTimeout(
+  command: string,
+  args: string[],
+  { env }: { env: NodeJS.ProcessEnv }
+): Promise<SpawnResult> {
+  const spawnPromise: SpawnPromise<SpawnResult> = spawn(command, args, {
+    env,
+    stdio: 'pipe',
+  });
+  const timeout = setTimeout(() => {
+    spawnPromise.child.kill('SIGKILL');
+  }, PREWARM_TIMEOUT_MS);
+  timeout.unref();
+
+  try {
+    return await spawnPromise;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/packages/worker/src/ios/prewarmXcodeBuildTools.ts
+++ b/packages/worker/src/ios/prewarmXcodeBuildTools.ts
@@ -60,10 +60,7 @@ const COLOR_SET_CONTENTS = JSON.stringify({
 
 let prewarmPromise: Promise<void> | undefined;
 
-/**
- * The worker starts this promise during process startup. The SPIN_UP_BUILDER phase calls this
- * function again and waits for the same promise before any project work starts.
- */
+/** Starts prewarming at most once without making a prewarm failure fail the build. */
 export function startXcodeBuildToolsPrewarming({
   env,
   logger,
@@ -113,7 +110,7 @@ async function prewarmXcodeBuildToolsAsync({
       fs.ensureDir(deviceOutputPath),
     ]);
 
-    logger.info('Prewarming Xcode interface and asset build tools during worker startup.');
+    logger.info('Prewarming Xcode interface and asset build tools in the background.');
 
     // ibtool performs the expensive shared Interface Builder initialization. Start actool only
     // after it finishes to avoid running two instances of the same initialization concurrently.

--- a/packages/worker/src/main.ts
+++ b/packages/worker/src/main.ts
@@ -1,5 +1,4 @@
 import config from './config';
-import { startXcodeBuildToolsPrewarming } from './ios/prewarmXcodeBuildTools';
 import logger from './logger';
 import { startServer } from './metricsServer';
 import sentry from './sentry';
@@ -7,7 +6,6 @@ import { prepareWorkingdir } from './workingdir';
 import startWsServer from './ws';
 
 async function main(): Promise<void> {
-  void startXcodeBuildToolsPrewarming({ env: process.env, logger });
   await prepareWorkingdir();
   startWsServer();
   if (config.runMetricsServer) {

--- a/packages/worker/src/main.ts
+++ b/packages/worker/src/main.ts
@@ -1,4 +1,5 @@
 import config from './config';
+import { startXcodeBuildToolsPrewarming } from './ios/prewarmXcodeBuildTools';
 import logger from './logger';
 import { startServer } from './metricsServer';
 import sentry from './sentry';
@@ -6,6 +7,7 @@ import { prepareWorkingdir } from './workingdir';
 import startWsServer from './ws';
 
 async function main(): Promise<void> {
+  void startXcodeBuildToolsPrewarming({ env: process.env, logger });
   await prepareWorkingdir();
   startWsServer();
   if (config.runMetricsServer) {


### PR DESCRIPTION
## Summary

- for standard iOS build jobs, start Xcode interface and asset tool prewarming in the background after builder runtime information is printed
- skip prewarming for Android, generic, resign, repack, and custom jobs
- do not wait for prewarming in `SPIN_UP_BUILDER`
- run `ibtool` before `actool` to avoid concurrent shared initialization
- prewarm `actool` for both simulator and device targets
- continue the build if prewarming fails or exceeds its timeout

## Why

The first `ibtool` and `actool` use in an Xcode 26 VM can initialize shared Xcode services. This can make the first real storyboard or asset-catalog build much slower.

This PR tests whether the worker can hide that initialization behind project setup. The controlled staging result shows that it cannot remove the cold cost. It only moves the cost earlier in the same build.

## Staging comparison

The controlled comparison used the same managed Expo SDK 57 simulator project, Xcode 26.6 image revision, worker revision, project fingerprint, build profile, and restored ccache state. Every run had 790 ccache hits and 790 misses. Each run used a fresh VM.

| Image state | Worker prewarm | Build | Prewarm | Pods | Fastlane |
| --- | --- | ---: | ---: | ---: | ---: |
| Cold | Disabled | 404.522s | - | 61.974s | 284.101s |
| Cold | Enabled | 396.708s | 170.7s | 63.422s | 130.345s |
| Prewarmed | Disabled | 243.134s | - | 62.691s | 126.060s |
| Prewarmed | Enabled | 245.835s | 14.0s | 62.253s | 125.684s |

On a cold image, worker prewarming took 170.7 seconds. It reduced Fastlane time, but total build time improved by only 7.814 seconds, or 1.9%. The initialization remained inside the customer build.

Image prewarming alone reduced the build by 161.388 seconds, or 39.9%. On the prewarmed image, enabling worker prewarming made the build 2.701 seconds, or 1.1%, slower. This is normal run-to-run variance and shows no additional benefit.

- cold image, worker disabled: https://staging.expo.dev/accounts/expo-services/projects/worker-system-tests/builds/220ef880-c880-4929-8c1d-19f26537f5a8
- cold image, worker enabled: https://staging.expo.dev/accounts/expo-services/projects/worker-system-tests/builds/e12628b7-96dc-4560-aca5-0ef4dc446097
- prewarmed image, worker disabled: https://staging.expo.dev/accounts/expo-services/projects/worker-system-tests/builds/78083111-cf72-4824-8d99-05665c9f7106
- prewarmed image, worker enabled: https://staging.expo.dev/accounts/expo-services/projects/worker-system-tests/builds/1af590d1-02f8-4787-94c7-e4a78052c199
- benchmark worker deployment: https://github.com/expo/eas-cli/actions/runs/31867744447

## Validation

- worker prewarm unit tests: 3 passed
- worker TypeScript typecheck
- local Xcode 26.6 fixture compilation
- formatter and `git diff --check`
- four successful controlled end-to-end staging comparison builds
