### PR TITLE
[build-tools] Support flat app bundle archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Support downloading iOS simulator archives whose app bundle contents are stored at the archive root. ([#4262](https://github.com/expo/eas-cli/pull/4262) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [22.2.0](https://github.com/expo/eas-cli/releases/tag/v22.2.0) - 2026-08-20

--- a/packages/build-tools/src/steps/functions/__tests__/downloadBuild.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/downloadBuild.test.ts
@@ -4,8 +4,10 @@ import { Client, CombinedError } from '@urql/core';
 import fetch, { Response } from 'node-fetch';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { Readable } from 'node:stream';
+import * as tar from 'tar';
 
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createMockLogger } from '../../../__tests__/utils/logger';
@@ -18,6 +20,9 @@ const APP_TAR_GZ_BUFFER = Buffer.from(
     '=',
   'base64'
 );
+
+const FLAT_APP_INFO_PLIST_BASE64 =
+  'YnBsaXN0MDDSAQIDBF8QEkNGQnVuZGxlRXhlY3V0YWJsZV8QE0NGQnVuZGxlUGFja2FnZVR5cGVXVGVzdEFwcFRBUFBMCA0iOEAAAAAAAAABAQAAAAAAAAAFAAAAAAAAAAAAAAAAAAAARQ==';
 
 const APPLICATION_ARCHIVE_URL = `https://expo.dev/artifacts/eas/${randomUUID()}.tar.gz`;
 
@@ -74,6 +79,34 @@ function createSuccessfulResponse({
   } as unknown as Response;
 }
 
+async function createFlatAppTarGzBufferAsync(): Promise<Buffer> {
+  const sourceDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'flat-app-source-'));
+  const archivePath = path.join(os.tmpdir(), `${randomUUID()}.tar.gz`);
+
+  try {
+    await Promise.all([
+      fs.promises.writeFile(path.join(sourceDirectory, 'Info.plist'), FLAT_APP_INFO_PLIST_BASE64, {
+        encoding: 'base64',
+      }),
+      fs.promises.writeFile(path.join(sourceDirectory, 'TestApp'), 'i am executable\n'),
+    ]);
+    await tar.create(
+      {
+        cwd: sourceDirectory,
+        file: archivePath,
+        gzip: true,
+      },
+      ['Info.plist', 'TestApp']
+    );
+    return await fs.promises.readFile(archivePath);
+  } finally {
+    await Promise.all([
+      fs.promises.rm(sourceDirectory, { recursive: true, force: true }),
+      fs.promises.rm(archivePath, { force: true }),
+    ]);
+  }
+}
+
 describe('downloadBuild', () => {
   it('downloads from applicationArchiveUrl returned by GraphQL', async () => {
     const buildId = randomUUID();
@@ -101,6 +134,28 @@ describe('downloadBuild', () => {
       expect.objectContaining({ headers: undefined })
     );
     expect(artifactPath).toBeDefined();
+    expect(await fs.promises.readFile(path.join(artifactPath, 'TestApp'), 'utf8')).toBe(
+      'i am executable\n'
+    );
+  });
+
+  it('downloads an archive containing app bundle contents at its root', async () => {
+    jest.mocked(fetch).mockResolvedValue(
+      createSuccessfulResponse({
+        body: await createFlatAppTarGzBufferAsync(),
+        url: APPLICATION_ARCHIVE_URL,
+      })
+    );
+
+    const { artifactPath } = await downloadBuildAsync({
+      logger: createLogger({ name: 'test' }),
+      applicationArchiveUrl: APPLICATION_ARCHIVE_URL,
+      graphqlClient: createMockGraphqlClient({}),
+      robotAccessToken: null,
+      extensions: ['app'],
+    });
+
+    expect(path.extname(artifactPath)).toBe('.app');
     expect(await fs.promises.readFile(path.join(artifactPath, 'TestApp'), 'utf8')).toBe(
       'i am executable\n'
     );

--- a/packages/build-tools/src/steps/functions/downloadBuild.ts
+++ b/packages/build-tools/src/steps/functions/downloadBuild.ts
@@ -19,6 +19,8 @@ import path from 'node:path';
 import stream from 'stream';
 import { promisify } from 'util';
 import { z } from 'zod';
+import bplistParser from 'bplist-parser';
+import plist from 'plist';
 
 import { CustomBuildContext } from '../../customBuildContext';
 import { formatBytes } from '../../utils/artifacts';
@@ -226,6 +228,18 @@ export async function downloadBuildAsync(
     onlyFiles: false,
     onlyDirectories: false,
   });
+  let matchingFilesRoot = extractionDirectory;
+
+  if (
+    matchingFiles.length === 0 &&
+    extensions.includes('app') &&
+    (await isIosAppBundleAsync(extractionDirectory))
+  ) {
+    const appBundlePath = `${extractionDirectory}.app`;
+    await fs.promises.rename(extractionDirectory, appBundlePath);
+    matchingFiles.push(appBundlePath);
+    matchingFilesRoot = path.dirname(appBundlePath);
+  }
 
   if (matchingFiles.length === 0) {
     throw new UserError(
@@ -238,10 +252,26 @@ export async function downloadBuildAsync(
     `Found ${matchingFiles.length} matching ${pluralize(
       matchingFiles.length,
       'entry'
-    )}:\n${matchingFiles.map(f => `- ${path.relative(extractionDirectory, f)}`).join('\n')}`
+    )}:\n${matchingFiles.map(f => `- ${path.relative(matchingFilesRoot, f)}`).join('\n')}`
   );
 
   return { artifactPath: matchingFiles[0] };
+}
+
+async function isIosAppBundleAsync(directory: string): Promise<boolean> {
+  try {
+    const infoPlist = await fs.promises.readFile(path.join(directory, 'Info.plist'));
+    const isBinaryPlist = infoPlist.subarray(0, 8).toString('ascii') === 'bplist00';
+    const parsedInfoPlist = (
+      isBinaryPlist
+        ? bplistParser.parseBuffer(infoPlist)[0]
+        : plist.parse(infoPlist.toString('utf8'))
+    ) as Record<string, unknown> | undefined;
+
+    return parsedInfoPlist?.CFBundlePackageType === 'APPL';
+  } catch {
+    return false;
+  }
 }
 
 function parseHttpApplicationArchiveUrl(value: unknown): string {


### PR DESCRIPTION
# Why

The download_build function rejects Expo Go simulator archives such as https://github.com/expo/expo-go-releases/releases/download/Expo-Go-54.0.7/Expo-Go-54.0.7.tar.gz because they contain the app bundle contents at the archive root instead of an enclosing .app directory.

This prevents application_archive_url from being used with the published Expo Go simulator artifacts.

# How

- Detect an iOS application bundle at the extraction root by reading Info.plist and requiring CFBundlePackageType=APPL.
- Support both binary and XML Info.plist files.
- Rename a recognized flat bundle to a .app path before returning it to install_build.
- Preserve the existing behavior for archives that already contain a nested .app bundle.

# Test Plan

- Added a regression test that creates a flat app archive with a binary Info.plist and verifies that downloadBuildAsync returns a readable .app directory.
- Scoped build for build-tools and its workspace dependencies passes.
- Focused downloadBuild suite passes: 14 tests.
- Lint and formatter checks pass for both modified files.
- Full build-tools unit run reached 1,074 passing tests; 10 unrelated environment-dependent tests failed across npm resolution, Argent process-tree polling, and Fastlane keychain suites.