### PR TITLE
[build-tools] Support individual ASC API keys in upload_to_asc

### DIFF
--- a/packages/build-tools/src/steps/functions/uploadToAsc.ts
+++ b/packages/build-tools/src/steps/functions/uploadToAsc.ts
@@ -90,7 +90,6 @@ export function createUploadToAscBuildFunction(): BuildFunction {
       const ascApiKeyJson = await fs.readJson(ascApiKeyPath);
       const ascApiKey = z
         .object({
-          // Nullish issuer_id means an individual API key
           issuer_id: z.string().nullish(),
           key_id: z.string(),
           key: z.string(),
@@ -98,12 +97,15 @@ export function createUploadToAscBuildFunction(): BuildFunction {
         .parse(ascApiKeyJson);
 
       const privateKey = await jose.importPKCS8(ascApiKey.key, 'ES256');
-      const jwt = new jose.SignJWT(ascApiKey.issuer_id ? {} : { sub: 'user' })
+      const jwt = new jose.SignJWT({})
         .setProtectedHeader({ alg: 'ES256', kid: ascApiKey.key_id })
         .setAudience('appstoreconnect-v1')
         .setExpirationTime('20m');
       if (ascApiKey.issuer_id) {
         jwt.setIssuer(ascApiKey.issuer_id);
+      } else {
+        // Nullish issuer_id means an individual API key
+        jwt.setSubject('user');
       }
       const token = await jwt.sign(privateKey);
 

--- a/packages/build-tools/src/steps/functions/uploadToAsc.ts
+++ b/packages/build-tools/src/steps/functions/uploadToAsc.ts
@@ -90,19 +90,22 @@ export function createUploadToAscBuildFunction(): BuildFunction {
       const ascApiKeyJson = await fs.readJson(ascApiKeyPath);
       const ascApiKey = z
         .object({
-          issuer_id: z.string(),
+          // Nullish issuer_id means an individual API key
+          issuer_id: z.string().nullish(),
           key_id: z.string(),
           key: z.string(),
         })
         .parse(ascApiKeyJson);
 
       const privateKey = await jose.importPKCS8(ascApiKey.key, 'ES256');
-      const token = await new jose.SignJWT({})
+      const jwt = new jose.SignJWT(ascApiKey.issuer_id ? {} : { sub: 'user' })
         .setProtectedHeader({ alg: 'ES256', kid: ascApiKey.key_id })
-        .setIssuer(ascApiKey.issuer_id)
         .setAudience('appstoreconnect-v1')
-        .setExpirationTime('20m')
-        .sign(privateKey);
+        .setExpirationTime('20m');
+      if (ascApiKey.issuer_id) {
+        jwt.setIssuer(ascApiKey.issuer_id);
+      }
+      const token = await jwt.sign(privateKey);
 
       const client = new AscApiClient({ token, logger: stepsCtx.logger });
 


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

ASC submissions don't need a team API key. Individual key works too.

The `eas/upload-to-asc` function requires `issuer_id` in the API key json currently.

# How

- Make `issuer_id` optional in the zod schema for the API key in `eas/upload-to-asc`.
- When `issuer_id` nullish, `iss` is not set during the token creation, but `sub` is set to `user` instead.

# Test Plan

CI passes.