### PR TITLE
[eas-cli] Stream workflow run logs in real time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Cache CocoaPods dependencies between iOS builds. ([#4266](https://github.com/expo/eas-cli/pull/4266) by [@AbbanMustafa](https://github.com/AbbanMustafa))
 - [build-tools] Support `EAS_BUN_FILTER_WORKSPACE` to install only the selected workspace's dependencies with `bun install --filter`. ([#4292](https://github.com/expo/eas-cli/pull/4292) by [@konrad-armatys](https://github.com/konrad-armatys))
+- [eas-cli] Update workflow run logs in real time, instead of every 10 seconds. ([#4228](https://github.com/expo/eas-cli/pull/4228) by [@AHGIJMKLKKZNPJKQR](https://github.com/AHGIJMKLKKZNPJKQR))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Update workflow run logs in real time, instead of every 10 seconds. ([#4228](https://github.com/expo/eas-cli/pull/4228) by [@AHGIJMKLKKZNPJKQR](https://github.com/AHGIJMKLKKZNPJKQR))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores
@@ -43,7 +45,6 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Cache CocoaPods dependencies between iOS builds. ([#4266](https://github.com/expo/eas-cli/pull/4266) by [@AbbanMustafa](https://github.com/AbbanMustafa))
 - [build-tools] Support `EAS_BUN_FILTER_WORKSPACE` to install only the selected workspace's dependencies with `bun install --filter`. ([#4292](https://github.com/expo/eas-cli/pull/4292) by [@konrad-armatys](https://github.com/konrad-armatys))
-- [eas-cli] Update workflow run logs in real time, instead of every 10 seconds. ([#4228](https://github.com/expo/eas-cli/pull/4228) by [@AHGIJMKLKKZNPJKQR](https://github.com/AHGIJMKLKKZNPJKQR))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -77,6 +77,7 @@
     "ajv-formats": "2.1.1",
     "better-opn": "3.0.2",
     "bplist-parser": "^0.3.0",
+    "centrifuge": "5.7.1",
     "chalk": "4.1.2",
     "cli-progress": "3.12.0",
     "dateformat": "4.6.3",
@@ -132,6 +133,7 @@
     "untildify": "4.0.0",
     "uuid": "11.1.1",
     "wrap-ansi": "7.0.0",
+    "ws": "8.21.1",
     "yaml": "2.6.0",
     "zod": "^4.1.3"
   },
@@ -160,6 +162,7 @@
     "@types/tar-stream": "3.1.3",
     "@types/tough-cookie": "4.0.2",
     "@types/wrap-ansi": "3.0.0",
+    "@types/ws": "8.5.10",
     "axios": "1.18.1",
     "eslint-plugin-graphql": "4.0.0",
     "jest": "29.7.0",

--- a/packages/eas-cli/src/__tests__/commands/workflow-logs-test.ts
+++ b/packages/eas-cli/src/__tests__/commands/workflow-logs-test.ts
@@ -11,7 +11,7 @@ import {
 import {
   fetchRawLogsForBuildJobAsync,
   fetchRawLogsForCustomJobAsync,
-} from '../../commandUtils/workflow/fetchLogs';
+} from '../../commandUtils/workflow/logs/fetchLogs';
 import WorkflowLogView from '../../commands/workflow/logs';
 import { AppPlatform, BuildPriority, BuildStatus } from '../../graphql/generated';
 import { AppQuery } from '../../graphql/queries/AppQuery';
@@ -38,7 +38,7 @@ jest.mock('fs');
 jest.mock('../../log');
 jest.mock('../../prompts');
 jest.mock('../../utils/json');
-jest.mock('../../commandUtils/workflow/fetchLogs');
+jest.mock('../../commandUtils/workflow/logs/fetchLogs');
 
 describe(WorkflowLogView, () => {
   beforeEach(() => {

--- a/packages/eas-cli/src/__tests__/commands/workflow-logs-test.ts
+++ b/packages/eas-cli/src/__tests__/commands/workflow-logs-test.ts
@@ -8,10 +8,7 @@ import {
   mockProjectId,
   mockTestCommand,
 } from './utils';
-import {
-  fetchRawLogsForBuildJobAsync,
-  fetchRawLogsForCustomJobAsync,
-} from '../../commandUtils/workflow/logs/fetchLogs';
+import { fetchRawLogsForJobAsync } from '../../commandUtils/workflow/logs/fetchLogs';
 import WorkflowLogView from '../../commands/workflow/logs';
 import { AppPlatform, BuildPriority, BuildStatus } from '../../graphql/generated';
 import { AppQuery } from '../../graphql/queries/AppQuery';
@@ -49,6 +46,7 @@ describe(WorkflowLogView, () => {
   });
   afterEach(() => {
     jest.clearAllMocks();
+    jest.mocked(fetchRawLogsForJobAsync).mockReset();
   });
   test('view logs, passing in no parameters, no runs found', async () => {
     const ctx = mockCommandContext(WorkflowLogView, {
@@ -105,7 +103,7 @@ describe(WorkflowLogView, () => {
         return { selectedStep: 'step1' };
       }
     });
-    jest.mocked(fetchRawLogsForCustomJobAsync).mockResolvedValue(null);
+    jest.mocked(fetchRawLogsForJobAsync).mockResolvedValue(null);
     await cmd.run();
     expect(AppQuery.byIdWorkflowRunsFilteredByStatusAsync).toHaveBeenCalledWith(
       ctx.loggedIn.graphqlClient,
@@ -139,7 +137,7 @@ describe(WorkflowLogView, () => {
       }
     });
     jest
-      .mocked(fetchRawLogsForCustomJobAsync)
+      .mocked(fetchRawLogsForJobAsync)
       .mockResolvedValue(
         '{"result":"success","marker":"end-step","buildStepDisplayName":"Install dependencies","buildStepId":"step-id-1","time":"2022-01-01T00:00:00.000Z","msg":"test"}'
       );
@@ -209,7 +207,7 @@ describe(WorkflowLogView, () => {
       }
     });
     jest
-      .mocked(fetchRawLogsForBuildJobAsync)
+      .mocked(fetchRawLogsForJobAsync)
       .mockResolvedValue(
         '{"result":"success","marker":"end-step","buildStepDisplayName":"step1","buildStepId":"step-id-1","time":"2022-01-01T00:00:00.000Z","msg":"test"}'
       );
@@ -255,7 +253,7 @@ describe(WorkflowLogView, () => {
       }
     });
     jest
-      .mocked(fetchRawLogsForCustomJobAsync)
+      .mocked(fetchRawLogsForJobAsync)
       .mockResolvedValue(
         [
           '{"result":"success","marker":"end-step","buildStepDisplayName":"Install","buildStepId":"step-id-1","time":"2022-01-01T00:00:00.000Z","msg":"first"}',

--- a/packages/eas-cli/src/api.ts
+++ b/packages/eas-cli/src/api.ts
@@ -112,3 +112,13 @@ export function getEASUpdateURL(projectId: string, manifestHostOverride: string 
 export function getExpoApiWorkflowSchemaURL(): string {
   return getExpoApiBaseUrl() + '/v2/workflows/schema';
 }
+
+export function getEASLogsWebsocketUrl(): string {
+  if (process.env.EXPO_STAGING) {
+    return `wss://staging-logs.expo.dev/connection/websocket`;
+  } else if (process.env.EXPO_LOCAL) {
+    return `ws://localhost:4997/connection/websocket`;
+  } else {
+    return `wss://logs.expo.dev/connection/websocket`;
+  }
+}

--- a/packages/eas-cli/src/commandUtils/workflow/__tests__/utils-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/__tests__/utils-test.ts
@@ -1,29 +1,36 @@
 import { getMockWorkflowRunWithJobsFragment } from '../../../__tests__/commands/utils';
 import { WorkflowJobStatus } from '../../../graphql/generated';
 import { groupLogLinesIntoSteps, parseLogLines } from '../logs/parseLogs';
-import { formatActiveWorkflowRun } from '../utils';
+import { WorkflowLogs, WorkflowRawLogLine } from '../types';
+import { formatActiveWorkflowRun, formatFailedWorkflowRun } from '../utils';
 
-function inProgressJobWithLogs(rawLogs: string): {
+function jobWithLogs(
+  logLines: WorkflowRawLogLine[],
+  status: WorkflowJobStatus = WorkflowJobStatus.InProgress
+): {
   job: ReturnType<typeof getMockWorkflowRunWithJobsFragment>['jobs'][number];
-  logs: ReturnType<typeof groupLogLinesIntoSteps>;
+  logs: WorkflowLogs;
 } {
   return {
-    job: {
-      ...getMockWorkflowRunWithJobsFragment().jobs[0],
-      status: WorkflowJobStatus.InProgress,
-    },
-    logs: groupLogLinesIntoSteps(parseLogLines(rawLogs).logLines),
+    job: { ...getMockWorkflowRunWithJobsFragment().jobs[0], status },
+    logs: groupLogLinesIntoSteps(logLines),
   };
+}
+
+function stepLines(buildStepId: string, count: number): WorkflowRawLogLine[] {
+  return Array.from({ length: count }, (_, index) => ({ buildStepId, msg: `line${index}` }));
 }
 
 describe(formatActiveWorkflowRun, () => {
   test('shows the display name for the current step while keying logs by step id', () => {
     const output = formatActiveWorkflowRun([
-      inProgressJobWithLogs(
-        [
-          '{"buildStepId":"step-id-1","buildStepDisplayName":"Install dependencies","time":"2022-01-01T00:00:00.000Z","msg":"npm ci"}',
-          '{"buildStepId":"step-id-1","buildStepDisplayName":"Install dependencies","marker":"end-step","result":"success","time":"2022-01-01T00:00:01.000Z","msg":"done"}',
-        ].join('\n')
+      jobWithLogs(
+        parseLogLines(
+          [
+            '{"buildStepId":"step-id-1","buildStepDisplayName":"Install dependencies","time":"2022-01-01T00:00:00.000Z","msg":"npm ci"}',
+            '{"buildStepId":"step-id-1","buildStepDisplayName":"Install dependencies","marker":"end-step","result":"success","time":"2022-01-01T00:00:01.000Z","msg":"done"}',
+          ].join('\n')
+        ).logLines
       ),
     ]);
 
@@ -33,24 +40,98 @@ describe(formatActiveWorkflowRun, () => {
   });
 
   test('shows exactly maxLogLines trailing lines of the current step', () => {
-    const output = formatActiveWorkflowRun(
-      [
-        inProgressJobWithLogs(
-          Array.from({ length: 10 }, (_, index) =>
-            JSON.stringify({
-              buildStepId: 'step-id-1',
-              buildStepDisplayName: 'Install dependencies',
-              time: '2022-01-01T00:00:00.000Z',
-              msg: `line${index}`,
-            })
-          ).join('\n')
-        ),
-      ],
-      5
-    );
+    const output = formatActiveWorkflowRun([jobWithLogs(stepLines('step-id-1', 10))], 5);
 
     expect(output).toContain('line5');
     expect(output).toContain('line9');
     expect(output).not.toContain('line4');
+  });
+
+  test('keeps five trailing lines by default', () => {
+    const output = formatActiveWorkflowRun([jobWithLogs(stepLines('step-id-1', 10))]);
+
+    expect(output).toContain('line5');
+    expect(output).toContain('line9');
+    expect(output).not.toContain('line4');
+  });
+
+  test('reports the last step as the current one', () => {
+    const output = formatActiveWorkflowRun([
+      jobWithLogs([
+        { buildStepId: 'install', buildStepDisplayName: 'Install', msg: 'installing' },
+        { buildStepId: 'build', buildStepDisplayName: 'Build', msg: 'compiling' },
+      ]),
+    ]);
+
+    expect(output).toContain('Build');
+    expect(output).not.toContain('Install');
+  });
+
+  test('passes over a trailing skipped step', () => {
+    const output = formatActiveWorkflowRun([
+      jobWithLogs([
+        { buildStepId: 'install', buildStepDisplayName: 'Install', msg: 'installing' },
+        {
+          buildStepId: 'build',
+          buildStepDisplayName: 'Build',
+          msg: 'skipping',
+          marker: 'end-step',
+          result: 'skipped',
+        },
+      ]),
+    ]);
+
+    expect(output).toContain('Install');
+    expect(output).not.toContain('Build');
+  });
+
+  test('reports a step that has not ended yet', () => {
+    const output = formatActiveWorkflowRun([
+      jobWithLogs([
+        {
+          buildStepId: 'install',
+          buildStepDisplayName: 'Install',
+          msg: 'installed',
+          marker: 'end-step',
+          result: 'success',
+        },
+        { buildStepId: 'build', buildStepDisplayName: 'Build', msg: 'compiling' },
+      ]),
+    ]);
+
+    expect(output).toContain('Build');
+  });
+
+  test('omits the current step when the job has no steps yet', () => {
+    const output = formatActiveWorkflowRun([jobWithLogs([])]);
+
+    expect(output).not.toContain('Current step');
+    expect(output).not.toContain('Current logs');
+  });
+
+  test('omits the current step for a job that is not in progress', () => {
+    const output = formatActiveWorkflowRun([
+      jobWithLogs(stepLines('step-id-1', 3), WorkflowJobStatus.Success),
+    ]);
+
+    expect(output).not.toContain('Current step');
+    expect(output).not.toContain('line0');
+  });
+});
+
+describe(formatFailedWorkflowRun, () => {
+  test('prints every line of the failed step when there is no limit', () => {
+    const output = formatFailedWorkflowRun([
+      jobWithLogs(
+        [
+          ...stepLines('build', 8),
+          { buildStepId: 'build', msg: 'it failed', marker: 'end-step', result: 'fail' },
+        ],
+        WorkflowJobStatus.Failure
+      ),
+    ]);
+
+    expect(output).toContain('line0');
+    expect(output).toContain('line7');
   });
 });

--- a/packages/eas-cli/src/commandUtils/workflow/__tests__/utils-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/__tests__/utils-test.ts
@@ -1,35 +1,56 @@
 import { getMockWorkflowRunWithJobsFragment } from '../../../__tests__/commands/utils';
-import { fetchRawLogsForCustomJobAsync } from '../fetchLogs';
-import { infoForActiveWorkflowRunAsync } from '../utils';
 import { WorkflowJobStatus } from '../../../graphql/generated';
+import { groupLogLinesIntoSteps, parseLogLines } from '../logs/parseLogs';
+import { formatActiveWorkflowRun } from '../utils';
 
-jest.mock('../fetchLogs');
-
-describe('workflow utils', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  test('shows the display name for the current step while keying logs by step id', async () => {
-    const workflowRun = getMockWorkflowRunWithJobsFragment();
-    workflowRun.jobs = workflowRun.jobs.map(job => ({
-      ...job,
+function inProgressJobWithLogs(rawLogs: string): {
+  job: ReturnType<typeof getMockWorkflowRunWithJobsFragment>['jobs'][number];
+  logs: ReturnType<typeof groupLogLinesIntoSteps>;
+} {
+  return {
+    job: {
+      ...getMockWorkflowRunWithJobsFragment().jobs[0],
       status: WorkflowJobStatus.InProgress,
-    }));
+    },
+    logs: groupLogLinesIntoSteps(parseLogLines(rawLogs).logLines),
+  };
+}
 
-    jest
-      .mocked(fetchRawLogsForCustomJobAsync)
-      .mockResolvedValue(
+describe(formatActiveWorkflowRun, () => {
+  test('shows the display name for the current step while keying logs by step id', () => {
+    const output = formatActiveWorkflowRun([
+      inProgressJobWithLogs(
         [
           '{"buildStepId":"step-id-1","buildStepDisplayName":"Install dependencies","time":"2022-01-01T00:00:00.000Z","msg":"npm ci"}',
           '{"buildStepId":"step-id-1","buildStepDisplayName":"Install dependencies","marker":"end-step","result":"success","time":"2022-01-01T00:00:01.000Z","msg":"done"}',
         ].join('\n')
-      );
-
-    const output = await infoForActiveWorkflowRunAsync({} as any, workflowRun);
+      ),
+    ]);
 
     expect(output).toContain('Current step');
     expect(output).toContain('Install dependencies');
     expect(output).not.toContain('step-id-1');
+  });
+
+  test('shows exactly maxLogLines trailing lines of the current step', () => {
+    const output = formatActiveWorkflowRun(
+      [
+        inProgressJobWithLogs(
+          Array.from({ length: 10 }, (_, index) =>
+            JSON.stringify({
+              buildStepId: 'step-id-1',
+              buildStepDisplayName: 'Install dependencies',
+              time: '2022-01-01T00:00:00.000Z',
+              msg: `line${index}`,
+            })
+          ).join('\n')
+        ),
+      ],
+      5
+    );
+
+    expect(output).toContain('line5');
+    expect(output).toContain('line9');
+    expect(output).not.toContain('line4');
   });
 });

--- a/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/fetchLogs-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/fetchLogs-test.ts
@@ -1,0 +1,27 @@
+import { getMockWorkflowCustomJobFragment } from '../../../../__tests__/commands/utils';
+import { BuildQuery } from '../../../../graphql/queries/BuildQuery';
+import { ExpoGraphqlClient } from '../../../context/contextUtils/createGraphqlClient';
+import { fetchRawLogsForJobAsync } from '../fetchLogs';
+
+jest.mock('../../../../graphql/queries/BuildQuery');
+
+describe(fetchRawLogsForJobAsync, () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reads a custom job from its turtle job run log file', async () => {
+    const rawLogs = '{"logId":"1","buildStepId":"install","msg":"from the turtle job run"}';
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(rawLogs));
+
+    await expect(
+      fetchRawLogsForJobAsync(
+        { graphqlClient: {} as ExpoGraphqlClient },
+        getMockWorkflowCustomJobFragment()
+      )
+    ).resolves.toBe(rawLogs);
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://example.com/log1');
+    expect(BuildQuery.byIdAsync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/parseLogs-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/parseLogs-test.ts
@@ -159,4 +159,28 @@ describe(groupLogLinesIntoSteps, () => {
 
     expect(logs.size).toBe(0);
   });
+
+  it('records the result of the first end marker and ignores a later one', () => {
+    const logs = groupLogLinesIntoSteps([
+      logLine({ buildStepId: 'install', msg: 'skipping', marker: 'end-step', result: 'skipped' }),
+      logLine({ buildStepId: 'install', msg: 'retried', marker: 'end-step', result: 'success' }),
+    ]);
+
+    expect(logs.get('install')?.result).toBe('skipped');
+  });
+
+  it('leaves the result undefined for a step that has not ended', () => {
+    const logs = groupLogLinesIntoSteps([logLine({ buildStepId: 'install', msg: 'npm ci' })]);
+
+    expect(logs.get('install')?.result).toBeUndefined();
+  });
+
+  it('records an end marker that carries no result and does not let a later one replace it', () => {
+    const logs = groupLogLinesIntoSteps([
+      logLine({ buildStepId: 'install', msg: 'ended', marker: 'END_PHASE' }),
+      logLine({ buildStepId: 'install', msg: 'retried', marker: 'END_PHASE', result: 'success' }),
+    ]);
+
+    expect(logs.get('install')?.result).toBe('');
+  });
 });

--- a/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/parseLogs-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/parseLogs-test.ts
@@ -1,0 +1,143 @@
+import { groupLogLinesIntoSteps, mergeLogLines, parseLogLines } from '../parseLogs';
+import { WorkflowRawLogLine } from '../../types';
+
+function logLine(overrides: Partial<WorkflowRawLogLine> = {}): WorkflowRawLogLine {
+  return { msg: 'a message', ...overrides };
+}
+
+describe(parseLogLines, () => {
+  it('parses a JSONL log file', () => {
+    const { logLines, errors } = parseLogLines(
+      [
+        '{"logId":"1","buildStepId":"install","msg":"npm ci"}',
+        '{"logId":"2","buildStepId":"install","msg":"done"}',
+      ].join('\n')
+    );
+
+    expect(errors).toEqual([]);
+    expect(logLines).toEqual([
+      { logId: '1', buildStepId: 'install', msg: 'npm ci' },
+      { logId: '2', buildStepId: 'install', msg: 'done' },
+    ]);
+  });
+
+  it('skips blank lines, including a trailing newline', () => {
+    const { logLines, errors } = parseLogLines('{"logId":"1","msg":"one"}\n\n');
+
+    expect(errors).toEqual([]);
+    expect(logLines).toHaveLength(1);
+  });
+
+  it('reports malformed lines as errors while keeping the parsable ones', () => {
+    const { logLines, errors } = parseLogLines(
+      ['{"logId":"1","msg":"one"}', 'this is not json', '{"logId":"2","msg":"two"}'].join('\n')
+    );
+
+    expect(logLines.map(line => line.msg)).toEqual(['one', 'two']);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+  });
+
+  it('parses a line that carries no message', () => {
+    const { logLines, errors } = parseLogLines('{"logId":"1"}');
+
+    expect(errors).toEqual([]);
+    expect(logLines).toEqual([{ logId: '1' }]);
+  });
+});
+
+describe(mergeLogLines, () => {
+  it('keeps the rightmost line for a repeated logId', () => {
+    const fileLogLines = [
+      logLine({ logId: '1', msg: 'from the file' }),
+      logLine({ logId: '2', msg: 'from the file' }),
+    ];
+    const realtimeLogLines = [
+      logLine({ logId: '2', msg: 'from realtime' }),
+      logLine({ logId: '3', msg: 'from realtime' }),
+    ];
+
+    expect(mergeLogLines(fileLogLines, realtimeLogLines)).toEqual([
+      { logId: '1', msg: 'from the file' },
+      { logId: '2', msg: 'from realtime' },
+      { logId: '3', msg: 'from realtime' },
+    ]);
+  });
+
+  it('keeps identical messages that have different logIds', () => {
+    const merged = mergeLogLines(
+      [logLine({ logId: '1', msg: 'Repeated text' })],
+      [logLine({ logId: '2', msg: 'Repeated text' })]
+    );
+
+    expect(merged).toEqual([
+      { logId: '1', msg: 'Repeated text' },
+      { logId: '2', msg: 'Repeated text' },
+    ]);
+  });
+
+  it('keeps identical lines without logId', () => {
+    const merged = mergeLogLines(
+      [logLine({ msg: 'same' }), logLine({ msg: 'same' })],
+      [logLine({ msg: 'same' })]
+    );
+
+    expect(merged).toHaveLength(3);
+  });
+
+  it('deduplicates within a single group', () => {
+    const merged = mergeLogLines([logLine({ logId: '1' }), logLine({ logId: '1' })]);
+
+    expect(merged).toHaveLength(1);
+  });
+});
+
+describe(groupLogLinesIntoSteps, () => {
+  it('groups lines by step id and labels the step with its display name', () => {
+    const logs = groupLogLinesIntoSteps([
+      logLine({ buildStepId: 'step-id-1', msg: 'npm ci' }),
+      logLine({
+        buildStepId: 'step-id-1',
+        buildStepDisplayName: 'Install dependencies',
+        msg: 'ok',
+      }),
+    ]);
+
+    expect(Array.from(logs.keys())).toEqual(['step-id-1']);
+    expect(logs.get('step-id-1')).toEqual({
+      key: 'step-id-1',
+      label: 'Install dependencies',
+      logLines: [
+        { time: undefined, msg: 'npm ci', result: undefined, marker: undefined, err: undefined },
+        { time: undefined, msg: 'ok', result: undefined, marker: undefined, err: undefined },
+      ],
+    });
+  });
+
+  it('keeps steps in the order they first appear', () => {
+    const logs = groupLogLinesIntoSteps([
+      logLine({ buildStepId: 'first' }),
+      logLine({ buildStepId: 'second' }),
+      logLine({ buildStepId: 'first' }),
+      logLine({ buildStepId: 'third' }),
+    ]);
+
+    expect(Array.from(logs.keys())).toEqual(['first', 'second', 'third']);
+  });
+
+  it('falls back to the display name, then the phase, when there is no step id', () => {
+    const logs = groupLogLinesIntoSteps([
+      logLine({ buildStepDisplayName: 'Run fastlane' }),
+      logLine({ phase: 'PREPARE_CREDENTIALS' }),
+    ]);
+
+    expect(Array.from(logs.keys())).toEqual(['Run fastlane', 'PREPARE_CREDENTIALS']);
+    expect(logs.get('PREPARE_CREDENTIALS')?.label).toBe('PREPARE_CREDENTIALS');
+  });
+
+  it('drops lines that belong to no step', () => {
+    const logs = groupLogLinesIntoSteps([logLine({ msg: 'a line with no step' })]);
+
+    expect(logs.size).toBe(0);
+  });
+});

--- a/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/parseLogs-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/parseLogs-test.ts
@@ -140,4 +140,23 @@ describe(groupLogLinesIntoSteps, () => {
 
     expect(logs.size).toBe(0);
   });
+
+  it('drops lines that carry no message, keeping the rest of the step', () => {
+    const logs = groupLogLinesIntoSteps([
+      logLine({ buildStepId: 'install', msg: undefined, marker: 'start-step' }),
+      logLine({ buildStepId: 'install', msg: 'npm ci' }),
+    ]);
+
+    expect(logs.get('install')?.logLines).toEqual([
+      { time: undefined, msg: 'npm ci', result: undefined, marker: undefined, err: undefined },
+    ]);
+  });
+
+  it('creates no step for a line that carries no message', () => {
+    const logs = groupLogLinesIntoSteps([
+      logLine({ buildStepId: 'install', msg: undefined, marker: 'end-step', result: 'success' }),
+    ]);
+
+    expect(logs.size).toBe(0);
+  });
 });

--- a/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/watcher-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/watcher-test.ts
@@ -1,0 +1,279 @@
+import { getMockWorkflowRunWithJobsFragment } from '../../../../__tests__/commands/utils';
+import { RealtimeLogsTargetType, WorkflowJobStatus } from '../../../../graphql/generated';
+import { RealtimeLogsClient } from '../../../../utils/centrifuge';
+import { fetchAndParseLogsFromJobAsync } from '../parseLogs';
+import { WorkflowJobLogsState, WorkflowRunLogsWatcher, realtimeLogsTargetForJob } from '../watcher';
+import { WorkflowJobResult, WorkflowRawLogLine } from '../../types';
+
+jest.mock('../parseLogs', () => ({
+  ...jest.requireActual('../parseLogs'),
+  fetchAndParseLogsFromJobAsync: jest.fn(),
+}));
+
+function createFakeClient(): {
+  client: RealtimeLogsClient;
+  publish: (data: unknown) => void;
+  subscribeCalls: unknown[];
+  closeCount: () => number;
+} {
+  const listeners: ((data: unknown) => void)[] = [];
+  const subscribeCalls: unknown[] = [];
+  let closed = 0;
+  return {
+    subscribeCalls,
+    closeCount: () => closed,
+    publish: data => listeners.forEach(listener => listener(data)),
+    client: {
+      subscribeAsync: async (args, onPublication) => {
+        subscribeCalls.push(args);
+        listeners.push(onPublication);
+        return { close: () => closed++ };
+      },
+      close: () => closed++,
+    },
+  };
+}
+
+function inProgressJob(): WorkflowJobResult {
+  const job = getMockWorkflowRunWithJobsFragment().jobs[0];
+  return { ...job, status: WorkflowJobStatus.InProgress };
+}
+
+describe(realtimeLogsTargetForJob, () => {
+  it('targets the turtle job run when there is one', () => {
+    const job = { ...inProgressJob(), turtleJobRun: { id: 'job-run-id' } } as WorkflowJobResult;
+
+    expect(realtimeLogsTargetForJob(job)).toEqual({
+      type: RealtimeLogsTargetType.JobRun,
+      id: 'job-run-id',
+    });
+  });
+
+  it('falls back to the build when there is no turtle job run', () => {
+    const job = {
+      ...inProgressJob(),
+      turtleJobRun: null,
+      turtleBuild: { id: 'build-id' },
+    } as WorkflowJobResult;
+
+    expect(realtimeLogsTargetForJob(job)).toEqual({
+      type: RealtimeLogsTargetType.Build,
+      id: 'build-id',
+    });
+  });
+
+  it('has no target when neither is present', () => {
+    const job = {
+      ...inProgressJob(),
+      turtleJobRun: null,
+      turtleBuild: null,
+      outputs: null,
+    } as WorkflowJobResult;
+
+    expect(realtimeLogsTargetForJob(job)).toBeNull();
+  });
+});
+
+describe(WorkflowRunLogsWatcher, () => {
+  beforeEach(() => {
+    jest
+      .mocked(fetchAndParseLogsFromJobAsync)
+      .mockResolvedValue([{ logId: '1', buildStepId: 'install', msg: 'from the file' }]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('subscribes once per in-progress job', async () => {
+    const fake = createFakeClient();
+    const watcher = new WorkflowRunLogsWatcher(
+      {} as any,
+      () => fake.client,
+      () => {}
+    );
+    const job = inProgressJob();
+
+    await watcher.syncJobsAsync([job]);
+    await watcher.syncJobsAsync([job]);
+
+    expect(fake.subscribeCalls).toHaveLength(1);
+  });
+
+  it('reports realtime logs as they arrive', async () => {
+    const fake = createFakeClient();
+    const onRealtimeLogs = jest.fn();
+    const watcher = new WorkflowRunLogsWatcher({} as any, () => fake.client, onRealtimeLogs);
+    await watcher.syncJobsAsync([inProgressJob()]);
+
+    fake.publish([{ logId: '2', buildStepId: 'install', msg: 'pushed' }]);
+
+    expect(onRealtimeLogs).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not report a publication that carries no usable log lines', async () => {
+    const fake = createFakeClient();
+    const onRealtimeLogs = jest.fn();
+    const watcher = new WorkflowRunLogsWatcher({} as any, () => fake.client, onRealtimeLogs);
+    await watcher.syncJobsAsync([inProgressJob()]);
+
+    fake.publish([{ msg: 'no logId' }]);
+
+    expect(onRealtimeLogs).not.toHaveBeenCalled();
+  });
+
+  it('still fetches logs when the realtime logs client is unavailable', async () => {
+    const watcher = new WorkflowRunLogsWatcher(
+      {} as any,
+      () => null,
+      () => {}
+    );
+
+    await watcher.syncJobsAsync([inProgressJob()]);
+
+    expect(fetchAndParseLogsFromJobAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches logs on every sync while in progress, and stops once the job completes', async () => {
+    const fake = createFakeClient();
+    const watcher = new WorkflowRunLogsWatcher(
+      {} as any,
+      () => fake.client,
+      () => {}
+    );
+    const job = inProgressJob();
+
+    await watcher.syncJobsAsync([job]);
+    await watcher.syncJobsAsync([job]);
+    expect(fetchAndParseLogsFromJobAsync).toHaveBeenCalledTimes(2);
+
+    await watcher.syncJobsAsync([{ ...job, status: WorkflowJobStatus.Success }]);
+    expect(fetchAndParseLogsFromJobAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not fetch logs for a job that has not started', async () => {
+    const fake = createFakeClient();
+    const watcher = new WorkflowRunLogsWatcher(
+      {} as any,
+      () => fake.client,
+      () => {}
+    );
+
+    await watcher.syncJobsAsync([{ ...inProgressJob(), status: WorkflowJobStatus.New }]);
+
+    expect(fetchAndParseLogsFromJobAsync).not.toHaveBeenCalled();
+  });
+
+  it('closes the subscription when a job leaves in-progress', async () => {
+    const fake = createFakeClient();
+    const watcher = new WorkflowRunLogsWatcher(
+      {} as any,
+      () => fake.client,
+      () => {}
+    );
+    const job = inProgressJob();
+
+    await watcher.syncJobsAsync([job]);
+    expect(fake.closeCount()).toBe(0);
+
+    await watcher.syncJobsAsync([{ ...job, status: WorkflowJobStatus.Failure }]);
+    expect(fake.closeCount()).toBe(1);
+  });
+
+  it('closes the client and its subscriptions', async () => {
+    const fake = createFakeClient();
+    const watcher = new WorkflowRunLogsWatcher(
+      {} as any,
+      () => fake.client,
+      () => {}
+    );
+
+    await watcher.syncJobsAsync([inProgressJob()]);
+    watcher.close();
+
+    expect(fake.closeCount()).toBe(2);
+  });
+});
+
+function fileLine(logId: string, msg: string): WorkflowRawLogLine {
+  return { logId, buildStepId: 'install', msg };
+}
+
+function stepMessages(logsState: WorkflowJobLogsState, isCompleted = false): string[] {
+  const logs = logsState.getLogs({ isCompleted });
+  return Array.from(logs.values()).flatMap(group => group.logLines.map(line => line.msg));
+}
+
+describe(WorkflowJobLogsState, () => {
+  it('hides realtime lines until the file logs reach them', () => {
+    const logsState = new WorkflowJobLogsState();
+    logsState.ingestFileLogLines([fileLine('1', 'first')]);
+    logsState.ingestRealtimeLogLines([fileLine('5', 'pushed')]);
+
+    expect(stepMessages(logsState)).toEqual(['first']);
+  });
+
+  it('shows realtime lines once a published logId also appears in the file', () => {
+    const logsState = new WorkflowJobLogsState();
+    logsState.ingestFileLogLines([fileLine('1', 'first')]);
+    logsState.ingestRealtimeLogLines([fileLine('2', 'pushed')]);
+    logsState.ingestFileLogLines([fileLine('1', 'first'), fileLine('2', 'pushed')]);
+    logsState.ingestRealtimeLogLines([fileLine('3', 'newer')]);
+
+    expect(stepMessages(logsState)).toEqual(['first', 'pushed', 'newer']);
+  });
+
+  it('opens the gate when a publication repeats a logId already in the file', () => {
+    const logsState = new WorkflowJobLogsState();
+    logsState.ingestFileLogLines([fileLine('1', 'first')]);
+    logsState.ingestRealtimeLogLines([fileLine('1', 'first'), fileLine('2', 'pushed')]);
+
+    expect(stepMessages(logsState)).toEqual(['first', 'pushed']);
+  });
+
+  it('shows buffered realtime lines once the job is completed even without catch-up', () => {
+    const logsState = new WorkflowJobLogsState();
+    logsState.ingestFileLogLines([fileLine('1', 'first')]);
+    logsState.ingestRealtimeLogLines([fileLine('9', 'pushed')]);
+
+    expect(stepMessages(logsState, true)).toEqual(['first', 'pushed']);
+  });
+
+  it('replaces the file snapshot instead of accumulating it', () => {
+    const logsState = new WorkflowJobLogsState();
+    const keyless: WorkflowRawLogLine = { buildStepId: 'install', msg: 'submission log' };
+
+    logsState.ingestFileLogLines([keyless]);
+    logsState.ingestFileLogLines([keyless]);
+
+    expect(stepMessages(logsState)).toEqual(['submission log']);
+  });
+
+  it('drops a buffered realtime line once it lands in the file', () => {
+    const logsState = new WorkflowJobLogsState();
+    logsState.ingestFileLogLines([fileLine('1', 'first')]);
+    logsState.ingestRealtimeLogLines([fileLine('2', 'pushed')]);
+    logsState.ingestFileLogLines([fileLine('1', 'first'), fileLine('2', 'pushed')]);
+
+    expect(stepMessages(logsState)).toEqual(['first', 'pushed']);
+  });
+
+  it('ignores publications that are not arrays of log lines', () => {
+    const logsState = new WorkflowJobLogsState();
+    logsState.ingestFileLogLines([fileLine('1', 'first')]);
+
+    expect(logsState.ingestRealtimeLogLines({ logId: '2', msg: 'not an array' })).toBe(false);
+    expect(logsState.ingestRealtimeLogLines(['a string', 42, null])).toBe(false);
+    expect(logsState.ingestRealtimeLogLines([{ msg: 'no logId' }])).toBe(false);
+    expect(stepMessages(logsState)).toEqual(['first']);
+  });
+
+  it('deduplicates a line republished on the same channel', () => {
+    const logsState = new WorkflowJobLogsState();
+    logsState.ingestFileLogLines([fileLine('1', 'first')]);
+    logsState.ingestRealtimeLogLines([fileLine('1', 'first'), fileLine('2', 'pushed')]);
+    logsState.ingestRealtimeLogLines([fileLine('2', 'pushed')]);
+
+    expect(stepMessages(logsState)).toEqual(['first', 'pushed']);
+  });
+});

--- a/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/watcher-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/watcher-test.ts
@@ -22,7 +22,11 @@ function createFakeClient(): {
   return {
     subscribeCalls,
     closeCount: () => closed,
-    publish: data => listeners.forEach(listener => listener(data)),
+    publish: data => {
+      listeners.forEach(listener => {
+        listener(data);
+      });
+    },
     client: {
       subscribeAsync: async (args, onPublication) => {
         subscribeCalls.push(args);

--- a/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/watcher-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/watcher-test.ts
@@ -199,13 +199,14 @@ describe(WorkflowRunLogsWatcher, () => {
   });
 });
 
-function fileLine(logId: string, msg: string): WorkflowRawLogLine {
-  return { logId, buildStepId: 'install', msg };
+function fileLine(logId: string, msg: string, buildStepId = 'install'): WorkflowRawLogLine {
+  return { logId, buildStepId, msg };
 }
 
-function stepMessages(logsState: WorkflowJobLogsState, isCompleted = false): string[] {
-  const logs = logsState.getLogs({ isCompleted });
-  return Array.from(logs.values()).flatMap(group => group.logLines.map(line => line.msg));
+function stepMessages(logsState: WorkflowJobLogsState): string[] {
+  return Array.from(logsState.getLogs().values()).flatMap(group =>
+    group.logLines.map(logLine => logLine.msg)
+  );
 }
 
 describe(WorkflowJobLogsState, () => {
@@ -227,7 +228,7 @@ describe(WorkflowJobLogsState, () => {
     expect(stepMessages(logsState)).toEqual(['first', 'pushed', 'newer']);
   });
 
-  it('opens the gate when a publication repeats a logId already in the file', () => {
+  it('shows realtime logs when a publication repeats a logId already in the file', () => {
     const logsState = new WorkflowJobLogsState();
     logsState.ingestFileLogLines([fileLine('1', 'first')]);
     logsState.ingestRealtimeLogLines([fileLine('1', 'first'), fileLine('2', 'pushed')]);
@@ -235,12 +236,26 @@ describe(WorkflowJobLogsState, () => {
     expect(stepMessages(logsState)).toEqual(['first', 'pushed']);
   });
 
-  it('shows buffered realtime lines once the job is completed even without catch-up', () => {
+  it('shows buffered realtime lines once the job is completed', () => {
     const logsState = new WorkflowJobLogsState();
     logsState.ingestFileLogLines([fileLine('1', 'first')]);
     logsState.ingestRealtimeLogLines([fileLine('9', 'pushed')]);
 
-    expect(stepMessages(logsState, true)).toEqual(['first', 'pushed']);
+    logsState.markCompleted();
+    logsState.markCompleted();
+
+    expect(stepMessages(logsState)).toEqual(['first', 'pushed']);
+  });
+
+  it('folds later publications once completion showed them', () => {
+    const logsState = new WorkflowJobLogsState();
+    logsState.ingestFileLogLines([fileLine('1', 'first')]);
+    logsState.ingestRealtimeLogLines([fileLine('9', 'buffered')]);
+    logsState.markCompleted();
+
+    logsState.ingestRealtimeLogLines([fileLine('10', 'pushed')]);
+
+    expect(stepMessages(logsState)).toEqual(['first', 'buffered', 'pushed']);
   });
 
   it('replaces the file snapshot instead of accumulating it', () => {
@@ -279,5 +294,15 @@ describe(WorkflowJobLogsState, () => {
     logsState.ingestRealtimeLogLines([fileLine('2', 'pushed')]);
 
     expect(stepMessages(logsState)).toEqual(['first', 'pushed']);
+  });
+
+  it('deduplicates a line republished later', () => {
+    const logsState = new WorkflowJobLogsState();
+    logsState.ingestFileLogLines([fileLine('1', 'first')]);
+    logsState.ingestRealtimeLogLines([fileLine('1', 'first'), fileLine('2', 'pushed')]);
+    logsState.ingestRealtimeLogLines([fileLine('3', 'newer')]);
+    logsState.ingestRealtimeLogLines([fileLine('2', 'pushed')]);
+
+    expect(stepMessages(logsState)).toEqual(['first', 'pushed', 'newer']);
   });
 });

--- a/packages/eas-cli/src/commandUtils/workflow/logs/fetchLogs.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/fetchLogs.ts
@@ -2,18 +2,7 @@ import { WorkflowJobResult } from '../types';
 import { BuildQuery } from '../../../graphql/queries/BuildQuery';
 import { ExpoGraphqlClient } from '../../context/contextUtils/createGraphqlClient';
 
-export async function fetchRawLogsForCustomJobAsync(
-  job: WorkflowJobResult
-): Promise<string | null> {
-  const firstLogFileUrl = job.turtleJobRun?.logFileUrls?.[0];
-  if (!firstLogFileUrl) {
-    return null;
-  }
-  const response = await fetch(firstLogFileUrl);
-  return await response.text();
-}
-
-export async function fetchRawLogsForBuildJobAsync(
+export async function fetchRawLogsForJobAsync(
   state: { graphqlClient: ExpoGraphqlClient },
   job: WorkflowJobResult
 ): Promise<string | null> {

--- a/packages/eas-cli/src/commandUtils/workflow/logs/fetchLogs.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/fetchLogs.ts
@@ -1,8 +1,6 @@
-import { WorkflowJobResult } from './types';
-import { BuildQuery } from '../../graphql/queries/BuildQuery';
-import { ExpoGraphqlClient } from '../context/contextUtils/createGraphqlClient';
-
-// This function is in a separate module for testing purposes
+import { WorkflowJobResult } from '../types';
+import { BuildQuery } from '../../../graphql/queries/BuildQuery';
+import { ExpoGraphqlClient } from '../../context/contextUtils/createGraphqlClient';
 
 export async function fetchRawLogsForCustomJobAsync(
   job: WorkflowJobResult
@@ -11,28 +9,20 @@ export async function fetchRawLogsForCustomJobAsync(
   if (!firstLogFileUrl) {
     return null;
   }
-  const response = await fetch(firstLogFileUrl, {
-    method: 'GET',
-  });
-  const rawLogs = await response.text();
-  return rawLogs;
+  const response = await fetch(firstLogFileUrl);
+  return await response.text();
 }
 
 export async function fetchRawLogsForBuildJobAsync(
   state: { graphqlClient: ExpoGraphqlClient },
   job: WorkflowJobResult
 ): Promise<string | null> {
-  // Prefer turtleJobRun logs, which contain JSONL-formatted step logs
-  // for both built-in and custom build steps
   const turtleLogFileUrl = job.turtleJobRun?.logFileUrls?.[0];
   if (turtleLogFileUrl) {
-    const response = await fetch(turtleLogFileUrl, {
-      method: 'GET',
-    });
+    const response = await fetch(turtleLogFileUrl);
     return await response.text();
   }
 
-  // Fall back to build logFiles
   const buildId = job.outputs?.build_id;
   if (!buildId) {
     return null;
@@ -44,8 +34,6 @@ export async function fetchRawLogsForBuildJobAsync(
   if (!firstLogFileUrl) {
     return null;
   }
-  const response = await fetch(firstLogFileUrl, {
-    method: 'GET',
-  });
+  const response = await fetch(firstLogFileUrl);
   return await response.text();
 }

--- a/packages/eas-cli/src/commandUtils/workflow/logs/parseLogs.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/parseLogs.ts
@@ -37,7 +37,7 @@ export function groupLogLinesIntoSteps(logLines: WorkflowRawLogLine[]): Workflow
     const { buildStepDisplayName, buildStepId, phase, time, msg, result, marker, err } = logLine;
     const stepKey = buildStepId ?? buildStepDisplayName ?? phase;
     const stepLabel = buildStepDisplayName ?? buildStepId ?? phase;
-    if (!stepKey || !stepLabel) {
+    if (!stepKey || !stepLabel || !msg) {
       continue;
     }
 

--- a/packages/eas-cli/src/commandUtils/workflow/logs/parseLogs.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/parseLogs.ts
@@ -1,0 +1,89 @@
+import { fetchRawLogsForBuildJobAsync, fetchRawLogsForCustomJobAsync } from './fetchLogs';
+import { WorkflowJobResult, WorkflowLogs, WorkflowRawLogLine } from '../types';
+import { WorkflowJobType } from '../../../graphql/generated';
+import Log from '../../../log';
+import uniqBy from '../../../utils/expodash/uniqBy';
+import { ExpoGraphqlClient } from '../../context/contextUtils/createGraphqlClient';
+
+export function parseLogLines(rawLogs: string): {
+  logLines: WorkflowRawLogLine[];
+  errors: Error[];
+} {
+  const logLines: WorkflowRawLogLine[] = [];
+  const errors: Error[] = [];
+
+  for (const rawLogLine of rawLogs.split('\n')) {
+    if (!rawLogLine) {
+      continue;
+    }
+    try {
+      logLines.push(JSON.parse(rawLogLine));
+    } catch (err) {
+      errors.push(err as Error);
+    }
+  }
+
+  return { logLines, errors };
+}
+
+export function mergeLogLines<T extends WorkflowRawLogLine>(...logLineGroups: T[][]): T[] {
+  return uniqBy(logLineGroups.flat().reverse(), logLine => logLine.logId ?? Symbol()).reverse();
+}
+
+export function groupLogLinesIntoSteps(logLines: WorkflowRawLogLine[]): WorkflowLogs {
+  const logs: WorkflowLogs = new Map();
+
+  for (const logLine of logLines) {
+    const { buildStepDisplayName, buildStepId, phase, time, msg, result, marker, err } = logLine;
+    const stepKey = buildStepId ?? buildStepDisplayName ?? phase;
+    const stepLabel = buildStepDisplayName ?? buildStepId ?? phase;
+    if (!stepKey || !stepLabel) {
+      continue;
+    }
+
+    let logGroup = logs.get(stepKey);
+    if (!logGroup) {
+      logGroup = { key: stepKey, label: stepLabel, logLines: [] };
+      logs.set(stepKey, logGroup);
+    }
+    if (buildStepDisplayName) {
+      logGroup.label = buildStepDisplayName;
+    }
+    logGroup.logLines.push({ time, msg, result, marker, err });
+  }
+
+  return logs;
+}
+
+export async function fetchAndParseLogsFromJobAsync(
+  state: { graphqlClient: ExpoGraphqlClient },
+  job: WorkflowJobResult
+): Promise<WorkflowRawLogLine[] | null> {
+  let rawLogs: string | null;
+  switch (job.type) {
+    case WorkflowJobType.Build:
+    case WorkflowJobType.Repack:
+      rawLogs = await fetchRawLogsForBuildJobAsync(state, job);
+      break;
+    default:
+      rawLogs = await fetchRawLogsForCustomJobAsync(job);
+      break;
+  }
+  if (!rawLogs) {
+    return null;
+  }
+  Log.debug(`rawLogs = ${JSON.stringify(rawLogs, null, 2)}`);
+  const { logLines, errors } = parseLogLines(rawLogs);
+  for (const error of errors) {
+    Log.debug(`Failed to parse a log line: ${error.message}`);
+  }
+  return logLines;
+}
+
+export async function fetchAndProcessLogsFromJobAsync(
+  state: { graphqlClient: ExpoGraphqlClient },
+  job: WorkflowJobResult
+): Promise<WorkflowLogs | null> {
+  const logLines = await fetchAndParseLogsFromJobAsync(state, job);
+  return logLines && groupLogLinesIntoSteps(logLines);
+}

--- a/packages/eas-cli/src/commandUtils/workflow/logs/parseLogs.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/parseLogs.ts
@@ -1,6 +1,5 @@
-import { fetchRawLogsForBuildJobAsync, fetchRawLogsForCustomJobAsync } from './fetchLogs';
+import { fetchRawLogsForJobAsync } from './fetchLogs';
 import { WorkflowJobResult, WorkflowLogs, WorkflowRawLogLine } from '../types';
-import { WorkflowJobType } from '../../../graphql/generated';
 import Log from '../../../log';
 import uniqBy from '../../../utils/expodash/uniqBy';
 import { ExpoGraphqlClient } from '../../context/contextUtils/createGraphqlClient';
@@ -59,16 +58,7 @@ export async function fetchAndParseLogsFromJobAsync(
   state: { graphqlClient: ExpoGraphqlClient },
   job: WorkflowJobResult
 ): Promise<WorkflowRawLogLine[] | null> {
-  let rawLogs: string | null;
-  switch (job.type) {
-    case WorkflowJobType.Build:
-    case WorkflowJobType.Repack:
-      rawLogs = await fetchRawLogsForBuildJobAsync(state, job);
-      break;
-    default:
-      rawLogs = await fetchRawLogsForCustomJobAsync(job);
-      break;
-  }
+  const rawLogs = await fetchRawLogsForJobAsync(state, job);
   if (!rawLogs) {
     return null;
   }

--- a/packages/eas-cli/src/commandUtils/workflow/logs/parseLogs.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/parseLogs.ts
@@ -29,9 +29,10 @@ export function mergeLogLines<T extends WorkflowRawLogLine>(...logLineGroups: T[
   return uniqBy(logLineGroups.flat().reverse(), logLine => logLine.logId ?? Symbol()).reverse();
 }
 
-export function groupLogLinesIntoSteps(logLines: WorkflowRawLogLine[]): WorkflowLogs {
-  const logs: WorkflowLogs = new Map();
-
+export function groupLogLinesIntoSteps(
+  logLines: WorkflowRawLogLine[],
+  accumulator: WorkflowLogs = new Map()
+): WorkflowLogs {
   for (const logLine of logLines) {
     const { buildStepDisplayName, buildStepId, phase, time, msg, result, marker, err } = logLine;
     const stepKey = buildStepId ?? buildStepDisplayName ?? phase;
@@ -40,18 +41,21 @@ export function groupLogLinesIntoSteps(logLines: WorkflowRawLogLine[]): Workflow
       continue;
     }
 
-    let logGroup = logs.get(stepKey);
+    let logGroup = accumulator.get(stepKey);
     if (!logGroup) {
       logGroup = { key: stepKey, label: stepLabel, logLines: [] };
-      logs.set(stepKey, logGroup);
+      accumulator.set(stepKey, logGroup);
     }
     if (buildStepDisplayName) {
       logGroup.label = buildStepDisplayName;
     }
+    if (logGroup.result === undefined && (marker === 'end-step' || marker === 'END_PHASE')) {
+      logGroup.result = result ?? '';
+    }
     logGroup.logLines.push({ time, msg, result, marker, err });
   }
 
-  return logs;
+  return accumulator;
 }
 
 export async function fetchAndParseLogsFromJobAsync(

--- a/packages/eas-cli/src/commandUtils/workflow/logs/watcher.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/watcher.ts
@@ -1,0 +1,187 @@
+import { fetchAndParseLogsFromJobAsync, groupLogLinesIntoSteps, mergeLogLines } from './parseLogs';
+import { WorkflowJobResult, WorkflowLogs, WorkflowRawLogLine } from '../types';
+import {
+  RealtimeLogsTargetInput,
+  RealtimeLogsTargetType,
+  WorkflowJobStatus,
+} from '../../../graphql/generated';
+import Log from '../../../log';
+import { RealtimeLogsClient, RealtimeLogsSubscription } from '../../../utils/centrifuge';
+import { ExpoGraphqlClient } from '../../context/contextUtils/createGraphqlClient';
+import nullthrows from 'nullthrows';
+
+type RealtimeLogLine = WorkflowRawLogLine & { logId: string };
+
+function isRealtimeLogLine(entry: unknown): entry is RealtimeLogLine {
+  return (
+    typeof entry === 'object' &&
+    entry !== null &&
+    typeof (entry as Partial<WorkflowRawLogLine>).logId === 'string'
+  );
+}
+
+export class WorkflowJobLogsState {
+  private fileLogLines: WorkflowRawLogLine[] = [];
+  private fileLogIds = new Set<string>();
+  private realtimeLogLines: RealtimeLogLine[] = [];
+  private haveFileLogsCaughtUp = false;
+  private cachedLogs: WorkflowLogs | null = null;
+  private cachedLogsIsCompleted = false;
+
+  public ingestFileLogLines(logLines: WorkflowRawLogLine[]): void {
+    this.fileLogLines = logLines;
+    this.fileLogIds = new Set(logLines.flatMap(logLine => (logLine.logId ? [logLine.logId] : [])));
+
+    if (
+      !this.haveFileLogsCaughtUp &&
+      this.realtimeLogLines.some(logLine => this.fileLogIds.has(logLine.logId))
+    ) {
+      this.haveFileLogsCaughtUp = true;
+    }
+    this.realtimeLogLines = this.realtimeLogLines.filter(
+      logLine => !this.fileLogIds.has(logLine.logId)
+    );
+    this.cachedLogs = null;
+  }
+
+  public ingestRealtimeLogLines(data: unknown): boolean {
+    if (!Array.isArray(data)) {
+      return false;
+    }
+    const publishedLogLines = data.filter(isRealtimeLogLine);
+    if (publishedLogLines.length === 0) {
+      return false;
+    }
+
+    if (
+      !this.haveFileLogsCaughtUp &&
+      publishedLogLines.some(logLine => this.fileLogIds.has(logLine.logId))
+    ) {
+      this.haveFileLogsCaughtUp = true;
+    }
+    this.realtimeLogLines = mergeLogLines(
+      this.realtimeLogLines,
+      publishedLogLines.filter(logLine => !this.fileLogIds.has(logLine.logId))
+    );
+    this.cachedLogs = null;
+
+    return true;
+  }
+
+  public getLogs({ isCompleted = false }: { isCompleted?: boolean } = {}): WorkflowLogs {
+    if (this.cachedLogs && this.cachedLogsIsCompleted === isCompleted) {
+      return this.cachedLogs;
+    }
+    const realtimeLogLines = this.haveFileLogsCaughtUp || isCompleted ? this.realtimeLogLines : [];
+    this.cachedLogs = groupLogLinesIntoSteps(mergeLogLines(this.fileLogLines, realtimeLogLines));
+    this.cachedLogsIsCompleted = isCompleted;
+    return this.cachedLogs;
+  }
+}
+
+type TrackedJob = {
+  logsState: WorkflowJobLogsState;
+  subscription: RealtimeLogsSubscription | null;
+};
+
+export function realtimeLogsTargetForJob(job: WorkflowJobResult): RealtimeLogsTargetInput | null {
+  if (job.turtleJobRun?.id) {
+    return { type: RealtimeLogsTargetType.JobRun, id: job.turtleJobRun.id };
+  }
+  const buildId = job.turtleBuild?.id ?? job.outputs?.build_id;
+  if (buildId) {
+    return { type: RealtimeLogsTargetType.Build, id: buildId };
+  }
+  return null;
+}
+
+export class WorkflowRunLogsWatcher {
+  private readonly trackedJobs = new Map<string, TrackedJob>();
+  private realtimeLogsClient?: RealtimeLogsClient | null;
+
+  constructor(
+    private readonly graphqlClient: ExpoGraphqlClient,
+    private readonly createRealtimeLogsClient: () => RealtimeLogsClient | null,
+    private readonly onRealtimeLogs: () => void
+  ) {}
+
+  public async syncJobsAsync(
+    jobs: WorkflowJobResult[]
+  ): Promise<Map<string, WorkflowJobLogsState>> {
+    await Promise.all(jobs.map(job => this.syncJobAsync(job)));
+    return new Map(
+      jobs.map(job => [
+        job.id,
+        nullthrows(
+          this.trackedJobs.get(job.id),
+          'job has to be in tracked jobs after it was synced'
+        ).logsState,
+      ])
+    );
+  }
+
+  public close(): void {
+    for (const trackedJob of this.trackedJobs.values()) {
+      trackedJob.subscription?.close();
+      trackedJob.subscription = null;
+    }
+    this.realtimeLogsClient?.close();
+  }
+
+  private async syncJobAsync(job: WorkflowJobResult): Promise<void> {
+    let trackedJob = this.trackedJobs.get(job.id);
+    if (!trackedJob) {
+      trackedJob = { logsState: new WorkflowJobLogsState(), subscription: null };
+      this.trackedJobs.set(job.id, trackedJob);
+    }
+
+    const workflowInProgress = job.status === WorkflowJobStatus.InProgress;
+    if (!workflowInProgress) {
+      trackedJob.subscription?.close();
+      trackedJob.subscription = null;
+      return;
+    }
+
+    await Promise.all([
+      trackedJob.subscription ? Promise.resolve() : this.subscribeAsync(job, trackedJob),
+      this.fetchLogsAsync(job, trackedJob),
+    ]);
+  }
+
+  private async fetchLogsAsync(job: WorkflowJobResult, trackedJob: TrackedJob): Promise<void> {
+    try {
+      const logLines = await fetchAndParseLogsFromJobAsync(
+        { graphqlClient: this.graphqlClient },
+        job
+      );
+      if (logLines) {
+        trackedJob.logsState.ingestFileLogLines(logLines);
+      }
+    } catch (err: any) {
+      Log.debug(`Failed to fetch logs for job ${job.id}: ${err.message}`);
+    }
+  }
+
+  private getRealtimeLogsClient(): RealtimeLogsClient | null {
+    if (this.realtimeLogsClient === undefined) {
+      this.realtimeLogsClient = this.createRealtimeLogsClient();
+    }
+    return this.realtimeLogsClient;
+  }
+
+  private async subscribeAsync(job: WorkflowJobResult, trackedJob: TrackedJob): Promise<void> {
+    const target = realtimeLogsTargetForJob(job);
+    if (!target) {
+      return;
+    }
+    const realtimeLogsClient = this.getRealtimeLogsClient();
+    if (!realtimeLogsClient) {
+      return;
+    }
+    trackedJob.subscription = await realtimeLogsClient.subscribeAsync({ target }, data => {
+      if (trackedJob.logsState.ingestRealtimeLogLines(data)) {
+        this.onRealtimeLogs();
+      }
+    });
+  }
+}

--- a/packages/eas-cli/src/commandUtils/workflow/logs/watcher.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/watcher.ts
@@ -21,15 +21,14 @@ function isRealtimeLogLine(entry: unknown): entry is RealtimeLogLine {
 }
 
 export class WorkflowJobLogsState {
-  private fileLogLines: WorkflowRawLogLine[] = [];
   private fileLogIds = new Set<string>();
   private realtimeLogLines: RealtimeLogLine[] = [];
+  private realtimeLogIds = new Set<string>();
   private haveFileLogsCaughtUp = false;
-  private cachedLogs: WorkflowLogs | null = null;
-  private cachedLogsIsCompleted = false;
+  private realtimeLogsRevealed = false;
+  private groupedLogs: WorkflowLogs = new Map();
 
   public ingestFileLogLines(logLines: WorkflowRawLogLine[]): void {
-    this.fileLogLines = logLines;
     this.fileLogIds = new Set(logLines.flatMap(logLine => (logLine.logId ? [logLine.logId] : [])));
 
     if (
@@ -41,7 +40,14 @@ export class WorkflowJobLogsState {
     this.realtimeLogLines = this.realtimeLogLines.filter(
       logLine => !this.fileLogIds.has(logLine.logId)
     );
-    this.cachedLogs = null;
+    this.realtimeLogIds = new Set(this.realtimeLogLines.map(logLine => logLine.logId));
+
+    if (this.haveFileLogsCaughtUp) {
+      this.realtimeLogsRevealed = true;
+    }
+    this.groupedLogs = groupLogLinesIntoSteps(
+      mergeLogLines(logLines, this.realtimeLogsRevealed ? this.realtimeLogLines : [])
+    );
   }
 
   public ingestRealtimeLogLines(data: unknown): boolean {
@@ -59,23 +65,40 @@ export class WorkflowJobLogsState {
     ) {
       this.haveFileLogsCaughtUp = true;
     }
-    this.realtimeLogLines = mergeLogLines(
-      this.realtimeLogLines,
-      publishedLogLines.filter(logLine => !this.fileLogIds.has(logLine.logId))
+
+    const newLogLines = publishedLogLines.filter(
+      logLine => !this.fileLogIds.has(logLine.logId) && !this.realtimeLogIds.has(logLine.logId)
     );
-    this.cachedLogs = null;
+    for (const logLine of newLogLines) {
+      this.realtimeLogLines.push(logLine);
+      this.realtimeLogIds.add(logLine.logId);
+    }
+
+    if (!this.realtimeLogsRevealed) {
+      if (this.haveFileLogsCaughtUp) {
+        this.revealRealtimeLogs();
+      }
+    } else if (newLogLines.length > 0) {
+      groupLogLinesIntoSteps(newLogLines, this.groupedLogs);
+    }
 
     return true;
   }
 
-  public getLogs({ isCompleted = false }: { isCompleted?: boolean } = {}): WorkflowLogs {
-    if (this.cachedLogs && this.cachedLogsIsCompleted === isCompleted) {
-      return this.cachedLogs;
+  public markCompleted(): void {
+    this.revealRealtimeLogs();
+  }
+
+  public getLogs(): WorkflowLogs {
+    return this.groupedLogs;
+  }
+
+  private revealRealtimeLogs(): void {
+    if (this.realtimeLogsRevealed) {
+      return;
     }
-    const realtimeLogLines = this.haveFileLogsCaughtUp || isCompleted ? this.realtimeLogLines : [];
-    this.cachedLogs = groupLogLinesIntoSteps(mergeLogLines(this.fileLogLines, realtimeLogLines));
-    this.cachedLogsIsCompleted = isCompleted;
-    return this.cachedLogs;
+    this.realtimeLogsRevealed = true;
+    groupLogLinesIntoSteps(this.realtimeLogLines, this.groupedLogs);
   }
 }
 

--- a/packages/eas-cli/src/commandUtils/workflow/stateMachine.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/stateMachine.ts
@@ -1,11 +1,11 @@
 import { Choice } from 'prompts';
 
 import { WorkflowJobResult, WorkflowLogs } from './types';
+import { fetchAndProcessLogsFromJobAsync } from './logs/parseLogs';
 import {
   choiceFromWorkflowJob,
   choiceFromWorkflowRun,
   choicesFromWorkflowLogs,
-  fetchAndProcessLogsFromJobAsync,
   processWorkflowRuns,
 } from './utils';
 import { AppQuery } from '../../graphql/queries/AppQuery';

--- a/packages/eas-cli/src/commandUtils/workflow/types.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/types.ts
@@ -48,16 +48,14 @@ export type WorkflowRawLogLine = {
   buildStepDisplayName?: string;
   phase?: string;
   time?: string;
-  msg: string;
+  msg?: string;
   result?: string;
   marker?: string;
   err?: any;
 };
 
-export type WorkflowLogLine = Pick<
-  WorkflowRawLogLine,
-  'time' | 'msg' | 'result' | 'marker' | 'err'
->;
+export type WorkflowLogLine = Pick<WorkflowRawLogLine, 'time' | 'result' | 'marker' | 'err'> &
+  Required<Pick<WorkflowRawLogLine, 'msg'>>;
 
 export type WorkflowLogs = Map<
   string,

--- a/packages/eas-cli/src/commandUtils/workflow/types.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/types.ts
@@ -57,11 +57,11 @@ export type WorkflowRawLogLine = {
 export type WorkflowLogLine = Pick<WorkflowRawLogLine, 'time' | 'result' | 'marker' | 'err'> &
   Required<Pick<WorkflowRawLogLine, 'msg'>>;
 
-export type WorkflowLogs = Map<
-  string,
-  {
-    key: string;
-    label: string;
-    logLines: WorkflowLogLine[];
-  }
->;
+export type StepLogs = {
+  key: string;
+  label: string;
+  result?: string;
+  logLines: WorkflowLogLine[];
+};
+
+export type WorkflowLogs = Map<string, StepLogs>;

--- a/packages/eas-cli/src/commandUtils/workflow/types.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/types.ts
@@ -42,13 +42,22 @@ export type WorkflowRunWithJobsResult = WorkflowRunResult & {
   logs?: string;
 };
 
-export type WorkflowLogLine = {
-  time: string;
+export type WorkflowRawLogLine = {
+  logId?: string;
+  buildStepId?: string;
+  buildStepDisplayName?: string;
+  phase?: string;
+  time?: string;
   msg: string;
   result?: string;
   marker?: string;
   err?: any;
 };
+
+export type WorkflowLogLine = Pick<
+  WorkflowRawLogLine,
+  'time' | 'msg' | 'result' | 'marker' | 'err'
+>;
 
 export type WorkflowLogs = Map<
   string,

--- a/packages/eas-cli/src/commandUtils/workflow/utils.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/utils.ts
@@ -20,7 +20,7 @@ import {
 import { WorkflowRunLogsWatcher } from './logs/watcher';
 import { WorkflowRunQuery } from '../../graphql/queries/WorkflowRunQuery';
 import Log from '../../log';
-import { ora } from '../../ora';
+import { ora, updateSpinnerText } from '../../ora';
 import { Choice } from '../../prompts';
 import formatFields from '../../utils/formatFields';
 import { createRealtimeLogsClient } from '../../utils/centrifuge';
@@ -276,7 +276,9 @@ export async function showWorkflowStatusAsync(
     stream: spinnerUsesStdErr ? process.stderr : process.stdout,
     text: '',
   }).start();
-  spinner.prefixText = chalk`{bold.yellow Workflow run is waiting to start:}`;
+  updateSpinnerText(spinner, {
+    prefixText: chalk`{bold.yellow Workflow run is waiting to start:}`,
+  });
 
   const watcher = new WorkflowRunLogsWatcher(
     graphqlClient,
@@ -301,10 +303,12 @@ export async function showWorkflowStatusAsync(
           case WorkflowRunStatus.New:
             break;
           case WorkflowRunStatus.InProgress: {
-            spinner.prefixText = chalk`{bold.green Workflow run is in progress:}`;
+            updateSpinnerText(spinner, {
+              prefixText: chalk`{bold.green Workflow run is in progress:}`,
+            });
             const logsStates = await watcher.syncJobsAsync(workflowRun.jobs);
             renderActiveWorkflowRun = () => {
-              spinner.text = formatActiveWorkflowRun(
+              const text = formatActiveWorkflowRun(
                 workflowRun.jobs.map(job => ({
                   job,
                   logs: nullthrows(
@@ -316,28 +320,36 @@ export async function showWorkflowStatusAsync(
                 })),
                 5
               );
+              updateSpinnerText(spinner, { text });
             };
             renderActiveWorkflowRun();
             break;
           }
           case WorkflowRunStatus.ActionRequired:
-            spinner.prefixText = chalk`{bold.yellow Workflow run is waiting for action:}`;
+            updateSpinnerText(spinner, {
+              prefixText: chalk`{bold.yellow Workflow run is waiting for action:}`,
+            });
             break;
 
           case WorkflowRunStatus.Canceled:
-            spinner.prefixText = chalk`{bold.yellow Workflow has been canceled.}`;
+            updateSpinnerText(spinner, {
+              prefixText: chalk`{bold.yellow Workflow has been canceled.}`,
+            });
             spinner.stopAndPersist();
             return workflowRun;
 
           case WorkflowRunStatus.Failure: {
-            spinner.prefixText = chalk`{bold.red Workflow has failed.}`;
+            updateSpinnerText(spinner, {
+              prefixText: chalk`{bold.red Workflow has failed.}`,
+            });
             const jobLogs = await logsForFailedWorkflowRunAsync(graphqlClient, workflowRun);
             spinner.fail(formatFailedWorkflowRun(jobLogs, 30));
             return workflowRun;
           }
           case WorkflowRunStatus.Success:
-            spinner.prefixText = chalk`{bold.green Workflow has completed successfully.}`;
-            spinner.text = '';
+            updateSpinnerText(spinner, {
+              prefixText: chalk`{bold.green Workflow has completed successfully.}`,
+            });
             spinner.succeed('');
             return workflowRun;
         }
@@ -348,7 +360,9 @@ export async function showWorkflowStatusAsync(
           return workflowRun;
         }
       } catch {
-        spinner.text = '⚠ Failed to fetch the workflow run status. Check your network connection.';
+        updateSpinnerText(spinner, {
+          text: '⚠ Failed to fetch the workflow run status. Check your network connection.',
+        });
 
         failedFetchesCount += 1;
 

--- a/packages/eas-cli/src/commandUtils/workflow/utils.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/utils.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import * as fs from 'node:fs';
 
-import { fetchRawLogsForBuildJobAsync, fetchRawLogsForCustomJobAsync } from './fetchLogs';
+import { fetchAndProcessLogsFromJobAsync } from './logs/parseLogs';
 import {
   WorkflowJobResult,
   WorkflowLogLine,
@@ -11,20 +11,22 @@ import {
 } from './types';
 import {
   WorkflowJobStatus,
-  WorkflowJobType,
   WorkflowRunByIdQuery,
   WorkflowRunByIdWithJobsQuery,
   WorkflowRunFragment,
   WorkflowRunStatus,
   WorkflowRunTriggerEventType,
 } from '../../graphql/generated';
+import { WorkflowRunLogsWatcher } from './logs/watcher';
 import { WorkflowRunQuery } from '../../graphql/queries/WorkflowRunQuery';
 import Log from '../../log';
 import { ora } from '../../ora';
 import { Choice } from '../../prompts';
 import formatFields from '../../utils/formatFields';
+import { createRealtimeLogsClient } from '../../utils/centrifuge';
 import { sleepAsync } from '../../utils/promise';
 import { ExpoGraphqlClient } from '../context/contextUtils/createGraphqlClient';
+import nullthrows from 'nullthrows';
 
 export function computeTriggerInfoForWorkflowRun(run: WorkflowRunFragment): {
   triggerType: WorkflowTriggerType;
@@ -121,52 +123,6 @@ export function processWorkflowRuns(runs: WorkflowRunFragment[]): WorkflowRunRes
   });
 }
 
-export async function fetchAndProcessLogsFromJobAsync(
-  state: { graphqlClient: ExpoGraphqlClient },
-  job: WorkflowJobResult
-): Promise<WorkflowLogs | null> {
-  let rawLogs: string | null;
-  switch (job.type) {
-    case WorkflowJobType.Build:
-    case WorkflowJobType.Repack:
-      rawLogs = await fetchRawLogsForBuildJobAsync(state, job);
-      break;
-    default:
-      rawLogs = await fetchRawLogsForCustomJobAsync(job);
-      break;
-  }
-  if (!rawLogs) {
-    return null;
-  }
-  Log.debug(`rawLogs = ${JSON.stringify(rawLogs, null, 2)}`);
-  const logs: WorkflowLogs = new Map();
-  rawLogs.split('\n').forEach((line, index) => {
-    Log.debug(`line ${index} = ${JSON.stringify(line, null, 2)}`);
-    try {
-      const parsedLine = JSON.parse(line);
-      const { buildStepDisplayName, buildStepId, phase, time, msg, result, marker, err } =
-        parsedLine;
-      const stepKey = buildStepId ?? buildStepDisplayName ?? phase;
-      const stepLabel = buildStepDisplayName ?? buildStepId ?? phase;
-      if (stepKey && stepLabel) {
-        if (!logs.has(stepKey)) {
-          logs.set(stepKey, {
-            key: stepKey,
-            label: stepLabel,
-            logLines: [],
-          });
-        }
-        const logGroup = logs.get(stepKey)!;
-        if (buildStepDisplayName) {
-          logGroup.label = buildStepDisplayName;
-        }
-        logGroup.logLines.push({ time, msg, result, marker, err });
-      }
-    } catch {}
-  });
-  return logs;
-}
-
 function descriptionForJobStatus(status: WorkflowJobStatus): string {
   switch (status) {
     case WorkflowJobStatus.New:
@@ -188,82 +144,90 @@ function descriptionForJobStatus(status: WorkflowJobStatus): string {
   }
 }
 
-export async function infoForActiveWorkflowRunAsync(
+type WorkflowRunWithJobs = WorkflowRunByIdWithJobsQuery['workflowRuns']['byId'];
+
+type JobWithLogs = {
+  job: WorkflowRunWithJobs['jobs'][number];
+  logs: WorkflowLogs;
+};
+
+function stepLogTail(
+  step: { logLines?: WorkflowLogLine[] },
+  maxLogLines: number // -1 means no limit
+): string[] {
+  const messages = step.logLines?.map(line => line.msg) ?? [];
+  return maxLogLines === -1 ? messages : messages.slice(-maxLogLines);
+}
+
+export async function logsForFailedWorkflowRunAsync(
   graphqlClient: ExpoGraphqlClient,
-  workflowRun: WorkflowRunByIdWithJobsQuery['workflowRuns']['byId'],
+  workflowRun: WorkflowRunWithJobs
+): Promise<JobWithLogs[]> {
+  const jobs = workflowRun.jobs.filter(job => job.status === WorkflowJobStatus.Failure);
+  return await Promise.all(
+    jobs.map(async job => {
+      const maybeLogs = await fetchAndProcessLogsFromJobAsync({ graphqlClient }, job);
+      return { job, logs: maybeLogs ?? new Map() };
+    })
+  );
+}
+
+export function formatActiveWorkflowRun(
+  jobLogs: JobWithLogs[],
   maxLogLines: number = 5 // -1 means no limit
-): Promise<string> {
-  const statusLines = [];
+): string {
   const statusValues = [];
-  for (const job of workflowRun.jobs) {
+
+  for (const { job, logs } of jobLogs) {
     statusValues.push({ label: '', value: '' });
     statusValues.push({ label: '  Job', value: job.name });
     statusValues.push({ label: '  Status', value: descriptionForJobStatus(job.status) });
     if (job.status !== WorkflowJobStatus.InProgress) {
       continue;
     }
-    const logs = await fetchAndProcessLogsFromJobAsync({ graphqlClient }, job);
-    const steps = logs ? choicesFromWorkflowLogs(logs) : [];
-    if (steps.length > 0) {
-      const currentStep = steps[steps.length - 1];
-      statusValues.push({ label: '  Current step', value: currentStep.name });
-      if (currentStep?.logLines?.length) {
-        statusValues.push({ label: '  Current logs', value: '' });
-        const currentLogs =
-          currentStep.logLines
-            ?.map(line => line.msg)
-            .filter((_, index) => {
-              if (maxLogLines === -1) {
-                return true;
-              }
-              return index > (currentStep.logLines?.length ?? 0) - maxLogLines;
-            }) ?? [];
-        for (const log of currentLogs) {
-          statusValues.push({ label: '', value: log });
-        }
-      }
-    }
-  }
-  statusValues.push({ label: '', value: '' });
-  statusLines.push(formatFields(statusValues));
-  return statusLines.join('\n');
-}
-
-export async function infoForFailedWorkflowRunAsync(
-  graphqlClient: ExpoGraphqlClient,
-  workflowRun: WorkflowRunByIdWithJobsQuery['workflowRuns']['byId'],
-  maxLogLines: number = -1 // -1 means no limit
-): Promise<string> {
-  const statusLines = [];
-  const statusValues = [];
-  const logLinesToKeep = maxLogLines === -1 ? Infinity : maxLogLines;
-  for (const job of workflowRun.jobs) {
-    if (job.status !== WorkflowJobStatus.Failure) {
+    const steps = choicesFromWorkflowLogs(logs);
+    if (steps.length === 0) {
       continue;
     }
-    const logs = await fetchAndProcessLogsFromJobAsync({ graphqlClient }, job);
-    const steps = logs ? choicesFromWorkflowLogs(logs) : [];
-    statusValues.push({ label: '', value: '' });
-    statusValues.push({ label: '  Failed job', value: job.name });
-    if (steps.length > 0) {
-      const failedStep = steps.find(step => step.status === 'fail' || step.status === 'failed');
-      if (failedStep) {
-        const logs = failedStep.logLines?.map(line => line.msg).slice(-logLinesToKeep) ?? [];
-        statusValues.push({ label: '  Failed step', value: failedStep.name });
-        statusValues.push({
-          label: '  Logs for failed step',
-          value: '',
-        });
-        for (const log of logs) {
-          statusValues.push({ label: '', value: log });
-        }
+    const currentStep = steps[steps.length - 1];
+    statusValues.push({ label: '  Current step', value: currentStep.name });
+    if (currentStep.logLines?.length) {
+      statusValues.push({ label: '  Current logs', value: '' });
+      for (const log of stepLogTail(currentStep, maxLogLines)) {
+        statusValues.push({ label: '', value: log });
       }
     }
   }
+
   statusValues.push({ label: '', value: '' });
-  statusLines.push(formatFields(statusValues));
-  return statusLines.join('\n');
+  return formatFields(statusValues);
 }
+
+export function formatFailedWorkflowRun(
+  jobLogs: JobWithLogs[],
+  maxLogLines: number = -1 // -1 means no limit
+): string {
+  const statusValues = [];
+
+  for (const { job, logs } of jobLogs) {
+    statusValues.push({ label: '', value: '' });
+    statusValues.push({ label: '  Failed job', value: job.name });
+    const steps = choicesFromWorkflowLogs(logs);
+    const failedStep = steps.find(step => step.status === 'fail' || step.status === 'failed');
+    if (!failedStep) {
+      continue;
+    }
+    statusValues.push({ label: '  Failed step', value: failedStep.name });
+    statusValues.push({ label: '  Logs for failed step', value: '' });
+    for (const log of stepLogTail(failedStep, maxLogLines)) {
+      statusValues.push({ label: '', value: log });
+    }
+  }
+
+  statusValues.push({ label: '', value: '' });
+  return formatFields(statusValues);
+}
+
 export async function fileExistsAsync(filePath: string): Promise<boolean> {
   return await fs.promises
     .access(filePath, fs.constants.F_OK)
@@ -314,63 +278,90 @@ export async function showWorkflowStatusAsync(
   }).start();
   spinner.prefixText = chalk`{bold.yellow Workflow run is waiting to start:}`;
 
-  let failedFetchesCount = 0;
-
-  while (true) {
-    try {
-      const workflowRun = await WorkflowRunQuery.withJobsByIdAsync(graphqlClient, workflowRunId, {
-        useCache: false,
-      });
-
-      failedFetchesCount = 0;
-
-      switch (workflowRun.status) {
-        case WorkflowRunStatus.New:
-          break;
-        case WorkflowRunStatus.InProgress: {
-          spinner.prefixText = chalk`{bold.green Workflow run is in progress:}`;
-          spinner.text = await infoForActiveWorkflowRunAsync(graphqlClient, workflowRun, 5);
-          break;
-        }
-        case WorkflowRunStatus.ActionRequired:
-          spinner.prefixText = chalk`{bold.yellow Workflow run is waiting for action:}`;
-          break;
-
-        case WorkflowRunStatus.Canceled:
-          spinner.prefixText = chalk`{bold.yellow Workflow has been canceled.}`;
-          spinner.stopAndPersist();
-          return workflowRun;
-
-        case WorkflowRunStatus.Failure: {
-          spinner.prefixText = chalk`{bold.red Workflow has failed.}`;
-          const failedInfo = await infoForFailedWorkflowRunAsync(graphqlClient, workflowRun, 30);
-          spinner.fail(failedInfo);
-          return workflowRun;
-        }
-        case WorkflowRunStatus.Success:
-          spinner.prefixText = chalk`{bold.green Workflow has completed successfully.}`;
-          spinner.text = '';
-          spinner.succeed('');
-          return workflowRun;
-      }
-      if (!waitForCompletion) {
-        if (spinner.isSpinning) {
-          spinner.stopAndPersist();
-        }
-        return workflowRun;
-      }
-    } catch {
-      spinner.text = '⚠ Failed to fetch the workflow run status. Check your network connection.';
-
-      failedFetchesCount += 1;
-
-      if (failedFetchesCount > 6) {
-        spinner.fail('Failed to fetch the workflow run status 6 times in a row. Aborting wait.');
-        process.exit(workflowRunExitCodes.WAIT_ABORTED);
-      }
+  const watcher = new WorkflowRunLogsWatcher(
+    graphqlClient,
+    () => createRealtimeLogsClient(graphqlClient),
+    () => {
+      renderActiveWorkflowRun();
     }
+  );
+  let failedFetchesCount = 0;
+  let renderActiveWorkflowRun = (): void => {};
 
-    await sleepAsync(10 /* seconds */ * 1000 /* milliseconds */);
+  try {
+    while (true) {
+      try {
+        const workflowRun = await WorkflowRunQuery.withJobsByIdAsync(graphqlClient, workflowRunId, {
+          useCache: false,
+        });
+
+        failedFetchesCount = 0;
+
+        switch (workflowRun.status) {
+          case WorkflowRunStatus.New:
+            break;
+          case WorkflowRunStatus.InProgress: {
+            spinner.prefixText = chalk`{bold.green Workflow run is in progress:}`;
+            const logsStates = await watcher.syncJobsAsync(workflowRun.jobs);
+            renderActiveWorkflowRun = () => {
+              spinner.text = formatActiveWorkflowRun(
+                workflowRun.jobs.map(job => ({
+                  job,
+                  logs: nullthrows(
+                    logsStates.get(job.id),
+                    'syncJobsAsync must have been called before getLogs'
+                  ).getLogs({
+                    isCompleted: job.status !== WorkflowJobStatus.InProgress,
+                  }),
+                })),
+                5
+              );
+            };
+            renderActiveWorkflowRun();
+            break;
+          }
+          case WorkflowRunStatus.ActionRequired:
+            spinner.prefixText = chalk`{bold.yellow Workflow run is waiting for action:}`;
+            break;
+
+          case WorkflowRunStatus.Canceled:
+            spinner.prefixText = chalk`{bold.yellow Workflow has been canceled.}`;
+            spinner.stopAndPersist();
+            return workflowRun;
+
+          case WorkflowRunStatus.Failure: {
+            spinner.prefixText = chalk`{bold.red Workflow has failed.}`;
+            const jobLogs = await logsForFailedWorkflowRunAsync(graphqlClient, workflowRun);
+            spinner.fail(formatFailedWorkflowRun(jobLogs, 30));
+            return workflowRun;
+          }
+          case WorkflowRunStatus.Success:
+            spinner.prefixText = chalk`{bold.green Workflow has completed successfully.}`;
+            spinner.text = '';
+            spinner.succeed('');
+            return workflowRun;
+        }
+        if (!waitForCompletion) {
+          if (spinner.isSpinning) {
+            spinner.stopAndPersist();
+          }
+          return workflowRun;
+        }
+      } catch {
+        spinner.text = '⚠ Failed to fetch the workflow run status. Check your network connection.';
+
+        failedFetchesCount += 1;
+
+        if (failedFetchesCount > 6) {
+          spinner.fail('Failed to fetch the workflow run status 6 times in a row. Aborting wait.');
+          process.exit(workflowRunExitCodes.WAIT_ABORTED);
+        }
+      }
+
+      await sleepAsync(10 /* seconds */ * 1000 /* milliseconds */);
+    }
+  } finally {
+    watcher.close();
   }
 }
 

--- a/packages/eas-cli/src/commandUtils/workflow/utils.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/utils.ts
@@ -87,19 +87,13 @@ export function choicesFromWorkflowLogs(
   logs: WorkflowLogs
 ): (Choice & { name: string; status: string; logLines: WorkflowLogLine[] | undefined })[] {
   return Array.from(logs.values())
-    .map(({ key, label, logLines }) => {
-      const stepStatus =
-        logLines?.filter(
-          (line: WorkflowLogLine) => line.marker === 'end-step' || line.marker === 'END_PHASE'
-        )[0]?.result ?? '';
-      return {
-        title: `${label} - ${stepStatus}`,
-        name: label,
-        status: stepStatus,
-        value: key,
-        logLines,
-      };
-    })
+    .map(({ key, label, result, logLines }) => ({
+      title: `${label} - ${result ?? ''}`,
+      name: label,
+      status: result ?? '',
+      value: key,
+      logLines,
+    }))
     .filter(step => step.status !== 'skipped');
 }
 
@@ -144,6 +138,21 @@ function descriptionForJobStatus(status: WorkflowJobStatus): string {
   }
 }
 
+function isJobCompleted(status: WorkflowJobStatus): boolean {
+  switch (status) {
+    case WorkflowJobStatus.Success:
+    case WorkflowJobStatus.Failure:
+    case WorkflowJobStatus.Canceled:
+    case WorkflowJobStatus.Skipped:
+      return true;
+    case WorkflowJobStatus.New:
+    case WorkflowJobStatus.InProgress:
+    case WorkflowJobStatus.ActionRequired:
+    case WorkflowJobStatus.PendingCancel:
+      return false;
+  }
+}
+
 type WorkflowRunWithJobs = WorkflowRunByIdWithJobsQuery['workflowRuns']['byId'];
 
 type JobWithLogs = {
@@ -155,8 +164,9 @@ function stepLogTail(
   step: { logLines?: WorkflowLogLine[] },
   maxLogLines: number // -1 means no limit
 ): string[] {
-  const messages = step.logLines?.map(line => line.msg) ?? [];
-  return maxLogLines === -1 ? messages : messages.slice(-maxLogLines);
+  const logLines = step.logLines ?? [];
+  const tail = maxLogLines === -1 ? logLines : logLines.slice(-maxLogLines);
+  return tail.map(line => line.msg);
 }
 
 export async function logsForFailedWorkflowRunAsync(
@@ -307,6 +317,14 @@ export async function showWorkflowStatusAsync(
               prefixText: chalk`{bold.green Workflow run is in progress:}`,
             });
             const logsStates = await watcher.syncJobsAsync(workflowRun.jobs);
+            for (const job of workflowRun.jobs) {
+              if (isJobCompleted(job.status)) {
+                nullthrows(
+                  logsStates.get(job.id),
+                  'syncJobsAsync must have been called before markCompleted'
+                ).markCompleted();
+              }
+            }
             renderActiveWorkflowRun = () => {
               const text = formatActiveWorkflowRun(
                 workflowRun.jobs.map(job => ({
@@ -314,11 +332,8 @@ export async function showWorkflowStatusAsync(
                   logs: nullthrows(
                     logsStates.get(job.id),
                     'syncJobsAsync must have been called before getLogs'
-                  ).getLogs({
-                    isCompleted: job.status !== WorkflowJobStatus.InProgress,
-                  }),
-                })),
-                5
+                  ).getLogs(),
+                }))
               );
               updateSpinnerText(spinner, { text });
             };

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -14706,6 +14706,19 @@ export type SetRolloutPercentageMutation = { __typename?: 'RootMutation', update
         | { __typename: 'User', username: string, id: string }
        | null, branch: { __typename?: 'UpdateBranch', id: string, name: string }, codeSigningInfo?: { __typename?: 'CodeSigningInfo', keyid: string, sig: string, alg: string } | null, rolloutControlUpdate?: { __typename?: 'Update', id: string, group: string } | null, fingerprint?: { __typename?: 'Fingerprint', id: string, hash: string, debugInfoUrl?: string | null, source?: { __typename?: 'FingerprintSource', type: FingerprintSourceType, bucketKey: string, isDebugFingerprint?: boolean | null } | null } | null } } };
 
+export type GenerateRealtimeLogsCentrifugoConnectionTokenMutationVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GenerateRealtimeLogsCentrifugoConnectionTokenMutation = { __typename?: 'RootMutation', realtimeLogs: { __typename?: 'RealtimeLogsMutation', generateCentrifugoConnectionToken: { __typename?: 'RealtimeLogsCentrifugoConnectionToken', token: string } } };
+
+export type GenerateRealtimeLogsCentrifugoSubscriptionTokenMutationVariables = Exact<{
+  target: RealtimeLogsTargetInput;
+  thread?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type GenerateRealtimeLogsCentrifugoSubscriptionTokenMutation = { __typename?: 'RootMutation', realtimeLogs: { __typename?: 'RealtimeLogsMutation', generateCentrifugoSubscriptionToken: { __typename?: 'RealtimeLogsCentrifugoSubscriptionToken', channel: string, token: string } } };
+
 export type CreateAndroidSubmissionMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
   config: AndroidSubmissionConfigInput;

--- a/packages/eas-cli/src/graphql/mutations/RealtimeLogsMutation.ts
+++ b/packages/eas-cli/src/graphql/mutations/RealtimeLogsMutation.ts
@@ -1,0 +1,69 @@
+import gql from 'graphql-tag';
+
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../client';
+import {
+  GenerateRealtimeLogsCentrifugoConnectionTokenMutation,
+  GenerateRealtimeLogsCentrifugoConnectionTokenMutationVariables,
+  GenerateRealtimeLogsCentrifugoSubscriptionTokenMutation,
+  GenerateRealtimeLogsCentrifugoSubscriptionTokenMutationVariables,
+  RealtimeLogsCentrifugoConnectionToken,
+  RealtimeLogsCentrifugoSubscriptionToken,
+  RealtimeLogsMutationGenerateCentrifugoSubscriptionTokenArgs,
+} from '../generated';
+
+export const RealtimeLogsMutation = {
+  async generateCentrifugoConnectionTokenAsync(
+    graphqlClient: ExpoGraphqlClient
+  ): Promise<RealtimeLogsCentrifugoConnectionToken> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<
+          GenerateRealtimeLogsCentrifugoConnectionTokenMutation,
+          GenerateRealtimeLogsCentrifugoConnectionTokenMutationVariables
+        >(
+          gql`
+            mutation GenerateRealtimeLogsCentrifugoConnectionToken {
+              realtimeLogs {
+                generateCentrifugoConnectionToken {
+                  token
+                }
+              }
+            }
+          `,
+          {}
+        )
+        .toPromise()
+    );
+    return data.realtimeLogs.generateCentrifugoConnectionToken;
+  },
+  async generateCentrifugoSubscriptionTokenAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { target, thread }: RealtimeLogsMutationGenerateCentrifugoSubscriptionTokenArgs
+  ): Promise<RealtimeLogsCentrifugoSubscriptionToken> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .mutation<
+          GenerateRealtimeLogsCentrifugoSubscriptionTokenMutation,
+          GenerateRealtimeLogsCentrifugoSubscriptionTokenMutationVariables
+        >(
+          gql`
+            mutation GenerateRealtimeLogsCentrifugoSubscriptionToken(
+              $target: RealtimeLogsTargetInput!
+              $thread: String
+            ) {
+              realtimeLogs {
+                generateCentrifugoSubscriptionToken(target: $target, thread: $thread) {
+                  channel
+                  token
+                }
+              }
+            }
+          `,
+          { target, thread }
+        )
+        .toPromise()
+    );
+    return data.realtimeLogs.generateCentrifugoSubscriptionToken;
+  },
+};

--- a/packages/eas-cli/src/ora.ts
+++ b/packages/eas-cli/src/ora.ts
@@ -110,3 +110,18 @@ export function ora(options?: Options | string): Ora {
 
   return spinner;
 }
+
+/**
+ * Updates the text of a spinner. Does nothing if new text is the same as old text to prevent flickering.
+ */
+export function updateSpinnerText(
+  spinner: Ora,
+  { prefixText, text }: { prefixText?: string; text?: string }
+): void {
+  if (prefixText !== undefined && spinner.prefixText !== prefixText) {
+    spinner.prefixText = prefixText;
+  }
+  if (text !== undefined && spinner.text !== text) {
+    spinner.text = text;
+  }
+}

--- a/packages/eas-cli/src/utils/__tests__/centrifuge-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/centrifuge-test.ts
@@ -1,0 +1,26 @@
+import { Centrifuge } from 'centrifuge';
+
+import { createRealtimeLogsClient } from '../centrifuge';
+
+jest.mock('centrifuge');
+
+describe(createRealtimeLogsClient, () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null instead of throwing when the connection cannot be created', () => {
+    jest.mocked(Centrifuge).mockImplementationOnce(() => {
+      throw new Error('unsupported url scheme');
+    });
+
+    expect(createRealtimeLogsClient({} as any)).toBeNull();
+  });
+
+  it('connects and returns a client when the connection can be created', () => {
+    expect(createRealtimeLogsClient({} as any)).not.toBeNull();
+
+    const centrifuge = jest.mocked(Centrifuge).mock.instances[0];
+    expect(jest.mocked(centrifuge.connect)).toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/utils/centrifuge.ts
+++ b/packages/eas-cli/src/utils/centrifuge.ts
@@ -1,0 +1,115 @@
+import { Centrifuge, Subscription } from 'centrifuge';
+import { Agent } from 'https';
+import WebSocket from 'ws';
+
+import { getEASLogsWebsocketUrl } from '../api';
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import { RealtimeLogsMutationGenerateCentrifugoSubscriptionTokenArgs } from '../graphql/generated';
+import { RealtimeLogsMutation } from '../graphql/mutations/RealtimeLogsMutation';
+import { httpsProxyAgent } from '../fetch';
+import Log from '../log';
+
+export type RealtimeLogsSubscription = {
+  close: () => void;
+};
+
+export type RealtimeLogsClient = {
+  subscribeAsync: (
+    args: RealtimeLogsMutationGenerateCentrifugoSubscriptionTokenArgs,
+    onPublication: (data: unknown) => void
+  ) => Promise<RealtimeLogsSubscription | null>;
+  close: () => void;
+};
+
+function createProxiedWebSocketConstructor(agent: Agent) {
+  return class ProxiedWebSocket extends WebSocket {
+    constructor(address: string | URL, protocols?: string | string[]) {
+      super(address, protocols, { agent });
+    }
+  };
+}
+
+function createWebSocketConstructor() {
+  return httpsProxyAgent ? createProxiedWebSocketConstructor(httpsProxyAgent) : WebSocket;
+}
+
+export function createRealtimeLogsClient(
+  graphqlClient: ExpoGraphqlClient
+): RealtimeLogsClient | null {
+  const getTokenAsync = async (): Promise<string> => {
+    const { token } =
+      await RealtimeLogsMutation.generateCentrifugoConnectionTokenAsync(graphqlClient);
+    return token;
+  };
+
+  let client: Centrifuge;
+  try {
+    client = new Centrifuge(getEASLogsWebsocketUrl(), {
+      websocket: createWebSocketConstructor(),
+      getToken: getTokenAsync,
+    });
+    client.on('error', ({ error }) => {
+      Log.debug(`Realtime logs connection error: ${error.message}`);
+    });
+    client.connect();
+  } catch (err: any) {
+    Log.debug(`Failed to connect to realtime logs: ${err.message}`);
+    return null;
+  }
+
+  return {
+    subscribeAsync: async (args, onPublication) => {
+      const getSubscriptionTokenAsync = async (): Promise<string> => {
+        const { token } = await RealtimeLogsMutation.generateCentrifugoSubscriptionTokenAsync(
+          graphqlClient,
+          args
+        );
+        return token;
+      };
+
+      try {
+        const { channel, token } =
+          await RealtimeLogsMutation.generateCentrifugoSubscriptionTokenAsync(graphqlClient, args);
+
+        const subscription = client.newSubscription(channel, {
+          token,
+          getToken: getSubscriptionTokenAsync,
+        });
+
+        subscription.on('error', ({ error }) => {
+          Log.debug(`Realtime logs subscription error on ${channel}: ${error.message}`);
+        });
+        subscription.on('publication', ({ data }) => {
+          onPublication(data);
+        });
+        subscription.subscribe();
+
+        return {
+          close: () => {
+            closeSubscription(client, subscription);
+          },
+        };
+      } catch (err: any) {
+        Log.debug(`Failed to subscribe to realtime logs: ${err.message}`);
+        return null;
+      }
+    },
+    close: () => {
+      for (const subscription of Object.values(client.subscriptions())) {
+        closeSubscription(client, subscription);
+      }
+      client.removeAllListeners();
+      client.disconnect();
+    },
+  };
+}
+
+function closeSubscription(client: Centrifuge, subscription: Subscription): void {
+  try {
+    subscription.unsubscribe();
+    subscription.removeAllListeners();
+    client.removeSubscription(subscription);
+  } catch (err: any) {
+    Log.debug(`Failed to close realtime logs subscription: ${err.message}`);
+  }
+}

--- a/packages/eas-cli/src/utils/centrifuge.ts
+++ b/packages/eas-cli/src/utils/centrifuge.ts
@@ -21,7 +21,9 @@ export type RealtimeLogsClient = {
   close: () => void;
 };
 
-function createProxiedWebSocketConstructor(agent: Agent) {
+type WebSocketConstructor = new (address: string, protocols?: string | string[]) => WebSocket;
+
+function createProxiedWebSocketConstructor(agent: Agent): WebSocketConstructor {
   return class ProxiedWebSocket extends WebSocket {
     constructor(address: string | URL, protocols?: string | string[]) {
       super(address, protocols, { agent });
@@ -29,7 +31,7 @@ function createProxiedWebSocketConstructor(agent: Agent) {
   };
 }
 
-function createWebSocketConstructor() {
+function createWebSocketConstructor(): WebSocketConstructor {
   return httpsProxyAgent ? createProxiedWebSocketConstructor(httpsProxyAgent) : WebSocket;
 }
 

--- a/packages/eas-cli/src/utils/expodash/__tests__/uniqBy-test.ts
+++ b/packages/eas-cli/src/utils/expodash/__tests__/uniqBy-test.ts
@@ -18,4 +18,12 @@ describe(uniqBy, () => {
       { a: 4, b: 12 },
     ]);
   });
+
+  it('calls getKey once per item', () => {
+    const getKey = jest.fn(({ a }: { a: number }) => a);
+
+    uniqBy([{ a: 1 }, { a: 2 }, { a: 2 }], getKey);
+
+    expect(getKey).toHaveBeenCalledTimes(3);
+  });
 });

--- a/packages/eas-cli/src/utils/expodash/uniqBy.ts
+++ b/packages/eas-cli/src/utils/expodash/uniqBy.ts
@@ -1,10 +1,11 @@
 export default function uniqBy<T, K = any>(list: T[], getKey: (item: T) => K): T[] {
-  const uniqueValues = new Set();
+  const uniqueValues = new Set<K>();
   const result: T[] = [];
   for (const i of list) {
-    if (!uniqueValues.has(getKey(i))) {
+    const key = getKey(i);
+    if (!uniqueValues.has(key)) {
       result.push(i);
-      uniqueValues.add(getKey(i));
+      uniqueValues.add(key);
     }
   }
   return result;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6031,6 +6031,71 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
+  checksum: 10c0/a83343a468ff5b5ec6bff36fd788a64c839e48a07ff9f4f813564f58caf44d011cd6504ed2147bf34835bd7a7dd2107052af755961c6b098fd8902b4f6500d0f
+  languageName: node
+  linkType: hard
+
+"@protobufjs/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/base64@npm:1.1.2"
+  checksum: 10c0/eec925e681081af190b8ee231f9bad3101e189abbc182ff279da6b531e7dbd2a56f1f306f37a80b1be9e00aa2d271690d08dcc5f326f71c9eed8546675c8caf6
+  languageName: node
+  linkType: hard
+
+"@protobufjs/codegen@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@protobufjs/codegen@npm:2.0.5"
+  checksum: 10c0/1b8a2ae56ee60a56e9d205cd4b6072a1503c5069b8ebb905710f974ff0098a0d0700641c137e0a8d98dedf14423156a106a9433695cbf52574810f55000fdcab
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/eventemitter@npm:1.1.1"
+  checksum: 10c0/8e06193d4629c5e7c09d4f8c2ddba8fc4dfa739f0149f33a1d901568d35bb7b8b5277a4e8452baf3bdd0b302fd599cf255d193267aa93a0a4747e23cd073c4ac
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/fetch@npm:1.1.1"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.1"
+  checksum: 10c0/a497ff5433854e8577f0427983ea39b9113b49a8120f94515291d763327061d2c3013e60e24ea436d091dafae01a0f6eb1867e3b1616045d96a31d8b3c646ed4
+  languageName: node
+  linkType: hard
+
+"@protobufjs/float@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@protobufjs/float@npm:1.0.2"
+  checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+  languageName: node
+  linkType: hard
+
+"@protobufjs/path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/path@npm:1.1.2"
+  checksum: 10c0/cece0a938e7f5dfd2fa03f8c14f2f1cf8b0d6e13ac7326ff4c96ea311effd5fb7ae0bba754fbf505312af2e38500250c90e68506b97c02360a43793d88a0d8b4
+  languageName: node
+  linkType: hard
+
+"@protobufjs/pool@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/pool@npm:1.1.0"
+  checksum: 10c0/eda2718b7f222ac6e6ad36f758a92ef90d26526026a19f4f17f668f45e0306a5bd734def3f48f51f8134ae0978b6262a5c517c08b115a551756d1a3aadfcf038
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "@protobufjs/utf8@npm:1.1.2"
+  checksum: 10c0/975c6e2c0319bd50c17531d186b537a88cb4d3205e3ca9297cd842b631d341da0ee3ff16be8656cd2660756dc753b29c8a6a14c0ad8ed602c1f91ddf22e7b3f3
+  languageName: node
+  linkType: hard
+
 "@react-native/normalize-colors@npm:0.79.6":
   version: 0.79.6
   resolution: "@react-native/normalize-colors@npm:0.79.6"
@@ -7530,6 +7595,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:>=13.7.0":
+  version: 26.2.0
+  resolution: "@types/node@npm:26.2.0"
+  dependencies:
+    undici-types: "npm:~8.3.0"
+  checksum: 10c0/f8566d88162241eb55a46f7e4ea097188eab0aaafefea7a58e63adab8c4144eb98c08b7911452c846104c339a0f82282f5e1ed4b26b578d60709614fe2843f4d
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^22.5.5":
   version: 22.19.15
   resolution: "@types/node@npm:22.19.15"
@@ -9015,6 +9089,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"centrifuge@npm:5.7.1":
+  version: 5.7.1
+  resolution: "centrifuge@npm:5.7.1"
+  dependencies:
+    events: "npm:^3.3.0"
+    protobufjs: "npm:^7.6.0"
+  checksum: 10c0/fb5547b7f30383a0086bd47d3e27f2d1442fc7c6c89c0e48e76621e5c3bd17cf362d53d4bfb1d2d3c4461e48c95b3cc90654da3b0958152d7afdbf6318996357
+  languageName: node
+  linkType: hard
+
 "chalk@npm:4.1.0, chalk@npm:^4.0.0, chalk@npm:^4.1.0":
   version: 4.1.0
   resolution: "chalk@npm:4.1.0"
@@ -10431,6 +10515,7 @@ __metadata:
     "@types/tar-stream": "npm:3.1.3"
     "@types/tough-cookie": "npm:4.0.2"
     "@types/wrap-ansi": "npm:3.0.0"
+    "@types/ws": "npm:8.5.10"
     "@urql/core": "npm:4.0.11"
     "@urql/exchange-retry": "npm:1.2.0"
     agent-cli-detector: "npm:0.1.7"
@@ -10439,6 +10524,7 @@ __metadata:
     axios: "npm:1.18.1"
     better-opn: "npm:3.0.2"
     bplist-parser: "npm:^0.3.0"
+    centrifuge: "npm:5.7.1"
     chalk: "npm:4.1.2"
     cli-progress: "npm:3.12.0"
     dateformat: "npm:4.6.3"
@@ -10503,6 +10589,7 @@ __metadata:
     untildify: "npm:4.0.0"
     uuid: "npm:11.1.1"
     wrap-ansi: "npm:7.0.0"
+    ws: "npm:8.21.1"
     yaml: "npm:2.6.0"
     zod: "npm:^4.1.3"
   bin:
@@ -10872,6 +10959,13 @@ __metadata:
   version: 5.0.4
   resolution: "eventemitter3@npm:5.0.4"
   checksum: 10c0/575b8cac8d709e1473da46f8f15ef311b57ff7609445a7c71af5cd42598583eee6f098fa7a593e30f27e94b8865642baa0689e8fa97c016f742abdb3b1bf6d9a
+  languageName: node
+  linkType: hard
+
+"events@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: 10c0/d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
   languageName: node
   linkType: hard
 
@@ -14339,6 +14433,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"long@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "long@npm:5.3.2"
+  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
+  languageName: node
+  linkType: hard
+
 "loose-envify@npm:^1.0.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -16871,6 +16972,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"protobufjs@npm:^7.6.0":
+  version: 7.6.5
+  resolution: "protobufjs@npm:7.6.5"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.5"
+    "@protobufjs/eventemitter": "npm:^1.1.1"
+    "@protobufjs/fetch": "npm:^1.1.1"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.1"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^5.3.2"
+  checksum: 10c0/863eaca9c6f45bfcfb8787c545f53e9c6696507e328e3981b4643c12d35df7f2826021c10e3fd30bef342c13a8e9d306547bac9c0849ee3bf50f770a12f01dc5
+  languageName: node
+  linkType: hard
+
 "protocols@npm:^2.0.0, protocols@npm:^2.0.1":
   version: 2.0.1
   resolution: "protocols@npm:2.0.1"
@@ -19225,6 +19345,13 @@ __metadata:
   version: 6.21.0
   resolution: "undici-types@npm:6.21.0"
   checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~8.3.0":
+  version: 8.3.0
+  resolution: "undici-types@npm:8.3.0"
+  checksum: 10c0/c8aa7e2fbebfce519654dafadc0ece59be888d2ccaf180fb4495da875e7b536d2456345c384069c7e6f3e9c9ab7435f074957da306f142343eee86ff8048855a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

We can increase the responsiveness of workflow logs by using the new centrifugo realtime logs, received over websocket, instead of polling every 10 seconds.

# How

Added `centrifuge` and `ws` to deps. `ws` added for two reasons: node 20 doesn't have the native client and the native client doesn't support proxies

Added `centrifuge.ts`, which wraps the centrifuge client + subscriptions

Added mutations to obtain connection and subscription tokens for the realtime logs

Refactored the workflow log polling loop to persist state between polls. 

Split up log fetching and parsing to reuse parsing in the realtime logs. The state consists of the workflow run state and a `WorkflowRunLogsWatcher`, which updates the logs of each workflow job. The logs are merged from 2 sources: from the old polling endpoint and the new centrifuge subscriber

# Test Plan

- CI passes with new tests for added features
- Tested `workflow:run` against staging with a workflow that produces a log every second and verified that the logs appear 1 by 1 instead of batches of 10
