### PR TITLE
[build-tools] Add ios_signing_backend option to the repack step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [build-tools] Add `ios_signing_backend` option to the repack step. ([#4239](https://github.com/expo/eas-cli/pull/4239) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -77,7 +77,7 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
-    "@expo/repack-app": "~0.6.1",
+    "@expo/repack-app": "~0.9.0",
     "@types/fs-extra": "^11.0.4",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.4",

--- a/packages/build-tools/src/steps/functions/__tests__/repack.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/repack.test.ts
@@ -1,4 +1,5 @@
 import { type bunyan } from '@expo/logger';
+import assert from 'node:assert';
 import fg from 'fast-glob';
 import { vol } from 'memfs';
 import path from 'node:path';
@@ -193,14 +194,44 @@ describe(resolveIosSigningOptionsAsync, () => {
     const signingOptions = await resolveIosSigningOptionsAsync({
       job,
       logger: mockLogger,
+      tmpDir: '/tmp',
     });
 
     expect(signingOptions).not.toBeNull();
-    expect(signingOptions?.keychainPath).toEqual('/tmp/ios_keychain');
-    expect(signingOptions?.signingIdentity).toEqual('Test App Certificate');
-    expect(signingOptions?.provisioningProfile).toEqual({
-      'com.example.testapp': '/tmp/ios_provisioning_profile',
+    expect(signingOptions).toMatchObject({
+      keychainPath: '/tmp/ios_keychain',
+      signingIdentity: 'Test App Certificate',
+      provisioningProfile: {
+        'com.example.testapp': '/tmp/ios_provisioning_profile',
+      },
     });
+  });
+
+  it('should resolve zsign signing options without touching the keychain', async () => {
+    const job = createTestIosJob();
+    const tmpDir = '/tmp';
+    vol.mkdirSync(tmpDir, { recursive: true });
+    const credentialsManagerSpy = jest.spyOn(IosCredentialsManager.prototype, 'prepare');
+
+    const signingOptions = await resolveIosSigningOptionsAsync({
+      job,
+      logger: mockLogger,
+      backend: 'zsign',
+      tmpDir,
+    });
+
+    expect(credentialsManagerSpy).not.toHaveBeenCalled();
+    expect(signingOptions).toMatchObject({
+      backend: 'zsign',
+      keyPassword: job.secrets?.buildCredentials?.['testapp'].distributionCertificate.password,
+    });
+    assert(signingOptions?.backend === 'zsign');
+    expect(signingOptions.certificatePath).toMatch(/\/tmp\/dist-cert-.*\.p12/);
+    expect(vol.existsSync(signingOptions.certificatePath)).toBe(true);
+    assert(typeof signingOptions.provisioningProfile === 'object');
+    const profilePath = signingOptions.provisioningProfile['testapp'];
+    expect(profilePath).toMatch(/\/tmp\/profile-testapp-.*\.mobileprovision/);
+    expect(vol.existsSync(profilePath)).toBe(true);
   });
 
   it('should return undefined if no build credentials are provided', async () => {
@@ -209,6 +240,7 @@ describe(resolveIosSigningOptionsAsync, () => {
     const signingOptions = await resolveIosSigningOptionsAsync({
       job,
       logger: mockLogger,
+      tmpDir: '/tmp',
     });
     expect(signingOptions).toBeUndefined();
   });
@@ -219,6 +251,7 @@ describe(resolveIosSigningOptionsAsync, () => {
     const signingOptions = await resolveIosSigningOptionsAsync({
       job,
       logger: mockLogger,
+      tmpDir: '/tmp',
     });
     expect(signingOptions).toBeUndefined();
   });

--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -305,7 +305,8 @@ export async function resolveAndroidSigningOptionsAsync({
 }
 
 /**
- * Resolves iOS signing options from the job secrets.
+ * Resolves iOS signing options from the job secrets, dispatching on the
+ * requested signing backend.
  */
 export async function resolveIosSigningOptionsAsync({
   job,
@@ -327,17 +328,28 @@ export async function resolveIosSigningOptionsAsync({
   if (iosJob.simulator || buildCredentials == null) {
     return undefined;
   }
+  const commonOptions = { buildCredentials, logger, useAppEntitlements, entitlementsPath };
+  return backend === 'zsign'
+    ? await createIosZsignOptionsAsync({ ...commonOptions, tmpDir })
+    : await createIosFastlaneOptionsAsync(commonOptions);
+}
 
-  if (backend === 'zsign') {
-    return await resolveZsignSigningOptionsAsync({
-      buildCredentials,
-      logger,
-      useAppEntitlements,
-      entitlementsPath,
-      tmpDir,
-    });
-  }
-
+/**
+ * Creates signing options for the fastlane backend: certificates are imported
+ * into a temporary keychain and provisioning profiles are parsed with the
+ * macOS `security` tool.
+ */
+async function createIosFastlaneOptionsAsync({
+  buildCredentials,
+  logger,
+  useAppEntitlements,
+  entitlementsPath,
+}: {
+  buildCredentials: Ios.BuildCredentials;
+  logger: bunyan;
+  useAppEntitlements?: boolean;
+  entitlementsPath?: string;
+}): Promise<IosSigningOptions> {
   const credentialsManager = new IosCredentialsManager(buildCredentials);
   const credentials = await credentialsManager.prepare(logger);
 
@@ -355,9 +367,11 @@ export async function resolveIosSigningOptionsAsync({
 }
 
 /**
- * Resolves iOS signing options for the zsign backend without using keychain, so this also runs on Linux workers.
+ * Creates signing options for the zsign backend. The distribution certificate
+ * secret is already a PKCS#12 file, so it goes to disk as-is together with the
+ * provisioning profiles.
  */
-async function resolveZsignSigningOptionsAsync({
+async function createIosZsignOptionsAsync({
   buildCredentials,
   logger,
   useAppEntitlements,

--- a/packages/build-tools/src/steps/functions/repack.ts
+++ b/packages/build-tools/src/steps/functions/repack.ts
@@ -63,6 +63,12 @@ export function createRepackBuildFunction(): BuildFunction {
         required: false,
       }),
       BuildStepInput.createProvider({
+        id: 'ios_signing_backend',
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+        required: false,
+        allowedValues: ['fastlane', 'zsign'],
+      }),
+      BuildStepInput.createProvider({
         id: 'repack_version',
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
         required: false,
@@ -144,12 +150,14 @@ export function createRepackBuildFunction(): BuildFunction {
             iosSigningOptions: await resolveIosSigningOptionsAsync({
               job: stepsCtx.global.staticContext.job,
               logger: stepsCtx.logger,
+              backend: inputs.ios_signing_backend.value as 'fastlane' | 'zsign' | undefined,
               useAppEntitlements: inputs.ios_signing_use_source_app_entitlements.value as
                 | boolean
                 | undefined,
               entitlementsPath: inputs.ios_signing_app_entitlements_path.value as
                 | string
                 | undefined,
+              tmpDir,
             }),
             logger: stepsCtx.logger,
             spawnAsync: repackSpawnAsync,
@@ -302,19 +310,34 @@ export async function resolveAndroidSigningOptionsAsync({
 export async function resolveIosSigningOptionsAsync({
   job,
   logger,
+  backend,
   useAppEntitlements,
   entitlementsPath,
+  tmpDir,
 }: {
   job: Job;
   logger: bunyan;
+  backend?: 'fastlane' | 'zsign';
   useAppEntitlements?: boolean;
   entitlementsPath?: string;
+  tmpDir: string;
 }): Promise<IosSigningOptions | undefined> {
   const iosJob = job as Ios.Job;
   const buildCredentials = iosJob.secrets?.buildCredentials;
   if (iosJob.simulator || buildCredentials == null) {
     return undefined;
   }
+
+  if (backend === 'zsign') {
+    return await resolveZsignSigningOptionsAsync({
+      buildCredentials,
+      logger,
+      useAppEntitlements,
+      entitlementsPath,
+      tmpDir,
+    });
+  }
+
   const credentialsManager = new IosCredentialsManager(buildCredentials);
   const credentials = await credentialsManager.prepare(logger);
 
@@ -326,6 +349,54 @@ export async function resolveIosSigningOptionsAsync({
     provisioningProfile,
     keychainPath: credentials.keychainPath,
     signingIdentity: credentials.applicationTargetProvisioningProfile.data.certificateCommonName,
+    useAppEntitlements,
+    entitlementsPath,
+  };
+}
+
+/**
+ * Resolves iOS signing options for the zsign backend without using keychain, so this also runs on Linux workers.
+ */
+async function resolveZsignSigningOptionsAsync({
+  buildCredentials,
+  logger,
+  useAppEntitlements,
+  entitlementsPath,
+  tmpDir,
+}: {
+  buildCredentials: Ios.BuildCredentials;
+  logger: bunyan;
+  useAppEntitlements?: boolean;
+  entitlementsPath?: string;
+  tmpDir: string;
+}): Promise<IosSigningOptions> {
+  const targets = Object.entries(buildCredentials);
+  const [targetName, targetCredentials] = targets[0];
+  logger.info(`Using the distribution certificate from target '${targetName}' for zsign`);
+
+  const certificatePath = path.join(tmpDir, `dist-cert-${randomUUID()}.p12`);
+  await fs.promises.writeFile(
+    certificatePath,
+    new Uint8Array(Buffer.from(targetCredentials.distributionCertificate.dataBase64, 'base64'))
+  );
+
+  // zsign matches profiles to bundles by the app-id suffix itself, so the
+  // record keys are informational only.
+  const provisioningProfile: Record<string, string> = {};
+  for (const [target, credentials] of targets) {
+    const profilePath = path.join(tmpDir, `profile-${target}-${randomUUID()}.mobileprovision`);
+    await fs.promises.writeFile(
+      profilePath,
+      new Uint8Array(Buffer.from(credentials.provisioningProfileBase64, 'base64'))
+    );
+    provisioningProfile[target] = profilePath;
+  }
+
+  return {
+    backend: 'zsign',
+    certificatePath,
+    keyPassword: targetCredentials.distributionCertificate.password,
+    provisioningProfile,
     useAppEntitlements,
     entitlementsPath,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2303,7 +2303,7 @@ __metadata:
     "@expo/logger": "npm:22.0.0"
     "@expo/package-manager": "npm:1.9.10"
     "@expo/plist": "npm:^0.3.5"
-    "@expo/repack-app": "npm:~0.6.1"
+    "@expo/repack-app": "npm:~0.9.0"
     "@expo/results": "npm:^1.0.0"
     "@expo/spawn-async": "npm:1.7.2"
     "@expo/steps": "npm:22.1.0"
@@ -2818,15 +2818,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/repack-app@npm:~0.6.1":
-  version: 0.6.1
-  resolution: "@expo/repack-app@npm:0.6.1"
+"@expo/repack-app@npm:~0.9.0":
+  version: 0.9.0
+  resolution: "@expo/repack-app@npm:0.9.0"
   dependencies:
     commander: "npm:^14.0.2"
     picocolors: "npm:^1.1.1"
+    zsign-wasm: "npm:^0.0.2"
   bin:
     repack-app: bin/cli.js
-  checksum: 10c0/fdf3088b4f327393056631270bf90a67ba949e7994892a62abc985bd9478119ab2f1d5be35fa1efb6bd1d2780c49a3dbb87cb669d9c65b44e3d9a0b41fbf091f
+  checksum: 10c0/0a493d97b80b98a1a90172baf81d7efee6b65399bf15171aae9c6505be3eedd4e59d05a8a33b3a6b6b720a2a96b7c2c5043c8ec92e390a5f917e2dd139d88aab
   languageName: node
   linkType: hard
 
@@ -12327,6 +12328,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immediate@npm:~3.0.5":
+  version: 3.0.6
+  resolution: "immediate@npm:3.0.6"
+  checksum: 10c0/f8ba7ede69bee9260241ad078d2d535848745ff5f6995c7c7cb41cfdc9ccc213f66e10fa5afb881f90298b24a3f7344b637b592beb4f54e582770cdce3f1f039
+  languageName: node
+  linkType: hard
+
 "immutable@npm:^5.1.5":
   version: 5.1.9
   resolution: "immutable@npm:5.1.9"
@@ -13769,6 +13777,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jszip@npm:^3.10.1":
+  version: 3.10.1
+  resolution: "jszip@npm:3.10.1"
+  dependencies:
+    lie: "npm:~3.3.0"
+    pako: "npm:~1.0.2"
+    readable-stream: "npm:~2.3.6"
+    setimmediate: "npm:^1.0.5"
+  checksum: 10c0/58e01ec9c4960383fb8b38dd5f67b83ccc1ec215bf74c8a5b32f42b6e5fb79fada5176842a11409c4051b5b94275044851814a31076bf49e1be218d3ef57c863
+  languageName: node
+  linkType: hard
+
 "just-diff-apply@npm:^5.2.0":
   version: 5.5.0
   resolution: "just-diff-apply@npm:5.5.0"
@@ -14008,6 +14028,15 @@ __metadata:
     sigstore: "npm:^4.0.0"
     ssri: "npm:^12.0.0"
   checksum: 10c0/213cd2aeb65822892c3723a81d191a385e97f126ec63800f7051609e24c38c3fa36ea529b26739dc56dfba21f7f456347889f3aa1e6024c8c6a40bfa4cd9d184
+  languageName: node
+  linkType: hard
+
+"lie@npm:~3.3.0":
+  version: 3.3.0
+  resolution: "lie@npm:3.3.0"
+  dependencies:
+    immediate: "npm:~3.0.5"
+  checksum: 10c0/56dd113091978f82f9dc5081769c6f3b947852ecf9feccaf83e14a123bc630c2301439ce6182521e5fbafbde88e88ac38314327a4e0493a1bea7e0699a7af808
   languageName: node
   linkType: hard
 
@@ -16196,6 +16225,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pako@npm:~1.0.2":
+  version: 1.0.11
+  resolution: "pako@npm:1.0.11"
+  checksum: 10c0/86dd99d8b34c3930345b8bbeb5e1cd8a05f608eeb40967b293f72fe469d0e9c88b783a8777e4cc7dc7c91ce54c5e93d88ff4b4f060e6ff18408fd21030d9ffbe
+  languageName: node
+  linkType: hard
+
 "param-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "param-case@npm:3.0.4"
@@ -17453,6 +17489,13 @@ __metadata:
   version: 3.0.3
   resolution: "set-interval-async@npm:3.0.3"
   checksum: 10c0/7547bb5265648951f3f799391d970f39be16bae2b462ad54b58e96a6a3eb9dda1f183a3b9a4bfdc0a62637b026b494fae74cda075db1c5762b58d0c9172e6d4c
+  languageName: node
+  linkType: hard
+
+"setimmediate@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "setimmediate@npm:1.0.5"
+  checksum: 10c0/5bae81bfdbfbd0ce992893286d49c9693c82b1bcc00dcaaf3a09c8f428fdeacf4190c013598b81875dfac2b08a572422db7df779a99332d0fce186d15a3e4d49
   languageName: node
   linkType: hard
 
@@ -19990,5 +20033,14 @@ __metadata:
   version: 4.3.5
   resolution: "zod@npm:4.3.5"
   checksum: 10c0/5a2db7e59177a3d7e202543f5136cb87b97b047b77c8a3d824098d3fa8b80d3aa40a0a5f296965c3b82dfdccdd05dbbfacce91347f16a39c675680fd7b1ab109
+  languageName: node
+  linkType: hard
+
+"zsign-wasm@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "zsign-wasm@npm:0.0.2"
+  dependencies:
+    jszip: "npm:^3.10.1"
+  checksum: 10c0/f8919b66031c93970987fa9ac0e742cc7975e4c4c6fbf60fa477e1154109a50a4bf907b75dff8afe72b457df49ce5d060e3a3b93ba3c92b8c453d85206058f22
   languageName: node
   linkType: hard


### PR DESCRIPTION
# Why

We recently added experimental support for running repack for iOS apps on Linux machines starting from the package version 0.9.0. The idea for using Linux machines is that these are cheaper and more available than macOS ones. 

This PR exposes that backend as an opt-in input on the `eas/repack` step so we can test it end-to-end on EAS. A follow-up PR in universe adds the matching `ios_signing_backend` param to workflow repack jobs.

# How

- Adds optional `ios_signing_backend` input to `eas/repack` (`fastlane` | `zsign`). Default stays fastlane 
- Bumped the `@expo/repack-app` devDependency to `~0.9.0` for the backend-discriminated `IosSigningOptions` union. Even though the runtime package is still installed dynamically per job via `repack_version`.

# Test Plan

- Added a new unit test: resolving zsign options writes the `.p12` and profiles to the temp dir, returns `backend: 'zsign'`, and never touches `IosCredentialsManager`.  
- After this lands: run a workflow repack job with `ios_signing_backend: zsign` and `runs_on: linux-medium` against a real build.

Note: v0.9.0 is published as `next` on npm, so jobs opting this require setting `repack_version: next` for now
