### PR TITLE
[eas-cli] update agent-cli-detector to 0.1.6

### DIFF
--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -72,7 +72,7 @@
     "@sentry/node": "7.77.0",
     "@urql/core": "4.0.11",
     "@urql/exchange-retry": "1.2.0",
-    "agent-cli-detector": "0.1.2",
+    "agent-cli-detector": "0.1.6",
     "ajv": "8.11.0",
     "ajv-formats": "2.1.1",
     "better-opn": "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8024,12 +8024,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-cli-detector@npm:0.1.2":
-  version: 0.1.2
-  resolution: "agent-cli-detector@npm:0.1.2"
+"agent-cli-detector@npm:0.1.6":
+  version: 0.1.6
+  resolution: "agent-cli-detector@npm:0.1.6"
   bin:
     agent-cli-detector: dist/cli.js
-  checksum: 10c0/d7751eab293c4543f079988ffe519951859c254edb204fd3105ff49c114ac466d8ef05ba00b3b574fdd5038f9c4e24414d977918f5bccfe9a147628f83d013c3
+  checksum: 10c0/0653c78987a7382ebd6e19334a2c9362eae700486614354fcf4d10b173202997b7b330545391deab343fe830930ea1b1db90c0d2a5106e6e9a3254abeef6ed6d
   languageName: node
   linkType: hard
 
@@ -10404,7 +10404,7 @@ __metadata:
     "@types/wrap-ansi": "npm:3.0.0"
     "@urql/core": "npm:4.0.11"
     "@urql/exchange-retry": "npm:1.2.0"
-    agent-cli-detector: "npm:0.1.2"
+    agent-cli-detector: "npm:0.1.6"
     ajv: "npm:8.11.0"
     ajv-formats: "npm:2.1.1"
     axios: "npm:1.18.1"


### PR DESCRIPTION
updates agent-cli-detector to 0.1.6 to detect opencode and muse code in telemetry context