### PR TITLE
[eas-cli] Explain the missing companyName App Store Connect error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
+- [eas-cli] Point at `submit.<profile>.ios.companyName` in eas.json when App Store Connect rejects app creation with "You must provide a value for the attribute 'companyName'". ([#4243](https://github.com/expo/eas-cli/pull/4243) by [@dennytosp](https://github.com/dennytosp))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/ensureAppExists-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/ensureAppExists-test.ts
@@ -1,7 +1,7 @@
 import { Session } from '@expo/apple-utils';
 import nock from 'nock';
 
-import { createAppAsync } from '../ensureAppExists';
+import { createAppAsync, explainCreateAppError } from '../ensureAppExists';
 
 const FIXTURE_SUCCESS = {
   data: {
@@ -164,5 +164,25 @@ it('doubles up entropy', async () => {
     bundleId: 'com.bacon.jan27.x',
     name: 'Expo',
     companyName: 'expo',
+  });
+});
+
+describe(explainCreateAppError, () => {
+  it('points at eas.json when App Store Connect requires a company name', () => {
+    const error = explainCreateAppError(
+      new Error(
+        "The provided entity is missing a required attribute - You must provide a value for the attribute 'companyName' with this request"
+      )
+    );
+
+    expect(error.message).toContain('submit.<profile>.ios.companyName');
+    expect(error.message).toContain('https://docs.expo.dev/eas/json/#companyname');
+  });
+
+  it('keeps the App Store Connect hint for any other failure', () => {
+    const error = explainCreateAppError(new Error('Something else went wrong'));
+
+    expect(error.message).toContain('Something else went wrong');
+    expect(error.message).toContain('https://appstoreconnect.apple.com');
   });
 });

--- a/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/ensureAppExists.ts
@@ -8,7 +8,7 @@ import { AuthCtx, UserAuthCtx } from './authenticateTypes';
 import { syncCapabilitiesForEntitlementsAsync } from './bundleIdCapabilities';
 import { syncCapabilityIdentifiersForEntitlementsAsync } from './capabilityIdentifiers';
 import { assertContractMessagesAsync } from './contractMessages';
-import Log from '../../../log';
+import Log, { learnMore } from '../../../log';
 import { ora } from '../../../ora';
 
 /**
@@ -273,9 +273,7 @@ export async function ensureAppExistsAsync(
       }
 
       spinner.fail(`Failed to create App Store app ${chalk.dim(name)}`);
-      error.message +=
-        '\nVisit https://appstoreconnect.apple.com and resolve any warnings, then try again.';
-      throw error;
+      throw explainCreateAppError(error);
     }
   } else {
     // TODO: Update app name when API gives us that possibility
@@ -284,6 +282,24 @@ export async function ensureAppExistsAsync(
     `Prepared App Store Connect for ${chalk.bold(name)} ${chalk.dim(bundleIdentifier)}`
   );
   return app;
+}
+
+/**
+ * App Store Connect reports a missing company name by attribute name alone, which does not
+ * hint at all that the value comes from the submit profile in eas.json.
+ */
+export function explainCreateAppError(error: Error): Error {
+  if (error.message.match(/value for the attribute 'companyName'/)) {
+    return new Error(
+      `\nApp Store Connect needs a company name to display on the App Store for the first app created on this Apple account. Set ${chalk.bold(
+        'submit.<profile>.ios.companyName'
+      )} in eas.json and try again.\n${learnMore('https://docs.expo.dev/eas/json/#companyname')}\n`
+    );
+  }
+
+  error.message +=
+    '\nVisit https://appstoreconnect.apple.com and resolve any warnings, then try again.';
+  return error;
 }
 
 function sanitizeName(name: string): string {


### PR DESCRIPTION
# Why

Fixes #3033.

When App Store Connect needs a company name, it reports the failure by attribute name only, and the CLI appends a hint that points somewhere unhelpful:

```
The provided entity is missing a required attribute - You must provide a value for the attribute 'companyName' with this request
Visit https://appstoreconnect.apple.com and resolve any warnings, then try again.
Submission failed
```

Nothing here says the value comes from `submit.<profile>.ios.companyName` in eas.json, and there is no warning to resolve on App Store Connect, so the suggested next step is a dead end. This only affects accounts creating their first app, which is exactly the audience least likely to guess.

# How

Match that error in the app-creation catch and replace the message with one that names the eas.json field and links to the reference docs.

The error mapping moved into an exported `explainCreateAppError` so it can be tested without standing up an App Store Connect session; the spinner handling around it is unchanged.

# Test Plan

Two cases added to `packages/eas-cli/src/credentials/ios/appstore/__tests__/ensureAppExists-test.ts`: the `companyName` error is rewritten to mention the eas.json field and the docs anchor, and any other error keeps the existing App Store Connect hint.

The docs anchor was verified to exist on https://docs.expo.dev/eas/json/#companyname.

```
$ yarn test
Test Suites: 288 passed, 288 total
Tests:       4 skipped, 2444 passed, 2448 total
```

`yarn typecheck`, `yarn lint` (0 warnings), and `yarn fmt:check` are clean.
