### PR TITLE
[worker] Install package managers with Corepack

### DIFF
--- a/packages/worker/src/__unit__/runtimeEnvironment.test.ts
+++ b/packages/worker/src/__unit__/runtimeEnvironment.test.ts
@@ -148,6 +148,75 @@ describe('prepareRuntimeEnvironment', () => {
         );
       });
 
+      it('uses Corepack to install package managers after installing custom Node.js', async () => {
+        const testCtx = { ...ctx, env: { ...ctx.env } };
+        mockRuntimeEnvironmentVersions();
+
+        await prepareRuntimeEnvironment(
+          testCtx,
+          {
+            node: '22.20.0',
+            corepack: true,
+            pnpm: '9.15.5',
+            yarn: '1.22.22',
+          },
+          false
+        );
+
+        expect(spawn).toHaveBeenCalledWith('corepack', ['enable'], expect.anything());
+        expect(spawn).toHaveBeenCalledWith(
+          'corepack',
+          ['prepare', 'pnpm@9.15.5', '--activate'],
+          expect.anything()
+        );
+        expect(spawn).toHaveBeenCalledWith(
+          'corepack',
+          ['prepare', 'yarn@1.22.22', '--activate'],
+          expect.anything()
+        );
+        expect(spawn).not.toHaveBeenCalledWith(
+          'npm',
+          ['-g', 'install', 'pnpm@9.15.5'],
+          expect.anything()
+        );
+        expect(spawn).not.toHaveBeenCalledWith(
+          'npm',
+          ['-g', 'install', 'yarn@1.22.22'],
+          expect.anything()
+        );
+      });
+
+      it('uses npm to install package managers when Corepack is disabled', async () => {
+        const testCtx = { ...ctx, env: { ...ctx.env } };
+        mockRuntimeEnvironmentVersions();
+
+        await prepareRuntimeEnvironment(
+          testCtx,
+          {
+            node: '22.20.0',
+            pnpm: '9.15.5',
+            yarn: '1.22.22',
+          },
+          false
+        );
+
+        expect(spawn).toHaveBeenCalledWith(
+          'npm',
+          ['-g', 'install', 'pnpm@9.15.5'],
+          expect.anything()
+        );
+        expect(spawn).toHaveBeenCalledWith(
+          'npm',
+          ['-g', 'install', 'yarn@1.22.22'],
+          expect.anything()
+        );
+        expect(spawn).not.toHaveBeenCalledWith(
+          'corepack',
+          expect.arrayContaining(['prepare']),
+          expect.anything()
+        );
+      });
+
       it('installs Bun when a specified version is different from installed version', async () => {
         let isFirstTimeCheckingBunVersion = true;
         jest.mocked(spawn).mockImplementation((cmd, _args, _opts) => {
@@ -266,6 +335,26 @@ function mockProcessPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', {
     configurable: true,
     value: platform,
+  });
+}
+
+function mockRuntimeEnvironmentVersions(): void {
+  jest.mocked(spawn).mockImplementation((cmd, args) => {
+    if (cmd === 'bash' && args[1]?.includes('nvm install')) {
+      return Promise.resolve({
+        ...spawnResult,
+        stdout: 'Now using node v22.20.0 (npm v10.9.3)\n',
+      });
+    } else if (cmd === 'pnpm') {
+      return Promise.resolve({ ...spawnResult, stdout: '9.15.5\n' });
+    } else if (cmd === 'yarn') {
+      return Promise.resolve({ ...spawnResult, stdout: '1.22.22\n' });
+    } else if (cmd === 'bun') {
+      return Promise.resolve({ ...spawnResult, stdout: '1.2.23\n' });
+    } else if (cmd === 'sharp') {
+      return Promise.resolve({ ...spawnResult, stdout: '5.2.0\n' });
+    }
+    return Promise.resolve(spawnResult);
   });
 }
 

--- a/packages/worker/src/runtimeEnvironment.ts
+++ b/packages/worker/src/runtimeEnvironment.ts
@@ -99,6 +99,7 @@ export async function prepareRuntimeEnvironment(
       ctx,
       userSpecifiedVersion: builderConfig.pnpm,
       currentVersion: currentPnpmVersion,
+      useCorepack: Boolean(builderConfig.corepack),
     });
   }
   if (
@@ -109,6 +110,7 @@ export async function prepareRuntimeEnvironment(
       ctx,
       userSpecifiedVersion: builderConfig.yarn,
       currentVersion: currentYarnVersion,
+      useCorepack: Boolean(builderConfig.corepack),
     });
   }
   if (builderConfig.bun && currentBunVersion !== builderConfig.bun) {
@@ -235,19 +237,18 @@ async function installPnpm({
   ctx,
   userSpecifiedVersion,
   currentVersion,
+  useCorepack,
 }: {
   ctx: PreDownloadBuildContext;
   userSpecifiedVersion: string | undefined;
   currentVersion: string;
+  useCorepack: boolean;
 }): Promise<void> {
   const versionToInstall = userSpecifiedVersion ?? currentVersion;
   try {
     ctx.logger.info(`Installing pnpm@${versionToInstall}`);
 
-    await spawn('npm', ['-g', 'install', `pnpm@${versionToInstall}`], {
-      logger: ctx.logger,
-      env: ctx.env,
-    });
+    await installPackageManager(ctx, 'pnpm', versionToInstall, useCorepack);
     const currentPnpmVersion = (
       await spawn('pnpm', ['--version'], { stdio: 'pipe', env: ctx.env, cwd: os.tmpdir() })
     ).stdout.trim();
@@ -273,18 +274,17 @@ async function installYarn({
   ctx,
   userSpecifiedVersion,
   currentVersion,
+  useCorepack,
 }: {
   ctx: PreDownloadBuildContext;
   userSpecifiedVersion: string | undefined;
   currentVersion: string;
+  useCorepack: boolean;
 }): Promise<void> {
   const versionToInstall = userSpecifiedVersion ?? currentVersion;
   try {
     ctx.logger.info(`Installing yarn@${versionToInstall}`);
-    await spawn('npm', ['-g', 'install', `yarn@${versionToInstall}`], {
-      logger: ctx.logger,
-      env: ctx.env,
-    });
+    await installPackageManager(ctx, 'yarn', versionToInstall, useCorepack);
     const currentYarnVersion = (
       await spawn('yarn', ['--version'], { stdio: 'pipe', env: ctx.env, cwd: os.tmpdir() })
     ).stdout.trim();
@@ -303,6 +303,25 @@ async function installYarn({
         `Failed to install yarn@${versionToInstall}. Continuing because yarn is not the primary package manager for this project.`
       );
     }
+  }
+}
+
+async function installPackageManager(
+  ctx: PreDownloadBuildContext,
+  packageManager: 'pnpm' | 'yarn',
+  version: string,
+  useCorepack: boolean
+): Promise<void> {
+  if (useCorepack) {
+    await spawn('corepack', ['prepare', `${packageManager}@${version}`, '--activate'], {
+      logger: ctx.logger,
+      env: ctx.env,
+    });
+  } else {
+    await spawn('npm', ['-g', 'install', `${packageManager}@${version}`], {
+      logger: ctx.logger,
+      env: ctx.env,
+    });
   }
 }
 


### PR DESCRIPTION
# Why

Builds that install a custom Node.js version with Corepack enabled can fail during INSTALL_CUSTOM_TOOLS. corepack enable creates pnpm and Yarn shims, then the worker attempts to overwrite them with npm -g install, which exits with EEXIST.

This affected 251 builds across 138 accounts in the visible hot-log window: [Datadog failure cluster](https://app.datadoghq.com/logs?query=source%3Aeas-build+build_phase%3Ainstall_custom_tools+%22npm+error+code+EEXIST%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1785456000000&to_ts=1786752000000&live=false).

# How

Use Corepack to prepare and activate the requested pnpm and Yarn versions when Corepack is enabled. Keep the existing npm global installation path for builds that do not enable Corepack.

# Test Plan

- Added a regression test verifying custom Node.js + Corepack uses corepack prepare for pnpm and Yarn without invoking the conflicting npm installs; the control test verifies Corepack-disabled builds still use npm.
- Ran all 57 worker unit tests, worker typechecking, linting, and formatting checks.