### PR TITLE
[eas-cli] Strip control characters from the eas new project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
+- [eas-cli] Strip control characters from the `eas new` project name prompt, so clearing the prefilled name with Ctrl-U no longer creates a directory with an invisible `U+0015` prefix and fails with "Invalid slug". ([#4241](https://github.com/expo/eas-cli/pull/4241) by [@dennytosp](https://github.com/dennytosp))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commandUtils/new/__tests__/configs.test.ts
+++ b/packages/eas-cli/src/commandUtils/new/__tests__/configs.test.ts
@@ -90,6 +90,33 @@ describe('configs', () => {
         logSpy.expectLogToContain('Using project name: user-custom-name');
       });
 
+      it('should strip control characters left by terminal editing shortcuts', async () => {
+        (fs.pathExists as jest.Mock).mockResolvedValue(false);
+        jest.mocked(findProjectIdByAccountNameAndSlugNullableAsync).mockResolvedValue(null);
+        // Ctrl-U clears the prefilled name but leaves a literal U+0015 behind.
+        mockUserInput({ name: '\u0015my-project' });
+
+        const result = await generateProjectConfigAsync(undefined, mockOptions);
+
+        expect(result).toEqual({
+          projectName: 'my-project',
+          projectDirectory: expect.stringContaining('/my-project'),
+        });
+      });
+
+      it('should fall back to the default name when the answer is left empty', async () => {
+        (fs.pathExists as jest.Mock).mockResolvedValue(false);
+        jest.mocked(findProjectIdByAccountNameAndSlugNullableAsync).mockResolvedValue(null);
+        mockUserInput({ name: '\u0015' });
+
+        const result = await generateProjectConfigAsync(undefined, mockOptions);
+
+        expect(result).toEqual({
+          projectName: 'expo-project',
+          projectDirectory: expect.stringContaining('/expo-project'),
+        });
+      });
+
       it('should use shortid when prompted name exists', async () => {
         (fs.pathExists as jest.Mock).mockResolvedValue(true); // base name exists
         jest.mocked(findProjectIdByAccountNameAndSlugNullableAsync).mockResolvedValue(null);

--- a/packages/eas-cli/src/commandUtils/new/configs.ts
+++ b/packages/eas-cli/src/commandUtils/new/configs.ts
@@ -10,6 +10,17 @@ import { Choice, promptAsync } from '../../prompts';
 import { Actor } from '../../user/User';
 import { ExpoGraphqlClient } from '../context/contextUtils/createGraphqlClient';
 
+const DEFAULT_PROJECT_NAME = 'expo-project';
+
+/**
+ * Terminal editing shortcuts the prompt does not implement — Ctrl-U to clear the line, for
+ * example — are left in the answer as raw control characters. Kept, they produce an
+ * unreadable project directory and a slug the API rejects with "Invalid slug".
+ */
+function sanitizeProjectName(name: string): string {
+  return name.replace(/[\u0000-\u001f\u007f-\u009f]/g, '').trim();
+}
+
 function validateProjectPath(resolvedPath: string): void {
   const normalizedPath = path.normalize(resolvedPath);
 
@@ -41,7 +52,7 @@ export async function generateProjectConfigAsync(
   projectName: string;
   projectDirectory: string;
 }> {
-  let baseName = 'expo-project';
+  let baseName = DEFAULT_PROJECT_NAME;
   let parentDirectory = process.cwd();
 
   if (pathArg) {
@@ -50,14 +61,13 @@ export async function generateProjectConfigAsync(
     baseName = path.basename(resolvedPath);
     parentDirectory = path.dirname(resolvedPath);
   } else {
-    baseName = (
-      await promptAsync({
-        type: 'text',
-        name: 'name',
-        message: 'What would you like to name your project?',
-        initial: 'expo-project',
-      })
-    ).name;
+    const { name } = await promptAsync({
+      type: 'text',
+      name: 'name',
+      message: 'What would you like to name your project?',
+      initial: DEFAULT_PROJECT_NAME,
+    });
+    baseName = sanitizeProjectName(name) || DEFAULT_PROJECT_NAME;
   }
 
   // Find an available name checking both local filesystem and remote server


### PR DESCRIPTION
# Why

Fixes #3382.

The `What would you like to name your project?` prompt is prefilled with `expo-project`. Ctrl-U is the standard way to clear a line, but the prompt does not implement it, so the keystroke is left in the answer as a literal U+0015. The name is then used as-is for both the project directory and the slug, so the run creates a directory with an invisible prefix, installs dependencies into it, and only then fails:

```
% npx eas-cli@latest new
- What would you like to name your project? ... terraformation-subscription-mobile
x Creating @bhamilton/terraformation-subscription-mobile
Invalid slug
% ls -lbd *terraformation-subscription-mobile*
drwxr-xr-x  15 benhamilton  staff  480 Feb  5 09:56 \025terraformation-subscription-mobile
```

The `Invalid slug` error gives no hint about the invisible character, so this is hard to diagnose.

# How

Strip control characters from the prompt answer before it is used as the base name, and fall back to `expo-project` when nothing readable is left. That second case is reachable today: clearing the prefilled name and pressing enter currently produces a bare `-<nanoid>` directory name.

Deliberately narrow: only C0/C1 control characters and DEL are removed, so this does not start rejecting or rewriting names people typed on purpose.

# Test Plan

Two cases added to `packages/eas-cli/src/commandUtils/new/__tests__/configs.test.ts`, covering the Ctrl-U answer (resolves to `my-project`) and the cleared-then-submitted answer (falls back to `expo-project`).

```
$ yarn test
Test Suites: 288 passed, 288 total
Tests:       4 skipped, 2444 passed, 2448 total
```

`yarn typecheck`, `yarn lint` (0 warnings), and `yarn fmt:check` are clean.
