### PR TITLE
[eas-cli] add --build-number to observe:metrics and observe:events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] Add `--build-id`, `--application-archive-url`, and `--expo-go` to `eas simulator` to install and launch an application before the session is ready. ([#4223](https://github.com/expo/eas-cli/pull/4223) by [@szdziedzic](https://github.com/szdziedzic))
 - [eas-cli] Add `--environment` flag to the `eas observe:*` commands. ([#4275](https://github.com/expo/eas-cli/pull/4275) by [@kadikraman](https://github.com/kadikraman))
 - [eas-cli] Add `apple` value to the `--platform` flag of the `eas observe:*` commands. ([#4276](https://github.com/expo/eas-cli/pull/4276) by [@kadikraman](https://github.com/kadikraman))
+- [eas-cli] Add `--build-number` flag to `eas observe:metrics` and `eas observe:events`. ([#4278](https://github.com/expo/eas-cli/pull/4278) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/observe/__tests__/events.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/events.test.ts
@@ -275,6 +275,14 @@ describe(ObserveEvents, () => {
     expect(options.appVersion).toBe('2.1.0');
   });
 
+  it('passes --build-number', async () => {
+    const command = createCommand(['my_event', '--build-number', '42']);
+    await command.runAsync();
+
+    const options = mockFetchObserveCustomEventsAsync.mock.calls[0][2];
+    expect(options.buildNumber).toBe('42');
+  });
+
   it('passes --update-id', async () => {
     const command = createCommand(['my_event', '--update-id', 'update-xyz']);
     await command.runAsync();

--- a/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
@@ -217,6 +217,14 @@ describe(ObserveMetrics, () => {
     expect(options.appVersion).toBe('2.1.0');
   });
 
+  it('passes --build-number to fetchObserveEventsAsync', async () => {
+    const command = createCommand(['tti', '--build-number', '42']);
+    await command.runAsync();
+
+    const options = mockFetchObserveEventsAsync.mock.calls[0][2];
+    expect(options.buildNumber).toBe('42');
+  });
+
   it('passes --update-id to fetchObserveEventsAsync', async () => {
     const command = createCommand(['tti', '--update-id', 'update-xyz']);
     await command.runAsync();

--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -12,6 +12,7 @@ import { fetchObserveCustomEventsAsync } from '../../observe/fetchCustomEvents';
 import {
   ObserveAfterFlag,
   ObserveAppVersionFlag,
+  ObserveBuildNumberFlag,
   ObserveEnvironmentFlag,
   ObservePlatformFlag,
   ObserveProjectIdFlag,
@@ -54,6 +55,7 @@ export default class ObserveEvents extends EasCommand {
     }),
     ...ObserveTimeRangeFlags,
     ...ObserveAppVersionFlag,
+    ...ObserveBuildNumberFlag,
     ...ObserveUpdateIdFlag,
     ...ObserveEnvironmentFlag,
     'session-id': Flags.string({
@@ -143,6 +145,7 @@ export default class ObserveEvents extends EasCommand {
         endTime,
         platforms,
         appVersion: flags['app-version'],
+        buildNumber: flags['build-number'],
         updateId: flags['update-id'],
         sessionId: flags['session-id'],
         environment: flags.environment,

--- a/packages/eas-cli/src/commands/observe/metrics.ts
+++ b/packages/eas-cli/src/commands/observe/metrics.ts
@@ -17,6 +17,7 @@ import {
 import {
   ObserveAfterFlag,
   ObserveAppVersionFlag,
+  ObserveBuildNumberFlag,
   ObserveEnvironmentFlag,
   ObservePlatformFlag,
   ObserveProjectIdFlag,
@@ -60,6 +61,7 @@ export default class ObserveMetrics extends EasCommand {
     }),
     ...ObserveTimeRangeFlags,
     ...ObserveAppVersionFlag,
+    ...ObserveBuildNumberFlag,
     ...ObserveUpdateIdFlag,
     ...ObserveEnvironmentFlag,
     ...ObserveProjectIdFlag,
@@ -124,6 +126,7 @@ export default class ObserveMetrics extends EasCommand {
           endTime,
           platforms,
           appVersion: flags['app-version'],
+          buildNumber: flags['build-number'],
           updateId: flags['update-id'],
           environment: flags.environment,
         }),

--- a/packages/eas-cli/src/commands/observe/routes.ts
+++ b/packages/eas-cli/src/commands/observe/routes.ts
@@ -11,6 +11,7 @@ import { fetchObserveNavigationRoutesAsync } from '../../observe/fetchNavigation
 import {
   ObserveAfterFlag,
   ObserveAppVersionFlag,
+  ObserveBuildNumberFlag,
   ObserveEnvironmentFlag,
   ObservePlatformFlag,
   ObserveProjectIdFlag,
@@ -62,10 +63,8 @@ export default class ObserveRoutes extends EasCommand {
     }),
     ...ObserveTimeRangeFlags,
     ...ObserveAppVersionFlag,
+    ...ObserveBuildNumberFlag,
     ...ObserveUpdateIdFlag,
-    'build-number': Flags.string({
-      description: 'Filter by app build number',
-    }),
     'route-name': Flags.string({
       description:
         'Filter by route name (can be specified multiple times to include several routes)',

--- a/packages/eas-cli/src/observe/fetchCustomEvents.ts
+++ b/packages/eas-cli/src/observe/fetchCustomEvents.ts
@@ -16,6 +16,7 @@ interface FetchCustomEventsOptions {
   endTime?: string;
   platforms?: AppObservePlatform[];
   appVersion?: string;
+  buildNumber?: string;
   updateId?: string;
   sessionId?: string;
   environment?: string;
@@ -38,6 +39,7 @@ export async function fetchObserveCustomEventsAsync(
     ...(options.eventName && { eventName: options.eventName }),
     ...(options.platforms?.length && { platforms: options.platforms }),
     ...(options.appVersion && { appVersion: options.appVersion }),
+    ...(options.buildNumber && { appBuildNumber: options.buildNumber }),
     ...(options.updateId && { appUpdateId: options.updateId }),
     ...(options.sessionId && { sessionId: options.sessionId }),
     ...(options.environment && { environment: options.environment }),

--- a/packages/eas-cli/src/observe/fetchEvents.ts
+++ b/packages/eas-cli/src/observe/fetchEvents.ts
@@ -54,6 +54,7 @@ interface FetchObserveEventsOptions {
   endTime?: string;
   platforms?: AppObservePlatform[];
   appVersion?: string;
+  buildNumber?: string;
   updateId?: string;
   sessionId?: string;
   environment?: string;
@@ -75,6 +76,7 @@ export async function fetchObserveEventsAsync(
     ...(options.metricName && { metricName: options.metricName }),
     ...(options.platforms?.length && { platforms: options.platforms }),
     ...(options.appVersion && { appVersion: options.appVersion }),
+    ...(options.buildNumber && { appBuildNumber: options.buildNumber }),
     ...(options.updateId && { appUpdateId: options.updateId }),
     ...(options.sessionId && { sessionId: options.sessionId }),
     ...(options.environment && { environment: options.environment }),

--- a/packages/eas-cli/src/observe/flags.ts
+++ b/packages/eas-cli/src/observe/flags.ts
@@ -55,3 +55,9 @@ export const ObserveUpdateIdFlag = {
     description: 'Filter by EAS update ID',
   }),
 };
+
+export const ObserveBuildNumberFlag = {
+  'build-number': Flags.string({
+    description: 'Filter by app build number',
+  }),
+};


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Resolves ENG-26159.

We were missing a `--build-number` filter from metrics and events.

# How

- Move the `build-number` flag to the shared observe flags.
- Add it to `observe:metrics` and `observe:events`

# Test Plan

Unit tests.

## Metrics

```sh
eas observe:metrics tti --build-number 2     # returns only build-2 samples
eas observe:metrics tti --build-number 99    # "No events found."
```

## Events

```sh
eas observe:events my_event --build-number 1
```
