### PR TITLE
[eas-cli] carry the serve-sim session token in simulator preview links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Start Argent remote sessions with `bun x` so they work when the `bunx` symlink is missing. ([491b372a](https://github.com/expo/eas-cli/commit/491b372a) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
+- [eas-cli] Print the session token in simulator preview links, so they still open once the preview is gated. ([#4312](https://github.com/expo/eas-cli/pull/4312) by [@gwdp](https://github.com/gwdp))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -92910,6 +92910,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "webPreviewToken",
+            "description": "Session token gating the web preview. Null when the preview runs ungated.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,

--- a/packages/eas-cli/src/commands/simulator/get.ts
+++ b/packages/eas-cli/src/commands/simulator/get.ts
@@ -18,6 +18,7 @@ import {
 import {
   deviceRunSessionTypeToFlagValue,
   formatRemoteSessionInstructions,
+  sanitizeRemoteConfigForJson,
 } from '../../simulator/utils';
 import { formatBytes } from '../../utils/files';
 import formatFields, { FormatFieldsItem } from '../../utils/formatFields';
@@ -96,7 +97,9 @@ export default class SimulatorGet extends EasCommand {
         finishedAt: session.finishedAt ?? undefined,
         updatedAt: session.updatedAt,
         deviceRunSessionUrl,
-        remoteConfig: session.remoteConfig,
+        remoteConfig: session.remoteConfig
+          ? sanitizeRemoteConfigForJson(session.remoteConfig)
+          : session.remoteConfig,
         artifacts: session.artifacts,
       });
       return;

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -38,6 +38,7 @@ import {
   formatRemoteSessionInstructions,
   formatSimulatorUnavailableMessage,
   getRemoteSessionEnvironmentVariables,
+  sanitizeRemoteConfigForJson,
 } from '../../simulator/utils';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import { sleepAsync } from '../../utils/promise';
@@ -385,7 +386,7 @@ export default class Simulator extends EasCommand {
         name,
         type: flags.type,
         deviceRunSessionUrl,
-        remoteConfig,
+        remoteConfig: sanitizeRemoteConfigForJson(remoteConfig),
       });
       return;
     }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -13135,6 +13135,8 @@ export type WebNotificationUpdateReadStateInput = {
 
 export type WebPreviewOnlyRunSessionRemoteConfig = {
   __typename?: 'WebPreviewOnlyRunSessionRemoteConfig';
+  /** Session token gating the web preview. Null when the preview runs ungated. */
+  webPreviewToken?: Maybe<Scalars['String']['output']>;
   webPreviewUrl: Scalars['String']['output'];
 };
 
@@ -16176,11 +16178,11 @@ export type DeviceRunSessionByIdQueryVariables = Exact<{
 
 
 export type DeviceRunSessionByIdQuery = { __typename?: 'RootQuery', deviceRunSessions: { __typename?: 'DeviceRunSessionQuery', byId: { __typename?: 'DeviceRunSession', id: string, name?: string | null, tags: Array<string>, status: DeviceRunSessionStatus, type: DeviceRunSessionType, platform: AppPlatform, createdAt: any, startedAt?: any | null, finishedAt?: any | null, updatedAt: any, app: { __typename?: 'App', id: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string } }, artifacts: Array<{ __typename?: 'DeviceRunSessionArtifact', id: string, name: string, filename: string, downloadUrl: string, fileSizeBytes?: number | null, metadata?: any | null, createdAt: any, updatedAt: any }>, remoteConfig?:
-        | { __typename: 'AgentDeviceRunSessionRemoteConfig', agentDeviceRemoteSessionUrl: string, agentDeviceRemoteSessionToken: string, webPreviewUrl?: string | null }
-        | { __typename: 'AppiumRunSessionRemoteConfig', appiumUrl: string, capabilities: any, webPreviewUrl?: string | null }
-        | { __typename: 'ArgentRunSessionRemoteConfig', toolsUrl: string, toolsAuthToken?: string | null, webPreviewUrl?: string | null }
-        | { __typename: 'ServeSimRunSessionRemoteConfig', previewUrl: string }
-        | { __typename: 'WebPreviewOnlyRunSessionRemoteConfig', previewUrl: string }
+        | { __typename: 'AgentDeviceRunSessionRemoteConfig', agentDeviceRemoteSessionUrl: string, agentDeviceRemoteSessionToken: string, webPreviewUrl?: string | null, webPreviewToken?: string | null }
+        | { __typename: 'AppiumRunSessionRemoteConfig', appiumUrl: string, capabilities: any, webPreviewUrl?: string | null, webPreviewToken?: string | null }
+        | { __typename: 'ArgentRunSessionRemoteConfig', toolsUrl: string, toolsAuthToken?: string | null, webPreviewUrl?: string | null, webPreviewToken?: string | null }
+        | { __typename: 'ServeSimRunSessionRemoteConfig', previewUrl: string, previewToken?: string | null }
+        | { __typename: 'WebPreviewOnlyRunSessionRemoteConfig', previewUrl: string, previewToken?: string | null }
        | null, turtleJobRun?: { __typename?: 'JobRun', id: string, status: JobRunStatus } | null } } };
 
 export type DeviceRunSessionsByAppIdQueryVariables = Exact<{

--- a/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/DeviceRunSessionQuery.ts
@@ -87,22 +87,27 @@ export const DeviceRunSessionQuery = {
                       agentDeviceRemoteSessionUrl
                       agentDeviceRemoteSessionToken
                       webPreviewUrl
+                      webPreviewToken
                     }
                     ... on ArgentRunSessionRemoteConfig {
                       toolsUrl
                       toolsAuthToken
                       webPreviewUrl
+                      webPreviewToken
                     }
                     ... on AppiumRunSessionRemoteConfig {
                       appiumUrl
                       capabilities
                       webPreviewUrl
+                      webPreviewToken
                     }
                     ... on ServeSimRunSessionRemoteConfig {
                       previewUrl
+                      previewToken
                     }
                     ... on WebPreviewOnlyRunSessionRemoteConfig {
                       previewUrl: webPreviewUrl
+                      previewToken: webPreviewToken
                     }
                   }
                   turtleJobRun {

--- a/packages/eas-cli/src/simulator/__tests__/utils.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/utils.test.ts
@@ -9,6 +9,7 @@ import {
   formatRemoteSessionInstructions,
   formatSimulatorUnavailableMessage,
   getRemoteSessionEnvironmentVariables,
+  sanitizeRemoteConfigForJson,
 } from '../utils';
 
 const iosAppiumConfig = {
@@ -91,6 +92,64 @@ describe(formatPreviewUrl, () => {
     expect(formatPreviewUrl('https://preview.example.test', undefined)).toBe(
       'https://preview.example.test'
     );
+  });
+});
+
+describe(sanitizeRemoteConfigForJson, () => {
+  const PREVIEW_URL = 'https://preview.example.test';
+
+  it('moves the token into the preview url and drops the standalone field', () => {
+    const sanitized = sanitizeRemoteConfigForJson({
+      __typename: 'ServeSimRunSessionRemoteConfig' as const,
+      previewUrl: PREVIEW_URL,
+      previewToken: 'tok-1',
+    });
+
+    expect(sanitized).toEqual({
+      __typename: 'ServeSimRunSessionRemoteConfig',
+      previewUrl: `${PREVIEW_URL}/?token=tok-1`,
+    });
+    expect(JSON.stringify(sanitized)).not.toContain('previewToken');
+  });
+
+  it('does the same for a controller session', () => {
+    const sanitized = sanitizeRemoteConfigForJson({
+      __typename: 'ArgentRunSessionRemoteConfig' as const,
+      toolsUrl: 'https://argent.example.test',
+      toolsAuthToken: 'argent-token',
+      webPreviewUrl: PREVIEW_URL,
+      webPreviewToken: 'tok-1',
+    });
+
+    expect(sanitized).toMatchObject({ webPreviewUrl: `${PREVIEW_URL}/?token=tok-1` });
+    expect(JSON.stringify(sanitized)).not.toContain('webPreviewToken');
+    // The controller credential is a different secret and stays: it is what simulator:exec needs.
+    expect(sanitized).toMatchObject({ toolsAuthToken: 'argent-token' });
+  });
+
+  it('leaves an ungated session untouched', () => {
+    const remoteConfig = {
+      __typename: 'ServeSimRunSessionRemoteConfig' as const,
+      previewUrl: PREVIEW_URL,
+      previewToken: null,
+    };
+
+    expect(sanitizeRemoteConfigForJson(remoteConfig)).toEqual({
+      __typename: 'ServeSimRunSessionRemoteConfig',
+      previewUrl: PREVIEW_URL,
+    });
+  });
+
+  it('leaves a controller session with no web preview alone', () => {
+    const sanitized = sanitizeRemoteConfigForJson({
+      __typename: 'AppiumRunSessionRemoteConfig' as const,
+      appiumUrl: 'https://appium.example.test',
+      capabilities: {},
+      webPreviewUrl: null,
+      webPreviewToken: null,
+    });
+
+    expect(sanitized).toMatchObject({ webPreviewUrl: null });
   });
 });
 

--- a/packages/eas-cli/src/simulator/__tests__/utils.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/utils.test.ts
@@ -3,8 +3,11 @@ import {
   DEVICE_RUN_SESSION_RESOURCE_CLASS_BY_FLAG_VALUE,
   DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE,
   DEVICE_RUN_SESSION_TYPE_FLAG_VALUES,
+  EAS_SIMULATOR_WAITLIST_URL,
   deviceRunSessionTypeToFlagValue,
+  formatPreviewUrl,
   formatRemoteSessionInstructions,
+  formatSimulatorUnavailableMessage,
   getRemoteSessionEnvironmentVariables,
 } from '../utils';
 
@@ -71,5 +74,160 @@ describe('simulator resource class flags', () => {
     expect(DEVICE_RUN_SESSION_RESOURCE_CLASS_BY_FLAG_VALUE.medium).toBe(
       DeviceRunSessionResourceClass.Medium
     );
+  });
+});
+
+describe(formatPreviewUrl, () => {
+  it('appends the session token for a gated preview', () => {
+    expect(formatPreviewUrl('https://preview.example.test', 'tok-1')).toBe(
+      'https://preview.example.test/?token=tok-1'
+    );
+  });
+
+  it('leaves the url alone when the preview is ungated', () => {
+    expect(formatPreviewUrl('https://preview.example.test', null)).toBe(
+      'https://preview.example.test'
+    );
+    expect(formatPreviewUrl('https://preview.example.test', undefined)).toBe(
+      'https://preview.example.test'
+    );
+  });
+});
+
+describe('gated preview links', () => {
+  const PREVIEW = 'https://preview.example.test';
+  const GATED = `${PREVIEW}/?token=tok-1`;
+
+  it('prints the tokenized preview for a serve-sim session', () => {
+    const instructions = formatRemoteSessionInstructions(
+      {
+        __typename: 'ServeSimRunSessionRemoteConfig' as const,
+        previewUrl: PREVIEW,
+        previewToken: 'tok-1',
+      },
+      'env'
+    );
+
+    expect(instructions).toContain(GATED);
+  });
+
+  it('prints the tokenized preview for a web-preview-only session', () => {
+    const instructions = formatRemoteSessionInstructions(
+      {
+        __typename: 'WebPreviewOnlyRunSessionRemoteConfig' as const,
+        previewUrl: PREVIEW,
+        previewToken: 'tok-1',
+      },
+      'env'
+    );
+
+    expect(instructions).toContain(GATED);
+  });
+
+  it('prints the tokenized preview for every controller session type', () => {
+    const controllers = [
+      {
+        __typename: 'AgentDeviceRunSessionRemoteConfig' as const,
+        agentDeviceRemoteSessionUrl: 'https://daemon.example.test',
+        agentDeviceRemoteSessionToken: 'daemon-token',
+        webPreviewUrl: PREVIEW,
+        webPreviewToken: 'tok-1',
+      },
+      {
+        __typename: 'ArgentRunSessionRemoteConfig' as const,
+        toolsUrl: 'https://argent.example.test',
+        toolsAuthToken: 'argent-token',
+        webPreviewUrl: PREVIEW,
+        webPreviewToken: 'tok-1',
+      },
+      { ...iosAppiumConfig, webPreviewToken: 'tok-1' },
+    ];
+
+    for (const remoteConfig of controllers) {
+      expect(formatRemoteSessionInstructions(remoteConfig, 'env')).toContain(GATED);
+    }
+  });
+
+  it('prints the plain url when the preview is ungated', () => {
+    const instructions = formatRemoteSessionInstructions(
+      { __typename: 'ServeSimRunSessionRemoteConfig' as const, previewUrl: PREVIEW },
+      'env'
+    );
+
+    expect(instructions).toContain(PREVIEW);
+    expect(instructions).not.toContain('token=');
+  });
+});
+
+describe('preview-only session environment', () => {
+  it.each([
+    { __typename: 'ServeSimRunSessionRemoteConfig' as const, previewUrl: 'https://p.example.test' },
+    {
+      __typename: 'WebPreviewOnlyRunSessionRemoteConfig' as const,
+      previewUrl: 'https://p.example.test',
+    },
+  ])('has no controller variables for $__typename', remoteConfig => {
+    expect(getRemoteSessionEnvironmentVariables(remoteConfig)).toEqual({});
+  });
+});
+
+describe('Argent session without a tools token', () => {
+  const untokenizedArgent = {
+    __typename: 'ArgentRunSessionRemoteConfig' as const,
+    toolsUrl: 'https://argent.example.test',
+    webPreviewUrl: null,
+  };
+
+  it('omits the auth variable', () => {
+    expect(getRemoteSessionEnvironmentVariables(untokenizedArgent)).toEqual({
+      ARGENT_TOOLS_URL: 'https://argent.example.test',
+    });
+  });
+
+  it('omits the --token flag from the link command', () => {
+    const instructions = formatRemoteSessionInstructions(untokenizedArgent, 'dotenv');
+
+    expect(instructions).toContain("argent link 'https://argent.example.test'");
+    expect(instructions).not.toContain('--token');
+  });
+});
+
+describe('dotenv instructions', () => {
+  it('tells an agent-device session to use simulator:exec', () => {
+    const instructions = formatRemoteSessionInstructions(
+      {
+        __typename: 'AgentDeviceRunSessionRemoteConfig' as const,
+        agentDeviceRemoteSessionUrl: 'https://daemon.example.test',
+        agentDeviceRemoteSessionToken: 'daemon-token',
+        webPreviewUrl: null,
+      },
+      'dotenv'
+    );
+
+    expect(instructions).toContain('eas simulator:exec npx agent-device <command>');
+  });
+
+  it('tells an argent session to link its local client', () => {
+    const instructions = formatRemoteSessionInstructions(
+      {
+        __typename: 'ArgentRunSessionRemoteConfig' as const,
+        toolsUrl: 'https://argent.example.test',
+        toolsAuthToken: 'argent-token',
+        webPreviewUrl: null,
+      },
+      'dotenv'
+    );
+
+    expect(instructions).toContain('link your local Argent client');
+    expect(instructions).toContain("--token 'argent-token'");
+  });
+});
+
+describe(formatSimulatorUnavailableMessage, () => {
+  it('names the account and points at the waitlist', () => {
+    const message = formatSimulatorUnavailableMessage('acme');
+
+    expect(message).toContain('acme');
+    expect(message).toContain(EAS_SIMULATOR_WAITLIST_URL);
   });
 });

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -99,6 +99,34 @@ export function formatPreviewUrl(url: string, token: string | null | undefined):
   return withToken.toString();
 }
 
+/**
+ * Remote config for `--json`. The preview URL carries the token and the standalone token field is
+ * dropped, so a consumer gets one URL that works rather than a bare URL that 401s next to a secret
+ * it has to know to combine.
+ */
+export function sanitizeRemoteConfigForJson(
+  remoteConfig: DeviceRunSessionRemoteConfig
+): DeviceRunSessionRemoteConfig {
+  switch (remoteConfig.__typename) {
+    case 'ServeSimRunSessionRemoteConfig':
+    case 'WebPreviewOnlyRunSessionRemoteConfig': {
+      const { previewToken, ...rest } = remoteConfig;
+      return { ...rest, previewUrl: formatPreviewUrl(remoteConfig.previewUrl, previewToken) };
+    }
+    case 'AgentDeviceRunSessionRemoteConfig':
+    case 'ArgentRunSessionRemoteConfig':
+    case 'AppiumRunSessionRemoteConfig': {
+      const { webPreviewToken, ...rest } = remoteConfig;
+      return {
+        ...rest,
+        webPreviewUrl: remoteConfig.webPreviewUrl
+          ? formatPreviewUrl(remoteConfig.webPreviewUrl, webPreviewToken)
+          : remoteConfig.webPreviewUrl,
+      };
+    }
+  }
+}
+
 export function formatRemoteSessionInstructions(
   remoteConfig: DeviceRunSessionRemoteConfig,
   configType: RemoteSessionInstructionsConfigType

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -86,6 +86,19 @@ export function getRemoteSessionEnvironmentVariables(
 
 type RemoteSessionInstructionsConfigType = 'env' | 'dotenv';
 
+/**
+ * Preview link for a session. A gated serve-sim needs the session token, and a browser cannot send
+ * a header on a page load, so it rides the query. serve-sim swaps it for a cookie on the first load.
+ */
+export function formatPreviewUrl(url: string, token: string | null | undefined): string {
+  if (!token) {
+    return url;
+  }
+  const withToken = new URL(url);
+  withToken.searchParams.set('token', token);
+  return withToken.toString();
+}
+
 export function formatRemoteSessionInstructions(
   remoteConfig: DeviceRunSessionRemoteConfig,
   configType: RemoteSessionInstructionsConfigType
@@ -112,7 +125,7 @@ export function formatRemoteSessionInstructions(
           '',
           '🌐 Open the following URL in your browser to preview the simulator:',
           '',
-          remoteConfig.webPreviewUrl
+          formatPreviewUrl(remoteConfig.webPreviewUrl, remoteConfig.webPreviewToken)
         );
       }
       return lines.join('\n');
@@ -150,7 +163,7 @@ export function formatRemoteSessionInstructions(
           '',
           '🌐 Open the following URL in your browser to preview the simulator:',
           '',
-          remoteConfig.webPreviewUrl
+          formatPreviewUrl(remoteConfig.webPreviewUrl, remoteConfig.webPreviewToken)
         );
       }
       return lines.join('\n');
@@ -174,7 +187,12 @@ export function formatRemoteSessionInstructions(
               '<appium-client> [args...]',
             ];
       if (remoteConfig.webPreviewUrl) {
-        lines.push('', 'Open the simulator preview:', '', remoteConfig.webPreviewUrl);
+        lines.push(
+          '',
+          'Open the simulator preview:',
+          '',
+          formatPreviewUrl(remoteConfig.webPreviewUrl, remoteConfig.webPreviewToken)
+        );
       }
       return lines.join('\n');
     }
@@ -182,13 +200,13 @@ export function formatRemoteSessionInstructions(
       return [
         '🌐 Open the following URL in your browser to access the simulator:',
         '',
-        remoteConfig.previewUrl,
+        formatPreviewUrl(remoteConfig.previewUrl, remoteConfig.previewToken),
       ].join('\n');
     case 'WebPreviewOnlyRunSessionRemoteConfig':
       return [
         '🌐 Open the following URL in your browser to access the simulator:',
         '',
-        remoteConfig.previewUrl,
+        formatPreviewUrl(remoteConfig.previewUrl, remoteConfig.previewToken),
       ].join('\n');
   }
 }


### PR DESCRIPTION

# Why

`eas simulator` and `eas simulator get` print the preview link. Once the preview is gated by expo/serve-sim#49, a bare link returns 401, so the printed instructions stop working. This affects every iOS session type, not only serve-sim ones.

# How

- Ask for the token in the session query, then append `?token=` when there is one. All four print sites go through the same `formatPreviewUrl` helper.
- Nothing changes for a session without a token, which is every session today.
- Ships before #4306, which is what turns gating on.

# Test Plan

- CI
