### PR TITLE
[build-tools] Separate iOS ccache by destination

### DIFF
--- a/packages/build-tools/src/builders/android.ts
+++ b/packages/build-tools/src/builders/android.ts
@@ -98,7 +98,7 @@ async function buildInnerAsync(
     await restoreCcacheAsync({
       logger: ctx.logger,
       workingDirectory,
-      platform: ctx.job.platform,
+      target: { platform: ctx.job.platform },
       env: ctx.env,
       secrets: ctx.job.secrets,
     });
@@ -238,7 +238,7 @@ async function buildInnerAsync(
     await saveCcacheAsync({
       logger: ctx.logger,
       workingDirectory,
-      platform: ctx.job.platform,
+      target: { platform: ctx.job.platform },
       evictUsedBefore,
       env: ctx.env,
       secrets: ctx.job.secrets,

--- a/packages/build-tools/src/builders/ios.ts
+++ b/packages/build-tools/src/builders/ios.ts
@@ -103,7 +103,7 @@ async function buildInnerAsync(
       await restoreCcacheAsync({
         logger: ctx.logger,
         workingDirectory,
-        platform: ctx.job.platform,
+        target: { platform: ctx.job.platform, simulator: ctx.job.simulator === true },
         env: ctx.env,
         secrets: ctx.job.secrets,
       });
@@ -245,7 +245,7 @@ async function buildInnerAsync(
     await saveCcacheAsync({
       logger: ctx.logger,
       workingDirectory,
-      platform: ctx.job.platform,
+      target: { platform: ctx.job.platform, simulator: ctx.job.simulator === true },
       evictUsedBefore,
       env: ctx.env,
       secrets: ctx.job.secrets,

--- a/packages/build-tools/src/steps/functions/restoreBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/restoreBuildCache.ts
@@ -15,8 +15,9 @@ import path from 'path';
 import { sendCcacheStatsAsync } from './ccacheStats';
 import { decompressCacheAsync, downloadCacheAsync, downloadPublicCacheAsync } from './restoreCache';
 import {
-  CACHE_KEY_PREFIX_BY_PLATFORM,
+  CcacheBuildTarget,
   generateDefaultBuildCacheKeyAsync,
+  getCcacheKeyPrefix,
   getCcachePath,
 } from '../../utils/cacheKey';
 import { Datadog } from '../../datadog';
@@ -35,6 +36,11 @@ export function createRestoreBuildCacheFunction(): BuildFunction {
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
+      BuildStepInput.createProvider({
+        id: 'simulator',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+      }),
     ],
     fn: async (stepCtx, { env, inputs }) => {
       const { logger } = stepCtx;
@@ -48,10 +54,20 @@ export function createRestoreBuildCacheFunction(): BuildFunction {
         );
       }
 
+      const target: CcacheBuildTarget =
+        platform === Platform.IOS
+          ? {
+              platform,
+              simulator:
+                (inputs.simulator.value as boolean | undefined) ??
+                (stepCtx.global.staticContext.job.platform === Platform.IOS &&
+                  stepCtx.global.staticContext.job.simulator === true),
+            }
+          : { platform };
       await restoreCcacheAsync({
         logger,
         workingDirectory,
-        platform,
+        target,
         env,
         secrets: stepCtx.global.staticContext.job.secrets,
       });
@@ -92,13 +108,13 @@ export function createCacheStatsBuildFunction(): BuildFunction {
 export async function restoreCcacheAsync({
   logger,
   workingDirectory,
-  platform,
+  target,
   env,
   secrets,
 }: {
   logger: bunyan;
   workingDirectory: string;
-  platform: Platform;
+  target: CcacheBuildTarget;
   env: Record<string, string | undefined>;
   secrets?: { robotAccessToken?: string };
 }): Promise<void> {
@@ -136,7 +152,7 @@ export async function restoreCcacheAsync({
       })
     );
 
-    const cacheKey = await generateDefaultBuildCacheKeyAsync(workingDirectory, platform);
+    const cacheKey = await generateDefaultBuildCacheKeyAsync(workingDirectory, target);
     logger.info(`Restoring cache key: ${cacheKey}`);
 
     const jobId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
@@ -147,8 +163,8 @@ export async function restoreCcacheAsync({
       robotAccessToken,
       paths: [cachePath],
       key: cacheKey,
-      keyPrefixes: [CACHE_KEY_PREFIX_BY_PLATFORM[platform]],
-      platform,
+      keyPrefixes: [getCcacheKeyPrefix(target)],
+      platform: target.platform,
     });
 
     await decompressCacheAsync({
@@ -175,7 +191,7 @@ export async function restoreCcacheAsync({
           expoApiServerURL,
           robotAccessToken,
           paths: [cachePath],
-          platform,
+          platform: target.platform,
         });
         await decompressCacheAsync({
           archivePath,

--- a/packages/build-tools/src/steps/functions/saveBuildCache.ts
+++ b/packages/build-tools/src/steps/functions/saveBuildCache.ts
@@ -15,7 +15,11 @@ import path from 'path';
 
 import { compressCacheAsync, uploadCacheAsync } from './saveCache';
 import { formatBytes } from '../../utils/artifacts';
-import { generateDefaultBuildCacheKeyAsync, getCcachePath } from '../../utils/cacheKey';
+import {
+  CcacheBuildTarget,
+  generateDefaultBuildCacheKeyAsync,
+  getCcachePath,
+} from '../../utils/cacheKey';
 import { generateGradleCacheKeyAsync } from '../../utils/gradleCacheKey';
 
 export function createSaveBuildCacheFunction(evictUsedBefore: Date): BuildFunction {
@@ -30,6 +34,11 @@ export function createSaveBuildCacheFunction(evictUsedBefore: Date): BuildFuncti
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
+      BuildStepInput.createProvider({
+        id: 'simulator',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.BOOLEAN,
+      }),
     ],
     fn: async (stepCtx, { env, inputs }) => {
       const { logger } = stepCtx;
@@ -43,10 +52,20 @@ export function createSaveBuildCacheFunction(evictUsedBefore: Date): BuildFuncti
         );
       }
 
+      const target: CcacheBuildTarget =
+        platform === Platform.IOS
+          ? {
+              platform,
+              simulator:
+                (inputs.simulator.value as boolean | undefined) ??
+                (stepCtx.global.staticContext.job.platform === Platform.IOS &&
+                  stepCtx.global.staticContext.job.simulator === true),
+            }
+          : { platform };
       await saveCcacheAsync({
         logger,
         workingDirectory,
-        platform,
+        target,
         evictUsedBefore,
         env,
         secrets: stepCtx.global.staticContext.job.secrets,
@@ -67,14 +86,14 @@ export function createSaveBuildCacheFunction(evictUsedBefore: Date): BuildFuncti
 export async function saveCcacheAsync({
   logger,
   workingDirectory,
-  platform,
+  target,
   evictUsedBefore,
   env,
   secrets,
 }: {
   logger: bunyan;
   workingDirectory: string;
-  platform: Platform;
+  target: CcacheBuildTarget;
   evictUsedBefore: Date;
   env: Record<string, string | undefined>;
   secrets?: { robotAccessToken?: string };
@@ -99,7 +118,7 @@ export async function saveCcacheAsync({
   }
 
   try {
-    const cacheKey = await generateDefaultBuildCacheKeyAsync(workingDirectory, platform);
+    const cacheKey = await generateDefaultBuildCacheKeyAsync(workingDirectory, target);
     logger.info(`Saving cache key: ${cacheKey}`);
 
     const jobId = nullthrows(env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
@@ -143,7 +162,7 @@ export async function saveCcacheAsync({
       key: cacheKey,
       paths: [cachePath],
       size,
-      platform,
+      platform: target.platform,
     });
   } catch (err) {
     logger.error({ err }, 'Failed to save cache');

--- a/packages/build-tools/src/utils/__tests__/cacheKey.test.ts
+++ b/packages/build-tools/src/utils/__tests__/cacheKey.test.ts
@@ -1,0 +1,18 @@
+import { Platform } from '@expo/eas-build-job';
+
+import { getCcacheKeyPrefix } from '../cacheKey';
+
+describe(getCcacheKeyPrefix, () => {
+  it('uses separate prefixes for iOS device and simulator builds', () => {
+    expect(getCcacheKeyPrefix({ platform: Platform.IOS, simulator: false })).toBe(
+      'ios-device-ccache-'
+    );
+    expect(getCcacheKeyPrefix({ platform: Platform.IOS, simulator: true })).toBe(
+      'ios-simulator-ccache-'
+    );
+  });
+
+  it('does not change the Android prefix', () => {
+    expect(getCcacheKeyPrefix({ platform: Platform.ANDROID })).toBe('android-ccache-');
+  });
+});

--- a/packages/build-tools/src/utils/cacheKey.ts
+++ b/packages/build-tools/src/utils/cacheKey.ts
@@ -7,17 +7,24 @@ import path from 'path';
 
 import { findPackagerRootDir } from './packageManager';
 
-const IOS_CACHE_KEY_PREFIX = 'ios-ccache-';
+const IOS_DEVICE_CACHE_KEY_PREFIX = 'ios-device-ccache-';
+const IOS_SIMULATOR_CACHE_KEY_PREFIX = 'ios-simulator-ccache-';
 const ANDROID_CACHE_KEY_PREFIX = 'android-ccache-';
 const PUBLIC_IOS_CACHE_KEY_PREFIX = 'public-ios-ccache-';
 const PUBLIC_ANDROID_CACHE_KEY_PREFIX = 'public-android-ccache-';
 const DARWIN_CACHE_PATH = 'Library/Caches/ccache';
 const LINUX_CACHE_PATH = '.cache/ccache';
 
-export const CACHE_KEY_PREFIX_BY_PLATFORM: Record<Platform, string> = {
-  [Platform.ANDROID]: ANDROID_CACHE_KEY_PREFIX,
-  [Platform.IOS]: IOS_CACHE_KEY_PREFIX,
-};
+export type CcacheBuildTarget =
+  | { platform: Platform.ANDROID }
+  | { platform: Platform.IOS; simulator: boolean };
+
+export function getCcacheKeyPrefix(target: CcacheBuildTarget): string {
+  if (target.platform === Platform.IOS) {
+    return target.simulator ? IOS_SIMULATOR_CACHE_KEY_PREFIX : IOS_DEVICE_CACHE_KEY_PREFIX;
+  }
+  return ANDROID_CACHE_KEY_PREFIX;
+}
 
 export const PUBLIC_CACHE_KEY_PREFIX_BY_PLATFORM: Record<Platform, string> = {
   [Platform.ANDROID]: PUBLIC_ANDROID_CACHE_KEY_PREFIX,
@@ -36,7 +43,7 @@ export function getCcachePath(env: Record<string, string | undefined>): string {
 
 export async function generateDefaultBuildCacheKeyAsync(
   workingDirectory: string,
-  platform: Platform
+  target: CcacheBuildTarget
 ): Promise<string> {
   // This will resolve which package manager and use the relevant lock file
   // The lock file hash is the key and ensures cache is fresh
@@ -45,7 +52,7 @@ export async function generateDefaultBuildCacheKeyAsync(
   const lockPath = path.join(packagerRunDir, manager.lockFile);
 
   try {
-    return `${CACHE_KEY_PREFIX_BY_PLATFORM[platform]}${hashFiles([lockPath])}`;
+    return `${getCcacheKeyPrefix(target)}${hashFiles([lockPath])}`;
   } catch (err: any) {
     throw new Error(`Failed to read lockfile for cache key generation: ${err.message}`);
   }


### PR DESCRIPTION
# Why

Looks like ccache cache built for iOS simulator is not helpful for iOS device builds and vice versa.

Context: https://exponent-internal.slack.com/archives/C08PBDW7ZC3/p1787242902697509?thread_ts=1787171142.251299&cid=C08PBDW7ZC3

# How

Separated `ios-device-ccache-` and `ios-simulator-ccache-` ccaches.

# Test Plan

- Before: the [simulator build](https://staging.expo.dev/accounts/expo-services/projects/worker-system-tests/builds/5b9eccae-58a7-4a20-919e-61fbbd8ab68d) restored the [device build’s](https://staging.expo.dev/accounts/expo-services/projects/worker-system-tests/builds/026d0b35-0a6d-418d-bf34-488ed68f7d19) cache, got 0 hits, and could not save its own cache because the key already existed.
- After: the [device](https://staging.expo.dev/accounts/expo-services/projects/worker-system-tests/builds/02279218-8450-4679-b377-aec998dff0dd) and [simulator](https://staging.expo.dev/accounts/expo-services/projects/worker-system-tests/builds/0e6892fd-a9ee-4a90-ba23-97c7a17ad1e9) builds used separate keys. The simulator build got 48 direct hits.
