### PR TITLE
[eas-cli] Add individual key type prompt for submission keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [eas-cli] Accept individual App Store Connect API keys for submissions, TestFlight setup, and metadata. ([#4249](https://github.com/expo/eas-cli/pull/4249) by [@sswrk](https://github.com/sswrk))
+- [eas-cli] Ask for the App Store Connect API key type (team or individual) in the submission key prompt and skip the Issuer ID prompt for individual keys. ([#4250](https://github.com/expo/eas-cli/pull/4250) by [@sswrk](https://github.com/sswrk))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -34,8 +34,26 @@ export enum AppStoreApiKeyPurpose {
   ASC_APP_CONNECTION = 'EAS Connect',
 }
 
-export async function promptForAscApiKeyPathAsync(ctx: CredentialsContext): Promise<AscApiKeyPath> {
+export async function promptForAscApiKeyPathAsync(
+  ctx: CredentialsContext,
+  purpose: AppStoreApiKeyPurpose
+): Promise<AscApiKeyPath> {
+  // Individual keys are valid only as submission keys. Every other purpose
+  // requires a team key, so the key type question is not asked there.
+  const isIndividualKey =
+    purpose === AppStoreApiKeyPurpose.SUBMISSION_SERVICE &&
+    !ctx.nonInteractive &&
+    (await promptForAscApiKeyTypeIsIndividualAsync());
+
   const { keyId, keyP8Path } = await promptForKeyP8AndIdAsync();
+
+  if (isIndividualKey) {
+    Log.log(
+      'Individual API keys can be used for submissions, TestFlight setup, and metadata only. ' +
+        'They cannot manage certificates or provisioning profiles.'
+    );
+    return { keyId, keyP8Path };
+  }
 
   const bestEffortIssuerId = await getBestEffortIssuerIdAsync(ctx, keyId);
   if (bestEffortIssuerId) {
@@ -44,6 +62,13 @@ export async function promptForAscApiKeyPathAsync(ctx: CredentialsContext): Prom
   }
   const issuerId = await promptForIssuerIdAsync();
   return { keyId, issuerId, keyP8Path };
+}
+
+async function promptForAscApiKeyTypeIsIndividualAsync(): Promise<boolean> {
+  return await selectAsync<boolean>('Which type of App Store Connect API key do you want to use?', [
+    { title: 'Team key (recommended)', value: false },
+    { title: 'Individual key (submissions only)', value: true },
+  ]);
 }
 
 export async function promptForIssuerIdAsync(): Promise<string> {
@@ -79,7 +104,7 @@ export async function provideOrGenerateAscApiKeyAsync(
     return await generateAscApiKeyAsync(ctx, purpose);
   }
 
-  const userProvided = await promptForAscApiKeyAsync(ctx);
+  const userProvided = await promptForAscApiKeyAsync(ctx, purpose);
   if (!userProvided) {
     return await generateAscApiKeyAsync(ctx, purpose);
   }
@@ -133,12 +158,15 @@ export function getAscApiKeyName(purpose: AppStoreApiKeyPurpose): string {
   return nameParts.join(' ');
 }
 
-async function promptForAscApiKeyAsync(ctx: CredentialsContext): Promise<MinimalAscApiKey | null> {
+async function promptForAscApiKeyAsync(
+  ctx: CredentialsContext,
+  purpose: AppStoreApiKeyPurpose
+): Promise<MinimalAscApiKey | null> {
   const shouldAutoGenerateCredentials = await shouldAutoGenerateCredentialsAsync(ascApiKeyIdSchema);
   if (shouldAutoGenerateCredentials) {
     return null;
   }
-  const ascApiKeyPath = await promptForAscApiKeyPathAsync(ctx);
+  const ascApiKeyPath = await promptForAscApiKeyPathAsync(ctx, purpose);
   const { keyP8Path, keyId, issuerId } = ascApiKeyPath;
   return { keyP8: await fs.readFile(keyP8Path, 'utf-8'), keyId, issuerId };
 }

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/AscApiKeyUtils-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/AscApiKeyUtils-test.ts
@@ -85,6 +85,7 @@ describe(getAscApiKeyName, () => {
 
 describe(promptForAscApiKeyPathAsync, () => {
   it('prompts for keyId, keyP8Path and issuerId when user is not authenticated to Apple', async () => {
+    jest.mocked(selectAsync).mockResolvedValueOnce(false); // team key
     jest.mocked(promptAsync).mockImplementationOnce(async () => ({
       keyP8Path: '/asc-api-key.p8',
     }));
@@ -102,16 +103,21 @@ describe(promptForAscApiKeyPathAsync, () => {
         authCtx: null,
       },
     });
-    const ascApiKeyPath = await promptForAscApiKeyPathAsync(ctx);
+    const ascApiKeyPath = await promptForAscApiKeyPathAsync(
+      ctx,
+      AppStoreApiKeyPurpose.SUBMISSION_SERVICE
+    );
     expect(ascApiKeyPath).toEqual({
       keyId: 'test-key-id',
       issuerId: 'test-issuer-id',
       keyP8Path: '/asc-api-key.p8',
     });
+    expect(selectAsync).toHaveBeenCalledTimes(1); // key type
     expect(promptAsync).toHaveBeenCalledTimes(1); // keyP8Path
     expect(getCredentialsFromUserAsync).toHaveBeenCalledTimes(2); // keyId, issuerId
   });
   it('prompts for keyId, keyP8Path and detects issuerId when user is authenticated to Apple', async () => {
+    jest.mocked(selectAsync).mockResolvedValueOnce(false); // team key
     jest.mocked(promptAsync).mockImplementationOnce(async () => ({
       keyP8Path: '/asc-api-key.p8',
     }));
@@ -127,7 +133,10 @@ describe(promptForAscApiKeyPathAsync, () => {
         getAscApiKeyAsync: jest.fn(() => testAscApiKey),
       },
     });
-    const ascApiKeyPath = await promptForAscApiKeyPathAsync(ctx);
+    const ascApiKeyPath = await promptForAscApiKeyPathAsync(
+      ctx,
+      AppStoreApiKeyPurpose.SUBMISSION_SERVICE
+    );
     expect(ascApiKeyPath).toEqual({
       keyId: 'test-key-id',
       issuerId: 'test-issuer-id-from-apple',
@@ -136,6 +145,60 @@ describe(promptForAscApiKeyPathAsync, () => {
     expect(promptAsync).toHaveBeenCalledTimes(1); // keyP8Path
     expect(getCredentialsFromUserAsync).toHaveBeenCalledTimes(1); // keyId
     expect(jest.mocked(ctx.appStore.getAscApiKeyAsync).mock.calls.length).toBe(1); // issuerId
+  });
+  it('skips the issuer prompt for an individual key in the submission flow', async () => {
+    jest.mocked(selectAsync).mockResolvedValueOnce(true); // individual key
+    jest.mocked(promptAsync).mockImplementationOnce(async () => ({
+      keyP8Path: '/asc-api-key.p8',
+    }));
+    jest.mocked(getCredentialsFromUserAsync).mockImplementation(async () => ({
+      keyId: 'test-key-id',
+    }));
+    const getAscApiKeyAsync = jest.fn(() => testAscApiKey);
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        authCtx: testAuthCtx,
+        getAscApiKeyAsync,
+      },
+    });
+    const ascApiKeyPath = await promptForAscApiKeyPathAsync(
+      ctx,
+      AppStoreApiKeyPurpose.SUBMISSION_SERVICE
+    );
+    expect(ascApiKeyPath).toEqual({
+      keyId: 'test-key-id',
+      keyP8Path: '/asc-api-key.p8',
+    });
+    expect(getCredentialsFromUserAsync).toHaveBeenCalledTimes(1); // keyId only
+    expect(getAscApiKeyAsync).not.toHaveBeenCalled(); // no issuer detection
+  });
+  it('does not ask the key type outside the submission flow', async () => {
+    jest.mocked(promptAsync).mockImplementationOnce(async () => ({
+      keyP8Path: '/asc-api-key.p8',
+    }));
+    jest.mocked(getCredentialsFromUserAsync).mockImplementation(async () => ({
+      keyId: 'test-key-id',
+      issuerId: 'test-issuer-id',
+    }));
+    const ctx = createCtxMock({
+      nonInteractive: false,
+      appStore: {
+        ...getAppstoreMock(),
+        authCtx: null,
+      },
+    });
+    const ascApiKeyPath = await promptForAscApiKeyPathAsync(
+      ctx,
+      AppStoreApiKeyPurpose.ASC_APP_CONNECTION
+    );
+    expect(ascApiKeyPath).toEqual({
+      keyId: 'test-key-id',
+      issuerId: 'test-issuer-id',
+      keyP8Path: '/asc-api-key.p8',
+    });
+    expect(selectAsync).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/eas-cli/src/submit/ios/AscApiKeySource.ts
+++ b/packages/eas-cli/src/submit/ios/AscApiKeySource.ts
@@ -189,7 +189,10 @@ async function handlePromptSourceAsync(
   ctx: SubmissionContext<Platform.IOS>,
   _source: AscApiKeyPromptSource
 ): Promise<AscApiKeyPath> {
-  const ascApiKeyPath = await promptForAscApiKeyPathAsync(ctx.credentialsCtx);
+  const ascApiKeyPath = await promptForAscApiKeyPathAsync(
+    ctx.credentialsCtx,
+    AppStoreApiKeyPurpose.SUBMISSION_SERVICE
+  );
   return await getAscApiKeyPathAsync(ctx, {
     sourceType: AscApiKeySourceType.path,
     path: ascApiKeyPath,


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

`eas-cli` now has all the support for individual ASC keys for submissions, TestFlight setup and metadata management, it just lacks the support for inputting the key in credentials setup in interactive mode.

# How

- `promptForAscApiKeyPathAsync` takes a new `purpose` argument. In submissions it asks the user to pick a team key or an individual key.
- For an individual key, skip Issuer ID detection and prompting.

# Test Plan

- Unit tests added.
- Tested manually: added an individual key via `eas credentials -p ios`, set it as submission key
