### PR TITLE
[steps] Report a broken composite `if:` on the call, not an inner step

### DIFF
--- a/packages/steps/src/BuildStepCompositeFunctionScope.ts
+++ b/packages/steps/src/BuildStepCompositeFunctionScope.ts
@@ -12,7 +12,7 @@ import type { BuildStepOutputAccessor } from './BuildStep';
 import { BuildStepGlobalContext } from './BuildStepContext';
 import { BuildStepEnv } from './BuildStepEnv';
 import { BuildStepInput } from './BuildStepInput';
-import { BuildStepRuntimeError } from './errors';
+import { BuildStepConditionEvaluationError, BuildStepRuntimeError } from './errors';
 import {
   resolveInterpolatedTarget,
   stringifyInterpolatedResult,
@@ -77,7 +77,23 @@ export class BuildStepCompositeFunctionScope {
     if (this.parent && !this.parent.isActive(evaluate, runByDefault)) {
       return false;
     }
-    this.cachedIsActive ??= this.evaluateCallIfCondition(evaluate, runByDefault);
+    if (this.cachedIsActive === undefined) {
+      try {
+        this.cachedIsActive = this.evaluateCallIfCondition(evaluate, runByDefault);
+      } catch (err) {
+        // An unevaluable gate skips the call, cache the skip before throwing.
+        // Only the first child reports the error, the rest skip silently.
+        this.cachedIsActive = false;
+        const ifCondition = this.ifCondition ?? '';
+        const subject = `composite function call "${this.compositeFunctionPath}"`;
+        throw new BuildStepConditionEvaluationError(
+          `Failed to evaluate the if condition "${ifCondition}" of ${subject}.`,
+          subject,
+          ifCondition,
+          { cause: err instanceof Error ? err : undefined }
+        );
+      }
+    }
     return this.cachedIsActive;
   }
 

--- a/packages/steps/src/BuildStepCompositeFunctionScope.ts
+++ b/packages/steps/src/BuildStepCompositeFunctionScope.ts
@@ -84,12 +84,9 @@ export class BuildStepCompositeFunctionScope {
         // An unevaluable gate skips the call, cache the skip before throwing.
         // Only the first child reports the error, the rest skip silently.
         this.cachedIsActive = false;
-        const ifCondition = this.ifCondition ?? '';
-        const subject = `composite function call "${this.compositeFunctionPath}"`;
         throw new BuildStepConditionEvaluationError(
-          `Failed to evaluate the if condition "${ifCondition}" of ${subject}.`,
-          subject,
-          ifCondition,
+          `composite function call "${this.compositeFunctionPath}"`,
+          this.ifCondition ?? '',
           { cause: err instanceof Error ? err : undefined }
         );
       }

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -288,11 +288,8 @@ function logConditionEvaluationError(
   ifCondition: string | undefined
 ): void {
   if (err instanceof BuildStepConditionEvaluationError) {
-    logger.error({ err: err.cause ?? err });
-    logger.error(
-      `Runner failed to evaluate if it should execute ${err.subject}, using its if condition "${err.ifCondition}". This can be caused by trying to access non-existing object property. If you think this is a bug report it here: https://github.com/expo/eas-cli/issues.`
-    );
-    return;
+    ({ subject, ifCondition } = err);
+    err = err.cause ?? err;
   }
   logger.error({ err });
   logger.error(

--- a/packages/steps/src/BuildWorkflow.ts
+++ b/packages/steps/src/BuildWorkflow.ts
@@ -7,6 +7,7 @@ import { BuildStep } from './BuildStep';
 import { BuildStepGlobalContext } from './BuildStepContext';
 import { CompositeBuildStep } from './CompositeBuildStep';
 import { StepMetricResult } from './StepMetrics';
+import { BuildStepConditionEvaluationError } from './errors';
 import { AnchorHooks, HookEntry } from './hooks';
 import { evaluateIfCondition } from './utils/jsepEval';
 
@@ -279,15 +280,20 @@ export async function executeHookStepsAsync(
   return { failedLocally, firstError };
 }
 
-// Shared wording for unevaluable `if:` gates. Callers pass the step's own
-// `if:`, but the throw may come from a composite call-site `if:` evaluated via
-// the step's scope. In that case the quoted condition is not the one that failed.
+// Shared wording for unevaluable `if:` gates.
 function logConditionEvaluationError(
   logger: bunyan,
   err: unknown,
   subject: string,
   ifCondition: string | undefined
 ): void {
+  if (err instanceof BuildStepConditionEvaluationError) {
+    logger.error({ err: err.cause ?? err });
+    logger.error(
+      `Runner failed to evaluate if it should execute ${err.subject}, using its if condition "${err.ifCondition}". This can be caused by trying to access non-existing object property. If you think this is a bug report it here: https://github.com/expo/eas-cli/issues.`
+    );
+    return;
+  }
   logger.error({ err });
   logger.error(
     `Runner failed to evaluate if it should execute ${subject}${

--- a/packages/steps/src/__tests__/BuildStepCompositeFunctionScope-test.ts
+++ b/packages/steps/src/__tests__/BuildStepCompositeFunctionScope-test.ts
@@ -2,16 +2,26 @@ import { JobInterpolationContext } from '@expo/eas-build-job';
 import { instance, mock, when } from 'ts-mockito';
 
 import { createGlobalContextMock } from './utils/context';
+import { getError } from './utils/error';
 import { BuildStep } from '../BuildStep';
 import { BuildStepCompositeFunctionScope } from '../BuildStepCompositeFunctionScope';
 import { BuildStepInput, BuildStepInputValueTypeName } from '../BuildStepInput';
 import { BuildStepOutput } from '../BuildStepOutput';
+import { BuildStepConditionEvaluationError } from '../errors';
 import { interpolateJobContext } from '../interpolation';
 
 describe(BuildStepCompositeFunctionScope, () => {
   const baseContext = {} as unknown as JobInterpolationContext;
 
-  function makeScope(): BuildStepCompositeFunctionScope {
+  function makeScope({
+    ifCondition,
+    parent,
+    compositeFunctionPath = 'test-action',
+  }: {
+    ifCondition?: string;
+    parent?: BuildStepCompositeFunctionScope;
+    compositeFunctionPath?: string;
+  } = {}): BuildStepCompositeFunctionScope {
     const ctx = createGlobalContextMock();
 
     const versionOutput = mock<BuildStepOutput>();
@@ -29,7 +39,9 @@ describe(BuildStepCompositeFunctionScope, () => {
     greeting.set('hello');
     return new BuildStepCompositeFunctionScope({
       ctx,
-      compositeFunctionPath: 'test-action',
+      parent,
+      ifCondition,
+      compositeFunctionPath,
       inputs: new Map([['greeting', greeting]]),
       providedInputKeys: new Set(['greeting']),
       childrenByLocalId: new Map([['build', instance(innerStep)]]),
@@ -68,6 +80,47 @@ describe(BuildStepCompositeFunctionScope, () => {
       const scope = makeScope();
       expect(scope.isActive(neverEvaluate, true)).toBe(true);
       expect(scope.isActive(neverEvaluate, false)).toBe(true);
+    });
+
+    it('wraps an evaluation failure with the call as subject, its condition, and the raw cause', () => {
+      const rawError = new Error('boom');
+      const scope = makeScope({ ifCondition: '${{ broken }}' });
+      const error = getError(() =>
+        scope.isActive(() => {
+          throw rawError;
+        }, true)
+      );
+      expect(error).toBeInstanceOf(BuildStepConditionEvaluationError);
+      expect(error.subject).toBe('composite function call "test-action"');
+      expect(error.ifCondition).toBe('${{ broken }}');
+      expect(error.cause).toBe(rawError);
+    });
+
+    it('reports an evaluation failure once; later calls skip without re-evaluating', () => {
+      let evaluations = 0;
+      const evaluate = (): boolean => {
+        evaluations += 1;
+        throw new Error('boom');
+      };
+      const scope = makeScope({ ifCondition: '${{ broken }}' });
+      expect(() => scope.isActive(evaluate, true)).toThrow(BuildStepConditionEvaluationError);
+      expect(scope.isActive(evaluate, true)).toBe(false);
+      expect(evaluations).toBe(1);
+    });
+
+    it('propagates a parent call-site failure naming the parent scope, not the child', () => {
+      const parent = makeScope({
+        ifCondition: '${{ broken }}',
+        compositeFunctionPath: 'parent-action',
+      });
+      const child = makeScope({ parent });
+      const error = getError(() =>
+        child.isActive(() => {
+          throw new Error('boom');
+        }, true)
+      );
+      expect(error).toBeInstanceOf(BuildStepConditionEvaluationError);
+      expect(error.subject).toBe('composite function call "parent-action"');
     });
   });
 });

--- a/packages/steps/src/__tests__/BuildWorkflow-hooks-test.ts
+++ b/packages/steps/src/__tests__/BuildWorkflow-hooks-test.ts
@@ -4,6 +4,7 @@ import { Hooks, Step } from '@expo/eas-build-job';
 
 import { makeCatalog } from './StepsConfigParser-composite-functions-test-utils';
 import { createGlobalContextMock } from './utils/context';
+import { createRecordingLogger } from './utils/logger';
 import { BuildFunction } from '../BuildFunction';
 import { BuildFunctionGroup } from '../BuildFunctionGroup';
 import { BuildStepStatus } from '../BuildStep';
@@ -13,17 +14,20 @@ import { BuildStepOutput } from '../BuildStepOutput';
 import { BuildWorkflow } from '../BuildWorkflow';
 import { StepsConfigParser } from '../StepsConfigParser';
 import { WorkflowHookMetric } from '../StepMetrics';
-import { BuildStepRuntimeError } from '../errors';
+import { BuildStepConditionEvaluationError, BuildStepRuntimeError } from '../errors';
 
 describe('BuildWorkflow hook execution', () => {
   let ctx: BuildStepGlobalContext;
   let executionLog: string[];
   let metrics: WorkflowHookMetric[];
+  let loggedMessages: string[];
 
   beforeEach(async () => {
     executionLog = [];
     metrics = [];
+    loggedMessages = [];
     ctx = createGlobalContextMock({
+      logger: createRecordingLogger(loggedMessages),
       reportWorkflowHookMetric: metric => metrics.push(metric),
     });
     await fs.mkdir(ctx.defaultWorkingDirectory, { recursive: true });
@@ -648,6 +652,44 @@ describe('BuildWorkflow hook execution', () => {
       expect(metrics).toEqual([
         { anchor: 'install_node_modules', timing: 'before', result: 'success' },
       ]);
+    });
+
+    it('attributes a broken composite call-site if: to the call, logs it once, and skips the anchor', async () => {
+      const workflow = await parseAsync({
+        steps: [{ uses: 'eas/install_node_modules' }],
+        hooks: {
+          before_install_node_modules: [
+            {
+              uses: './.eas/functions/setup',
+              id: 'setup',
+              if: '${{ nonexistent.object.property }}',
+            },
+          ],
+        },
+        externalFunctions: [anchorFunction(), recordingFunction('one'), recordingFunction('two')],
+        compositeFunctionCatalog: {
+          './.eas/functions/setup': {
+            runs: {
+              steps: [
+                { id: 'first', uses: 'test/one' },
+                { id: 'second', uses: 'test/two', if: '${{ always() }}' },
+              ],
+            },
+          },
+        },
+      });
+      await expect(workflow.executeAsync()).rejects.toThrow(BuildStepConditionEvaluationError);
+      expect(executionLog).toEqual([]);
+      expect(hookStepStatuses(workflow)['setup__first']).toBe(BuildStepStatus.SKIPPED);
+      expect(hookStepStatuses(workflow)['setup__second']).toBe(BuildStepStatus.SKIPPED);
+      expect(workflow.buildSteps[0].status).toBe(BuildStepStatus.SKIPPED);
+      expect(metrics).toEqual([]);
+
+      const gateMessages = loggedMessages.filter(m => m.includes('Runner failed to evaluate'));
+      expect(gateMessages).toHaveLength(1);
+      expect(gateMessages[0]).toContain('composite function call "./.eas/functions/setup"');
+      expect(gateMessages[0]).toContain('${{ nonexistent.object.property }}');
+      expect(loggedMessages.join('\n')).not.toContain('${{ always() }}');
     });
 
     it('skips every step of a composite call whose if condition is false and reports no metric', async () => {

--- a/packages/steps/src/__tests__/StepsConfigParser-composite-functions-scoping-test.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-composite-functions-scoping-test.ts
@@ -10,13 +10,18 @@ import {
 } from './StepsConfigParser-composite-functions-test-utils';
 import { createGlobalContextMock } from './utils/context';
 import { getErrorAsync } from './utils/error';
+import { createRecordingLogger } from './utils/logger';
 import { BuildFunction } from '../BuildFunction';
 import { StepsConfigParser } from '../StepsConfigParser';
 import { BuildStepStatus } from '../BuildStep';
 import { BuildStepInput, BuildStepInputValueTypeName } from '../BuildStepInput';
 import { BuildStepOutput } from '../BuildStepOutput';
 import { BuildWorkflow } from '../BuildWorkflow';
-import { BuildConfigError, BuildStepRuntimeError } from '../errors';
+import {
+  BuildConfigError,
+  BuildStepConditionEvaluationError,
+  BuildStepRuntimeError,
+} from '../errors';
 
 describe('StepsConfigParser local composite functions', () => {
   describe('step reference scoping', () => {
@@ -1250,6 +1255,75 @@ describe('StepsConfigParser local composite functions', () => {
       const show = workflow.buildSteps.find(s => s.id === 'wrap__inner__show');
       expect(show?.status).toBe(BuildStepStatus.SUCCESS);
       expect(show?.getOutputValueByName('out')).toBe('hello');
+    });
+  });
+  describe('call-site if evaluation errors', () => {
+    it('attributes a broken call-site if: to the composite call and logs it once', async () => {
+      const messages: string[] = [];
+      const workflow = await parseCompositeFunctions({
+        ctx: createGlobalContextMock({ logger: createRecordingLogger(messages) }),
+        catalog: {
+          [SETUP]: {
+            runs: {
+              steps: [
+                { id: 'first', uses: 'eas/echo', if: '${{ always() }}' },
+                { id: 'second', uses: 'eas/echo' },
+              ],
+            },
+          },
+        },
+        steps: [{ uses: SETUP, id: 'setup', if: '${{ nonexistent.object.property }}' }],
+        externalFunctions: [echoFunction()],
+      });
+
+      const error = await getErrorAsync(() => workflow.executeAsync());
+      expect(error).toBeInstanceOf(BuildStepConditionEvaluationError);
+      expect(error.ifCondition).toBe('${{ nonexistent.object.property }}');
+
+      for (const id of ['setup__first', 'setup__second']) {
+        expect(workflow.buildSteps.find(s => s.id === id)?.status).toBe(BuildStepStatus.SKIPPED);
+      }
+
+      const gateMessages = messages.filter(m => m.includes('Runner failed to evaluate'));
+      expect(gateMessages).toHaveLength(1);
+      expect(gateMessages[0]).toContain(`composite function call "${SETUP}"`);
+      expect(gateMessages[0]).toContain('${{ nonexistent.object.property }}');
+      expect(messages.join('\n')).not.toContain('${{ always() }}');
+    });
+
+    it('names the outer call when its broken if: gates a nested composite, still logging once', async () => {
+      const messages: string[] = [];
+      const workflow = await parseCompositeFunctions({
+        ctx: createGlobalContextMock({ logger: createRecordingLogger(messages) }),
+        catalog: {
+          './.eas/functions/outer': {
+            runs: {
+              steps: [
+                { uses: './.eas/functions/inner', id: 'nested' },
+                { id: 'tail', uses: 'eas/echo' },
+              ],
+            },
+          },
+          './.eas/functions/inner': {
+            runs: { steps: [{ id: 'leaf', uses: 'eas/echo' }] },
+          },
+        },
+        steps: [
+          { uses: './.eas/functions/outer', id: 'top', if: '${{ nonexistent.object.property }}' },
+        ],
+        externalFunctions: [echoFunction()],
+      });
+
+      const error = await getErrorAsync(() => workflow.executeAsync());
+      expect(error).toBeInstanceOf(BuildStepConditionEvaluationError);
+
+      for (const id of ['top__nested__leaf', 'top__tail']) {
+        expect(workflow.buildSteps.find(s => s.id === id)?.status).toBe(BuildStepStatus.SKIPPED);
+      }
+
+      const gateMessages = messages.filter(m => m.includes('Runner failed to evaluate'));
+      expect(gateMessages).toHaveLength(1);
+      expect(gateMessages[0]).toContain('composite function call "./.eas/functions/outer"');
     });
   });
 });

--- a/packages/steps/src/__tests__/StepsConfigParser-composite-functions-test-utils.ts
+++ b/packages/steps/src/__tests__/StepsConfigParser-composite-functions-test-utils.ts
@@ -2,6 +2,7 @@ import { CompositeFunctionCatalog, CompositeFunctionConfigZ, Step } from '@expo/
 
 import { createGlobalContextMock } from './utils/context';
 import { BuildFunction } from '../BuildFunction';
+import { BuildStepGlobalContext } from '../BuildStepContext';
 import { BuildFunctionGroup } from '../BuildFunctionGroup';
 import { BuildStepInput, BuildStepInputValueTypeName } from '../BuildStepInput';
 import { BuildStepOutput } from '../BuildStepOutput';
@@ -23,8 +24,9 @@ export async function parseCompositeFunctions(options: {
   steps: Step[];
   externalFunctions?: BuildFunction[];
   externalFunctionGroups?: BuildFunctionGroup[];
+  ctx?: BuildStepGlobalContext;
 }): Promise<BuildWorkflow> {
-  const ctx = createGlobalContextMock();
+  const ctx = options.ctx ?? createGlobalContextMock();
   const parser = new StepsConfigParser(ctx, {
     steps: options.steps,
     hooks: undefined,

--- a/packages/steps/src/__tests__/utils/logger.ts
+++ b/packages/steps/src/__tests__/utils/logger.ts
@@ -11,3 +11,20 @@ export function createMockLogger(): bunyan {
   } as unknown as bunyan;
   return logger;
 }
+
+export function createRecordingLogger(sink: string[]): bunyan {
+  const record = (...args: unknown[]): void => {
+    const message = args.find(arg => typeof arg === 'string');
+    if (typeof message === 'string') {
+      sink.push(message);
+    }
+  };
+  const logger = {
+    info: jest.fn(record),
+    debug: jest.fn(record),
+    error: jest.fn(record),
+    warn: jest.fn(record),
+    child: jest.fn(() => logger),
+  } as unknown as bunyan;
+  return logger;
+}

--- a/packages/steps/src/errors.ts
+++ b/packages/steps/src/errors.ts
@@ -25,14 +25,13 @@ export class BuildStepRuntimeError extends UserError {}
 
 export class BuildStepConditionEvaluationError extends UserError {
   constructor(
-    public override readonly message: string,
     public readonly subject: string,
     public readonly ifCondition: string,
     extra?: {
       cause?: Error;
     }
   ) {
-    super(message, extra);
+    super(`Failed to evaluate the if condition "${ifCondition}" of ${subject}.`, extra);
   }
 }
 

--- a/packages/steps/src/errors.ts
+++ b/packages/steps/src/errors.ts
@@ -23,6 +23,19 @@ export class BuildInternalError extends Error {}
 
 export class BuildStepRuntimeError extends UserError {}
 
+export class BuildStepConditionEvaluationError extends UserError {
+  constructor(
+    public override readonly message: string,
+    public readonly subject: string,
+    public readonly ifCondition: string,
+    extra?: {
+      cause?: Error;
+    }
+  ) {
+    super(message, extra);
+  }
+}
+
 export class BuildWorkflowError extends UserError {
   constructor(
     public override readonly message: string,


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

When a composite function a call errors on a callsite `if:` condition, the runner logs the error as an error coming from inside of the composite function. This is an unexpected behavior that points users to a wrong `if:`. This PR fixes it.

# How

- Added a new `BuildStepConditionEvaluationError` error type.
- In `BuildStepCompositeFunctionScope`, when `evaluateCallIfCondition` throws, set `cachedIsActive` as `false` first, so later steps in the same call skip without re-evaluating. Then throw a `BuildStepConditionEvaluationError` with the caller's details.
- In `BuildWorkflow.logConditionEvaluationError`, handle the `BuildStepConditionEvaluationError` error by logging its details.

# Test Plan

Added and updated unit tests.
