### PR TITLE
[build-tools] Lower serve-sim preview resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Reduce serve-sim preview resolution from 1280 px to 960 px to lower streaming bandwidth. ([#4297](https://github.com/expo/eas-cli/pull/4297) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 - [worker] Use turtle cache upload and download URLs for eas.json build cache restore and save. ([#3860](https://github.com/expo/eas-cli/pull/3860) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -132,7 +132,7 @@ describe(createServeSimArgs, () => {
       '--webrtc-codec',
       'vp8',
       '--max-dimension',
-      '1280',
+      '960',
       '--mjpeg-quality',
       '0.55',
       '--video-bitrate',

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -21,7 +21,7 @@ import { turtleFetch } from '../../utils/turtleFetch';
 const XCODE_DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer';
 const SERVE_SIM_PACKAGE_NAME = '@expo/serve-sim';
 const SERVE_SIM_HOST = '127.0.0.1';
-const SERVE_SIM_MAX_DIMENSION = '1280';
+const SERVE_SIM_MAX_DIMENSION = '960';
 const SERVE_SIM_MJPEG_QUALITY = '0.55';
 const SERVE_SIM_VIDEO_BITRATE = '6000000';
 const SERVE_SIM_VIDEO_FPS = '60';


### PR DESCRIPTION
# Why

Reduce the bandwidth and rendering cost of remote simulator previews while keeping them clear enough for interactive use.

# How

- lower serve-sim's maximum preview dimension from 1280 px to 960 px
- update the streaming-policy unit test to lock in the new default

# Test Plan

- `corepack yarn workspace @expo/build-tools jest-unit src/steps/utils/__tests__/remoteDeviceRunSession.test.ts --runInBand` (31 tests passed)
- `corepack yarn workspace @expo/build-tools typecheck`
- type-aware oxlint on both modified files
- targeted oxfmt check