### PR TITLE
[eas-cli] Add dynamic retries for deploy command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Prevent user npm minimum release age settings from applying to internal EAS CLI commands. ([#4296](https://github.com/expo/eas-cli/pull/4296) by [@sjchmiela](https://github.com/sjchmiela))
 - [build-tools] Reduce serve-sim preview resolution from 1280 px to 960 px to lower streaming bandwidth. ([#4297](https://github.com/expo/eas-cli/pull/4297) by [@szdziedzic](https://github.com/szdziedzic))
+- [eas-cli] Add dynamic retries to deploy command that scale up more generously, depending on deployment size ([#4299](https://github.com/expo/eas-cli/pull/4299) by [@kitten](https://github.com/kitten))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/worker/__tests__/upload.test.ts
+++ b/packages/eas-cli/src/worker/__tests__/upload.test.ts
@@ -4,11 +4,11 @@ import fetch, { Headers, Response } from 'node-fetch';
 import Log from '../../log';
 import { AssetFileEntry } from '../assets';
 import {
+  UploadPayload,
   batchUploadAsync,
   callUploadApiAsync,
   createProgressBar,
   uploadAsync,
-  UploadPayload,
 } from '../upload';
 
 jest.mock('node-fetch', () => ({
@@ -180,6 +180,36 @@ describe(uploadAsync, () => {
     expect(mockedFetch).toHaveBeenCalledTimes(9);
   });
 
+  it('keeps the retry state when it switches to network mode', async () => {
+    let calls = 0;
+    mockedFetch.mockImplementation(async () => {
+      if (++calls <= 7) {
+        return response(503, { error: 'overloaded' });
+      }
+      throw new Error('socket disconnected');
+    });
+
+    const promise = uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset }, undefined, {
+      totalRequests: 1_000,
+    });
+    await runTimersAndExpectRejection(promise, 'socket disconnected');
+
+    // The warning must not repeat once the network-mode attempts take over.
+    expect(Log.warn).toHaveBeenCalledTimes(1);
+    expect(Log.warn).toHaveBeenCalledWith(
+      'The upload encountered an error but is still retrying: overloaded'
+    );
+  });
+
+  it('warns before a short retry budget is exhausted', async () => {
+    mockedFetch.mockImplementation(async () => response(503, { error: 'overloaded' }));
+
+    const promise = uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset });
+    await runTimersAndExpectRejection(promise, 'overloaded');
+
+    expect(Log.warn).toHaveBeenCalledTimes(1);
+  });
+
   it('does not retry or enter network mode after cancellation', async () => {
     const controller = new AbortController();
     controller.abort();
@@ -222,7 +252,8 @@ describe(callUploadApiAsync, () => {
 
     const promise = callUploadApiAsync('https://eas.expo.app/finalize');
     await runTimersAndExpectRejection(promise, 'Deployment failed: Request failed');
-    expect(mockedFetch).toHaveBeenCalledTimes(5);
+    // Deploy API calls get a much larger retry budget than a single asset upload.
+    expect(mockedFetch).toHaveBeenCalledTimes(11);
   });
 
   it('retries invalid JSON responses', async () => {
@@ -242,7 +273,7 @@ describe(callUploadApiAsync, () => {
 
     const promise = callUploadApiAsync('https://eas.expo.app/finalize');
     await runTimersAndExpectRejection(promise, networkError.message);
-    expect(mockedFetch).toHaveBeenCalledTimes(8);
+    expect(mockedFetch).toHaveBeenCalledTimes(14);
   });
 
   it('does not retry an aborted request', async () => {
@@ -308,7 +339,9 @@ describe(batchUploadAsync, () => {
         return response(400, { error: 'terminal failure' });
       }
       return await new Promise((_resolve, reject) => {
-        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        init?.signal?.addEventListener('abort', () => {
+          reject(new Error('aborted'));
+        });
       });
     });
 

--- a/packages/eas-cli/src/worker/__tests__/upload.test.ts
+++ b/packages/eas-cli/src/worker/__tests__/upload.test.ts
@@ -224,8 +224,8 @@ describe(uploadAsync, () => {
     expect(Date.now()).toBeLessThanOrEqual(40_000 + 10_000);
   });
 
-  it('clears the retry clock and the network flag after a success', async () => {
-    const state = { hasSeenNetworkError: false, hasWarned: false, firstRetryAt: undefined };
+  it('clears the network flag after a success', async () => {
+    const state = { shared: { hasSeenNetworkError: false, hasWarned: false } };
     mockedFetch.mockResolvedValueOnce(response(503)).mockResolvedValueOnce(response());
 
     const promise = uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset }, undefined, {
@@ -234,8 +234,25 @@ describe(uploadAsync, () => {
     await jest.runAllTimersAsync();
     await promise;
 
-    expect(state.firstRetryAt).toBeUndefined();
-    expect(state.hasSeenNetworkError).toBe(false);
+    expect(state.shared.hasSeenNetworkError).toBe(false);
+  });
+
+  it('keeps retry warning clocks independent when retry state is shared', async () => {
+    const shared = { hasSeenNetworkError: false, hasWarned: false };
+    mockedFetch
+      .mockResolvedValueOnce(response(503, { error: 'overloaded' }))
+      .mockResolvedValueOnce(response())
+      .mockImplementation(async () => response(503, { error: 'overloaded' }));
+
+    const retryingUpload = uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset }, undefined, {
+      state: { shared },
+    });
+    await uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset }, undefined, {
+      state: { shared },
+    });
+    await runTimersAndExpectRejection(retryingUpload, 'overloaded');
+
+    expect(Log.warn).toHaveBeenCalledTimes(1);
   });
 
   it('does not retry or enter network mode after cancellation', async () => {

--- a/packages/eas-cli/src/worker/__tests__/upload.test.ts
+++ b/packages/eas-cli/src/worker/__tests__/upload.test.ts
@@ -1,0 +1,346 @@
+import cliProgress from 'cli-progress';
+import fetch, { Headers, Response } from 'node-fetch';
+
+import Log from '../../log';
+import { AssetFileEntry } from '../assets';
+import {
+  batchUploadAsync,
+  callUploadApiAsync,
+  createProgressBar,
+  uploadAsync,
+  UploadPayload,
+} from '../upload';
+
+jest.mock('node-fetch', () => ({
+  ...jest.requireActual('node-fetch'),
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockedFetch = jest.mocked(fetch);
+
+const asset: AssetFileEntry = {
+  normalizedPath: 'index.html',
+  path: __filename,
+  size: 123,
+  sha512: 'a'.repeat(128),
+  type: 'text/html',
+};
+
+const response = (status = 200, body: unknown = { success: true }): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? 'OK' : 'Request failed',
+    headers: { 'content-type': 'application/json' },
+  });
+
+async function runTimersAndExpectRejection(
+  promise: Promise<unknown>,
+  expected: string | RegExp
+): Promise<void> {
+  const expectation = expect(promise).rejects.toThrow(expected);
+  await jest.runAllTimersAsync();
+  await expectation;
+}
+
+describe(uploadAsync, () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ now: 0 });
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    mockedFetch.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('uploads an individual asset with its hash and metadata', async () => {
+    mockedFetch.mockResolvedValue(response());
+
+    const result = await uploadAsync({ baseURL: 'https://eas.expo.app/?token=secret' }, { asset });
+
+    expect(result.payload).toEqual({ asset });
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockedFetch.mock.calls[0];
+    expect(String(url)).toBe(`https://eas.expo.app/asset/${asset.sha512}?token=secret`);
+    expect(init?.method).toBe('POST');
+    expect((init?.headers as Headers).get('content-type')).toBe('text/html');
+    expect((init?.headers as Headers).get('content-length')).toBe('123');
+    expect(init?.body).toBeDefined();
+  });
+
+  it('uploads a worker deployment file without changing the URL', async () => {
+    mockedFetch.mockResolvedValue(response());
+
+    await uploadAsync({ baseURL: 'https://eas.expo.app/deploy' }, { filePath: __filename });
+
+    const [url, init] = mockedFetch.mock.calls[0];
+    expect(String(url)).toBe('https://eas.expo.app/deploy');
+    expect(init?.method).toBe('POST');
+    expect(init?.body).toBeDefined();
+  });
+
+  it('uploads multipart assets to the batch endpoint and reports progress', async () => {
+    mockedFetch.mockResolvedValue(response());
+    const onProgress = jest.fn();
+
+    await uploadAsync(
+      { baseURL: 'https://eas.expo.app/asset/?token=secret' },
+      { multipart: [asset, { ...asset, sha512: 'b'.repeat(128) }] },
+      onProgress
+    );
+
+    const [url, init] = mockedFetch.mock.calls[0];
+    expect(String(url)).toBe('https://eas.expo.app/asset/batch?token=secret');
+    expect(init?.method).toBe('PATCH');
+    expect((init?.headers as Headers).get('content-type')).toMatch(/^multipart\/form-data;/);
+    expect(onProgress).toHaveBeenNthCalledWith(1, 0);
+    expect(onProgress).toHaveBeenLastCalledWith(1);
+  });
+
+  it.each([408, 409, 429, 500, 503])('retries HTTP %s responses', async status => {
+    mockedFetch.mockImplementation(async () => response(status, { error: `status ${status}` }));
+
+    const promise = uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset });
+    await runTimersAndExpectRejection(promise, `status ${status}`);
+
+    expect(mockedFetch).toHaveBeenCalledTimes(5);
+  });
+
+  it('does not retry a terminal HTTP response', async () => {
+    mockedFetch.mockResolvedValue(response(400, { error: 'invalid upload' }));
+
+    await expect(uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset })).rejects.toThrow(
+      'invalid upload'
+    );
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports payload-too-large responses without retrying', async () => {
+    mockedFetch.mockResolvedValue(response(413));
+
+    await expect(uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset })).rejects.toThrow(
+      'File size exceeded the upload limit'
+    );
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports CDN HTML errors with the request ID', async () => {
+    mockedFetch.mockResolvedValue(
+      new Response('<html></html>', {
+        status: 403,
+        statusText: 'Forbidden',
+        headers: { 'content-type': 'text/html', 'cf-ray': 'ray-id' },
+      })
+    );
+
+    await expect(uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset })).rejects.toThrow(
+      'Request ID ray-id'
+    );
+  });
+
+  it('switches to network mode and preserves the original network error', async () => {
+    const networkError = Object.assign(new Error('getaddrinfo ENOTFOUND eas.expo.app'), {
+      code: 'ENOTFOUND',
+    });
+    mockedFetch.mockRejectedValue(networkError);
+
+    const promise = uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset });
+    await runTimersAndExpectRejection(promise, networkError.message);
+
+    expect(mockedFetch).toHaveBeenCalledTimes(8);
+    expect(Log.warn).toHaveBeenCalledTimes(1);
+    expect(Log.warn).toHaveBeenCalledWith(
+      `The upload encountered an error but is still retrying: ${networkError.message}`
+    );
+  });
+
+  it('smoothly increases retries based on the total request count', async () => {
+    mockedFetch.mockImplementation(async () => response(503, { error: 'overloaded' }));
+
+    const promise = uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset }, undefined, {
+      totalRequests: 32,
+    });
+    await runTimersAndExpectRejection(promise, 'overloaded');
+
+    // log10(32) / 3 results in six retries, plus the initial request.
+    expect(mockedFetch).toHaveBeenCalledTimes(7);
+  });
+
+  it('caps request-count scaling at 1,000 requests', async () => {
+    mockedFetch.mockImplementation(async () => response(503, { error: 'overloaded' }));
+
+    const promise = uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset }, undefined, {
+      totalRequests: 1_000_000,
+    });
+    await runTimersAndExpectRejection(promise, 'overloaded');
+
+    expect(mockedFetch).toHaveBeenCalledTimes(9);
+  });
+
+  it('does not retry or enter network mode after cancellation', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const abortError = Object.assign(new Error('The operation was aborted'), {
+      name: 'AbortError',
+    });
+    mockedFetch.mockRejectedValue(abortError);
+
+    await expect(
+      uploadAsync({ baseURL: 'https://eas.expo.app', signal: controller.signal }, { asset })
+    ).rejects.toBe(abortError);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+    expect(Log.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe(callUploadApiAsync, () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ now: 0 });
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    mockedFetch.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('returns a successful JSON response', async () => {
+    mockedFetch.mockResolvedValue(response(200, { result: 'complete' }));
+
+    await expect(callUploadApiAsync('https://eas.expo.app/finalize')).resolves.toEqual({
+      result: 'complete',
+    });
+  });
+
+  it('retries server errors and passes through the final error', async () => {
+    mockedFetch.mockResolvedValue(response(503));
+
+    const promise = callUploadApiAsync('https://eas.expo.app/finalize');
+    await runTimersAndExpectRejection(promise, 'Deployment failed: Request failed');
+    expect(mockedFetch).toHaveBeenCalledTimes(5);
+  });
+
+  it('retries invalid JSON responses', async () => {
+    mockedFetch
+      .mockResolvedValueOnce(new Response('invalid JSON'))
+      .mockResolvedValueOnce(response(200, { success: true }));
+
+    const promise = callUploadApiAsync('https://eas.expo.app/finalize');
+    await jest.runAllTimersAsync();
+    await expect(promise).resolves.toEqual({ success: true });
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses network retries for fetch errors', async () => {
+    const networkError = new Error('socket disconnected');
+    mockedFetch.mockRejectedValue(networkError);
+
+    const promise = callUploadApiAsync('https://eas.expo.app/finalize');
+    await runTimersAndExpectRejection(promise, networkError.message);
+    expect(mockedFetch).toHaveBeenCalledTimes(8);
+  });
+
+  it('does not retry an aborted request', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const abortError = Object.assign(new Error('The operation was aborted'), {
+      name: 'AbortError',
+    });
+    mockedFetch.mockRejectedValue(abortError);
+
+    await expect(
+      callUploadApiAsync('https://eas.expo.app/finalize', { signal: controller.signal as any })
+    ).rejects.toBe(abortError);
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe(batchUploadAsync, () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uploads every payload and reports aggregate progress', async () => {
+    mockedFetch.mockResolvedValue(response());
+    const payloads: UploadPayload[] = [
+      { asset },
+      { asset: { ...asset, sha512: 'b'.repeat(128) } },
+      { asset: { ...asset, sha512: 'c'.repeat(128) } },
+    ];
+    const progress = jest.fn();
+
+    const results = [];
+    for await (const result of batchUploadAsync(
+      { baseURL: 'https://eas.expo.app' },
+      payloads,
+      progress
+    )) {
+      results.push(result);
+    }
+
+    expect(mockedFetch).toHaveBeenCalledTimes(3);
+    expect(results.at(-1)?.progress).toBe(1);
+    expect(progress).toHaveBeenLastCalledWith(1);
+  });
+
+  it('accepts an empty upload queue', async () => {
+    const results = [];
+    for await (const result of batchUploadAsync({ baseURL: 'https://eas.expo.app' }, [])) {
+      results.push(result);
+    }
+
+    expect(results).toEqual([]);
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it('aborts sibling requests after the first upload failure', async () => {
+    mockedFetch.mockImplementation(async (url, init) => {
+      if (String(url).includes(asset.sha512)) {
+        return response(400, { error: 'terminal failure' });
+      }
+      return await new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+    });
+
+    const iterator = batchUploadAsync({ baseURL: 'https://eas.expo.app' }, [
+      { asset },
+      { asset: { ...asset, sha512: 'b'.repeat(128) } },
+    ]);
+
+    await iterator.next();
+    await iterator.next();
+    await expect(iterator.next()).rejects.toThrow('terminal failure');
+  });
+});
+
+describe(createProgressBar, () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('starts, updates, and stops the upload progress bar', () => {
+    const start = jest.spyOn(cliProgress.SingleBar.prototype, 'start').mockImplementation(() => {});
+    const update = jest
+      .spyOn(cliProgress.SingleBar.prototype, 'update')
+      .mockImplementation(() => {});
+    const stop = jest.spyOn(cliProgress.SingleBar.prototype, 'stop').mockImplementation(() => {});
+
+    const progressBar = createProgressBar('Uploading 3 assets');
+    progressBar.update(0.5);
+    progressBar.stop();
+
+    expect(start).toHaveBeenCalledWith(1, 0);
+    expect(update).toHaveBeenCalledWith(0.5);
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/eas-cli/src/worker/__tests__/upload.test.ts
+++ b/packages/eas-cli/src/worker/__tests__/upload.test.ts
@@ -177,7 +177,8 @@ describe(uploadAsync, () => {
     });
     await runTimersAndExpectRejection(promise, 'overloaded');
 
-    expect(mockedFetch).toHaveBeenCalledTimes(9);
+    // The scaled 40s ceiling cuts the last attempt the backoff schedule would have allowed.
+    expect(mockedFetch).toHaveBeenCalledTimes(8);
   });
 
   it('keeps the retry state when it switches to network mode', async () => {
@@ -208,6 +209,33 @@ describe(uploadAsync, () => {
     await runTimersAndExpectRejection(promise, 'overloaded');
 
     expect(Log.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops retrying at the scaled upload ceiling', async () => {
+    mockedFetch.mockImplementation(async () => response(503, { error: 'overloaded' }));
+
+    const promise = uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset }, undefined, {
+      totalRequests: 1_000,
+    });
+    await runTimersAndExpectRejection(promise, 'overloaded');
+
+    // The ceiling stops the next retry from being scheduled, so the last attempt already in
+    // flight can overshoot it by up to one maxTimeout (10s at this scale).
+    expect(Date.now()).toBeLessThanOrEqual(40_000 + 10_000);
+  });
+
+  it('clears the retry clock and the network flag after a success', async () => {
+    const state = { hasSeenNetworkError: false, hasWarned: false, firstRetryAt: undefined };
+    mockedFetch.mockResolvedValueOnce(response(503)).mockResolvedValueOnce(response());
+
+    const promise = uploadAsync({ baseURL: 'https://eas.expo.app' }, { asset }, undefined, {
+      state,
+    });
+    await jest.runAllTimersAsync();
+    await promise;
+
+    expect(state.firstRetryAt).toBeUndefined();
+    expect(state.hasSeenNetworkError).toBe(false);
   });
 
   it('does not retry or enter network mode after cancellation', async () => {
@@ -252,8 +280,8 @@ describe(callUploadApiAsync, () => {
 
     const promise = callUploadApiAsync('https://eas.expo.app/finalize');
     await runTimersAndExpectRejection(promise, 'Deployment failed: Request failed');
-    // Deploy API calls get a much larger retry budget than a single asset upload.
-    expect(mockedFetch).toHaveBeenCalledTimes(11);
+    // Deploy API calls get a somewhat larger retry budget than a single asset upload.
+    expect(mockedFetch).toHaveBeenCalledTimes(7);
   });
 
   it('retries invalid JSON responses', async () => {
@@ -273,7 +301,26 @@ describe(callUploadApiAsync, () => {
 
     const promise = callUploadApiAsync('https://eas.expo.app/finalize');
     await runTimersAndExpectRejection(promise, networkError.message);
-    expect(mockedFetch).toHaveBeenCalledTimes(14);
+    // Network mode adds attempts but shares the 30s deadline, so it cannot double the wait.
+    expect(mockedFetch).toHaveBeenCalledTimes(10);
+  });
+
+  it('stops retrying at the 30s ceiling', async () => {
+    mockedFetch.mockResolvedValue(response(503));
+
+    const promise = callUploadApiAsync('https://eas.expo.app/finalize');
+    await runTimersAndExpectRejection(promise, 'Deployment failed: Request failed');
+
+    expect(Date.now()).toBeLessThanOrEqual(30_000);
+  });
+
+  it('shares the ceiling with the network-mode attempts', async () => {
+    mockedFetch.mockRejectedValue(new Error('socket disconnected'));
+
+    const promise = callUploadApiAsync('https://eas.expo.app/finalize');
+    await runTimersAndExpectRejection(promise, 'socket disconnected');
+
+    expect(Date.now()).toBeLessThanOrEqual(30_000 + 5_000);
   });
 
   it('does not retry an aborted request', async () => {

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -16,7 +16,9 @@ import {
 } from './utils/multipart';
 
 const MAX_CONCURRENCY = Math.min(10, Math.max(os.availableParallelism() * 2, 20));
-const RETRY_WARNING_DELAY_MS = 30_000;
+const MAX_RETRY_WARNING_DELAY_MS = 30_000;
+const UPLOAD_RETRY_LIMITS: RetryLimits = { retries: 4, maxTimeout: 5_000 };
+const API_RETRY_LIMITS: RetryLimits = { retries: 10, maxTimeout: 30_000 };
 
 interface RetryState {
   firstRetryAt?: number;
@@ -29,6 +31,19 @@ interface UploadRetryOptions {
   state?: RetryState;
 }
 
+interface RetryLimits {
+  retries: number;
+  maxTimeout: number;
+}
+
+interface RetryOptions {
+  retries: number;
+  factor: number;
+  minTimeout: number;
+  maxTimeout: number;
+  randomize: boolean;
+}
+
 const getRetryScale = (totalRequests: number): number =>
   Math.min(1, Math.log10(Math.max(1, totalRequests)) / 3);
 
@@ -36,37 +51,37 @@ const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
 const getRetryOptions = (
+  limits: RetryLimits,
   totalRequests: number,
   networkMode: boolean
-): {
-  retries: number;
-  factor: number;
-  minTimeout: number;
-  maxTimeout: number;
-  randomize: boolean;
-} => {
+): RetryOptions => {
   const scale = getRetryScale(totalRequests);
   return {
-    retries: Math.round(4 + scale * 4) + (networkMode ? 2 : 0),
+    retries: Math.round(limits.retries * (1 + scale)) + (networkMode ? 2 : 0),
     factor: 2,
     minTimeout: 1_000,
-    maxTimeout: Math.round((networkMode ? 10_000 : 5_000) * (1 + scale)),
+    maxTimeout: Math.round(limits.maxTimeout * (networkMode ? 2 : 1) * (1 + scale)),
     randomize: true,
   };
+};
+
+const getRetryWarningDelay = (options: RetryOptions): number => {
+  let budget = 0;
+  for (let attempt = 0; attempt < options.retries; attempt++) {
+    budget += Math.min(options.minTimeout * options.factor ** attempt, options.maxTimeout);
+  }
+  return Math.min(MAX_RETRY_WARNING_DELAY_MS, Math.round(budget / 2));
 };
 
 const retryWithWarning = (
   retry: (error: unknown) => never,
   error: unknown,
   attempt: number,
-  state: RetryState
+  state: RetryState,
+  warningDelayMs: number
 ): never => {
   state.firstRetryAt ??= Date.now();
-  if (
-    !state.hasWarned &&
-    attempt > 1 &&
-    Date.now() - state.firstRetryAt >= RETRY_WARNING_DELAY_MS
-  ) {
+  if (!state.hasWarned && attempt > 1 && Date.now() - state.firstRetryAt >= warningDelayMs) {
     state.hasWarned = true;
     Log.warn(`The upload encountered an error but is still retrying: ${getErrorMessage(error)}`);
   }
@@ -116,114 +131,121 @@ export async function uploadAsync(
   retryOptions: UploadRetryOptions = {},
   networkMode = retryOptions.state?.hasSeenNetworkError ?? false
 ): Promise<UploadResult> {
-  const state =
-    retryOptions.state ?? { firstRetryAt: undefined, hasSeenNetworkError: false, hasWarned: false };
-  return await promiseRetry(
-    async (retry, attempt) => {
-      if (onProgressUpdate) {
-        onProgressUpdate(0);
-      }
-
-      const headers = new Headers(init.headers);
-
-      const url = new URL(`${init.baseURL}`);
-      let errorPrefix: string;
-      let body: BodyInit | undefined;
-      let method = init.method || 'POST';
-      if ('asset' in payload) {
-        const { asset } = payload;
-        errorPrefix = `Upload of "${asset.normalizedPath}" failed`;
-        if (asset.type) {
-          headers.set('content-type', asset.type);
-        }
-        if (asset.size) {
-          headers.set('content-length', `${asset.size}`);
-        }
-        method = 'POST';
-        url.pathname = `/asset/${asset.sha512}`;
-        body = Readable.from(createReadStreamAsync(asset), { objectMode: false });
-      } else if ('filePath' in payload) {
-        const { filePath } = payload;
-        errorPrefix = 'Worker deployment failed';
-        body = fs.createReadStream(filePath);
-      } else if ('multipart' in payload) {
-        const { multipart } = payload;
-        errorPrefix = `Upload of ${multipart.length} assets failed`;
-        headers.set('content-type', multipartContentType);
-        method = 'PATCH';
-        url.pathname = '/asset/batch';
-        body = Readable.from(createMultipartBodyFromFilesAsync(multipart, onProgressUpdate), {
-          objectMode: false,
-        });
-      }
-
-      let response: Response;
-      try {
-        response = await fetch(url, {
-          method,
-          body,
-          headers,
-          agent: getAgent(),
-          signal: init.signal as any,
-        });
-      } catch (error) {
-        if (init.signal?.aborted) {
-          throw error;
-        }
-        if (!networkMode) {
-          state.hasSeenNetworkError = true;
-          return await uploadAsync(init, payload, onProgressUpdate, retryOptions, true);
-        }
-        return retryWithWarning(retry, error, attempt, state);
-      }
-
-      const getErrorMessageAsync = async (): Promise<string> => {
-        const rayId = response.headers.get('cf-ray');
-        const contentType = response.headers.get('Content-Type');
-        if (contentType?.startsWith('text/html')) {
-          // NOTE(@kitten): We've received a CDN error most likely. There's not much we can do
-          // except for quoting the Request ID, so a user can send it to us. We can check
-          // why a request was blocked by looking up a WAF event via the "Ray ID" here:
-          // https://dash.cloudflare.com/e6f39f67f543faa6038768e8f37e4234/expo.app/security/events
-          let message = `CDN firewall has aborted the upload with ${response.statusText}.`;
-          if (rayId) {
-            message += `\nReport this error quoting Request ID ${rayId}`;
-          }
-          return `${errorPrefix}: ${message}`;
-        } else {
-          const json = await response.json().catch(() => null);
-          return json?.error ?? `${errorPrefix}: ${response.statusText}`;
-        }
-      };
-
-      if (
-        response.status === 408 ||
-        response.status === 409 ||
-        response.status === 429 ||
-        (response.status >= 500 && response.status <= 599)
-      ) {
-        return retryWithWarning(
-          retry,
-          new Error(await getErrorMessageAsync()),
-          attempt,
-          state
-        );
-      } else if (response.status === 413) {
-        const message = `${errorPrefix!}: File size exceeded the upload limit`;
-        throw new Error(message);
-      } else if (!response.ok) {
-        throw new Error(await getErrorMessageAsync());
-      } else if (onProgressUpdate) {
-        onProgressUpdate(1);
-      }
-
-      return {
-        payload,
-        response,
-      };
-    },
-    getRetryOptions(retryOptions.totalRequests ?? 1, networkMode)
+  const state = retryOptions.state ?? {
+    firstRetryAt: undefined,
+    hasSeenNetworkError: false,
+    hasWarned: false,
+  };
+  const retryOptionsForAttempts = getRetryOptions(
+    UPLOAD_RETRY_LIMITS,
+    retryOptions.totalRequests ?? 1,
+    networkMode
   );
+  const warningDelayMs = getRetryWarningDelay(retryOptionsForAttempts);
+  return await promiseRetry(async (retry, attempt) => {
+    if (onProgressUpdate) {
+      onProgressUpdate(0);
+    }
+
+    const headers = new Headers(init.headers);
+
+    const url = new URL(`${init.baseURL}`);
+    let errorPrefix: string;
+    let body: BodyInit | undefined;
+    let method = init.method || 'POST';
+    if ('asset' in payload) {
+      const { asset } = payload;
+      errorPrefix = `Upload of "${asset.normalizedPath}" failed`;
+      if (asset.type) {
+        headers.set('content-type', asset.type);
+      }
+      if (asset.size) {
+        headers.set('content-length', `${asset.size}`);
+      }
+      method = 'POST';
+      url.pathname = `/asset/${asset.sha512}`;
+      body = Readable.from(createReadStreamAsync(asset), { objectMode: false });
+    } else if ('filePath' in payload) {
+      const { filePath } = payload;
+      errorPrefix = 'Worker deployment failed';
+      body = fs.createReadStream(filePath);
+    } else if ('multipart' in payload) {
+      const { multipart } = payload;
+      errorPrefix = `Upload of ${multipart.length} assets failed`;
+      headers.set('content-type', multipartContentType);
+      method = 'PATCH';
+      url.pathname = '/asset/batch';
+      body = Readable.from(createMultipartBodyFromFilesAsync(multipart, onProgressUpdate), {
+        objectMode: false,
+      });
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method,
+        body,
+        headers,
+        agent: getAgent(),
+        signal: init.signal as any,
+      });
+    } catch (error) {
+      if (init.signal?.aborted) {
+        throw error;
+      }
+      if (!networkMode) {
+        state.hasSeenNetworkError = true;
+        return await uploadAsync(init, payload, onProgressUpdate, { ...retryOptions, state }, true);
+      }
+      return retryWithWarning(retry, error, attempt, state, warningDelayMs);
+    }
+
+    const getErrorMessageAsync = async (): Promise<string> => {
+      const rayId = response.headers.get('cf-ray');
+      const contentType = response.headers.get('Content-Type');
+      if (contentType?.startsWith('text/html')) {
+        // NOTE(@kitten): We've received a CDN error most likely. There's not much we can do
+        // except for quoting the Request ID, so a user can send it to us. We can check
+        // why a request was blocked by looking up a WAF event via the "Ray ID" here:
+        // https://dash.cloudflare.com/e6f39f67f543faa6038768e8f37e4234/expo.app/security/events
+        let message = `CDN firewall has aborted the upload with ${response.statusText}.`;
+        if (rayId) {
+          message += `\nReport this error quoting Request ID ${rayId}`;
+        }
+        return `${errorPrefix}: ${message}`;
+      } else {
+        const json = await response.json().catch(() => null);
+        return json?.error ?? `${errorPrefix}: ${response.statusText}`;
+      }
+    };
+
+    if (
+      response.status === 408 ||
+      response.status === 409 ||
+      response.status === 429 ||
+      (response.status >= 500 && response.status <= 599)
+    ) {
+      return retryWithWarning(
+        retry,
+        new Error(await getErrorMessageAsync()),
+        attempt,
+        state,
+        warningDelayMs
+      );
+    } else if (response.status === 413) {
+      const message = `${errorPrefix!}: File size exceeded the upload limit`;
+      throw new Error(message);
+    } else if (!response.ok) {
+      throw new Error(await getErrorMessageAsync());
+    } else if (onProgressUpdate) {
+      onProgressUpdate(1);
+    }
+
+    return {
+      payload,
+      response,
+    };
+  }, retryOptionsForAttempts);
 }
 
 async function callUploadApiWithRetryAsync(
@@ -232,6 +254,8 @@ async function callUploadApiWithRetryAsync(
   networkMode = false,
   state: RetryState = { hasSeenNetworkError: false, hasWarned: false }
 ): Promise<unknown> {
+  const retryOptions = getRetryOptions(API_RETRY_LIMITS, 1, networkMode);
+  const warningDelayMs = getRetryWarningDelay(retryOptions);
   return await promiseRetry(async (retry, attempt) => {
     let response: Response;
     try {
@@ -247,14 +271,15 @@ async function callUploadApiWithRetryAsync(
         state.hasSeenNetworkError = true;
         return await callUploadApiWithRetryAsync(url, init, true, state);
       }
-      return retryWithWarning(retry, error, attempt, state);
+      return retryWithWarning(retry, error, attempt, state, warningDelayMs);
     }
     if (response.status >= 500 && response.status <= 599) {
       retryWithWarning(
         retry,
         new Error(`Deployment failed: ${response.statusText}`),
         attempt,
-        state
+        state,
+        warningDelayMs
       );
     }
     try {
@@ -262,7 +287,7 @@ async function callUploadApiWithRetryAsync(
     } catch (error) {
       retry(error);
     }
-  }, getRetryOptions(1, networkMode));
+  }, retryOptions);
 }
 
 export async function callUploadApiAsync(url: string | URL, init?: RequestInit): Promise<unknown> {

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -17,8 +17,9 @@ import {
 
 const MAX_CONCURRENCY = Math.min(10, Math.max(os.availableParallelism() * 2, 20));
 const MAX_RETRY_WARNING_DELAY_MS = 30_000;
-const UPLOAD_RETRY_LIMITS: RetryLimits = { retries: 4, maxTimeout: 5_000 };
-const API_RETRY_LIMITS: RetryLimits = { retries: 10, maxTimeout: 30_000 };
+
+const UPLOAD_RETRY_LIMITS: RetryLimits = { retries: 4, maxTimeout: 5_000, maxRetryTime: 20_000 };
+const API_RETRY_LIMITS: RetryLimits = { retries: 6, maxTimeout: 5_000, maxRetryTime: 30_000 };
 
 interface RetryState {
   firstRetryAt?: number;
@@ -29,11 +30,13 @@ interface RetryState {
 interface UploadRetryOptions {
   totalRequests?: number;
   state?: RetryState;
+  deadlineAt?: number;
 }
 
 interface RetryLimits {
   retries: number;
   maxTimeout: number;
+  maxRetryTime: number;
 }
 
 interface RetryOptions {
@@ -41,7 +44,14 @@ interface RetryOptions {
   factor: number;
   minTimeout: number;
   maxTimeout: number;
+  maxRetryTime: number;
   randomize: boolean;
+}
+
+interface RetryWarningContext {
+  state: RetryState;
+  warningDelayMs: number;
+  subject: string;
 }
 
 const getRetryScale = (totalRequests: number): number =>
@@ -60,30 +70,25 @@ const getRetryOptions = (
     retries: Math.round(limits.retries * (1 + scale)) + (networkMode ? 2 : 0),
     factor: 2,
     minTimeout: 1_000,
-    maxTimeout: Math.round(limits.maxTimeout * (networkMode ? 2 : 1) * (1 + scale)),
+    maxTimeout: Math.round(limits.maxTimeout * (1 + scale)),
+    maxRetryTime: Math.round(limits.maxRetryTime * (1 + scale)),
     randomize: true,
   };
 };
 
-const getRetryWarningDelay = (options: RetryOptions): number => {
-  let budget = 0;
-  for (let attempt = 0; attempt < options.retries; attempt++) {
-    budget += Math.min(options.minTimeout * options.factor ** attempt, options.maxTimeout);
-  }
-  return Math.min(MAX_RETRY_WARNING_DELAY_MS, Math.round(budget / 2));
-};
+const getRetryWarningDelay = (maxRetryTime: number): number =>
+  Math.min(MAX_RETRY_WARNING_DELAY_MS, Math.round(maxRetryTime / 2));
 
 const retryWithWarning = (
   retry: (error: unknown) => never,
   error: unknown,
   attempt: number,
-  state: RetryState,
-  warningDelayMs: number
+  { state, warningDelayMs, subject }: RetryWarningContext
 ): never => {
   state.firstRetryAt ??= Date.now();
   if (!state.hasWarned && attempt > 1 && Date.now() - state.firstRetryAt >= warningDelayMs) {
     state.hasWarned = true;
-    Log.warn(`The upload encountered an error but is still retrying: ${getErrorMessage(error)}`);
+    Log.warn(`${subject} encountered an error but is still retrying: ${getErrorMessage(error)}`);
   }
   return retry(error);
 };
@@ -141,7 +146,10 @@ export async function uploadAsync(
     retryOptions.totalRequests ?? 1,
     networkMode
   );
-  const warningDelayMs = getRetryWarningDelay(retryOptionsForAttempts);
+  const warningDelayMs = getRetryWarningDelay(retryOptionsForAttempts.maxRetryTime);
+  const deadlineAt = retryOptions.deadlineAt ?? Date.now() + retryOptionsForAttempts.maxRetryTime;
+  retryOptionsForAttempts.maxRetryTime = Math.max(0, deadlineAt - Date.now());
+  const warningContext: RetryWarningContext = { state, warningDelayMs, subject: 'The upload' };
   return await promiseRetry(async (retry, attempt) => {
     if (onProgressUpdate) {
       onProgressUpdate(0);
@@ -195,9 +203,15 @@ export async function uploadAsync(
       }
       if (!networkMode) {
         state.hasSeenNetworkError = true;
-        return await uploadAsync(init, payload, onProgressUpdate, { ...retryOptions, state }, true);
+        return await uploadAsync(
+          init,
+          payload,
+          onProgressUpdate,
+          { ...retryOptions, state, deadlineAt },
+          true
+        );
       }
-      return retryWithWarning(retry, error, attempt, state, warningDelayMs);
+      return retryWithWarning(retry, error, attempt, warningContext);
     }
 
     const getErrorMessageAsync = async (): Promise<string> => {
@@ -229,8 +243,7 @@ export async function uploadAsync(
         retry,
         new Error(await getErrorMessageAsync()),
         attempt,
-        state,
-        warningDelayMs
+        warningContext
       );
     } else if (response.status === 413) {
       const message = `${errorPrefix!}: File size exceeded the upload limit`;
@@ -240,6 +253,9 @@ export async function uploadAsync(
     } else if (onProgressUpdate) {
       onProgressUpdate(1);
     }
+
+    state.firstRetryAt = undefined;
+    state.hasSeenNetworkError = false;
 
     return {
       payload,
@@ -252,10 +268,18 @@ async function callUploadApiWithRetryAsync(
   url: string | URL,
   init: RequestInit | undefined,
   networkMode = false,
-  state: RetryState = { hasSeenNetworkError: false, hasWarned: false }
+  state: RetryState = { hasSeenNetworkError: false, hasWarned: false },
+  deadlineAt?: number
 ): Promise<unknown> {
   const retryOptions = getRetryOptions(API_RETRY_LIMITS, 1, networkMode);
-  const warningDelayMs = getRetryWarningDelay(retryOptions);
+  const warningDelayMs = getRetryWarningDelay(retryOptions.maxRetryTime);
+  const retryDeadlineAt = deadlineAt ?? Date.now() + retryOptions.maxRetryTime;
+  retryOptions.maxRetryTime = Math.max(0, retryDeadlineAt - Date.now());
+  const warningContext: RetryWarningContext = {
+    state,
+    warningDelayMs,
+    subject: 'The deployment',
+  };
   return await promiseRetry(async (retry, attempt) => {
     let response: Response;
     try {
@@ -269,23 +293,22 @@ async function callUploadApiWithRetryAsync(
       }
       if (!networkMode) {
         state.hasSeenNetworkError = true;
-        return await callUploadApiWithRetryAsync(url, init, true, state);
+        return await callUploadApiWithRetryAsync(url, init, true, state, retryDeadlineAt);
       }
-      return retryWithWarning(retry, error, attempt, state, warningDelayMs);
+      return retryWithWarning(retry, error, attempt, warningContext);
     }
     if (response.status >= 500 && response.status <= 599) {
       retryWithWarning(
         retry,
         new Error(`Deployment failed: ${response.statusText}`),
         attempt,
-        state,
-        warningDelayMs
+        warningContext
       );
     }
     try {
       return await response.json();
     } catch (error) {
-      retry(error);
+      return retryWithWarning(retry, error, attempt, warningContext);
     }
   }, retryOptions);
 }

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -15,7 +15,13 @@ import {
 } from './utils/multipart';
 
 const MAX_CONCURRENCY = Math.min(10, Math.max(os.availableParallelism() * 2, 20));
-const MAX_RETRIES = 4;
+const RETRY_OPTIONS = {
+  retries: 10,
+  factor: 2,
+  minTimeout: 1_000,
+  maxTimeout: 30_000,
+  randomize: true,
+};
 
 export type UploadPayload =
   | { filePath: string }
@@ -150,11 +156,7 @@ export async function uploadAsync(
         response,
       };
     },
-    {
-      retries: MAX_RETRIES,
-      minTimeout: 50,
-      randomize: false,
-    }
+    RETRY_OPTIONS
   );
 }
 
@@ -177,7 +179,7 @@ export async function callUploadApiAsync(url: string | URL, init?: RequestInit):
     } catch (error) {
       retry(error);
     }
-  });
+  }, RETRY_OPTIONS);
 }
 
 export interface UploadPending {

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -167,6 +167,9 @@ export async function uploadAsync(
           signal: init.signal as any,
         });
       } catch (error) {
+        if (init.signal?.aborted) {
+          throw error;
+        }
         if (!networkMode) {
           state.hasSeenNetworkError = true;
           return await uploadAsync(init, payload, onProgressUpdate, retryOptions, true);
@@ -237,6 +240,9 @@ async function callUploadApiWithRetryAsync(
         agent: getAgent(),
       });
     } catch (error) {
+      if (init?.signal?.aborted) {
+        throw error;
+      }
       if (!networkMode) {
         state.hasSeenNetworkError = true;
         return await callUploadApiWithRetryAsync(url, init, true, state);

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -7,6 +7,7 @@ import os from 'node:os';
 import { Readable } from 'node:stream';
 import promiseRetry from 'promise-retry';
 
+import Log from '../log';
 import { AssetFileEntry } from './assets';
 import {
   createMultipartBodyFromFilesAsync,
@@ -15,12 +16,61 @@ import {
 } from './utils/multipart';
 
 const MAX_CONCURRENCY = Math.min(10, Math.max(os.availableParallelism() * 2, 20));
-const RETRY_OPTIONS = {
-  retries: 10,
-  factor: 2,
-  minTimeout: 1_000,
-  maxTimeout: 30_000,
-  randomize: true,
+const RETRY_WARNING_DELAY_MS = 30_000;
+
+interface RetryState {
+  firstRetryAt?: number;
+  hasSeenNetworkError: boolean;
+  hasWarned: boolean;
+}
+
+interface UploadRetryOptions {
+  totalRequests?: number;
+  state?: RetryState;
+}
+
+const getRetryScale = (totalRequests: number): number =>
+  Math.min(1, Math.log10(Math.max(1, totalRequests)) / 3);
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+const getRetryOptions = (
+  totalRequests: number,
+  networkMode: boolean
+): {
+  retries: number;
+  factor: number;
+  minTimeout: number;
+  maxTimeout: number;
+  randomize: boolean;
+} => {
+  const scale = getRetryScale(totalRequests);
+  return {
+    retries: Math.round(4 + scale * 4) + (networkMode ? 2 : 0),
+    factor: 2,
+    minTimeout: 1_000,
+    maxTimeout: Math.round((networkMode ? 10_000 : 5_000) * (1 + scale)),
+    randomize: true,
+  };
+};
+
+const retryWithWarning = (
+  retry: (error: unknown) => never,
+  error: unknown,
+  attempt: number,
+  state: RetryState
+): never => {
+  state.firstRetryAt ??= Date.now();
+  if (
+    !state.hasWarned &&
+    attempt > 1 &&
+    Date.now() - state.firstRetryAt >= RETRY_WARNING_DELAY_MS
+  ) {
+    state.hasWarned = true;
+    Log.warn(`The upload encountered an error but is still retrying: ${getErrorMessage(error)}`);
+  }
+  return retry(error);
 };
 
 export type UploadPayload =
@@ -62,10 +112,14 @@ type OnProgressUpdateCallback = (progress: number) => void;
 export async function uploadAsync(
   init: UploadRequestInit,
   payload: UploadPayload,
-  onProgressUpdate?: OnProgressUpdateCallback
+  onProgressUpdate?: OnProgressUpdateCallback,
+  retryOptions: UploadRetryOptions = {},
+  networkMode = retryOptions.state?.hasSeenNetworkError ?? false
 ): Promise<UploadResult> {
+  const state =
+    retryOptions.state ?? { firstRetryAt: undefined, hasSeenNetworkError: false, hasWarned: false };
   return await promiseRetry(
-    async retry => {
+    async (retry, attempt) => {
       if (onProgressUpdate) {
         onProgressUpdate(0);
       }
@@ -113,7 +167,11 @@ export async function uploadAsync(
           signal: init.signal as any,
         });
       } catch (error) {
-        return retry(error);
+        if (!networkMode) {
+          state.hasSeenNetworkError = true;
+          return await uploadAsync(init, payload, onProgressUpdate, retryOptions, true);
+        }
+        return retryWithWarning(retry, error, attempt, state);
       }
 
       const getErrorMessageAsync = async (): Promise<string> => {
@@ -141,7 +199,12 @@ export async function uploadAsync(
         response.status === 429 ||
         (response.status >= 500 && response.status <= 599)
       ) {
-        return retry(new Error(await getErrorMessageAsync()));
+        return retryWithWarning(
+          retry,
+          new Error(await getErrorMessageAsync()),
+          attempt,
+          state
+        );
       } else if (response.status === 413) {
         const message = `${errorPrefix!}: File size exceeded the upload limit`;
         throw new Error(message);
@@ -156,12 +219,17 @@ export async function uploadAsync(
         response,
       };
     },
-    RETRY_OPTIONS
+    getRetryOptions(retryOptions.totalRequests ?? 1, networkMode)
   );
 }
 
-export async function callUploadApiAsync(url: string | URL, init?: RequestInit): Promise<unknown> {
-  return await promiseRetry(async retry => {
+async function callUploadApiWithRetryAsync(
+  url: string | URL,
+  init: RequestInit | undefined,
+  networkMode = false,
+  state: RetryState = { hasSeenNetworkError: false, hasWarned: false }
+): Promise<unknown> {
+  return await promiseRetry(async (retry, attempt) => {
     let response: Response;
     try {
       response = await fetch(url, {
@@ -169,17 +237,30 @@ export async function callUploadApiAsync(url: string | URL, init?: RequestInit):
         agent: getAgent(),
       });
     } catch (error) {
-      return retry(error);
+      if (!networkMode) {
+        state.hasSeenNetworkError = true;
+        return await callUploadApiWithRetryAsync(url, init, true, state);
+      }
+      return retryWithWarning(retry, error, attempt, state);
     }
     if (response.status >= 500 && response.status <= 599) {
-      retry(new Error(`Deployment failed: ${response.statusText}`));
+      retryWithWarning(
+        retry,
+        new Error(`Deployment failed: ${response.statusText}`),
+        attempt,
+        state
+      );
     }
     try {
       return await response.json();
     } catch (error) {
       retry(error);
     }
-  }, RETRY_OPTIONS);
+  }, getRetryOptions(1, networkMode));
+}
+
+export async function callUploadApiAsync(url: string | URL, init?: RequestInit): Promise<unknown> {
+  return await callUploadApiWithRetryAsync(url, init);
 }
 
 export interface UploadPending {
@@ -194,6 +275,7 @@ export async function* batchUploadAsync(
 ): AsyncGenerator<UploadPending> {
   const progressTracker = new Array(payloads.length).fill(0);
   const controller = new AbortController();
+  const retryState: RetryState = { hasSeenNetworkError: false, hasWarned: false };
   const queue = new Set<Promise<UploadResult>>();
   const initWithSignal = { ...init, signal: controller.signal };
   const getProgressValue = (): number => {
@@ -218,7 +300,10 @@ export async function* batchUploadAsync(
             progressTracker[currentIndex] = progress;
             sendProgressUpdate();
           });
-        const uploadPromise = uploadAsync(initWithSignal, payload, onChildProgressUpdate).then(
+        const uploadPromise = uploadAsync(initWithSignal, payload, onChildProgressUpdate, {
+          totalRequests: payloads.length,
+          state: retryState,
+        }).then(
           result => {
             queue.delete(uploadPromise);
             progressTracker[currentIndex] = 1;

--- a/packages/eas-cli/src/worker/upload.ts
+++ b/packages/eas-cli/src/worker/upload.ts
@@ -21,10 +21,14 @@ const MAX_RETRY_WARNING_DELAY_MS = 30_000;
 const UPLOAD_RETRY_LIMITS: RetryLimits = { retries: 4, maxTimeout: 5_000, maxRetryTime: 20_000 };
 const API_RETRY_LIMITS: RetryLimits = { retries: 6, maxTimeout: 5_000, maxRetryTime: 30_000 };
 
-interface RetryState {
-  firstRetryAt?: number;
+interface SharedRetryState {
   hasSeenNetworkError: boolean;
   hasWarned: boolean;
+}
+
+interface RetryState {
+  shared: SharedRetryState;
+  firstRetryAt?: number;
 }
 
 interface UploadRetryOptions {
@@ -86,8 +90,8 @@ const retryWithWarning = (
   { state, warningDelayMs, subject }: RetryWarningContext
 ): never => {
   state.firstRetryAt ??= Date.now();
-  if (!state.hasWarned && attempt > 1 && Date.now() - state.firstRetryAt >= warningDelayMs) {
-    state.hasWarned = true;
+  if (!state.shared.hasWarned && attempt > 1 && Date.now() - state.firstRetryAt >= warningDelayMs) {
+    state.shared.hasWarned = true;
     Log.warn(`${subject} encountered an error but is still retrying: ${getErrorMessage(error)}`);
   }
   return retry(error);
@@ -134,12 +138,10 @@ export async function uploadAsync(
   payload: UploadPayload,
   onProgressUpdate?: OnProgressUpdateCallback,
   retryOptions: UploadRetryOptions = {},
-  networkMode = retryOptions.state?.hasSeenNetworkError ?? false
+  networkMode = retryOptions.state?.shared.hasSeenNetworkError ?? false
 ): Promise<UploadResult> {
   const state = retryOptions.state ?? {
-    firstRetryAt: undefined,
-    hasSeenNetworkError: false,
-    hasWarned: false,
+    shared: { hasSeenNetworkError: false, hasWarned: false },
   };
   const retryOptionsForAttempts = getRetryOptions(
     UPLOAD_RETRY_LIMITS,
@@ -149,7 +151,11 @@ export async function uploadAsync(
   const warningDelayMs = getRetryWarningDelay(retryOptionsForAttempts.maxRetryTime);
   const deadlineAt = retryOptions.deadlineAt ?? Date.now() + retryOptionsForAttempts.maxRetryTime;
   retryOptionsForAttempts.maxRetryTime = Math.max(0, deadlineAt - Date.now());
-  const warningContext: RetryWarningContext = { state, warningDelayMs, subject: 'The upload' };
+  const warningContext: RetryWarningContext = {
+    state,
+    warningDelayMs,
+    subject: 'The upload',
+  };
   return await promiseRetry(async (retry, attempt) => {
     if (onProgressUpdate) {
       onProgressUpdate(0);
@@ -202,7 +208,7 @@ export async function uploadAsync(
         throw error;
       }
       if (!networkMode) {
-        state.hasSeenNetworkError = true;
+        state.shared.hasSeenNetworkError = true;
         return await uploadAsync(
           init,
           payload,
@@ -254,8 +260,7 @@ export async function uploadAsync(
       onProgressUpdate(1);
     }
 
-    state.firstRetryAt = undefined;
-    state.hasSeenNetworkError = false;
+    state.shared.hasSeenNetworkError = false;
 
     return {
       payload,
@@ -268,7 +273,7 @@ async function callUploadApiWithRetryAsync(
   url: string | URL,
   init: RequestInit | undefined,
   networkMode = false,
-  state: RetryState = { hasSeenNetworkError: false, hasWarned: false },
+  state: RetryState = { shared: { hasSeenNetworkError: false, hasWarned: false } },
   deadlineAt?: number
 ): Promise<unknown> {
   const retryOptions = getRetryOptions(API_RETRY_LIMITS, 1, networkMode);
@@ -292,7 +297,7 @@ async function callUploadApiWithRetryAsync(
         throw error;
       }
       if (!networkMode) {
-        state.hasSeenNetworkError = true;
+        state.shared.hasSeenNetworkError = true;
         return await callUploadApiWithRetryAsync(url, init, true, state, retryDeadlineAt);
       }
       return retryWithWarning(retry, error, attempt, warningContext);
@@ -329,7 +334,7 @@ export async function* batchUploadAsync(
 ): AsyncGenerator<UploadPending> {
   const progressTracker = new Array(payloads.length).fill(0);
   const controller = new AbortController();
-  const retryState: RetryState = { hasSeenNetworkError: false, hasWarned: false };
+  const sharedRetryState: SharedRetryState = { hasSeenNetworkError: false, hasWarned: false };
   const queue = new Set<Promise<UploadResult>>();
   const initWithSignal = { ...init, signal: controller.signal };
   const getProgressValue = (): number => {
@@ -356,7 +361,7 @@ export async function* batchUploadAsync(
           });
         const uploadPromise = uploadAsync(initWithSignal, payload, onChildProgressUpdate, {
           totalRequests: payloads.length,
-          state: retryState,
+          state: { shared: sharedRetryState },
         }).then(
           result => {
             queue.delete(uploadPromise);


### PR DESCRIPTION
# Why

When we encounter transient errors, we don't account for network errors that could be an ongoing internal failure or outage on the machine that's deploying. This is especially punishing when the deployment is larger and has more missing assets to upload, since it has to fully retry.

# How

- Expand maximum retry attempts and timeouts to be much longer
- Dynamically scale retry attempts and timeouts based on amount of asset requests we'll have
- Scale up retries for network errors (ENOTFOUND and ECONNRESET, and others)
- Issue a visible warning to the user when we're still retrying but have waited for longer than 30s for a successful upload

# Test Plan

- LLM-derived tests added to capture this behaviour
