### PR TITLE
[build-tools] Default Android emulator to Pixel 9 on API 36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- [build-tools] Update the default Android emulator to a Pixel 9 running Android 36.
+- [build-tools] Update the default Android emulator to a Pixel 9 running Android 36. ([#4316](https://github.com/expo/eas-cli/pull/4316) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ## [23.1.0](https://github.com/expo/eas-cli/releases/tag/v23.1.0) - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [build-tools] Update the default Android emulator to a Pixel 9 running Android 36.
+
 ## [23.1.0](https://github.com/expo/eas-cli/releases/tag/v23.1.0) - 2026-08-31
 
 ### 🎉 New features

--- a/packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts
@@ -21,7 +21,8 @@ jest.mock('../../../utils/retry', () => ({
 
 jest.mock('../../../utils/AndroidEmulatorUtils', () => ({
   AndroidEmulatorUtils: {
-    defaultSystemImagePackage: 'system-images;android-30;default;x86_64',
+    defaultDeviceIdentifier: 'pixel_9',
+    defaultSystemImagePackage: 'system-images;android-36;default;x86_64',
     getAvailableDevicesAsync: jest.fn(),
     createAsync: jest.fn(),
     cloneAsync: jest.fn(),
@@ -255,6 +256,25 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
     expect(mockedAndroidUtils.waitForReadyAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         serialId: 'emulator-default',
+      })
+    );
+  });
+
+  it('creates a Pixel 9 emulator with the Android 36 system image by default', async () => {
+    await createStep().executeAsync();
+
+    expect(mockedSpawn).toHaveBeenCalledWith(
+      'sdkmanager',
+      ['system-images;android-36;default;x86_64'],
+      expect.objectContaining({
+        env: expect.any(Object),
+      })
+    );
+    expect(mockedAndroidUtils.createAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deviceIdentifier: 'pixel_9',
+        deviceName: 'EasAndroidDevice01',
+        systemImagePackage: 'system-images;android-36;default;x86_64',
       })
     );
   });

--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -38,6 +38,7 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
       BuildStepInput.createProvider({
         id: 'device_identifier',
         required: false,
+        defaultValue: AndroidEmulatorUtils.defaultDeviceIdentifier,
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
       BuildStepInput.createProvider({

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -24,7 +24,8 @@ export type AndroidDeviceSerialId = string & z.BRAND<'AndroidDeviceSerialId'>;
 export namespace AndroidEmulatorUtils {
   const RETRY_INTERVAL_MS = 1_000;
 
-  export const defaultSystemImagePackage = `system-images;android-30;default;${
+  export const defaultDeviceIdentifier = 'pixel_9' as AndroidDeviceName;
+  export const defaultSystemImagePackage = `system-images;android-36;default;${
     process.arch === 'arm64' ? 'arm64-v8a' : 'x86_64'
   }`;
 


### PR DESCRIPTION
## Why

Android emulator sessions defaulted to an Android 30 system image without a specific hardware profile. Update the defaults to represent a current Android device and SDK.

## How

- default the AVD hardware profile to `pixel_9`
- default the system image to Android 36 while retaining host-aware ARM64/x86_64 selection
- preserve explicit `device_identifier` and `system_image_package` overrides
- add regression coverage for image installation and AVD creation inputs

## Test plan

- `yarn workspace @expo/build-tools jest-unit src/steps/functions/__tests__/startAndroidEmulator.test.ts --runInBand`
- `yarn workspace @expo/build-tools typecheck`
- format modified files with `oxfmt`
- `git diff --check`
