### PR TITLE
[build-tools] Bypass simulator URL confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Preapprove custom URL schemes before opening them in iOS Simulator sessions to avoid the first-use confirmation prompt. ([#4274](https://github.com/expo/eas-cli/pull/4274) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Support downloading iOS simulator archives whose app bundle contents are stored at the archive root. ([#4262](https://github.com/expo/eas-cli/pull/4262) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🧹 Chores

--- a/packages/build-tools/src/steps/functions/__tests__/launchApplication.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/launchApplication.test.ts
@@ -103,6 +103,33 @@ describe(launchApplicationAsync, () => {
     expect(mockedSpawn).toHaveBeenCalledTimes(2);
   });
 
+  it('opens a custom URL on iOS when scheme preapproval fails', async () => {
+    const logger = createMockLogger();
+    const approvalError = new Error('Scheme approval is unavailable.');
+    mockedSpawn
+      .mockResolvedValueOnce({ stdout: '', stderr: '' } as any)
+      .mockRejectedValueOnce(approvalError);
+
+    await launchApplicationAsync({
+      applicationIdentifier: 'host.exp.Exponent',
+      openUrl: 'exp://example.test',
+      runtimePlatform: BuildRuntimePlatform.DARWIN,
+      env: {},
+      logger,
+    });
+
+    expect(mockedSpawn).toHaveBeenNthCalledWith(
+      3,
+      'xcrun',
+      ['simctl', 'openurl', 'booted', 'exp://example.test'],
+      { env: {}, logger }
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: approvalError },
+      'Could not preapprove the exp URL scheme for host.exp.Exponent. Opening the URL anyway; the Simulator might require manual confirmation.'
+    );
+  });
+
   it('launches an Android Emulator application by package and activity', async () => {
     const logger = createMockLogger();
 

--- a/packages/build-tools/src/steps/functions/__tests__/launchApplication.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/launchApplication.test.ts
@@ -56,9 +56,51 @@ describe(launchApplicationAsync, () => {
     expect(mockedSpawn).toHaveBeenNthCalledWith(
       2,
       'xcrun',
+      [
+        'simctl',
+        'spawn',
+        'booted',
+        'defaults',
+        'write',
+        'com.apple.launchservices.schemeapproval',
+        'com.apple.CoreSimulator.CoreSimulatorBridge-->exp',
+        '-string',
+        'host.exp.Exponent',
+      ],
+      { env: {}, logger }
+    );
+    expect(mockedSpawn).toHaveBeenNthCalledWith(
+      3,
+      'xcrun',
       ['simctl', 'openurl', 'booted', 'exp://example.test'],
       { env: {}, logger }
     );
+  });
+
+  it('opens a web URL on iOS without preapproving its scheme', async () => {
+    const logger = createMockLogger();
+
+    await launchApplicationAsync({
+      applicationIdentifier: 'com.example.app',
+      openUrl: 'https://example.test',
+      runtimePlatform: BuildRuntimePlatform.DARWIN,
+      env: {},
+      logger,
+    });
+
+    expect(mockedSpawn).toHaveBeenNthCalledWith(
+      1,
+      'xcrun',
+      ['simctl', 'launch', 'booted', 'com.example.app'],
+      { env: {}, logger }
+    );
+    expect(mockedSpawn).toHaveBeenNthCalledWith(
+      2,
+      'xcrun',
+      ['simctl', 'openurl', 'booted', 'https://example.test'],
+      { env: {}, logger }
+    );
+    expect(mockedSpawn).toHaveBeenCalledTimes(2);
   });
 
   it('launches an Android Emulator application by package and activity', async () => {

--- a/packages/build-tools/src/steps/functions/launchApplication.ts
+++ b/packages/build-tools/src/steps/functions/launchApplication.ts
@@ -145,26 +145,33 @@ async function preapproveIosUrlSchemeAsync({
   env: BuildStepEnv;
   logger: bunyan;
 }): Promise<void> {
-  const urlScheme = new URL(openUrl).protocol;
-  if (urlScheme === 'http:' || urlScheme === 'https:') {
+  const urlScheme = new URL(openUrl).protocol.slice(0, -1);
+  if (urlScheme === 'http' || urlScheme === 'https') {
     return;
   }
 
-  await spawn(
-    'xcrun',
-    [
-      'simctl',
-      'spawn',
-      'booted',
-      'defaults',
-      'write',
-      IOS_URL_SCHEME_APPROVAL_DOMAIN,
-      `${IOS_URL_SCHEME_APPROVAL_KEY_PREFIX}${urlScheme.slice(0, -1)}`,
-      '-string',
-      applicationIdentifier,
-    ],
-    { env, logger }
-  );
+  try {
+    await spawn(
+      'xcrun',
+      [
+        'simctl',
+        'spawn',
+        'booted',
+        'defaults',
+        'write',
+        IOS_URL_SCHEME_APPROVAL_DOMAIN,
+        `${IOS_URL_SCHEME_APPROVAL_KEY_PREFIX}${urlScheme}`,
+        '-string',
+        applicationIdentifier,
+      ],
+      { env, logger }
+    );
+  } catch (error) {
+    logger.warn(
+      { err: error },
+      `Could not preapprove the ${urlScheme} URL scheme for ${applicationIdentifier}. Opening the URL anyway; the Simulator might require manual confirmation.`
+    );
+  }
 }
 
 function logApplicationLaunch(

--- a/packages/build-tools/src/steps/functions/launchApplication.ts
+++ b/packages/build-tools/src/steps/functions/launchApplication.ts
@@ -9,6 +9,9 @@ import {
 } from '@expo/steps';
 import spawn from '@expo/turtle-spawn';
 
+const IOS_URL_SCHEME_APPROVAL_DOMAIN = 'com.apple.launchservices.schemeapproval';
+const IOS_URL_SCHEME_APPROVAL_KEY_PREFIX = 'com.apple.CoreSimulator.CoreSimulatorBridge-->';
+
 export function createLaunchApplicationFunction(): BuildFunction {
   return new BuildFunction({
     namespace: 'eas',
@@ -86,6 +89,7 @@ export async function launchApplicationAsync({
       logger,
     });
     if (openUrl) {
+      await preapproveIosUrlSchemeAsync({ applicationIdentifier, openUrl, env, logger });
       logger.info(`Opening ${openUrl} in ${applicationIdentifier}.`);
       await spawn('xcrun', ['simctl', 'openurl', 'booted', openUrl], { env, logger });
     }
@@ -128,6 +132,39 @@ export async function launchApplicationAsync({
       { env, logger }
     );
   }
+}
+
+async function preapproveIosUrlSchemeAsync({
+  applicationIdentifier,
+  openUrl,
+  env,
+  logger,
+}: {
+  applicationIdentifier: string;
+  openUrl: string;
+  env: BuildStepEnv;
+  logger: bunyan;
+}): Promise<void> {
+  const urlScheme = new URL(openUrl).protocol;
+  if (urlScheme === 'http:' || urlScheme === 'https:') {
+    return;
+  }
+
+  await spawn(
+    'xcrun',
+    [
+      'simctl',
+      'spawn',
+      'booted',
+      'defaults',
+      'write',
+      IOS_URL_SCHEME_APPROVAL_DOMAIN,
+      `${IOS_URL_SCHEME_APPROVAL_KEY_PREFIX}${urlScheme.slice(0, -1)}`,
+      '-string',
+      applicationIdentifier,
+    ],
+    { env, logger }
+  );
 }
 
 function logApplicationLaunch(


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Opening a custom URL scheme with `eas/launch_application` on a fresh iOS Simulator shows the system “Open in <application>?” confirmation. `simctl openurl` delivers the URL, but the simulator session remains blocked on that prompt instead of opening the URL automatically.

This is a follow-up to #4263 and #4264.

# How

Before calling `simctl openurl` for a custom scheme, write the corresponding application approval to the booted Simulator's `com.apple.launchservices.schemeapproval` preferences. The approval maps the scheme opened by CoreSimulatorBridge to the installed application's bundle identifier.

HTTP and HTTPS URLs keep their existing behavior. Android launch behavior is unchanged.

# Test Plan

Tests
