### PR TITLE
[eas-cli] Quote env:pull values dotenv cannot read back verbatim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
+- [eas-cli] Quote `eas env:pull` values that `dotenv` would not read back verbatim, so values containing `#`, quotes, newlines or surrounding whitespace are no longer truncated or dropped. ([#4240](https://github.com/expo/eas-cli/pull/4240) by [@dennytosp](https://github.com/dennytosp))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/env/__tests__/EnvPull.test.ts
+++ b/packages/eas-cli/src/commands/env/__tests__/EnvPull.test.ts
@@ -1,3 +1,4 @@
+import dotenv from 'dotenv';
 import * as fs from 'fs-extra';
 import path from 'path';
 
@@ -61,6 +62,17 @@ describe(EnvPull, () => {
       updatedAt: new Date().toISOString(),
       scope: EnvironmentVariableScope.Project,
       visibility: EnvironmentVariableVisibility.Secret,
+      type: EnvironmentSecretType.String,
+    },
+    {
+      id: 'var5',
+      name: 'EXPO_PUBLIC_BRAND_COLOR',
+      value: '#99ccff',
+      environments: [DefaultEnvironment.Development],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      scope: EnvironmentVariableScope.Project,
+      visibility: EnvironmentVariableVisibility.Public,
       type: EnvironmentSecretType.String,
     },
     {
@@ -182,6 +194,27 @@ describe(EnvPull, () => {
       expect(fileContent).toContain('EXPO_PUBLIC_API_URL=https://api.example.com');
       expect(fileContent).toContain('DATABASE_URL=postgres://localhost:5432/mydb');
       expect(fileContent).toContain('# SECRET_KEY=***** (secret)');
+    });
+
+    it('quotes values dotenv would not read back verbatim', async () => {
+      const command = new EnvPull(['development'], mockConfig);
+
+      // @ts-expect-error
+      jest.spyOn(command, 'getContextAsync').mockReturnValue({
+        loggedIn: { graphqlClient },
+        projectId: testProjectId,
+        projectDir: testProjectDir,
+      });
+
+      await command.runAsync();
+
+      const writeFileCalls = jest.mocked(fs.writeFile).mock.calls;
+      const envFileCall = writeFileCalls.find(call => call[0] === testTargetPath);
+      const fileContent = envFileCall![1] as string;
+
+      // Unquoted, dotenv would read `#99ccff` as the start of a comment and drop the value.
+      expect(fileContent).toContain('EXPO_PUBLIC_BRAND_COLOR="#99ccff"');
+      expect(dotenv.parse(fileContent).EXPO_PUBLIC_BRAND_COLOR).toBe('#99ccff');
     });
 
     it('handles file variables correctly', async () => {

--- a/packages/eas-cli/src/commands/env/pull.ts
+++ b/packages/eas-cli/src/commands/env/pull.ts
@@ -12,6 +12,7 @@ import {
 } from '../../graphql/queries/EnvironmentVariablesQuery';
 import Log from '../../log';
 import { confirmAsync } from '../../prompts';
+import { formatEnvValue } from '../../utils/dotenv';
 import { promptVariableEnvironmentAsync } from '../../utils/prompts';
 
 export default class EnvPull extends EasCommand {
@@ -111,7 +112,7 @@ export default class EnvPull extends EasCommand {
         if (variable.visibility === EnvironmentVariableVisibility.Secret) {
           if (currentEnvLocal[variable.name]) {
             overridenSecretVariables.push(variable.name);
-            return `${variable.name}=${currentEnvLocal[variable.name]}`;
+            return `${variable.name}=${formatEnvValue(currentEnvLocal[variable.name])}`;
           }
           skippedSecretVariables.push(variable.name);
           return `# ${variable.name}=***** (secret)`;
@@ -119,9 +120,9 @@ export default class EnvPull extends EasCommand {
         if (variable.type === EnvironmentSecretType.FileBase64 && variable.valueWithFileContent) {
           const filePath = path.join(envDir, variable.name);
           await fs.writeFile(filePath, variable.valueWithFileContent, 'base64');
-          return `${variable.name}=${filePath}`;
+          return `${variable.name}=${formatEnvValue(filePath)}`;
         }
-        return `${variable.name}=${variable.value}`;
+        return `${variable.name}=${formatEnvValue(variable.value ?? '')}`;
       })
     );
 

--- a/packages/eas-cli/src/integrations/shared/envFile.ts
+++ b/packages/eas-cli/src/integrations/shared/envFile.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { EnvVar } from '../../environments/variables';
 import Log from '../../log';
 import { confirmAsync } from '../../prompts';
+import { formatEnvValue } from '../../utils/dotenv';
 
 export async function writeEnvLocalAsync(
   projectDir: string,
@@ -53,15 +54,6 @@ export async function writeEnvLocalAsync(
 // Copied from dotenv (lib/main.js) so this finds exactly the keys dotenv.parse reports above.
 const DOTENV_LINE =
   /^\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?$/gm;
-
-// dotenv trims unquoted values, cuts them at `#`, and strips one layer of quotes. Inside double
-// quotes it unescapes only `\n` and `\r`, so `"` and `\` stay literal.
-function formatEnvValue(value: string): string {
-  if (value === value.trim() && !/[#\r\n'"`]/.test(value.charAt(0) + value)) {
-    return value;
-  }
-  return `"${value.replace(/\n/g, '\\n').replace(/\r/g, '\\r')}"`;
-}
 
 export function mergeEnvContent(rawContent: string, newVars: Record<string, string>): string {
   const edits: { start: number; end: number; text: string }[] = [];

--- a/packages/eas-cli/src/utils/__tests__/dotenv-test.ts
+++ b/packages/eas-cli/src/utils/__tests__/dotenv-test.ts
@@ -1,0 +1,67 @@
+import dotenv from 'dotenv';
+
+import { formatEnvValue } from '../dotenv';
+
+function roundTrip(value: string): string | undefined {
+  return dotenv.parse(`KEY=${formatEnvValue(value)}`).KEY;
+}
+
+describe(formatEnvValue, () => {
+  it('leaves values dotenv already reads back unchanged unquoted', () => {
+    expect(formatEnvValue('')).toBe('');
+    expect(formatEnvValue('https://api.example.com')).toBe('https://api.example.com');
+    expect(formatEnvValue('postgres://localhost:5432/mydb')).toBe('postgres://localhost:5432/mydb');
+    expect(formatEnvValue('a$&b$1c')).toBe('a$&b$1c');
+    expect(formatEnvValue('{"a":1}')).toBe('{"a":1}');
+    expect(formatEnvValue("it's")).toBe("it's");
+    expect(formatEnvValue('literal\\nsequence')).toBe('literal\\nsequence');
+  });
+
+  it('quotes values dotenv would otherwise truncate, trim or drop', () => {
+    expect(formatEnvValue('#ffffff')).toBe('"#ffffff"');
+    expect(formatEnvValue('  padded ')).toBe('"  padded "');
+    expect(formatEnvValue('line\nbreak')).toBe('"line\\nbreak"');
+    expect(formatEnvValue("'single'")).toBe('"\'single\'"');
+  });
+
+  it('avoids double quotes for values that carry their own quotes or escapes', () => {
+    expect(formatEnvValue('{"color":"#f00"}')).toBe('\'{"color":"#f00"}\'');
+    expect(formatEnvValue('literal\\nsequence with a # in it')).toBe(
+      "'literal\\nsequence with a # in it'"
+    );
+    expect(formatEnvValue('mixed "double" and \'single\' #quotes')).toBe(
+      '`mixed "double" and \'single\' #quotes`'
+    );
+  });
+
+  it.each([
+    ['a plain value', 'https://api.example.com'],
+    ['a hex color', '#ffffff'],
+    ['a url with a fragment', 'https://example.com/docs#install'],
+    ['a value with an inline comment marker', 'secret#123'],
+    ['surrounding whitespace', '  padded '],
+    ['a single space', ' '],
+    ['an empty value', ''],
+    ['an apostrophe', "it's"],
+    ['a fully quoted value', '"quoted"'],
+    ['a single quoted value', "'quoted'"],
+    ['a backtick quoted value', '`quoted`'],
+    ['a newline', 'multi\nline'],
+    ['a carriage return', 'multi\r\nline'],
+    ['json', '{"a":1,"b":"two"}'],
+    ['json with a comment marker', '{"color":"#f00"}'],
+    ['a literal backslash-n sequence', 'literal\\nsequence'],
+    ['a backslash', 'C:\\Users\\expo'],
+    ['every quote character', 'mixed "double" and \'single\' and `backtick`'],
+    ['an rsa private key', '-----BEGIN KEY-----\nabc\ndef\n-----END KEY-----'],
+  ])('round-trips %s through dotenv', (_name, value) => {
+    expect(roundTrip(value)).toBe(value);
+  });
+
+  it('cannot be used to define another variable through a value', () => {
+    const parsed = dotenv.parse(`KEY=${formatEnvValue('value\nINJECTED=hijacked')}\nOTHER=kept\n`);
+    expect(parsed.KEY).toBe('value\nINJECTED=hijacked');
+    expect(parsed.INJECTED).toBeUndefined();
+    expect(parsed.OTHER).toBe('kept');
+  });
+});

--- a/packages/eas-cli/src/utils/dotenv.ts
+++ b/packages/eas-cli/src/utils/dotenv.ts
@@ -1,0 +1,32 @@
+/**
+ * Format a value so that `dotenv` reads the written `.env` line back unchanged.
+ *
+ * dotenv trims unquoted values, cuts them at the first `#`, and strips one layer of quotes.
+ * Inside double quotes it unescapes only `\n` and `\r`, so a `"` or a `\` stays literal and
+ * cannot be escaped away. See https://github.com/motdotla/dotenv#comments.
+ */
+export function formatEnvValue(value: string): string {
+  // Quotes only matter when they wrap the whole value, since dotenv strips just the outer
+  // pair; anything else is read back as written as long as there is nothing to trim or cut.
+  if (value === value.trim() && !/[#\r\n]/.test(value) && !/^(['"`])[\s\S]*\1$/.test(value)) {
+    return value;
+  }
+
+  // Double quotes are the readable form: they keep the value on a single line, because
+  // dotenv turns the `\n` and `\r` escapes back into newlines. That only holds for values
+  // that contain neither a `"` of their own nor a literal `\n`/`\r` sequence to preserve.
+  if (!value.includes('"') && !/\\[nr]/.test(value)) {
+    return `"${value.replace(/\n/g, '\\n').replace(/\r/g, '\\r')}"`;
+  }
+
+  // Single quotes and backticks are read back verbatim, so they carry the values double
+  // quotes cannot, at the cost of writing newlines out as real line breaks.
+  const quote = ["'", '`'].find(candidate => !value.includes(candidate));
+  if (quote) {
+    return `${quote}${value}${quote}`;
+  }
+
+  // A value using all three quote characters has no lossless representation. Escape it so
+  // at least the rest of the file still parses and the value cannot define another key.
+  return `"${value.replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r')}"`;
+}


### PR DESCRIPTION
# Why

Fixes #2813.

`eas env:pull` writes every value straight into the `.env` file without quoting, but `dotenv` does not read every string back the way it was written. It trims unquoted values, cuts them at the first `#`, and strips one layer of surrounding quotes. So a variable holding a hex colour, a URL with a fragment, or any value with a comment marker is silently truncated:

```
eas env:create --name TEST --value '#ffffff' --type string --visibility plaintext --environment development
eas env:pull --environment development
# .env.local contains `TEST=#ffffff`, which dotenv reads as an empty value
```

The same applies to values with surrounding whitespace or newlines (an RSA key, for example), which are dropped or split across lines.

# How

`packages/eas-cli/src/integrations/shared/envFile.ts` already carried a private `formatEnvValue` for exactly this problem, so rather than adding a second copy of the same dotenv trivia this moves it to `src/utils/dotenv.ts` and uses it for every line `env:pull` writes.

While sharing it, it also grew two cases the original could not represent, both reachable from real values:

- A value containing a `"` cannot be double quoted, because dotenv strips the outer pair but never unescapes `\"`. JSON values were only surviving by accident, and a JSON value that also contains a `#` was being cut in half. These now use single quotes (or backticks), which dotenv reads verbatim.
- A value containing a literal `\n` two-character sequence cannot be double quoted either, since dotenv turns that back into a real newline. It is quoted the same way.

Plain values are still written unquoted, so existing `.env.local` files do not churn.

# Test Plan

`packages/eas-cli/src/utils/__tests__/dotenv-test.ts` round-trips values through the real `dotenv.parse`, so the assertions are about what dotenv actually does rather than about the string shape: hex colours, URL fragments, surrounding whitespace, every quote character, literal escape sequences, JSON, and a multi-line private key. It also asserts a value cannot smuggle in a second key definition.

`EnvPull.test.ts` gets a variable holding `#99ccff` and asserts the written file parses back to `#99ccff`.

```
$ yarn test
Test Suites: 289 passed, 289 total
Tests:       4 skipped, 2466 passed, 2470 total
```

`yarn typecheck`, `yarn lint` (0 warnings), and `yarn fmt:check` are clean.
