### PR TITLE
[eas-cli] Escape Apple credentials before scrubbing them from metadata telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
+- [eas-cli] Escape Apple credentials before scrubbing them from `eas metadata` telemetry, so a value containing `+`, `.` or `(` is redacted instead of being sent verbatim or throwing. ([#4256](https://github.com/expo/eas-cli/pull/4256) by [@dennytosp](https://github.com/dennytosp))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/metadata/utils/__tests__/telemetry.test.ts
+++ b/packages/eas-cli/src/metadata/utils/__tests__/telemetry.test.ts
@@ -79,6 +79,30 @@ describe(makeDataScrubberAsync, () => {
     ).toBe('{APPLE_TOKEN} {APPLE_USERNAME} {APPLE_PASSWORD}');
   });
 
+  it('scrubs credentials that contain characters with a meaning in a pattern', async () => {
+    const scrubber = await makeDataScrubberAsync({
+      ...stub,
+      auth: {
+        ...stub.auth,
+        username: 'user+eas@icloud.com',
+        password: 'S3cret(1)',
+      },
+    });
+
+    expect(scrubber('login user+eas@icloud.com with S3cret(1)')).toBe(
+      'login {APPLE_USERNAME} with {APPLE_PASSWORD}'
+    );
+  });
+
+  it('leaves text that only looks like a credential alone', async () => {
+    const scrubber = await makeDataScrubberAsync({
+      ...stub,
+      auth: { ...stub.auth, password: 'a.c' },
+    });
+
+    expect(scrubber('abc')).toBe('abc');
+  });
+
   it('scrubs json and transforms it to string', async () => {
     const scrubber = await makeDataScrubberAsync(stub);
     expect(scrubber({ foo: 'bar' })).toBe('{"foo":"bar"}');

--- a/packages/eas-cli/src/metadata/utils/telemetry.ts
+++ b/packages/eas-cli/src/metadata/utils/telemetry.ts
@@ -3,6 +3,7 @@ import type { AxiosError } from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Analytics, MetadataEvent } from '../../analytics/AnalyticsManager';
+import escapeRegExp from '../../utils/expodash/escapeRegExp';
 
 export type TelemetryContext = {
   app: App;
@@ -74,14 +75,12 @@ export async function makeDataScrubberAsync({
 }: TelemetryContext): Promise<<T>(data: T) => string> {
   const token = await getAuthTokenStringAsync(auth);
   const patterns: Record<string, RegExp | null> = {
-    APPLE_APP_ID: new RegExp(app.id, 'gi'),
-    APPLE_USERNAME: auth.username ? new RegExp(auth.username, 'gi') : null,
-    APPLE_PASSWORD: auth.password ? new RegExp(auth.password, 'gi') : null,
-    APPLE_TOKEN: token ? new RegExp(token, 'gi') : null,
-    APPLE_TEAM_ID: auth.context?.teamId ? new RegExp(auth.context.teamId, 'gi') : null,
-    APPLE_PROVIDER_ID: auth.context?.providerId
-      ? new RegExp(String(auth.context.providerId), 'gi')
-      : null,
+    APPLE_APP_ID: literalPattern(app.id),
+    APPLE_USERNAME: literalPattern(auth.username),
+    APPLE_PASSWORD: literalPattern(auth.password),
+    APPLE_TOKEN: literalPattern(token),
+    APPLE_TEAM_ID: literalPattern(auth.context?.teamId),
+    APPLE_PROVIDER_ID: literalPattern(auth.context?.providerId),
   };
 
   const iterator = Object.entries(patterns);
@@ -99,6 +98,18 @@ export async function makeDataScrubberAsync({
     }
     return value;
   };
+}
+
+/**
+ * A pattern matching the value itself, and nothing else.
+ *
+ * The values scrubbed here are chosen by the user, so they routinely contain characters that mean
+ * something in a pattern. Left unescaped, an Apple ID like `user+eas@icloud.com` or a password like
+ * `p+ssw0rd` is not matched by the pattern built from it and reaches the telemetry unscrubbed, and
+ * one containing `(` or `[` makes `new RegExp` throw before the first request goes out.
+ */
+function literalPattern(value: string | number | null | undefined): RegExp | null {
+  return value || value === 0 ? new RegExp(escapeRegExp(String(value)), 'gi') : null;
 }
 
 async function getAuthTokenStringAsync(auth: TelemetryContext['auth']): Promise<string | null> {

--- a/packages/eas-cli/src/utils/expodash/__tests__/escapeRegExp-test.ts
+++ b/packages/eas-cli/src/utils/expodash/__tests__/escapeRegExp-test.ts
@@ -1,0 +1,22 @@
+import escapeRegExp from '../escapeRegExp';
+
+describe(escapeRegExp, () => {
+  it('leaves a value without special characters alone', () => {
+    expect(escapeRegExp('SECRET_PASSWORD')).toBe('SECRET_PASSWORD');
+  });
+
+  it('escapes every character with a meaning in a pattern', () => {
+    expect(escapeRegExp('\\^$.*+?()[]{}|')).toBe('\\\\\\^\\$\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|');
+  });
+
+  it('makes a pattern that matches the value itself', () => {
+    for (const value of ['user+eas@icloud.com', 'p+ssw0rd', 'S3cret(1', 'a.c', '^end$']) {
+      expect(new RegExp(escapeRegExp(value)).test(value)).toBe(true);
+    }
+  });
+
+  it('makes a pattern that matches nothing else', () => {
+    expect(new RegExp(escapeRegExp('a.c')).test('abc')).toBe(false);
+    expect(new RegExp(escapeRegExp('a+b')).test('aab')).toBe(false);
+  });
+});

--- a/packages/eas-cli/src/utils/expodash/escapeRegExp.ts
+++ b/packages/eas-cli/src/utils/expodash/escapeRegExp.ts
@@ -1,0 +1,6 @@
+/** `lodash.escapeRegExp` */
+const REGEXP_SPECIAL_CHARACTERS = /[\\^$.*+?()[\]{}|]/g;
+
+export default function escapeRegExp(value: string): string {
+  return value.replace(REGEXP_SPECIAL_CHARACTERS, '\\$&');
+}


### PR DESCRIPTION
# Why

`makeDataScrubberAsync` in `src/metadata/utils/telemetry.ts` redacts the Apple app ID, username, password, token, team ID and provider ID from the request and response data that `eas metadata:push` / `eas metadata:pull` send to analytics. It builds those patterns by passing the value straight to `new RegExp`, but every one of them is chosen by the user, so they routinely contain characters that mean something in a pattern.

That breaks the redaction in both directions:

```js
'my p+ssw0rd here'.replace(new RegExp('p+ssw0rd', 'gi'), '{APPLE_PASSWORD}')
// -> 'my p+ssw0rd here'          the password is sent verbatim

('login ' + 'user+eas@icloud.com').replace(new RegExp('user+eas@icloud.com', 'gi'), '{APPLE_USERNAME}')
// -> 'login user+eas@icloud.com'  plus-addressed Apple IDs are never redacted

new RegExp('S3cret(1', 'gi')
// -> SyntaxError: Invalid regular expression: /S3cret(1/gi: Unterminated group

'my passXword'.replace(new RegExp('pass.word', 'gi'), '{APPLE_PASSWORD}')
// -> 'my {APPLE_PASSWORD}'        unrelated text is redacted instead
```

So a credential with `+`, `.` or `*` in it is the one thing the scrubber is there to catch and the one thing it lets through, and a credential with an unbalanced `(` or `[` throws out of `subscribeTelemetryAsync` before the first request is made.

An empty `app.id` has the same shape of problem: `new RegExp('', 'gi')` matches at every position, so `{APPLE_APP_ID}` would be spliced between every character of the payload.

# How

The values are escaped before they become patterns, through a new `escapeRegExp` in `src/utils/expodash`, matching how `@expo/build-tools` already handles this with `lodash/escapeRegExp` (`eas-cli` does not depend on lodash, and `expodash` is where the package keeps its lodash replacements).

The six patterns now go through one `literalPattern` helper, which also skips empty values so a missing app ID cannot produce a match-everything pattern.

# Test Plan

`yarn test`, `yarn typecheck`, `yarn lint` and `yarn fmt:check` all pass.

Two cases were added to `telemetry.test.ts`: one asserting that a `user+eas@icloud.com` / `S3cret(1)` pair is redacted, and one asserting that a password of `a.c` no longer redacts the unrelated text `abc`. Both fail on `main`. `escapeRegExp` has its own unit tests, including a round-trip check that the escaped pattern matches the value itself and nothing else.
