### PR TITLE
[eas-cli] Fix lint and enforce max-warnings=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Fix lint and enforce max-warnings=0. ([#4219](https://github.com/expo/eas-cli/pull/4219) by [@wschurman](https://github.com/wschurman))
+
 ## [22.0.0](https://github.com/expo/eas-cli/releases/tag/v22.0.0) - 2026-08-14
 
 ### 🛠 Breaking changes

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch": "yarn start",
     "eas": "packages/eas-cli/bin/run",
     "actionlint": "actionlint",
-    "lint": "oxlint --type-aware --import-plugin --tsconfig ./tsconfig.oxlint.json .",
+    "lint": "oxlint --type-aware --import-plugin --max-warnings=0 --tsconfig ./tsconfig.oxlint.json .",
     "fmt": "oxfmt .",
     "fmt:check": "oxfmt --check .",
     "lint-changelog": "./scripts/bin/run lint-changelog",

--- a/packages/build-tools/src/utils/__tests__/expoCli.test.ts
+++ b/packages/build-tools/src/utils/__tests__/expoCli.test.ts
@@ -1,7 +1,7 @@
 import resolveFrom from 'resolve-from';
 import spawnAsync from '@expo/turtle-spawn';
 
-import { expoCommandAsync, ExpoCLIModuleNotFoundError } from '../expoCli';
+import { ExpoCLIModuleNotFoundError, expoCommandAsync } from '../expoCli';
 
 jest.mock('resolve-from', () => ({
   __esModule: true,

--- a/packages/create-eas-build-function/package.json
+++ b/packages/create-eas-build-function/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "prepack": "yarn run clean && yarn run build",
-    "lint": "oxlint --type-aware --tsconfig ../../tsconfig.oxlint.json .",
+    "lint": "oxlint --type-aware --max-warnings=0 --tsconfig ../../tsconfig.oxlint.json .",
     "test": "echo 'No tests yet.'",
     "watch": "yarn run build:dev -w",
     "build:dev": "ncc build ./src/index.ts -o build/",

--- a/packages/eas-cli/src/__tests__/commands/go-test.ts
+++ b/packages/eas-cli/src/__tests__/commands/go-test.ts
@@ -112,7 +112,7 @@ describe('Go command', () => {
     jest.clearAllMocks();
   });
 
-  function makeCmd(argv: string[] = []) {
+  function makeCmd(argv: string[] = []): Go {
     const ctx = {
       loggedIn: { actor: mockActor as any, graphqlClient: {} as any },
       analytics: {} as any,

--- a/packages/eas-cli/src/commands/integrations/supabase/__tests__/dashboard.test.ts
+++ b/packages/eas-cli/src/commands/integrations/supabase/__tests__/dashboard.test.ts
@@ -99,7 +99,7 @@ describe(IntegrationsSupabaseDashboard, () => {
 
   it('fails the spinner when the browser cannot be opened', async () => {
     jest.mocked(openBrowserAsync).mockResolvedValue(false as never);
-    const { ora } = jest.requireMock('../../../../ora') as { ora: jest.Mock };
+    const { ora } = jest.requireMock('../../../../ora');
     const spinner = {
       start: jest.fn().mockReturnThis(),
       succeed: jest.fn().mockReturnThis(),
@@ -116,7 +116,7 @@ describe(IntegrationsSupabaseDashboard, () => {
 
   it('fails the spinner and rethrows when opening the browser throws', async () => {
     jest.mocked(openBrowserAsync).mockRejectedValue(new Error('no browser'));
-    const { ora } = jest.requireMock('../../../../ora') as { ora: jest.Mock };
+    const { ora } = jest.requireMock('../../../../ora');
     const spinner = {
       start: jest.fn().mockReturnThis(),
       succeed: jest.fn().mockReturnThis(),

--- a/packages/eas-cli/src/commands/update/embedded/__tests__/list.test.ts
+++ b/packages/eas-cli/src/commands/update/embedded/__tests__/list.test.ts
@@ -260,7 +260,7 @@ describe(UpdateEmbeddedList, () => {
       pageInfo: { hasNextPage: false, hasPreviousPage: false, startCursor: 'c1', endCursor: 'c1' },
     });
     await createCommand(['--non-interactive']).run();
-    expect(mockLogLog.mock.calls.some(c => /ago/.test(String(c[0])))).toBe(true);
+    expect(mockLogLog.mock.calls.some(c => String(c[0]).includes('ago'))).toBe(true);
   });
 
   it('puts "All channels" first in the prompt, then channels in order', async () => {

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAdhocProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAdhocProvisioningProfile-test.ts
@@ -24,7 +24,7 @@ import { assignBuildCredentialsAsync, getBuildCredentialsAsync } from '../BuildC
 import { chooseDevicesAsync } from '../DeviceUtils';
 import { SetUpAdhocProvisioningProfile, doUDIDsMatch } from '../SetUpAdhocProvisioningProfile';
 import { getAscApiKeyForAppSubmissionsAsync } from '../../api/GraphqlClient';
-import { AuthenticationMode, AppleTeamType } from '../../appstore/authenticateTypes';
+import { AppleTeamType, AuthenticationMode } from '../../appstore/authenticateTypes';
 import { hasAscEnvVars } from '../../appstore/resolveCredentials';
 import { AppStoreConnectApiKeyQuery } from '../../../../graphql/queries/AppStoreConnectApiKeyQuery';
 

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/resolveCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/resolveCredentials-test.ts
@@ -6,8 +6,8 @@ import { promptAsync } from '../../../../prompts';
 import { AppleTeamType } from '../authenticateTypes';
 import * as Keychain from '../keychain';
 import {
-  resolveAppleTeamTypeFromEnvironment,
   resolveAppleTeamAsync,
+  resolveAppleTeamTypeFromEnvironment,
   resolveAscApiKeyAsync,
   resolveUserCredentialsAsync,
 } from '../resolveCredentials';

--- a/packages/eas-cli/src/integrations/shared/envFile.ts
+++ b/packages/eas-cli/src/integrations/shared/envFile.ts
@@ -74,10 +74,10 @@ export function mergeEnvContent(rawContent: string, newVars: Record<string, stri
       continue;
     }
     // match[0] runs past the value onto a following comment line, so spans come from the groups.
-    const [keyStart, keyEnd] = match.indices[1]!;
+    const [keyStart, keyEnd] = match.indices[1];
     const valueRange = match.indices[2];
     const definitionEnd = valueRange
-      ? valueRange[1] - (/\s+$/.exec(match[2]!)?.[0].length ?? 0)
+      ? valueRange[1] - (/\s+$/.exec(match[2])?.[0].length ?? 0)
       : keyEnd + (/^[ \t]*(?:=[ \t]*|:[ \t]+)/.exec(rawContent.slice(keyEnd))?.[0].length ?? 0);
 
     if (!rewritten.has(key)) {

--- a/packages/eas-cli/src/metadata/__tests__/auth.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/auth.test.ts
@@ -61,7 +61,7 @@ const { AppStoreConnectApiKeyQuery } =
 
 const mockApp = { id: '123', bundleId: 'com.example.app' };
 
-function createMockCredentialsCtx(ensureAuthResult?: any) {
+function createMockCredentialsCtx(ensureAuthResult?: any): any {
   return {
     appStore: {
       ensureAuthenticatedAsync: jest.fn(() => ({
@@ -73,7 +73,7 @@ function createMockCredentialsCtx(ensureAuthResult?: any) {
   } as any;
 }
 
-function createBaseArgs(overrides: Record<string, any> = {}) {
+function createBaseArgs(overrides: Record<string, any> = {}): any {
   return {
     projectDir: '/app',
     profile: { bundleIdentifier: 'com.example.app' } as SubmitProfile,

--- a/packages/eas-cli/src/metadata/__tests__/download.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/download.test.ts
@@ -41,7 +41,7 @@ jest.mock('../../prompts', () => ({
 
 const { confirmAsync } = require('../../prompts') as jest.Mocked<typeof import('../../prompts')>;
 
-function createArgs(overrides: Record<string, any> = {}) {
+function createArgs(overrides: Record<string, any> = {}): any {
   return {
     projectDir: '/app',
     profile: { bundleIdentifier: 'com.example.app' } as any,

--- a/packages/eas-cli/src/metadata/__tests__/upload.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/upload.test.ts
@@ -37,7 +37,7 @@ const { loadConfigAsync } = require('../config/resolve') as jest.Mocked<
 >;
 const { confirmAsync } = require('../../prompts') as jest.Mocked<typeof import('../../prompts')>;
 
-function createArgs(overrides: Record<string, any> = {}) {
+function createArgs(overrides: Record<string, any> = {}): any {
   return {
     projectDir: '/app',
     profile: { metadataPath: 'store.config.json', bundleIdentifier: 'com.example.app' } as any,

--- a/packages/eas-cli/src/metadata/apple/tasks/previews.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/previews.ts
@@ -278,7 +278,7 @@ async function syncPreviewSetAsync(
   await logAsync(
     () =>
       AppPreview.uploadAsync(localization.context, {
-        id: previewSet!.id,
+        id: previewSet.id,
         filePath: absolutePath,
         waitForProcessing: true,
         previewFrameTimeCode: previewConfig.previewFrameTimeCode,

--- a/packages/eas-cli/src/metadata/apple/tasks/screenshots.ts
+++ b/packages/eas-cli/src/metadata/apple/tasks/screenshots.ts
@@ -234,7 +234,7 @@ async function syncScreenshotSetAsync(
     const newScreenshot = await logAsync(
       () =>
         AppScreenshot.uploadAsync(localization.context, {
-          id: screenshotSet!.id,
+          id: screenshotSet.id,
           filePath: absolutePath,
           waitForProcessing: true,
         }),

--- a/packages/eas-cli/src/observe/startAndEndTime.ts
+++ b/packages/eas-cli/src/observe/startAndEndTime.ts
@@ -10,7 +10,7 @@ export function startAndEndTime({
   daysBack?: number;
   start?: string;
   end?: string;
-}) {
+}): { startTime: string; endTime: string } {
   let startTime: string;
   let endTime: string;
 

--- a/packages/eas-cli/src/submit/status.ts
+++ b/packages/eas-cli/src/submit/status.ts
@@ -1,4 +1,4 @@
-import { App, Platform as ApplePlatform, AppStoreVersion, Build } from '@expo/apple-utils';
+import { App, AppStoreVersion, Platform as ApplePlatform, Build } from '@expo/apple-utils';
 import chalk from 'chalk';
 
 import { getSubmissionDetailsUrl } from './utils/urls';

--- a/packages/eas-cli/src/utils/__tests__/image-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/image-test.ts
@@ -36,7 +36,9 @@ describe(ensurePNGIsNotTransparentAsync, () => {
         fs.createReadStream(transparentPngPath).pipe(response);
       });
       await new Promise<void>((res, rej) => {
-        const onError = (error: Error): void => rej(error);
+        const onError = (error: Error): void => {
+          rej(error);
+        };
         server.once('error', onError);
         server.listen(0, '127.0.0.1', () => {
           server.off('error', onError);

--- a/packages/eas-cli/src/utils/__tests__/pollForBackgroundJobReceiptAsync-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/pollForBackgroundJobReceiptAsync-test.ts
@@ -163,7 +163,7 @@ describe(pollForBackgroundJobReceiptAsync, () => {
   });
 
   it('tolerates consecutive CombinedError fetches before NULL_RECEIPT', async () => {
-    const { CombinedError } = jest.requireActual('@urql/core') as typeof import('@urql/core');
+    const { CombinedError } = jest.requireActual('@urql/core');
     const graphqlClient = instance(mock<ExpoGraphqlClient>());
 
     const receiptId = '123';


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Noticed while writing a recent PR that there were a bunch of lint warnings in main, thus adding noise to the process. This PR fixes those warnings and prevents new ones from being added (fails CI).

# Test Plan

`yarn lint`, CI