### PR TITLE
[eas-cli] Add simulator launch options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- [eas-cli] Add `--launch-arg`, `--tunnel-url`, and Expo Go `--sdk-version` options to `eas simulator`. ([#4264](https://github.com/expo/eas-cli/pull/4264) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Add `--launch-arg`, `--open-url`, and Expo Go `--sdk-version` options to `eas simulator`. ([#4264](https://github.com/expo/eas-cli/pull/4264) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Pass launch arguments and a URL to open when launching applications in simulator sessions. ([#4263](https://github.com/expo/eas-cli/pull/4263) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Add `ios_signing_backend` option to the repack step. ([#4239](https://github.com/expo/eas-cli/pull/4239) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [build-tools] Support an optional `package_version` input on `eas/start_serve_sim_remote_session`, so a simulator session can pin the `@expo/serve-sim` version instead of always running `latest`. ([#4253](https://github.com/expo/eas-cli/pull/4253) by [@gwdp](https://github.com/gwdp))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add `--launch-arg`, `--tunnel-url`, and Expo Go `--sdk-version` options to `eas simulator`. ([#4264](https://github.com/expo/eas-cli/pull/4264) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Pass launch arguments and a URL to open when launching applications in simulator sessions. ([#4263](https://github.com/expo/eas-cli/pull/4263) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Add `ios_signing_backend` option to the repack step. ([#4239](https://github.com/expo/eas-cli/pull/4239) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [build-tools] Support an optional `package_version` input on `eas/start_serve_sim_remote_session`, so a simulator session can pin the `@expo/serve-sim` version instead of always running `latest`. ([#4253](https://github.com/expo/eas-cli/pull/4253) by [@gwdp](https://github.com/gwdp))

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -37248,6 +37248,26 @@
             "deprecationReason": null
           },
           {
+            "name": "launchArgs",
+            "description": "Arguments passed to the installed application when it is launched. Requires buildId or\napplicationArchiveUrl.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "maxIdleTimeMinutes",
             "description": "Stop the session automatically after this many minutes without observed\nsession activity. Must be positive and smaller than the session's maximum\nduration (2 hours, or maxRunTimeMinutes when set). Only supported for\nagent-device, argent, and Appium sessions. If omitted, the session has no idle\ntimeout.",
             "type": {
@@ -37306,6 +37326,18 @@
                 "name": "AppPlatform",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tunnelUrl",
+            "description": "Expo or development-client URL to open after launching the installed application. Requires\nbuildId or applicationArchiveUrl.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -37213,7 +37213,7 @@
           },
           {
             "name": "applicationArchiveUrl",
-            "description": "Application archive URL to download, install, and launch before the simulator session\nbecomes available. Mutually exclusive with buildId.",
+            "description": "Application archive URL to download, install, and launch before the simulator session\nbecomes available. Mutually exclusive with buildId and expoGo.",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -37225,7 +37225,7 @@
           },
           {
             "name": "buildId",
-            "description": "EAS Build to install and launch before the simulator session becomes available.\nMutually exclusive with applicationArchiveUrl.",
+            "description": "EAS Build to install and launch before the simulator session becomes available.\nMutually exclusive with applicationArchiveUrl and expoGo.",
             "type": {
               "kind": "SCALAR",
               "name": "ID",
@@ -37248,8 +37248,20 @@
             "deprecationReason": null
           },
           {
+            "name": "expoGo",
+            "description": "Install and launch Expo Go before the simulator session becomes available. The server resolves\nthe platform-specific application archive. Mutually exclusive with buildId and\napplicationArchiveUrl.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "launchArgs",
-            "description": "Arguments passed to the installed application when it is launched. Requires buildId or\napplicationArchiveUrl.",
+            "description": "Arguments passed to the installed application when it is launched. Requires buildId,\napplicationArchiveUrl, or expoGo.",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -37332,8 +37344,20 @@
             "deprecationReason": null
           },
           {
+            "name": "sdkVersion",
+            "description": "Expo SDK version used to select an Expo Go application archive. Only supported when expoGo is\ntrue. If omitted, the current Expo Go archive for the platform is used.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "tunnelUrl",
-            "description": "Expo or development-client URL to open after launching the installed application. Requires\nbuildId or applicationArchiveUrl.",
+            "description": "Expo or development-client URL to open after launching the installed application. Requires\nbuildId, applicationArchiveUrl, or expoGo.",
             "type": {
               "kind": "SCALAR",
               "name": "String",

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -37316,6 +37316,18 @@
             "deprecationReason": null
           },
           {
+            "name": "openUrl",
+            "description": "Expo or development-client URL to open after launching the installed application. Requires\nbuildId, applicationArchiveUrl, or expoGo.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "packageVersion",
             "description": "The version of the package backing the device run session (e.g. \"0.1.3-alpha.3\").\nIf omitted, consumers treat the session as pinned to \"latest\".",
             "type": {
@@ -37346,18 +37358,6 @@
           {
             "name": "sdkVersion",
             "description": "Expo SDK version used to select an Expo Go application archive. Only supported when expoGo is\ntrue. If omitted, the current Expo Go archive for the platform is used.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "tunnelUrl",
-            "description": "Expo or development-client URL to open after launching the installed application. Requires\nbuildId, applicationArchiveUrl, or expoGo.",
             "type": {
               "kind": "SCALAR",
               "name": "String",

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -23,7 +23,7 @@ import {
   loadSimulatorEnvAsync,
   resetSimulatorEnvAsync,
 } from '../../../simulator/env';
-import { resolveExpoGoApplicationArchiveUrlAsync } from '../../../simulator/expoGo';
+import { resolveExpoGoSdkVersionAsync } from '../../../simulator/expoGo';
 import Simulator from '../index';
 
 jest.mock('fs-extra');
@@ -80,9 +80,7 @@ const mockAvailabilityByAppIdAsync = jest.mocked(DeviceRunSessionAvailabilityQue
 const mockByIdAsync = jest.mocked(DeviceRunSessionQuery.byIdAsync);
 const mockLoadSimulatorEnvAsync = jest.mocked(loadSimulatorEnvAsync);
 const mockResetSimulatorEnvAsync = jest.mocked(resetSimulatorEnvAsync);
-const mockResolveExpoGoApplicationArchiveUrlAsync = jest.mocked(
-  resolveExpoGoApplicationArchiveUrlAsync
-);
+const mockResolveExpoGoSdkVersionAsync = jest.mocked(resolveExpoGoSdkVersionAsync);
 const mockOra = jest.mocked(ora);
 const mockPromptAsync = jest.mocked(promptAsync);
 
@@ -166,9 +164,7 @@ describe(Simulator, () => {
     mockByIdAsync.mockResolvedValue(makeDeviceRunSession());
     mockLoadSimulatorEnvAsync.mockResolvedValue();
     mockResetSimulatorEnvAsync.mockResolvedValue();
-    mockResolveExpoGoApplicationArchiveUrlAsync.mockResolvedValue(
-      'https://example.test/expo-go.tar.gz'
-    );
+    mockResolveExpoGoSdkVersionAsync.mockResolvedValue('55.0.0');
     jest.mocked(fs.writeFile).mockResolvedValue(undefined as never);
   });
 
@@ -541,12 +537,11 @@ describe(Simulator, () => {
   });
 
   it.each([
-    ['ios', AppPlatform.Ios, 'https://example.test/expo-go.tar.gz'],
-    ['android', AppPlatform.Android, 'https://example.test/expo-go.apk'],
+    ['ios', AppPlatform.Ios],
+    ['android', AppPlatform.Android],
   ] as const)(
-    'resolves and forwards the %s Expo Go archive when --expo-go is passed',
-    async (platformFlag, appPlatform, applicationArchiveUrl) => {
-      mockResolveExpoGoApplicationArchiveUrlAsync.mockResolvedValue(applicationArchiveUrl);
+    'forwards Expo Go and the project SDK for %s when --expo-go is passed',
+    async (platformFlag, appPlatform) => {
       const { command } = createCommand([
         '--platform',
         platformFlag,
@@ -556,22 +551,27 @@ describe(Simulator, () => {
 
       await command.runAsync();
 
-      expect(mockResolveExpoGoApplicationArchiveUrlAsync).toHaveBeenCalledWith({
-        platform: platformFlag,
+      expect(mockResolveExpoGoSdkVersionAsync).toHaveBeenCalledWith({
         projectDir,
         sdkVersion: undefined,
       });
       expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
         graphqlClient,
         expect.objectContaining({
-          applicationArchiveUrl,
+          expoGo: true,
+          sdkVersion: '55.0.0',
           platform: appPlatform,
         })
+      );
+      expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+        graphqlClient,
+        expect.not.objectContaining({ applicationArchiveUrl: expect.anything() })
       );
     }
   );
 
   it('uses --sdk-version to select Expo Go', async () => {
+    mockResolveExpoGoSdkVersionAsync.mockResolvedValueOnce('57.0.0');
     const { command } = createCommand([
       '--platform',
       'ios',
@@ -583,11 +583,14 @@ describe(Simulator, () => {
 
     await command.runAsync();
 
-    expect(mockResolveExpoGoApplicationArchiveUrlAsync).toHaveBeenCalledWith({
-      platform: 'ios',
+    expect(mockResolveExpoGoSdkVersionAsync).toHaveBeenCalledWith({
       projectDir,
       sdkVersion: '57.0.0',
     });
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ expoGo: true, sdkVersion: '57.0.0' })
+    );
   });
 
   it('forwards repeated launch arguments and a tunnel URL', async () => {
@@ -646,7 +649,7 @@ describe(Simulator, () => {
     await expect(command.runAsync()).rejects.toThrow(
       'The --sdk-version flag can only be used with --expo-go.'
     );
-    expect(mockResolveExpoGoApplicationArchiveUrlAsync).not.toHaveBeenCalled();
+    expect(mockResolveExpoGoSdkVersionAsync).not.toHaveBeenCalled();
     expect(mockCreateDeviceRunSessionAsync).not.toHaveBeenCalled();
   });
 
@@ -679,7 +682,7 @@ describe(Simulator, () => {
     ]);
 
     await expect(command.runAsync()).rejects.toThrow();
-    expect(mockResolveExpoGoApplicationArchiveUrlAsync).not.toHaveBeenCalled();
+    expect(mockResolveExpoGoSdkVersionAsync).not.toHaveBeenCalled();
     expect(mockCreateDeviceRunSessionAsync).not.toHaveBeenCalled();
   });
 

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -614,7 +614,7 @@ describe(Simulator, () => {
       graphqlClient,
       expect.objectContaining({
         launchArgs: ['--uitesting', 'true'],
-        tunnelUrl: 'exp://example.test',
+        openUrl: 'exp://example.test',
       })
     );
   });

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -593,7 +593,7 @@ describe(Simulator, () => {
     );
   });
 
-  it('forwards repeated launch arguments and a tunnel URL', async () => {
+  it('forwards repeated launch arguments and a URL to open', async () => {
     const { command } = createCommand([
       '--platform',
       'ios',
@@ -604,7 +604,7 @@ describe(Simulator, () => {
       '--uitesting',
       '--launch-arg',
       'true',
-      '--tunnel-url',
+      '--open-url',
       '  exp://example.test  ',
     ]);
 
@@ -621,7 +621,7 @@ describe(Simulator, () => {
 
   it.each([
     ['--launch-arg', '--uitesting'],
-    ['--tunnel-url', 'exp://example.test'],
+    ['--open-url', 'exp://example.test'],
   ])('rejects %s without an application source', async (launchFlag, launchValue) => {
     const { command } = createCommand([
       '--platform',

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -559,6 +559,7 @@ describe(Simulator, () => {
       expect(mockResolveExpoGoApplicationArchiveUrlAsync).toHaveBeenCalledWith({
         platform: platformFlag,
         projectDir,
+        sdkVersion: undefined,
       });
       expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
         graphqlClient,
@@ -569,6 +570,85 @@ describe(Simulator, () => {
       );
     }
   );
+
+  it('uses --sdk-version to select Expo Go', async () => {
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      '--expo-go',
+      '--sdk-version',
+      '57.0.0',
+    ]);
+
+    await command.runAsync();
+
+    expect(mockResolveExpoGoApplicationArchiveUrlAsync).toHaveBeenCalledWith({
+      platform: 'ios',
+      projectDir,
+      sdkVersion: '57.0.0',
+    });
+  });
+
+  it('forwards repeated launch arguments and a tunnel URL', async () => {
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      '--build-id',
+      '8d8b713c-1834-4bd3-91e6-46f895422cbc',
+      '--launch-arg',
+      '--uitesting',
+      '--launch-arg',
+      'true',
+      '--tunnel-url',
+      '  exp://example.test  ',
+    ]);
+
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({
+        launchArgs: ['--uitesting', 'true'],
+        tunnelUrl: 'exp://example.test',
+      })
+    );
+  });
+
+  it.each([
+    ['--launch-arg', '--uitesting'],
+    ['--tunnel-url', 'exp://example.test'],
+  ])('rejects %s without an application source', async (launchFlag, launchValue) => {
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      launchFlag,
+      launchValue,
+    ]);
+
+    await expect(command.runAsync()).rejects.toThrow(
+      'Launch options require an application source.'
+    );
+    expect(mockCreateDeviceRunSessionAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects --sdk-version without --expo-go', async () => {
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--non-interactive',
+      '--sdk-version',
+      '57',
+    ]);
+
+    await expect(command.runAsync()).rejects.toThrow(
+      'The --sdk-version flag can only be used with --expo-go.'
+    );
+    expect(mockResolveExpoGoApplicationArchiveUrlAsync).not.toHaveBeenCalled();
+    expect(mockCreateDeviceRunSessionAsync).not.toHaveBeenCalled();
+  });
 
   it('rejects passing --build-id and --application-archive-url together', async () => {
     const { command } = createCommand([

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -28,7 +28,7 @@ import {
   resetSimulatorEnvAsync,
   writeSimulatorEnvAsync,
 } from '../../simulator/env';
-import { resolveExpoGoApplicationArchiveUrlAsync } from '../../simulator/expoGo';
+import { resolveExpoGoSdkVersionAsync } from '../../simulator/expoGo';
 import {
   DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE,
   DEVICE_RUN_SESSION_TYPE_FLAG_VALUES,
@@ -169,11 +169,11 @@ export default class Simulator extends EasCommand {
     const deviceIdentifier = flags.device?.trim() || undefined;
     const buildId = flags['build-id']?.trim() || undefined;
     const applicationArchiveUrlFromFlag = flags['application-archive-url']?.trim() || undefined;
-    const sdkVersion = flags['sdk-version']?.trim() || undefined;
+    const sdkVersionFromFlag = flags['sdk-version']?.trim() || undefined;
     const launchArgs = flags['launch-arg'];
     const tunnelUrl = flags['tunnel-url']?.trim() || undefined;
 
-    if (sdkVersion && !flags['expo-go']) {
+    if (sdkVersionFromFlag && !flags['expo-go']) {
       throw new EasCommandError('The --sdk-version flag can only be used with --expo-go.');
     }
     if (
@@ -196,13 +196,9 @@ export default class Simulator extends EasCommand {
     }
 
     const platform = await resolvePlatformAsync(flags.platform, nonInteractive);
-    const applicationArchiveUrl = flags['expo-go']
-      ? await resolveExpoGoApplicationArchiveUrlAsync({
-          platform: platform === AppPlatform.Ios ? 'ios' : 'android',
-          projectDir,
-          sdkVersion,
-        })
-      : applicationArchiveUrlFromFlag;
+    const expoGoSdkVersion = flags['expo-go']
+      ? await resolveExpoGoSdkVersionAsync({ projectDir, sdkVersion: sdkVersionFromFlag })
+      : undefined;
 
     if (existingDeviceRunSessionId) {
       Log.warn(
@@ -226,7 +222,10 @@ export default class Simulator extends EasCommand {
         packageVersion: flags['package-version'],
         deviceIdentifier,
         ...(buildId ? { buildId } : {}),
-        ...(applicationArchiveUrl ? { applicationArchiveUrl } : {}),
+        ...(applicationArchiveUrlFromFlag
+          ? { applicationArchiveUrl: applicationArchiveUrlFromFlag }
+          : {}),
+        ...(expoGoSdkVersion ? { expoGo: true, sdkVersion: expoGoSdkVersion } : {}),
         ...(launchArgs?.length ? { launchArgs } : {}),
         ...(tunnelUrl ? { tunnelUrl } : {}),
         maxRunTimeMinutes: flags['max-duration-minutes'],

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -171,13 +171,13 @@ export default class Simulator extends EasCommand {
     const applicationArchiveUrlFromFlag = flags['application-archive-url']?.trim() || undefined;
     const sdkVersionFromFlag = flags['sdk-version']?.trim() || undefined;
     const launchArgs = flags['launch-arg'];
-    const tunnelUrl = flags['open-url']?.trim() || undefined;
+    const openUrl = flags['open-url']?.trim() || undefined;
 
     if (sdkVersionFromFlag && !flags['expo-go']) {
       throw new EasCommandError('The --sdk-version flag can only be used with --expo-go.');
     }
     if (
-      (launchArgs?.length || tunnelUrl) &&
+      (launchArgs?.length || openUrl) &&
       !buildId &&
       !applicationArchiveUrlFromFlag &&
       !flags['expo-go']
@@ -227,7 +227,7 @@ export default class Simulator extends EasCommand {
           : {}),
         ...(expoGoSdkVersion ? { expoGo: true, sdkVersion: expoGoSdkVersion } : {}),
         ...(launchArgs?.length ? { launchArgs } : {}),
-        ...(tunnelUrl ? { tunnelUrl } : {}),
+        ...(openUrl ? { openUrl } : {}),
         maxRunTimeMinutes: flags['max-duration-minutes'],
       });
       deviceRunSessionId = session.id;

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -87,6 +87,19 @@ export default class Simulator extends EasCommand {
         "Install and launch Expo Go matching the current project's Expo SDK before the simulator session is ready.",
       exclusive: ['build-id', 'application-archive-url'],
     }),
+    'sdk-version': Flags.string({
+      description:
+        'Expo SDK version used to select Expo Go when --expo-go is passed. Defaults to the current project SDK.',
+    }),
+    'launch-arg': Flags.string({
+      description:
+        'Argument passed to the installed application when it launches. Repeat for multiple arguments.',
+      multiple: true,
+    }),
+    'tunnel-url': Flags.string({
+      description:
+        'Expo or development-client URL to open in the installed application after it launches.',
+    }),
     type: Flags.option({
       description: 'Type of simulator session to create',
       options: Object.values(DEVICE_RUN_SESSION_TYPE_FLAG_VALUES),
@@ -156,6 +169,23 @@ export default class Simulator extends EasCommand {
     const deviceIdentifier = flags.device?.trim() || undefined;
     const buildId = flags['build-id']?.trim() || undefined;
     const applicationArchiveUrlFromFlag = flags['application-archive-url']?.trim() || undefined;
+    const sdkVersion = flags['sdk-version']?.trim() || undefined;
+    const launchArgs = flags['launch-arg'];
+    const tunnelUrl = flags['tunnel-url']?.trim() || undefined;
+
+    if (sdkVersion && !flags['expo-go']) {
+      throw new EasCommandError('The --sdk-version flag can only be used with --expo-go.');
+    }
+    if (
+      (launchArgs?.length || tunnelUrl) &&
+      !buildId &&
+      !applicationArchiveUrlFromFlag &&
+      !flags['expo-go']
+    ) {
+      throw new EasCommandError(
+        'Launch options require an application source. Pass --build-id, --application-archive-url, or --expo-go.'
+      );
+    }
 
     await loadSimulatorEnvAsync(projectDir);
     const existingDeviceRunSessionId = process.env[EAS_SIMULATOR_SESSION_ID];
@@ -170,6 +200,7 @@ export default class Simulator extends EasCommand {
       ? await resolveExpoGoApplicationArchiveUrlAsync({
           platform: platform === AppPlatform.Ios ? 'ios' : 'android',
           projectDir,
+          sdkVersion,
         })
       : applicationArchiveUrlFromFlag;
 
@@ -196,6 +227,8 @@ export default class Simulator extends EasCommand {
         deviceIdentifier,
         ...(buildId ? { buildId } : {}),
         ...(applicationArchiveUrl ? { applicationArchiveUrl } : {}),
+        ...(launchArgs?.length ? { launchArgs } : {}),
+        ...(tunnelUrl ? { tunnelUrl } : {}),
         maxRunTimeMinutes: flags['max-duration-minutes'],
       });
       deviceRunSessionId = session.id;

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -96,7 +96,7 @@ export default class Simulator extends EasCommand {
         'Argument passed to the installed application when it launches. Repeat for multiple arguments.',
       multiple: true,
     }),
-    'tunnel-url': Flags.string({
+    'open-url': Flags.string({
       description:
         'Expo or development-client URL to open in the installed application after it launches.',
     }),
@@ -171,7 +171,7 @@ export default class Simulator extends EasCommand {
     const applicationArchiveUrlFromFlag = flags['application-archive-url']?.trim() || undefined;
     const sdkVersionFromFlag = flags['sdk-version']?.trim() || undefined;
     const launchArgs = flags['launch-arg'];
-    const tunnelUrl = flags['tunnel-url']?.trim() || undefined;
+    const tunnelUrl = flags['open-url']?.trim() || undefined;
 
     if (sdkVersionFromFlag && !flags['expo-go']) {
       throw new EasCommandError('The --sdk-version flag can only be used with --expo-go.');

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -5283,6 +5283,11 @@ export type CreateDeviceRunSessionInput = {
    */
   name?: InputMaybe<Scalars['String']['input']>;
   /**
+   * Expo or development-client URL to open after launching the installed application. Requires
+   * buildId, applicationArchiveUrl, or expoGo.
+   */
+  openUrl?: InputMaybe<Scalars['String']['input']>;
+  /**
    * The version of the package backing the device run session (e.g. "0.1.3-alpha.3").
    * If omitted, consumers treat the session as pinned to "latest".
    */
@@ -5293,11 +5298,6 @@ export type CreateDeviceRunSessionInput = {
    * true. If omitted, the current Expo Go archive for the platform is used.
    */
   sdkVersion?: InputMaybe<Scalars['String']['input']>;
-  /**
-   * Expo or development-client URL to open after launching the installed application. Requires
-   * buildId, applicationArchiveUrl, or expoGo.
-   */
-  tunnelUrl?: InputMaybe<Scalars['String']['input']>;
   type: DeviceRunSessionType;
 };
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -5252,6 +5252,11 @@ export type CreateDeviceRunSessionInput = {
    */
   deviceIdentifier?: InputMaybe<Scalars['String']['input']>;
   /**
+   * Arguments passed to the installed application when it is launched. Requires buildId or
+   * applicationArchiveUrl.
+   */
+  launchArgs?: InputMaybe<Array<Scalars['String']['input']>>;
+  /**
    * Stop the session automatically after this many minutes without observed
    * session activity. Must be positive and smaller than the session's maximum
    * duration (2 hours, or maxRunTimeMinutes when set). Only supported for
@@ -5277,6 +5282,11 @@ export type CreateDeviceRunSessionInput = {
    */
   packageVersion?: InputMaybe<Scalars['String']['input']>;
   platform: AppPlatform;
+  /**
+   * Expo or development-client URL to open after launching the installed application. Requires
+   * buildId or applicationArchiveUrl.
+   */
+  tunnelUrl?: InputMaybe<Scalars['String']['input']>;
   type: DeviceRunSessionType;
 };
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -5236,12 +5236,12 @@ export type CreateDeviceRunSessionInput = {
   appId: Scalars['ID']['input'];
   /**
    * Application archive URL to download, install, and launch before the simulator session
-   * becomes available. Mutually exclusive with buildId.
+   * becomes available. Mutually exclusive with buildId and expoGo.
    */
   applicationArchiveUrl?: InputMaybe<Scalars['String']['input']>;
   /**
    * EAS Build to install and launch before the simulator session becomes available.
-   * Mutually exclusive with applicationArchiveUrl.
+   * Mutually exclusive with applicationArchiveUrl and expoGo.
    */
   buildId?: InputMaybe<Scalars['ID']['input']>;
   /**
@@ -5252,8 +5252,14 @@ export type CreateDeviceRunSessionInput = {
    */
   deviceIdentifier?: InputMaybe<Scalars['String']['input']>;
   /**
-   * Arguments passed to the installed application when it is launched. Requires buildId or
+   * Install and launch Expo Go before the simulator session becomes available. The server resolves
+   * the platform-specific application archive. Mutually exclusive with buildId and
    * applicationArchiveUrl.
+   */
+  expoGo?: InputMaybe<Scalars['Boolean']['input']>;
+  /**
+   * Arguments passed to the installed application when it is launched. Requires buildId,
+   * applicationArchiveUrl, or expoGo.
    */
   launchArgs?: InputMaybe<Array<Scalars['String']['input']>>;
   /**
@@ -5283,8 +5289,13 @@ export type CreateDeviceRunSessionInput = {
   packageVersion?: InputMaybe<Scalars['String']['input']>;
   platform: AppPlatform;
   /**
+   * Expo SDK version used to select an Expo Go application archive. Only supported when expoGo is
+   * true. If omitted, the current Expo Go archive for the platform is used.
+   */
+  sdkVersion?: InputMaybe<Scalars['String']['input']>;
+  /**
    * Expo or development-client URL to open after launching the installed application. Requires
-   * buildId or applicationArchiveUrl.
+   * buildId, applicationArchiveUrl, or expoGo.
    */
   tunnelUrl?: InputMaybe<Scalars['String']['input']>;
   type: DeviceRunSessionType;

--- a/packages/eas-cli/src/simulator/__tests__/expoGo.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/expoGo.test.ts
@@ -37,6 +37,37 @@ describe(resolveExpoGoApplicationArchiveUrlAsync, () => {
     }
   );
 
+  it('uses an explicit SDK version without reading the project SDK', async () => {
+    await expect(
+      resolveExpoGoApplicationArchiveUrlAsync({
+        platform: 'ios',
+        projectDir,
+        sdkVersion: '57.0.0',
+      })
+    ).resolves.toBe('https://example.test/expo-go.tar.gz');
+
+    expect(mockDetectProjectSdkVersionAsync).not.toHaveBeenCalled();
+    expect(mockSpawnAsync).toHaveBeenCalledWith('npx', ['--yes', 'expo-go', 'url', 'ios', '57'], {
+      cwd: projectDir,
+      stdio: 'pipe',
+    });
+  });
+
+  it('rejects an invalid explicit SDK version', async () => {
+    await expect(
+      resolveExpoGoApplicationArchiveUrlAsync({
+        platform: 'ios',
+        projectDir,
+        sdkVersion: 'not-a-version',
+      })
+    ).rejects.toThrow(
+      'Unable to parse Expo SDK version "not-a-version". Pass a major or semantic version, such as --sdk-version 57.'
+    );
+
+    expect(mockDetectProjectSdkVersionAsync).not.toHaveBeenCalled();
+    expect(mockSpawnAsync).not.toHaveBeenCalled();
+  });
+
   it.each([
     [
       'plain output',

--- a/packages/eas-cli/src/simulator/__tests__/expoGo.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/expoGo.test.ts
@@ -1,96 +1,40 @@
-import spawnAsync from '@expo/spawn-async';
-
 import { detectProjectSdkVersionAsync } from '../../project/detectProjectSdkVersionAsync';
-import { resolveExpoGoApplicationArchiveUrlAsync } from '../expoGo';
+import { resolveExpoGoSdkVersionAsync } from '../expoGo';
 
-jest.mock('@expo/spawn-async');
 jest.mock('../../project/detectProjectSdkVersionAsync');
 
 const projectDir = '/test/project';
 const mockDetectProjectSdkVersionAsync = jest.mocked(detectProjectSdkVersionAsync);
-const mockSpawnAsync = jest.mocked(spawnAsync);
 
-describe(resolveExpoGoApplicationArchiveUrlAsync, () => {
+describe(resolveExpoGoSdkVersionAsync, () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDetectProjectSdkVersionAsync.mockResolvedValue('55.0.0');
-    mockSpawnAsync.mockResolvedValue({
-      stdout: 'https://example.test/expo-go.tar.gz\n',
-    } as never);
   });
 
-  it.each(['ios', 'android'] as const)(
-    'resolves the Expo Go URL for SDK 55 on %s',
-    async platform => {
-      await expect(resolveExpoGoApplicationArchiveUrlAsync({ platform, projectDir })).resolves.toBe(
-        'https://example.test/expo-go.tar.gz'
-      );
+  it('normalizes the detected project SDK version', async () => {
+    await expect(resolveExpoGoSdkVersionAsync({ projectDir })).resolves.toBe('55.0.0');
+    expect(mockDetectProjectSdkVersionAsync).toHaveBeenCalledWith(projectDir);
+  });
 
-      expect(mockSpawnAsync).toHaveBeenCalledWith(
-        'npx',
-        ['--yes', 'expo-go', 'url', platform, '55'],
-        {
-          cwd: projectDir,
-          stdio: 'pipe',
-        }
-      );
-    }
-  );
-
-  it('uses an explicit SDK version without reading the project SDK', async () => {
-    await expect(
-      resolveExpoGoApplicationArchiveUrlAsync({
-        platform: 'ios',
-        projectDir,
-        sdkVersion: '57.0.0',
-      })
-    ).resolves.toBe('https://example.test/expo-go.tar.gz');
-
+  it.each([
+    ['57', '57.0.0'],
+    ['57.0.0', '57.0.0'],
+    ['57.0.9', '57.0.0'],
+  ])('normalizes an explicit SDK version (%s)', async (sdkVersion, expectedSdkVersion) => {
+    await expect(resolveExpoGoSdkVersionAsync({ projectDir, sdkVersion })).resolves.toBe(
+      expectedSdkVersion
+    );
     expect(mockDetectProjectSdkVersionAsync).not.toHaveBeenCalled();
-    expect(mockSpawnAsync).toHaveBeenCalledWith('npx', ['--yes', 'expo-go', 'url', 'ios', '57'], {
-      cwd: projectDir,
-      stdio: 'pipe',
-    });
   });
 
   it('rejects an invalid explicit SDK version', async () => {
     await expect(
-      resolveExpoGoApplicationArchiveUrlAsync({
-        platform: 'ios',
-        projectDir,
-        sdkVersion: 'not-a-version',
-      })
+      resolveExpoGoSdkVersionAsync({ projectDir, sdkVersion: 'not-a-version' })
     ).rejects.toThrow(
       'Unable to parse Expo SDK version "not-a-version". Pass a major or semantic version, such as --sdk-version 57.'
     );
-
     expect(mockDetectProjectSdkVersionAsync).not.toHaveBeenCalled();
-    expect(mockSpawnAsync).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    [
-      'plain output',
-      'Resolving the correct Expo Go version...\n' +
-        'Download Expo Go from https://example.test/Expo-Go-57.0.9.tar.gz\n',
-    ],
-    [
-      'Markdown hyperlink output',
-      'Resolving the correct Expo Go version...\n' +
-        'Download Expo Go from [https://example.test/Expo-Go-57.0.9.tar.gz](https://example.test/Expo-Go-57.0.9.tar.gz)\n',
-    ],
-    [
-      'terminal hyperlink output',
-      'Resolving the correct Expo Go version...\n' +
-        'Download Expo Go from \u001B]8;;https://example.test/Expo-Go-57.0.9.tar.gz\u0007' +
-        'https://example.test/Expo-Go-57.0.9.tar.gz\u001B]8;;\u0007\n',
-    ],
-  ])('extracts the URL from %s', async (_description, stdout) => {
-    mockSpawnAsync.mockResolvedValue({ stdout } as never);
-
-    await expect(
-      resolveExpoGoApplicationArchiveUrlAsync({ platform: 'ios', projectDir })
-    ).resolves.toBe('https://example.test/Expo-Go-57.0.9.tar.gz');
   });
 
   it.each([undefined, 'UNVERSIONED'])(
@@ -98,36 +42,9 @@ describe(resolveExpoGoApplicationArchiveUrlAsync, () => {
     async sdkVersion => {
       mockDetectProjectSdkVersionAsync.mockResolvedValue(sdkVersion);
 
-      await expect(
-        resolveExpoGoApplicationArchiveUrlAsync({ platform: 'ios', projectDir })
-      ).rejects.toThrow(
+      await expect(resolveExpoGoSdkVersionAsync({ projectDir })).rejects.toThrow(
         "Unable to determine this project's Expo SDK version, so Expo Go could not be selected."
       );
-      expect(mockSpawnAsync).not.toHaveBeenCalled();
     }
   );
-
-  it('reports how to diagnose an expo-go failure', async () => {
-    mockSpawnAsync.mockRejectedValue(new Error('network unavailable') as never);
-
-    await expect(
-      resolveExpoGoApplicationArchiveUrlAsync({ platform: 'android', projectDir })
-    ).rejects.toThrow(
-      'Failed to resolve the Expo Go download URL for SDK 55 on android. network unavailable ' +
-        'Run "npx expo-go url android 55" to diagnose the problem'
-    );
-  });
-
-  it.each([
-    '',
-    'not a URL',
-    'file:///tmp/expo-go.app',
-    'Resolving the correct Expo Go version...\nDownload Expo Go from nowhere\n',
-  ])('rejects an invalid expo-go URL (%s)', async stdout => {
-    mockSpawnAsync.mockResolvedValue({ stdout } as never);
-
-    await expect(
-      resolveExpoGoApplicationArchiveUrlAsync({ platform: 'ios', projectDir })
-    ).rejects.toThrow('expo-go returned an invalid download URL for SDK 55 on ios.');
-  });
 });

--- a/packages/eas-cli/src/simulator/expoGo.ts
+++ b/packages/eas-cli/src/simulator/expoGo.ts
@@ -23,13 +23,20 @@ function extractApplicationArchiveUrl(stdout: string): string | undefined {
 export async function resolveExpoGoApplicationArchiveUrlAsync({
   platform,
   projectDir,
+  sdkVersion: sdkVersionFromFlag,
 }: {
   platform: ExpoGoPlatform;
   projectDir: string;
+  sdkVersion?: string;
 }): Promise<string> {
-  const sdkVersion = await detectProjectSdkVersionAsync(projectDir);
+  const sdkVersion = sdkVersionFromFlag ?? (await detectProjectSdkVersionAsync(projectDir));
   const sdkMajorVersion = semver.coerce(sdkVersion)?.major;
   if (!sdkMajorVersion) {
+    if (sdkVersionFromFlag) {
+      throw new EasCommandError(
+        `Unable to parse Expo SDK version "${sdkVersionFromFlag}". Pass a major or semantic version, such as --sdk-version 57.`
+      );
+    }
     throw new EasCommandError(
       "Unable to determine this project's Expo SDK version, so Expo Go could not be selected. " +
         'Make sure the project has Expo installed and a valid app config, or use --build-id or --application-archive-url instead.'

--- a/packages/eas-cli/src/simulator/expoGo.ts
+++ b/packages/eas-cli/src/simulator/expoGo.ts
@@ -1,31 +1,12 @@
-import { stripVTControlCharacters } from 'util';
-
-import spawnAsync from '@expo/spawn-async';
 import semver from 'semver';
 
 import { EasCommandError } from '../commandUtils/errors';
 import { detectProjectSdkVersionAsync } from '../project/detectProjectSdkVersionAsync';
 
-export type ExpoGoPlatform = 'android' | 'ios';
-
-const EXPO_GO_DOWNLOAD_MESSAGE = 'Download Expo Go from';
-
-function extractApplicationArchiveUrl(stdout: string): string | undefined {
-  const output = stripVTControlCharacters(stdout);
-  const outputLines = output.trim().split(/\r?\n/);
-  const downloadMessageLine = outputLines.find(line => line.includes(EXPO_GO_DOWNLOAD_MESSAGE));
-  const bareUrlOutput = outputLines.length === 1 ? outputLines[0] : undefined;
-  const lineWithUrl = downloadMessageLine ?? bareUrlOutput;
-
-  return lineWithUrl?.match(/https?:\/\/[^\s\])]+/)?.[0];
-}
-
-export async function resolveExpoGoApplicationArchiveUrlAsync({
-  platform,
+export async function resolveExpoGoSdkVersionAsync({
   projectDir,
   sdkVersion: sdkVersionFromFlag,
 }: {
-  platform: ExpoGoPlatform;
   projectDir: string;
   sdkVersion?: string;
 }): Promise<string> {
@@ -43,36 +24,5 @@ export async function resolveExpoGoApplicationArchiveUrlAsync({
     );
   }
 
-  const args = ['--yes', 'expo-go', 'url', platform, String(sdkMajorVersion)];
-  let stdout: string;
-  try {
-    ({ stdout } = await spawnAsync('npx', args, {
-      cwd: projectDir,
-      stdio: 'pipe',
-    }));
-  } catch (error) {
-    const reason = error instanceof Error ? ` ${error.message}` : '';
-    throw new EasCommandError(
-      `Failed to resolve the Expo Go download URL for SDK ${sdkMajorVersion} on ${platform}.${reason} ` +
-        `Run "npx expo-go url ${platform} ${sdkMajorVersion}" to diagnose the problem, or use --build-id or --application-archive-url instead.`
-    );
-  }
-
-  const applicationArchiveUrl = extractApplicationArchiveUrl(stdout);
-  try {
-    if (!applicationArchiveUrl) {
-      throw new Error('Missing URL');
-    }
-    const parsedUrl = new URL(applicationArchiveUrl);
-    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
-      throw new Error('Unsupported protocol');
-    }
-  } catch {
-    throw new EasCommandError(
-      `expo-go returned an invalid download URL for SDK ${sdkMajorVersion} on ${platform}. ` +
-        `Run "npx expo-go url ${platform} ${sdkMajorVersion}" to diagnose the problem, or use --build-id or --application-archive-url instead.`
-    );
-  }
-
-  return applicationArchiveUrl;
+  return `${sdkMajorVersion}.0.0`;
 }


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Follow up to https://github.com/expo/eas-cli/pull/4263. Add launch args and open url params to eas simulator command.

# How

Follow up to https://github.com/expo/eas-cli/pull/4263. Add launch args and open url params to eas simulator command.

Make sure launch args or open url can be only provided when we preinstall app on a sim.

Pass args to mutation.

Move resolving expo go download url to www so it works also for runs triggered from website.

# Test Plan

Tests.
