### PR TITLE
[eas-cli] Accept individual ASC API keys for submissions, guard provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Accept individual App Store Connect API keys for submissions, TestFlight setup, and metadata. ([#4249](https://github.com/expo/eas-cli/pull/4249) by [@sswrk](https://github.com/sswrk))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/packages/eas-cli/src/commands/integrations/asc/__tests__/connect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/asc/__tests__/connect.test.ts
@@ -101,6 +101,7 @@ describe(IntegrationsAscConnect, () => {
       {
         id: 'key-id',
         keyIdentifier: 'FAKEKEY000',
+        issuerIdentifier: 'FAKEISSUER',
       },
     ] as any);
 
@@ -139,6 +140,7 @@ describe(IntegrationsAscConnect, () => {
       {
         id: 'eas-key-uuid',
         keyIdentifier: 'FAKEKEY000',
+        issuerIdentifier: 'FAKEISSUER',
       },
     ] as any);
 
@@ -207,6 +209,7 @@ describe(IntegrationsAscConnect, () => {
       {
         id: 'key-id',
         keyIdentifier: 'FAKEKEY000',
+        issuerIdentifier: 'FAKEISSUER',
       },
     ] as any);
 
@@ -234,6 +237,7 @@ describe(IntegrationsAscConnect, () => {
       {
         id: 'eas-key-uuid',
         keyIdentifier: 'FAKEKEY000',
+        issuerIdentifier: 'FAKEISSUER',
       },
     ] as any);
 
@@ -255,6 +259,35 @@ describe(IntegrationsAscConnect, () => {
     );
   });
 
+  it('fails when --api-key-id points at an individual key', async () => {
+    jest
+      .mocked(AscAppLinkQuery.getAppMetadataAsync)
+      .mockResolvedValueOnce(mockMetadataDisconnected);
+    jest.mocked(AppStoreConnectApiKeyQuery.getAllForAccountAsync).mockResolvedValueOnce([
+      {
+        id: 'key-id',
+        keyIdentifier: 'FAKEKEY000',
+        issuerIdentifier: null,
+      },
+    ] as any);
+
+    const command = new IntegrationsAscConnect(
+      ['--api-key-id', 'FAKEKEY000', '--asc-app-id', '9876543210', '--non-interactive'],
+      mockConfig
+    );
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      projectId: testProjectId,
+      projectDir: '/test/project',
+      analytics,
+      vcsClient,
+      loggedIn: { graphqlClient, actor },
+    });
+
+    await expect(command.runAsync()).rejects.toThrow('is an individual key');
+    expect(AscAppLinkQuery.discoverAccessibleAppsAsync).not.toHaveBeenCalled();
+  });
+
   it('fails when multiple keys match Apple key identifier', async () => {
     jest
       .mocked(AscAppLinkQuery.getAppMetadataAsync)
@@ -263,10 +296,12 @@ describe(IntegrationsAscConnect, () => {
       {
         id: 'eas-key-uuid-1',
         keyIdentifier: 'FAKEKEY000',
+        issuerIdentifier: 'FAKEISSUER',
       },
       {
         id: 'eas-key-uuid-2',
         keyIdentifier: 'FAKEKEY000',
+        issuerIdentifier: 'FAKEISSUER',
       },
     ] as any);
 
@@ -297,6 +332,7 @@ describe(IntegrationsAscConnect, () => {
       {
         id: 'key-id',
         keyIdentifier: 'FAKEKEY000',
+        issuerIdentifier: 'FAKEISSUER',
       },
     ] as any);
 
@@ -329,6 +365,7 @@ describe(IntegrationsAscConnect, () => {
       {
         id: 'key-id',
         keyIdentifier: 'FAKEKEY000',
+        issuerIdentifier: 'FAKEISSUER',
       },
     ] as any);
 

--- a/packages/eas-cli/src/commands/integrations/asc/connect.ts
+++ b/packages/eas-cli/src/commands/integrations/asc/connect.ts
@@ -113,6 +113,11 @@ export default class IntegrationsAscConnect extends EasCommand {
           `Multiple App Store Connect API keys match Apple key identifier "${apiKeyId}".`
         );
       } else if (keysByAppleId.length === 1) {
+        if (!keysByAppleId[0].issuerIdentifier) {
+          throw new EasCommandError(
+            `App Store Connect API key "${apiKeyId}" is an individual key (it has no Issuer ID). Individual keys are not supported for the App Store Connect connection. Use a team API key.`
+          );
+        }
         apiKeyId = keysByAppleId[0].id;
       } else {
         throw new EasCommandError(

--- a/packages/eas-cli/src/commands/submit/__tests__/internal.test.ts
+++ b/packages/eas-cli/src/commands/submit/__tests__/internal.test.ts
@@ -1,0 +1,94 @@
+import { getAppStoreConnectApiKeyJsonAsync } from '../internal';
+import { AppStoreConnectApiKeyQuery } from '../../../graphql/queries/AppStoreConnectApiKeyQuery';
+
+jest.mock('../../../graphql/queries/AppStoreConnectApiKeyQuery', () => ({
+  AppStoreConnectApiKeyQuery: {
+    getByIdAsync: jest.fn(),
+  },
+}));
+
+describe(getAppStoreConnectApiKeyJsonAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('writes issuer_id for an inline team key', async () => {
+    const json = await getAppStoreConnectApiKeyJsonAsync({
+      iosConfig: {
+        ascApiKey: {
+          keyIdentifier: 'KEY123',
+          issuerIdentifier: 'ISSUER456',
+          keyP8: 'p8-content',
+        },
+      } as any,
+      graphqlClient: {} as any,
+    });
+
+    expect(JSON.parse(json!)).toEqual({
+      key_id: 'KEY123',
+      issuer_id: 'ISSUER456',
+      key: 'p8-content',
+    });
+  });
+
+  it('omits issuer_id for an inline individual key', async () => {
+    const json = await getAppStoreConnectApiKeyJsonAsync({
+      iosConfig: {
+        ascApiKey: {
+          keyIdentifier: 'KEY123',
+          keyP8: 'p8-content',
+        },
+      } as any,
+      graphqlClient: {} as any,
+    });
+
+    const parsed = JSON.parse(json!);
+    expect(parsed).toEqual({ key_id: 'KEY123', key: 'p8-content' });
+    expect('issuer_id' in parsed).toBe(false);
+  });
+
+  it('writes issuer_id for a stored team key', async () => {
+    jest.mocked(AppStoreConnectApiKeyQuery.getByIdAsync).mockResolvedValue({
+      keyIdentifier: 'KEY123',
+      issuerIdentifier: 'ISSUER456',
+      keyP8: 'p8-content',
+    });
+
+    const json = await getAppStoreConnectApiKeyJsonAsync({
+      iosConfig: { ascApiKeyId: 'stored-key-id' } as any,
+      graphqlClient: {} as any,
+    });
+
+    expect(JSON.parse(json!)).toEqual({
+      key_id: 'KEY123',
+      issuer_id: 'ISSUER456',
+      key: 'p8-content',
+    });
+  });
+
+  it('omits issuer_id for a stored individual key', async () => {
+    jest.mocked(AppStoreConnectApiKeyQuery.getByIdAsync).mockResolvedValue({
+      keyIdentifier: 'KEY123',
+      issuerIdentifier: undefined,
+      keyP8: 'p8-content',
+    });
+
+    const json = await getAppStoreConnectApiKeyJsonAsync({
+      iosConfig: { ascApiKeyId: 'stored-key-id' } as any,
+      graphqlClient: {} as any,
+    });
+
+    const parsed = JSON.parse(json!);
+    expect(parsed).toEqual({ key_id: 'KEY123', key: 'p8-content' });
+    expect('issuer_id' in parsed).toBe(false);
+  });
+
+  it('returns null without key input', async () => {
+    const json = await getAppStoreConnectApiKeyJsonAsync({
+      iosConfig: {} as any,
+      graphqlClient: {} as any,
+    });
+
+    expect(json).toBeNull();
+  });
+});

--- a/packages/eas-cli/src/commands/submit/internal.ts
+++ b/packages/eas-cli/src/commands/submit/internal.ts
@@ -183,17 +183,20 @@ async function getGoogleServiceAccountKeyJsonAsync({
   return null;
 }
 
-async function getAppStoreConnectApiKeyJsonAsync({
+export async function getAppStoreConnectApiKeyJsonAsync({
   iosConfig,
   graphqlClient,
 }: {
   iosConfig: IosSubmissionConfigInput;
   graphqlClient: ExpoGraphqlClient;
 }): Promise<string | null> {
+  // Individual API keys have no issuer. fastlane detects them by the absence of the issuer_id field.
   if (iosConfig.ascApiKey) {
     return JSON.stringify({
       key_id: iosConfig.ascApiKey.keyIdentifier,
-      issuer_id: iosConfig.ascApiKey.issuerIdentifier,
+      ...(iosConfig.ascApiKey.issuerIdentifier
+        ? { issuer_id: iosConfig.ascApiKey.issuerIdentifier }
+        : null),
       key: iosConfig.ascApiKey.keyP8,
     });
   } else if (iosConfig.ascApiKeyId) {
@@ -201,7 +204,7 @@ async function getAppStoreConnectApiKeyJsonAsync({
 
     return JSON.stringify({
       key_id: key.keyIdentifier,
-      issuer_id: key.issuerIdentifier,
+      ...(key.issuerIdentifier ? { issuer_id: key.issuerIdentifier } : null),
       key: key.keyP8,
     });
   }

--- a/packages/eas-cli/src/credentials/__tests__/fixtures-appstore.ts
+++ b/packages/eas-cli/src/credentials/__tests__/fixtures-appstore.ts
@@ -11,6 +11,7 @@ export function getAppstoreMock(): AppStoreApi {
   return {
     defaultAuthenticationMode: AuthenticationMode.USER,
     ensureAuthenticatedAsync: jest.fn(),
+    ensureProvisioningAuthenticatedAsync: jest.fn(),
     ensureBundleIdExistsAsync: jest.fn(),
     listDistributionCertificatesAsync: jest.fn(),
     createDistributionCertificateAsync: jest.fn(),

--- a/packages/eas-cli/src/credentials/context.ts
+++ b/packages/eas-cli/src/credentials/context.ts
@@ -105,6 +105,17 @@ export class CredentialsContext {
     }
 
     if (this.appStore.defaultAuthenticationMode === AuthenticationMode.API_KEY) {
+      if (
+        process.env.EXPO_ASC_API_KEY_PATH &&
+        process.env.EXPO_ASC_KEY_ID &&
+        !process.env.EXPO_ASC_ISSUER_ID
+      ) {
+        Log.debug(
+          `App Store Connect API key ${process.env.EXPO_ASC_KEY_ID} has no Issuer ID (individual key). Skipping authentication with Apple. Set EXPO_ASC_ISSUER_ID if this is a team key.`
+        );
+        this.shouldAskAuthenticateAppStore = false;
+        return;
+      }
       await this.appStore.ensureAuthenticatedAsync();
       return;
     }

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -260,6 +260,23 @@ function filterKeysFromDifferentAppleTeam(
   return keys.filter(key => !key.appleTeam || key.appleTeam?.appleTeamIdentifier === teamId);
 }
 
+export function filterOutIndividualAscApiKeys(
+  keys: AppStoreConnectApiKeyFragment[]
+): AppStoreConnectApiKeyFragment[] {
+  const teamKeys = keys.filter(key => !!key.issuerIdentifier);
+  const hiddenCount = keys.length - teamKeys.length;
+  if (hiddenCount > 0) {
+    Log.log(
+      chalk.gray(
+        `${hiddenCount} individual API ${
+          hiddenCount === 1 ? 'key' : 'keys'
+        } hidden: individual keys are valid only for submissions.`
+      )
+    );
+  }
+  return teamKeys;
+}
+
 export function sortAscApiKeysByUpdatedAtDesc(
   keys: AppStoreConnectApiKeyFragment[]
 ): AppStoreConnectApiKeyFragment[] {

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -329,6 +329,16 @@ export async function tryAuthenticateAppStoreWithEasAscApiKeyAsync(
   }
   try {
     if (hasAscEnvVars()) {
+      if (
+        process.env.EXPO_ASC_API_KEY_PATH &&
+        process.env.EXPO_ASC_KEY_ID &&
+        !process.env.EXPO_ASC_ISSUER_ID
+      ) {
+        Log.debug(
+          `App Store Connect API key ${process.env.EXPO_ASC_KEY_ID} has no Issuer ID (individual key). Skipping authentication with Apple. Set EXPO_ASC_ISSUER_ID if this is a team key.`
+        );
+        return false;
+      }
       await ctx.appStore.ensureAuthenticatedAsync({
         mode: AuthenticationMode.API_KEY,
         teamType,
@@ -340,6 +350,12 @@ export async function tryAuthenticateAppStoreWithEasAscApiKeyAsync(
       app,
     });
     if (!resolvedKey) {
+      return false;
+    }
+    if (!resolvedKey.ascApiKey.issuerId) {
+      Log.debug(
+        `App Store Connect API key ${resolvedKey.ascApiKey.keyId} has no Issuer ID (individual key). Skipping authentication with Apple. Run 'eas credentials' and upload the key again with its Issuer ID if this is a team key.`
+      );
       return false;
     }
     Log.log('Using App Store Connect API Key from EAS credentials service.');

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/AscApiKeyUtils-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/AscApiKeyUtils-test.ts
@@ -1,6 +1,8 @@
 import { UserRole } from '@expo/apple-utils';
 import fs from 'fs-extra';
 
+import { AppStoreConnectApiKeyQuery } from '../../../../graphql/queries/AppStoreConnectApiKeyQuery';
+import Log from '../../../../log';
 import { promptAsync, selectAsync } from '../../../../prompts';
 import { getAppstoreMock, testAuthCtx } from '../../../__tests__/fixtures-appstore';
 import { createCtxMock } from '../../../__tests__/fixtures-context';
@@ -9,16 +11,32 @@ import {
   getCredentialsFromUserAsync,
   shouldAutoGenerateCredentialsAsync,
 } from '../../../utils/promptForCredentials';
+import { getAscApiKeyForAppSubmissionsAsync } from '../../api/GraphqlClient';
+import { AppleTeamType } from '../../appstore/authenticateTypes';
+import { hasAscEnvVars } from '../../appstore/resolveCredentials';
 import {
   AppStoreApiKeyPurpose,
   getAscApiKeyName,
   promptForAscApiKeyPathAsync,
   provideOrGenerateAscApiKeyAsync,
+  tryAuthenticateAppStoreWithEasAscApiKeyAsync,
 } from '../AscApiKeyUtils';
 
 jest.mock('../../../../prompts');
 jest.mock('../../../utils/promptForCredentials');
 jest.mock('fs-extra');
+jest.mock('../../api/GraphqlClient', () => ({
+  ...jest.requireActual('../../api/GraphqlClient'),
+  getAscApiKeyForAppSubmissionsAsync: jest.fn(),
+}));
+jest.mock('../../appstore/resolveCredentials', () => ({
+  hasAscEnvVars: jest.fn(),
+}));
+jest.mock('../../../../graphql/queries/AppStoreConnectApiKeyQuery', () => ({
+  AppStoreConnectApiKeyQuery: {
+    getByIdAsync: jest.fn(),
+  },
+}));
 
 function enumKeys<O extends object, K extends keyof O = keyof O>(obj: O): K[] {
   return Object.keys(obj) as K[];
@@ -30,6 +48,9 @@ afterEach(() => {
   jest.mocked(getCredentialsFromUserAsync).mockClear();
   jest.mocked(shouldAutoGenerateCredentialsAsync).mockClear();
   jest.mocked(fs.readFile).mockClear();
+  jest.mocked(hasAscEnvVars).mockReset();
+  jest.mocked(getAscApiKeyForAppSubmissionsAsync).mockReset();
+  jest.mocked(AppStoreConnectApiKeyQuery.getByIdAsync).mockReset();
 });
 
 describe(getAscApiKeyName, () => {
@@ -177,5 +198,97 @@ describe(provideOrGenerateAscApiKeyAsync, () => {
     });
     expect(selectAsync).not.toHaveBeenCalled();
     expect(createAscApiKeyAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe(tryAuthenticateAppStoreWithEasAscApiKeyAsync, () => {
+  const app = {
+    account: { name: 'test-account' },
+    projectName: 'test-project',
+    bundleIdentifier: 'com.test.app',
+  } as any;
+
+  afterEach(() => {
+    delete process.env.EXPO_ASC_API_KEY_PATH;
+    delete process.env.EXPO_ASC_KEY_ID;
+    delete process.env.EXPO_ASC_ISSUER_ID;
+  });
+
+  function createNonInteractiveCtx(): ReturnType<typeof createCtxMock> {
+    return createCtxMock({
+      nonInteractive: true,
+      appStore: {
+        ...getAppstoreMock(),
+        authCtx: null,
+        ensureAuthenticatedAsync: jest.fn(),
+      },
+    });
+  }
+
+  it('skips authentication without a warning when the environment key has no issuer ID', async () => {
+    const logWarnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    process.env.EXPO_ASC_API_KEY_PATH = '/asc-api-key.p8';
+    process.env.EXPO_ASC_KEY_ID = 'env-key-id';
+    jest.mocked(hasAscEnvVars).mockReturnValue(true);
+    const ctx = createNonInteractiveCtx();
+
+    const result = await tryAuthenticateAppStoreWithEasAscApiKeyAsync(
+      ctx,
+      app,
+      AppleTeamType.COMPANY_OR_ORGANIZATION
+    );
+
+    expect(result).toBe(false);
+    expect(ctx.appStore.ensureAuthenticatedAsync).not.toHaveBeenCalled();
+    expect(getAscApiKeyForAppSubmissionsAsync).not.toHaveBeenCalled();
+    expect(logWarnSpy).not.toHaveBeenCalled();
+    logWarnSpy.mockRestore();
+  });
+
+  it('authenticates with the environment key when it has an issuer ID', async () => {
+    process.env.EXPO_ASC_API_KEY_PATH = '/asc-api-key.p8';
+    process.env.EXPO_ASC_KEY_ID = 'env-key-id';
+    process.env.EXPO_ASC_ISSUER_ID = 'env-issuer-id';
+    jest.mocked(hasAscEnvVars).mockReturnValue(true);
+    const ctx = createNonInteractiveCtx();
+    jest.mocked(ctx.appStore.ensureAuthenticatedAsync).mockImplementation(async () => {
+      (ctx.appStore as any).authCtx = testAuthCtx;
+      return testAuthCtx;
+    });
+
+    const result = await tryAuthenticateAppStoreWithEasAscApiKeyAsync(
+      ctx,
+      app,
+      AppleTeamType.COMPANY_OR_ORGANIZATION
+    );
+
+    expect(result).toBe(true);
+    expect(ctx.appStore.ensureAuthenticatedAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips authentication without a warning when the stored submission key has no issuer ID', async () => {
+    const logWarnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    jest.mocked(hasAscEnvVars).mockReturnValue(false);
+    jest.mocked(getAscApiKeyForAppSubmissionsAsync).mockResolvedValue({
+      id: 'asc-key-id',
+      appleTeam: { appleTeamIdentifier: 'TEAM123', appleTeamName: 'Team Name' },
+    } as any);
+    jest.mocked(AppStoreConnectApiKeyQuery.getByIdAsync).mockResolvedValue({
+      keyP8: 'key-p8',
+      keyIdentifier: 'stored-key-id',
+      issuerIdentifier: null,
+    } as any);
+    const ctx = createNonInteractiveCtx();
+
+    const result = await tryAuthenticateAppStoreWithEasAscApiKeyAsync(
+      ctx,
+      app,
+      AppleTeamType.COMPANY_OR_ORGANIZATION
+    );
+
+    expect(result).toBe(false);
+    expect(ctx.appStore.ensureAuthenticatedAsync).not.toHaveBeenCalled();
+    expect(logWarnSpy).not.toHaveBeenCalled();
+    logWarnSpy.mockRestore();
   });
 });

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/AscApiKeyUtils-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/AscApiKeyUtils-test.ts
@@ -16,6 +16,7 @@ import { AppleTeamType } from '../../appstore/authenticateTypes';
 import { hasAscEnvVars } from '../../appstore/resolveCredentials';
 import {
   AppStoreApiKeyPurpose,
+  filterOutIndividualAscApiKeys,
   getAscApiKeyName,
   promptForAscApiKeyPathAsync,
   provideOrGenerateAscApiKeyAsync,
@@ -51,6 +52,24 @@ afterEach(() => {
   jest.mocked(hasAscEnvVars).mockReset();
   jest.mocked(getAscApiKeyForAppSubmissionsAsync).mockReset();
   jest.mocked(AppStoreConnectApiKeyQuery.getByIdAsync).mockReset();
+});
+
+describe(filterOutIndividualAscApiKeys, () => {
+  it('removes keys without an issuer identifier and keeps the rest', () => {
+    const teamKey = { id: 'team', issuerIdentifier: 'issuer-id' } as any;
+    const individualKey = { id: 'individual', issuerIdentifier: null } as any;
+
+    expect(filterOutIndividualAscApiKeys([teamKey, individualKey])).toEqual([teamKey]);
+  });
+
+  it('returns all keys when none is individual', () => {
+    const keys = [
+      { id: 'a', issuerIdentifier: 'issuer-a' },
+      { id: 'b', issuerIdentifier: 'issuer-b' },
+    ] as any[];
+
+    expect(filterOutIndividualAscApiKeys(keys)).toEqual(keys);
+  });
 });
 
 describe(getAscApiKeyName, () => {

--- a/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/AppStoreApi.ts
@@ -19,6 +19,7 @@ import {
 } from './ascApiKey';
 import {
   Options as AuthenticateOptions,
+  assertProvisioningAuthCtx,
   assertUserAuthCtx,
   authenticateAsync,
   isUserAuthCtx,
@@ -80,26 +81,38 @@ export default class AppStoreApi {
     return this.authCtx;
   }
 
+  /**
+   * Use for operations against Apple's Provisioning endpoints (bundle IDs, certificates,
+   * profiles, devices).
+   */
+  public async ensureProvisioningAuthenticatedAsync(
+    options?: AuthenticateOptions
+  ): Promise<AuthCtx> {
+    const authCtx = await this.ensureAuthenticatedAsync(options);
+    assertProvisioningAuthCtx(authCtx);
+    return authCtx;
+  }
+
   public async ensureBundleIdExistsAsync(
     app: AppLookupParams,
     options?: IosCapabilitiesOptions
   ): Promise<void> {
-    const ctx = await this.ensureAuthenticatedAsync();
+    const ctx = await this.ensureProvisioningAuthenticatedAsync();
     await ensureBundleIdExistsAsync(ctx, app, options);
   }
 
   public async listDistributionCertificatesAsync(): Promise<DistributionCertificateStoreInfo[]> {
-    const ctx = await this.ensureAuthenticatedAsync();
+    const ctx = await this.ensureProvisioningAuthenticatedAsync();
     return await listDistributionCertificatesAsync(ctx);
   }
 
   public async createDistributionCertificateAsync(): Promise<DistributionCertificate> {
-    const ctx = await this.ensureAuthenticatedAsync();
+    const ctx = await this.ensureProvisioningAuthenticatedAsync();
     return await createDistributionCertificateAsync(ctx);
   }
 
   public async revokeDistributionCertificateAsync(ids: string[]): Promise<void> {
-    const ctx = await this.ensureAuthenticatedAsync();
+    const ctx = await this.ensureProvisioningAuthenticatedAsync();
     await revokeDistributionCertificateAsync(ctx, ids);
   }
 
@@ -123,7 +136,7 @@ export default class AppStoreApi {
     provisioningProfile: ProvisioningProfile,
     distCert: DistributionCertificate
   ): Promise<ProvisioningProfile> {
-    const ctx = await this.ensureAuthenticatedAsync();
+    const ctx = await this.ensureProvisioningAuthenticatedAsync();
     return await useExistingProvisioningProfileAsync(
       ctx,
       bundleIdentifier,
@@ -137,7 +150,7 @@ export default class AppStoreApi {
     applePlatform: ApplePlatform,
     profileClass?: ProfileClass
   ): Promise<ProvisioningProfileStoreInfo[]> {
-    const ctx = await this.ensureAuthenticatedAsync();
+    const ctx = await this.ensureProvisioningAuthenticatedAsync();
     return await listProvisioningProfilesAsync(ctx, bundleIdentifier, applePlatform, profileClass);
   }
 
@@ -148,7 +161,7 @@ export default class AppStoreApi {
     applePlatform: ApplePlatform,
     profileClass?: ProfileClass
   ): Promise<ProvisioningProfile> {
-    const ctx = await this.ensureAuthenticatedAsync();
+    const ctx = await this.ensureProvisioningAuthenticatedAsync();
     return await createProvisioningProfileAsync(
       ctx,
       bundleIdentifier,
@@ -164,7 +177,7 @@ export default class AppStoreApi {
     applePlatform: ApplePlatform,
     profileClass?: ProfileClass
   ): Promise<void> {
-    const ctx = await this.ensureAuthenticatedAsync();
+    const ctx = await this.ensureProvisioningAuthenticatedAsync();
     await revokeProvisioningProfileAsync(ctx, bundleIdentifier, applePlatform, profileClass);
   }
 
@@ -174,7 +187,7 @@ export default class AppStoreApi {
     distCertSerialNumber: string,
     profileType: ProfileType
   ): Promise<ProvisioningProfile> {
-    const ctx = await this.ensureAuthenticatedAsync();
+    const ctx = await this.ensureProvisioningAuthenticatedAsync();
     return await createOrReuseAdhocProvisioningProfileAsync(
       ctx,
       udids,

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/AppStoreApi-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/AppStoreApi-test.ts
@@ -1,0 +1,56 @@
+import AppStoreApi from '../AppStoreApi';
+import { authenticateAsync } from '../authenticate';
+import { AuthCtx } from '../authenticateTypes';
+import { listDistributionCertificatesAsync } from '../distributionCertificate';
+
+jest.mock('../authenticate', () => ({
+  ...jest.requireActual('../authenticate'),
+  authenticateAsync: jest.fn(),
+}));
+jest.mock('../distributionCertificate');
+
+const individualKeyAuthCtx = {
+  ascApiKey: { keyP8: 'p8-content', keyId: 'key-id' },
+  team: { id: 'team-id' },
+} as AuthCtx;
+const teamKeyAuthCtx = {
+  ascApiKey: { keyP8: 'p8-content', keyId: 'key-id', issuerId: 'issuer-id' },
+  team: { id: 'team-id' },
+} as AuthCtx;
+
+beforeEach(() => {
+  jest.mocked(authenticateAsync).mockReset();
+  jest.mocked(listDistributionCertificatesAsync).mockReset();
+});
+
+describe(AppStoreApi, () => {
+  it('runs provisioning operations with a team API key', async () => {
+    jest.mocked(authenticateAsync).mockResolvedValue(teamKeyAuthCtx);
+    jest.mocked(listDistributionCertificatesAsync).mockResolvedValue([]);
+    const appStoreApi = new AppStoreApi();
+
+    await expect(appStoreApi.listDistributionCertificatesAsync()).resolves.toEqual([]);
+    expect(listDistributionCertificatesAsync).toHaveBeenCalledWith(teamKeyAuthCtx);
+  });
+
+  it('rejects provisioning operations with an individual API key before calling Apple', async () => {
+    jest.mocked(authenticateAsync).mockResolvedValue(individualKeyAuthCtx);
+    const appStoreApi = new AppStoreApi();
+
+    await expect(appStoreApi.listDistributionCertificatesAsync()).rejects.toThrow(
+      'individual API key'
+    );
+    expect(listDistributionCertificatesAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects provisioning operations with an individual API key cached by an earlier flow', async () => {
+    jest.mocked(authenticateAsync).mockResolvedValue(individualKeyAuthCtx);
+    const appStoreApi = new AppStoreApi();
+    await appStoreApi.ensureAuthenticatedAsync();
+
+    await expect(appStoreApi.ensureProvisioningAuthenticatedAsync()).rejects.toThrow(
+      'individual API key'
+    );
+    expect(authenticateAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/authenticate-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/authenticate-test.ts
@@ -1,6 +1,10 @@
 import { Token } from '@expo/apple-utils';
 
-import { authenticateAsync, isIndividualAscApiKeyAuthCtx } from '../authenticate';
+import {
+  assertProvisioningAuthCtx,
+  authenticateAsync,
+  isIndividualAscApiKeyAuthCtx,
+} from '../authenticate';
 import { ApiKeyAuthCtx, AppleTeamType, AuthCtx, AuthenticationMode } from '../authenticateTypes';
 
 jest.mock('@expo/apple-utils', () => ({
@@ -66,5 +70,25 @@ describe(isIndividualAscApiKeyAuthCtx, () => {
     expect(isIndividualAscApiKeyAuthCtx(teamKeyAuthCtx)).toBe(false);
     expect(isIndividualAscApiKeyAuthCtx(userAuthCtx)).toBe(false);
     expect(isIndividualAscApiKeyAuthCtx(undefined)).toBe(false);
+  });
+});
+
+describe(assertProvisioningAuthCtx, () => {
+  it('rejects an individual API key auth context', () => {
+    expect(() => {
+      assertProvisioningAuthCtx(individualKeyAuthCtx);
+    }).toThrow('individual API key');
+    expect(() => {
+      assertProvisioningAuthCtx(individualKeyAuthCtx);
+    }).toThrow('EXPO_ASC_ISSUER_ID');
+  });
+
+  it('accepts team API key and user auth contexts', () => {
+    expect(() => {
+      assertProvisioningAuthCtx(teamKeyAuthCtx);
+    }).not.toThrow();
+    expect(() => {
+      assertProvisioningAuthCtx(userAuthCtx);
+    }).not.toThrow();
   });
 });

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/authenticate-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/authenticate-test.ts
@@ -1,0 +1,70 @@
+import { Token } from '@expo/apple-utils';
+
+import { authenticateAsync, isIndividualAscApiKeyAuthCtx } from '../authenticate';
+import { ApiKeyAuthCtx, AppleTeamType, AuthCtx, AuthenticationMode } from '../authenticateTypes';
+
+jest.mock('@expo/apple-utils', () => ({
+  ...jest.requireActual('@expo/apple-utils'),
+  Token: jest.fn(() => ({})),
+}));
+
+const apiKeyAuthOptions = {
+  mode: AuthenticationMode.API_KEY,
+  teamId: 'team-id',
+  teamType: AppleTeamType.COMPANY_OR_ORGANIZATION,
+};
+
+describe(authenticateAsync, () => {
+  beforeEach(() => {
+    delete process.env.EXPO_ASC_API_KEY_PATH;
+    delete process.env.EXPO_ASC_KEY_ID;
+    delete process.env.EXPO_ASC_ISSUER_ID;
+    jest.mocked(Token).mockClear();
+  });
+
+  it('authenticates with a team API key', async () => {
+    const authCtx = (await authenticateAsync({
+      ...apiKeyAuthOptions,
+      ascApiKey: { keyP8: 'p8-content', keyId: 'key-id', issuerId: 'issuer-id' },
+    })) as ApiKeyAuthCtx;
+
+    expect(authCtx.ascApiKey.issuerId).toBe('issuer-id');
+    expect(Token).toHaveBeenCalledWith(
+      expect.objectContaining({ keyId: 'key-id', issuerId: 'issuer-id' })
+    );
+  });
+
+  it('authenticates with an individual (issuer-less) API key', async () => {
+    const authCtx = (await authenticateAsync({
+      ...apiKeyAuthOptions,
+      ascApiKey: { keyP8: 'p8-content', keyId: 'key-id' },
+    })) as ApiKeyAuthCtx;
+
+    expect(authCtx.ascApiKey.issuerId).toBeUndefined();
+    expect(Token).toHaveBeenCalledWith(
+      expect.objectContaining({ keyId: 'key-id', issuerId: undefined })
+    );
+  });
+});
+
+const individualKeyAuthCtx = {
+  ascApiKey: { keyP8: 'p8-content', keyId: 'key-id' },
+  team: { id: 'team-id' },
+} as AuthCtx;
+const teamKeyAuthCtx = {
+  ascApiKey: { keyP8: 'p8-content', keyId: 'key-id', issuerId: 'issuer-id' },
+  team: { id: 'team-id' },
+} as AuthCtx;
+const userAuthCtx = {
+  appleId: 'user@example.com',
+  team: { id: 'team-id' },
+} as AuthCtx;
+
+describe(isIndividualAscApiKeyAuthCtx, () => {
+  it('detects an individual API key auth context', () => {
+    expect(isIndividualAscApiKeyAuthCtx(individualKeyAuthCtx)).toBe(true);
+    expect(isIndividualAscApiKeyAuthCtx(teamKeyAuthCtx)).toBe(false);
+    expect(isIndividualAscApiKeyAuthCtx(userAuthCtx)).toBe(false);
+    expect(isIndividualAscApiKeyAuthCtx(undefined)).toBe(false);
+  });
+});

--- a/packages/eas-cli/src/credentials/ios/appstore/__tests__/resolveCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/__tests__/resolveCredentials-test.ts
@@ -2,6 +2,7 @@ import { JsonFileCache } from '@expo/apple-utils';
 import * as fs from 'fs-extra';
 import { vol } from 'memfs';
 
+import Log from '../../../../log';
 import { promptAsync } from '../../../../prompts';
 import { AppleTeamType } from '../authenticateTypes';
 import * as Keychain from '../keychain';
@@ -66,6 +67,104 @@ describe(resolveAscApiKeyAsync, () => {
     }));
     const ascApiKey = await resolveAscApiKeyAsync();
     expect(ascApiKey).toMatchObject(testAscApiKey);
+  });
+  it(`fills a missing issuer ID on a key passed in options from EXPO_ASC_ISSUER_ID and warns`, async () => {
+    process.env.EXPO_ASC_ISSUER_ID = testAscApiKey.issuerId;
+    const logWarnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {});
+
+    const ascApiKey = await resolveAscApiKeyAsync({
+      keyP8: testAscApiKey.keyP8,
+      keyId: testAscApiKey.keyId,
+    });
+    expect(ascApiKey).toEqual({
+      keyP8: testAscApiKey.keyP8,
+      keyId: testAscApiKey.keyId,
+      issuerId: testAscApiKey.issuerId,
+    });
+    expect(promptAsync).not.toHaveBeenCalled();
+    expect(logWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unset EXPO_ASC_ISSUER_ID if test-key-id is an individual API key')
+    );
+    logWarnSpy.mockRestore();
+  });
+
+  it(`does not warn about EXPO_ASC_ISSUER_ID when the key comes from the environment too`, async () => {
+    vol.fromJSON({
+      '/test-asc-key.p8': testAscApiKey.keyP8,
+    });
+    process.env.EXPO_ASC_API_KEY_PATH = '/test-asc-key.p8';
+    process.env.EXPO_ASC_KEY_ID = testAscApiKey.keyId;
+    process.env.EXPO_ASC_ISSUER_ID = testAscApiKey.issuerId;
+    const logWarnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {});
+
+    await expect(resolveAscApiKeyAsync()).resolves.toEqual(testAscApiKey);
+    expect(logWarnSpy).not.toHaveBeenCalled();
+    logWarnSpy.mockRestore();
+  });
+
+  it(`treats a key passed in options without an issuer ID as individual without prompting`, async () => {
+    const ascApiKey = await resolveAscApiKeyAsync({
+      keyP8: testAscApiKey.keyP8,
+      keyId: testAscApiKey.keyId,
+    });
+    expect(ascApiKey).toEqual({
+      keyP8: testAscApiKey.keyP8,
+      keyId: testAscApiKey.keyId,
+      issuerId: undefined,
+    });
+    expect(promptAsync).not.toHaveBeenCalled();
+  });
+
+  it(`treats an environment key without EXPO_ASC_ISSUER_ID as individual without prompting`, async () => {
+    vol.fromJSON({
+      '/test-asc-key.p8': testAscApiKey.keyP8,
+    });
+    process.env.EXPO_ASC_API_KEY_PATH = '/test-asc-key.p8';
+    process.env.EXPO_ASC_KEY_ID = testAscApiKey.keyId;
+    const logWarnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    const logDebugSpy = jest.spyOn(Log, 'debug').mockImplementation(() => {});
+
+    const ascApiKey = await resolveAscApiKeyAsync();
+    expect(ascApiKey).toEqual({
+      keyP8: testAscApiKey.keyP8,
+      keyId: testAscApiKey.keyId,
+      issuerId: undefined,
+    });
+    expect(promptAsync).not.toHaveBeenCalled();
+    expect(logWarnSpy).not.toHaveBeenCalled();
+    expect(logDebugSpy).toHaveBeenCalledWith(expect.stringContaining('individual API key'));
+    logWarnSpy.mockRestore();
+    logDebugSpy.mockRestore();
+  });
+  it(`accepts an empty issuer from the prompt as an individual key`, async () => {
+    vol.fromJSON({
+      '/test-asc-key.p8': testAscApiKey.keyP8,
+    });
+    process.env.EXPO_ASC_API_KEY_PATH = '/test-asc-key.p8';
+    const logWarnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    const logDebugSpy = jest.spyOn(Log, 'debug').mockImplementation(() => {});
+    jest
+      .mocked(promptAsync)
+      .mockResolvedValueOnce({ ascApiKeyId: testAscApiKey.keyId })
+      .mockResolvedValueOnce({ ascIssuerId: '' });
+
+    const ascApiKey = await resolveAscApiKeyAsync();
+    expect(ascApiKey).toEqual({
+      keyP8: testAscApiKey.keyP8,
+      keyId: testAscApiKey.keyId,
+      issuerId: undefined,
+    });
+    expect(promptAsync).toHaveBeenCalledTimes(2);
+    const question = jest.mocked(promptAsync).mock.calls[1][0] as unknown as {
+      message: string;
+      validate?: unknown;
+    };
+    expect(question.message).toContain('leave empty');
+    expect(question.validate).toBeUndefined();
+    expect(logWarnSpy).not.toHaveBeenCalled();
+    expect(logDebugSpy).toHaveBeenCalledWith(expect.stringContaining('individual API key'));
+    logWarnSpy.mockRestore();
+    logDebugSpy.mockRestore();
   });
 });
 

--- a/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
@@ -56,6 +56,10 @@ export function assertUserAuthCtx(authCtx: AuthCtx | undefined): UserAuthCtx {
   throw new Error('Expected user authentication context (login/password).');
 }
 
+export function isIndividualAscApiKeyAuthCtx(authCtx: AuthCtx | undefined): boolean {
+  return !!authCtx && 'ascApiKey' in authCtx && !!authCtx.ascApiKey && !authCtx.ascApiKey.issuerId;
+}
+
 export function getRequestContext(authCtx: AuthCtx): RequestContext {
   assert(authCtx.authState?.context, 'Apple request context must be defined');
   return authCtx.authState.context;

--- a/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/authenticate.ts
@@ -25,7 +25,7 @@ import {
   resolveAscApiKeyAsync,
   resolveUserCredentialsAsync,
 } from './resolveCredentials';
-import Log from '../../../log';
+import Log, { learnMore } from '../../../log';
 import { toggleConfirmAsync } from '../../../prompts';
 import { MinimalAscApiKey } from '../credentials';
 
@@ -58,6 +58,29 @@ export function assertUserAuthCtx(authCtx: AuthCtx | undefined): UserAuthCtx {
 
 export function isIndividualAscApiKeyAuthCtx(authCtx: AuthCtx | undefined): boolean {
   return !!authCtx && 'ascApiKey' in authCtx && !!authCtx.ascApiKey && !authCtx.ascApiKey.issuerId;
+}
+
+/**
+ * Apple blocks individual (issuer-less) ASC API keys from the Provisioning endpoints
+ * (certificates, profiles, bundle IDs, devices).
+ */
+export function assertProvisioningAuthCtx(authCtx: AuthCtx): void {
+  if (!isIndividualAscApiKeyAuthCtx(authCtx)) {
+    return;
+  }
+  throw new Error(
+    'The App Store Connect API key in use has no Issuer ID, so it is an individual API key. ' +
+      'Apple blocks individual API keys from managing certificates, provisioning profiles, and devices (Provisioning endpoints). ' +
+      'If this is a team key, provide its Issuer ID: set EXPO_ASC_ISSUER_ID when the key comes from environment variables, ' +
+      "or run 'eas credentials' and upload the key again with its Issuer ID when it is stored on EAS.\n" +
+      'To continue, do one of the following:\n' +
+      `  - Use a team API key (one with an Issuer ID). Run 'eas credentials' to set one up, or set EXPO_ASC_API_KEY_PATH, EXPO_ASC_KEY_ID and EXPO_ASC_ISSUER_ID. ${learnMore(
+        'https://expo.fyi/creating-asc-api-key'
+      )}\n` +
+      `  - Provide a distribution certificate and provisioning profile via credentials.json. ${learnMore(
+        'https://docs.expo.dev/app-signing/local-credentials/'
+      )}`
+  );
 }
 
 export function getRequestContext(authCtx: AuthCtx): RequestContext {

--- a/packages/eas-cli/src/credentials/ios/appstore/resolveCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/appstore/resolveCredentials.ts
@@ -87,19 +87,40 @@ async function getAscKeyIdFromEnvironmentOrOptionsAsync(
 
 async function getAscIssuerIdFromEnvironmentOrOptionsAsync(
   ascApiKey?: MinimalAscApiKey
-): Promise<string> {
+): Promise<string | undefined> {
   if (ascApiKey?.issuerId) {
-    return ascApiKey?.issuerId;
-  } else if (process.env.EXPO_ASC_ISSUER_ID) {
+    return ascApiKey.issuerId;
+  }
+
+  if (process.env.EXPO_ASC_ISSUER_ID) {
+    if (ascApiKey?.keyId) {
+      Log.warn(
+        `App Store Connect API key ${ascApiKey.keyId} was configured without an Issuer ID, so EXPO_ASC_ISSUER_ID is used for it instead. App Store Connect rejects requests when the Issuer ID belongs to a different key. Unset EXPO_ASC_ISSUER_ID if ${ascApiKey.keyId} is an individual API key, or configure the Issuer ID that belongs to it.`
+      );
+    }
     return process.env.EXPO_ASC_ISSUER_ID;
+  }
+
+  const keyId = ascApiKey?.keyId ?? process.env.EXPO_ASC_KEY_ID;
+  const keyP8IsResolvable = !!ascApiKey?.keyP8 || !!process.env.EXPO_ASC_API_KEY_PATH;
+  if (keyId && keyP8IsResolvable) {
+    Log.debug(
+      `App Store Connect API key ${keyId} has no Issuer ID, treating it as an individual API key.`
+    );
+    return undefined;
   }
 
   const { ascIssuerId } = await promptAsync({
     type: 'text',
     name: 'ascIssuerId',
-    message: `ASC Issuer ID:`,
-    validate: (val: string) => val !== '',
+    message: `ASC Issuer ID (leave empty for an individual API key):`,
   });
+  if (!ascIssuerId) {
+    Log.debug(
+      'No Issuer ID provided, treating the App Store Connect API key as an individual API key.'
+    );
+    return undefined;
+  }
   return ascIssuerId;
 }
 

--- a/packages/eas-cli/src/credentials/ios/utils/__tests__/printCredentials-test.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/__tests__/printCredentials-test.ts
@@ -54,4 +54,41 @@ describe('print credentials', () => {
       .mock.calls.reduce((acc, mockValue) => acc + mockValue, '');
     expect(loggedSoFar).toMatchSnapshot();
   });
+
+  it('prints the key type for an individual (issuer-less) ASC API key', async () => {
+    jest.mocked(Log.log).mockClear();
+    const graphqlClient = instance(mock<ExpoGraphqlClient>());
+    const app: App = {
+      account: {
+        id: 'account-id',
+        name: 'quinlanj',
+        viewerUserPermission: { role: Role.Owner },
+      },
+      projectName: 'test52',
+    };
+    const testIosAppCredentialsData = JSON.parse(
+      JSON.stringify(
+        nullthrows(
+          await IosAppCredentialsQuery.withCommonFieldsByAppIdentifierIdAsync(
+            graphqlClient,
+            '@quinlanj/test52',
+            {
+              appleAppIdentifierId: 'test-id',
+            }
+          )
+        )
+      )
+    );
+    testIosAppCredentialsData.appStoreConnectApiKeyForSubmissions.issuerIdentifier = null;
+    const targets: Target[] = [
+      { targetName: 'test52', bundleIdentifier: 'com.quinlanj.test52', entitlements: {} },
+    ];
+    displayIosCredentials(app, { test52: testIosAppCredentialsData }, targets);
+    const loggedSoFar = jest
+      .mocked(Log.log)
+      .mock.calls.reduce((acc, mockValue) => acc + mockValue, '');
+    expect(loggedSoFar).toContain('Key Type');
+    expect(loggedSoFar).toContain('Individual (submissions only)');
+    expect(loggedSoFar).not.toContain('Issuer ID');
+  });
 });

--- a/packages/eas-cli/src/devices/actions/create/developerPortalMethod.ts
+++ b/packages/eas-cli/src/devices/actions/create/developerPortalMethod.ts
@@ -28,7 +28,7 @@ export async function runDeveloperPortalMethodAsync(
   account: AccountFragment,
   appleTeam: Pick<AppleTeam, 'appleTeamIdentifier' | 'appleTeamName' | 'id'>
 ): Promise<void> {
-  const appleAuthCtx = await appStoreApi.ensureAuthenticatedAsync();
+  const appleAuthCtx = await appStoreApi.ensureProvisioningAuthenticatedAsync();
   const unregisteredPortalDevices = await findUnregisteredPortalDevicesAsync(
     graphqlClient,
     appleAuthCtx,

--- a/packages/eas-cli/src/integrations/asc/ascApiKey.ts
+++ b/packages/eas-cli/src/integrations/asc/ascApiKey.ts
@@ -2,6 +2,7 @@ import { selectAsync } from '../../prompts';
 import { CredentialsContext } from '../../credentials/context';
 import {
   AppStoreApiKeyPurpose,
+  filterOutIndividualAscApiKeys,
   formatAscApiKey,
   provideOrGenerateAscApiKeyAsync,
   sortAscApiKeysByUpdatedAtDesc,
@@ -17,7 +18,8 @@ export async function selectOrCreateAscApiKeyIdAsync({
   existingKeys: AppStoreConnectApiKeyFragment[];
   ownerAccount: AccountFragment;
 }): Promise<string> {
-  const sortedKeys = sortAscApiKeysByUpdatedAtDesc(existingKeys);
+  // Individual API keys are not supported for the ASC connection yet.
+  const sortedKeys = sortAscApiKeysByUpdatedAtDesc(filterOutIndividualAscApiKeys(existingKeys));
   const createKeyOption = {
     title: '[Create or upload a new API key]',
     value: '__create_new_key__',

--- a/packages/eas-cli/src/metadata/__tests__/auth.test.ts
+++ b/packages/eas-cli/src/metadata/__tests__/auth.test.ts
@@ -130,6 +130,29 @@ describe(getAppStoreAuthAsync, () => {
     expect(result.app).toBe(mockApp);
   });
 
+  it('uses individual API key from submit profile when ascApiKeyIssuerId is absent', async () => {
+    const profile = {
+      bundleIdentifier: 'com.example.app',
+      ascApiKeyPath: '/path/to/key.p8',
+      ascApiKeyId: 'KEY123',
+    } as any;
+    const args = createBaseArgs({ profile });
+
+    const result = await getAppStoreAuthAsync(args);
+
+    expect(args.credentialsCtx.appStore.ensureAuthenticatedAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: AuthenticationMode.API_KEY,
+        ascApiKey: {
+          keyP8: 'mock-key-p8-content',
+          keyId: 'KEY123',
+          issuerId: undefined,
+        },
+      })
+    );
+    expect(result.app).toBe(mockApp);
+  });
+
   it('uses API key from EAS credentials service when available', async () => {
     (getAscApiKeyForAppSubmissionsAsync as jest.Mock).mockResolvedValue({
       id: 'asc-key-id',

--- a/packages/eas-cli/src/metadata/auth.ts
+++ b/packages/eas-cli/src/metadata/auth.ts
@@ -68,9 +68,9 @@ async function tryResolveAscApiKeyAsync({
   bundleId: string;
 }): Promise<ResolvedAscApiKey | null> {
   // 1. Check submit profile for ASC API key fields
-  if ('ascApiKeyPath' in profile && 'ascApiKeyIssuerId' in profile && 'ascApiKeyId' in profile) {
+  if ('ascApiKeyPath' in profile && 'ascApiKeyId' in profile) {
     const { ascApiKeyPath, ascApiKeyIssuerId, ascApiKeyId } = profile;
-    if (ascApiKeyPath && ascApiKeyIssuerId && ascApiKeyId) {
+    if (ascApiKeyPath && ascApiKeyId) {
       const keyP8 = await fs.promises.readFile(ascApiKeyPath, 'utf-8');
       // Also try to get teamId from the profile if available
       const teamId = 'appleTeamId' in profile ? (profile as any).appleTeamId : undefined;
@@ -186,8 +186,8 @@ export async function getAppStoreAuthAsync({
   if (nonInteractive) {
     throw new Error(
       'No App Store Connect API Key found. In non-interactive mode, provide one via:\n' +
-        '  - Environment variables: EXPO_ASC_API_KEY_PATH, EXPO_ASC_KEY_ID, EXPO_ASC_ISSUER_ID\n' +
-        '  - eas.json submit profile: ascApiKeyPath, ascApiKeyId, ascApiKeyIssuerId\n' +
+        '  - Environment variables: EXPO_ASC_API_KEY_PATH, EXPO_ASC_KEY_ID, EXPO_ASC_ISSUER_ID (omit the issuer ID for individual API keys)\n' +
+        '  - eas.json submit profile: ascApiKeyPath, ascApiKeyId, ascApiKeyIssuerId (omit the issuer ID for individual API keys)\n' +
         '  - EAS credentials service: run `eas credentials` to set up an API key'
     );
   }

--- a/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
+++ b/packages/eas-cli/src/submit/ios/IosSubmitCommand.ts
@@ -132,7 +132,7 @@ export default class IosSubmitCommand {
   private resolveAscApiKeySource(): Result<AscApiKeySource> {
     const { ascApiKeyPath, ascApiKeyIssuerId, ascApiKeyId } = this.ctx.profile;
 
-    if (ascApiKeyPath && ascApiKeyIssuerId && ascApiKeyId) {
+    if (ascApiKeyPath && ascApiKeyId) {
       return result({
         sourceType: AscApiKeySourceType.path,
         path: {
@@ -145,7 +145,7 @@ export default class IosSubmitCommand {
 
     // interpret this to mean the user had some intention of passing in ASC Api key
     if (ascApiKeyPath || ascApiKeyIssuerId || ascApiKeyId) {
-      const message = `ascApiKeyPath, ascApiKeyIssuerId and ascApiKeyId must all be defined in eas.json`;
+      const message = `ascApiKeyPath and ascApiKeyId must both be defined in eas.json (ascApiKeyIssuerId is also required unless the key is an individual API key)`;
 
       // in non-interactive mode, we should fail
       if (this.ctx.nonInteractive) {

--- a/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/IosSubmitCommand-test.ts
@@ -64,6 +64,7 @@ describe(IosSubmitCommand, () => {
 
   const fakeFiles: Record<string, string> = {
     '/artifacts/fake.ipa': 'fake ipa',
+    '/artifacts/asc-key.p8': 'fake asc key p8',
   };
 
   beforeAll(() => {
@@ -214,6 +215,60 @@ describe(IosSubmitCommand, () => {
 
       delete process.env.EXPO_APPLE_APP_SPECIFIC_PASSWORD;
     });
+
+    it('sends a request to EAS Submit with an individual (issuer-less) ASC API key', async () => {
+      const projectId = uuidv4();
+      const graphqlClient = {} as any as ExpoGraphqlClient;
+      const analytics = instance(mock<Analytics>());
+      jest
+        .mocked(getArchiveAsync)
+        .mockImplementation(jest.requireActual('../../ArchiveSource').getArchiveAsync);
+
+      const ctx = await createSubmissionContextAsync({
+        platform: Platform.IOS,
+        projectDir: testProject.projectRoot,
+        archiveFlags: {
+          url: 'http://expo.dev/fake.ipa',
+        },
+        profile: {
+          language: 'en-US',
+          ascAppId: '12345678',
+          ascApiKeyPath: '/artifacts/asc-key.p8',
+          ascApiKeyId: 'KEY123',
+        },
+        nonInteractive: true,
+        isVerboseFastlaneEnabled: false,
+        groups: [],
+        actor: mockJester,
+        graphqlClient,
+        analytics,
+        exp: testProject.appJSON.expo,
+        projectId,
+        vcsClient,
+      });
+      const command = new IosSubmitCommand(ctx);
+      const submitter = await command.runAsync();
+      await submitter.submitAsync();
+
+      expect(SubmissionMutation.createIosSubmissionAsync).toHaveBeenCalledWith(graphqlClient, {
+        appId: projectId,
+        archiveSource: { type: SubmissionArchiveSourceType.Url, url: 'http://expo.dev/fake.ipa' },
+        config: {
+          ascAppIdentifier: '12345678',
+          isVerboseFastlaneEnabled: false,
+          groups: [],
+          changelog: undefined,
+          appleIdUsername: undefined,
+          ascApiKey: {
+            keyP8: 'fake asc key p8',
+            keyIdentifier: 'KEY123',
+            issuerIdentifier: undefined,
+          },
+        },
+        submittedBuildId: undefined,
+      });
+    });
+
     describe('build selected from EAS', () => {
       it('sends a request to EAS Submit with profile data matching selected build profile', async () => {
         const projectId = uuidv4();

--- a/packages/eas-cli/src/submit/ios/__tests__/ensureTestFlightSetup-test.ts
+++ b/packages/eas-cli/src/submit/ios/__tests__/ensureTestFlightSetup-test.ts
@@ -118,6 +118,25 @@ describe(ensureTestFlightSetupForExistingAppAsync, () => {
     });
   });
 
+  it('sets up TestFlight when environment credentials have no issuer ID (individual key)', async () => {
+    jest.mocked(hasAscEnvVars).mockReturnValue(true);
+    process.env.EXPO_ASC_API_KEY_PATH = '/path/to/key.p8';
+    process.env.EXPO_ASC_KEY_ID = 'key-id';
+    process.env.EXPO_APPLE_TEAM_ID = 'team-id';
+    const { ctx, ensureAuthenticatedAsync } = createContext({ nonInteractive: true });
+
+    await ensureTestFlightSetupForExistingAppAsync(ctx, '12345678');
+
+    expect(ensureAuthenticatedAsync).toHaveBeenCalledWith({
+      mode: AuthenticationMode.API_KEY,
+      teamId: 'team-id',
+      teamType: expect.any(String),
+    });
+    expect(ensureTestFlightGroupExistsAsync).toHaveBeenCalledWith(expect.anything(), {
+      nonInteractive: true,
+    });
+  });
+
   it('skips setup when environment credentials are incomplete', async () => {
     jest.mocked(hasAscEnvVars).mockReturnValue(true);
     process.env.EXPO_ASC_KEY_ID = 'key-id';

--- a/packages/eas-cli/src/submit/ios/ensureTestFlightSetup.ts
+++ b/packages/eas-cli/src/submit/ios/ensureTestFlightSetup.ts
@@ -49,12 +49,7 @@ export async function ensureTestFlightSetupForExistingAppAsync(
         resolveAppleTeamTypeFromEnvironment() ?? AppleTeamType.COMPANY_OR_ORGANIZATION;
       if (hasAscEnvVars()) {
         const teamId = process.env.EXPO_APPLE_TEAM_ID;
-        if (
-          !process.env.EXPO_ASC_API_KEY_PATH ||
-          !process.env.EXPO_ASC_KEY_ID ||
-          !process.env.EXPO_ASC_ISSUER_ID ||
-          !teamId
-        ) {
+        if (!process.env.EXPO_ASC_API_KEY_PATH || !process.env.EXPO_ASC_KEY_ID || !teamId) {
           Log.log('App Store Connect credentials are incomplete, skipping TestFlight setup');
           return;
         }


### PR DESCRIPTION
# Why

We're adding support for individual ASC API keys for submissions. 

This PR adds all the eas-cli logic to properly support such keys, apart from the interactive input (that's coming in the follow-up PR in the same PR stack). Adding support for individual keys in submissions, TestFlight setup and metadata management. Rejecting such keys for provisioning operations (individual keys are not capable of this) and ASC integration connection (something to possibly add later).

# How

- Key resolution in `resolveCredentials.ts` allows the issuer ID to be empty.
- Authentication adds a check for whether an auth context belongs to an individual key (no Issuer ID).
- Skip App Store authentication up front when env vars show an individual key.
- Every certificate/profile/device provisioning method now goes through a guard that blocks individual keys.
- In ASC app integration paths individual keys are filtered out of key selection and rejected on connect.
- EAS submit, Metadata and TestFlight: authenticate without requiring an Issuer ID.

# Test Plan

- Unit tests added.
- Manual testing:
  - `eas build -p ios`: confirmed a warning about skipping provisioning validation, build went on with the currently set up provisioning configuration.
  - `eas submit -p ios --latest`: confirmed it works with individual key just like with team key.
  - `eas credentials -p ios`: confirmed provisioning management is guarded
  - `eas integrations:asc:connect`: confirmed individual keys are not available to choose
  - `eas metadata:pull` and `eas metadata:push`: confirmed working with individual key.