### PR TITLE
[eas-cli] Rename serve-sim session type to web-preview-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
-- [eas-cli] Rename the EAS Simulator web preview session type from `--type serve-sim` to `--type web-preview`. ([#4298](https://github.com/expo/eas-cli/pull/4298) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Rename the EAS Simulator preview-only session type from `--type serve-sim` to `--type web-preview-only`. ([#4298](https://github.com/expo/eas-cli/pull/4298) by [@szdziedzic](https://github.com/szdziedzic))
 
 ### 🎉 New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- [eas-cli] Rename the EAS Simulator web preview session type from `--type serve-sim` to `--type web-preview`. ([#4298](https://github.com/expo/eas-cli/pull/4298) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🎉 New features
 
 - [build-tools] Cache CocoaPods dependencies between iOS builds. ([#4266](https://github.com/expo/eas-cli/pull/4266) by [@AbbanMustafa](https://github.com/AbbanMustafa))

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -2556,8 +2556,8 @@ _See code: [packages/eas-cli/src/commands/project/new.ts](https://github.com/exp
 USAGE
   $ eas sim [-p android|ios] [--name <value>] [--device <value>] [--build-id <value> |
     --application-archive-url <value> | --expo-go] [--sdk-version <value>] [--launch-arg <value>...] [--open-url
-    <value>] [--type agent-device|appium|argent|serve-sim] [--package-version <value>] [--max-duration-minutes <value>]
-    [--max-idle-time-minutes <value>] [--force] [--out-config-type env|dotenv] [--json] [--non-interactive]
+    <value>] [--type agent-device|appium|argent|web-preview] [--package-version <value>] [--max-duration-minutes
+    <value>] [--max-idle-time-minutes <value>] [--force] [--out-config-type env|dotenv] [--json] [--non-interactive]
 
 FLAGS
   -p, --platform=<option>                Device platform
@@ -2595,7 +2595,7 @@ FLAGS
       --sdk-version=<value>              Expo SDK version used to select Expo Go when --expo-go is passed. Defaults to
                                          the current project SDK.
       --type=<option>                    [default: agent-device] Type of simulator session to create
-                                         <options: agent-device|appium|argent|serve-sim>
+                                         <options: agent-device|appium|argent|web-preview>
 
 DESCRIPTION
   [EXPERIMENTAL] start a remote simulator session on EAS and get instructions to connect to it
@@ -2688,7 +2688,7 @@ ALIASES
 ```
 USAGE
   $ eas sim:list [--status new|in-progress|stopped|errored...] [--type
-    agent-device|appium|argent|serve-sim...] [--platform android|ios...] [--name <value>] [--limit <value>] [--after
+    agent-device|appium|argent|web-preview...] [--platform android|ios...] [--name <value>] [--limit <value>] [--after
     <value>] [--json] [--non-interactive]
 
 FLAGS
@@ -2702,7 +2702,7 @@ FLAGS
   --status=<option>...    Filter by session status (repeatable)
                           <options: new|in-progress|stopped|errored>
   --type=<option>...      Filter by session type (repeatable)
-                          <options: agent-device|appium|argent|serve-sim>
+                          <options: agent-device|appium|argent|web-preview>
 
 DESCRIPTION
   [EXPERIMENTAL] list remote simulator sessions for the current project
@@ -2719,8 +2719,8 @@ ALIASES
 USAGE
   $ eas sim:start [-p android|ios] [--name <value>] [--device <value>] [--build-id <value> |
     --application-archive-url <value> | --expo-go] [--sdk-version <value>] [--launch-arg <value>...] [--open-url
-    <value>] [--type agent-device|appium|argent|serve-sim] [--package-version <value>] [--max-duration-minutes <value>]
-    [--max-idle-time-minutes <value>] [--force] [--out-config-type env|dotenv] [--json] [--non-interactive]
+    <value>] [--type agent-device|appium|argent|web-preview] [--package-version <value>] [--max-duration-minutes
+    <value>] [--max-idle-time-minutes <value>] [--force] [--out-config-type env|dotenv] [--json] [--non-interactive]
 
 FLAGS
   -p, --platform=<option>                Device platform
@@ -2758,7 +2758,7 @@ FLAGS
       --sdk-version=<value>              Expo SDK version used to select Expo Go when --expo-go is passed. Defaults to
                                          the current project SDK.
       --type=<option>                    [default: agent-device] Type of simulator session to create
-                                         <options: agent-device|appium|argent|serve-sim>
+                                         <options: agent-device|appium|argent|web-preview>
 
 DESCRIPTION
   [EXPERIMENTAL] start a remote simulator session on EAS and get instructions to connect to it
@@ -2797,8 +2797,8 @@ ALIASES
 USAGE
   $ eas simulator:start [-p android|ios] [--name <value>] [--device <value>] [--build-id <value> |
     --application-archive-url <value> | --expo-go] [--sdk-version <value>] [--launch-arg <value>...] [--open-url
-    <value>] [--type agent-device|appium|argent|serve-sim] [--package-version <value>] [--max-duration-minutes <value>]
-    [--max-idle-time-minutes <value>] [--force] [--out-config-type env|dotenv] [--json] [--non-interactive]
+    <value>] [--type agent-device|appium|argent|web-preview] [--package-version <value>] [--max-duration-minutes
+    <value>] [--max-idle-time-minutes <value>] [--force] [--out-config-type env|dotenv] [--json] [--non-interactive]
 
 FLAGS
   -p, --platform=<option>                Device platform
@@ -2836,7 +2836,7 @@ FLAGS
       --sdk-version=<value>              Expo SDK version used to select Expo Go when --expo-go is passed. Defaults to
                                          the current project SDK.
       --type=<option>                    [default: agent-device] Type of simulator session to create
-                                         <options: agent-device|appium|argent|serve-sim>
+                                         <options: agent-device|appium|argent|web-preview>
 
 DESCRIPTION
   [EXPERIMENTAL] start a remote simulator session on EAS and get instructions to connect to it

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -2556,7 +2556,7 @@ _See code: [packages/eas-cli/src/commands/project/new.ts](https://github.com/exp
 USAGE
   $ eas sim [-p android|ios] [--name <value>] [--device <value>] [--build-id <value> |
     --application-archive-url <value> | --expo-go] [--sdk-version <value>] [--launch-arg <value>...] [--open-url
-    <value>] [--type agent-device|appium|argent|web-preview] [--package-version <value>] [--max-duration-minutes
+    <value>] [--type agent-device|appium|argent|web-preview-only] [--package-version <value>] [--max-duration-minutes
     <value>] [--max-idle-time-minutes <value>] [--force] [--out-config-type env|dotenv] [--json] [--non-interactive]
 
 FLAGS
@@ -2594,8 +2594,10 @@ FLAGS
                                          Defaults to "latest" when omitted.
       --sdk-version=<value>              Expo SDK version used to select Expo Go when --expo-go is passed. Defaults to
                                          the current project SDK.
-      --type=<option>                    [default: agent-device] Type of simulator session to create
-                                         <options: agent-device|appium|argent|web-preview>
+      --type=<option>                    [default: agent-device] Type of simulator session to create. All session types
+                                         include a web preview. agent-device, appium, and argent also include an
+                                         automation interface; web-preview-only includes no automation interface.
+                                         <options: agent-device|appium|argent|web-preview-only>
 
 DESCRIPTION
   [EXPERIMENTAL] start a remote simulator session on EAS and get instructions to connect to it
@@ -2688,8 +2690,8 @@ ALIASES
 ```
 USAGE
   $ eas sim:list [--status new|in-progress|stopped|errored...] [--type
-    agent-device|appium|argent|web-preview...] [--platform android|ios...] [--name <value>] [--limit <value>] [--after
-    <value>] [--json] [--non-interactive]
+    agent-device|appium|argent|web-preview-only...] [--platform android|ios...] [--name <value>] [--limit <value>]
+    [--after <value>] [--json] [--non-interactive]
 
 FLAGS
   --after=<value>         Cursor for pagination. Use the endCursor from a previous query to fetch the next page.
@@ -2701,8 +2703,10 @@ FLAGS
                           <options: android|ios>
   --status=<option>...    Filter by session status (repeatable)
                           <options: new|in-progress|stopped|errored>
-  --type=<option>...      Filter by session type (repeatable)
-                          <options: agent-device|appium|argent|web-preview>
+  --type=<option>...      Filter by session type (repeatable). All session types include a web preview. agent-device,
+                          appium, and argent also include an automation interface; web-preview-only includes no
+                          automation interface.
+                          <options: agent-device|appium|argent|web-preview-only>
 
 DESCRIPTION
   [EXPERIMENTAL] list remote simulator sessions for the current project
@@ -2719,7 +2723,7 @@ ALIASES
 USAGE
   $ eas sim:start [-p android|ios] [--name <value>] [--device <value>] [--build-id <value> |
     --application-archive-url <value> | --expo-go] [--sdk-version <value>] [--launch-arg <value>...] [--open-url
-    <value>] [--type agent-device|appium|argent|web-preview] [--package-version <value>] [--max-duration-minutes
+    <value>] [--type agent-device|appium|argent|web-preview-only] [--package-version <value>] [--max-duration-minutes
     <value>] [--max-idle-time-minutes <value>] [--force] [--out-config-type env|dotenv] [--json] [--non-interactive]
 
 FLAGS
@@ -2757,8 +2761,10 @@ FLAGS
                                          Defaults to "latest" when omitted.
       --sdk-version=<value>              Expo SDK version used to select Expo Go when --expo-go is passed. Defaults to
                                          the current project SDK.
-      --type=<option>                    [default: agent-device] Type of simulator session to create
-                                         <options: agent-device|appium|argent|web-preview>
+      --type=<option>                    [default: agent-device] Type of simulator session to create. All session types
+                                         include a web preview. agent-device, appium, and argent also include an
+                                         automation interface; web-preview-only includes no automation interface.
+                                         <options: agent-device|appium|argent|web-preview-only>
 
 DESCRIPTION
   [EXPERIMENTAL] start a remote simulator session on EAS and get instructions to connect to it
@@ -2797,7 +2803,7 @@ ALIASES
 USAGE
   $ eas simulator:start [-p android|ios] [--name <value>] [--device <value>] [--build-id <value> |
     --application-archive-url <value> | --expo-go] [--sdk-version <value>] [--launch-arg <value>...] [--open-url
-    <value>] [--type agent-device|appium|argent|web-preview] [--package-version <value>] [--max-duration-minutes
+    <value>] [--type agent-device|appium|argent|web-preview-only] [--package-version <value>] [--max-duration-minutes
     <value>] [--max-idle-time-minutes <value>] [--force] [--out-config-type env|dotenv] [--json] [--non-interactive]
 
 FLAGS
@@ -2835,8 +2841,10 @@ FLAGS
                                          Defaults to "latest" when omitted.
       --sdk-version=<value>              Expo SDK version used to select Expo Go when --expo-go is passed. Defaults to
                                          the current project SDK.
-      --type=<option>                    [default: agent-device] Type of simulator session to create
-                                         <options: agent-device|appium|argent|web-preview>
+      --type=<option>                    [default: agent-device] Type of simulator session to create. All session types
+                                         include a web preview. agent-device, appium, and argent also include an
+                                         automation interface; web-preview-only includes no automation interface.
+                                         <options: agent-device|appium|argent|web-preview-only>
 
 DESCRIPTION
   [EXPERIMENTAL] start a remote simulator session on EAS and get instructions to connect to it

--- a/packages/eas-cli/src/commands/simulator/__tests__/get.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/get.test.ts
@@ -122,7 +122,13 @@ describe(SimulatorGet, () => {
   }
 
   it('emits JSON when --json is passed', async () => {
-    const session = makeDeviceRunSession();
+    const session = makeDeviceRunSession({
+      type: DeviceRunSessionType.ServeSim,
+      remoteConfig: {
+        __typename: 'ServeSimRunSessionRemoteConfig',
+        previewUrl: 'https://preview.example.com',
+      },
+    });
     mockByIdAsync.mockResolvedValue(session);
 
     const { command, getContextAsync } = createCommand(['--id', 'session-123', '--json']);
@@ -137,7 +143,7 @@ describe(SimulatorGet, () => {
     expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
       id: 'session-123',
       name: undefined,
-      type: 'agent-device',
+      type: 'web-preview',
       status: DeviceRunSessionStatus.InProgress,
       platform: AppPlatform.Ios,
       createdAt: '2025-01-01T00:00:00.000Z',

--- a/packages/eas-cli/src/commands/simulator/__tests__/get.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/get.test.ts
@@ -143,7 +143,7 @@ describe(SimulatorGet, () => {
     expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
       id: 'session-123',
       name: undefined,
-      type: 'web-preview',
+      type: 'web-preview-only',
       status: DeviceRunSessionStatus.InProgress,
       platform: AppPlatform.Ios,
       createdAt: '2025-01-01T00:00:00.000Z',

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -332,6 +332,33 @@ describe(Simulator, () => {
     );
   });
 
+  it('creates a ServeSim session for --type web-preview', async () => {
+    mockByIdAsync.mockResolvedValue(
+      makeDeviceRunSession({
+        type: DeviceRunSessionType.ServeSim,
+        remoteConfig: {
+          __typename: 'ServeSimRunSessionRemoteConfig',
+          previewUrl: 'https://preview.example.test',
+        },
+      })
+    );
+
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--type',
+      'web-preview',
+      '--non-interactive',
+    ]);
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ type: DeviceRunSessionType.ServeSim })
+    );
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('https://preview.example.test'));
+  });
+
   it('overwrites .env.eas-simulator when outputting dotenv and the file exists', async () => {
     const { command } = createCommand([
       '--platform',

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -332,7 +332,7 @@ describe(Simulator, () => {
     );
   });
 
-  it('creates a ServeSim session for --type web-preview', async () => {
+  it('creates a ServeSim session for --type web-preview-only', async () => {
     mockByIdAsync.mockResolvedValue(
       makeDeviceRunSession({
         type: DeviceRunSessionType.ServeSim,
@@ -347,7 +347,7 @@ describe(Simulator, () => {
       '--platform',
       'ios',
       '--type',
-      'web-preview',
+      'web-preview-only',
       '--non-interactive',
     ]);
     await command.runAsync();

--- a/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
@@ -132,7 +132,7 @@ describe(SimulatorList, () => {
         {
           id: 'session-123',
           name: undefined,
-          type: 'web-preview',
+          type: 'web-preview-only',
           status: DeviceRunSessionStatus.InProgress,
           platform: AppPlatform.Ios,
           createdAt: '2025-01-01T00:00:00.000Z',
@@ -163,7 +163,7 @@ describe(SimulatorList, () => {
       '--type',
       'appium',
       '--type',
-      'web-preview',
+      'web-preview-only',
       '--platform',
       'ios',
       '--name',

--- a/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/list.test.ts
@@ -111,7 +111,7 @@ describe(SimulatorList, () => {
   }
 
   it('emits JSON when --json is passed', async () => {
-    const session = makeSession();
+    const session = makeSession({ type: DeviceRunSessionType.ServeSim });
     mockListByAppIdAsync.mockResolvedValue(makeConnection([session]));
 
     const { command, getContextAsync } = createCommand(['--json']);
@@ -132,7 +132,7 @@ describe(SimulatorList, () => {
         {
           id: 'session-123',
           name: undefined,
-          type: 'agent-device',
+          type: 'web-preview',
           status: DeviceRunSessionStatus.InProgress,
           platform: AppPlatform.Ios,
           createdAt: '2025-01-01T00:00:00.000Z',
@@ -162,6 +162,8 @@ describe(SimulatorList, () => {
       'new',
       '--type',
       'appium',
+      '--type',
+      'web-preview',
       '--platform',
       'ios',
       '--name',
@@ -179,7 +181,7 @@ describe(SimulatorList, () => {
       after: 'page-cursor',
       filter: {
         statuses: [DeviceRunSessionStatus.InProgress, DeviceRunSessionStatus.New],
-        types: [DeviceRunSessionType.Appium],
+        types: [DeviceRunSessionType.Appium, DeviceRunSessionType.ServeSim],
         platforms: [AppPlatform.Ios],
         name: 'checkout',
       },

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -103,7 +103,8 @@ export default class Simulator extends EasCommand {
         'Expo or development-client URL to open in the installed application after it launches.',
     }),
     type: Flags.option({
-      description: 'Type of simulator session to create',
+      description:
+        'Type of simulator session to create. All session types include a web preview. agent-device, appium, and argent also include an automation interface; web-preview-only includes no automation interface.',
       options: Object.values(DEVICE_RUN_SESSION_TYPE_FLAG_VALUES),
       default: DEVICE_RUN_SESSION_TYPE_FLAG_VALUES[DeviceRunSessionType.AgentDevice],
     })(),

--- a/packages/eas-cli/src/commands/simulator/list.ts
+++ b/packages/eas-cli/src/commands/simulator/list.ts
@@ -61,7 +61,8 @@ export default class SimulatorList extends EasCommand {
       multiple: true,
     })(),
     type: Flags.option({
-      description: 'Filter by session type (repeatable)',
+      description:
+        'Filter by session type (repeatable). All session types include a web preview. agent-device, appium, and argent also include an automation interface; web-preview-only includes no automation interface.',
       options: Object.values(DEVICE_RUN_SESSION_TYPE_FLAG_VALUES),
       multiple: true,
     })(),

--- a/packages/eas-cli/src/simulator/__tests__/utils.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/utils.test.ts
@@ -2,6 +2,8 @@ import { DeviceRunSessionResourceClass, DeviceRunSessionType } from '../../graph
 import {
   DEVICE_RUN_SESSION_RESOURCE_CLASS_BY_FLAG_VALUE,
   DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE,
+  DEVICE_RUN_SESSION_TYPE_FLAG_VALUES,
+  deviceRunSessionTypeToFlagValue,
   formatRemoteSessionInstructions,
   getRemoteSessionEnvironmentVariables,
 } from '../utils';
@@ -36,6 +38,17 @@ describe('Appium simulator configuration', () => {
     expect(instructions).toContain('eas simulator:exec <appium-client> [args...]');
     expect(instructions).toContain('https://preview.example.test');
     expect(instructions).not.toContain('https://appium.example.test');
+  });
+});
+
+describe('simulator session type flags', () => {
+  it('maps web-preview to the ServeSim GraphQL enum', () => {
+    expect(DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE['web-preview']).toBe(
+      DeviceRunSessionType.ServeSim
+    );
+    expect(DEVICE_RUN_SESSION_TYPE_FLAG_VALUES[DeviceRunSessionType.ServeSim]).toBe('web-preview');
+    expect(deviceRunSessionTypeToFlagValue(DeviceRunSessionType.ServeSim)).toBe('web-preview');
+    expect(DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE['serve-sim']).toBeUndefined();
   });
 });
 

--- a/packages/eas-cli/src/simulator/__tests__/utils.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/utils.test.ts
@@ -42,13 +42,16 @@ describe('Appium simulator configuration', () => {
 });
 
 describe('simulator session type flags', () => {
-  it('maps web-preview to the ServeSim GraphQL enum', () => {
-    expect(DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE['web-preview']).toBe(
+  it('maps web-preview-only to the ServeSim GraphQL enum', () => {
+    expect(DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE['web-preview-only']).toBe(
       DeviceRunSessionType.ServeSim
     );
-    expect(DEVICE_RUN_SESSION_TYPE_FLAG_VALUES[DeviceRunSessionType.ServeSim]).toBe('web-preview');
-    expect(deviceRunSessionTypeToFlagValue(DeviceRunSessionType.ServeSim)).toBe('web-preview');
+    expect(DEVICE_RUN_SESSION_TYPE_FLAG_VALUES[DeviceRunSessionType.ServeSim]).toBe(
+      'web-preview-only'
+    );
+    expect(deviceRunSessionTypeToFlagValue(DeviceRunSessionType.ServeSim)).toBe('web-preview-only');
     expect(DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE['serve-sim']).toBeUndefined();
+    expect(DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE['web-preview']).toBeUndefined();
   });
 });
 

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -28,7 +28,7 @@ export const DEVICE_RUN_SESSION_TYPE_FLAG_VALUES: Record<DeviceRunSessionType, s
   [DeviceRunSessionType.AgentDevice]: 'agent-device',
   [DeviceRunSessionType.Appium]: 'appium',
   [DeviceRunSessionType.Argent]: 'argent',
-  [DeviceRunSessionType.ServeSim]: 'web-preview',
+  [DeviceRunSessionType.ServeSim]: 'web-preview-only',
 };
 
 export const DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE = Object.fromEntries(

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -28,7 +28,7 @@ export const DEVICE_RUN_SESSION_TYPE_FLAG_VALUES: Record<DeviceRunSessionType, s
   [DeviceRunSessionType.AgentDevice]: 'agent-device',
   [DeviceRunSessionType.Appium]: 'appium',
   [DeviceRunSessionType.Argent]: 'argent',
-  [DeviceRunSessionType.ServeSim]: 'serve-sim',
+  [DeviceRunSessionType.ServeSim]: 'web-preview',
 };
 
 export const DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE = Object.fromEntries(


### PR DESCRIPTION
# Why

The preview-only simulator session type is exposed as `--type serve-sim`, which leaks the implementation package name. Every EAS Simulator session type includes a web preview, so call this mode `web-preview-only` to distinguish it from the controller-backed types.

# How

- Map the backend `ServeSim` session type to the `web-preview-only` CLI flag value.
- Explain in the start and list flag help that every type includes a web preview, while `agent-device`, `appium`, and `argent` also include an automation interface.
- Cover session creation, list filtering, and JSON output from `simulator:list` and `simulator:get`.
- Regenerate the CLI README so every simulator alias advertises the new value.

# Test Plan

- `yarn test src/simulator/__tests__/utils.test.ts src/commands/simulator/__tests__/index.test.ts src/commands/simulator/__tests__/list.test.ts src/commands/simulator/__tests__/get.test.ts --runInBand`
- `yarn typecheck`
- `yarn lint`
- `yarn fmt:check`
