### PR TITLE
[eas-cli] Make ASC API key issuer identifier optional in types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Make ASC API key issuer identifier optional in GraphQL and credentials types. ([#4248](https://github.com/expo/eas-cli/pull/4248) by [@sswrk](https://github.com/sswrk))
+
 ## [23.2.0](https://github.com/expo/eas-cli/releases/tag/v23.2.0) - 2026-08-31
 
 ### 🎉 New features

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -44,7 +44,7 @@
     "copy-new-templates": "rimraf build/commandUtils/new/templates && mkdir -p build/commandUtils/new && cp -r src/commandUtils/new/templates build/commandUtils/new"
   },
   "dependencies": {
-    "@expo/apple-utils": "2.1.22",
+    "@expo/apple-utils": "2.2.0",
     "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "55.0.10",
     "@expo/config-plugins": "55.0.7",

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -304,7 +304,7 @@ export async function resolveAscApiKeyForAppCredentialsAsync({
     ascApiKey: {
       keyP8: fullKey.keyP8,
       keyId: fullKey.keyIdentifier,
-      issuerId: fullKey.issuerIdentifier ?? '',
+      issuerId: fullKey.issuerIdentifier,
     },
     teamId: ascKeyFragment.appleTeam?.appleTeamIdentifier,
     teamName: ascKeyFragment.appleTeam?.appleTeamName ?? undefined,

--- a/packages/eas-cli/src/credentials/ios/credentials.ts
+++ b/packages/eas-cli/src/credentials/ios/credentials.ts
@@ -105,7 +105,8 @@ export const distributionCertificateSchema: CredentialSchema<DistributionCertifi
 export type MinimalAscApiKey = {
   keyP8: string;
   keyId: string;
-  issuerId: string;
+  // Absent for individual API keys, which are valid only for submissions.
+  issuerId?: string;
   teamId?: string;
   teamName?: string;
   roles?: UserRole[];
@@ -115,7 +116,7 @@ export type MinimalAscApiKey = {
 export interface AscApiKeyPath {
   keyP8Path: string;
   keyId: string;
-  issuerId: string;
+  issuerId?: string;
 }
 
 export const ascApiKeyIdSchema: CredentialSchema<Pick<MinimalAscApiKey, 'keyId'>> = {
@@ -129,7 +130,7 @@ export const ascApiKeyIdSchema: CredentialSchema<Pick<MinimalAscApiKey, 'keyId'>
   ],
 };
 
-export const ascApiKeyIssuerIdSchema: CredentialSchema<Pick<MinimalAscApiKey, 'issuerId'>> = {
+export const ascApiKeyIssuerIdSchema: CredentialSchema<{ issuerId: string }> = {
   name: 'App Store Connect API Key',
   questions: [
     {

--- a/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
@@ -248,6 +248,8 @@ function displayAscApiKey(
     }
     if (issuerIdentifier) {
       fields.push({ label: 'Issuer ID', value: issuerIdentifier });
+    } else {
+      fields.push({ label: 'Key Type', value: 'Individual (submissions only)' });
     }
     if (roles) {
       fields.push({ label: 'Roles', value: roles.join(',') });

--- a/packages/eas-cli/src/graphql/queries/AppStoreConnectApiKeyQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/AppStoreConnectApiKeyQuery.ts
@@ -12,7 +12,7 @@ export const AppStoreConnectApiKeyQuery = {
     graphqlClient: ExpoGraphqlClient,
     ascApiKeyId: string
   ): Promise<{
-    issuerIdentifier: string | null | undefined;
+    issuerIdentifier: string | undefined;
     keyIdentifier: string;
     keyP8: string;
   }> {
@@ -42,7 +42,7 @@ export const AppStoreConnectApiKeyQuery = {
     const key = data.appStoreConnectApiKey.byId;
 
     return {
-      issuerIdentifier: key.issuerIdentifier,
+      issuerIdentifier: key.issuerIdentifier ?? undefined,
       keyIdentifier: key.keyIdentifier,
       keyP8: key.keyP8,
     };

--- a/packages/eas-cli/src/metadata/auth.ts
+++ b/packages/eas-cli/src/metadata/auth.ts
@@ -105,7 +105,7 @@ async function tryResolveAscApiKeyAsync({
         ascApiKey: {
           keyP8: fullKey.keyP8,
           keyId: fullKey.keyIdentifier,
-          issuerId: fullKey.issuerIdentifier ?? '',
+          issuerId: fullKey.issuerIdentifier,
         },
         teamId: ascKeyFragment.appleTeam?.appleTeamIdentifier,
         teamName: ascKeyFragment.appleTeam?.appleTeamName ?? undefined,

--- a/packages/eas-cli/src/testflight/app.ts
+++ b/packages/eas-cli/src/testflight/app.ts
@@ -76,7 +76,7 @@ async function findAppWithAccountAscApiKeysAsync({
         token: new Token({
           key: keyP8,
           keyId: keyIdentifier,
-          issuerId: issuerIdentifier ?? '',
+          issuerId: issuerIdentifier,
           duration: ASC_TOKEN_DURATION_SECONDS,
         }),
       };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2282,12 +2282,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/apple-utils@npm:2.1.22":
-  version: 2.1.22
-  resolution: "@expo/apple-utils@npm:2.1.22"
+"@expo/apple-utils@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@expo/apple-utils@npm:2.2.0"
   bin:
     apple-utils: bin.js
-  checksum: 10c0/19a5d21f80cde11e7502d7380b17bb4634568dcd243eb72ce741277dd71aab2b20168e44060143b10bfa01f0b03a6b8a2628b3cf3e5d697b12cf7f78a16d469a
+  checksum: 10c0/527bbe07536f5ff7aeb3774feaa4d9ed89e1ffec54f414125e9a85ba5048eb6471fa5ae6b4ce25f7387601383b4e34e2490c62d3778e12f79bff13167447187e
   languageName: node
   linkType: hard
 
@@ -10465,7 +10465,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "eas-cli@workspace:packages/eas-cli"
   dependencies:
-    "@expo/apple-utils": "npm:2.1.22"
+    "@expo/apple-utils": "npm:2.2.0"
     "@expo/code-signing-certificates": "npm:0.0.5"
     "@expo/config": "npm:55.0.10"
     "@expo/config-plugins": "npm:55.0.7"


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Follow-up PR to ASC API key `issueIdentifier` becoming nullable in `www` GraphQL API and to an analogical update in `@expo/apple-utils`.

# How

- Made `issuerId` optional in `credentials.ts`.
- Changed `AppStoreConnectApiKeyQuery` to return `issuerIdentifier: string | undefined` instead of `string | null | undefined`.
- Removed the `?? ''` fallbacks in `AscApiKeyUtils.ts` and `metadata/auth.ts`.
- Bumped `@expo/apple-utils` to `2.2.0`
- Passed the optional `issuerIdentifier` through to the TestFlight app lookup, removed the `?? ''` fallback.
- Updated `printCredentials.ts` to show "Individual (submissions only)" when issuerIdentifier is not present.

# Test Plan

CI passes.