### PR TITLE
[build-tools] Rename serve-sim preview URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - [eas-cli] Fix lint and enforce max-warnings=0. ([#4219](https://github.com/expo/eas-cli/pull/4219) by [@wschurman](https://github.com/wschurman))
-- [build-tools] Rename serve-sim ngrok preview URLs to use the `web-preview` prefix.
+- [build-tools] Rename serve-sim ngrok preview URLs to use the `web-preview` prefix. ([#4231](https://github.com/expo/eas-cli/pull/4231) by [@szdziedzic](https://github.com/szdziedzic))
 
 ## [22.0.0](https://github.com/expo/eas-cli/releases/tag/v22.0.0) - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🧹 Chores
 
 - [eas-cli] Fix lint and enforce max-warnings=0. ([#4219](https://github.com/expo/eas-cli/pull/4219) by [@wschurman](https://github.com/wschurman))
+- [build-tools] Rename serve-sim ngrok preview URLs to use the `web-preview` prefix.
 
 ## [22.0.0](https://github.com/expo/eas-cli/releases/tag/v22.0.0) - 2026-08-14
 

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -221,14 +221,14 @@ describe(startNgrokTunnelAsync, () => {
   it('uses a 128-bit capability hostname and exposes explicit cleanup', async () => {
     const close = jest.fn().mockResolvedValue(undefined);
     jest.mocked(ngrok.forward).mockResolvedValue({
-      url: () => 'https://serve-sim.example.test',
+      url: () => 'https://web-preview.example.test',
       close,
     } as never);
 
     const tunnel = await startNgrokTunnelAsync({
       port: 4321,
-      subdomainPrefix: 'serve-sim',
-      baseDomain: 'tunnel.example.test',
+      subdomainPrefix: 'web-preview',
+      baseDomain: 'eas-simulator.ngrok.dev',
       authtoken: 'token',
       logger: createLoggerMock(),
     });
@@ -237,10 +237,10 @@ describe(startNgrokTunnelAsync, () => {
       expect.objectContaining({
         addr: 4321,
         authtoken: 'token',
-        domain: expect.stringMatching(/^serve-sim-[a-f0-9]{32}\.tunnel\.example\.test$/),
+        domain: expect.stringMatching(/^web-preview-[a-f0-9]{32}\.eas-simulator\.ngrok\.dev$/),
       })
     );
-    expect(tunnel.url).toBe('https://serve-sim.example.test');
+    expect(tunnel.url).toBe('https://web-preview.example.test');
     await tunnel.stopAsync();
     await tunnel.stopAsync();
     expect(close).toHaveBeenCalledTimes(1);

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -722,7 +722,7 @@ export async function startServeSimWithTunnelAsync(
     await waitForServeSimReadyAsync({ serveSim, port, timeoutMs });
     const tunnel = await startNgrokTunnelAsync({
       port,
-      subdomainPrefix: 'serve-sim',
+      subdomainPrefix: 'web-preview',
       baseDomain,
       authtoken: getNgrokAuthtokenOrThrow(env),
       logger,


### PR DESCRIPTION
## Why

Rename web preview URLs so they don't contain serve-sim in name

## How

Rename web preview URLs so they don't contain serve-sim in name

## Validation

Tests