### PR TITLE
[eas-cli] Stop looping forever when device registration adds no devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
+- [eas-cli] Stop `eas build` from looping forever printing "There are still no registered devices." when a device registration method other than Website registers no devices. ([#4254](https://github.com/expo/eas-cli/pull/4254) by [@dennytosp](https://github.com/dennytosp))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/SetUpAdhocProvisioningProfile.ts
@@ -388,14 +388,23 @@ export class SetUpAdhocProvisioningProfile {
       const devices = await ctx.ios.getDevicesForAppleTeamAsync(ctx.graphqlClient, app, appleTeam, {
         useCache: false,
       });
-      if (devices.length === 0) {
-        Log.warn('There are still no registered devices.');
-        // if the user used the input method there should be some devices available
-        if (method === RegistrationMethod.INPUT) {
-          throw new Error('Input registration method has failed');
-        }
-      } else {
+      if (devices.length > 0) {
         return devices;
+      }
+
+      Log.warn('There are still no registered devices.');
+      // if the user used the input method there should be some devices available
+      if (method === RegistrationMethod.INPUT) {
+        throw new Error('Input registration method has failed');
+      }
+      // Only the website method registers devices out of band, so only there does waiting and
+      // reading the list again stand a chance of returning something. Every other method is done
+      // registering by the time it resolves - with nothing to wait for, looping would just reread
+      // the same empty list forever and leave the user no way out but killing the process.
+      if (method !== RegistrationMethod.WEBSITE) {
+        throw new Error(
+          `No devices were registered. Run 'eas device:create' to register your devices first.`
+        );
       }
     }
   }

--- a/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAdhocProvisioningProfile-test.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/__tests__/SetUpAdhocProvisioningProfile-test.ts
@@ -3,6 +3,7 @@ import { EasJson } from '@expo/eas-json';
 
 import { Analytics } from '../../../../analytics/AnalyticsManager';
 import { ExpoGraphqlClient } from '../../../../commandUtils/context/contextUtils/createGraphqlClient';
+import DeviceCreateAction, { RegistrationMethod } from '../../../../devices/actions/create/action';
 import {
   Account,
   AppleAppIdentifierFragment,
@@ -10,11 +11,12 @@ import {
   AppleDeviceClass,
   AppleDeviceFragment,
   AppleDistributionCertificateFragment,
+  AppleTeamFragment,
   IosAppBuildCredentialsFragment,
 } from '../../../../graphql/generated';
 import Log from '../../../../log';
 import { getApplePlatformFromTarget } from '../../../../project/ios/target';
-import { selectAsync } from '../../../../prompts';
+import { pressAnyKeyToContinueAsync, selectAsync } from '../../../../prompts';
 import { Actor } from '../../../../user/User';
 import { Client } from '../../../../vcs/vcs';
 import { CredentialsContext, CredentialsContextProjectInfo } from '../../../context';
@@ -56,6 +58,11 @@ jest.mock('../SetUpDistributionCertificate', () => ({
 import { SetUpDistributionCertificate } from '../SetUpDistributionCertificate';
 jest.mock('../../../../project/ios/target');
 jest.mock('../../../../prompts');
+jest.mock('../../../../devices/actions/create/action', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../../../devices/actions/create/action'),
+  default: jest.fn(),
+}));
 
 describe(doUDIDsMatch, () => {
   it('return false if UDIDs do not match', () => {
@@ -225,6 +232,73 @@ describe('runAsync', () => {
     await expect(setUpAdhocProvisioningProfile.runAsync(ctx)).rejects.toThrow(
       'Cannot refresh ad-hoc provisioning profile when credentials are frozen'
     );
+  });
+});
+
+describe('registerDevicesAsync', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  const setUpAdhocProvisioningProfile = new SetUpAdhocProvisioningProfile({
+    app: { account: {} as Account, projectName: 'projName', bundleIdentifier: 'bundleId' },
+    target: { targetName: 'targetName', bundleIdentifier: 'bundleId', entitlements: {} },
+  });
+
+  async function registerDevicesAsync(
+    ctx: CredentialsContext,
+    method: RegistrationMethod
+  ): Promise<AppleDeviceFragment[]> {
+    jest
+      .mocked(DeviceCreateAction)
+      .mockImplementation(() => ({ runAsync: jest.fn().mockResolvedValue(method) }) as any);
+    return await (setUpAdhocProvisioningProfile as any).registerDevicesAsync(
+      ctx,
+      {} as AppleTeamFragment
+    );
+  }
+
+  it('returns the devices registered by the chosen method', async () => {
+    const { ctx } = setUpTest();
+
+    await expect(registerDevicesAsync(ctx, RegistrationMethod.DEVELOPER_PORTAL)).resolves.toEqual([
+      { identifier: 'id1' },
+      { identifier: 'id2' },
+      { identifier: 'id3' },
+    ]);
+  });
+
+  it('gives up when the developer portal method registers nothing', async () => {
+    const { ctx } = setUpTest();
+    ctx.ios.getDevicesForAppleTeamAsync = jest.fn().mockResolvedValue([]);
+
+    await expect(registerDevicesAsync(ctx, RegistrationMethod.DEVELOPER_PORTAL)).rejects.toThrow(
+      `No devices were registered. Run 'eas device:create' to register your devices first.`
+    );
+    expect(ctx.ios.getDevicesForAppleTeamAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the input method failing on its own', async () => {
+    const { ctx } = setUpTest();
+    ctx.ios.getDevicesForAppleTeamAsync = jest.fn().mockResolvedValue([]);
+
+    await expect(registerDevicesAsync(ctx, RegistrationMethod.INPUT)).rejects.toThrow(
+      'Input registration method has failed'
+    );
+  });
+
+  it('waits for the website method until the devices show up', async () => {
+    const { ctx } = setUpTest();
+    ctx.ios.getDevicesForAppleTeamAsync = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([{ identifier: 'id1' }] as AppleDeviceFragment[]);
+
+    await expect(registerDevicesAsync(ctx, RegistrationMethod.WEBSITE)).resolves.toEqual([
+      { identifier: 'id1' },
+    ]);
+    expect(pressAnyKeyToContinueAsync).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/eas-cli/issues/2059.

`SetUpAdhocProvisioningProfile` runs the device registration action once and then loops until at least one device shows up. The loop only ever pauses for the *Website* method, where the CLI waits for a key press between reads. Every other method registers whatever it can before returning, so when it registers nothing the loop just rereads the same empty list as fast as the network allows:

- **Developer Portal** with no devices on the portal logs "All your devices registered on Apple Developer Portal are already imported to EAS." and returns normally.
- **Developer Portal** when the user deselects every device in the import multiselect.
- **Current Machine** when the user answers "no" to "Is this what you want to register?".

In all three the CLI prints "There are still no registered devices." forever and hammers `getDevicesForAppleTeamAsync` (which is called with `useCache: false`) until the user kills the process. That is exactly what the issue reports for the Developer Portal case.

# How

Only the Website method keeps looping, since it is the only one where devices are registered out of band and waiting can actually change the answer. When any other method leaves the list empty, the command now fails with a message pointing at `eas device:create` instead of spinning. The Input method keeps its existing, more specific error.

# Test Plan

`yarn test`, `yarn typecheck`, `yarn lint` and `yarn fmt:check` all pass.

Four unit tests were added around `registerDevicesAsync`. Without the fix, `gives up when the developer portal method registers nothing` never resolves and the suite times out; with it, the call rejects after a single read of the device list. The website test still loops and returns the devices once they appear, so the wait-and-retry behaviour is unchanged.
