### PR TITLE
[local-build-plugin] Replace bunyan with @expo/bunyan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Upload tvOS (and other non-iOS) IPAs to the App Store Connect platform declared in the bundle's `DTPlatformName`, instead of always uploading to the iOS train. ([#4234](https://github.com/expo/eas-cli/pull/4234) by [@douglowder](https://github.com/douglowder))
 
+- [local-build-plugin] Replace `bunyan` with `@expo/bunyan` while preserving the Steps formatter binary. ([#4284](https://github.com/expo/eas-cli/pull/4284) by [@brentvatne](https://github.com/brentvatne))
 - [steps] Replace deprecated `lodash.get` with a local helper. ([#4283](https://github.com/expo/eas-cli/pull/4283) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli][steps] Bump `uuid` to v11 and remove the redundant `@types/uuid` dependency. ([#4282](https://github.com/expo/eas-cli/pull/4282) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli] Bump `minizlib` to 3.1.0 to drop its deprecated `rimraf@5` transitive dependency. ([#4281](https://github.com/expo/eas-cli/pull/4281) by [@brentvatne](https://github.com/brentvatne))

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -92,7 +92,6 @@
     "@types/retry": "^0.12.5",
     "@types/semver": "^7.5.8",
     "@types/uuid": "^9.0.8",
-    "bunyan": "^1.8.15",
     "jest": "^29.7.0",
     "memfs": "^4.17.1",
     "nock": "13.4.0",

--- a/packages/build-tools/src/__mocks__/@expo/logger.ts
+++ b/packages/build-tools/src/__mocks__/@expo/logger.ts
@@ -1,4 +1,4 @@
-import bunyan from 'bunyan';
+import type { bunyan } from '@expo/logger';
 
 export function createLogger(): bunyan {
   const logger = {

--- a/packages/local-build-plugin/package.json
+++ b/packages/local-build-plugin/package.json
@@ -27,11 +27,11 @@
   },
   "dependencies": {
     "@expo/build-tools": "23.0.0",
+    "@expo/bunyan": "^4.0.1",
     "@expo/eas-build-job": "23.0.0",
     "@expo/logger": "23.0.0",
     "@expo/spawn-async": "^1.7.2",
     "@expo/turtle-spawn": "23.0.0",
-    "bunyan": "^1.8.15",
     "chalk": "4.1.2",
     "env-paths": "^2.2.1",
     "fs-extra": "^11.2.0",
@@ -43,7 +43,6 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@types/bunyan": "^1.8.11",
     "@types/fs-extra": "^11.0.4",
     "@types/hapi__joi": "^17.1.14",
     "@types/lodash": "^4.17.4",

--- a/packages/local-build-plugin/src/build.ts
+++ b/packages/local-build-plugin/src/build.ts
@@ -1,6 +1,6 @@
 import { Artifacts, SkipNativeBuildError } from '@expo/build-tools';
 import { ArchiveSourceType, BuildJob, Metadata, Platform, Workflow } from '@expo/eas-build-job';
-import { DEBUG } from 'bunyan';
+import { DEBUG } from '@expo/bunyan';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import pickBy from 'lodash/pickBy';

--- a/packages/local-build-plugin/src/logger.ts
+++ b/packages/local-build-plugin/src/logger.ts
@@ -1,6 +1,7 @@
 import { LogBuffer } from '@expo/build-tools';
 import { LoggerLevel } from '@expo/logger';
-import bunyan from 'bunyan';
+import type { bunyan as ExpoLogger } from '@expo/logger';
+import bunyan from '@expo/bunyan';
 import chalk from 'chalk';
 import omit from 'lodash/omit';
 import { Writable } from 'stream';
@@ -129,7 +130,9 @@ class PrettyStream extends Writable {
 
 export const logBuffer = new BuildCliLogBuffer(MAX_LINES_IN_BUFFER);
 
-export function createLogger(level?: LoggerLevel): bunyan {
+export function createLogger(level?: LoggerLevel): ExpoLogger {
+  // @expo/bunyan provides the Bunyan API used here, but its stricter stream types are not
+  // structurally compatible with the legacy @types/bunyan types exposed by @expo/logger.
   return bunyan.createLogger({
     name: 'eas-build-cli',
     serializers: bunyan.stdSerializers,
@@ -143,5 +146,5 @@ export function createLogger(level?: LoggerLevel): bunyan {
         stream: logBuffer,
       },
     ],
-  });
+  }) as unknown as ExpoLogger;
 }

--- a/packages/logger/src/__tests__/index.test.ts
+++ b/packages/logger/src/__tests__/index.test.ts
@@ -1,0 +1,192 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Readable } from 'stream';
+
+import bunyan from 'bunyan';
+
+import defaultLogger, { LoggerLevel, PipeMode, createLogger, pipeSpawnOutput } from '../index';
+
+// Collects raw bunyan records written to the logger.
+function createRecordCollector(logger: ReturnType<typeof createLogger>): any[] {
+  const records: any[] = [];
+  logger.addStream({
+    type: 'raw',
+    stream: {
+      write(record: any) {
+        records.push(record);
+      },
+    } as any,
+    level: bunyan.TRACE,
+  });
+  return records;
+}
+
+function createSilentLogger(): ReturnType<typeof createLogger> {
+  const logger = createLogger({ name: 'test-logger', streams: [] });
+  return logger;
+}
+
+describe(createLogger, () => {
+  it('creates a logger that writes records with name, level, and msg', () => {
+    const logger = createSilentLogger();
+    const records = createRecordCollector(logger);
+
+    logger.info('hello world');
+
+    expect(records).toHaveLength(1);
+    expect(records[0].name).toBe('test-logger');
+    expect(records[0].level).toBe(bunyan.INFO);
+    expect(records[0].msg).toBe('hello world');
+  });
+
+  it('supports structured fields and util.format-style messages', () => {
+    const logger = createSilentLogger();
+    const records = createRecordCollector(logger);
+
+    logger.info({ phase: 'INSTALL_DEPENDENCIES' }, 'step %d done', 2);
+
+    expect(records[0].phase).toBe('INSTALL_DEPENDENCIES');
+    expect(records[0].msg).toBe('step 2 done');
+  });
+
+  it('serializes errors with the standard err serializer', () => {
+    const logger = createSilentLogger();
+    const records = createRecordCollector(logger);
+
+    logger.error(new Error('boom'));
+
+    expect(records[0].err.message).toBe('boom');
+    expect(records[0].err.stack).toEqual(expect.stringContaining('boom'));
+    expect(records[0].msg).toBe('boom');
+  });
+
+  it('creates child loggers that inherit fields and add their own', () => {
+    const logger = createSilentLogger();
+    const records = createRecordCollector(logger);
+
+    const child = logger.child({ source: 'stdout' });
+    child.warn('from child');
+
+    expect(records[0].name).toBe('test-logger');
+    expect(records[0].source).toBe('stdout');
+    expect(records[0].level).toBe(bunyan.WARN);
+  });
+
+  it('respects the configured level', () => {
+    const logger = createLogger({ name: 'test-logger', streams: [] });
+    const records: any[] = [];
+    logger.addStream({
+      type: 'raw',
+      stream: {
+        write(record: any) {
+          records.push(record);
+        },
+      } as any,
+      level: bunyan.INFO,
+    });
+
+    logger.debug('too quiet');
+    logger.info('loud enough');
+
+    expect(records).toHaveLength(1);
+    expect(records[0].msg).toBe('loud enough');
+  });
+
+  it('reports and sets the level programmatically', () => {
+    const logger = createLogger({
+      name: 'test-logger',
+      streams: [
+        {
+          type: 'raw',
+          stream: { write() {} } as any,
+          level: LoggerLevel.INFO,
+        },
+      ],
+    });
+
+    expect(logger.level()).toBe(bunyan.INFO);
+    logger.level(LoggerLevel.DEBUG);
+    expect(logger.level()).toBe(bunyan.DEBUG);
+  });
+
+  it('supports rotating-file streams', async () => {
+    const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'expo-logger-test-'));
+    const logPath = path.join(directory, 'rotating.log');
+    let rotatingStream: any;
+
+    try {
+      const logger = createLogger({
+        name: 'test-logger',
+        streams: [
+          {
+            type: 'rotating-file',
+            path: logPath,
+            period: '1d',
+            count: 1,
+          },
+        ],
+      });
+      rotatingStream = (logger as any).streams[0].stream;
+
+      logger.info('written to a rotating file');
+
+      await new Promise<void>((resolve, reject) => {
+        rotatingStream.stream.once('error', reject);
+        rotatingStream.stream.end(resolve);
+      });
+      expect(await fs.promises.readFile(logPath, 'utf8')).toContain('written to a rotating file');
+    } finally {
+      clearTimeout(rotatingStream?.timeout);
+      rotatingStream?.stream.destroy();
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('defaultLogger', () => {
+  it('is configured with the expo-logger name at INFO level', () => {
+    expect(defaultLogger.fields.name).toBe('expo-logger');
+    expect(defaultLogger.level()).toBe(bunyan.INFO);
+  });
+});
+
+describe(pipeSpawnOutput, () => {
+  async function pipeAndCollect(
+    stdoutData: string | null,
+    stderrData: string | null,
+    options?: Parameters<typeof pipeSpawnOutput>[2]
+  ): Promise<any[]> {
+    const logger = createSilentLogger();
+    const records = createRecordCollector(logger);
+    const stdout = stdoutData === null ? null : Readable.from([stdoutData]);
+    const stderr = stderrData === null ? null : Readable.from([stderrData]);
+    pipeSpawnOutput(logger, { stdout, stderr }, options);
+    await new Promise(resolve => setImmediate(resolve));
+    return records;
+  }
+
+  it('logs stdout and stderr lines tagged with their source', async () => {
+    const records = await pipeAndCollect('out line 1\nout line 2\n', 'err line\n');
+
+    const stdoutRecords = records.filter(r => r.source === 'stdout');
+    const stderrRecords = records.filter(r => r.source === 'stderr');
+    expect(stdoutRecords.map(r => r.msg)).toEqual(['out line 1', 'out line 2']);
+    expect(stderrRecords.map(r => r.msg)).toEqual(['err line']);
+  });
+
+  it('tags stderr as stdout in COMBINED_AS_STDOUT mode', async () => {
+    const records = await pipeAndCollect('out\n', 'err\n', { mode: PipeMode.COMBINED_AS_STDOUT });
+
+    expect(records).toHaveLength(2);
+    expect(records.every(r => r.source === 'stdout')).toBe(true);
+  });
+
+  it('applies the line transformer and drops lines it nulls out', async () => {
+    const records = await pipeAndCollect('keep\ndrop\n', null, {
+      lineTransformer: line => (line === 'drop' ? null : `[prefix] ${line}`),
+    });
+
+    expect(records.map(r => r.msg)).toEqual(['[prefix] keep']);
+  });
+});

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -45,6 +45,7 @@
     "@types/jest": "^29.5.12",
     "@types/lodash.clonedeep": "^4.5.9",
     "@types/node": "20.14.2",
+    "bunyan": "^1.8.15",
     "eslint-plugin-async-protect": "^3.1.0",
     "jest": "^29.7.0",
     "rimraf": "3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,7 +2326,6 @@ __metadata:
     "@types/uuid": "npm:^9.0.8"
     "@urql/core": "npm:^6.0.1"
     bplist-parser: "npm:0.3.2"
-    bunyan: "npm:^1.8.15"
     content-disposition: "npm:1.0.1"
     fast-glob: "npm:^3.3.2"
     fast-xml-parser: "npm:^4.4.1"
@@ -2373,6 +2372,15 @@ __metadata:
     safe-json-stringify:
       optional: true
   checksum: 10c0/2f9de15556708ef8e2fb7cc9264ef79ec7525e3906d1a095af1fcad5edac6d6f0da5e47d2ab4c3f67f0a71b5b7422dedfa5b3d6a3dfdd1fa0c614c8535c171aa
+  languageName: node
+  linkType: hard
+
+"@expo/bunyan@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@expo/bunyan@npm:4.0.1"
+  dependencies:
+    uuid: "npm:^8.0.0"
+  checksum: 10c0/ebbec51c7b19dcfcbd981da9c1c6262c0dc03ea118356fefca3b427f445308845fc33d97da92350d68fda174f9f1d5ee95ed3ac978f1f6cc88de73d785b909cc
   languageName: node
   linkType: hard
 
@@ -2899,6 +2907,7 @@ __metadata:
     "@types/lodash.clonedeep": "npm:^4.5.9"
     "@types/node": "npm:20.14.2"
     arg: "npm:^5.0.2"
+    bunyan: "npm:^1.8.15"
     eslint-plugin-async-protect: "npm:^3.1.0"
     fast-glob: "npm:^3.3.2"
     fs-extra: "npm:^11.2.0"
@@ -10320,17 +10329,16 @@ __metadata:
   resolution: "eas-cli-local-build-plugin@workspace:packages/local-build-plugin"
   dependencies:
     "@expo/build-tools": "npm:23.0.0"
+    "@expo/bunyan": "npm:^4.0.1"
     "@expo/eas-build-job": "npm:23.0.0"
     "@expo/logger": "npm:23.0.0"
     "@expo/spawn-async": "npm:^1.7.2"
     "@expo/turtle-spawn": "npm:23.0.0"
-    "@types/bunyan": "npm:^1.8.11"
     "@types/fs-extra": "npm:^11.0.4"
     "@types/hapi__joi": "npm:^17.1.14"
     "@types/lodash": "npm:^4.17.4"
     "@types/semver": "npm:^7.5.8"
     "@types/uuid": "npm:^9.0.7"
-    bunyan: "npm:^1.8.15"
     chalk: "npm:4.1.2"
     env-paths: "npm:^2.2.1"
     fs-extra: "npm:^11.2.0"


### PR DESCRIPTION
# Why

The local-build plugin directly depends on legacy `bunyan`, which brings deprecated transitive packages and the `dtrace-provider` install script.

# How

- Replace Bunyan with `@expo/bunyan` only in the local-build plugin.
- Keep public `@expo/logger` on legacy Bunyan so rotating-file streams remain supported.
- Remove the incidental Bunyan development dependency from Build Tools and use the logger-exported type in its test mock.
- Declare Bunyan directly in Steps because `packages/steps/cli.sh` invokes its formatter binary.
- Add public logger contract tests, including rotating-file streams, to prevent the replacement from expanding beyond the compatible scope.

# Test Plan

- `yarn workspace @expo/logger test --runInBand --watchman=false` (11 tests)
- `yarn workspace @expo/logger typecheck`
- `yarn workspace @expo/build-tools typecheck`
- `yarn workspace eas-cli-local-build-plugin typecheck`
- `yarn workspace @expo/steps typecheck`
- `yarn workspace @expo/steps run bunyan --version`

# Stack

1. [#4281 — `minizlib` 3.1.0](https://github.com/expo/eas-cli/pull/4281)
2. [#4282 — `uuid` v11](https://github.com/expo/eas-cli/pull/4282)
3. [#4283 — remove `lodash.get`](https://github.com/expo/eas-cli/pull/4283)
4. [#4284 — local-build `@expo/bunyan`](https://github.com/expo/eas-cli/pull/4284)
5. [#4285 — prebuild fallback regression tests](https://github.com/expo/eas-cli/pull/4285)

This PR depends on #4283.