### PR TITLE
[build-tools] Cache Gradle file access time journal with the build cache

### DIFF
--- a/packages/build-tools/src/steps/functions/__tests__/saveRestoreCache.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/saveRestoreCache.test.ts
@@ -48,4 +48,36 @@ describe('cache compress/decompress round trip', () => {
       )
     ).toBe('inception=1');
   });
+
+  it('preserves file modification times so journal-fallback entries can still age out', async () => {
+    const logger = createLoggerMock();
+
+    const sourceDir = path.join(os.tmpdir(), 'mtime-source');
+    await fs.promises.mkdir(sourceDir, { recursive: true });
+    const filePath = path.join(sourceDir, 'entry');
+    await fs.promises.writeFile(filePath, 'cache entry');
+
+    // A whole-second value in the past — tar stores mtimes at one-second resolution.
+    const mtime = new Date('2026-08-01T00:00:00.000Z');
+    await fs.promises.utimes(filePath, mtime, mtime);
+
+    const { archivePath } = await compressCacheAsync({
+      paths: [sourceDir],
+      workingDirectory: sourceDir,
+      verbose: false,
+      logger,
+    });
+
+    const restoreDir = path.join(os.tmpdir(), 'mtime-restored');
+    await fs.promises.mkdir(restoreDir, { recursive: true });
+    await decompressCacheAsync({
+      archivePath,
+      workingDirectory: restoreDir,
+      verbose: false,
+      logger,
+    });
+
+    const restoredStat = await fs.promises.stat(path.join(restoreDir, 'entry'));
+    expect(Math.floor(restoredStat.mtimeMs / 1000)).toBe(Math.floor(mtime.getTime() / 1000));
+  });
 });

--- a/packages/build-tools/src/steps/functions/__tests__/saveRestoreCache.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/saveRestoreCache.test.ts
@@ -1,0 +1,51 @@
+import { type bunyan } from '@expo/logger';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { compressCacheAsync } from '../saveCache';
+import { decompressCacheAsync } from '../restoreCache';
+
+function createLoggerMock(): bunyan {
+  return { info: jest.fn(), warn: jest.fn(), error: jest.fn() } as unknown as bunyan;
+}
+
+describe('cache compress/decompress round trip', () => {
+  it('preserves multiple sibling directories archived together', async () => {
+    const logger = createLoggerMock();
+
+    const cachesDir = path.join(os.tmpdir(), 'gradle-caches');
+    const buildCacheDir = path.join(cachesDir, 'build-cache-1');
+    const journalDir = path.join(cachesDir, 'journal-1');
+    await fs.promises.mkdir(buildCacheDir, { recursive: true });
+    await fs.promises.mkdir(journalDir, { recursive: true });
+    await fs.promises.writeFile(path.join(buildCacheDir, 'entry'), 'cache entry');
+    await fs.promises.writeFile(path.join(journalDir, 'file-access.properties'), 'inception=1');
+
+    const { archivePath } = await compressCacheAsync({
+      paths: [buildCacheDir, journalDir],
+      workingDirectory: cachesDir,
+      verbose: false,
+      logger,
+    });
+
+    const restoreDir = path.join(os.tmpdir(), 'gradle-caches-restored');
+    await fs.promises.mkdir(restoreDir, { recursive: true });
+    await decompressCacheAsync({
+      archivePath,
+      workingDirectory: restoreDir,
+      verbose: false,
+      logger,
+    });
+
+    expect(
+      await fs.promises.readFile(path.join(restoreDir, 'build-cache-1', 'entry'), 'utf8')
+    ).toBe('cache entry');
+    expect(
+      await fs.promises.readFile(
+        path.join(restoreDir, 'journal-1', 'file-access.properties'),
+        'utf8'
+      )
+    ).toBe('inception=1');
+  });
+});

--- a/packages/build-tools/src/steps/functions/restoreBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreBuildCache.ts
@@ -258,13 +258,14 @@ export async function restoreGradleCacheAsync({
     const gradleCachesPath = path.join(os.homedir(), '.gradle', 'caches');
 
     const buildCachePath = path.join(gradleCachesPath, 'build-cache-1');
+    const journalPath = path.join(gradleCachesPath, 'journal-1');
 
     const { archivePath, matchedKey } = await downloadCacheAsync({
       logger,
       jobId,
       expoApiServerURL,
       robotAccessToken,
-      paths: [buildCachePath],
+      paths: [buildCachePath, journalPath],
       key: cacheKey,
       keyPrefixes: [GRADLE_CACHE_KEY_PREFIX],
       platform: Platform.ANDROID,

--- a/packages/build-tools/src/steps/functions/saveBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/saveBuildCache.ts
@@ -167,6 +167,7 @@ export async function saveGradleCacheAsync({
 
   const gradleCachesPath = path.join(os.homedir(), '.gradle', 'caches');
   const buildCachePath = path.join(gradleCachesPath, 'build-cache-1');
+  const journalPath = path.join(gradleCachesPath, 'journal-1');
 
   try {
     await fs.promises.access(buildCachePath);
@@ -186,9 +187,11 @@ export async function saveGradleCacheAsync({
     );
     const expoApiServerURL = nullthrows(env.__API_SERVER_URL, '__API_SERVER_URL is not set');
 
+    await fs.promises.mkdir(journalPath, { recursive: true });
+
     logger.info('Compressing Gradle build cache...');
     const { archivePath } = await compressCacheAsync({
-      paths: [buildCachePath],
+      paths: [buildCachePath, journalPath],
       workingDirectory: gradleCachesPath,
       verbose: env.EXPO_DEBUG === '1',
       logger,
@@ -204,7 +207,7 @@ export async function saveGradleCacheAsync({
       robotAccessToken,
       archivePath,
       key: cacheKey,
-      paths: [buildCachePath],
+      paths: [buildCachePath, journalPath],
       size,
       platform: Platform.ANDROID,
     });

--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -349,6 +349,14 @@ export async function compressCacheAsync({
       const targetPath = path.join(tempDir, targetRelativePath);
       await fs.promises.mkdir(path.dirname(targetPath), { recursive: true });
       await fs.promises.copyFile(absolutePath, targetPath);
+      // Preserve the source mtime instead of letting fs.copyFile reset it to "now". Gradle's build
+      // cache cleanup reads its file access time journal, but for entries the journal has no record
+      // of it falls back to max(journalInceptionTimestamp, file.lastModified()). A reset "now" mtime
+      // would make those fallback entries look permanently fresh so they never age out; keeping the
+      // real mtime lets them be evicted. Entries the journal does track are unaffected (their stored
+      // access time is used and the mtime ignored).
+      const { atime, mtime } = await fs.promises.stat(absolutePath);
+      await fs.promises.utimes(targetPath, atime, mtime);
 
       if (verbose) {
         logger.info(`- ${targetRelativePath}`);

--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -348,9 +348,7 @@ export async function compressCacheAsync({
     for (const { absolutePath, archivePath: targetRelativePath } of allFiles) {
       const targetPath = path.join(tempDir, targetRelativePath);
       await fs.promises.mkdir(path.dirname(targetPath), { recursive: true });
-      // Preserve the source timestamps; copyFile alone resets them to "now". Gradle's build cache
-      // cleanup falls back to file mtime for entries missing from its access-time journal, so a
-      // reset mtime would stop those entries from ever aging out.
+      // We want to keep source timestamps since Gradle may check them when pruning cache.
       const { atime, mtime } = await fs.promises.stat(absolutePath);
       await fs.promises.copyFile(absolutePath, targetPath);
       await fs.promises.utimes(targetPath, atime, mtime);

--- a/packages/build-tools/src/steps/functions/saveCache.ts
+++ b/packages/build-tools/src/steps/functions/saveCache.ts
@@ -348,14 +348,11 @@ export async function compressCacheAsync({
     for (const { absolutePath, archivePath: targetRelativePath } of allFiles) {
       const targetPath = path.join(tempDir, targetRelativePath);
       await fs.promises.mkdir(path.dirname(targetPath), { recursive: true });
-      await fs.promises.copyFile(absolutePath, targetPath);
-      // Preserve the source mtime instead of letting fs.copyFile reset it to "now". Gradle's build
-      // cache cleanup reads its file access time journal, but for entries the journal has no record
-      // of it falls back to max(journalInceptionTimestamp, file.lastModified()). A reset "now" mtime
-      // would make those fallback entries look permanently fresh so they never age out; keeping the
-      // real mtime lets them be evicted. Entries the journal does track are unaffected (their stored
-      // access time is used and the mtime ignored).
+      // Preserve the source timestamps; copyFile alone resets them to "now". Gradle's build cache
+      // cleanup falls back to file mtime for entries missing from its access-time journal, so a
+      // reset mtime would stop those entries from ever aging out.
       const { atime, mtime } = await fs.promises.stat(absolutePath);
+      await fs.promises.copyFile(absolutePath, targetPath);
       await fs.promises.utimes(targetPath, atime, mtime);
 
       if (verbose) {


### PR DESCRIPTION
# Why

It seems the cache is not getting pruned properly. It looks like Gradle uses journal to keep track of accessed files. Since we're not caching it alongside build cache, Gradle defaults all files to "they have been used now".

# How

When caching Gradle build cache, cache journal too.

# Test Plan

Verified locally.

With `build-cache-1` only kept, everything was retained after cleanup because journal inception was "now".

With both `build-cache-1` and `journal-1` kept AND inception timestamp backdated, cache was pruned.

Didn't test pruning across multiple days.