### PR TITLE
[build-tools] Update @expo/env to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [build-tools] Update `@expo/env` to v1.0. ([#4232](https://github.com/expo/eas-cli/pull/4232) by [@ramonclaudio](https://github.com/ramonclaudio))
+
 ## [22.2.0](https://github.com/expo/eas-cli/releases/tag/v22.2.0) - 2026-08-20
 
 ### 🎉 New features

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -40,7 +40,7 @@
     "@expo/config-plugins": "55.0.7",
     "@expo/downloader": "22.0.0",
     "@expo/eas-build-job": "22.0.0",
-    "@expo/env": "^0.4.0",
+    "@expo/env": "^1.0.0",
     "@expo/logger": "22.0.0",
     "@expo/package-manager": "1.9.10",
     "@expo/plist": "^0.3.5",

--- a/packages/build-tools/src/utils/__tests__/appConfig.test.ts
+++ b/packages/build-tools/src/utils/__tests__/appConfig.test.ts
@@ -3,7 +3,7 @@ import { bunyan } from '@expo/logger';
 import { readAppConfig } from '../appConfig';
 
 jest.mock('@expo/env', () => ({
-  load: jest.fn(),
+  parseProjectEnv: jest.fn(),
 }));
 
 jest.mock('@expo/config', () => ({
@@ -20,8 +20,8 @@ const { getConfig } = jest.requireMock('@expo/config') as {
   getConfig: jest.Mock;
 };
 
-const { load: loadEnv } = jest.requireMock('@expo/env') as {
-  load: jest.Mock;
+const { parseProjectEnv } = jest.requireMock('@expo/env') as {
+  parseProjectEnv: jest.Mock;
 };
 
 const logger = { warn: jest.fn(), info: jest.fn(), error: jest.fn() } as unknown as bunyan;
@@ -35,6 +35,7 @@ const baseParams = {
 describe(readAppConfig, () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    parseProjectEnv.mockReturnValue({ env: {}, files: [] });
     getConfig.mockReturnValue({
       exp: { name: 'fallback-app', slug: 'fallback-app' },
     });
@@ -101,13 +102,18 @@ describe(readAppConfig, () => {
     const config = { exp: { name: 'test-app', slug: 'test-app' } };
     expoCommandAsync.mockResolvedValue({ stdout: JSON.stringify(config) });
     const originalProcessEnv = process.env;
-    let nodeEnvWhenLoaded: string | undefined;
-    loadEnv.mockImplementation(() => {
-      nodeEnvWhenLoaded = process.env.NODE_ENV;
-      process.env.FROM_BUILD ??= 'from-dotenv';
-      process.env.FROM_DOTENV = 'true';
-      process.env.__EXPO_CONFIG_MODE = 'development';
-      return process.env;
+    let nodeEnvWhenParsed: string | undefined;
+    parseProjectEnv.mockImplementation(() => {
+      nodeEnvWhenParsed = process.env.NODE_ENV;
+      return {
+        env: {
+          NODE_ENV: 'development',
+          FROM_BUILD: 'from-dotenv',
+          FROM_DOTENV: 'true',
+          __EXPO_CONFIG_MODE: 'development',
+        },
+        files: [],
+      };
     });
 
     await readAppConfig({
@@ -116,8 +122,14 @@ describe(readAppConfig, () => {
       sdkVersion: '49.0.0',
     });
 
-    expect(loadEnv).toHaveBeenCalledWith('/project');
-    expect(nodeEnvWhenLoaded).toBe('production');
+    expect(parseProjectEnv).toHaveBeenCalledWith('/project', {
+      mode: 'production',
+      systemEnv: {
+        NODE_ENV: 'production',
+        FROM_BUILD: 'true',
+      },
+    });
+    expect(nodeEnvWhenParsed).toBe('production');
     expect(process.env).toBe(originalProcessEnv);
     expect(expoCommandAsync).toHaveBeenCalledWith('/project', expect.any(Array), {
       env: {
@@ -129,12 +141,32 @@ describe(readAppConfig, () => {
     });
   });
 
+  it('uses EXPO_NO_DOTENV from the build env', async () => {
+    const config = { exp: { name: 'test-app', slug: 'test-app' } };
+    expoCommandAsync.mockResolvedValue({ stdout: JSON.stringify(config) });
+    const originalProcessEnv = process.env;
+    let noDotenvWhenParsed: string | undefined;
+    parseProjectEnv.mockImplementation(() => {
+      noDotenvWhenParsed = process.env.EXPO_NO_DOTENV;
+      return { env: {}, files: [] };
+    });
+
+    await readAppConfig({
+      ...baseParams,
+      env: { ...baseParams.env, EXPO_NO_DOTENV: '1' },
+      sdkVersion: '49.0.0',
+    });
+
+    expect(noDotenvWhenParsed).toBe('1');
+    expect(process.env).toBe(originalProcessEnv);
+  });
+
   it('does not load env vars from dotenv for SDK < 49', async () => {
     const config = { exp: { name: 'test-app', slug: 'test-app' } };
     expoCommandAsync.mockResolvedValue({ stdout: JSON.stringify(config) });
 
     await readAppConfig({ ...baseParams, sdkVersion: '48.0.0' });
 
-    expect(loadEnv).not.toHaveBeenCalled();
+    expect(parseProjectEnv).not.toHaveBeenCalled();
   });
 });

--- a/packages/build-tools/src/utils/__tests__/appConfig.test.ts
+++ b/packages/build-tools/src/utils/__tests__/appConfig.test.ts
@@ -102,9 +102,7 @@ describe(readAppConfig, () => {
     const config = { exp: { name: 'test-app', slug: 'test-app' } };
     expoCommandAsync.mockResolvedValue({ stdout: JSON.stringify(config) });
     const originalProcessEnv = process.env;
-    let nodeEnvWhenParsed: string | undefined;
     parseProjectEnv.mockImplementation(() => {
-      nodeEnvWhenParsed = process.env.NODE_ENV;
       return {
         env: {
           NODE_ENV: 'development',
@@ -129,7 +127,6 @@ describe(readAppConfig, () => {
         FROM_BUILD: 'true',
       },
     });
-    expect(nodeEnvWhenParsed).toBe('production');
     expect(process.env).toBe(originalProcessEnv);
     expect(expoCommandAsync).toHaveBeenCalledWith('/project', expect.any(Array), {
       env: {

--- a/packages/build-tools/src/utils/appConfig.ts
+++ b/packages/build-tools/src/utils/appConfig.ts
@@ -67,7 +67,7 @@ async function getAppConfigFromExpo({
 function loadEnvVarsFromDotenvFile(projectDir: string, env: Env): Env {
   const originalProcessEnv = process.env;
   try {
-    // @expo/env@0.4 reads the mode from NODE_ENV.
+    // The legacy @expo/env API reads the mode from NODE_ENV.
     process.env = { ...env };
     load(projectDir);
     return getLegacyExpoConfigEnv(process.env as Env, 'production');

--- a/packages/build-tools/src/utils/appConfig.ts
+++ b/packages/build-tools/src/utils/appConfig.ts
@@ -1,6 +1,6 @@
 import { ProjectConfig, getConfig } from '@expo/config';
 import { Env } from '@expo/eas-build-job';
-import { load } from '@expo/env';
+import { parseProjectEnv } from '@expo/env';
 import { LoggerLevel, bunyan } from '@expo/logger';
 import semver from 'semver';
 
@@ -67,10 +67,14 @@ async function getAppConfigFromExpo({
 function loadEnvVarsFromDotenvFile(projectDir: string, env: Env): Env {
   const originalProcessEnv = process.env;
   try {
-    // The legacy @expo/env API reads the mode from NODE_ENV.
-    process.env = { ...env };
-    load(projectDir);
-    return getLegacyExpoConfigEnv(process.env as Env, 'production');
+    // @expo/env reads EXPO_NO_DOTENV from process.env.
+    const systemEnv = { ...env };
+    process.env = systemEnv;
+    const { env: dotenvEnv } = parseProjectEnv(projectDir, {
+      mode: 'production',
+      systemEnv,
+    });
+    return getLegacyExpoConfigEnv({ ...dotenvEnv, ...systemEnv }, 'production');
   } finally {
     process.env = originalProcessEnv;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,7 +2299,7 @@ __metadata:
     "@expo/config-plugins": "npm:55.0.7"
     "@expo/downloader": "npm:22.0.0"
     "@expo/eas-build-job": "npm:22.0.0"
-    "@expo/env": "npm:^0.4.0"
+    "@expo/env": "npm:^1.0.0"
     "@expo/logger": "npm:22.0.0"
     "@expo/package-manager": "npm:1.9.10"
     "@expo/plist": "npm:^0.3.5"
@@ -2590,19 +2590,6 @@ __metadata:
     typescript: "npm:5.5.4"
   languageName: unknown
   linkType: soft
-
-"@expo/env@npm:^0.4.0":
-  version: 0.4.2
-  resolution: "@expo/env@npm:0.4.2"
-  dependencies:
-    chalk: "npm:^4.0.0"
-    debug: "npm:^4.3.4"
-    dotenv: "npm:~16.4.5"
-    dotenv-expand: "npm:~11.0.6"
-    getenv: "npm:^1.0.0"
-  checksum: 10c0/46e175f07d025b1f12f7be2ae6a3f9ec721bb38d894d4bfab09276e697e199fe6aed615ce89aff98e62af3371955db05296cfb2fd8ee23dea2d748ebd497c81e
-  languageName: node
-  linkType: hard
 
 "@expo/env@npm:^1.0.0":
   version: 1.0.0


### PR DESCRIPTION
Stacked on [#4229](https://github.com/expo/eas-cli/pull/4229).

# Why

Build tools currently uses `@expo/env` v0.4 while EAS CLI uses v1.0. We can't update to the latest version yet because it requires Node 20.12.0, so v1.0 lets us use one version for now and pass production mode directly when build tools loads app config env files.

# How

I updated build tools to use `@expo/env` v1.0 and changed app config to use `parseProjectEnv()` instead of the old `load()` API.

# Test Plan

Tests and package checks pass.
