### PR TITLE
[ci] Bump both STAGING and PRODUCTION cli-versions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,10 +81,13 @@ jobs:
           jq --arg version "$EAS_CLI_VERSION" '.STAGING = $version' \
             cli-versions.json > cli-versions.json.tmp
           mv cli-versions.json.tmp cli-versions.json
+          jq --arg version "$EAS_CLI_VERSION" '.PRODUCTION = $version' \
+            cli-versions.json > cli-versions.json.tmp
+          mv cli-versions.json.tmp cli-versions.json
           git config --global user.email "support+ci@expo.io"
           git config --global user.name "Expo CI"
           git add cli-versions.json CHANGELOG.md
-          git commit --allow-empty -m "update CHANGELOG.md and bump STAGING in cli-versions.json"
+          git commit --allow-empty -m "update CHANGELOG.md and bump STAGING and PRODUCTION in cli-versions.json"
           git push
       - name: Prepare changelog for Slack
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [ci] Bump both STAGING and PRODUCTION cli-versions in release workflow. ([#4290](https://github.com/expo/eas-cli/pull/4290) by [@douglowder](https://github.com/douglowder))
+
 ## [22.6.0](https://github.com/expo/eas-cli/releases/tag/v22.6.0) - 2026-08-26
 
 ### 🎉 New features


### PR DESCRIPTION
# Why

Since updating the release workflow to use `cli-versions.json` instead of NPM tags, there have been issues where the version of the CLI used in www production has gone out of date.

# How

Align the new workflow with the old workflow, which updated both staging and production NPM tags on release. After this change, both STAGING and PRODUCTION values in `cli-versions.json` will be bumped for a new release.

# Test Plan

CI should pass.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>