### PR TITLE
[eas-cli] add environment filter to observe commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Support an optional `package_version` input on `eas/start_serve_sim_remote_session`, so a simulator session can pin the `@expo/serve-sim` version instead of always running `latest`. ([#4253](https://github.com/expo/eas-cli/pull/4253) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Add composable custom build functions for downloading, installing, and launching application archives in simulator sessions. ([#4222](https://github.com/expo/eas-cli/pull/4222) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Add `--build-id`, `--application-archive-url`, and `--expo-go` to `eas simulator` to install and launch an application before the session is ready. ([#4223](https://github.com/expo/eas-cli/pull/4223) by [@szdziedzic](https://github.com/szdziedzic))
-- [eas-cli] Add `--environment` flag to the observe commands
+- [eas-cli] Add `--environment` flag to the `eas observe:*` commands. ([#4275](https://github.com/expo/eas-cli/pull/4275) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Support an optional `package_version` input on `eas/start_serve_sim_remote_session`, so a simulator session can pin the `@expo/serve-sim` version instead of always running `latest`. ([#4253](https://github.com/expo/eas-cli/pull/4253) by [@gwdp](https://github.com/gwdp))
 - [build-tools] Add composable custom build functions for downloading, installing, and launching application archives in simulator sessions. ([#4222](https://github.com/expo/eas-cli/pull/4222) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Add `--build-id`, `--application-archive-url`, and `--expo-go` to `eas simulator` to install and launch an application before the session is ready. ([#4223](https://github.com/expo/eas-cli/pull/4223) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Add `--environment` flag to the observe commands
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/observe/__tests__/events.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/events.test.ts
@@ -115,6 +115,25 @@ describe(ObserveEvents, () => {
     expect(mockCustomEventNamesAsync).not.toHaveBeenCalled();
   });
 
+  it('passes --environment to the custom events filter', async () => {
+    mockFetchObserveCustomEventsAsync.mockResolvedValue({
+      events: [{ id: 'evt-1' } as any],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    });
+    const command = createCommand(['my_event', '--environment', 'production']);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.environment).toBe('production');
+  });
+
+  it('passes --environment to customEventNamesAsync when listing event names', async () => {
+    const command = createCommand(['--environment', 'production']);
+    await command.runAsync();
+
+    expect(mockCustomEventNamesAsync.mock.calls[0][1].environment).toBe('production');
+  });
+
   it('routes to customEventNamesAsync when no positional arg is provided', async () => {
     const command = createCommand([]);
     await command.runAsync();

--- a/packages/eas-cli/src/commands/observe/__tests__/metrics-summary.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metrics-summary.test.ts
@@ -104,6 +104,13 @@ describe(ObserveMetricsSummary, () => {
     expect(platforms).toEqual([AppPlatform.Ios]);
   });
 
+  it('passes --environment through to fetchObserveMetricsAsync', async () => {
+    const command = createCommand(['--environment', 'production']);
+    await command.runAsync();
+
+    expect(mockFetchObserveMetricsSummaryAsync.mock.calls[0][6]).toBe('production');
+  });
+
   it('resolves --metric aliases before passing to fetchObserveMetricsAsync', async () => {
     const command = createCommand(['--metric', 'tti', '--metric', 'cold_launch']);
     await command.runAsync();

--- a/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
@@ -135,6 +135,14 @@ describe(ObserveMetrics, () => {
     expect(options.endTime).toBe('2025-02-01T00:00:00.000Z');
   });
 
+  it('passes --environment to the events filter', async () => {
+    const command = createCommand(['tti', '--environment', 'production']);
+    await command.runAsync();
+
+    const options = mockFetchObserveEventsAsync.mock.calls[0][2];
+    expect(options.environment).toBe('production');
+  });
+
   it('defaults endTime to now when only --start is provided', async () => {
     const now = new Date('2025-06-15T12:00:00.000Z');
     jest.useFakeTimers({ now });

--- a/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/routes.test.ts
@@ -174,6 +174,14 @@ describe(ObserveRoutes, () => {
     expect(options.buildNumber).toBe('42');
   });
 
+  it('passes --environment through to the fetcher', async () => {
+    const command = createCommand(['--environment', 'production']);
+    await command.runAsync();
+
+    const options = mockFetchObserveNavigationRoutesAsync.mock.calls[0][2];
+    expect(options.environment).toBe('production');
+  });
+
   it('passes --route-name flags through as routeNames array', async () => {
     const command = createCommand(['--route-name', '/home', '--route-name', '/profile']);
     await command.runAsync();

--- a/packages/eas-cli/src/commands/observe/__tests__/session.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/session.test.ts
@@ -239,6 +239,11 @@ describe(ObserveSession, () => {
     await expect(command.runAsync()).rejects.toThrow(/picker flags/);
   });
 
+  it('rejects --environment when a session ID is also provided', async () => {
+    const command = createCommand(['session-abc', '--environment', 'production']);
+    await expect(command.runAsync()).rejects.toThrow(/picker flags/);
+  });
+
   it('picker mode with --event-name tti fetches metric events and threads selected sessionId', async () => {
     mockFetchSessionMetricCandidatesAsync.mockResolvedValue([
       makeMetricEvent({ sessionId: 'picked-session-1' }),

--- a/packages/eas-cli/src/commands/observe/__tests__/versions.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/versions.test.ts
@@ -73,6 +73,13 @@ describe(ObserveVersions, () => {
     expect(platforms).toEqual([AppPlatform.Ios]);
   });
 
+  it('passes --environment through to fetchObserveVersionsAsync', async () => {
+    const command = createCommand(['--environment', 'production']);
+    await command.runAsync();
+
+    expect(mockFetchObserveVersionsAsync.mock.calls[0][5]).toBe('production');
+  });
+
   it('uses default time range (60 days back) when no --start/--end flags', async () => {
     const now = new Date('2025-06-15T12:00:00.000Z');
     jest.useFakeTimers({ now });

--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -12,6 +12,7 @@ import { fetchObserveCustomEventsAsync } from '../../observe/fetchCustomEvents';
 import {
   ObserveAfterFlag,
   ObserveAppVersionFlag,
+  ObserveEnvironmentFlag,
   ObservePlatformFlag,
   ObserveProjectIdFlag,
   ObserveTimeRangeFlags,
@@ -54,6 +55,7 @@ export default class ObserveEvents extends EasCommand {
     ...ObserveTimeRangeFlags,
     ...ObserveAppVersionFlag,
     ...ObserveUpdateIdFlag,
+    ...ObserveEnvironmentFlag,
     'session-id': Flags.string({
       description:
         'Filter by session ID. When no event name is given, lists the events in the session instead of the event-name summary.',
@@ -112,6 +114,7 @@ export default class ObserveEvents extends EasCommand {
           startTime,
           endTime,
           platform,
+          environment: flags.environment,
         })
       );
 
@@ -142,6 +145,7 @@ export default class ObserveEvents extends EasCommand {
         appVersion: flags['app-version'],
         updateId: flags['update-id'],
         sessionId: flags['session-id'],
+        environment: flags.environment,
       })
     );
 
@@ -151,6 +155,7 @@ export default class ObserveEvents extends EasCommand {
         startTime,
         endTime,
         platform,
+        environment: flags.environment,
       });
 
       if (json) {

--- a/packages/eas-cli/src/commands/observe/metrics-summary.ts
+++ b/packages/eas-cli/src/commands/observe/metrics-summary.ts
@@ -8,6 +8,7 @@ import {
 import Log from '../../log';
 import { fetchObserveMetricsAsync } from '../../observe/fetchMetrics';
 import {
+  ObserveEnvironmentFlag,
   ObservePlatformFlag,
   ObserveProjectIdFlag,
   ObserveTimeRangeFlags,
@@ -62,6 +63,7 @@ export default class ObserveMetricsSummary extends EasCommand {
       options: DEFAULT_STATS_JSON,
     })(),
     ...ObserveTimeRangeFlags,
+    ...ObserveEnvironmentFlag,
     ...ObserveProjectIdFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -107,7 +109,8 @@ export default class ObserveMetricsSummary extends EasCommand {
           metricNames,
           platforms,
           startTime,
-          endTime
+          endTime,
+          flags.environment
         )
       );
 

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -17,6 +17,7 @@ import {
 import {
   ObserveAfterFlag,
   ObserveAppVersionFlag,
+  ObserveEnvironmentFlag,
   ObservePlatformFlag,
   ObserveProjectIdFlag,
   ObserveTimeRangeFlags,
@@ -60,6 +61,7 @@ export default class ObserveMetrics extends EasCommand {
     ...ObserveTimeRangeFlags,
     ...ObserveAppVersionFlag,
     ...ObserveUpdateIdFlag,
+    ...ObserveEnvironmentFlag,
     ...ObserveProjectIdFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -123,6 +125,7 @@ export default class ObserveMetrics extends EasCommand {
           platform,
           appVersion: flags['app-version'],
           updateId: flags['update-id'],
+          environment: flags.environment,
         }),
         fetchTotalEventCountAsync(
           graphqlClient,
@@ -130,7 +133,8 @@ export default class ObserveMetrics extends EasCommand {
           metricName,
           platforms,
           startTime,
-          endTime
+          endTime,
+          flags.environment
         ),
       ])
     );

--- a/packages/eas-cli/src/commands/observe/routes.ts
+++ b/packages/eas-cli/src/commands/observe/routes.ts
@@ -11,6 +11,7 @@ import { fetchObserveNavigationRoutesAsync } from '../../observe/fetchNavigation
 import {
   ObserveAfterFlag,
   ObserveAppVersionFlag,
+  ObserveEnvironmentFlag,
   ObservePlatformFlag,
   ObserveProjectIdFlag,
   ObserveTimeRangeFlags,
@@ -70,6 +71,7 @@ export default class ObserveRoutes extends EasCommand {
         'Filter by route name (can be specified multiple times to include several routes)',
       multiple: true,
     }),
+    ...ObserveEnvironmentFlag,
     ...ObserveProjectIdFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -125,6 +127,7 @@ export default class ObserveRoutes extends EasCommand {
         updateId: flags['update-id'],
         buildNumber: flags['build-number'],
         routeNames,
+        environment: flags.environment,
       })
     );
 

--- a/packages/eas-cli/src/commands/observe/session.ts
+++ b/packages/eas-cli/src/commands/observe/session.ts
@@ -16,7 +16,11 @@ import {
   fetchSessionMetricCandidatesAsync,
   verifyObserveSessionAccessAsync,
 } from '../../observe/fetchSessions';
-import { ObserveProjectIdFlag, ObserveTimeRangeFlags } from '../../observe/flags';
+import {
+  ObserveEnvironmentFlag,
+  ObserveProjectIdFlag,
+  ObserveTimeRangeFlags,
+} from '../../observe/flags';
 import { withObservePlanGateHandlingAsync } from '../../observe/planGating';
 import {
   buildObserveSessionEventsJson,
@@ -66,6 +70,7 @@ export default class ObserveSession extends EasCommand {
         'Metric or log event name to pick candidate sessions by (e.g. tti, cold_launch, login_pressed). If omitted in interactive mode, you will be prompted.',
     }),
     ...ObserveTimeRangeFlags,
+    ...ObserveEnvironmentFlag,
     ...ObserveProjectIdFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -102,10 +107,11 @@ export default class ObserveSession extends EasCommand {
         flags.sort !== undefined ||
         flags.days !== undefined ||
         flags.start !== undefined ||
-        flags.end !== undefined;
+        flags.end !== undefined ||
+        flags.environment !== undefined;
       if (pickerFlagsProvided) {
         throw new EasCommandError(
-          'The picker flags (--event-name, --sort, --days, --start, --end) describe how to find a session and cannot be combined with a session ID argument.'
+          'The picker flags (--event-name, --sort, --days, --start, --end, --environment) describe how to find a session and cannot be combined with a session ID argument.'
         );
       }
       sessionId = args.sessionId;
@@ -127,6 +133,7 @@ export default class ObserveSession extends EasCommand {
         eventNameFlag: flags['event-name'],
         sort: flags.sort,
         timeRangeFlags: { days: flags.days, start: flags.start, end: flags.end },
+        environment: flags.environment,
       });
     }
 
@@ -172,18 +179,20 @@ async function pickSessionIdInteractivelyAsync({
   eventNameFlag,
   sort,
   timeRangeFlags,
+  environment,
 }: {
   graphqlClient: ExpoGraphqlClient;
   projectId: string;
   eventNameFlag: string | undefined;
   sort: string | undefined;
   timeRangeFlags: { days: number | undefined; start: string | undefined; end: string | undefined };
+  environment: string | undefined;
 }): Promise<string> {
   const { startTime, endTime } = resolveTimeRange(timeRangeFlags);
 
   const eventNameChoice: EventNameChoice = eventNameFlag
     ? { name: eventNameFlag, isMetric: isKnownMetricName(eventNameFlag) }
-    : await promptForEventNameAsync({ graphqlClient, projectId, startTime, endTime });
+    : await promptForEventNameAsync({ graphqlClient, projectId, startTime, endTime, environment });
 
   let sortValue: string;
   if (sort) {
@@ -208,6 +217,7 @@ async function pickSessionIdInteractivelyAsync({
           startTime,
           endTime,
           limit: PICKER_CANDIDATE_LIMIT,
+          environment,
         })
       ).map(event => ({ sessionId: event.sessionId, title: formatMetricCandidateTitle(event) }))
     : (
@@ -217,6 +227,7 @@ async function pickSessionIdInteractivelyAsync({
           startTime,
           endTime,
           limit: PICKER_CANDIDATE_LIMIT,
+          environment,
         })
       ).map(event => ({ sessionId: event.sessionId, title: formatLogCandidateTitle(event) }));
 
@@ -254,16 +265,19 @@ async function promptForEventNameAsync({
   projectId,
   startTime,
   endTime,
+  environment,
 }: {
   graphqlClient: ExpoGraphqlClient;
   projectId: string;
   startTime: string;
   endTime: string;
+  environment: string | undefined;
 }): Promise<EventNameChoice> {
   const { names: customEventNames } = await ObserveQuery.customEventNamesAsync(graphqlClient, {
     appId: projectId,
     startTime,
     endTime,
+    environment,
   });
 
   const metricChoices: ExpoChoice<EventNameChoice>[] = Object.entries(METRIC_SHORT_NAMES).map(

--- a/packages/eas-cli/src/commands/observe/versions.ts
+++ b/packages/eas-cli/src/commands/observe/versions.ts
@@ -6,6 +6,7 @@ import {
 import Log from '../../log';
 import { fetchObserveVersionsAsync } from '../../observe/fetchVersions';
 import {
+  ObserveEnvironmentFlag,
   ObservePlatformFlag,
   ObserveProjectIdFlag,
   ObserveTimeRangeFlags,
@@ -22,6 +23,7 @@ export default class ObserveVersions extends EasCommand {
   static override flags = {
     ...ObservePlatformFlag,
     ...ObserveTimeRangeFlags,
+    ...ObserveEnvironmentFlag,
     ...ObserveProjectIdFlag,
     ...EasNonInteractiveAndJsonFlags,
   };
@@ -60,7 +62,8 @@ export default class ObserveVersions extends EasCommand {
       projectId,
       platforms,
       startTime,
-      endTime
+      endTime,
+      flags.environment
     );
 
     if (json) {

--- a/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
@@ -221,12 +221,14 @@ export const ObserveQuery = {
       startTime,
       endTime,
       metricNames,
+      environment,
     }: {
       appId: string;
       platform: AppObservePlatform;
       startTime: string;
       endTime: string;
       metricNames?: string[];
+      environment?: string;
     }
   ): Promise<AppObserveAppVersion[]> {
     const data = await withErrorHandlingAsync(
@@ -252,7 +254,13 @@ export const ObserveQuery = {
           `,
           {
             appId,
-            input: { platform, startTime, endTime, ...(metricNames && { metricNames }) },
+            input: {
+              platform,
+              startTime,
+              endTime,
+              ...(metricNames && { metricNames }),
+              ...(environment && { environment }),
+            },
           }
         )
         .toPromise()

--- a/packages/eas-cli/src/observe/fetchCustomEvents.ts
+++ b/packages/eas-cli/src/observe/fetchCustomEvents.ts
@@ -18,6 +18,7 @@ interface FetchCustomEventsOptions {
   appVersion?: string;
   updateId?: string;
   sessionId?: string;
+  environment?: string;
   orderBy?: AppObserveCustomEventListOrderBy;
 }
 
@@ -39,6 +40,7 @@ export async function fetchObserveCustomEventsAsync(
     ...(options.appVersion && { appVersion: options.appVersion }),
     ...(options.updateId && { appUpdateId: options.updateId }),
     ...(options.sessionId && { sessionId: options.sessionId }),
+    ...(options.environment && { environment: options.environment }),
   };
 
   return await ObserveQuery.customEventListAsync(graphqlClient, {

--- a/packages/eas-cli/src/observe/fetchEvents.ts
+++ b/packages/eas-cli/src/observe/fetchEvents.ts
@@ -56,6 +56,7 @@ interface FetchObserveEventsOptions {
   appVersion?: string;
   updateId?: string;
   sessionId?: string;
+  environment?: string;
 }
 
 interface FetchObserveEventsResult {
@@ -76,6 +77,7 @@ export async function fetchObserveEventsAsync(
     ...(options.appVersion && { appVersion: options.appVersion }),
     ...(options.updateId && { appUpdateId: options.updateId }),
     ...(options.sessionId && { sessionId: options.sessionId }),
+    ...(options.environment && { environment: options.environment }),
   };
 
   return await ObserveQuery.eventsAsync(graphqlClient, {
@@ -98,7 +100,8 @@ export async function fetchTotalEventCountAsync(
   metricName: string,
   platforms: AppPlatform[],
   startTime: string,
-  endTime: string
+  endTime: string,
+  environment?: string
 ): Promise<number> {
   const queries = platforms.map(async appPlatform => {
     try {
@@ -108,6 +111,7 @@ export async function fetchTotalEventCountAsync(
         startTime,
         endTime,
         metricNames: [metricName],
+        environment,
       });
       return versions.reduce((sum, v) => {
         const metric = v.metrics.find(m => m.metricName === metricName);

--- a/packages/eas-cli/src/observe/fetchMetrics.ts
+++ b/packages/eas-cli/src/observe/fetchMetrics.ts
@@ -35,7 +35,8 @@ export async function fetchObserveMetricsAsync(
   metricNames: string[],
   platforms: AppPlatform[],
   startTime: string,
-  endTime: string
+  endTime: string,
+  environment?: string
 ): Promise<FetchObserveMetricsResult> {
   const queries = platforms.map(async appPlatform => {
     const observePlatform = appPlatformToObservePlatform[appPlatform];
@@ -46,6 +47,7 @@ export async function fetchObserveMetricsAsync(
         startTime,
         endTime,
         metricNames,
+        environment,
       });
       return { appPlatform, appVersions };
     } catch (error: any) {

--- a/packages/eas-cli/src/observe/fetchNavigationRoutes.ts
+++ b/packages/eas-cli/src/observe/fetchNavigationRoutes.ts
@@ -27,6 +27,7 @@ export interface FetchNavigationRoutesOptions {
   updateId?: string;
   buildNumber?: string;
   routeNames?: string[];
+  environment?: string;
   orderBy?: AppObserveNavigationRoutesOrderBy;
 }
 
@@ -58,6 +59,7 @@ export async function fetchObserveNavigationRoutesAsync(
           ...(options.updateId && { appUpdateId: options.updateId }),
           ...(options.buildNumber && { appBuildNumber: options.buildNumber }),
           ...(options.routeNames?.length && { routeNames: options.routeNames }),
+          ...(options.environment && { environment: options.environment }),
         },
         first: options.limit,
         ...(options.after && { after: options.after }),

--- a/packages/eas-cli/src/observe/fetchSessions.ts
+++ b/packages/eas-cli/src/observe/fetchSessions.ts
@@ -181,6 +181,7 @@ export interface FetchSessionMetricCandidatesOptions {
   startTime: string;
   endTime: string;
   limit: number;
+  environment?: string;
 }
 
 /**
@@ -199,6 +200,7 @@ export async function fetchSessionMetricCandidatesAsync(
     limit: options.limit,
     startTime: options.startTime,
     endTime: options.endTime,
+    environment: options.environment,
   });
   return events.filter((e): e is SessionMetricCandidate => !!e.sessionId);
 }
@@ -216,6 +218,7 @@ export interface FetchSessionLogCandidatesOptions {
   startTime: string;
   endTime: string;
   limit: number;
+  environment?: string;
 }
 
 /**
@@ -232,6 +235,7 @@ export async function fetchSessionLogCandidatesAsync(
     limit: options.limit,
     startTime: options.startTime,
     endTime: options.endTime,
+    environment: options.environment,
     orderBy: {
       field: AppObserveCustomEventListOrderByField.Timestamp,
       direction: options.orderAscending

--- a/packages/eas-cli/src/observe/fetchVersions.ts
+++ b/packages/eas-cli/src/observe/fetchVersions.ts
@@ -18,7 +18,8 @@ export async function fetchObserveVersionsAsync(
   appId: string,
   platforms: AppPlatform[],
   startTime: string,
-  endTime: string
+  endTime: string,
+  environment?: string
 ): Promise<AppVersionsResult[]> {
   const queries = platforms.map(async (appPlatform): Promise<AppVersionsResult | null> => {
     const observePlatform = appPlatformToObservePlatform[appPlatform];
@@ -28,6 +29,7 @@ export async function fetchObserveVersionsAsync(
         platform: observePlatform,
         startTime,
         endTime,
+        environment,
       });
       return { platform: appPlatform, appVersions };
     } catch (error: any) {

--- a/packages/eas-cli/src/observe/flags.ts
+++ b/packages/eas-cli/src/observe/flags.ts
@@ -15,6 +15,12 @@ export const ObservePlatformFlag = {
   })(),
 };
 
+export const ObserveEnvironmentFlag = {
+  environment: Flags.string({
+    description: 'Filter by environment (e.g. production, development)',
+  }),
+};
+
 export const ObserveTimeRangeFlags = {
   start: Flags.string({
     description: 'Start of time range (ISO date)',


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Part of ENG-26159

We want to match the filters on the dashboard to we could correctly pre-fill them in the prompts.

# How

Add the `--environment` filter to `metrics-summary`, `routes`, `events`, `versions` and `session`

# Test Plan

Tested locally against staging (I used `--environment playground` in my personal app just fyi, but I'll past the examples with the more popular `--environment production`):

## Metrics summary

```sh
eas observe:metrics-summary --environment production
eas observe:metrics-summary --metric tti --stat median --days 7 --environment production
```

## Metrics

```sh
eas observe:metrics tti --environment production
eas observe:metrics cold_launch --environment development --sort slowest --limit 20
eas observe:metrics tti --environment production --app-version 2.1.0 --platform ios
```

## Routes

```sh
eas observe:routes --environment production
eas observe:routes --metric cold_ttr --route-name /home --environment preview
```

## Events

```sh
eas observe:events --environment production            # summary of event names + counts
eas observe:events login_pressed --environment production
eas observe:events --all-events --environment development --days 3
```

## Versions

```sh
eas observe:versions --environment production
eas observe:versions --platform android --days 30 --environment production
```


## Session

```sh
eas observe:session --event-name tti --sort slowest --environment production
```
