### PR TITLE
[build-tools] Preserve Argent artifact kinds

### DIFF
--- a/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/argentArtifacts.test.ts
@@ -67,8 +67,15 @@ describe(listArgentArtifactsAsync, () => {
           artifacts: [
             {
               id: 'artifact-id',
+              kind: 'native-profile-report',
               filename: 'report.json',
               mimeType: 'application/json',
+              isDirectory: false,
+            },
+            {
+              id: 'legacy-artifact-id',
+              filename: 'screen.png',
+              mimeType: 'image/png',
               isDirectory: false,
             },
           ],
@@ -84,8 +91,15 @@ describe(listArgentArtifactsAsync, () => {
     expect(artifacts).toEqual([
       {
         id: 'artifact-id',
+        kind: 'native-profile-report',
         filename: 'report.json',
         mimeType: 'application/json',
+        isDirectory: false,
+      },
+      {
+        id: 'legacy-artifact-id',
+        filename: 'screen.png',
+        mimeType: 'image/png',
         isDirectory: false,
       },
     ]);
@@ -143,6 +157,7 @@ describe(uploadArgentArtifactAsync, () => {
 
   async function uploadAsync(artifact: {
     id: string;
+    kind?: string;
     filename: string;
     mimeType: string;
     isDirectory?: boolean;
@@ -185,7 +200,42 @@ describe(uploadArgentArtifactAsync, () => {
     );
   });
 
-  it('leaves directory artifacts unclassified because they are uploaded as a tarball', async () => {
+  it('uses the semantic kind reported by Argent', async () => {
+    const ctx = await uploadAsync({
+      id: 'artifact-id',
+      kind: 'native-profile-report',
+      filename: 'native-profile-report.md',
+      mimeType: 'text/markdown',
+    });
+
+    expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        filename: 'native-profile-report.md',
+        kind: 'native-profile-report',
+      })
+    );
+  });
+
+  it('keeps the semantic kind when a directory is uploaded as a tarball', async () => {
+    const ctx = await uploadAsync({
+      id: 'artifact-id',
+      kind: 'native-profile-trace',
+      filename: 'native-profile.trace',
+      mimeType: 'application/octet-stream',
+      isDirectory: true,
+    });
+
+    expect(jest.mocked(uploadDeviceRunSessionArtifactAsync)).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        filename: 'native-profile.trace.tar.gz',
+        kind: 'native-profile-trace',
+      })
+    );
+  });
+
+  it('leaves an older unclassified directory artifact without a kind', async () => {
     const ctx = await uploadAsync({
       id: 'artifact-id',
       filename: 'screenshots',

--- a/packages/build-tools/src/steps/utils/argentArtifacts.ts
+++ b/packages/build-tools/src/steps/utils/argentArtifacts.ts
@@ -18,11 +18,11 @@ const ARGENT_ARTIFACT_UPLOAD_POLL_INTERVAL_MS = 5_000;
 const ARGENT_ARTIFACT_UPLOAD_CLEANUP_TIMEOUT_MS = 30_000;
 const ARGENT_ARTIFACT_FETCH_TIMEOUT_MS = 10_000;
 
-// Kinds the EAS dashboard groups device run session artifacts by. Only media types the dashboard
-// renders specially are mapped; anything else stays unclassified and lands in its "Other" group.
-// Note that these kinds only affect grouping and labelling. The dashboard gates its inline video
-// player on the `__eas_screen_recording` metadata flag, which Argent artifacts deliberately do not
-// set, so a `screen-recording` kind here does not add a player to the session page.
+// Fallback kinds for Argent versions that do not include a semantic artifact kind. Only media types
+// the EAS dashboard renders specially can be inferred safely. Note that these kinds only affect
+// grouping and labelling. The dashboard gates its inline video player on the
+// `__eas_screen_recording` metadata flag, which Argent artifacts deliberately do not set, so a
+// `screen-recording` kind here does not add a player to the session page.
 const ARGENT_ARTIFACT_KIND_BY_MIME_TYPE = new Map<string, string>([
   ['image/png', 'screenshot'],
   ['image/jpeg', 'screenshot'],
@@ -32,6 +32,9 @@ const ARGENT_ARTIFACT_KIND_BY_MIME_TYPE = new Map<string, string>([
 
 const ArgentArtifactSchema = z.object({
   id: z.string(),
+  // Optional for compatibility with older Argent tool servers. Keep this open to new kinds so a
+  // newer Argent version can add a category without requiring an EAS worker release first.
+  kind: z.string().optional(),
   filename: z.string(),
   mimeType: z.string(),
   isDirectory: z.boolean().optional(),
@@ -43,8 +46,12 @@ const ArgentArtifactsListResponseSchema = z.object({
 type ArgentArtifact = z.infer<typeof ArgentArtifactSchema>;
 
 function getArgentArtifactKind(artifact: ArgentArtifact): string | undefined {
+  if (artifact.kind) {
+    return artifact.kind;
+  }
   // Directories are repackaged as a tarball before upload, so the reported media type describes the
-  // contents rather than the file we actually store.
+  // contents rather than the file we actually store. A semantic kind above remains valid because it
+  // describes what the artifact represents, not its transport format.
   if (artifact.isDirectory) {
     return undefined;
   }


### PR DESCRIPTION
# Why

Argent now exposes artifact kind!!

# How

Extended the schema. Kept mime-types though I'd be more than happy to remove it (mime types can lie).

# Test Plan

CI should pass.