### PR TITLE
[eas-cli] Add simulator build source flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Add `ios_signing_backend` option to the repack step. ([#4239](https://github.com/expo/eas-cli/pull/4239) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [build-tools] Support an optional `package_version` input on `eas/start_serve_sim_remote_session`, so a simulator session can pin the `@expo/serve-sim` version instead of always running `latest`. ([#4253](https://github.com/expo/eas-cli/pull/4253) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Add composable custom build functions for downloading, installing, and launching application archives in simulator sessions. ([#4222](https://github.com/expo/eas-cli/pull/4222) by [@szdziedzic](https://github.com/szdziedzic))
-- [eas-cli] Add `--build-id` and `--build-artifact-url` to `eas simulator` to install and launch an application before the session is ready. ([#4223](https://github.com/expo/eas-cli/pull/4223) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Add `--build-id`, `--build-artifact-url`, and `--go` to `eas simulator` to install and launch an application before the session is ready. ([#4223](https://github.com/expo/eas-cli/pull/4223) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Add `ios_signing_backend` option to the repack step. ([#4239](https://github.com/expo/eas-cli/pull/4239) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [build-tools] Support an optional `package_version` input on `eas/start_serve_sim_remote_session`, so a simulator session can pin the `@expo/serve-sim` version instead of always running `latest`. ([#4253](https://github.com/expo/eas-cli/pull/4253) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Add composable custom build functions for downloading, installing, and launching application archives in simulator sessions. ([#4222](https://github.com/expo/eas-cli/pull/4222) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Add `--build-id` and `--build-artifact-url` to `eas simulator` to install and launch an application before the session is ready. ([#4223](https://github.com/expo/eas-cli/pull/4223) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Add `ios_signing_backend` option to the repack step. ([#4239](https://github.com/expo/eas-cli/pull/4239) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [build-tools] Support an optional `package_version` input on `eas/start_serve_sim_remote_session`, so a simulator session can pin the `@expo/serve-sim` version instead of always running `latest`. ([#4253](https://github.com/expo/eas-cli/pull/4253) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Add composable custom build functions for downloading, installing, and launching application archives in simulator sessions. ([#4222](https://github.com/expo/eas-cli/pull/4222) by [@szdziedzic](https://github.com/szdziedzic))
-- [eas-cli] Add `--build-id`, `--build-artifact-url`, and `--expo-go` to `eas simulator` to install and launch an application before the session is ready. ([#4223](https://github.com/expo/eas-cli/pull/4223) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Add `--build-id`, `--application-archive-url`, and `--expo-go` to `eas simulator` to install and launch an application before the session is ready. ([#4223](https://github.com/expo/eas-cli/pull/4223) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Add `ios_signing_backend` option to the repack step. ([#4239](https://github.com/expo/eas-cli/pull/4239) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [build-tools] Support an optional `package_version` input on `eas/start_serve_sim_remote_session`, so a simulator session can pin the `@expo/serve-sim` version instead of always running `latest`. ([#4253](https://github.com/expo/eas-cli/pull/4253) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Add composable custom build functions for downloading, installing, and launching application archives in simulator sessions. ([#4222](https://github.com/expo/eas-cli/pull/4222) by [@szdziedzic](https://github.com/szdziedzic))
-- [eas-cli] Add `--build-id`, `--build-artifact-url`, and `--go` to `eas simulator` to install and launch an application before the session is ready. ([#4223](https://github.com/expo/eas-cli/pull/4223) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Add `--build-id`, `--build-artifact-url`, and `--expo-go` to `eas simulator` to install and launch an application before the session is ready. ([#4223](https://github.com/expo/eas-cli/pull/4223) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -37212,8 +37212,8 @@
             "deprecationReason": null
           },
           {
-            "name": "buildArtifactUrl",
-            "description": "Build artifact URL to download, install, and launch before the simulator session\nbecomes available. Mutually exclusive with buildId.",
+            "name": "applicationArchiveUrl",
+            "description": "Application archive URL to download, install, and launch before the simulator session\nbecomes available. Mutually exclusive with buildId.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -37225,7 +37225,7 @@
           },
           {
             "name": "buildId",
-            "description": "EAS Build to install and launch before the simulator session becomes available.\nMutually exclusive with buildArtifactUrl.",
+            "description": "EAS Build to install and launch before the simulator session becomes available.\nMutually exclusive with applicationArchiveUrl.",
             "type": {
               "kind": "SCALAR",
               "name": "ID",

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -37212,6 +37212,30 @@
             "deprecationReason": null
           },
           {
+            "name": "buildArtifactUrl",
+            "description": "Build artifact URL to download, install, and launch before the simulator session\nbecomes available. Mutually exclusive with buildId.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buildId",
+            "description": "EAS Build to install and launch before the simulator session becomes available.\nMutually exclusive with buildArtifactUrl.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "deviceIdentifier",
             "description": "Identifier of the virtual device to start for the session. On iOS this is a\nSimulator device name or UDID (e.g. \"iPhone 16 Pro\"). On Android this is an\nAVD hardware profile id (e.g. \"pixel_7\"). If omitted, the runner picks a\ndefault device.",
             "type": {

--- a/packages/eas-cli/src/__tests__/commands/go-test.ts
+++ b/packages/eas-cli/src/__tests__/commands/go-test.ts
@@ -1,17 +1,17 @@
 import { getConfigFilePaths } from '@expo/config';
 
 import { getWorkflowRunUrl } from '../../build/utils/url';
-import Go from '../../commands/go';
+import Go, { toRepackTargetSdkVersion } from '../../commands/go';
 import { WorkflowRunStatus } from '../../graphql/generated';
 import { WorkflowRunMutation } from '../../graphql/mutations/WorkflowRunMutation';
 import { WorkflowRunQuery } from '../../graphql/queries/WorkflowRunQuery';
 import Log from '../../log';
 import { selectAsync } from '../../prompts';
+import { detectProjectSdkVersionAsync } from '../../project/detectProjectSdkVersionAsync';
 import { getPrivateExpoConfigAsync } from '../../project/expoConfig';
 import { uploadAccountScopedFileAsync } from '../../project/uploadAccountScopedFileAsync';
 import { uploadAccountScopedProjectSourceAsync } from '../../project/uploadAccountScopedProjectSourceAsync';
 import { ensureActorHasPrimaryAccount } from '../../user/actions';
-import { detectProjectSdkVersionAsync, toRepackTargetSdkVersion } from '../../commands/go';
 import { mockTestCommand } from './utils';
 
 jest.mock('@expo/config', () => ({

--- a/packages/eas-cli/src/commands/go.ts
+++ b/packages/eas-cli/src/commands/go.ts
@@ -1,4 +1,4 @@
-import { ExpoConfig, getConfigFilePaths } from '@expo/config';
+import { ExpoConfig } from '@expo/config';
 import { App } from '@expo/apple-utils';
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
@@ -30,7 +30,7 @@ import { WorkflowRunQuery } from '../graphql/queries/WorkflowRunQuery';
 import Log, { learnMore } from '../log';
 import { confirmAsync, selectAsync } from '../prompts';
 import { ora } from '../ora';
-import { getPrivateExpoConfigAsync } from '../project/expoConfig';
+import { detectProjectSdkVersionAsync } from '../project/detectProjectSdkVersionAsync';
 import { findProjectIdByAccountNameAndSlugNullableAsync } from '../project/fetchOrCreateProjectIDForWriteToConfigWithConfirmationAsync';
 import { uploadAccountScopedFileAsync } from '../project/uploadAccountScopedFileAsync';
 import { uploadAccountScopedProjectSourceAsync } from '../project/uploadAccountScopedProjectSourceAsync';
@@ -46,20 +46,6 @@ import {
 
 function deriveBundleIdSlug(bundleId: string): string {
   return bundleId.split('.').filter(Boolean).pop()!;
-}
-
-export async function detectProjectSdkVersionAsync(
-  projectDir: string
-): Promise<string | undefined> {
-  const paths = getConfigFilePaths(projectDir);
-  if (!paths.staticConfigPath && !paths.dynamicConfigPath) {
-    return;
-  }
-  try {
-    return (await getPrivateExpoConfigAsync(projectDir)).sdkVersion;
-  } catch {
-    return;
-  }
 }
 
 export function toRepackTargetSdkVersion(sdkVersion: string | undefined): string | undefined {

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -527,7 +527,7 @@ describe(Simulator, () => {
     expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
       graphqlClient,
       expect.objectContaining({
-        buildArtifactUrl: 'https://example.test/builds/app.apk',
+        applicationArchiveUrl: 'https://example.test/builds/app.apk',
       })
     );
   });

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -544,10 +544,15 @@ describe(Simulator, () => {
     ['ios', AppPlatform.Ios, 'https://example.test/expo-go.tar.gz'],
     ['android', AppPlatform.Android, 'https://example.test/expo-go.apk'],
   ] as const)(
-    'resolves and forwards the %s Expo Go archive when --go is passed',
+    'resolves and forwards the %s Expo Go archive when --expo-go is passed',
     async (platformFlag, appPlatform, applicationArchiveUrl) => {
       mockResolveExpoGoApplicationArchiveUrlAsync.mockResolvedValue(applicationArchiveUrl);
-      const { command } = createCommand(['--platform', platformFlag, '--non-interactive', '--go']);
+      const { command } = createCommand([
+        '--platform',
+        platformFlag,
+        '--non-interactive',
+        '--expo-go',
+      ]);
 
       await command.runAsync();
 
@@ -583,12 +588,12 @@ describe(Simulator, () => {
   it.each([
     ['--build-id', '8d8b713c-1834-4bd3-91e6-46f895422cbc'],
     ['--build-artifact-url', 'https://example.test/builds/app.tar.gz'],
-  ])('rejects passing --go with %s', async (sourceFlag, sourceValue) => {
+  ])('rejects passing --expo-go with %s', async (sourceFlag, sourceValue) => {
     const { command } = createCommand([
       '--platform',
       'ios',
       '--non-interactive',
-      '--go',
+      '--expo-go',
       sourceFlag,
       sourceValue,
     ]);

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -522,12 +522,12 @@ describe(Simulator, () => {
     );
   });
 
-  it('forwards --build-artifact-url to the create mutation', async () => {
+  it('forwards --application-archive-url to the create mutation', async () => {
     const { command } = createCommand([
       '--platform',
       'android',
       '--non-interactive',
-      '--build-artifact-url',
+      '--application-archive-url',
       '  https://example.test/builds/app.apk  ',
     ]);
     await command.runAsync();
@@ -570,14 +570,14 @@ describe(Simulator, () => {
     }
   );
 
-  it('rejects passing --build-id and --build-artifact-url together', async () => {
+  it('rejects passing --build-id and --application-archive-url together', async () => {
     const { command } = createCommand([
       '--platform',
       'ios',
       '--non-interactive',
       '--build-id',
       '8d8b713c-1834-4bd3-91e6-46f895422cbc',
-      '--build-artifact-url',
+      '--application-archive-url',
       'https://example.test/builds/app.tar.gz',
     ]);
 
@@ -587,7 +587,7 @@ describe(Simulator, () => {
 
   it.each([
     ['--build-id', '8d8b713c-1834-4bd3-91e6-46f895422cbc'],
-    ['--build-artifact-url', 'https://example.test/builds/app.tar.gz'],
+    ['--application-archive-url', 'https://example.test/builds/app.tar.gz'],
   ])('rejects passing --expo-go with %s', async (sourceFlag, sourceValue) => {
     const { command } = createCommand([
       '--platform',

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -23,6 +23,7 @@ import {
   loadSimulatorEnvAsync,
   resetSimulatorEnvAsync,
 } from '../../../simulator/env';
+import { resolveExpoGoApplicationArchiveUrlAsync } from '../../../simulator/expoGo';
 import Simulator from '../index';
 
 jest.mock('fs-extra');
@@ -45,6 +46,7 @@ jest.mock('../../../simulator/env', () => ({
   loadSimulatorEnvAsync: jest.fn(),
   resetSimulatorEnvAsync: jest.fn(),
 }));
+jest.mock('../../../simulator/expoGo');
 jest.mock('../../../prompts');
 jest.mock('../../../ora', () => ({
   ora: jest.fn(() => {
@@ -78,6 +80,9 @@ const mockAvailabilityByAppIdAsync = jest.mocked(DeviceRunSessionAvailabilityQue
 const mockByIdAsync = jest.mocked(DeviceRunSessionQuery.byIdAsync);
 const mockLoadSimulatorEnvAsync = jest.mocked(loadSimulatorEnvAsync);
 const mockResetSimulatorEnvAsync = jest.mocked(resetSimulatorEnvAsync);
+const mockResolveExpoGoApplicationArchiveUrlAsync = jest.mocked(
+  resolveExpoGoApplicationArchiveUrlAsync
+);
 const mockOra = jest.mocked(ora);
 const mockPromptAsync = jest.mocked(promptAsync);
 
@@ -161,6 +166,9 @@ describe(Simulator, () => {
     mockByIdAsync.mockResolvedValue(makeDeviceRunSession());
     mockLoadSimulatorEnvAsync.mockResolvedValue();
     mockResetSimulatorEnvAsync.mockResolvedValue();
+    mockResolveExpoGoApplicationArchiveUrlAsync.mockResolvedValue(
+      'https://example.test/expo-go.tar.gz'
+    );
     jest.mocked(fs.writeFile).mockResolvedValue(undefined as never);
   });
 
@@ -532,6 +540,31 @@ describe(Simulator, () => {
     );
   });
 
+  it.each([
+    ['ios', AppPlatform.Ios, 'https://example.test/expo-go.tar.gz'],
+    ['android', AppPlatform.Android, 'https://example.test/expo-go.apk'],
+  ] as const)(
+    'resolves and forwards the %s Expo Go archive when --go is passed',
+    async (platformFlag, appPlatform, applicationArchiveUrl) => {
+      mockResolveExpoGoApplicationArchiveUrlAsync.mockResolvedValue(applicationArchiveUrl);
+      const { command } = createCommand(['--platform', platformFlag, '--non-interactive', '--go']);
+
+      await command.runAsync();
+
+      expect(mockResolveExpoGoApplicationArchiveUrlAsync).toHaveBeenCalledWith({
+        platform: platformFlag,
+        projectDir,
+      });
+      expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+        graphqlClient,
+        expect.objectContaining({
+          applicationArchiveUrl,
+          platform: appPlatform,
+        })
+      );
+    }
+  );
+
   it('rejects passing --build-id and --build-artifact-url together', async () => {
     const { command } = createCommand([
       '--platform',
@@ -544,6 +577,24 @@ describe(Simulator, () => {
     ]);
 
     await expect(command.runAsync()).rejects.toThrow();
+    expect(mockCreateDeviceRunSessionAsync).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['--build-id', '8d8b713c-1834-4bd3-91e6-46f895422cbc'],
+    ['--build-artifact-url', 'https://example.test/builds/app.tar.gz'],
+  ])('rejects passing --go with %s', async (sourceFlag, sourceValue) => {
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      '--go',
+      sourceFlag,
+      sourceValue,
+    ]);
+
+    await expect(command.runAsync()).rejects.toThrow();
+    expect(mockResolveExpoGoApplicationArchiveUrlAsync).not.toHaveBeenCalled();
     expect(mockCreateDeviceRunSessionAsync).not.toHaveBeenCalled();
   });
 

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -498,6 +498,55 @@ describe(Simulator, () => {
     );
   });
 
+  it('forwards --build-id to the create mutation', async () => {
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      '--build-id',
+      '  8d8b713c-1834-4bd3-91e6-46f895422cbc  ',
+    ]);
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ buildId: '8d8b713c-1834-4bd3-91e6-46f895422cbc' })
+    );
+  });
+
+  it('forwards --build-artifact-url to the create mutation', async () => {
+    const { command } = createCommand([
+      '--platform',
+      'android',
+      '--non-interactive',
+      '--build-artifact-url',
+      '  https://example.test/builds/app.apk  ',
+    ]);
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({
+        buildArtifactUrl: 'https://example.test/builds/app.apk',
+      })
+    );
+  });
+
+  it('rejects passing --build-id and --build-artifact-url together', async () => {
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      '--build-id',
+      '8d8b713c-1834-4bd3-91e6-46f895422cbc',
+      '--build-artifact-url',
+      'https://example.test/builds/app.tar.gz',
+    ]);
+
+    await expect(command.runAsync()).rejects.toThrow();
+    expect(mockCreateDeviceRunSessionAsync).not.toHaveBeenCalled();
+  });
+
   it('stops the simulator session when interrupted before the session is ready', async () => {
     const processExitSpy = jest.spyOn(process, 'exit').mockImplementation(code => {
       throw new Error(`process.exit(${code})`);

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -28,6 +28,7 @@ import {
   resetSimulatorEnvAsync,
   writeSimulatorEnvAsync,
 } from '../../simulator/env';
+import { resolveExpoGoApplicationArchiveUrlAsync } from '../../simulator/expoGo';
 import {
   DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE,
   DEVICE_RUN_SESSION_TYPE_FLAG_VALUES,
@@ -74,12 +75,17 @@ export default class Simulator extends EasCommand {
     }),
     'build-id': Flags.string({
       description: 'EAS Build to install and launch before the simulator session is ready.',
-      exclusive: ['build-artifact-url'],
+      exclusive: ['build-artifact-url', 'go'],
     }),
     'build-artifact-url': Flags.string({
       description:
         'Build artifact URL to download, install, and launch before the simulator session is ready.',
-      exclusive: ['build-id'],
+      exclusive: ['build-id', 'go'],
+    }),
+    go: Flags.boolean({
+      description:
+        "Install and launch Expo Go matching the current project's Expo SDK before the simulator session is ready.",
+      exclusive: ['build-id', 'build-artifact-url'],
     }),
     type: Flags.option({
       description: 'Type of simulator session to create',
@@ -160,6 +166,12 @@ export default class Simulator extends EasCommand {
     }
 
     const platform = await resolvePlatformAsync(flags.platform, nonInteractive);
+    const applicationArchiveUrl = flags.go
+      ? await resolveExpoGoApplicationArchiveUrlAsync({
+          platform: platform === AppPlatform.Ios ? 'ios' : 'android',
+          projectDir,
+        })
+      : buildArtifactUrl;
 
     if (existingDeviceRunSessionId) {
       Log.warn(
@@ -183,7 +195,7 @@ export default class Simulator extends EasCommand {
         packageVersion: flags['package-version'],
         deviceIdentifier,
         ...(buildId ? { buildId } : {}),
-        ...(buildArtifactUrl ? { applicationArchiveUrl: buildArtifactUrl } : {}),
+        ...(applicationArchiveUrl ? { applicationArchiveUrl } : {}),
         maxRunTimeMinutes: flags['max-duration-minutes'],
       });
       deviceRunSessionId = session.id;

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -72,6 +72,15 @@ export default class Simulator extends EasCommand {
       description:
         'Virtual device to start for the session. On iOS, a Simulator device name or UDID (e.g. "iPhone 16 Pro"). On Android, an AVD hardware profile id (e.g. "pixel_7"). Defaults to a device chosen by the runner.',
     }),
+    'build-id': Flags.string({
+      description: 'EAS Build to install and launch before the simulator session is ready.',
+      exclusive: ['build-artifact-url'],
+    }),
+    'build-artifact-url': Flags.string({
+      description:
+        'Build artifact URL to download, install, and launch before the simulator session is ready.',
+      exclusive: ['build-id'],
+    }),
     type: Flags.option({
       description: 'Type of simulator session to create',
       options: Object.values(DEVICE_RUN_SESSION_TYPE_FLAG_VALUES),
@@ -139,6 +148,8 @@ export default class Simulator extends EasCommand {
     // --name as if it had been omitted rather than surfacing a validation error.
     const name = flags.name?.trim() || undefined;
     const deviceIdentifier = flags.device?.trim() || undefined;
+    const buildId = flags['build-id']?.trim() || undefined;
+    const buildArtifactUrl = flags['build-artifact-url']?.trim() || undefined;
 
     await loadSimulatorEnvAsync(projectDir);
     const existingDeviceRunSessionId = process.env[EAS_SIMULATOR_SESSION_ID];
@@ -171,6 +182,8 @@ export default class Simulator extends EasCommand {
         type: DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE[flags.type],
         packageVersion: flags['package-version'],
         deviceIdentifier,
+        ...(buildId ? { buildId } : {}),
+        ...(buildArtifactUrl ? { buildArtifactUrl } : {}),
         maxRunTimeMinutes: flags['max-duration-minutes'],
       });
       deviceRunSessionId = session.id;

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -75,14 +75,14 @@ export default class Simulator extends EasCommand {
     }),
     'build-id': Flags.string({
       description: 'EAS Build to install and launch before the simulator session is ready.',
-      exclusive: ['build-artifact-url', 'go'],
+      exclusive: ['build-artifact-url', 'expo-go'],
     }),
     'build-artifact-url': Flags.string({
       description:
         'Build artifact URL to download, install, and launch before the simulator session is ready.',
-      exclusive: ['build-id', 'go'],
+      exclusive: ['build-id', 'expo-go'],
     }),
-    go: Flags.boolean({
+    'expo-go': Flags.boolean({
       description:
         "Install and launch Expo Go matching the current project's Expo SDK before the simulator session is ready.",
       exclusive: ['build-id', 'build-artifact-url'],
@@ -166,7 +166,7 @@ export default class Simulator extends EasCommand {
     }
 
     const platform = await resolvePlatformAsync(flags.platform, nonInteractive);
-    const applicationArchiveUrl = flags.go
+    const applicationArchiveUrl = flags['expo-go']
       ? await resolveExpoGoApplicationArchiveUrlAsync({
           platform: platform === AppPlatform.Ios ? 'ios' : 'android',
           projectDir,

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -75,17 +75,17 @@ export default class Simulator extends EasCommand {
     }),
     'build-id': Flags.string({
       description: 'EAS Build to install and launch before the simulator session is ready.',
-      exclusive: ['build-artifact-url', 'expo-go'],
+      exclusive: ['application-archive-url', 'expo-go'],
     }),
-    'build-artifact-url': Flags.string({
+    'application-archive-url': Flags.string({
       description:
-        'Build artifact URL to download, install, and launch before the simulator session is ready.',
+        'Application archive URL to download, install, and launch before the simulator session is ready.',
       exclusive: ['build-id', 'expo-go'],
     }),
     'expo-go': Flags.boolean({
       description:
         "Install and launch Expo Go matching the current project's Expo SDK before the simulator session is ready.",
-      exclusive: ['build-id', 'build-artifact-url'],
+      exclusive: ['build-id', 'application-archive-url'],
     }),
     type: Flags.option({
       description: 'Type of simulator session to create',
@@ -155,7 +155,7 @@ export default class Simulator extends EasCommand {
     const name = flags.name?.trim() || undefined;
     const deviceIdentifier = flags.device?.trim() || undefined;
     const buildId = flags['build-id']?.trim() || undefined;
-    const buildArtifactUrl = flags['build-artifact-url']?.trim() || undefined;
+    const applicationArchiveUrlFromFlag = flags['application-archive-url']?.trim() || undefined;
 
     await loadSimulatorEnvAsync(projectDir);
     const existingDeviceRunSessionId = process.env[EAS_SIMULATOR_SESSION_ID];
@@ -171,7 +171,7 @@ export default class Simulator extends EasCommand {
           platform: platform === AppPlatform.Ios ? 'ios' : 'android',
           projectDir,
         })
-      : buildArtifactUrl;
+      : applicationArchiveUrlFromFlag;
 
     if (existingDeviceRunSessionId) {
       Log.warn(

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -183,7 +183,7 @@ export default class Simulator extends EasCommand {
         packageVersion: flags['package-version'],
         deviceIdentifier,
         ...(buildId ? { buildId } : {}),
-        ...(buildArtifactUrl ? { buildArtifactUrl } : {}),
+        ...(buildArtifactUrl ? { applicationArchiveUrl: buildArtifactUrl } : {}),
         maxRunTimeMinutes: flags['max-duration-minutes'],
       });
       deviceRunSessionId = session.id;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -5235,13 +5235,13 @@ export type CreateDeviceRunSessionEventLogUploadSessionResult = {
 export type CreateDeviceRunSessionInput = {
   appId: Scalars['ID']['input'];
   /**
-   * Build artifact URL to download, install, and launch before the simulator session
+   * Application archive URL to download, install, and launch before the simulator session
    * becomes available. Mutually exclusive with buildId.
    */
-  buildArtifactUrl?: InputMaybe<Scalars['String']['input']>;
+  applicationArchiveUrl?: InputMaybe<Scalars['String']['input']>;
   /**
    * EAS Build to install and launch before the simulator session becomes available.
-   * Mutually exclusive with buildArtifactUrl.
+   * Mutually exclusive with applicationArchiveUrl.
    */
   buildId?: InputMaybe<Scalars['ID']['input']>;
   /**

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -5235,6 +5235,16 @@ export type CreateDeviceRunSessionEventLogUploadSessionResult = {
 export type CreateDeviceRunSessionInput = {
   appId: Scalars['ID']['input'];
   /**
+   * Build artifact URL to download, install, and launch before the simulator session
+   * becomes available. Mutually exclusive with buildId.
+   */
+  buildArtifactUrl?: InputMaybe<Scalars['String']['input']>;
+  /**
+   * EAS Build to install and launch before the simulator session becomes available.
+   * Mutually exclusive with buildArtifactUrl.
+   */
+  buildId?: InputMaybe<Scalars['ID']['input']>;
+  /**
    * Identifier of the virtual device to start for the session. On iOS this is a
    * Simulator device name or UDID (e.g. "iPhone 16 Pro"). On Android this is an
    * AVD hardware profile id (e.g. "pixel_7"). If omitted, the runner picks a

--- a/packages/eas-cli/src/project/detectProjectSdkVersionAsync.ts
+++ b/packages/eas-cli/src/project/detectProjectSdkVersionAsync.ts
@@ -1,0 +1,17 @@
+import { getConfigFilePaths } from '@expo/config';
+
+import { getPrivateExpoConfigAsync } from './expoConfig';
+
+export async function detectProjectSdkVersionAsync(
+  projectDir: string
+): Promise<string | undefined> {
+  const paths = getConfigFilePaths(projectDir);
+  if (!paths.staticConfigPath && !paths.dynamicConfigPath) {
+    return;
+  }
+  try {
+    return (await getPrivateExpoConfigAsync(projectDir)).sdkVersion;
+  } catch {
+    return;
+  }
+}

--- a/packages/eas-cli/src/simulator/__tests__/expoGo.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/expoGo.test.ts
@@ -1,0 +1,75 @@
+import spawnAsync from '@expo/spawn-async';
+
+import { detectProjectSdkVersionAsync } from '../../project/detectProjectSdkVersionAsync';
+import { resolveExpoGoApplicationArchiveUrlAsync } from '../expoGo';
+
+jest.mock('@expo/spawn-async');
+jest.mock('../../project/detectProjectSdkVersionAsync');
+
+const projectDir = '/test/project';
+const mockDetectProjectSdkVersionAsync = jest.mocked(detectProjectSdkVersionAsync);
+const mockSpawnAsync = jest.mocked(spawnAsync);
+
+describe(resolveExpoGoApplicationArchiveUrlAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDetectProjectSdkVersionAsync.mockResolvedValue('55.0.0');
+    mockSpawnAsync.mockResolvedValue({
+      stdout: 'https://example.test/expo-go.tar.gz\n',
+    } as never);
+  });
+
+  it.each(['ios', 'android'] as const)(
+    'resolves the Expo Go URL for SDK 55 on %s',
+    async platform => {
+      await expect(resolveExpoGoApplicationArchiveUrlAsync({ platform, projectDir })).resolves.toBe(
+        'https://example.test/expo-go.tar.gz'
+      );
+
+      expect(mockSpawnAsync).toHaveBeenCalledWith(
+        'npx',
+        ['--yes', 'expo-go', 'url', platform, '55'],
+        {
+          cwd: projectDir,
+          stdio: 'pipe',
+        }
+      );
+    }
+  );
+
+  it.each([undefined, 'UNVERSIONED'])(
+    'rejects an undetectable SDK version (%s)',
+    async sdkVersion => {
+      mockDetectProjectSdkVersionAsync.mockResolvedValue(sdkVersion);
+
+      await expect(
+        resolveExpoGoApplicationArchiveUrlAsync({ platform: 'ios', projectDir })
+      ).rejects.toThrow(
+        "Unable to determine this project's Expo SDK version, so Expo Go could not be selected."
+      );
+      expect(mockSpawnAsync).not.toHaveBeenCalled();
+    }
+  );
+
+  it('reports how to diagnose an expo-go failure', async () => {
+    mockSpawnAsync.mockRejectedValue(new Error('network unavailable') as never);
+
+    await expect(
+      resolveExpoGoApplicationArchiveUrlAsync({ platform: 'android', projectDir })
+    ).rejects.toThrow(
+      'Failed to resolve the Expo Go download URL for SDK 55 on android. network unavailable ' +
+        'Run "npx expo-go url android 55" to diagnose the problem'
+    );
+  });
+
+  it.each(['', 'not a URL', 'file:///tmp/expo-go.app'])(
+    'rejects an invalid expo-go URL (%s)',
+    async stdout => {
+      mockSpawnAsync.mockResolvedValue({ stdout } as never);
+
+      await expect(
+        resolveExpoGoApplicationArchiveUrlAsync({ platform: 'ios', projectDir })
+      ).rejects.toThrow('expo-go returned an invalid download URL for SDK 55 on ios.');
+    }
+  );
+});

--- a/packages/eas-cli/src/simulator/__tests__/expoGo.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/expoGo.test.ts
@@ -37,6 +37,31 @@ describe(resolveExpoGoApplicationArchiveUrlAsync, () => {
     }
   );
 
+  it.each([
+    [
+      'plain output',
+      'Resolving the correct Expo Go version...\n' +
+        'Download Expo Go from https://example.test/Expo-Go-57.0.9.tar.gz\n',
+    ],
+    [
+      'Markdown hyperlink output',
+      'Resolving the correct Expo Go version...\n' +
+        'Download Expo Go from [https://example.test/Expo-Go-57.0.9.tar.gz](https://example.test/Expo-Go-57.0.9.tar.gz)\n',
+    ],
+    [
+      'terminal hyperlink output',
+      'Resolving the correct Expo Go version...\n' +
+        'Download Expo Go from \u001B]8;;https://example.test/Expo-Go-57.0.9.tar.gz\u0007' +
+        'https://example.test/Expo-Go-57.0.9.tar.gz\u001B]8;;\u0007\n',
+    ],
+  ])('extracts the URL from %s', async (_description, stdout) => {
+    mockSpawnAsync.mockResolvedValue({ stdout } as never);
+
+    await expect(
+      resolveExpoGoApplicationArchiveUrlAsync({ platform: 'ios', projectDir })
+    ).resolves.toBe('https://example.test/Expo-Go-57.0.9.tar.gz');
+  });
+
   it.each([undefined, 'UNVERSIONED'])(
     'rejects an undetectable SDK version (%s)',
     async sdkVersion => {
@@ -62,14 +87,16 @@ describe(resolveExpoGoApplicationArchiveUrlAsync, () => {
     );
   });
 
-  it.each(['', 'not a URL', 'file:///tmp/expo-go.app'])(
-    'rejects an invalid expo-go URL (%s)',
-    async stdout => {
-      mockSpawnAsync.mockResolvedValue({ stdout } as never);
+  it.each([
+    '',
+    'not a URL',
+    'file:///tmp/expo-go.app',
+    'Resolving the correct Expo Go version...\nDownload Expo Go from nowhere\n',
+  ])('rejects an invalid expo-go URL (%s)', async stdout => {
+    mockSpawnAsync.mockResolvedValue({ stdout } as never);
 
-      await expect(
-        resolveExpoGoApplicationArchiveUrlAsync({ platform: 'ios', projectDir })
-      ).rejects.toThrow('expo-go returned an invalid download URL for SDK 55 on ios.');
-    }
-  );
+    await expect(
+      resolveExpoGoApplicationArchiveUrlAsync({ platform: 'ios', projectDir })
+    ).rejects.toThrow('expo-go returned an invalid download URL for SDK 55 on ios.');
+  });
 });

--- a/packages/eas-cli/src/simulator/expoGo.ts
+++ b/packages/eas-cli/src/simulator/expoGo.ts
@@ -18,7 +18,7 @@ export async function resolveExpoGoApplicationArchiveUrlAsync({
   if (!sdkMajorVersion) {
     throw new EasCommandError(
       "Unable to determine this project's Expo SDK version, so Expo Go could not be selected. " +
-        'Make sure the project has Expo installed and a valid app config, or use --build-id or --build-artifact-url instead.'
+        'Make sure the project has Expo installed and a valid app config, or use --build-id or --application-archive-url instead.'
     );
   }
 
@@ -33,7 +33,7 @@ export async function resolveExpoGoApplicationArchiveUrlAsync({
     const reason = error instanceof Error ? ` ${error.message}` : '';
     throw new EasCommandError(
       `Failed to resolve the Expo Go download URL for SDK ${sdkMajorVersion} on ${platform}.${reason} ` +
-        `Run "npx expo-go url ${platform} ${sdkMajorVersion}" to diagnose the problem, or use --build-id or --build-artifact-url instead.`
+        `Run "npx expo-go url ${platform} ${sdkMajorVersion}" to diagnose the problem, or use --build-id or --application-archive-url instead.`
     );
   }
 
@@ -46,7 +46,7 @@ export async function resolveExpoGoApplicationArchiveUrlAsync({
   } catch {
     throw new EasCommandError(
       `expo-go returned an invalid download URL for SDK ${sdkMajorVersion} on ${platform}. ` +
-        `Run "npx expo-go url ${platform} ${sdkMajorVersion}" to diagnose the problem, or use --build-id or --build-artifact-url instead.`
+        `Run "npx expo-go url ${platform} ${sdkMajorVersion}" to diagnose the problem, or use --build-id or --application-archive-url instead.`
     );
   }
 

--- a/packages/eas-cli/src/simulator/expoGo.ts
+++ b/packages/eas-cli/src/simulator/expoGo.ts
@@ -1,0 +1,54 @@
+import spawnAsync from '@expo/spawn-async';
+import semver from 'semver';
+
+import { EasCommandError } from '../commandUtils/errors';
+import { detectProjectSdkVersionAsync } from '../project/detectProjectSdkVersionAsync';
+
+export type ExpoGoPlatform = 'android' | 'ios';
+
+export async function resolveExpoGoApplicationArchiveUrlAsync({
+  platform,
+  projectDir,
+}: {
+  platform: ExpoGoPlatform;
+  projectDir: string;
+}): Promise<string> {
+  const sdkVersion = await detectProjectSdkVersionAsync(projectDir);
+  const sdkMajorVersion = semver.coerce(sdkVersion)?.major;
+  if (!sdkMajorVersion) {
+    throw new EasCommandError(
+      "Unable to determine this project's Expo SDK version, so Expo Go could not be selected. " +
+        'Make sure the project has Expo installed and a valid app config, or use --build-id or --build-artifact-url instead.'
+    );
+  }
+
+  const args = ['--yes', 'expo-go', 'url', platform, String(sdkMajorVersion)];
+  let stdout: string;
+  try {
+    ({ stdout } = await spawnAsync('npx', args, {
+      cwd: projectDir,
+      stdio: 'pipe',
+    }));
+  } catch (error) {
+    const reason = error instanceof Error ? ` ${error.message}` : '';
+    throw new EasCommandError(
+      `Failed to resolve the Expo Go download URL for SDK ${sdkMajorVersion} on ${platform}.${reason} ` +
+        `Run "npx expo-go url ${platform} ${sdkMajorVersion}" to diagnose the problem, or use --build-id or --build-artifact-url instead.`
+    );
+  }
+
+  const applicationArchiveUrl = stdout.trim();
+  try {
+    const parsedUrl = new URL(applicationArchiveUrl);
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      throw new Error('Unsupported protocol');
+    }
+  } catch {
+    throw new EasCommandError(
+      `expo-go returned an invalid download URL for SDK ${sdkMajorVersion} on ${platform}. ` +
+        `Run "npx expo-go url ${platform} ${sdkMajorVersion}" to diagnose the problem, or use --build-id or --build-artifact-url instead.`
+    );
+  }
+
+  return applicationArchiveUrl;
+}

--- a/packages/eas-cli/src/simulator/expoGo.ts
+++ b/packages/eas-cli/src/simulator/expoGo.ts
@@ -1,3 +1,5 @@
+import { stripVTControlCharacters } from 'util';
+
 import spawnAsync from '@expo/spawn-async';
 import semver from 'semver';
 
@@ -5,6 +7,18 @@ import { EasCommandError } from '../commandUtils/errors';
 import { detectProjectSdkVersionAsync } from '../project/detectProjectSdkVersionAsync';
 
 export type ExpoGoPlatform = 'android' | 'ios';
+
+const EXPO_GO_DOWNLOAD_MESSAGE = 'Download Expo Go from';
+
+function extractApplicationArchiveUrl(stdout: string): string | undefined {
+  const output = stripVTControlCharacters(stdout);
+  const outputLines = output.trim().split(/\r?\n/);
+  const downloadMessageLine = outputLines.find(line => line.includes(EXPO_GO_DOWNLOAD_MESSAGE));
+  const bareUrlOutput = outputLines.length === 1 ? outputLines[0] : undefined;
+  const lineWithUrl = downloadMessageLine ?? bareUrlOutput;
+
+  return lineWithUrl?.match(/https?:\/\/[^\s\])]+/)?.[0];
+}
 
 export async function resolveExpoGoApplicationArchiveUrlAsync({
   platform,
@@ -37,8 +51,11 @@ export async function resolveExpoGoApplicationArchiveUrlAsync({
     );
   }
 
-  const applicationArchiveUrl = stdout.trim();
+  const applicationArchiveUrl = extractApplicationArchiveUrl(stdout);
   try {
+    if (!applicationArchiveUrl) {
+      throw new Error('Missing URL');
+    }
     const parsedUrl = new URL(applicationArchiveUrl);
     if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
       throw new Error('Unsupported protocol');


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Companion to https://github.com/expo/eas-cli/pull/4222/changes and https://github.com/expo/universe/pull/30191

We want to enable users to easily preinstall apps they want to test when booting sim session.

# How

Add support for `--build-id` and `--application-archive-url` args (passed directly as mutation input to our backend) and `--expo-go` (expo go version is being resolved based on SDK installed for project and we get download url by running `npx expo-go` cli + pass it as `--application-archive-url`)

# Test Plan

Tests
