### PR TITLE
[eas-cli] Lint the App Store review demo password length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
+- [eas-cli] Make `eas metadata:lint` report an `apple.review.demoPassword` longer than 100 characters, instead of letting `eas metadata:push` fail at upload time with "Password cannot be longer than 100 characters". ([#4242](https://github.com/expo/eas-cli/pull/4242) by [@dennytosp](https://github.com/dennytosp))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/schema/metadata-0.json
+++ b/packages/eas-cli/schema/metadata-0.json
@@ -672,7 +672,8 @@
           },
           "demoPassword": {
             "type": "string",
-            "description": "The password to sign in to your app to review its features."
+            "description": "The password to sign in to your app to review its features.",
+            "maxLength": 100
           },
           "demoRequired": {
             "type": "boolean",

--- a/packages/eas-cli/src/metadata/config/__tests__/validate-test.ts
+++ b/packages/eas-cli/src/metadata/config/__tests__/validate-test.ts
@@ -1,0 +1,34 @@
+import { validateConfig } from '../validate';
+
+function reviewConfig(review: Record<string, unknown>): Record<string, unknown> {
+  return {
+    configVersion: 0,
+    apple: {
+      review: {
+        firstName: 'Expo',
+        lastName: 'Tester',
+        email: 'review@example.com',
+        phone: '+1 555 0100',
+        ...review,
+      },
+    },
+  };
+}
+
+describe(validateConfig, () => {
+  it('accepts a demo password within the App Store Connect limit', () => {
+    expect(validateConfig(reviewConfig({ demoPassword: 'p'.repeat(100) }))).toEqual([]);
+  });
+
+  it('reports a demo password longer than App Store Connect accepts', () => {
+    // Without this, the push only fails at upload time with "An attribute value is too
+    // long. - Password cannot be longer than 100 characters."
+    const issues = validateConfig(reviewConfig({ demoPassword: 'p'.repeat(101) }));
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      path: ['apple', 'review', 'demoPassword'],
+      message: expect.stringContaining('100 characters or fewer'),
+    });
+  });
+});


### PR DESCRIPTION
# Why

Fixes #2785.

`apple.review.demoPassword` has no length constraint in the metadata schema, so `eas metadata:lint` passes on a password App Store Connect will reject. The failure only shows up part-way through `eas metadata:push`, after other entities have already been synced:

```
x Failed creating store review details for 1.0

Store configuration upload encountered an error.

An attribute value is too long. - Password cannot be longer than 100 characters.
```

# How

Add `"maxLength": 100` to `demoPassword` in `packages/eas-cli/schema/metadata-0.json`, matching the limit Apple's API enforces, so the lint reports it before the push starts.

Note the App Store Connect web UI caps the field at 50 characters (see the screenshot in #2785), but the API accepts up to 100. Linting to the API limit avoids rejecting configs that push successfully today.

# Test Plan

New `packages/eas-cli/src/metadata/config/__tests__/validate-test.ts` asserts a 100-character password validates and a 101-character one is reported against `apple.review.demoPassword`.

```
$ yarn test
Test Suites: 289 passed, 289 total
Tests:       4 skipped, 2444 passed, 2448 total
```

`yarn typecheck`, `yarn lint` (0 warnings), and `yarn fmt:check` are clean.
