### PR TITLE
[eas-cli] Support protected update channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- [eas-cli] Add commands to protect and unprotect EAS Update channels, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))
+- [eas-cli] Add `eas channel:protect` and `eas channel:unprotect` to manage EAS Update channel protection, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add commands to protect and unprotect EAS Update channels, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))
+
 ### 🐛 Bug fixes
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))

--- a/packages/eas-cli/src/channel/__tests__/fixtures.ts
+++ b/packages/eas-cli/src/channel/__tests__/fixtures.ts
@@ -133,6 +133,7 @@ export const testChannelObject: UpdateChannelObject = {
     '{"data":[{"branchId":"754bf17f-efc0-46ab-8a59-a03f20e53e9b","branchMappingLogic":{"operand":0.15,"clientKey":"rolloutToken","branchMappingOperator":"hash_lt"}},{"branchId":"6941a8dd-5c0a-48bc-8876-f49c88ed419f","branchMappingLogic":"true"}],"version":0}',
   updateBranches: [testUpdateBranch1, testUpdateBranch2],
   isPaused: false,
+  isProtected: false,
   __typename: 'UpdateChannel',
 };
 
@@ -141,6 +142,7 @@ export const testBasicChannelInfo: UpdateChannelBasicInfoFragment = {
   name: 'production',
   branchMapping:
     '{"data":[{"branchId":"754bf17f-efc0-46ab-8a59-a03f20e53e9b","branchMappingLogic":{"operand":0.1,"clientKey":"rolloutToken","branchMappingOperator":"hash_lt"}},{"branchId":"6941a8dd-5c0a-48bc-8876-f49c88ed419f","branchMappingLogic":"true"}],"version":0}',
+  isProtected: false,
   __typename: 'UpdateChannel',
 };
 
@@ -149,5 +151,6 @@ export const testBasicChannelInfo2: UpdateChannelBasicInfoFragment = {
   name: 'staging',
   branchMapping:
     '{"data":[{"branchId":"d7d68e32-d9c9-4a8d-8d1b-21e53100a5e8","branchMappingLogic":{"operand":0.1,"clientKey":"rolloutToken","branchMappingOperator":"hash_lt"}},{"branchId":"f9f708c2-0c91-4360-b2a4-0b61834aef4a","branchMappingLogic":"true"}],"version":0}',
+  isProtected: false,
   __typename: 'UpdateChannel',
 };

--- a/packages/eas-cli/src/channel/__tests__/protection-test.ts
+++ b/packages/eas-cli/src/channel/__tests__/protection-test.ts
@@ -1,0 +1,54 @@
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { protectUpdateChannelAsync, unprotectUpdateChannelAsync } from '../protection';
+
+function makeGraphqlClient(data: unknown): {
+  graphqlClient: ExpoGraphqlClient;
+  mutation: jest.Mock;
+} {
+  const mutation = jest.fn().mockReturnValue({
+    toPromise: jest.fn().mockResolvedValue({ data }),
+  });
+  return { graphqlClient: { mutation } as unknown as ExpoGraphqlClient, mutation };
+}
+
+describe(protectUpdateChannelAsync.name, () => {
+  it('protects a channel by ID and returns the server state', async () => {
+    const channel = {
+      id: 'channel-id',
+      name: 'production',
+      branchMapping: '{"version":0,"data":[]}',
+      isProtected: true,
+    };
+    const { graphqlClient, mutation } = makeGraphqlClient({
+      updateChannel: { protectUpdateChannel: channel },
+    });
+
+    await expect(
+      protectUpdateChannelAsync(graphqlClient, { channelId: 'channel-id' })
+    ).resolves.toEqual(channel);
+
+    expect(mutation.mock.calls[0][0].loc.source.body).toContain('protectUpdateChannel');
+    expect(mutation.mock.calls[0][1]).toEqual({ channelId: 'channel-id' });
+  });
+});
+
+describe(unprotectUpdateChannelAsync.name, () => {
+  it('unprotects a channel by ID and returns the server state', async () => {
+    const channel = {
+      id: 'channel-id',
+      name: 'production',
+      branchMapping: '{"version":0,"data":[]}',
+      isProtected: false,
+    };
+    const { graphqlClient, mutation } = makeGraphqlClient({
+      updateChannel: { unprotectUpdateChannel: channel },
+    });
+
+    await expect(
+      unprotectUpdateChannelAsync(graphqlClient, { channelId: 'channel-id' })
+    ).resolves.toEqual(channel);
+
+    expect(mutation.mock.calls[0][0].loc.source.body).toContain('unprotectUpdateChannel');
+    expect(mutation.mock.calls[0][1]).toEqual({ channelId: 'channel-id' });
+  });
+});

--- a/packages/eas-cli/src/channel/__tests__/protection-test.ts
+++ b/packages/eas-cli/src/channel/__tests__/protection-test.ts
@@ -30,6 +30,16 @@ describe(protectUpdateChannelAsync.name, () => {
     expect(mutation.mock.calls[0][0].loc.source.body).toContain('protectUpdateChannel');
     expect(mutation.mock.calls[0][1]).toEqual({ channelId: 'channel-id' });
   });
+
+  it('throws a clear error when the channel is not returned', async () => {
+    const { graphqlClient } = makeGraphqlClient({
+      updateChannel: { protectUpdateChannel: null },
+    });
+
+    await expect(
+      protectUpdateChannelAsync(graphqlClient, { channelId: 'missing-channel-id' })
+    ).rejects.toThrow('Could not find a channel with id: missing-channel-id');
+  });
 });
 
 describe(unprotectUpdateChannelAsync.name, () => {
@@ -50,5 +60,15 @@ describe(unprotectUpdateChannelAsync.name, () => {
 
     expect(mutation.mock.calls[0][0].loc.source.body).toContain('unprotectUpdateChannel');
     expect(mutation.mock.calls[0][1]).toEqual({ channelId: 'channel-id' });
+  });
+
+  it('throws a clear error when the channel is not returned', async () => {
+    const { graphqlClient } = makeGraphqlClient({
+      updateChannel: { unprotectUpdateChannel: null },
+    });
+
+    await expect(
+      unprotectUpdateChannelAsync(graphqlClient, { channelId: 'missing-channel-id' })
+    ).rejects.toThrow('Could not find a channel with id: missing-channel-id');
   });
 });

--- a/packages/eas-cli/src/channel/__tests__/queries-test.ts
+++ b/packages/eas-cli/src/channel/__tests__/queries-test.ts
@@ -1,0 +1,26 @@
+import { renderChannelHeaderContent } from '../queries';
+import Log from '../../log';
+
+jest.mock('../../log');
+
+describe(renderChannelHeaderContent.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [true, 'Protected'],
+    [false, 'Unprotected'],
+  ])('renders protection state when isProtected is %s', (isProtected, expected) => {
+    renderChannelHeaderContent({
+      channelName: 'production',
+      channelId: 'channel-id',
+      isPaused: false,
+      isProtected,
+    });
+
+    const output = jest.mocked(Log.log).mock.calls.flat().join('\n');
+    expect(output).toContain('Protection');
+    expect(output).toContain(expected);
+  });
+});

--- a/packages/eas-cli/src/channel/protection.ts
+++ b/packages/eas-cli/src/channel/protection.ts
@@ -34,7 +34,11 @@ export async function protectUpdateChannelAsync(
       )
       .toPromise()
   );
-  return data.updateChannel.protectUpdateChannel;
+  const channel = data.updateChannel.protectUpdateChannel;
+  if (!channel) {
+    throw new Error(`Could not find a channel with id: ${channelId}`);
+  }
+  return channel;
 }
 
 export async function unprotectUpdateChannelAsync(
@@ -59,5 +63,9 @@ export async function unprotectUpdateChannelAsync(
       )
       .toPromise()
   );
-  return data.updateChannel.unprotectUpdateChannel;
+  const channel = data.updateChannel.unprotectUpdateChannel;
+  if (!channel) {
+    throw new Error(`Could not find a channel with id: ${channelId}`);
+  }
+  return channel;
 }

--- a/packages/eas-cli/src/channel/protection.ts
+++ b/packages/eas-cli/src/channel/protection.ts
@@ -1,0 +1,63 @@
+import { print } from 'graphql';
+import gql from 'graphql-tag';
+
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import { withErrorHandlingAsync } from '../graphql/client';
+import {
+  ProtectUpdateChannelMutation,
+  ProtectUpdateChannelMutationVariables,
+  UnprotectUpdateChannelMutation,
+  UnprotectUpdateChannelMutationVariables,
+  UpdateChannelBasicInfoFragment,
+} from '../graphql/generated';
+import { UpdateChannelBasicInfoFragmentNode } from '../graphql/types/UpdateChannelBasicInfo';
+
+export async function protectUpdateChannelAsync(
+  graphqlClient: ExpoGraphqlClient,
+  { channelId }: ProtectUpdateChannelMutationVariables
+): Promise<UpdateChannelBasicInfoFragment> {
+  const data = await withErrorHandlingAsync(
+    graphqlClient
+      .mutation<ProtectUpdateChannelMutation, ProtectUpdateChannelMutationVariables>(
+        gql`
+          mutation ProtectUpdateChannel($channelId: ID!) {
+            updateChannel {
+              protectUpdateChannel(channelId: $channelId) {
+                id
+                ...UpdateChannelBasicInfoFragment
+              }
+            }
+          }
+          ${print(UpdateChannelBasicInfoFragmentNode)}
+        `,
+        { channelId }
+      )
+      .toPromise()
+  );
+  return data.updateChannel.protectUpdateChannel;
+}
+
+export async function unprotectUpdateChannelAsync(
+  graphqlClient: ExpoGraphqlClient,
+  { channelId }: UnprotectUpdateChannelMutationVariables
+): Promise<UpdateChannelBasicInfoFragment> {
+  const data = await withErrorHandlingAsync(
+    graphqlClient
+      .mutation<UnprotectUpdateChannelMutation, UnprotectUpdateChannelMutationVariables>(
+        gql`
+          mutation UnprotectUpdateChannel($channelId: ID!) {
+            updateChannel {
+              unprotectUpdateChannel(channelId: $channelId) {
+                id
+                ...UpdateChannelBasicInfoFragment
+              }
+            }
+          }
+          ${print(UpdateChannelBasicInfoFragmentNode)}
+        `,
+        { channelId }
+      )
+      .toPromise()
+  );
+  return data.updateChannel.unprotectUpdateChannel;
+}

--- a/packages/eas-cli/src/channel/queries.ts
+++ b/packages/eas-cli/src/channel/queries.ts
@@ -125,6 +125,7 @@ export async function listAndRenderBranchesAndUpdatesOnChannelAsync(
     channelName: channel.name,
     channelId: channel.id,
     isPaused: channel.isPaused,
+    isProtected: channel.isProtected,
   });
 
   if (paginatedQueryOptions.nonInteractive) {
@@ -186,6 +187,7 @@ function renderPageOfChannels(
         channelName: channel.name,
         channelId: channel.id,
         isPaused: channel.isPaused,
+        isProtected: channel.isProtected,
       });
       Log.addNewLineIfNone();
       logChannelDetails(channel);
@@ -212,14 +214,16 @@ function renderPageOfBranchesOnChannel(
   }
 }
 
-function renderChannelHeaderContent({
+export function renderChannelHeaderContent({
   channelName,
   channelId,
   isPaused,
+  isProtected,
 }: {
   channelName: string;
   channelId: string;
   isPaused: boolean;
+  isProtected: boolean;
 }): void {
   Log.addNewLineIfNone();
   Log.log(chalk.bold('Channel:'));
@@ -228,6 +232,7 @@ function renderChannelHeaderContent({
       { label: 'Name', value: channelName },
       { label: 'ID', value: channelId },
       { label: 'Status', value: isPaused ? 'Paused' : 'Active' },
+      { label: 'Protection', value: isProtected ? 'Protected' : 'Unprotected' },
     ])
   );
   Log.addNewLineIfNone();

--- a/packages/eas-cli/src/commands/channel/__tests__/protection.test.ts
+++ b/packages/eas-cli/src/commands/channel/__tests__/protection.test.ts
@@ -36,7 +36,10 @@ function setContext(command: ChannelProtect | ChannelUnprotect): void {
 describe(ChannelProtect, () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.mocked(ChannelQuery.viewUpdateChannelBasicInfoAsync).mockResolvedValue(channel);
+    jest.mocked(ChannelQuery.viewUpdateChannelBasicInfoAsync).mockResolvedValue({
+      ...channel,
+      isProtected: false,
+    });
     jest.mocked(protectUpdateChannelAsync).mockResolvedValue(channel);
   });
 
@@ -63,22 +66,43 @@ describe(ChannelProtect, () => {
     expect(Log.withTick).not.toHaveBeenCalled();
   });
 
+  it('does not mutate a channel that is already protected', async () => {
+    jest.mocked(ChannelQuery.viewUpdateChannelBasicInfoAsync).mockResolvedValue(channel);
+    const command = new ChannelProtect(['production'], getMockOclifConfig());
+    setContext(command);
+
+    await command.runAsync();
+
+    expect(protectUpdateChannelAsync).not.toHaveBeenCalled();
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('already protected'));
+  });
+
   it('requires a channel name in non-interactive mode', async () => {
-    const command = new ChannelProtect(['--non-interactive'], getMockOclifConfig());
+    const command = new ChannelProtect(['--non-interactive', '--json'], getMockOclifConfig());
 
     await expect(command.runAsync()).rejects.toThrow(
       'Channel name must be set when running in non-interactive mode'
     );
+    expect(enableJsonOutput).toHaveBeenCalled();
     expect(protectUpdateChannelAsync).not.toHaveBeenCalled();
   });
 });
 
 describe(ChannelUnprotect, () => {
+  let processExitSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
     jest.mocked(ChannelQuery.viewUpdateChannelBasicInfoAsync).mockResolvedValue(channel);
     jest.mocked(unprotectUpdateChannelAsync).mockResolvedValue({ ...channel, isProtected: false });
     jest.mocked(toggleConfirmAsync).mockResolvedValue(true);
+    processExitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit');
+    }) as never);
+  });
+
+  afterEach(() => {
+    processExitSpy.mockRestore();
   });
 
   it('asks for confirmation before removing protection', async () => {
@@ -100,10 +124,26 @@ describe(ChannelUnprotect, () => {
     const command = new ChannelUnprotect(['production'], getMockOclifConfig());
     setContext(command);
 
-    await command.runAsync();
+    await expect(command.runAsync()).rejects.toThrow('process.exit');
 
     expect(unprotectUpdateChannelAsync).not.toHaveBeenCalled();
-    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('production'));
+    expect(Log.error).toHaveBeenCalledWith(expect.stringContaining('production'));
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('does not mutate a channel that is already unprotected', async () => {
+    jest.mocked(ChannelQuery.viewUpdateChannelBasicInfoAsync).mockResolvedValue({
+      ...channel,
+      isProtected: false,
+    });
+    const command = new ChannelUnprotect(['production'], getMockOclifConfig());
+    setContext(command);
+
+    await command.runAsync();
+
+    expect(toggleConfirmAsync).not.toHaveBeenCalled();
+    expect(unprotectUpdateChannelAsync).not.toHaveBeenCalled();
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('already unprotected'));
   });
 
   it('does not prompt in non-interactive mode', async () => {
@@ -117,11 +157,12 @@ describe(ChannelUnprotect, () => {
   });
 
   it('requires a channel name in non-interactive mode', async () => {
-    const command = new ChannelUnprotect(['--non-interactive'], getMockOclifConfig());
+    const command = new ChannelUnprotect(['--non-interactive', '--json'], getMockOclifConfig());
 
     await expect(command.runAsync()).rejects.toThrow(
       'Channel name must be set when running in non-interactive mode'
     );
+    expect(enableJsonOutput).toHaveBeenCalled();
     expect(unprotectUpdateChannelAsync).not.toHaveBeenCalled();
   });
 });

--- a/packages/eas-cli/src/commands/channel/__tests__/protection.test.ts
+++ b/packages/eas-cli/src/commands/channel/__tests__/protection.test.ts
@@ -1,0 +1,127 @@
+import { getMockOclifConfig } from '../../../__tests__/commands/utils';
+import {
+  protectUpdateChannelAsync,
+  unprotectUpdateChannelAsync,
+} from '../../../channel/protection';
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { ChannelQuery } from '../../../graphql/queries/ChannelQuery';
+import Log from '../../../log';
+import { toggleConfirmAsync } from '../../../prompts';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+import ChannelProtect from '../protect';
+import ChannelUnprotect from '../unprotect';
+
+jest.mock('../../../channel/protection');
+jest.mock('../../../graphql/queries/ChannelQuery');
+jest.mock('../../../log');
+jest.mock('../../../prompts');
+jest.mock('../../../utils/json');
+
+const graphqlClient = {} as ExpoGraphqlClient;
+const channel = {
+  id: 'channel-id',
+  name: 'production',
+  branchMapping: '{"version":0,"data":[]}',
+  isProtected: true,
+};
+
+function setContext(command: ChannelProtect | ChannelUnprotect): void {
+  // @ts-expect-error getContextAsync is protected
+  jest.spyOn(command, 'getContextAsync').mockResolvedValue({
+    projectId: 'project-id',
+    loggedIn: { graphqlClient },
+  });
+}
+
+describe(ChannelProtect, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(ChannelQuery.viewUpdateChannelBasicInfoAsync).mockResolvedValue(channel);
+    jest.mocked(protectUpdateChannelAsync).mockResolvedValue(channel);
+  });
+
+  it('protects a named channel', async () => {
+    const command = new ChannelProtect(['production'], getMockOclifConfig());
+    setContext(command);
+
+    await command.runAsync();
+
+    expect(protectUpdateChannelAsync).toHaveBeenCalledWith(graphqlClient, {
+      channelId: 'channel-id',
+    });
+    expect(Log.withTick).toHaveBeenCalledWith(expect.stringContaining('production'));
+  });
+
+  it('prints the server response as JSON', async () => {
+    const command = new ChannelProtect(['production', '--json'], getMockOclifConfig());
+    setContext(command);
+
+    await command.runAsync();
+
+    expect(enableJsonOutput).toHaveBeenCalled();
+    expect(printJsonOnlyOutput).toHaveBeenCalledWith(channel);
+    expect(Log.withTick).not.toHaveBeenCalled();
+  });
+
+  it('requires a channel name in non-interactive mode', async () => {
+    const command = new ChannelProtect(['--non-interactive'], getMockOclifConfig());
+
+    await expect(command.runAsync()).rejects.toThrow(
+      'Channel name must be set when running in non-interactive mode'
+    );
+    expect(protectUpdateChannelAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe(ChannelUnprotect, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(ChannelQuery.viewUpdateChannelBasicInfoAsync).mockResolvedValue(channel);
+    jest.mocked(unprotectUpdateChannelAsync).mockResolvedValue({ ...channel, isProtected: false });
+    jest.mocked(toggleConfirmAsync).mockResolvedValue(true);
+  });
+
+  it('asks for confirmation before removing protection', async () => {
+    const command = new ChannelUnprotect(['production'], getMockOclifConfig());
+    setContext(command);
+
+    await command.runAsync();
+
+    expect(toggleConfirmAsync).toHaveBeenCalledWith({
+      message: expect.stringContaining('production'),
+    });
+    expect(unprotectUpdateChannelAsync).toHaveBeenCalledWith(graphqlClient, {
+      channelId: 'channel-id',
+    });
+  });
+
+  it('does not mutate the channel when confirmation is declined', async () => {
+    jest.mocked(toggleConfirmAsync).mockResolvedValue(false);
+    const command = new ChannelUnprotect(['production'], getMockOclifConfig());
+    setContext(command);
+
+    await command.runAsync();
+
+    expect(unprotectUpdateChannelAsync).not.toHaveBeenCalled();
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('production'));
+  });
+
+  it('does not prompt in non-interactive mode', async () => {
+    const command = new ChannelUnprotect(['production', '--non-interactive'], getMockOclifConfig());
+    setContext(command);
+
+    await command.runAsync();
+
+    expect(toggleConfirmAsync).not.toHaveBeenCalled();
+    expect(unprotectUpdateChannelAsync).toHaveBeenCalled();
+  });
+
+  it('requires a channel name in non-interactive mode', async () => {
+    const command = new ChannelUnprotect(['--non-interactive'], getMockOclifConfig());
+
+    await expect(command.runAsync()).rejects.toThrow(
+      'Channel name must be set when running in non-interactive mode'
+    );
+    expect(unprotectUpdateChannelAsync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/eas-cli/src/commands/channel/protect.ts
+++ b/packages/eas-cli/src/commands/channel/protect.ts
@@ -1,0 +1,69 @@
+import { Args } from '@oclif/core';
+import chalk from 'chalk';
+
+import { protectUpdateChannelAsync } from '../../channel/protection';
+import { selectChannelOnAppAsync } from '../../channel/queries';
+import EasCommand from '../../commandUtils/EasCommand';
+import {
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
+} from '../../commandUtils/flags';
+import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
+import Log from '../../log';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+
+export default class ChannelProtect extends EasCommand {
+  static override description = 'protect a channel';
+
+  static override args = {
+    name: Args.string({
+      required: false,
+      description: 'Name of the channel to protect',
+    }),
+  };
+
+  static override flags = {
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectId,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const { args, flags } = await this.parse(ChannelProtect);
+    const { json, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+    if (!args.name && nonInteractive) {
+      throw new Error('Channel name must be set when running in non-interactive mode');
+    }
+    const {
+      projectId,
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(ChannelProtect, { nonInteractive });
+    if (json) {
+      enableJsonOutput();
+    }
+
+    const existingChannel = args.name
+      ? await ChannelQuery.viewUpdateChannelBasicInfoAsync(graphqlClient, {
+          appId: projectId,
+          channelName: args.name,
+        })
+      : await selectChannelOnAppAsync(graphqlClient, {
+          projectId,
+          selectionPromptTitle: 'Select a channel to protect',
+          paginatedQueryOptions: { json, nonInteractive, offset: 0 },
+        });
+
+    const channel = await protectUpdateChannelAsync(graphqlClient, {
+      channelId: existingChannel.id,
+    });
+
+    if (json) {
+      printJsonOnlyOutput(channel);
+    } else {
+      Log.withTick(chalk`Channel {bold ${channel.name}} is now protected.`);
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/channel/protect.ts
+++ b/packages/eas-cli/src/commands/channel/protect.ts
@@ -13,7 +13,7 @@ import Log from '../../log';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class ChannelProtect extends EasCommand {
-  static override description = 'protect a channel';
+  static override description = 'protect a channel so only account admins can publish to it';
 
   static override args = {
     name: Args.string({
@@ -34,6 +34,9 @@ export default class ChannelProtect extends EasCommand {
   async runAsync(): Promise<void> {
     const { args, flags } = await this.parse(ChannelProtect);
     const { json, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+    if (json) {
+      enableJsonOutput();
+    }
     if (!args.name && nonInteractive) {
       throw new Error('Channel name must be set when running in non-interactive mode');
     }
@@ -41,10 +44,6 @@ export default class ChannelProtect extends EasCommand {
       projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelProtect, { nonInteractive });
-    if (json) {
-      enableJsonOutput();
-    }
-
     const existingChannel = args.name
       ? await ChannelQuery.viewUpdateChannelBasicInfoAsync(graphqlClient, {
           appId: projectId,
@@ -55,6 +54,15 @@ export default class ChannelProtect extends EasCommand {
           selectionPromptTitle: 'Select a channel to protect',
           paginatedQueryOptions: { json, nonInteractive, offset: 0 },
         });
+
+    if (existingChannel.isProtected) {
+      if (json) {
+        printJsonOnlyOutput(existingChannel);
+      } else {
+        Log.log(chalk`Channel {bold ${existingChannel.name}} is already protected.`);
+      }
+      return;
+    }
 
     const channel = await protectUpdateChannelAsync(graphqlClient, {
       channelId: existingChannel.id,

--- a/packages/eas-cli/src/commands/channel/unprotect.ts
+++ b/packages/eas-cli/src/commands/channel/unprotect.ts
@@ -1,0 +1,80 @@
+import { Args } from '@oclif/core';
+import chalk from 'chalk';
+
+import { unprotectUpdateChannelAsync } from '../../channel/protection';
+import { selectChannelOnAppAsync } from '../../channel/queries';
+import EasCommand from '../../commandUtils/EasCommand';
+import {
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
+} from '../../commandUtils/flags';
+import { ChannelQuery } from '../../graphql/queries/ChannelQuery';
+import Log from '../../log';
+import { toggleConfirmAsync } from '../../prompts';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+
+export default class ChannelUnprotect extends EasCommand {
+  static override description = 'remove protection from a channel';
+
+  static override args = {
+    name: Args.string({
+      required: false,
+      description: 'Name of the channel to unprotect',
+    }),
+  };
+
+  static override flags = {
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectId,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const { args, flags } = await this.parse(ChannelUnprotect);
+    const { json, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+    if (!args.name && nonInteractive) {
+      throw new Error('Channel name must be set when running in non-interactive mode');
+    }
+    const {
+      projectId,
+      loggedIn: { graphqlClient },
+    } = await this.getContextAsync(ChannelUnprotect, { nonInteractive });
+    if (json) {
+      enableJsonOutput();
+    }
+
+    const existingChannel = args.name
+      ? await ChannelQuery.viewUpdateChannelBasicInfoAsync(graphqlClient, {
+          appId: projectId,
+          channelName: args.name,
+        })
+      : await selectChannelOnAppAsync(graphqlClient, {
+          projectId,
+          selectionPromptTitle: 'Select a channel to unprotect',
+          paginatedQueryOptions: { json, nonInteractive, offset: 0 },
+        });
+
+    if (!nonInteractive) {
+      const confirmed = await toggleConfirmAsync({
+        message: chalk`Remove protection from channel {bold ${existingChannel.name}}?`,
+      });
+      if (!confirmed) {
+        Log.log(chalk`Canceled removing protection from channel {bold ${existingChannel.name}}.`);
+        return;
+      }
+    }
+
+    const channel = await unprotectUpdateChannelAsync(graphqlClient, {
+      channelId: existingChannel.id,
+    });
+
+    if (json) {
+      printJsonOnlyOutput(channel);
+    } else {
+      Log.withTick(chalk`Channel {bold ${channel.name}} is no longer protected.`);
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/channel/unprotect.ts
+++ b/packages/eas-cli/src/commands/channel/unprotect.ts
@@ -14,7 +14,7 @@ import { toggleConfirmAsync } from '../../prompts';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class ChannelUnprotect extends EasCommand {
-  static override description = 'remove protection from a channel';
+  static override description = "remove a channel's admin-only publishing restriction";
 
   static override args = {
     name: Args.string({
@@ -35,6 +35,9 @@ export default class ChannelUnprotect extends EasCommand {
   async runAsync(): Promise<void> {
     const { args, flags } = await this.parse(ChannelUnprotect);
     const { json, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+    if (json) {
+      enableJsonOutput();
+    }
     if (!args.name && nonInteractive) {
       throw new Error('Channel name must be set when running in non-interactive mode');
     }
@@ -42,10 +45,6 @@ export default class ChannelUnprotect extends EasCommand {
       projectId,
       loggedIn: { graphqlClient },
     } = await this.getContextAsync(ChannelUnprotect, { nonInteractive });
-    if (json) {
-      enableJsonOutput();
-    }
-
     const existingChannel = args.name
       ? await ChannelQuery.viewUpdateChannelBasicInfoAsync(graphqlClient, {
           appId: projectId,
@@ -57,13 +56,22 @@ export default class ChannelUnprotect extends EasCommand {
           paginatedQueryOptions: { json, nonInteractive, offset: 0 },
         });
 
+    if (!existingChannel.isProtected) {
+      if (json) {
+        printJsonOnlyOutput(existingChannel);
+      } else {
+        Log.log(chalk`Channel {bold ${existingChannel.name}} is already unprotected.`);
+      }
+      return;
+    }
+
     if (!nonInteractive) {
       const confirmed = await toggleConfirmAsync({
         message: chalk`Remove protection from channel {bold ${existingChannel.name}}?`,
       });
       if (!confirmed) {
-        Log.log(chalk`Canceled removing protection from channel {bold ${existingChannel.name}}.`);
-        return;
+        Log.error(chalk`Canceled removing protection from channel {bold ${existingChannel.name}}.`);
+        process.exit(1);
       }
     }
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -13835,6 +13835,20 @@ export type ScheduleChannelDeletionMutationVariables = Exact<{
 
 export type ScheduleChannelDeletionMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', scheduleUpdateChannelDeletion: { __typename?: 'BackgroundJobReceipt', id: string, state: BackgroundJobState, tries: number, willRetry: boolean, resultId?: string | null, resultType: BackgroundJobResultType, resultData?: any | null, errorCode?: string | null, errorMessage?: string | null, createdAt: any, updatedAt: any } } };
 
+export type ProtectUpdateChannelMutationVariables = Exact<{
+  channelId: Scalars['ID']['input'];
+}>;
+
+
+export type ProtectUpdateChannelMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', protectUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, isProtected: boolean } } };
+
+export type UnprotectUpdateChannelMutationVariables = Exact<{
+  channelId: Scalars['ID']['input'];
+}>;
+
+
+export type UnprotectUpdateChannelMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', unprotectUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, isProtected: boolean } } };
+
 export type CreateUpdateChannelOnAppMutationVariables = Exact<{
   appId: Scalars['ID']['input'];
   name: Scalars['String']['input'];
@@ -13842,7 +13856,7 @@ export type CreateUpdateChannelOnAppMutationVariables = Exact<{
 }>;
 
 
-export type CreateUpdateChannelOnAppMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', createUpdateChannelForApp: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
+export type CreateUpdateChannelOnAppMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', createUpdateChannelForApp: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, isProtected: boolean } } };
 
 export type GetBranchInfoQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -13879,21 +13893,21 @@ export type UpdateChannelBranchMappingMutationVariables = Exact<{
 }>;
 
 
-export type UpdateChannelBranchMappingMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', editUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
+export type UpdateChannelBranchMappingMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', editUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, isProtected: boolean } } };
 
 export type PauseUpdateChannelMutationVariables = Exact<{
   channelId: Scalars['ID']['input'];
 }>;
 
 
-export type PauseUpdateChannelMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', pauseUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
+export type PauseUpdateChannelMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', pauseUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, isProtected: boolean } } };
 
 export type ResumeUpdateChannelMutationVariables = Exact<{
   channelId: Scalars['ID']['input'];
 }>;
 
 
-export type ResumeUpdateChannelMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', resumeUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } } };
+export type ResumeUpdateChannelMutation = { __typename?: 'RootMutation', updateChannel: { __typename?: 'UpdateChannelMutation', resumeUpdateChannel: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, isProtected: boolean } } };
 
 export type AppInfoQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -15241,7 +15255,7 @@ export type ViewUpdateChannelBasicInfoOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateChannelBasicInfoOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } | null } } };
+export type ViewUpdateChannelBasicInfoOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, isProtected: boolean } | null } } };
 
 export type ViewUpdateChannelOnAppQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -15250,7 +15264,7 @@ export type ViewUpdateChannelOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateChannelOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, isPaused: boolean, name: string, updatedAt: any, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, isGitWorkingTreeDirty: boolean, environment?: any | null, rolloutPercentage?: number | null, manifestHostOverride?: string | null, assetHostOverride?: string | null, runtime: { __typename?: 'Runtime', id: string, version: string }, actor?:
+export type ViewUpdateChannelOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannelByName?: { __typename?: 'UpdateChannel', id: string, isPaused: boolean, isProtected: boolean, name: string, updatedAt: any, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, isGitWorkingTreeDirty: boolean, environment?: any | null, rolloutPercentage?: number | null, manifestHostOverride?: string | null, assetHostOverride?: string | null, runtime: { __typename?: 'Runtime', id: string, version: string }, actor?:
               | { __typename: 'PartnerActor', username: string, id: string }
               | { __typename: 'Robot', firstName?: string | null, id: string }
               | { __typename: 'SSOUser', username: string, id: string }
@@ -15264,7 +15278,7 @@ export type ViewUpdateChannelsOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateChannelsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, isPaused: boolean, name: string, updatedAt: any, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, isGitWorkingTreeDirty: boolean, environment?: any | null, rolloutPercentage?: number | null, manifestHostOverride?: string | null, assetHostOverride?: string | null, runtime: { __typename?: 'Runtime', id: string, version: string }, actor?:
+export type ViewUpdateChannelsOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, updateChannels: Array<{ __typename?: 'UpdateChannel', id: string, isPaused: boolean, isProtected: boolean, name: string, updatedAt: any, createdAt: any, branchMapping: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updateGroups: Array<Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, platform: string, manifestFragment: string, isRollBackToEmbedded: boolean, manifestPermalink: string, gitCommitHash?: string | null, isGitWorkingTreeDirty: boolean, environment?: any | null, rolloutPercentage?: number | null, manifestHostOverride?: string | null, assetHostOverride?: string | null, runtime: { __typename?: 'Runtime', id: string, version: string }, actor?:
               | { __typename: 'PartnerActor', username: string, id: string }
               | { __typename: 'Robot', firstName?: string | null, id: string }
               | { __typename: 'SSOUser', username: string, id: string }
@@ -15280,7 +15294,7 @@ export type ViewUpdateChannelsPaginatedOnAppQueryVariables = Exact<{
 }>;
 
 
-export type ViewUpdateChannelsPaginatedOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, channelsPaginated: { __typename?: 'AppChannelsConnection', edges: Array<{ __typename?: 'AppChannelEdge', cursor: string, node: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
+export type ViewUpdateChannelsPaginatedOnAppQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, channelsPaginated: { __typename?: 'AppChannelsConnection', edges: Array<{ __typename?: 'AppChannelEdge', cursor: string, node: { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, isProtected: boolean } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type ConvexTeamConnectionsByAccountIdQueryVariables = Exact<{
   accountId: Scalars['String']['input'];
@@ -15918,7 +15932,7 @@ export type UpdateBranchFragment = { __typename?: 'UpdateBranch', id: string, na
 
 export type UpdateBranchBasicInfoFragment = { __typename?: 'UpdateBranch', id: string, name: string };
 
-export type UpdateChannelBasicInfoFragment = { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string };
+export type UpdateChannelBasicInfoFragment = { __typename?: 'UpdateChannel', id: string, name: string, branchMapping: string, isProtected: boolean };
 
 export type WebhookFragment = { __typename?: 'Webhook', id: string, event: WebhookType, url: string, createdAt: any, updatedAt: any };
 

--- a/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ChannelQuery.ts
@@ -98,6 +98,7 @@ export const ChannelQuery = {
                   updateChannelByName(name: $channelName) {
                     id
                     isPaused
+                    isProtected
                     name
                     updatedAt
                     createdAt
@@ -144,6 +145,7 @@ export const ChannelQuery = {
                   updateChannels(offset: $offset, limit: $limit) {
                     id
                     isPaused
+                    isProtected
                     name
                     updatedAt
                     createdAt

--- a/packages/eas-cli/src/graphql/queries/__tests__/ChannelQuery-test.ts
+++ b/packages/eas-cli/src/graphql/queries/__tests__/ChannelQuery-test.ts
@@ -1,0 +1,69 @@
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { ChannelQuery } from '../ChannelQuery';
+
+function makeGraphqlClient(data: unknown): {
+  graphqlClient: ExpoGraphqlClient;
+  query: jest.Mock;
+} {
+  const query = jest.fn().mockReturnValue({
+    toPromise: jest.fn().mockResolvedValue({ data }),
+  });
+  return { graphqlClient: { query } as unknown as ExpoGraphqlClient, query };
+}
+
+describe(ChannelQuery.viewUpdateChannelAsync.name, () => {
+  it('requests and returns channel protection state', async () => {
+    const channel = {
+      id: 'channel-id',
+      name: 'production',
+      isPaused: false,
+      isProtected: true,
+      updatedAt: '2026-08-31T00:00:00.000Z',
+      createdAt: '2026-08-31T00:00:00.000Z',
+      branchMapping: '{"version":0,"data":[]}',
+      updateBranches: [],
+    };
+    const { graphqlClient, query } = makeGraphqlClient({
+      app: { byId: { id: 'app-id', updateChannelByName: channel } },
+    });
+
+    await expect(
+      ChannelQuery.viewUpdateChannelAsync(graphqlClient, {
+        appId: 'app-id',
+        channelName: 'production',
+      })
+    ).resolves.toEqual(channel);
+
+    expect(query.mock.calls[0][0].loc.source.body).toContain('isProtected');
+  });
+});
+
+describe(ChannelQuery.viewUpdateChannelsOnAppAsync.name, () => {
+  it('requests and returns protection state for every channel', async () => {
+    const channels = [
+      {
+        id: 'channel-id',
+        name: 'production',
+        isPaused: false,
+        isProtected: true,
+        updatedAt: '2026-08-31T00:00:00.000Z',
+        createdAt: '2026-08-31T00:00:00.000Z',
+        branchMapping: '{"version":0,"data":[]}',
+        updateBranches: [],
+      },
+    ];
+    const { graphqlClient, query } = makeGraphqlClient({
+      app: { byId: { id: 'app-id', updateChannels: channels } },
+    });
+
+    await expect(
+      ChannelQuery.viewUpdateChannelsOnAppAsync(graphqlClient, {
+        appId: 'app-id',
+        limit: 10,
+        offset: 0,
+      })
+    ).resolves.toEqual(channels);
+
+    expect(query.mock.calls[0][0].loc.source.body).toContain('isProtected');
+  });
+});

--- a/packages/eas-cli/src/graphql/types/UpdateChannelBasicInfo.ts
+++ b/packages/eas-cli/src/graphql/types/UpdateChannelBasicInfo.ts
@@ -5,5 +5,6 @@ export const UpdateChannelBasicInfoFragmentNode = gql`
     id
     name
     branchMapping
+    isProtected
   }
 `;

--- a/packages/eas-cli/src/update/__tests__/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync-test.ts
+++ b/packages/eas-cli/src/update/__tests__/getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync-test.ts
@@ -64,6 +64,7 @@ describe(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync, () => {
           name: 'test-channel-name',
           branchMapping:
             '{"data":[{"branchId":"test-branch-id","branchMappingLogic":"true"}],"version":0}',
+          isProtected: false,
         },
       },
     });
@@ -130,6 +131,7 @@ describe(getBranchFromChannelNameAndCreateAndLinkIfNotExistsAsync, () => {
           name: 'test-channel-name',
           branchMapping:
             '{"data":[{"branchId":"test-branch-id","branchMappingLogic":"true"}],"version":0}',
+          isProtected: false,
         },
       },
     });


### PR DESCRIPTION
# Why

Protected EAS Update channels are already supported by the API and dashboard, but eas-cli did not show their protection state or let an admin change it.

This addresses [ENG-25975](https://linear.app/expo/issue/ENG-25975/support-protected-channels-in-eas-cli).

# How

I added `eas channel:protect` and `eas channel:unprotect`, following the structure from other CLI commands.  Unprotecting asks for confirmation since it removes a release restriction. Non-interactive use requires the channel name to be passed explicitly.

The CLI calls the existing mutations and surfaces the resulting channel. Channel list and view output now include the protection state in both human-readable output and JSON.

# Test Plan

- Added tests for the queries, mutations, rendering, confirmation flow, JSON output, and non-interactive validation.
- Ran the eas-cli test suite, workspace build, typecheck, lint, and formatting checks.
- Tested the local CLI against a disposable channel on `@sjkim95/eas-operator`:

```text
Channel:
Name        eng-25975-dogfood-20260831
Status      Active
Protection  Unprotected
```
