### PR TITLE
[steps] Replace lodash.get with a local helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Upload tvOS (and other non-iOS) IPAs to the App Store Connect platform declared in the bundle's `DTPlatformName`, instead of always uploading to the iOS train. ([#4234](https://github.com/expo/eas-cli/pull/4234) by [@douglowder](https://github.com/douglowder))
 
+- [steps] Replace deprecated `lodash.get` with a local helper. ([#4283](https://github.com/expo/eas-cli/pull/4283) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli][steps] Bump `uuid` to v11 and remove the redundant `@types/uuid` dependency. ([#4282](https://github.com/expo/eas-cli/pull/4282) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli] Bump `minizlib` to 3.1.0 to drop its deprecated `rimraf@5` transitive dependency. ([#4281](https://github.com/expo/eas-cli/pull/4281) by [@brentvatne](https://github.com/brentvatne))
 

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -36,7 +36,6 @@
     "joi": "^17.13.1",
     "jsep": "^1.3.8",
     "lodash.clonedeep": "^4.5.0",
-    "lodash.get": "^4.4.2",
     "uuid": "^11.1.1",
     "yaml": "^2.4.3",
     "zod": "^4.3.5"
@@ -45,7 +44,6 @@
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.12",
     "@types/lodash.clonedeep": "^4.5.9",
-    "@types/lodash.get": "^4.4.9",
     "@types/node": "20.14.2",
     "eslint-plugin-async-protect": "^3.1.0",
     "jest": "^29.7.0",

--- a/packages/steps/src/utils/__tests__/get-test.ts
+++ b/packages/steps/src/utils/__tests__/get-test.ts
@@ -1,0 +1,92 @@
+import { get, parsePath } from '../get';
+
+describe(parsePath, () => {
+  it('splits dot-separated paths', () => {
+    expect(parsePath('steps.step1.outputs.out')).toEqual(['steps', 'step1', 'outputs', 'out']);
+  });
+
+  it('parses bracketed array indices', () => {
+    expect(parsePath('list[0].name')).toEqual(['list', '0', 'name']);
+    expect(parsePath('a[0][1]')).toEqual(['a', '0', '1']);
+  });
+
+  it('parses bracketed keys without quotes as emitted by jsepEval', () => {
+    expect(parsePath('a[b]')).toEqual(['a', 'b']);
+  });
+
+  it('parses quoted bracketed keys, keeping dots inside them intact', () => {
+    expect(parsePath('a["b.c"]')).toEqual(['a', 'b.c']);
+    expect(parsePath("a['b']")).toEqual(['a', 'b']);
+  });
+
+  it('throws on unterminated brackets', () => {
+    expect(() => parsePath('a[b')).toThrow('unterminated bracket');
+    expect(() => parsePath('a["b]')).toThrow('unterminated quoted bracket');
+  });
+});
+
+describe(get, () => {
+  const context = {
+    steps: {
+      step1: {
+        outputs: {
+          my_output: 'value1',
+        },
+      },
+    },
+    eas: {
+      job: {
+        version: { buildNumber: '42' },
+        secrets: null,
+        list: ['first', { name: 'second' }],
+      },
+      runtimeVersion: undefined,
+    },
+  };
+
+  it('resolves dot-separated paths, as used by template interpolation', () => {
+    expect(get(context, 'steps.step1.outputs.my_output')).toBe('value1');
+    expect(get(context, 'eas.job.version.buildNumber')).toBe('42');
+  });
+
+  it('resolves single identifiers, as used by jsepEval', () => {
+    expect(get(context, 'steps')).toBe(context.steps);
+  });
+
+  it('resolves array indices in both bracket and dot form', () => {
+    expect(get(context, 'eas.job.list[0]')).toBe('first');
+    expect(get(context, 'eas.job.list[1].name')).toBe('second');
+    expect(get(context, 'eas.job.list.1.name')).toBe('second');
+  });
+
+  it('resolves computed member paths emitted by jsepEval, e.g. a[b]', () => {
+    expect(get(context, 'eas[job]')).toBe(context.eas.job);
+    expect(get({ a: { b: 1 } }, 'a[b]')).toBe(1);
+  });
+
+  it('returns undefined for missing paths instead of throwing', () => {
+    expect(get(context, 'eas.job.doesNotExist')).toBe(undefined);
+    expect(get(context, 'eas.job.doesNotExist.nested')).toBe(undefined);
+    expect(get(context, 'doesNotExist.at.all')).toBe(undefined);
+  });
+
+  it('returns undefined when traversing through null or undefined', () => {
+    expect(get(context, 'eas.job.secrets.robotAccessToken')).toBe(undefined);
+    expect(get(context, 'eas.runtimeVersion.anything')).toBe(undefined);
+    expect(get(null, 'a.b')).toBe(undefined);
+    expect(get(undefined, 'a')).toBe(undefined);
+  });
+
+  it('returns null values as-is rather than undefined', () => {
+    expect(get(context, 'eas.job.secrets')).toBe(null);
+  });
+
+  it('prefers a verbatim own property over a nested path, like lodash.get', () => {
+    expect(get({ 'a.b': 'flat', a: { b: 'nested' } }, 'a.b')).toBe('flat');
+    expect(get({ a: { b: 'nested' } }, 'a.b')).toBe('nested');
+  });
+
+  it('reads properties of primitives encountered mid-path', () => {
+    expect(get({ a: 'text' }, 'a.length')).toBe(4);
+  });
+});

--- a/packages/steps/src/utils/get.ts
+++ b/packages/steps/src/utils/get.ts
@@ -1,0 +1,60 @@
+// Minimal replacement for lodash.get, covering the path shapes this package
+// produces: dot-separated keys (`steps.step1.outputs.out`), bracketed array
+// indices (`list[0].name`), and bracketed keys with or without quotes
+// (`a[b]`, `a["b.c"]`, `a['b']`) as emitted by jsepEval's getParameterPath.
+
+const QUOTE_CHARACTERS = ["'", '"'];
+
+export function parsePath(path: string): string[] {
+  const keys: string[] = [];
+  let index = 0;
+  while (index < path.length) {
+    const character = path[index];
+    if (character === '.') {
+      index += 1;
+    } else if (character === '[') {
+      const maybeQuote = path[index + 1];
+      if (QUOTE_CHARACTERS.includes(maybeQuote)) {
+        const closingQuoteIndex = path.indexOf(`${maybeQuote}]`, index + 2);
+        if (closingQuoteIndex === -1) {
+          throw new Error(`Invalid path: unterminated quoted bracket in "${path}"`);
+        }
+        keys.push(path.slice(index + 2, closingQuoteIndex));
+        index = closingQuoteIndex + 2;
+      } else {
+        const closingBracketIndex = path.indexOf(']', index + 1);
+        if (closingBracketIndex === -1) {
+          throw new Error(`Invalid path: unterminated bracket in "${path}"`);
+        }
+        keys.push(path.slice(index + 1, closingBracketIndex));
+        index = closingBracketIndex + 1;
+      }
+    } else {
+      let end = index;
+      while (end < path.length && path[end] !== '.' && path[end] !== '[') {
+        end += 1;
+      }
+      keys.push(path.slice(index, end));
+      index = end;
+    }
+  }
+  return keys;
+}
+
+export function get(object: unknown, path: string): any {
+  // Like lodash.get, a path that exists verbatim as an own property wins
+  // over interpreting it as a nested path.
+  if (object != null && typeof object === 'object' && Object.hasOwn(object, path)) {
+    return (object as Record<string, unknown>)[path];
+  }
+  let current: any = object;
+  for (const key of parsePath(path)) {
+    if (current == null) {
+      return undefined;
+    }
+    current = current[key];
+  }
+  return current;
+}
+
+export default get;

--- a/packages/steps/src/utils/jsepEval.ts
+++ b/packages/steps/src/utils/jsepEval.ts
@@ -6,7 +6,8 @@
 
 import assert from 'assert';
 import jsep from 'jsep';
-import get from 'lodash.get';
+
+import { get } from './get';
 
 const binaryOperatorFunctions = {
   '===': (a: any, b: any) => a === b,

--- a/packages/steps/src/utils/template.ts
+++ b/packages/steps/src/utils/template.ts
@@ -1,6 +1,6 @@
 import cloneDeep from 'lodash.clonedeep';
-import get from 'lodash.get';
 
+import { get } from './get';
 import { nullthrows } from './nullthrows';
 import { BuildStepInputValueTypeName } from '../BuildStepInput';
 import { BuildConfigError, BuildStepRuntimeError } from '../errors';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2897,7 +2897,6 @@ __metadata:
     "@jest/globals": "npm:^29.7.0"
     "@types/jest": "npm:^29.5.12"
     "@types/lodash.clonedeep": "npm:^4.5.9"
-    "@types/lodash.get": "npm:^4.4.9"
     "@types/node": "npm:20.14.2"
     arg: "npm:^5.0.2"
     eslint-plugin-async-protect: "npm:^3.1.0"
@@ -2907,7 +2906,6 @@ __metadata:
     joi: "npm:^17.13.1"
     jsep: "npm:^1.3.8"
     lodash.clonedeep: "npm:^4.5.0"
-    lodash.get: "npm:^4.4.2"
     rimraf: "npm:3.0.2"
     ts-jest: "npm:^29.1.4"
     ts-mockito: "npm:^2.6.1"
@@ -7355,15 +7353,6 @@ __metadata:
   dependencies:
     "@types/lodash": "npm:*"
   checksum: 10c0/2f224ce9578046bccd1cd9594fb73540600ebd3d59a45695166a6123e2c376b84ab106b005a00453f357907f25bc8bfd2271b822be76e8f5527eadb4690b5e96
-  languageName: node
-  linkType: hard
-
-"@types/lodash.get@npm:^4.4.9":
-  version: 4.4.9
-  resolution: "@types/lodash.get@npm:4.4.9"
-  dependencies:
-    "@types/lodash": "npm:*"
-  checksum: 10c0/934ae4f02831afdb9216cb5fcb702f8f4e0b45e13f2d10ed9c7ce7e891800e5dea726b513c98b8370d6292d42ad7745c622ae75733676746b711bea95b6259d5
   languageName: node
   linkType: hard
 
@@ -14228,7 +14217,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.get@npm:^4, lodash.get@npm:^4.4.2":
+"lodash.get@npm:^4":
   version: 4.4.2
   resolution: "lodash.get@npm:4.4.2"
   checksum: 10c0/48f40d471a1654397ed41685495acb31498d5ed696185ac8973daef424a749ca0c7871bf7b665d5c14f5cc479394479e0307e781f61d5573831769593411be6e


### PR DESCRIPTION
# Why

`@expo/steps` uses `lodash.get@4.4.2`, which is deprecated. Its call sites only need the path shapes generated by Steps templates and expression evaluation.

# How

- Replace `lodash.get` with a small local helper.
- Support dot paths, array indices, bracketed keys, quoted keys, nullish traversal, primitive properties, and verbatim own-property precedence.
- Remove `lodash.get` and `@types/lodash.get` from the Steps manifest.
- Add focused compatibility coverage for every supported path shape.

# Test Plan

- `yarn workspace @expo/steps typecheck`
- `yarn workspace @expo/steps test --runInBand --watchman=false` (569 tests)

# Stack

1. [#4281 — `minizlib` 3.1.0](https://github.com/expo/eas-cli/pull/4281)
2. [#4282 — `uuid` v11](https://github.com/expo/eas-cli/pull/4282)
3. [#4283 — remove `lodash.get`](https://github.com/expo/eas-cli/pull/4283)
4. [#4284 — local-build `@expo/bunyan`](https://github.com/expo/eas-cli/pull/4284)
5. [#4285 — prebuild fallback regression tests](https://github.com/expo/eas-cli/pull/4285)

This PR depends on #4282.