### PR TITLE
[build-tools] Fix 1.1.8 `idb_companion` pointer

### DIFF
--- a/packages/build-tools/src/steps/functions/installMaestro.ts
+++ b/packages/build-tools/src/steps/functions/installMaestro.ts
@@ -308,9 +308,9 @@ export async function installIdbFromBrew({
     });
     const tapPath = brewRepo.stdout.trim();
 
-    // b4f3751720e6b86eed28a8112e1fc1b92d9176ef is hash for 1.1.8 release,
-    // last known compatible version.
-    const gitSha = 'b4f3751720e6b86eed28a8112e1fc1b92d9176ef';
+    // c0386793f59da10c619787f2aa18d938ef1d69c9 is hash for 1.1.8 release,
+    // last known compatible version + post_install fix.
+    const gitSha = 'c0386793f59da10c619787f2aa18d938ef1d69c9';
     logger.info('Checking out facebook/fb at idb_companion@1.1.8...');
     await spawn('git', ['fetch', 'origin', gitSha], {
       cwd: tapPath,


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

1.1.8 [has issue with installation](https://staging.expo.dev/accounts/sjchmiela/projects/staging-app/workflows/01a0110d-e8f1-77d1-abed-08ff02f79941), later fixed with https://github.com/facebook/homebrew-fb/commit/c0386793f59da10c619787f2aa18d938ef1d69c9.

# How

Move idb commit pointer.

# Test Plan

Deployed to staging and verified (link incoming).
- [modern image](https://staging.expo.dev/accounts/sjchmiela/projects/staging-app/workflows/01a01111-1308-702d-b5f1-6f35e623e470)
- [older image](https://staging.expo.dev/accounts/sjchmiela/projects/staging-app/workflows/01a01118-2dff-780b-aa3b-164ebbdfcf7b)