### PR TITLE
[build-tools] Apply Appium event timings via default capabilities

### DIFF
--- a/packages/build-tools/src/steps/functions/startAppiumRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAppiumRemoteSession.ts
@@ -98,6 +98,8 @@ export function createStartAppiumRemoteSessionBuildFunction(
           // Appium Event Timings, so enable it for all drivers.
           '--allow-insecure',
           '*:session_discovery',
+          '--default-capabilities',
+          JSON.stringify({ 'appium:eventTimings': true }),
         ],
         env: appiumEnv,
       });
@@ -148,7 +150,6 @@ export function createStartAppiumRemoteSessionBuildFunction(
               platformName: device.platformName,
               'appium:automationName': device.automationName,
               'appium:udid': device.udid,
-              'appium:eventTimings': true,
             },
             ...(serveSim ? { webPreviewUrl: serveSim.previewUrl } : {}),
           },


### PR DESCRIPTION
# Why

Appium is able to run multiple sessions against multiple devices through one server. We want all of them to get the same `eventTimings` (which is for session events integration).

# How

Moved `appium:eventTimings: true` from remote config (which only applies to the one session) to `--default-capabilities` so all sessions get it.

# Test Plan

- Verified `--default-capabilities` is a valid Appium 3 flag and that requested caps take precedence over it.