### PR TITLE
[eas-cli] Use production mode for Expo Updates commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🛠 Breaking changes
 
 - [build-tools] Use production mode for app config, prebuild, Expo Doctor, and Expo Updates commands. ([#4180](https://github.com/expo/eas-cli/pull/4180) by [@ramonclaudio](https://github.com/ramonclaudio))
+- [eas-cli] Use production mode for runtime version resolution and Expo Updates config sync. ([#4229](https://github.com/expo/eas-cli/pull/4229) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 🎉 New features
 

--- a/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
+++ b/packages/eas-cli/src/project/resolveRuntimeVersionAsync.ts
@@ -38,7 +38,7 @@ export async function resolveRuntimeVersionUsingCLIAsync({
   const resolvedRuntimeVersionJSONResult = await expoUpdatesCommandAsync(
     projectDir,
     ['runtimeversion:resolve', '--platform', platform, '--workflow', workflow, ...extraArgs],
-    { env, cwd }
+    { env, cwd, mode: 'production' }
   );
   const runtimeVersionResult = JSON.parse(resolvedRuntimeVersionJSONResult);
 

--- a/packages/eas-cli/src/update/android/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/android/UpdatesModule.ts
@@ -30,7 +30,7 @@ export async function syncUpdatesConfigurationAsync({
     await expoUpdatesCommandAsync(
       projectDir,
       ['configuration:syncnative', '--platform', 'android', '--workflow', workflow],
-      { env }
+      { env, mode: 'production' }
     );
     return;
   }

--- a/packages/eas-cli/src/update/ios/UpdatesModule.ts
+++ b/packages/eas-cli/src/update/ios/UpdatesModule.ts
@@ -31,7 +31,7 @@ export async function syncUpdatesConfigurationAsync({
     await expoUpdatesCommandAsync(
       projectDir,
       ['configuration:syncnative', '--platform', 'ios', '--workflow', workflow],
-      { env }
+      { env, mode: 'production' }
     );
     return;
   }

--- a/packages/eas-cli/src/utils/__tests__/expoUpdatesCli-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/expoUpdatesCli-test.ts
@@ -21,13 +21,18 @@ describe(expoUpdatesCommandAsync, () => {
     const env = {
       NODE_ENV: 'staging',
       __EXPO_CONFIG_MODE: 'staging',
+      DOTENV_VALUE: 'from-command',
       FROM_COMMAND: 'true',
+      __EXPO_ENV_LOADED: '["DOTENV_VALUE"]',
     };
-    process.env = {
+    const processEnv = {
       NODE_ENV: 'development',
       __EXPO_CONFIG_MODE: 'development',
       FROM_PROCESS: 'true',
+      PARENT_DOTENV_VALUE: 'from-parent',
+      __EXPO_ENV_LOADED: '["PARENT_DOTENV_VALUE"]',
     };
+    process.env = processEnv;
 
     try {
       await expoUpdatesCommandAsync('/project', ['runtimeversion:resolve'], {
@@ -35,6 +40,9 @@ describe(expoUpdatesCommandAsync, () => {
         cwd: '/working-directory',
         mode: 'production',
       });
+      expect(process.env).toBe(processEnv);
+      expect(process.env.PARENT_DOTENV_VALUE).toBe('from-parent');
+      expect(process.env.__EXPO_ENV_LOADED).toBe('["PARENT_DOTENV_VALUE"]');
     } finally {
       process.env = originalProcessEnv;
     }
@@ -48,6 +56,7 @@ describe(expoUpdatesCommandAsync, () => {
           NODE_ENV: 'production',
           __EXPO_CONFIG_MODE: 'production',
           FROM_PROCESS: 'true',
+          DOTENV_VALUE: 'from-command',
           FROM_COMMAND: 'true',
         },
         cwd: '/working-directory',
@@ -56,7 +65,9 @@ describe(expoUpdatesCommandAsync, () => {
     expect(env).toEqual({
       NODE_ENV: 'staging',
       __EXPO_CONFIG_MODE: 'staging',
+      DOTENV_VALUE: 'from-command',
       FROM_COMMAND: 'true',
+      __EXPO_ENV_LOADED: '["DOTENV_VALUE"]',
     });
   });
 });

--- a/packages/eas-cli/src/utils/__tests__/expoUpdatesCli-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/expoUpdatesCli-test.ts
@@ -1,0 +1,62 @@
+import spawnAsync from '@expo/spawn-async';
+import { silent as silentResolveFrom } from 'resolve-from';
+
+import { expoUpdatesCommandAsync } from '../expoUpdatesCli';
+
+jest.mock('@expo/spawn-async', () => ({
+  __esModule: true,
+  default: jest.fn().mockResolvedValue({ stdout: '' }),
+}));
+
+jest.mock('resolve-from', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  silent: jest.fn(),
+}));
+
+describe(expoUpdatesCommandAsync, () => {
+  it('passes production mode to the Expo Updates child process and keeps the input env unchanged', async () => {
+    jest.mocked(silentResolveFrom).mockReturnValue('/project/node_modules/expo-updates/bin/cli');
+    const originalProcessEnv = process.env;
+    const env = {
+      NODE_ENV: 'staging',
+      __EXPO_CONFIG_MODE: 'staging',
+      FROM_COMMAND: 'true',
+    };
+    process.env = {
+      NODE_ENV: 'development',
+      __EXPO_CONFIG_MODE: 'development',
+      FROM_PROCESS: 'true',
+    };
+
+    try {
+      await expoUpdatesCommandAsync('/project', ['runtimeversion:resolve'], {
+        env,
+        cwd: '/working-directory',
+        mode: 'production',
+      });
+    } finally {
+      process.env = originalProcessEnv;
+    }
+
+    expect(spawnAsync).toHaveBeenCalledWith(
+      '/project/node_modules/expo-updates/bin/cli',
+      ['runtimeversion:resolve'],
+      {
+        stdio: 'pipe',
+        env: {
+          NODE_ENV: 'production',
+          __EXPO_CONFIG_MODE: 'production',
+          FROM_PROCESS: 'true',
+          FROM_COMMAND: 'true',
+        },
+        cwd: '/working-directory',
+      }
+    );
+    expect(env).toEqual({
+      NODE_ENV: 'staging',
+      __EXPO_CONFIG_MODE: 'staging',
+      FROM_COMMAND: 'true',
+    });
+  });
+});

--- a/packages/eas-cli/src/utils/__tests__/originalEnv-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/originalEnv-test.ts
@@ -1,0 +1,26 @@
+import { getEnvWithoutInheritedDotenvValues } from '../originalEnv';
+
+describe(getEnvWithoutInheritedDotenvValues, () => {
+  it('keeps a dotenv value allowed by the shell', () => {
+    const env = {
+      EXPO_UNSAFE_DOTENV_KEYS: 'ALLOWED_VALUE',
+      ALLOWED_VALUE: 'keep',
+      __EXPO_ENV_LOADED: '["ALLOWED_VALUE"]',
+    };
+
+    expect(getEnvWithoutInheritedDotenvValues(env)).toEqual({
+      EXPO_UNSAFE_DOTENV_KEYS: 'ALLOWED_VALUE',
+      ALLOWED_VALUE: 'keep',
+    });
+  });
+
+  it('removes an unsafe-key list inherited from the parent process', () => {
+    const env = {
+      EXPO_UNSAFE_DOTENV_KEYS: 'DOTENV_VALUE',
+      DOTENV_VALUE: 'remove',
+      __EXPO_ENV_LOADED: '["EXPO_UNSAFE_DOTENV_KEYS","DOTENV_VALUE"]',
+    };
+
+    expect(getEnvWithoutInheritedDotenvValues(env)).toEqual({});
+  });
+});

--- a/packages/eas-cli/src/utils/expoUpdatesCli.ts
+++ b/packages/eas-cli/src/utils/expoUpdatesCli.ts
@@ -8,10 +8,12 @@ export class ExpoUpdatesCLIModuleNotFoundError extends Error {}
 export class ExpoUpdatesCLIInvalidCommandError extends Error {}
 export class ExpoUpdatesCLICommandFailedError extends Error {}
 
+type EnvMode = 'development' | 'production';
+
 export async function expoUpdatesCommandAsync(
   projectDir: string,
   args: string[],
-  options: { env: Env | undefined; cwd?: string }
+  options: { env: Env | undefined; cwd?: string; mode: EnvMode }
 ): Promise<string> {
   let expoUpdatesCli;
   try {
@@ -33,7 +35,12 @@ export async function expoUpdatesCommandAsync(
     return (
       await spawnAsync(expoUpdatesCli, args, {
         stdio: 'pipe',
-        env: { ...process.env, ...options.env },
+        env: {
+          ...process.env,
+          ...options.env,
+          NODE_ENV: options.mode,
+          __EXPO_CONFIG_MODE: options.mode,
+        },
         cwd: options.cwd,
       })
     ).stdout;

--- a/packages/eas-cli/src/utils/expoUpdatesCli.ts
+++ b/packages/eas-cli/src/utils/expoUpdatesCli.ts
@@ -3,6 +3,7 @@ import spawnAsync from '@expo/spawn-async';
 import resolveFrom, { silent as silentResolveFrom } from 'resolve-from';
 
 import { link } from '../log';
+import { getEnvWithoutInheritedDotenvValues } from './originalEnv';
 
 export class ExpoUpdatesCLIModuleNotFoundError extends Error {}
 export class ExpoUpdatesCLIInvalidCommandError extends Error {}
@@ -32,12 +33,17 @@ export async function expoUpdatesCommandAsync(
   }
 
   try {
+    const commandEnv = {
+      ...getEnvWithoutInheritedDotenvValues(process.env),
+      ...options.env,
+    };
+    delete commandEnv.__EXPO_ENV_LOADED;
+
     return (
       await spawnAsync(expoUpdatesCli, args, {
         stdio: 'pipe',
         env: {
-          ...process.env,
-          ...options.env,
+          ...commandEnv,
           NODE_ENV: options.mode,
           __EXPO_CONFIG_MODE: options.mode,
         },

--- a/packages/eas-cli/src/utils/originalEnv.ts
+++ b/packages/eas-cli/src/utils/originalEnv.ts
@@ -1,0 +1,34 @@
+import { LOADED_ENV_NAME } from '@expo/env';
+
+// TODO(@ramonclaudio): Use `getOriginalEnv()` from `@expo/env` after EAS CLI
+// requires Node 20.12.0 or newer.
+/** Remove dotenv values listed by an inherited `__EXPO_ENV_LOADED` marker. */
+export function getEnvWithoutInheritedDotenvValues(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const result = { ...env };
+  const loadedKeys = getLoadedEnvKeys(result[LOADED_ENV_NAME]);
+  const unsafeAllowedKeys = loadedKeys.includes('EXPO_UNSAFE_DOTENV_KEYS')
+    ? new Set<string>()
+    : new Set(result.EXPO_UNSAFE_DOTENV_KEYS?.split(',').filter(key => key.length > 0));
+
+  for (const key of loadedKeys) {
+    if (!unsafeAllowedKeys.has(key)) {
+      delete result[key];
+    }
+  }
+  delete result[LOADED_ENV_NAME];
+  return result;
+}
+
+function getLoadedEnvKeys(marker: string | undefined): string[] {
+  if (!marker) {
+    return [];
+  }
+  try {
+    const loadedKeys = JSON.parse(marker);
+    return Array.isArray(loadedKeys)
+      ? loadedKeys.filter((key): key is string => typeof key === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
Stacked on [#4180](https://github.com/expo/eas-cli/pull/4180).

# Why

EAS CLI can use an existing `NODE_ENV` when it resolves the runtime version or syncs Expo Updates config, which can make it load different env files for the same build. EAS CLI can also pass dotenv values loaded by a parent process to Expo Updates, which can make Expo Updates reuse values from a different mode.

# How

I updated the Expo Updates commands to use `production` mode for runtime version resolution and Android and iOS config sync, and kept the original EAS CLI env unchanged. EAS CLI still supports Node 20.0.0, but `@expo/env` v2.5.0 requires Node 20.12.0, so I added the inherited dotenv cleanup locally for now.

# Test Plan

Tests and package checks pass.
