### PR TITLE
[build-tools] Submit tvOS IPAs to the correct App Store Connect platform endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] Send the expected `Content-MD5` checksum with GCS signed URL uploads so GCS rejects corrupted uploads. ([#4208](https://github.com/expo/eas-cli/pull/4208) by [@wschurman](https://github.com/wschurman))
 - [eas-cli] Resolve the `eas go` SDK version to its repack target, so `--sdk-version 57` no longer fails with "No Expo Go repack target is published for SDK 57". ([#4215](https://github.com/expo/eas-cli/pull/4215) by [@gwdp](https://github.com/gwdp))
 - [eas-cli] Handle missing fingerprint source in fingerprint:compare command. ([#4210](https://github.com/expo/eas-cli/pull/4210) by [@wschurman](https://github.com/wschurman))
+- [build-tools] Upload tvOS (and other non-iOS) IPAs to the App Store Connect platform declared in the bundle's `DTPlatformName`, instead of always uploading to the iOS train. ([#4234](https://github.com/expo/eas-cli/pull/4234) by [@douglowder](https://github.com/douglowder))
 
 ### 🧹 Chores
 

--- a/packages/build-tools/src/steps/functions/__tests__/readIpaInfo.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/readIpaInfo.test.ts
@@ -26,6 +26,7 @@ describe(readIpaInfoAsync, () => {
       bundleIdentifier: 'dev.expo.SmallestAppExample',
       bundleShortVersion: '1.0',
       bundleVersion: '1',
+      dtPlatformName: 'iphoneos',
     });
   });
 

--- a/packages/build-tools/src/steps/functions/readIpaInfo.ts
+++ b/packages/build-tools/src/steps/functions/readIpaInfo.ts
@@ -16,6 +16,10 @@ export type IpaInfo = {
   bundleIdentifier: string;
   bundleShortVersion: string;
   bundleVersion: string;
+  // `DTPlatformName` from the bundle's Info.plist (e.g. `iphoneos`, `appletvos`,
+  // `macosx`, `xros`), or null when absent. Used to pick the App Store Connect
+  // platform for the upload. See `AscApiUtils.ascPlatformFromDtPlatformName`.
+  dtPlatformName: string | null;
 };
 
 const INFO_PLIST_PATH_REGEXP = /^Payload\/[^/]+\.app\/Info\.plist$/;
@@ -91,10 +95,14 @@ export async function readIpaInfoAsync(ipaPath: string): Promise<IpaInfo> {
       );
     }
 
+    const dtPlatformName =
+      typeof infoPlist.DTPlatformName === 'string' ? infoPlist.DTPlatformName : null;
+
     return {
       bundleIdentifier,
       bundleShortVersion,
       bundleVersion,
+      dtPlatformName,
     };
   } catch (error) {
     if (error instanceof UserError) {

--- a/packages/build-tools/src/steps/functions/uploadToAsc.ts
+++ b/packages/build-tools/src/steps/functions/uploadToAsc.ts
@@ -115,16 +115,27 @@ export function createUploadToAscBuildFunction(): BuildFunction {
         `Uploading Build to "${appResponse.data.attributes.name}" (${ascAppBundleIdentifier})...`
       );
 
+      // Derive the App Store Connect platform from the IPA itself so tvOS (and
+      // other) binaries are uploaded to the correct version train instead of the
+      // iOS one. Falls back to `IOS` if the platform cannot be read.
+      const ipaInfoResult = await asyncResult(readIpaInfoAsync(ipaPath));
+      const platform = ipaInfoResult.ok
+        ? AscApiUtils.ascPlatformFromDtPlatformName(ipaInfoResult.value.dtPlatformName)
+        : 'IOS';
+      stepsCtx.logger.info(`Detected App Store Connect platform: ${platform}`);
+
       stepsCtx.logger.info('Creating Build Upload...');
       const buildUploadResponse = await AscApiUtils.createBuildUploadAsync({
         client,
         appleAppIdentifier,
         bundleShortVersion,
         bundleVersion,
+        platform,
       });
 
       const buildUploadId = buildUploadResponse.data.id;
-      const buildUploadUrl = `https://appstoreconnect.apple.com/apps/${appleAppIdentifier}/testflight/ios/${buildUploadId}`;
+      const platformPathSegment = AscApiUtils.testFlightPlatformPathSegment(platform);
+      const buildUploadUrl = `https://appstoreconnect.apple.com/apps/${appleAppIdentifier}/testflight/${platformPathSegment}/${buildUploadId}`;
       outputs.build_upload_id.set(buildUploadId);
       outputs.build_upload_url.set(buildUploadUrl);
 

--- a/packages/build-tools/src/steps/utils/ios/AscApiClient.ts
+++ b/packages/build-tools/src/steps/utils/ios/AscApiClient.ts
@@ -272,6 +272,10 @@ export type AscApiClientPostApi = {
   };
 };
 
+// https://developer.apple.com/documentation/appstoreconnectapi/platform
+export type AscPlatform =
+  AscApiClientPostApi['/v1/buildUploads']['request']['data']['attributes']['platform'];
+
 export type AscApiClientPatchApi = {
   [Path in keyof typeof PatchApi]: {
     request: z.input<(typeof PatchApi)[Path]['request']>;

--- a/packages/build-tools/src/steps/utils/ios/AscApiUtils.ts
+++ b/packages/build-tools/src/steps/utils/ios/AscApiUtils.ts
@@ -5,9 +5,44 @@ import {
   AscApiClientGetApi,
   AscApiClientPostApi,
   AscApiRequestError,
+  AscPlatform,
 } from './AscApiClient';
 
 export namespace AscApiUtils {
+  /**
+   * Maps a bundle's `DTPlatformName` (from its Info.plist) to the App Store
+   * Connect platform used for a build upload. Unknown or missing values fall
+   * back to `IOS` to preserve the previous default.
+   */
+  export function ascPlatformFromDtPlatformName(dtPlatformName: string | null): AscPlatform {
+    switch (dtPlatformName) {
+      case 'appletvos':
+        return 'TV_OS';
+      case 'macosx':
+        return 'MAC_OS';
+      case 'xros':
+        return 'VISION_OS';
+      case 'iphoneos':
+      default:
+        return 'IOS';
+    }
+  }
+
+  /** The App Store Connect TestFlight URL path segment for a platform. */
+  export function testFlightPlatformPathSegment(platform: AscPlatform): string {
+    switch (platform) {
+      case 'TV_OS':
+        return 'tvos';
+      case 'MAC_OS':
+        return 'macos';
+      case 'VISION_OS':
+        return 'visionos';
+      case 'IOS':
+      default:
+        return 'ios';
+    }
+  }
+
   export async function getAppInfoAsync({
     client,
     appleAppIdentifier,
@@ -61,18 +96,20 @@ export namespace AscApiUtils {
     appleAppIdentifier,
     bundleShortVersion,
     bundleVersion,
+    platform,
   }: {
     client: Pick<AscApiClient, 'postAsync'>;
     appleAppIdentifier: string;
     bundleShortVersion: string;
     bundleVersion: string;
+    platform: AscPlatform;
   }): Promise<AscApiClientPostApi['/v1/buildUploads']['response']> {
     try {
       return await client.postAsync('/v1/buildUploads', {
         data: {
           type: 'buildUploads',
           attributes: {
-            platform: 'IOS',
+            platform,
             cfBundleShortVersionString: bundleShortVersion,
             cfBundleVersion: bundleVersion,
           },

--- a/packages/build-tools/src/steps/utils/ios/__tests__/AscApiUtils.test.ts
+++ b/packages/build-tools/src/steps/utils/ios/__tests__/AscApiUtils.test.ts
@@ -148,6 +148,7 @@ describe('AscApiUtils', () => {
           appleAppIdentifier: '1491144534',
           bundleShortVersion: '1.2.3',
           bundleVersion: '42',
+          platform: 'IOS',
         })
       ).rejects.toEqual(
         expect.objectContaining({
@@ -176,8 +177,38 @@ describe('AscApiUtils', () => {
           appleAppIdentifier: '1491144534',
           bundleShortVersion: '1.2.3',
           bundleVersion: '42',
+          platform: 'IOS',
         })
       ).resolves.toEqual(response);
+    });
+
+    it('sends the requested platform in the build upload attributes', async () => {
+      const response = {
+        data: {
+          type: 'buildUploads',
+          id: 'fdf9c476-aaa4-4ead-b91c-6e3cc3a47805',
+        },
+      } as const;
+      const client = {
+        postAsync: jest.fn().mockResolvedValue(response),
+      };
+
+      await AscApiUtils.createBuildUploadAsync({
+        client,
+        appleAppIdentifier: '1491144534',
+        bundleShortVersion: '1.2.3',
+        bundleVersion: '42',
+        platform: 'TV_OS',
+      });
+
+      expect(client.postAsync).toHaveBeenCalledWith(
+        '/v1/buildUploads',
+        expect.objectContaining({
+          data: expect.objectContaining({
+            attributes: expect.objectContaining({ platform: 'TV_OS' }),
+          }),
+        })
+      );
     });
 
     it('rethrows when error payload includes mixed error codes', async () => {
@@ -208,8 +239,32 @@ describe('AscApiUtils', () => {
           appleAppIdentifier: '1491144534',
           bundleShortVersion: '1.2.3',
           bundleVersion: '42',
+          platform: 'IOS',
         })
       ).rejects.toBe(mixedError);
+    });
+  });
+
+  describe('ascPlatformFromDtPlatformName', () => {
+    it('maps known DTPlatformName values to App Store Connect platforms', () => {
+      expect(AscApiUtils.ascPlatformFromDtPlatformName('iphoneos')).toBe('IOS');
+      expect(AscApiUtils.ascPlatformFromDtPlatformName('appletvos')).toBe('TV_OS');
+      expect(AscApiUtils.ascPlatformFromDtPlatformName('macosx')).toBe('MAC_OS');
+      expect(AscApiUtils.ascPlatformFromDtPlatformName('xros')).toBe('VISION_OS');
+    });
+
+    it('falls back to IOS for unknown or missing values', () => {
+      expect(AscApiUtils.ascPlatformFromDtPlatformName(null)).toBe('IOS');
+      expect(AscApiUtils.ascPlatformFromDtPlatformName('watchos')).toBe('IOS');
+    });
+  });
+
+  describe('testFlightPlatformPathSegment', () => {
+    it('returns the TestFlight URL segment for each platform', () => {
+      expect(AscApiUtils.testFlightPlatformPathSegment('IOS')).toBe('ios');
+      expect(AscApiUtils.testFlightPlatformPathSegment('TV_OS')).toBe('tvos');
+      expect(AscApiUtils.testFlightPlatformPathSegment('MAC_OS')).toBe('macos');
+      expect(AscApiUtils.testFlightPlatformPathSegment('VISION_OS')).toBe('visionos');
     });
   });
 });


### PR DESCRIPTION
# Why

Customers see an issue with App Store submission for apps where iOS and tvOS have the same bundle ID. EAS Submit sends tvOS builds to the iOS App Store link, leading to errors and submit failure.

# How

build-tools now checks the actual platform of the IPA, and routes the App Store network request to the correct endpoint for that platform. The changes are all contained within the build-tools package.

Fixes #3985.

# Test Plan

- Test against a real tvOS app to verify correct submission
- Unit tests added and modified


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>