### PR TITLE
[eas-cli] Accept template expressions where the workflow schema wants a URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
+- [eas-cli] Stop `eas workflow:validate` and `eas workflow:create` from rejecting a `${{ ... }}` expression where the schema asks for a URI, such as the Slack job's `webhook_url`. ([#4255](https://github.com/expo/eas-cli/pull/4255) by [@dennytosp](https://github.com/dennytosp))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commandUtils/workflow/__tests__/fixtures/workflow-schema.json
+++ b/packages/eas-cli/src/commandUtils/workflow/__tests__/fixtures/workflow-schema.json
@@ -1,0 +1,67 @@
+{
+  "data": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "name": { "type": "string" },
+      "jobs": {
+        "type": "object",
+        "additionalProperties": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "type": { "const": "build" },
+                "params": {
+                  "type": "object",
+                  "properties": {
+                    "platform": { "type": "string" },
+                    "profile": { "type": "string" }
+                  },
+                  "required": ["platform"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["type", "params"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "type": { "const": "slack" },
+                "params": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": { "type": "string" },
+                        "webhook_url": { "type": "string", "format": "uri" }
+                      },
+                      "required": ["message"],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "payload": { "type": "object" },
+                        "webhook_url": { "type": "string", "format": "uri" }
+                      },
+                      "required": ["payload"],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              },
+              "required": ["type", "params"],
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "required": ["jobs"],
+    "additionalProperties": false
+  }
+}

--- a/packages/eas-cli/src/commandUtils/workflow/__tests__/validation-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/__tests__/validation-test.ts
@@ -1,0 +1,68 @@
+import path from 'path';
+
+import { ExpoGraphqlClient } from '../../context/contextUtils/createGraphqlClient';
+import { validateWorkflowFileAsync } from '../validation';
+
+jest.mock('../compositeFunctions', () => ({
+  validateWorkflowLocalCompositeFunctionsAsync: jest.fn(),
+}));
+jest.mock('../buildProfileUtils', () => ({
+  buildProfileNamesFromProjectAsync: jest.fn(async () => new Set(['production'])),
+}));
+jest.mock('../../../graphql/mutations/WorkflowRevisionMutation', () => ({
+  WorkflowRevisionMutation: {
+    validateWorkflowYamlConfigAsync: jest.fn(),
+  },
+}));
+
+const SCHEMA_PATH = path.join(__dirname, 'fixtures', 'workflow-schema.json');
+
+async function validateAsync(yamlConfig: string): Promise<void> {
+  await validateWorkflowFileAsync(
+    { yamlConfig, filePath: '.eas/workflows/test.yml' },
+    '/project',
+    {} as ExpoGraphqlClient,
+    'projectId'
+  );
+}
+
+function slackWorkflow(webhookUrl: string): string {
+  return `
+name: Notify
+jobs:
+  notify:
+    name: Notify
+    type: slack
+    params:
+      message: Build finished
+      webhook_url: ${webhookUrl}
+`;
+}
+
+describe(validateWorkflowFileAsync, () => {
+  const originalSchemaPath = process.env.EXPO_TESTING_WORKFLOW_SCHEMA_PATH;
+
+  beforeAll(() => {
+    process.env.EXPO_TESTING_WORKFLOW_SCHEMA_PATH = SCHEMA_PATH;
+  });
+
+  afterAll(() => {
+    process.env.EXPO_TESTING_WORKFLOW_SCHEMA_PATH = originalSchemaPath;
+  });
+
+  it('accepts a value that only becomes a URI once the workflow runs', async () => {
+    await expect(
+      validateAsync(slackWorkflow('${{ env.SLACK_WEBHOOK_URL }}'))
+    ).resolves.toBeUndefined();
+  });
+
+  it('accepts a URI written out in the file', async () => {
+    await expect(
+      validateAsync(slackWorkflow('https://hooks.slack.com/services/T000/B000/XXX'))
+    ).resolves.toBeUndefined();
+  });
+
+  it('still rejects a value that is neither a URI nor an expression', async () => {
+    await expect(validateAsync(slackWorkflow('"not a webhook"'))).rejects.toThrow(/webhook_url/);
+  });
+});

--- a/packages/eas-cli/src/commandUtils/workflow/validation.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/validation.ts
@@ -1,5 +1,6 @@
 import { InvalidEasJsonError, MissingEasJsonError } from '@expo/eas-json/build/errors';
 import { CombinedError } from '@urql/core';
+import Ajv, { FormatDefinition } from 'ajv';
 import { promises as fs } from 'fs';
 import path from 'path';
 import * as YAML from 'yaml';
@@ -142,7 +143,7 @@ function validateWorkflowJobTypes(parsedYaml: any, workflowJsonSchema: any): voi
 function validateWorkflowStructure(parsedYaml: any, workflowJsonSchema: any): void {
   delete workflowJsonSchema['$schema'];
 
-  const ajv = createValidator();
+  const ajv = createWorkflowValidator();
   const validate = ajv.compile(workflowJsonSchema);
   const result = validate(parsedYaml);
 
@@ -165,6 +166,69 @@ function validateWorkflowStructure(parsedYaml: any, workflowJsonSchema: any): vo
     }
     throw new Error([...processedErrors].join('\n'));
   }
+}
+
+// A `${{ ... }}` expression is only replaced with its value once the workflow runs.
+const TEMPLATE_EXPRESSION = /\$\{\{[\s\S]*?\}\}/;
+
+type AddedFormat = NonNullable<Ajv['formats'][string]>;
+
+/**
+ * A validator that accepts an interpolated value for any `format` it is checked against. Until the
+ * workflow runs, what the file holds is not the string the format describes -- `${{ env.WEBHOOK }}`
+ * is not a URI -- so the format is the one thing that cannot be decided here, and the server checks
+ * it once the value is resolved. Letting it through matters beyond the message itself, because jobs
+ * are matched with `anyOf`: one failed format drops its branch and the job is then reported against
+ * every other job type at once.
+ */
+function createWorkflowValidator(): Ajv {
+  const validator = createValidator();
+  for (const [name, format] of Object.entries(validator.formats)) {
+    const validate = format && stringFormatValidate(format);
+    if (!validate) {
+      continue;
+    }
+    const relaxed = (value: string): boolean => TEMPLATE_EXPRESSION.test(value) || validate(value);
+    validator.addFormat(
+      name,
+      isStringFormatDefinition(format) ? { ...format, validate: relaxed } : relaxed
+    );
+  }
+  return validator;
+}
+
+function isStringFormatDefinition(format: AddedFormat): format is FormatDefinition<string> {
+  return (
+    typeof format === 'object' &&
+    !(format instanceof RegExp) &&
+    // A definition without a `type` describes a string, which is also AJV's default.
+    format.type !== 'number' &&
+    format.async !== true
+  );
+}
+
+/** How a format checks a string, in whichever of the shapes AJV accepts it was registered. */
+function stringFormatValidate(format: AddedFormat): ((value: string) => boolean) | null {
+  if (format === true) {
+    // Every string is accepted as it is, so there is nothing left to relax.
+    return null;
+  }
+  if (format instanceof RegExp) {
+    return value => format.test(value);
+  }
+  if (typeof format === 'function') {
+    return format;
+  }
+  if (!isStringFormatDefinition(format)) {
+    // A number format, or an asynchronous one: neither can hold an expression to skip.
+    return null;
+  }
+  const { validate } = format;
+  if (typeof validate === 'function') {
+    return validate;
+  }
+  const pattern = validate instanceof RegExp ? validate : new RegExp(validate);
+  return value => pattern.test(value);
 }
 
 export function workflowContentsFromParsedYaml(parsedYaml: any): string {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/eas-cli/issues/3404.

`eas workflow:validate` and `eas workflow:create` compile the published workflow schema with AJV, and AJV is configured with `ajv-formats`, so `format` keywords are enforced. The schema declares the Slack job's `webhook_url` as `{"type": "string", "format": "uri"}`, but a `${{ ... }}` expression is only replaced with its value when the workflow runs. `${{ env.SLACK_WEBHOOK_URL }}` is not a URI, so the check fails on a workflow that is valid and that the server accepts.

The consequence is worse than one wrong message. Jobs are matched with `anyOf`, so the failed format drops both Slack branches and the job is then reported against every other job type. Against the schema at `https://api.expo.dev/v2/workflows/schema` today, a single interpolated `webhook_url` produces 71 errors, starting with the misleading `The value at /jobs/notify/type must be equal to constant`.

The CLI already has this idea for build profiles, where `buildProfileIsInterpolated` skips the check for an interpolated `params.profile`.

# How

The workflow schema is now compiled with a validator whose formats let an interpolated value through, instead of the shared one. Each format registered on the validator is rewrapped so it first accepts a string containing a `${{ ... }}` expression and otherwise defers to the original check, in whichever of the shapes AJV accepts a format (`RegExp`, validator function, or definition object). Number formats and formats registered as `true` are left alone, since neither can hold an expression.

Formats keep being enforced for everything the CLI can actually resolve: a literal `webhook_url` that is not a URI is still rejected locally, exactly as before. `uri` is the only format the current schema uses, but relaxing them all means a format added to the schema later does not reintroduce the same failure.

# Test Plan

`yarn test`, `yarn typecheck`, `yarn lint` and `yarn fmt:check` all pass.

Added `src/commandUtils/workflow/__tests__/validation-test.ts`, which runs `validateWorkflowFileAsync` against a schema fixture shaped like the published one (`anyOf` job types, Slack `params` as `anyOf`, `webhook_url` with `format: uri`). It covers the three cases that matter: an interpolated `webhook_url` validates, a literal URI validates, and a literal non-URI is still rejected. On `main` the first of those fails.
