### PR TITLE
[eas-cli] Bump minizlib to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Upload tvOS (and other non-iOS) IPAs to the App Store Connect platform declared in the bundle's `DTPlatformName`, instead of always uploading to the iOS train. ([#4234](https://github.com/expo/eas-cli/pull/4234) by [@douglowder](https://github.com/douglowder))
 
+- [eas-cli] Bump `minizlib` to 3.1.0 to drop its deprecated `rimraf@5` transitive dependency. ([#4281](https://github.com/expo/eas-cli/pull/4281) by [@brentvatne](https://github.com/brentvatne))
+
 ## [22.2.0](https://github.com/expo/eas-cli/releases/tag/v22.2.0) - 2026-08-20
 
 ### 🎉 New features

--- a/packages/eas-cli/package.json
+++ b/packages/eas-cli/package.json
@@ -104,7 +104,7 @@
     "log-symbols": "4.1.0",
     "mime": "3.0.0",
     "minimatch": "5.1.2",
-    "minizlib": "3.0.1",
+    "minizlib": "3.1.0",
     "nanoid": "3.3.8",
     "node-fetch": "2.6.7",
     "node-forge": "1.4.0",

--- a/packages/eas-cli/src/worker/__tests__/assets.test.ts
+++ b/packages/eas-cli/src/worker/__tests__/assets.test.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import { Readable } from 'node:stream';
+import { extract } from 'tar-stream';
+import zlib from 'node:zlib';
+
+import { FileEntry, packFilesIterableAsync } from '../assets';
+
+async function extractTarEntriesAsync(tarData: Buffer): Promise<Map<string, string>> {
+  const entries = new Map<string, string>();
+  const extractor = extract();
+  extractor.on('entry', (header, stream, next) => {
+    const chunks: Buffer[] = [];
+    stream.on('data', chunk => chunks.push(chunk));
+    stream.on('end', () => {
+      entries.set(header.name, Buffer.concat(chunks).toString('utf8'));
+      next();
+    });
+    stream.resume();
+  });
+  await new Promise<void>((resolve, reject) => {
+    extractor.on('finish', resolve);
+    extractor.on('error', reject);
+    Readable.from(tarData).pipe(extractor);
+  });
+  return entries;
+}
+
+describe(packFilesIterableAsync, () => {
+  let tarPath: string | null = null;
+
+  afterEach(async () => {
+    if (tarPath) {
+      await fs.promises.rm(tarPath, { force: true });
+      tarPath = null;
+    }
+  });
+
+  it('packs file entries into a gzip-compressed tarball', async () => {
+    const files: FileEntry[] = [
+      ['index.html', '<h1>hello</h1>'],
+      ['assets/data.json', '{"key":"value"}'],
+    ];
+    tarPath = await packFilesIterableAsync(files);
+
+    const compressed = await fs.promises.readFile(tarPath);
+    // gzip magic bytes
+    expect(compressed[0]).toBe(0x1f);
+    expect(compressed[1]).toBe(0x8b);
+    // portable mode zeroes the gzip MTIME field (bytes 4-7)
+    expect(compressed.subarray(4, 8)).toEqual(Buffer.from([0, 0, 0, 0]));
+
+    const entries = await extractTarEntriesAsync(zlib.gunzipSync(compressed));
+    expect(entries.get('index.html')).toBe('<h1>hello</h1>');
+    expect(entries.get('assets/data.json')).toBe('{"key":"value"}');
+    expect(entries.size).toBe(2);
+  });
+
+  it('accepts async iterables and forwards gzip options', async () => {
+    async function* files(): AsyncIterable<FileEntry> {
+      yield ['a.txt', 'aaaa'];
+      yield ['b.txt', Buffer.from('bbbb')];
+    }
+    tarPath = await packFilesIterableAsync(files(), { level: 9 });
+
+    const compressed = await fs.promises.readFile(tarPath);
+    const entries = await extractTarEntriesAsync(zlib.gunzipSync(compressed));
+    expect(entries.get('a.txt')).toBe('aaaa');
+    expect(entries.get('b.txt')).toBe('bbbb');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10480,7 +10480,7 @@ __metadata:
     memfs: "npm:3.4.13"
     mime: "npm:3.0.0"
     minimatch: "npm:5.1.2"
-    minizlib: "npm:3.0.1"
+    minizlib: "npm:3.1.0"
     mockdate: "npm:3.0.5"
     nanoid: "npm:3.3.8"
     nock: "npm:13.4.0"
@@ -11699,7 +11699,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7, glob@npm:^10.4.2":
+"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.4.2":
   version: 10.5.0
   resolution: "glob@npm:10.5.0"
   dependencies:
@@ -15026,13 +15026,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minizlib@npm:3.0.1":
-  version: 3.0.1
-  resolution: "minizlib@npm:3.0.1"
+"minizlib@npm:3.1.0, minizlib@npm:^3.0.1, minizlib@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "minizlib@npm:3.1.0"
   dependencies:
-    minipass: "npm:^7.0.4"
-    rimraf: "npm:^5.0.5"
-  checksum: 10c0/82f8bf70da8af656909a8ee299d7ed3b3372636749d29e105f97f20e88971be31f5ed7642f2e898f00283b68b701cc01307401cdc209b0efc5dd3818220e5093
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
   languageName: node
   linkType: hard
 
@@ -15043,15 +15042,6 @@ __metadata:
     minipass: "npm:^3.0.0"
     yallist: "npm:^4.0.0"
   checksum: 10c0/64fae024e1a7d0346a1102bb670085b17b7f95bf6cfdf5b128772ec8faf9ea211464ea4add406a3a6384a7d87a0cd1a96263692134323477b4fb43659a6cab78
-  languageName: node
-  linkType: hard
-
-"minizlib@npm:^3.0.1, minizlib@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "minizlib@npm:3.1.0"
-  dependencies:
-    minipass: "npm:^7.1.2"
-  checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
   languageName: node
   linkType: hard
 
@@ -17401,17 +17391,6 @@ __metadata:
   bin:
     rimraf: dist/cjs/src/bin.js
   checksum: 10c0/8c5e142d26d8b222be9dc9a1a41ba48e95d8f374e813e66a8533e87c6180174fcb3f573b9b592eca12740ebf8b78526d136acd971d4a790763d6f2232c34fa24
-  languageName: node
-  linkType: hard
-
-"rimraf@npm:^5.0.5":
-  version: 5.0.7
-  resolution: "rimraf@npm:5.0.7"
-  dependencies:
-    glob: "npm:^10.3.7"
-  bin:
-    rimraf: dist/esm/bin.mjs
-  checksum: 10c0/bd6dbfaa98ae34ce1e54d1e06045d2d63e8859d9a1979bb4a4628b652b459a2d17b17dc20ee072b034bd2d09bd691e801d24c4d9cfe94e16fdbcc8470a1d4807
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

`minizlib@3.0.1` pulls in deprecated `rimraf@5` and its `glob@10` dependency. `minizlib@3.1.0` removes that dependency.

# How

- Bump `minizlib` from 3.0.1 to 3.1.0.
- Add a gzip tarball round-trip test around the EAS asset packer, including async iterables and option forwarding.

# Test Plan

- `yarn workspace eas-cli test src/worker/__tests__/assets.test.ts --runInBand --watchman=false`
- `yarn workspace eas-cli typecheck`
- `yarn oxfmt CHANGELOG.md packages/eas-cli/package.json packages/eas-cli/src/worker/__tests__/assets.test.ts`

# Stack

1. [#4281 — `minizlib` 3.1.0](https://github.com/expo/eas-cli/pull/4281)
2. [#4282 — `uuid` v11](https://github.com/expo/eas-cli/pull/4282)
3. [#4283 — remove `lodash.get`](https://github.com/expo/eas-cli/pull/4283)
4. [#4284 — local-build `@expo/bunyan`](https://github.com/expo/eas-cli/pull/4284)
5. [#4285 — prebuild fallback regression tests](https://github.com/expo/eas-cli/pull/4285)

This is the base of the stack.