### PR TITLE
[build-tools] Stabilize remote simulator tunnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Stabilize EAS Simulator tunnels by supervising ngrok forwarding and backing processes. ([#4226](https://github.com/expo/eas-cli/pull/4226) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Disallow 0-length uploads. ([#4192](https://github.com/expo/eas-cli/pull/4192) by [@wschurman](https://github.com/wschurman))
 - [eas-cli] Send the expected `Content-MD5` checksum with GCS signed URL uploads so GCS rejects corrupted uploads. ([#4208](https://github.com/expo/eas-cli/pull/4208) by [@wschurman](https://github.com/wschurman))
 - [eas-cli] Resolve the `eas go` SDK version to its repack target, so `--sdk-version 57` no longer fails with "No Expo Go repack target is published for SDK 57". ([#4215](https://github.com/expo/eas-cli/pull/4215) by [@gwdp](https://github.com/gwdp))

--- a/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
@@ -16,7 +16,7 @@ import {
   spawnDetached,
   startNgrokTunnelAsync,
   uploadRemoteSessionConfigAsync,
-  waitForDeviceRunSessionStoppedAsync,
+  waitForDeviceRunSessionStoppedOrResourceFailureAsync,
 } from '../../utils/remoteDeviceRunSession';
 import { createStartArgentRemoteSessionBuildFunction } from '../startArgentRemoteSession';
 
@@ -49,7 +49,7 @@ jest.mock('../../utils/remoteDeviceRunSession', () => ({
   startNgrokTunnelAsync: jest.fn(),
   startServeSimWithTunnelAsync: jest.fn(),
   uploadRemoteSessionConfigAsync: jest.fn(),
-  waitForDeviceRunSessionStoppedAsync: jest.fn(),
+  waitForDeviceRunSessionStoppedOrResourceFailureAsync: jest.fn(),
 }));
 
 const TEST_HOME = path.join(os.tmpdir(), 'eas-argent-orchestration-home');
@@ -81,13 +81,15 @@ describe('createStartArgentRemoteSessionBuildFunction orchestration', () => {
       pid: 4242,
       getOutput: () => '',
       stopAsync: jest.fn(),
+      waitForFailureAsync: jest.fn(() => new Promise<void>(() => {})),
     });
     jest.mocked(startNgrokTunnelAsync).mockResolvedValue({
       url: 'https://argent-abc.tunnel.example.com',
       stopAsync: mockTunnelStopAsync,
+      waitForFailureAsync: jest.fn(() => new Promise<void>(() => {})),
     });
     jest.mocked(uploadRemoteSessionConfigAsync).mockResolvedValue(undefined);
-    jest.mocked(waitForDeviceRunSessionStoppedAsync).mockResolvedValue(undefined);
+    jest.mocked(waitForDeviceRunSessionStoppedOrResourceFailureAsync).mockResolvedValue(undefined);
 
     // The (real) tool-server state wait reads this file from the redirected ~/.argent.
     await fs.promises.mkdir(ARGENT_STATE_DIR, { recursive: true });
@@ -145,10 +147,10 @@ describe('createStartArgentRemoteSessionBuildFunction orchestration', () => {
     expect(startArgentEventCollectionAsync).toHaveBeenCalledTimes(1);
     expect(mockStopAsync).toHaveBeenCalledTimes(1);
     expect(jest.mocked(startArgentEventCollectionAsync).mock.invocationCallOrder[0]).toBeLessThan(
-      jest.mocked(waitForDeviceRunSessionStoppedAsync).mock.invocationCallOrder[0]
+      jest.mocked(waitForDeviceRunSessionStoppedOrResourceFailureAsync).mock.invocationCallOrder[0]
     );
     expect(mockStopAsync.mock.invocationCallOrder[0]).toBeGreaterThan(
-      jest.mocked(waitForDeviceRunSessionStoppedAsync).mock.invocationCallOrder[0]
+      jest.mocked(waitForDeviceRunSessionStoppedOrResourceFailureAsync).mock.invocationCallOrder[0]
     );
     expect(mockTunnelStopAsync).toHaveBeenCalledTimes(1);
   });

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -26,7 +26,7 @@ import {
   startNgrokTunnelAsync,
   startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
-  waitForDeviceRunSessionStoppedAsync,
+  waitForDeviceRunSessionStoppedOrResourceFailureAsync,
   waitForFileAsync,
 } from '../utils/remoteDeviceRunSession';
 
@@ -102,6 +102,7 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
         subdomainPrefix: 'agent-device',
         baseDomain: ngrokTunnelDomain,
         authtoken: ngrokAuthtoken,
+        deviceRunSessionId,
         logger,
       });
       const agentDeviceRemoteSessionUrl = agentDeviceTunnel.url;
@@ -148,12 +149,13 @@ export function createStartAgentDeviceRemoteSessionBuildFunction(
           logger,
         });
 
-        await waitForDeviceRunSessionStoppedAsync({
+        await waitForDeviceRunSessionStoppedOrResourceFailureAsync({
           ctx,
           deviceRunSessionId,
           logger,
           maxDurationSeconds,
           signal,
+          resources: [daemonProcess, agentDeviceTunnel, ...(serveSim ? [serveSim] : [])],
           idleTimeout:
             maxIdleTimeMinutes !== undefined && maxIdleTimeMinutes > 0
               ? {

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -29,7 +29,7 @@ import {
   startNgrokTunnelAsync,
   startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
-  waitForDeviceRunSessionStoppedAsync,
+  waitForDeviceRunSessionStoppedOrResourceFailureAsync,
 } from '../utils/remoteDeviceRunSession';
 
 const ARGENT_PACKAGE_NAME = '@swmansion/argent';
@@ -193,6 +193,7 @@ export function createStartArgentRemoteSessionBuildFunction(
           subdomainPrefix: 'argent',
           baseDomain: ngrokTunnelDomain,
           authtoken: ngrokAuthtoken,
+          deviceRunSessionId,
           rewriteHostHeader: true,
           logger,
         });
@@ -223,12 +224,13 @@ export function createStartArgentRemoteSessionBuildFunction(
           logger,
         });
 
-        await waitForDeviceRunSessionStoppedAsync({
+        await waitForDeviceRunSessionStoppedOrResourceFailureAsync({
           ctx,
           deviceRunSessionId,
           logger,
           maxDurationSeconds,
           signal,
+          resources: [argentServer, toolsTunnel, ...(serveSim ? [serveSim] : [])],
           idleTimeout:
             maxIdleTimeMinutes !== undefined && maxIdleTimeMinutes > 0
               ? {

--- a/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startServeSimRemoteSession.ts
@@ -12,7 +12,7 @@ import {
   selectXcodeDeveloperDirectoryAsync,
   startServeSimWithTunnelAsync,
   uploadRemoteSessionConfigAsync,
-  waitForDeviceRunSessionStoppedAsync,
+  waitForDeviceRunSessionStoppedOrResourceFailureAsync,
 } from '../utils/remoteDeviceRunSession';
 
 const STARTUP_TIMEOUT_MS = 60_000;
@@ -58,12 +58,13 @@ export function createStartServeSimRemoteSessionBuildFunction(
           logger,
         });
 
-        await waitForDeviceRunSessionStoppedAsync({
+        await waitForDeviceRunSessionStoppedOrResourceFailureAsync({
           ctx,
           deviceRunSessionId,
           logger,
           maxDurationSeconds,
           signal,
+          resources: [serveSim],
         });
       } finally {
         await serveSim.stopAsync();

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -7,6 +7,7 @@ import {
   setTimeout as setTimeoutCallback,
 } from 'node:timers';
 import { setTimeout as setTimeoutAsync } from 'node:timers/promises';
+import { PassThrough } from 'node:stream';
 
 import { CustomBuildContext } from '../../../customBuildContext';
 import { Sentry } from '../../../sentry';
@@ -17,9 +18,11 @@ import {
   ensureFfmpegInstalledAsync,
   fetchServeSimTurnArgsAsync,
   metricsCorsOriginToServeSimArgs,
+  spawnDetached,
   startNgrokTunnelAsync,
   turnIceServersToServeSimArgs,
   waitForDeviceRunSessionStoppedAsync,
+  waitForDeviceRunSessionStoppedOrResourceFailureAsync,
   waitForServeSimReadyAsync,
 } from '../remoteDeviceRunSession';
 
@@ -111,6 +114,44 @@ function createStatusCtxMock(
 
 function createEnvMock(): BuildStepEnv {
   return { DEVICE_RUN_SESSION_ID: 'drs-id' } as unknown as BuildStepEnv;
+}
+
+function mockNgrokSdk({
+  joinPromise = new Promise<void>(() => {}),
+}: { joinPromise?: Promise<void> } = {}): {
+  closeListener: jest.Mock;
+  closeSession: jest.Mock;
+  endpointBuilder: Record<string, jest.Mock>;
+  sessionBuilder: Record<string, jest.Mock>;
+} {
+  const closeListener = jest.fn().mockResolvedValue(undefined);
+  const listener = {
+    url: jest.fn().mockReturnValue('https://serve-sim.example.test'),
+    close: closeListener,
+    join: jest.fn().mockReturnValue(joinPromise),
+  };
+  const endpointBuilder = {
+    domain: jest.fn().mockReturnThis(),
+    metadata: jest.fn().mockReturnThis(),
+    requestHeader: jest.fn().mockReturnThis(),
+    listenAndForward: jest.fn().mockResolvedValue(listener),
+  };
+  const closeSession = jest.fn().mockResolvedValue(undefined);
+  const session = {
+    httpEndpoint: jest.fn().mockReturnValue(endpointBuilder),
+    close: closeSession,
+  };
+  const sessionBuilder = {
+    authtoken: jest.fn().mockReturnThis(),
+    metadata: jest.fn().mockReturnThis(),
+    handleDisconnection: jest.fn().mockReturnThis(),
+    handleHeartbeat: jest.fn().mockReturnThis(),
+    connect: jest.fn().mockResolvedValue(session),
+  };
+  jest
+    .mocked(ngrok.SessionBuilder)
+    .mockImplementation(() => sessionBuilder as unknown as ngrok.SessionBuilder);
+  return { closeListener, closeSession, endpointBuilder, sessionBuilder };
 }
 
 describe(createServeSimArgs, () => {
@@ -218,32 +259,172 @@ describe(waitForServeSimReadyAsync, () => {
 });
 
 describe(startNgrokTunnelAsync, () => {
-  it('uses a 128-bit capability hostname and exposes explicit cleanup', async () => {
-    const close = jest.fn().mockResolvedValue(undefined);
-    jest.mocked(ngrok.forward).mockResolvedValue({
-      url: () => 'https://serve-sim.example.test',
-      close,
-    } as never);
+  beforeEach(() => {
+    jest.mocked(ngrok.SessionBuilder).mockReset();
+    jest.mocked(setTimeoutCallback).mockReset();
+    jest.mocked(clearTimeoutCallback).mockReset();
+  });
+
+  it('uses a shared, observable session and a joinable listener', async () => {
+    const { closeListener, closeSession, endpointBuilder, sessionBuilder } = mockNgrokSdk();
 
     const tunnel = await startNgrokTunnelAsync({
       port: 4321,
       subdomainPrefix: 'serve-sim',
       baseDomain: 'tunnel.example.test',
       authtoken: 'token',
+      deviceRunSessionId: 'drs-id',
       logger: createLoggerMock(),
     });
 
-    expect(ngrok.forward).toHaveBeenCalledWith(
-      expect.objectContaining({
-        addr: 4321,
-        authtoken: 'token',
-        domain: expect.stringMatching(/^serve-sim-[a-f0-9]{32}\.tunnel\.example\.test$/),
-      })
+    expect(sessionBuilder.authtoken).toHaveBeenCalledWith('token');
+    expect(sessionBuilder.metadata).toHaveBeenCalledWith(
+      JSON.stringify({ deviceRunSessionId: 'drs-id', product: 'eas-simulator' })
     );
+    expect(endpointBuilder.domain).toHaveBeenCalledWith(
+      expect.stringMatching(/^serve-sim-[a-f0-9]{32}\.tunnel\.example\.test$/)
+    );
+    expect(endpointBuilder.metadata).toHaveBeenCalledWith(
+      JSON.stringify({ deviceRunSessionId: 'drs-id', tunnelType: 'serve-sim' })
+    );
+    expect(endpointBuilder.listenAndForward).toHaveBeenCalledWith('http://127.0.0.1:4321');
     expect(tunnel.url).toBe('https://serve-sim.example.test');
     await tunnel.stopAsync();
     await tunnel.stopAsync();
-    expect(close).toHaveBeenCalledTimes(1);
+    expect(closeListener).toHaveBeenCalledTimes(1);
+    expect(closeSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces terminal forwarding failures', async () => {
+    let rejectJoin: (error: Error) => void = () => {};
+    const joinPromise = new Promise<void>((_resolve, reject) => {
+      rejectJoin = reject;
+    });
+    mockNgrokSdk({ joinPromise });
+    const tunnel = await startNgrokTunnelAsync({
+      port: 4321,
+      subdomainPrefix: 'serve-sim',
+      baseDomain: 'tunnel.example.test',
+      authtoken: 'token',
+      deviceRunSessionId: 'drs-id',
+      logger: createLoggerMock(),
+    });
+
+    const failurePromise = tunnel.waitForFailureAsync();
+    rejectJoin(new Error('forwarder stopped'));
+    await expect(failurePromise).rejects.toThrow('forwarder stopped');
+    await tunnel.stopAsync();
+  });
+
+  it('keeps the shared session open until its last tunnel stops', async () => {
+    const { closeSession } = mockNgrokSdk();
+    const logger = createLoggerMock();
+    const tunnelOptions = {
+      baseDomain: 'tunnel.example.test',
+      authtoken: 'token',
+      deviceRunSessionId: 'drs-id',
+      logger,
+    };
+    const firstTunnel = await startNgrokTunnelAsync({
+      ...tunnelOptions,
+      port: 4321,
+      subdomainPrefix: 'argent',
+    });
+    const secondTunnel = await startNgrokTunnelAsync({
+      ...tunnelOptions,
+      port: 4322,
+      subdomainPrefix: 'serve-sim',
+    });
+
+    expect(ngrok.SessionBuilder).toHaveBeenCalledTimes(1);
+    await firstTunnel.stopAsync();
+    expect(closeSession).not.toHaveBeenCalled();
+    await secondTunnel.stopAsync();
+    expect(closeSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets ngrok reconnect transient disconnects and fails after the grace period', async () => {
+    const disconnectTimeout = { unref: jest.fn() } as unknown as NodeJS.Timeout;
+    jest.mocked(setTimeoutCallback).mockReturnValue(disconnectTimeout);
+    const logger = createLoggerMock();
+    const { sessionBuilder } = mockNgrokSdk();
+    const tunnel = await startNgrokTunnelAsync({
+      port: 4321,
+      subdomainPrefix: 'serve-sim',
+      baseDomain: 'tunnel.example.test',
+      authtoken: 'token',
+      deviceRunSessionId: 'drs-id',
+      logger,
+    });
+
+    const onDisconnect = sessionBuilder.handleDisconnection.mock.calls[0][0] as (
+      address: string,
+      error: string
+    ) => boolean;
+    expect(onDisconnect('connect.ngrok-agent.com:443', 'network unavailable')).toBe(true);
+    expect(setTimeoutCallback).toHaveBeenCalledWith(expect.any(Function), 60_000);
+
+    const failurePromise = tunnel.waitForFailureAsync();
+    const disconnectTimeoutCallback = jest.mocked(setTimeoutCallback).mock.calls[0][0];
+    disconnectTimeoutCallback();
+    await expect(failurePromise).rejects.toThrow('did not reconnect within 60 seconds');
+    await tunnel.stopAsync();
+  });
+});
+
+describe(spawnDetached, () => {
+  it('keeps bounded diagnostic output for long-running processes', async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const processPromise = Object.assign(new Promise<never>(() => {}), {
+      child: {
+        pid: undefined,
+        stdout,
+        stderr,
+        unref: jest.fn(),
+      },
+    });
+    jest.mocked(spawn).mockReturnValue(processPromise as never);
+
+    const process = spawnDetached({
+      command: 'long-running-command',
+      args: [],
+      env: {} as BuildStepEnv,
+    });
+    stdout.write('x'.repeat(300_000));
+
+    expect(process.getOutput().startsWith('[... earlier output truncated ...]\n')).toBe(true);
+    expect(process.getOutput().length).toBeLessThan(263_000);
+    await process.stopAsync();
+  });
+
+  it('surfaces an unexpected child-process exit', async () => {
+    let rejectProcess: (error: Error) => void = () => {};
+    const processPromise = Object.assign(
+      new Promise<never>((_resolve, reject) => {
+        rejectProcess = reject;
+      }),
+      {
+        child: {
+          pid: undefined,
+          stdout: new PassThrough(),
+          stderr: new PassThrough(),
+          unref: jest.fn(),
+        },
+      }
+    );
+    jest.mocked(spawn).mockReturnValue(processPromise as never);
+    const process = spawnDetached({
+      command: 'failing-command',
+      args: [],
+      env: {} as BuildStepEnv,
+    });
+
+    const failurePromise = process.waitForFailureAsync();
+    rejectProcess(new Error('exit code 1'));
+    await expect(failurePromise).rejects.toThrow(
+      'failing-command exited unexpectedly: exit code 1'
+    );
   });
 });
 
@@ -471,6 +652,35 @@ describe(waitForDeviceRunSessionStoppedAsync, () => {
 
     expect(ctx.graphqlClient.query).toHaveBeenCalledTimes(1);
     expect(clearTimeoutCallback).toHaveBeenCalledWith(durationTimeout);
+  });
+
+  it('stops polling and surfaces supervised resource failures', async () => {
+    const ctx = createStatusCtxMock([{ status: 'IN_PROGRESS' }]);
+    let pollSignal: AbortSignal | undefined;
+    jest.mocked(setTimeoutAsync).mockImplementation(
+      async (_timeoutMs, _value, options): Promise<undefined> =>
+        await new Promise<undefined>((_resolve, reject) => {
+          pollSignal = options?.signal;
+          pollSignal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        })
+    );
+    let rejectResource: (error: Error) => void = () => {};
+    const resourceFailure = new Promise<void>((_resolve, reject) => {
+      rejectResource = reject;
+    });
+    const waitPromise = waitForDeviceRunSessionStoppedOrResourceFailureAsync({
+      ctx,
+      deviceRunSessionId: 'drs-id',
+      logger: createLoggerMock(),
+      resources: [{ waitForFailureAsync: () => resourceFailure }],
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    rejectResource(new Error('tunnel failed'));
+    await expect(waitPromise).rejects.toThrow('tunnel failed');
+    expect(pollSignal?.aborted).toBe(true);
+    expect(ctx.graphqlClient.query).toHaveBeenCalledTimes(1);
   });
 
   it('logs and retries transient polling errors', async () => {

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -63,6 +63,9 @@ const ENSURE_DEVICE_RUN_SESSION_STOPPED_MUTATION = graphql(`
 `);
 
 const DEVICE_RUN_SESSION_STATUS_POLL_INTERVAL_MS = 5_000;
+const NGROK_DISCONNECT_GRACE_PERIOD_MS = 60_000;
+const MAX_DETACHED_PROCESS_OUTPUT_LENGTH = 256 * 1024;
+const DETACHED_PROCESS_OUTPUT_TRUNCATED_MARKER = '[... earlier output truncated ...]\n';
 
 export function getDeviceRunSessionIdOrThrow(env: BuildStepEnv): string {
   const deviceRunSessionId = env.DEVICE_RUN_SESSION_ID;
@@ -141,6 +144,19 @@ export type DeviceRunSessionIdleTimeout = {
   getLastEventObservedAt: () => Date | undefined;
 };
 
+export type SupervisedResource = {
+  waitForFailureAsync: () => Promise<void>;
+};
+
+export type WaitForDeviceRunSessionStoppedOptions = {
+  ctx: CustomBuildContext;
+  deviceRunSessionId: string;
+  logger: bunyan;
+  maxDurationSeconds?: number;
+  signal?: AbortSignal;
+  idleTimeout?: DeviceRunSessionIdleTimeout;
+};
+
 export async function waitForDeviceRunSessionStoppedAsync({
   ctx,
   deviceRunSessionId,
@@ -148,14 +164,7 @@ export async function waitForDeviceRunSessionStoppedAsync({
   maxDurationSeconds,
   signal: cancelSignal,
   idleTimeout,
-}: {
-  ctx: CustomBuildContext;
-  deviceRunSessionId: string;
-  logger: bunyan;
-  maxDurationSeconds?: number;
-  signal?: AbortSignal;
-  idleTimeout?: DeviceRunSessionIdleTimeout;
-}): Promise<void> {
+}: WaitForDeviceRunSessionStoppedOptions): Promise<void> {
   const durationAbortController = new AbortController();
   const signal = cancelSignal
     ? AbortSignal.any([cancelSignal, durationAbortController.signal])
@@ -246,6 +255,24 @@ export async function waitForDeviceRunSessionStoppedAsync({
     if (durationTimeout !== undefined) {
       clearTimeout(durationTimeout);
     }
+  }
+}
+
+export async function waitForDeviceRunSessionStoppedOrResourceFailureAsync({
+  resources,
+  ...options
+}: WaitForDeviceRunSessionStoppedOptions & { resources: SupervisedResource[] }): Promise<void> {
+  const resourceAbortController = new AbortController();
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, resourceAbortController.signal])
+    : resourceAbortController.signal;
+  try {
+    await Promise.race([
+      waitForDeviceRunSessionStoppedAsync({ ...options, signal }),
+      ...resources.map(resource => resource.waitForFailureAsync()),
+    ]);
+  } finally {
+    resourceAbortController.abort();
   }
 }
 
@@ -496,7 +523,7 @@ export async function uploadRemoteSessionConfigAsync({
   }
 }
 
-export type DetachedProcessHandle = {
+export type DetachedProcessHandle = SupervisedResource & {
   /** PID of the directly spawned process, if the OS assigned one. */
   pid: number | undefined;
   getOutput: () => string;
@@ -561,23 +588,51 @@ export function spawnDetached({
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,
   });
-  // We don't await the process — it should outlive this step. Failures show
-  // up in the captured output; suppress unhandled rejections here.
-  promise.catch(() => {});
+  // Capture completion as data so a child failure cannot become an unhandled
+  // rejection before the session starts waiting on this resource.
+  const completion = promise.then(
+    () => undefined,
+    error => (error instanceof Error ? error : new Error(String(error)))
+  );
   promise.child.unref();
 
   let output = '';
+  let outputWasTruncated = false;
   const appendChunk = (chunk: Buffer | string): void => {
     output += chunk.toString();
+    if (output.length > MAX_DETACHED_PROCESS_OUTPUT_LENGTH) {
+      output = output.slice(-MAX_DETACHED_PROCESS_OUTPUT_LENGTH);
+      outputWasTruncated = true;
+    }
   };
   promise.child.stdout?.on('data', appendChunk);
   promise.child.stderr?.on('data', appendChunk);
 
   const pid = promise.child.pid;
+  const getOutput = (): string =>
+    `${outputWasTruncated ? DETACHED_PROCESS_OUTPUT_TRUNCATED_MARKER : ''}${output}`;
+  let stopped = false;
   return {
     pid,
-    getOutput: () => output,
-    stopAsync: async () => await stopDetachedProcessAsync(pid),
+    getOutput,
+    waitForFailureAsync: async () => {
+      const error = await completion;
+      if (stopped) {
+        return;
+      }
+      const capturedOutput = getOutput();
+      throw new SystemError(
+        `${command} exited unexpectedly${error ? `: ${error.message}` : ''}.` +
+          (capturedOutput ? `\nLast output:\n${capturedOutput}` : '')
+      );
+    },
+    stopAsync: async () => {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      await stopDetachedProcessAsync(pid);
+    },
   };
 }
 
@@ -688,7 +743,7 @@ export async function waitForServeSimReadyAsync({
   );
 }
 
-export type ServeSimPreviewHandle = {
+export type ServeSimPreviewHandle = SupervisedResource & {
   previewUrl: string;
   stopAsync: () => Promise<void>;
 };
@@ -707,6 +762,7 @@ export async function startServeSimWithTunnelAsync(
     timeoutMs: number;
   }
 ): Promise<ServeSimPreviewHandle> {
+  const deviceRunSessionId = getDeviceRunSessionIdOrThrow(env);
   const port = await findAvailablePortAsync();
   logger.info(`Launching ${SERVE_SIM_PACKAGE_SPEC} on ${SERVE_SIM_HOST}:${port}.`);
   const turnArgs = await fetchServeSimTurnArgsAsync(ctx, { env, logger });
@@ -725,10 +781,14 @@ export async function startServeSimWithTunnelAsync(
       subdomainPrefix: 'serve-sim',
       baseDomain,
       authtoken: getNgrokAuthtokenOrThrow(env),
+      deviceRunSessionId,
       logger,
     });
     return {
       previewUrl: tunnel.url,
+      waitForFailureAsync: async () => {
+        await Promise.race([tunnel.waitForFailureAsync(), serveSim.waitForFailureAsync()]);
+      },
       stopAsync: async () => {
         const results = await Promise.allSettled([tunnel.stopAsync(), serveSim.stopAsync()]);
         for (const result of results) {
@@ -744,16 +804,155 @@ export async function startServeSimWithTunnelAsync(
   }
 }
 
-export type NgrokTunnelHandle = {
+export type NgrokTunnelHandle = SupervisedResource & {
   url: string;
   stopAsync: () => Promise<void>;
 };
+
+type SharedNgrokSession = {
+  authtoken: string;
+  deviceRunSessionId: string;
+  session: ngrok.Session;
+  connectionFailure: Promise<Error>;
+  retainCount: number;
+  closeAsync: () => Promise<void>;
+};
+
+let sharedNgrokSessionPromise: Promise<SharedNgrokSession> | undefined;
+
+async function createSharedNgrokSessionAsync({
+  authtoken,
+  deviceRunSessionId,
+  logger,
+}: {
+  authtoken: string;
+  deviceRunSessionId: string;
+  logger: bunyan;
+}): Promise<SharedNgrokSession> {
+  let disconnectedAt: number | undefined;
+  let disconnectTimeout: NodeJS.Timeout | undefined;
+  let closed = false;
+  let resolveConnectionFailure: (error: Error) => void = () => {};
+  const connectionFailure = new Promise<Error>(resolve => {
+    resolveConnectionFailure = resolve;
+  });
+
+  const sessionBuilder = new ngrok.SessionBuilder()
+    .authtoken(authtoken)
+    .metadata(JSON.stringify({ deviceRunSessionId, product: 'eas-simulator' }))
+    .handleDisconnection((address, errorMessage) => {
+      if (closed) {
+        return false;
+      }
+      if (disconnectedAt === undefined) {
+        disconnectedAt = Date.now();
+        logger.warn(
+          { address, error: errorMessage },
+          'The ngrok session disconnected; ngrok will keep reconnecting.'
+        );
+        disconnectTimeout = setTimeout(() => {
+          const error = new SystemError(
+            `The ngrok session did not reconnect within ${NGROK_DISCONNECT_GRACE_PERIOD_MS / 1_000} seconds.`
+          );
+          Sentry.capture('Ngrok session did not reconnect', error, {
+            extras: { address, deviceRunSessionId, errorMessage },
+          });
+          resolveConnectionFailure(error);
+        }, NGROK_DISCONNECT_GRACE_PERIOD_MS);
+        disconnectTimeout.unref?.();
+      }
+      return true;
+    })
+    .handleHeartbeat(latency => {
+      if (disconnectedAt === undefined) {
+        return;
+      }
+      const disconnectedForMs = Date.now() - disconnectedAt;
+      disconnectedAt = undefined;
+      if (disconnectTimeout) {
+        clearTimeout(disconnectTimeout);
+        disconnectTimeout = undefined;
+      }
+      logger.info(
+        { disconnectedForMs, heartbeatLatencyMs: latency },
+        'The ngrok session reconnected.'
+      );
+    });
+
+  const session = await sessionBuilder.connect();
+  return {
+    authtoken,
+    deviceRunSessionId,
+    session,
+    connectionFailure,
+    retainCount: 0,
+    closeAsync: async () => {
+      closed = true;
+      if (disconnectTimeout) {
+        clearTimeout(disconnectTimeout);
+        disconnectTimeout = undefined;
+      }
+      await session.close();
+    },
+  };
+}
+
+async function acquireSharedNgrokSessionAsync({
+  authtoken,
+  deviceRunSessionId,
+  logger,
+}: {
+  authtoken: string;
+  deviceRunSessionId: string;
+  logger: bunyan;
+}): Promise<SharedNgrokSession> {
+  if (!sharedNgrokSessionPromise) {
+    const creationPromise = createSharedNgrokSessionAsync({
+      authtoken,
+      deviceRunSessionId,
+      logger,
+    });
+    sharedNgrokSessionPromise = creationPromise;
+    void creationPromise.catch(() => {
+      if (sharedNgrokSessionPromise === creationPromise) {
+        sharedNgrokSessionPromise = undefined;
+      }
+    });
+  }
+
+  const sharedSession = await sharedNgrokSessionPromise;
+  if (
+    sharedSession.authtoken !== authtoken ||
+    sharedSession.deviceRunSessionId !== deviceRunSessionId
+  ) {
+    throw new SystemError('Cannot share an ngrok session between different device run sessions.');
+  }
+  sharedSession.retainCount += 1;
+  return sharedSession;
+}
+
+async function releaseSharedNgrokSessionAsync(
+  sharedSession: SharedNgrokSession,
+  logger: bunyan
+): Promise<void> {
+  sharedSession.retainCount -= 1;
+  if (sharedSession.retainCount > 0) {
+    return;
+  }
+  sharedNgrokSessionPromise = undefined;
+  try {
+    await sharedSession.closeAsync();
+  } catch (error) {
+    logger.warn({ err: error }, 'Could not close the shared ngrok session.');
+  }
+}
 
 export async function startNgrokTunnelAsync({
   port,
   subdomainPrefix,
   baseDomain,
   authtoken,
+  deviceRunSessionId,
   rewriteHostHeader,
   logger,
 }: {
@@ -761,27 +960,65 @@ export async function startNgrokTunnelAsync({
   subdomainPrefix: string;
   baseDomain: string;
   authtoken: string;
+  deviceRunSessionId: string;
   rewriteHostHeader?: boolean;
   logger: bunyan;
 }): Promise<NgrokTunnelHandle> {
   const domain = `${subdomainPrefix}-${randomBytes(16).toString('hex')}.${baseDomain}`;
   logger.info(`Starting ngrok tunnel ${domain} -> http://localhost:${port}.`);
-  // Run the ngrok agent in-process via the SDK; it keeps the session alive until
-  // the process exits, and the step blocks forever to hold it open.
-  const listener = await ngrok.forward({
-    addr: port,
+  const sharedSession = await acquireSharedNgrokSessionAsync({
     authtoken,
-    domain,
-    ...(rewriteHostHeader ? { request_header_add: [`Host:localhost:${port}`] } : {}),
+    deviceRunSessionId,
+    logger,
   });
+  const endpointBuilder = sharedSession.session
+    .httpEndpoint()
+    .domain(domain)
+    .metadata(JSON.stringify({ deviceRunSessionId, tunnelType: subdomainPrefix }));
+  if (rewriteHostHeader) {
+    endpointBuilder.requestHeader('Host', `localhost:${port}`);
+  }
+
+  let listener: ngrok.Listener;
+  try {
+    // Unlike ngrok.forward(), listenAndForward() returns a joinable listener.
+    // The SDK keeps reconnecting transient session failures; join() settles only
+    // when forwarding exits, which lets the device session surface terminal failures.
+    listener = await endpointBuilder.listenAndForward(`http://127.0.0.1:${port}`);
+  } catch (error) {
+    await releaseSharedNgrokSessionAsync(sharedSession, logger);
+    throw error;
+  }
   const url = listener.url();
   if (!url) {
-    await listener.close();
+    try {
+      await listener.close();
+    } catch (error) {
+      logger.warn({ err: error }, `Could not stop ngrok tunnel ${domain}.`);
+    } finally {
+      await releaseSharedNgrokSessionAsync(sharedSession, logger);
+    }
     throw new SystemError(`ngrok tunnel for ${domain} did not return a public URL.`);
   }
+
+  const listenerCompletion = listener.join().then(
+    () => new SystemError(`The ngrok tunnel ${domain} stopped forwarding unexpectedly.`),
+    error =>
+      new SystemError(
+        `The ngrok tunnel ${domain} stopped forwarding: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+  );
   let stopped = false;
   return {
     url,
+    waitForFailureAsync: async () => {
+      const error = await Promise.race([listenerCompletion, sharedSession.connectionFailure]);
+      if (!stopped) {
+        throw error;
+      }
+    },
     stopAsync: async () => {
       if (stopped) {
         return;
@@ -791,6 +1028,8 @@ export async function startNgrokTunnelAsync({
         await listener.close();
       } catch (error) {
         logger.warn({ err: error }, `Could not stop ngrok tunnel ${domain}.`);
+      } finally {
+        await releaseSharedNgrokSessionAsync(sharedSession, logger);
       }
     },
   };


### PR DESCRIPTION
## Why

Remote simulator jobs only polled the device-run session status while ngrok forwarding tasks and the agent-device, Argent, and serve-sim processes ran unsupervised. If one of those resources stopped, the already-published URL stayed visible but ngrok returned `ERR_NGROK_3200` because its endpoint was offline. The detached-process helper also retained unbounded output.

## How

- create one explicit ngrok session per device-run session and share it between its tool and serve-sim tunnels
- keep transient ngrok reconnects enabled, log disconnect/reconnect health, and fail after a 60-second disconnect grace period
- use joinable ngrok listeners so terminal forwarding failures are observable
- supervise the ngrok listeners and agent-device, Argent, and serve-sim processes while polling session status
- abort background status polling when a supervised resource fails
- cap detached process diagnostics at 256 KiB and include them in unexpected-exit errors
- attach device-run session metadata to ngrok sessions and endpoints for diagnosis

## Test plan

- `corepack yarn workspace @expo/build-tools jest-unit --runInBand src/steps/utils/__tests__/remoteDeviceRunSession.test.ts src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts` (36 tests passed)
- `corepack yarn workspace @expo/build-tools typecheck`
- `corepack yarn fmt:check`
- oxlint on all six changed files
- full build-tools unit run: 1,015 tests passed; the remaining pre-existing environment-dependent tests could not access npm, macOS keychain services, or `ps`/`pgrep` in the sandbox