### PR TITLE
[eas-cli] Ingest realtime incrementally instead of rebuilding full logs on every message

### DIFF
--- a/packages/eas-cli/src/commandUtils/workflow/__tests__/utils-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/__tests__/utils-test.ts
@@ -1,29 +1,36 @@
 import { getMockWorkflowRunWithJobsFragment } from '../../../__tests__/commands/utils';
 import { WorkflowJobStatus } from '../../../graphql/generated';
 import { groupLogLinesIntoSteps, parseLogLines } from '../logs/parseLogs';
-import { formatActiveWorkflowRun } from '../utils';
+import { WorkflowLogs, WorkflowRawLogLine } from '../types';
+import { formatActiveWorkflowRun, formatFailedWorkflowRun } from '../utils';
 
-function inProgressJobWithLogs(rawLogs: string): {
+function jobWithLogs(
+  logLines: WorkflowRawLogLine[],
+  status: WorkflowJobStatus = WorkflowJobStatus.InProgress
+): {
   job: ReturnType<typeof getMockWorkflowRunWithJobsFragment>['jobs'][number];
-  logs: ReturnType<typeof groupLogLinesIntoSteps>;
+  logs: WorkflowLogs;
 } {
   return {
-    job: {
-      ...getMockWorkflowRunWithJobsFragment().jobs[0],
-      status: WorkflowJobStatus.InProgress,
-    },
-    logs: groupLogLinesIntoSteps(parseLogLines(rawLogs).logLines),
+    job: { ...getMockWorkflowRunWithJobsFragment().jobs[0], status },
+    logs: groupLogLinesIntoSteps(logLines),
   };
+}
+
+function stepLines(buildStepId: string, count: number): WorkflowRawLogLine[] {
+  return Array.from({ length: count }, (_, index) => ({ buildStepId, msg: `line${index}` }));
 }
 
 describe(formatActiveWorkflowRun, () => {
   test('shows the display name for the current step while keying logs by step id', () => {
     const output = formatActiveWorkflowRun([
-      inProgressJobWithLogs(
-        [
-          '{"buildStepId":"step-id-1","buildStepDisplayName":"Install dependencies","time":"2022-01-01T00:00:00.000Z","msg":"npm ci"}',
-          '{"buildStepId":"step-id-1","buildStepDisplayName":"Install dependencies","marker":"end-step","result":"success","time":"2022-01-01T00:00:01.000Z","msg":"done"}',
-        ].join('\n')
+      jobWithLogs(
+        parseLogLines(
+          [
+            '{"buildStepId":"step-id-1","buildStepDisplayName":"Install dependencies","time":"2022-01-01T00:00:00.000Z","msg":"npm ci"}',
+            '{"buildStepId":"step-id-1","buildStepDisplayName":"Install dependencies","marker":"end-step","result":"success","time":"2022-01-01T00:00:01.000Z","msg":"done"}',
+          ].join('\n')
+        ).logLines
       ),
     ]);
 
@@ -33,24 +40,98 @@ describe(formatActiveWorkflowRun, () => {
   });
 
   test('shows exactly maxLogLines trailing lines of the current step', () => {
-    const output = formatActiveWorkflowRun(
-      [
-        inProgressJobWithLogs(
-          Array.from({ length: 10 }, (_, index) =>
-            JSON.stringify({
-              buildStepId: 'step-id-1',
-              buildStepDisplayName: 'Install dependencies',
-              time: '2022-01-01T00:00:00.000Z',
-              msg: `line${index}`,
-            })
-          ).join('\n')
-        ),
-      ],
-      5
-    );
+    const output = formatActiveWorkflowRun([jobWithLogs(stepLines('step-id-1', 10))], 5);
 
     expect(output).toContain('line5');
     expect(output).toContain('line9');
     expect(output).not.toContain('line4');
+  });
+
+  test('keeps five trailing lines by default', () => {
+    const output = formatActiveWorkflowRun([jobWithLogs(stepLines('step-id-1', 10))]);
+
+    expect(output).toContain('line5');
+    expect(output).toContain('line9');
+    expect(output).not.toContain('line4');
+  });
+
+  test('reports the last step as the current one', () => {
+    const output = formatActiveWorkflowRun([
+      jobWithLogs([
+        { buildStepId: 'install', buildStepDisplayName: 'Install', msg: 'installing' },
+        { buildStepId: 'build', buildStepDisplayName: 'Build', msg: 'compiling' },
+      ]),
+    ]);
+
+    expect(output).toContain('Build');
+    expect(output).not.toContain('Install');
+  });
+
+  test('passes over a trailing skipped step', () => {
+    const output = formatActiveWorkflowRun([
+      jobWithLogs([
+        { buildStepId: 'install', buildStepDisplayName: 'Install', msg: 'installing' },
+        {
+          buildStepId: 'build',
+          buildStepDisplayName: 'Build',
+          msg: 'skipping',
+          marker: 'end-step',
+          result: 'skipped',
+        },
+      ]),
+    ]);
+
+    expect(output).toContain('Install');
+    expect(output).not.toContain('Build');
+  });
+
+  test('reports a step that has not ended yet', () => {
+    const output = formatActiveWorkflowRun([
+      jobWithLogs([
+        {
+          buildStepId: 'install',
+          buildStepDisplayName: 'Install',
+          msg: 'installed',
+          marker: 'end-step',
+          result: 'success',
+        },
+        { buildStepId: 'build', buildStepDisplayName: 'Build', msg: 'compiling' },
+      ]),
+    ]);
+
+    expect(output).toContain('Build');
+  });
+
+  test('omits the current step when the job has no steps yet', () => {
+    const output = formatActiveWorkflowRun([jobWithLogs([])]);
+
+    expect(output).not.toContain('Current step');
+    expect(output).not.toContain('Current logs');
+  });
+
+  test('omits the current step for a job that is not in progress', () => {
+    const output = formatActiveWorkflowRun([
+      jobWithLogs(stepLines('step-id-1', 3), WorkflowJobStatus.Success),
+    ]);
+
+    expect(output).not.toContain('Current step');
+    expect(output).not.toContain('line0');
+  });
+});
+
+describe(formatFailedWorkflowRun, () => {
+  test('prints every line of the failed step when there is no limit', () => {
+    const output = formatFailedWorkflowRun([
+      jobWithLogs(
+        [
+          ...stepLines('build', 8),
+          { buildStepId: 'build', msg: 'it failed', marker: 'end-step', result: 'fail' },
+        ],
+        WorkflowJobStatus.Failure
+      ),
+    ]);
+
+    expect(output).toContain('line0');
+    expect(output).toContain('line7');
   });
 });

--- a/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/parseLogs-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/parseLogs-test.ts
@@ -159,4 +159,28 @@ describe(groupLogLinesIntoSteps, () => {
 
     expect(logs.size).toBe(0);
   });
+
+  it('records the result of the first end marker and ignores a later one', () => {
+    const logs = groupLogLinesIntoSteps([
+      logLine({ buildStepId: 'install', msg: 'skipping', marker: 'end-step', result: 'skipped' }),
+      logLine({ buildStepId: 'install', msg: 'retried', marker: 'end-step', result: 'success' }),
+    ]);
+
+    expect(logs.get('install')?.result).toBe('skipped');
+  });
+
+  it('leaves the result undefined for a step that has not ended', () => {
+    const logs = groupLogLinesIntoSteps([logLine({ buildStepId: 'install', msg: 'npm ci' })]);
+
+    expect(logs.get('install')?.result).toBeUndefined();
+  });
+
+  it('records an end marker that carries no result and does not let a later one replace it', () => {
+    const logs = groupLogLinesIntoSteps([
+      logLine({ buildStepId: 'install', msg: 'ended', marker: 'END_PHASE' }),
+      logLine({ buildStepId: 'install', msg: 'retried', marker: 'END_PHASE', result: 'success' }),
+    ]);
+
+    expect(logs.get('install')?.result).toBe('');
+  });
 });

--- a/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/watcher-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/__tests__/watcher-test.ts
@@ -199,13 +199,14 @@ describe(WorkflowRunLogsWatcher, () => {
   });
 });
 
-function fileLine(logId: string, msg: string): WorkflowRawLogLine {
-  return { logId, buildStepId: 'install', msg };
+function fileLine(logId: string, msg: string, buildStepId = 'install'): WorkflowRawLogLine {
+  return { logId, buildStepId, msg };
 }
 
-function stepMessages(logsState: WorkflowJobLogsState, isCompleted = false): string[] {
-  const logs = logsState.getLogs({ isCompleted });
-  return Array.from(logs.values()).flatMap(group => group.logLines.map(line => line.msg));
+function stepMessages(logsState: WorkflowJobLogsState): string[] {
+  return Array.from(logsState.getLogs().values()).flatMap(group =>
+    group.logLines.map(logLine => logLine.msg)
+  );
 }
 
 describe(WorkflowJobLogsState, () => {
@@ -227,7 +228,7 @@ describe(WorkflowJobLogsState, () => {
     expect(stepMessages(logsState)).toEqual(['first', 'pushed', 'newer']);
   });
 
-  it('opens the gate when a publication repeats a logId already in the file', () => {
+  it('shows realtime logs when a publication repeats a logId already in the file', () => {
     const logsState = new WorkflowJobLogsState();
     logsState.ingestFileLogLines([fileLine('1', 'first')]);
     logsState.ingestRealtimeLogLines([fileLine('1', 'first'), fileLine('2', 'pushed')]);
@@ -235,12 +236,26 @@ describe(WorkflowJobLogsState, () => {
     expect(stepMessages(logsState)).toEqual(['first', 'pushed']);
   });
 
-  it('shows buffered realtime lines once the job is completed even without catch-up', () => {
+  it('shows buffered realtime lines once the job is completed', () => {
     const logsState = new WorkflowJobLogsState();
     logsState.ingestFileLogLines([fileLine('1', 'first')]);
     logsState.ingestRealtimeLogLines([fileLine('9', 'pushed')]);
 
-    expect(stepMessages(logsState, true)).toEqual(['first', 'pushed']);
+    logsState.markCompleted();
+    logsState.markCompleted();
+
+    expect(stepMessages(logsState)).toEqual(['first', 'pushed']);
+  });
+
+  it('folds later publications once completion showed them', () => {
+    const logsState = new WorkflowJobLogsState();
+    logsState.ingestFileLogLines([fileLine('1', 'first')]);
+    logsState.ingestRealtimeLogLines([fileLine('9', 'buffered')]);
+    logsState.markCompleted();
+
+    logsState.ingestRealtimeLogLines([fileLine('10', 'pushed')]);
+
+    expect(stepMessages(logsState)).toEqual(['first', 'buffered', 'pushed']);
   });
 
   it('replaces the file snapshot instead of accumulating it', () => {
@@ -279,5 +294,15 @@ describe(WorkflowJobLogsState, () => {
     logsState.ingestRealtimeLogLines([fileLine('2', 'pushed')]);
 
     expect(stepMessages(logsState)).toEqual(['first', 'pushed']);
+  });
+
+  it('deduplicates a line republished later', () => {
+    const logsState = new WorkflowJobLogsState();
+    logsState.ingestFileLogLines([fileLine('1', 'first')]);
+    logsState.ingestRealtimeLogLines([fileLine('1', 'first'), fileLine('2', 'pushed')]);
+    logsState.ingestRealtimeLogLines([fileLine('3', 'newer')]);
+    logsState.ingestRealtimeLogLines([fileLine('2', 'pushed')]);
+
+    expect(stepMessages(logsState)).toEqual(['first', 'pushed', 'newer']);
   });
 });

--- a/packages/eas-cli/src/commandUtils/workflow/logs/parseLogs.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/parseLogs.ts
@@ -29,9 +29,10 @@ export function mergeLogLines<T extends WorkflowRawLogLine>(...logLineGroups: T[
   return uniqBy(logLineGroups.flat().reverse(), logLine => logLine.logId ?? Symbol()).reverse();
 }
 
-export function groupLogLinesIntoSteps(logLines: WorkflowRawLogLine[]): WorkflowLogs {
-  const logs: WorkflowLogs = new Map();
-
+export function groupLogLinesIntoSteps(
+  logLines: WorkflowRawLogLine[],
+  accumulator: WorkflowLogs = new Map()
+): WorkflowLogs {
   for (const logLine of logLines) {
     const { buildStepDisplayName, buildStepId, phase, time, msg, result, marker, err } = logLine;
     const stepKey = buildStepId ?? buildStepDisplayName ?? phase;
@@ -40,18 +41,21 @@ export function groupLogLinesIntoSteps(logLines: WorkflowRawLogLine[]): Workflow
       continue;
     }
 
-    let logGroup = logs.get(stepKey);
+    let logGroup = accumulator.get(stepKey);
     if (!logGroup) {
       logGroup = { key: stepKey, label: stepLabel, logLines: [] };
-      logs.set(stepKey, logGroup);
+      accumulator.set(stepKey, logGroup);
     }
     if (buildStepDisplayName) {
       logGroup.label = buildStepDisplayName;
     }
+    if (logGroup.result === undefined && (marker === 'end-step' || marker === 'END_PHASE')) {
+      logGroup.result = result ?? '';
+    }
     logGroup.logLines.push({ time, msg, result, marker, err });
   }
 
-  return logs;
+  return accumulator;
 }
 
 export async function fetchAndParseLogsFromJobAsync(

--- a/packages/eas-cli/src/commandUtils/workflow/logs/watcher.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/logs/watcher.ts
@@ -21,15 +21,14 @@ function isRealtimeLogLine(entry: unknown): entry is RealtimeLogLine {
 }
 
 export class WorkflowJobLogsState {
-  private fileLogLines: WorkflowRawLogLine[] = [];
   private fileLogIds = new Set<string>();
   private realtimeLogLines: RealtimeLogLine[] = [];
+  private realtimeLogIds = new Set<string>();
   private haveFileLogsCaughtUp = false;
-  private cachedLogs: WorkflowLogs | null = null;
-  private cachedLogsIsCompleted = false;
+  private realtimeLogsRevealed = false;
+  private groupedLogs: WorkflowLogs = new Map();
 
   public ingestFileLogLines(logLines: WorkflowRawLogLine[]): void {
-    this.fileLogLines = logLines;
     this.fileLogIds = new Set(logLines.flatMap(logLine => (logLine.logId ? [logLine.logId] : [])));
 
     if (
@@ -41,7 +40,14 @@ export class WorkflowJobLogsState {
     this.realtimeLogLines = this.realtimeLogLines.filter(
       logLine => !this.fileLogIds.has(logLine.logId)
     );
-    this.cachedLogs = null;
+    this.realtimeLogIds = new Set(this.realtimeLogLines.map(logLine => logLine.logId));
+
+    if (this.haveFileLogsCaughtUp) {
+      this.realtimeLogsRevealed = true;
+    }
+    this.groupedLogs = groupLogLinesIntoSteps(
+      mergeLogLines(logLines, this.realtimeLogsRevealed ? this.realtimeLogLines : [])
+    );
   }
 
   public ingestRealtimeLogLines(data: unknown): boolean {
@@ -59,23 +65,40 @@ export class WorkflowJobLogsState {
     ) {
       this.haveFileLogsCaughtUp = true;
     }
-    this.realtimeLogLines = mergeLogLines(
-      this.realtimeLogLines,
-      publishedLogLines.filter(logLine => !this.fileLogIds.has(logLine.logId))
+
+    const newLogLines = publishedLogLines.filter(
+      logLine => !this.fileLogIds.has(logLine.logId) && !this.realtimeLogIds.has(logLine.logId)
     );
-    this.cachedLogs = null;
+    for (const logLine of newLogLines) {
+      this.realtimeLogLines.push(logLine);
+      this.realtimeLogIds.add(logLine.logId);
+    }
+
+    if (!this.realtimeLogsRevealed) {
+      if (this.haveFileLogsCaughtUp) {
+        this.revealRealtimeLogs();
+      }
+    } else if (newLogLines.length > 0) {
+      groupLogLinesIntoSteps(newLogLines, this.groupedLogs);
+    }
 
     return true;
   }
 
-  public getLogs({ isCompleted = false }: { isCompleted?: boolean } = {}): WorkflowLogs {
-    if (this.cachedLogs && this.cachedLogsIsCompleted === isCompleted) {
-      return this.cachedLogs;
+  public markCompleted(): void {
+    this.revealRealtimeLogs();
+  }
+
+  public getLogs(): WorkflowLogs {
+    return this.groupedLogs;
+  }
+
+  private revealRealtimeLogs(): void {
+    if (this.realtimeLogsRevealed) {
+      return;
     }
-    const realtimeLogLines = this.haveFileLogsCaughtUp || isCompleted ? this.realtimeLogLines : [];
-    this.cachedLogs = groupLogLinesIntoSteps(mergeLogLines(this.fileLogLines, realtimeLogLines));
-    this.cachedLogsIsCompleted = isCompleted;
-    return this.cachedLogs;
+    this.realtimeLogsRevealed = true;
+    groupLogLinesIntoSteps(this.realtimeLogLines, this.groupedLogs);
   }
 }
 

--- a/packages/eas-cli/src/commandUtils/workflow/types.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/types.ts
@@ -57,11 +57,11 @@ export type WorkflowRawLogLine = {
 export type WorkflowLogLine = Pick<WorkflowRawLogLine, 'time' | 'result' | 'marker' | 'err'> &
   Required<Pick<WorkflowRawLogLine, 'msg'>>;
 
-export type WorkflowLogs = Map<
-  string,
-  {
-    key: string;
-    label: string;
-    logLines: WorkflowLogLine[];
-  }
->;
+export type StepLogs = {
+  key: string;
+  label: string;
+  result?: string;
+  logLines: WorkflowLogLine[];
+};
+
+export type WorkflowLogs = Map<string, StepLogs>;

--- a/packages/eas-cli/src/commandUtils/workflow/utils.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/utils.ts
@@ -87,19 +87,13 @@ export function choicesFromWorkflowLogs(
   logs: WorkflowLogs
 ): (Choice & { name: string; status: string; logLines: WorkflowLogLine[] | undefined })[] {
   return Array.from(logs.values())
-    .map(({ key, label, logLines }) => {
-      const stepStatus =
-        logLines?.filter(
-          (line: WorkflowLogLine) => line.marker === 'end-step' || line.marker === 'END_PHASE'
-        )[0]?.result ?? '';
-      return {
-        title: `${label} - ${stepStatus}`,
-        name: label,
-        status: stepStatus,
-        value: key,
-        logLines,
-      };
-    })
+    .map(({ key, label, result, logLines }) => ({
+      title: `${label} - ${result ?? ''}`,
+      name: label,
+      status: result ?? '',
+      value: key,
+      logLines,
+    }))
     .filter(step => step.status !== 'skipped');
 }
 
@@ -144,6 +138,21 @@ function descriptionForJobStatus(status: WorkflowJobStatus): string {
   }
 }
 
+function isJobCompleted(status: WorkflowJobStatus): boolean {
+  switch (status) {
+    case WorkflowJobStatus.Success:
+    case WorkflowJobStatus.Failure:
+    case WorkflowJobStatus.Canceled:
+    case WorkflowJobStatus.Skipped:
+      return true;
+    case WorkflowJobStatus.New:
+    case WorkflowJobStatus.InProgress:
+    case WorkflowJobStatus.ActionRequired:
+    case WorkflowJobStatus.PendingCancel:
+      return false;
+  }
+}
+
 type WorkflowRunWithJobs = WorkflowRunByIdWithJobsQuery['workflowRuns']['byId'];
 
 type JobWithLogs = {
@@ -155,8 +164,9 @@ function stepLogTail(
   step: { logLines?: WorkflowLogLine[] },
   maxLogLines: number // -1 means no limit
 ): string[] {
-  const messages = step.logLines?.map(line => line.msg) ?? [];
-  return maxLogLines === -1 ? messages : messages.slice(-maxLogLines);
+  const logLines = step.logLines ?? [];
+  const tail = maxLogLines === -1 ? logLines : logLines.slice(-maxLogLines);
+  return tail.map(line => line.msg);
 }
 
 export async function logsForFailedWorkflowRunAsync(
@@ -307,6 +317,14 @@ export async function showWorkflowStatusAsync(
               prefixText: chalk`{bold.green Workflow run is in progress:}`,
             });
             const logsStates = await watcher.syncJobsAsync(workflowRun.jobs);
+            for (const job of workflowRun.jobs) {
+              if (isJobCompleted(job.status)) {
+                nullthrows(
+                  logsStates.get(job.id),
+                  'syncJobsAsync must have been called before markCompleted'
+                ).markCompleted();
+              }
+            }
             renderActiveWorkflowRun = () => {
               const text = formatActiveWorkflowRun(
                 workflowRun.jobs.map(job => ({
@@ -314,11 +332,8 @@ export async function showWorkflowStatusAsync(
                   logs: nullthrows(
                     logsStates.get(job.id),
                     'syncJobsAsync must have been called before getLogs'
-                  ).getLogs({
-                    isCompleted: job.status !== WorkflowJobStatus.InProgress,
-                  }),
-                })),
-                5
+                  ).getLogs(),
+                }))
               );
               updateSpinnerText(spinner, { text });
             };


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why

Logs displayed by `workflow:run --wait` rebuild the entire stored logs on every realtime logs message, which hurts the performance when displaying large workflow runs with many MB of logs.

# How

- Updated `WorkflowJobLogsState` to maintain the current parsed logs and update them in place on realtime logs publications instead of rebuilding them from scratch on every publication.
- Updated `groupLogLinesIntoSteps` to take an accumulator argument for the result instead of building it from scratch
- Updated `stepLogTail` to slice then map, to prevent iterating over log lines

Separated this out of #4228 because I didn't want to complicate that PR too much. We should merge this into #4228 before merging to main.

# Test Plan

CI passes with new tests, `workflow:run --wait` tested manually

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>