### PR TITLE
[build-tools] Support simulator application launch options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [build-tools] Pass launch arguments and a tunnel URL when launching applications in simulator sessions. ([#4263](https://github.com/expo/eas-cli/pull/4263) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Add `ios_signing_backend` option to the repack step. ([#4239](https://github.com/expo/eas-cli/pull/4239) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [build-tools] Support an optional `package_version` input on `eas/start_serve_sim_remote_session`, so a simulator session can pin the `@expo/serve-sim` version instead of always running `latest`. ([#4253](https://github.com/expo/eas-cli/pull/4253) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Add composable custom build functions for downloading, installing, and launching application archives in simulator sessions. ([#4222](https://github.com/expo/eas-cli/pull/4222) by [@szdziedzic](https://github.com/szdziedzic))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- [build-tools] Pass launch arguments and a tunnel URL when launching applications in simulator sessions. ([#4263](https://github.com/expo/eas-cli/pull/4263) by [@szdziedzic](https://github.com/szdziedzic))
+- [build-tools] Pass launch arguments and a URL to open when launching applications in simulator sessions. ([#4263](https://github.com/expo/eas-cli/pull/4263) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Add `ios_signing_backend` option to the repack step. ([#4239](https://github.com/expo/eas-cli/pull/4239) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [build-tools] Support an optional `package_version` input on `eas/start_serve_sim_remote_session`, so a simulator session can pin the `@expo/serve-sim` version instead of always running `latest`. ([#4253](https://github.com/expo/eas-cli/pull/4253) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Add composable custom build functions for downloading, installing, and launching application archives in simulator sessions. ([#4222](https://github.com/expo/eas-cli/pull/4222) by [@szdziedzic](https://github.com/szdziedzic))

--- a/packages/build-tools/src/steps/functions/__tests__/launchApplication.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/launchApplication.test.ts
@@ -123,6 +123,10 @@ describe(launchApplicationAsync, () => {
       ],
       { env: {}, logger }
     );
+    expect(logger.info).toHaveBeenNthCalledWith(
+      1,
+      'Launching host.exp.exponent with arguments ["--ez","isTest","true"].'
+    );
   });
 
   it('requires an activity when launching an Android application', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/launchApplication.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/launchApplication.test.ts
@@ -35,13 +35,13 @@ describe(launchApplicationAsync, () => {
     );
   });
 
-  it('passes launch arguments and opens a tunnel URL on iOS', async () => {
+  it('passes launch arguments and opens a URL on iOS', async () => {
     const logger = createMockLogger();
 
     await launchApplicationAsync({
       applicationIdentifier: 'host.exp.Exponent',
       launchArgs: ['--uitesting', 'true'],
-      tunnelUrl: 'exp://example.test',
+      openUrl: 'exp://example.test',
       runtimePlatform: BuildRuntimePlatform.DARWIN,
       env: {},
       logger,
@@ -79,14 +79,14 @@ describe(launchApplicationAsync, () => {
     );
   });
 
-  it('passes launch arguments and opens a tunnel URL on Android', async () => {
+  it('passes launch arguments and opens a URL on Android', async () => {
     const logger = createMockLogger();
 
     await launchApplicationAsync({
       applicationIdentifier: 'host.exp.exponent',
       activityName: 'host.exp.exponent.MainActivity',
       launchArgs: ['--ez', 'isTest', 'true'],
-      tunnelUrl: 'exp://example.test',
+      openUrl: 'exp://example.test',
       runtimePlatform: BuildRuntimePlatform.LINUX,
       env: {},
       logger,
@@ -147,7 +147,7 @@ describe(launchApplicationAsync, () => {
           application_identifier: 'com.example.app',
           activity_name: 'com.example.app.MainActivity',
           launch_args: ['--ez', 'isTest', 'true'],
-          tunnel_url: 'exp://example.test',
+          open_url: 'exp://example.test',
         },
       }
     );
@@ -203,21 +203,21 @@ describe(launchApplicationAsync, () => {
     expect(mockedSpawn).not.toHaveBeenCalled();
   });
 
-  it('rejects an invalid tunnel URL', async () => {
+  it('rejects an invalid URL to open', async () => {
     const launchApplication = createLaunchApplicationFunction();
     const buildStep = launchApplication.createBuildStepFromFunctionCall(
       createGlobalContextMock({ runtimePlatform: BuildRuntimePlatform.DARWIN }),
       {
         callInputs: {
           application_identifier: 'com.example.app',
-          tunnel_url: 'not a URL',
+          open_url: 'not a URL',
         },
       }
     );
 
     await expect(buildStep.executeAsync()).rejects.toMatchObject({
       errorCode: 'EAS_LAUNCH_APPLICATION_INVALID_INPUT',
-      message: 'Input "tunnel_url" must be a valid URL.',
+      message: 'Input "open_url" must be a valid URL.',
     });
     expect(mockedSpawn).not.toHaveBeenCalled();
   });

--- a/packages/build-tools/src/steps/functions/__tests__/launchApplication.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/launchApplication.test.ts
@@ -35,6 +35,32 @@ describe(launchApplicationAsync, () => {
     );
   });
 
+  it('passes launch arguments and opens a tunnel URL on iOS', async () => {
+    const logger = createMockLogger();
+
+    await launchApplicationAsync({
+      applicationIdentifier: 'host.exp.Exponent',
+      launchArgs: ['--uitesting', 'true'],
+      tunnelUrl: 'exp://example.test',
+      runtimePlatform: BuildRuntimePlatform.DARWIN,
+      env: {},
+      logger,
+    });
+
+    expect(mockedSpawn).toHaveBeenNthCalledWith(
+      1,
+      'xcrun',
+      ['simctl', 'launch', 'booted', 'host.exp.Exponent', '--uitesting', 'true'],
+      { env: {}, logger }
+    );
+    expect(mockedSpawn).toHaveBeenNthCalledWith(
+      2,
+      'xcrun',
+      ['simctl', 'openurl', 'booted', 'exp://example.test'],
+      { env: {}, logger }
+    );
+  });
+
   it('launches an Android Emulator application by package and activity', async () => {
     const logger = createMockLogger();
 
@@ -49,6 +75,52 @@ describe(launchApplicationAsync, () => {
     expect(mockedSpawn).toHaveBeenCalledWith(
       'adb',
       ['shell', 'am', 'start', '-n', 'com.example.app/com.example.app.MainActivity'],
+      { env: {}, logger }
+    );
+  });
+
+  it('passes launch arguments and opens a tunnel URL on Android', async () => {
+    const logger = createMockLogger();
+
+    await launchApplicationAsync({
+      applicationIdentifier: 'host.exp.exponent',
+      activityName: 'host.exp.exponent.MainActivity',
+      launchArgs: ['--ez', 'isTest', 'true'],
+      tunnelUrl: 'exp://example.test',
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+      env: {},
+      logger,
+    });
+
+    expect(mockedSpawn).toHaveBeenNthCalledWith(
+      1,
+      'adb',
+      [
+        'shell',
+        'am',
+        'start',
+        '--ez',
+        'isTest',
+        'true',
+        '-n',
+        'host.exp.exponent/host.exp.exponent.MainActivity',
+      ],
+      { env: {}, logger }
+    );
+    expect(mockedSpawn).toHaveBeenNthCalledWith(
+      2,
+      'adb',
+      [
+        'shell',
+        'am',
+        'start',
+        '-a',
+        'android.intent.action.VIEW',
+        '-d',
+        'exp://example.test',
+        '-n',
+        'host.exp.exponent/host.exp.exponent.MainActivity',
+      ],
       { env: {}, logger }
     );
   });
@@ -74,6 +146,8 @@ describe(launchApplicationAsync, () => {
         callInputs: {
           application_identifier: 'com.example.app',
           activity_name: 'com.example.app.MainActivity',
+          launch_args: ['--ez', 'isTest', 'true'],
+          tunnel_url: 'exp://example.test',
         },
       }
     );
@@ -81,9 +155,71 @@ describe(launchApplicationAsync, () => {
 
     expect(mockedSpawn).toHaveBeenCalledWith(
       'adb',
-      ['shell', 'am', 'start', '-n', 'com.example.app/com.example.app.MainActivity'],
+      [
+        'shell',
+        'am',
+        'start',
+        '--ez',
+        'isTest',
+        'true',
+        '-n',
+        'com.example.app/com.example.app.MainActivity',
+      ],
       expect.any(Object)
     );
+    expect(mockedSpawn).toHaveBeenCalledWith(
+      'adb',
+      [
+        'shell',
+        'am',
+        'start',
+        '-a',
+        'android.intent.action.VIEW',
+        '-d',
+        'exp://example.test',
+        '-n',
+        'com.example.app/com.example.app.MainActivity',
+      ],
+      expect.any(Object)
+    );
+  });
+
+  it.each([{}, ['valid', 42]])('rejects invalid launch arguments (%j)', async launchArgs => {
+    const launchApplication = createLaunchApplicationFunction();
+    const buildStep = launchApplication.createBuildStepFromFunctionCall(
+      createGlobalContextMock({ runtimePlatform: BuildRuntimePlatform.DARWIN }),
+      {
+        callInputs: {
+          application_identifier: 'com.example.app',
+          launch_args: launchArgs,
+        },
+      }
+    );
+
+    await expect(buildStep.executeAsync()).rejects.toMatchObject({
+      errorCode: 'EAS_LAUNCH_APPLICATION_INVALID_INPUT',
+      message: 'Input "launch_args" must be an array of strings.',
+    });
+    expect(mockedSpawn).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid tunnel URL', async () => {
+    const launchApplication = createLaunchApplicationFunction();
+    const buildStep = launchApplication.createBuildStepFromFunctionCall(
+      createGlobalContextMock({ runtimePlatform: BuildRuntimePlatform.DARWIN }),
+      {
+        callInputs: {
+          application_identifier: 'com.example.app',
+          tunnel_url: 'not a URL',
+        },
+      }
+    );
+
+    await expect(buildStep.executeAsync()).rejects.toMatchObject({
+      errorCode: 'EAS_LAUNCH_APPLICATION_INVALID_INPUT',
+      message: 'Input "tunnel_url" must be a valid URL.',
+    });
+    expect(mockedSpawn).not.toHaveBeenCalled();
   });
 
   it.each(['application_identifier', 'activity_name'])(

--- a/packages/build-tools/src/steps/functions/launchApplication.ts
+++ b/packages/build-tools/src/steps/functions/launchApplication.ts
@@ -26,6 +26,16 @@ export function createLaunchApplicationFunction(): BuildFunction {
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
+      BuildStepInput.createProvider({
+        id: 'launch_args',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.JSON,
+      }),
+      BuildStepInput.createProvider({
+        id: 'tunnel_url',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.STRING,
+      }),
     ],
     fn: async ({ global, logger }, { inputs, env }) => {
       const applicationIdentifier = parseNonEmptyStringInput(
@@ -36,9 +46,16 @@ export function createLaunchApplicationFunction(): BuildFunction {
         inputs.activity_name.value === undefined
           ? undefined
           : parseNonEmptyStringInput(inputs.activity_name.value, 'activity_name');
+      const launchArgs = parseLaunchArgsInput(inputs.launch_args.value);
+      const tunnelUrl =
+        inputs.tunnel_url.value === undefined
+          ? undefined
+          : parseTunnelUrlInput(inputs.tunnel_url.value);
       await launchApplicationAsync({
         applicationIdentifier,
         activityName,
+        launchArgs,
+        tunnelUrl,
         runtimePlatform: global.runtimePlatform,
         env,
         logger,
@@ -50,22 +67,30 @@ export function createLaunchApplicationFunction(): BuildFunction {
 export async function launchApplicationAsync({
   applicationIdentifier,
   activityName,
+  launchArgs = [],
+  tunnelUrl,
   runtimePlatform,
   env,
   logger,
 }: {
   applicationIdentifier: string;
   activityName?: string;
+  launchArgs?: string[];
+  tunnelUrl?: string;
   runtimePlatform: BuildRuntimePlatform;
   env: BuildStepEnv;
   logger: bunyan;
 }): Promise<void> {
   if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
     logger.info(`Launching ${applicationIdentifier}.`);
-    await spawn('xcrun', ['simctl', 'launch', 'booted', applicationIdentifier], {
+    await spawn('xcrun', ['simctl', 'launch', 'booted', applicationIdentifier, ...launchArgs], {
       env,
       logger,
     });
+    if (tunnelUrl) {
+      logger.info(`Opening ${tunnelUrl} in ${applicationIdentifier}.`);
+      await spawn('xcrun', ['simctl', 'openurl', 'booted', tunnelUrl], { env, logger });
+    }
     return;
   }
 
@@ -77,10 +102,32 @@ export async function launchApplicationAsync({
   }
 
   logger.info(`Launching ${applicationIdentifier}.`);
-  await spawn('adb', ['shell', 'am', 'start', '-n', `${applicationIdentifier}/${activityName}`], {
-    env,
-    logger,
-  });
+  await spawn(
+    'adb',
+    ['shell', 'am', 'start', ...launchArgs, '-n', `${applicationIdentifier}/${activityName}`],
+    {
+      env,
+      logger,
+    }
+  );
+  if (tunnelUrl) {
+    logger.info(`Opening ${tunnelUrl} in ${applicationIdentifier}.`);
+    await spawn(
+      'adb',
+      [
+        'shell',
+        'am',
+        'start',
+        '-a',
+        'android.intent.action.VIEW',
+        '-d',
+        tunnelUrl,
+        '-n',
+        `${applicationIdentifier}/${activityName}`,
+      ],
+      { env, logger }
+    );
+  }
 }
 
 function parseNonEmptyStringInput(value: unknown, inputName: string): string {
@@ -91,4 +138,28 @@ function parseNonEmptyStringInput(value: unknown, inputName: string): string {
     );
   }
   return value;
+}
+
+function parseLaunchArgsInput(value: unknown): string[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value) || !value.every(argument => typeof argument === 'string')) {
+    throw new UserError(
+      'EAS_LAUNCH_APPLICATION_INVALID_INPUT',
+      'Input "launch_args" must be an array of strings.'
+    );
+  }
+  return value;
+}
+
+function parseTunnelUrlInput(value: unknown): string {
+  const tunnelUrl = parseNonEmptyStringInput(value, 'tunnel_url');
+  if (!URL.canParse(tunnelUrl)) {
+    throw new UserError(
+      'EAS_LAUNCH_APPLICATION_INVALID_INPUT',
+      'Input "tunnel_url" must be a valid URL.'
+    );
+  }
+  return tunnelUrl;
 }

--- a/packages/build-tools/src/steps/functions/launchApplication.ts
+++ b/packages/build-tools/src/steps/functions/launchApplication.ts
@@ -80,7 +80,7 @@ export async function launchApplicationAsync({
   logger: bunyan;
 }): Promise<void> {
   if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
-    logger.info(`Launching ${applicationIdentifier}.`);
+    logApplicationLaunch(logger, applicationIdentifier, launchArgs);
     await spawn('xcrun', ['simctl', 'launch', 'booted', applicationIdentifier, ...launchArgs], {
       env,
       logger,
@@ -99,7 +99,9 @@ export async function launchApplicationAsync({
     );
   }
 
-  logger.info(`Launching ${applicationIdentifier}.`);
+  logApplicationLaunch(logger, applicationIdentifier, launchArgs);
+  // Android does not support process arguments like iOS. Pass raw `am start` Intent
+  // arguments instead, such as `--es key value` or `--ez key true`.
   await spawn(
     'adb',
     ['shell', 'am', 'start', ...launchArgs, '-n', `${applicationIdentifier}/${activityName}`],
@@ -126,6 +128,16 @@ export async function launchApplicationAsync({
       { env, logger }
     );
   }
+}
+
+function logApplicationLaunch(
+  logger: bunyan,
+  applicationIdentifier: string,
+  launchArgs: string[]
+): void {
+  const argumentsDescription =
+    launchArgs.length > 0 ? ` with arguments ${JSON.stringify(launchArgs)}` : '';
+  logger.info(`Launching ${applicationIdentifier}${argumentsDescription}.`);
 }
 
 function parseNonEmptyStringInput(value: unknown, inputName: string): string {

--- a/packages/build-tools/src/steps/functions/launchApplication.ts
+++ b/packages/build-tools/src/steps/functions/launchApplication.ts
@@ -32,7 +32,7 @@ export function createLaunchApplicationFunction(): BuildFunction {
         allowedValueTypeName: BuildStepInputValueTypeName.JSON,
       }),
       BuildStepInput.createProvider({
-        id: 'tunnel_url',
+        id: 'open_url',
         required: false,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
@@ -47,15 +47,13 @@ export function createLaunchApplicationFunction(): BuildFunction {
           ? undefined
           : parseNonEmptyStringInput(inputs.activity_name.value, 'activity_name');
       const launchArgs = parseLaunchArgsInput(inputs.launch_args.value);
-      const tunnelUrl =
-        inputs.tunnel_url.value === undefined
-          ? undefined
-          : parseTunnelUrlInput(inputs.tunnel_url.value);
+      const openUrl =
+        inputs.open_url.value === undefined ? undefined : parseOpenUrlInput(inputs.open_url.value);
       await launchApplicationAsync({
         applicationIdentifier,
         activityName,
         launchArgs,
-        tunnelUrl,
+        openUrl,
         runtimePlatform: global.runtimePlatform,
         env,
         logger,
@@ -68,7 +66,7 @@ export async function launchApplicationAsync({
   applicationIdentifier,
   activityName,
   launchArgs = [],
-  tunnelUrl,
+  openUrl,
   runtimePlatform,
   env,
   logger,
@@ -76,7 +74,7 @@ export async function launchApplicationAsync({
   applicationIdentifier: string;
   activityName?: string;
   launchArgs?: string[];
-  tunnelUrl?: string;
+  openUrl?: string;
   runtimePlatform: BuildRuntimePlatform;
   env: BuildStepEnv;
   logger: bunyan;
@@ -87,9 +85,9 @@ export async function launchApplicationAsync({
       env,
       logger,
     });
-    if (tunnelUrl) {
-      logger.info(`Opening ${tunnelUrl} in ${applicationIdentifier}.`);
-      await spawn('xcrun', ['simctl', 'openurl', 'booted', tunnelUrl], { env, logger });
+    if (openUrl) {
+      logger.info(`Opening ${openUrl} in ${applicationIdentifier}.`);
+      await spawn('xcrun', ['simctl', 'openurl', 'booted', openUrl], { env, logger });
     }
     return;
   }
@@ -110,8 +108,8 @@ export async function launchApplicationAsync({
       logger,
     }
   );
-  if (tunnelUrl) {
-    logger.info(`Opening ${tunnelUrl} in ${applicationIdentifier}.`);
+  if (openUrl) {
+    logger.info(`Opening ${openUrl} in ${applicationIdentifier}.`);
     await spawn(
       'adb',
       [
@@ -121,7 +119,7 @@ export async function launchApplicationAsync({
         '-a',
         'android.intent.action.VIEW',
         '-d',
-        tunnelUrl,
+        openUrl,
         '-n',
         `${applicationIdentifier}/${activityName}`,
       ],
@@ -153,13 +151,13 @@ function parseLaunchArgsInput(value: unknown): string[] {
   return value;
 }
 
-function parseTunnelUrlInput(value: unknown): string {
-  const tunnelUrl = parseNonEmptyStringInput(value, 'tunnel_url');
-  if (!URL.canParse(tunnelUrl)) {
+function parseOpenUrlInput(value: unknown): string {
+  const openUrl = parseNonEmptyStringInput(value, 'open_url');
+  if (!URL.canParse(openUrl)) {
     throw new UserError(
       'EAS_LAUNCH_APPLICATION_INVALID_INPUT',
-      'Input "tunnel_url" must be a valid URL.'
+      'Input "open_url" must be a valid URL.'
     );
   }
-  return tunnelUrl;
+  return openUrl;
 }


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Companion to https://github.com/expo/universe/pull/30416

# How

Use launch args and tunnel url to actually do things.

Use launch args when launching the app.

Open tunnel url in launched build (it will work only if this is dev client or expo go)

# Test Plan

Tests
