### PR TITLE
[eas-cli] Accept a major SDK version in eas go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [eas-cli] Disallow 0-length uploads. ([#4192](https://github.com/expo/eas-cli/pull/4192) by [@wschurman](https://github.com/wschurman))
 - [eas-cli] Send the expected `Content-MD5` checksum with GCS signed URL uploads so GCS rejects corrupted uploads. ([#4208](https://github.com/expo/eas-cli/pull/4208) by [@wschurman](https://github.com/wschurman))
+- [eas-cli] Resolve the `eas go` SDK version to its repack target, so `--sdk-version 57` no longer fails with "No Expo Go repack target is published for SDK 57". ([#4215](https://github.com/expo/eas-cli/pull/4215) by [@gwdp](https://github.com/gwdp))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/__tests__/commands/go-test.ts
+++ b/packages/eas-cli/src/__tests__/commands/go-test.ts
@@ -11,7 +11,7 @@ import { getPrivateExpoConfigAsync } from '../../project/expoConfig';
 import { uploadAccountScopedFileAsync } from '../../project/uploadAccountScopedFileAsync';
 import { uploadAccountScopedProjectSourceAsync } from '../../project/uploadAccountScopedProjectSourceAsync';
 import { ensureActorHasPrimaryAccount } from '../../user/actions';
-import { detectProjectSdkVersionAsync } from '../../commands/go';
+import { detectProjectSdkVersionAsync, toRepackTargetSdkVersion } from '../../commands/go';
 import { mockTestCommand } from './utils';
 
 jest.mock('@expo/config', () => ({
@@ -81,6 +81,25 @@ describe('detectProjectSdkVersionAsync', () => {
   });
 });
 
+describe('toRepackTargetSdkVersion', () => {
+  it.each([
+    ['57', '57.0.0'],
+    ['57.0.0', '57.0.0'],
+    ['57.0.9', '57.0.0'],
+    ['57.0.0-canary-20260101', '57.0.0'],
+  ])('resolves %s to the %s repack target', (sdkVersion, expected) => {
+    expect(toRepackTargetSdkVersion(sdkVersion)).toBe(expected);
+  });
+
+  it('returns undefined when no version is requested', () => {
+    expect(toRepackTargetSdkVersion(undefined)).toBeUndefined();
+  });
+
+  it('returns the requested version unchanged when it holds no version number', () => {
+    expect(toRepackTargetSdkVersion('latest')).toBe('latest');
+  });
+});
+
 const mockAccount = { id: 'account-id', name: 'testuser' };
 const mockActor = {
   __typename: 'User' as const,
@@ -147,6 +166,17 @@ describe('Go command', () => {
     await makeCmd(['--sdk-version', '55.0.0']).run();
 
     expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('Auto-selected'));
+  });
+
+  it('requests the repack configuration with the repack target SDK version', async () => {
+    mockGetConfigFilePaths.mockReturnValue({ staticConfigPath: null, dynamicConfigPath: null });
+
+    await makeCmd(['--sdk-version', '57']).run();
+
+    expect(WorkflowRunQuery.expoGoRepackConfigurationAsync).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ sdkVersion: '57.0.0' })
+    );
   });
 
   it('prompts for SDK version when no project config is found', async () => {

--- a/packages/eas-cli/src/commands/go.ts
+++ b/packages/eas-cli/src/commands/go.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
+import semver from 'semver';
 import { Analytics } from '../analytics/AnalyticsManager';
 import EasCommand from '../commandUtils/EasCommand';
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
@@ -59,6 +60,11 @@ export async function detectProjectSdkVersionAsync(
   } catch {
     return;
   }
+}
+
+export function toRepackTargetSdkVersion(sdkVersion: string | undefined): string | undefined {
+  const coerced = semver.coerce(sdkVersion);
+  return coerced ? `${coerced.major}.0.0` : sdkVersion;
 }
 
 async function setupTestFlightAsync(ascApp: App): Promise<void> {
@@ -120,7 +126,8 @@ export default class Go extends EasCommand {
       default: 'My Expo Go',
     }),
     'sdk-version': Flags.string({
-      description: 'Expo Go SDK version to prepare (default: latest)',
+      description:
+        'Expo Go SDK version to prepare, for example 57 (default: the SDK version of the current project)',
       required: false,
     }),
     credentials: Flags.boolean({
@@ -157,7 +164,7 @@ export default class Go extends EasCommand {
         `Current project using SDK ${detectedSdkVersion.split('.')[0]}. Auto-selected same version. To use a different version, pass --sdk-version.`
       );
     }
-    let sdkVersion = flags['sdk-version'] ?? detectedSdkVersion;
+    let sdkVersion = toRepackTargetSdkVersion(flags['sdk-version'] ?? detectedSdkVersion);
     if (!sdkVersion) {
       ({ sdkVersion } = await this.selectSdkVersionAsync(graphqlClient));
     }


### PR DESCRIPTION
# Why

`eas go --sdk-version 57` fails. The server keys Expo Go repack targets by full version, so `57` misses and you get "No Expo Go repack target is published for SDK 57. Supported SDK versions: 54.0.0, 55.0.0, 56.0.0, 57.0.0.". A project on a canary SDK version misses the same way.

# How

Resolve the SDK version to its repack target before sending it, so `57` and `57.0.9` both become `57.0.0`. A value with no version number still goes to the server, which owns the supported list.


# Test Plan

CI