### PR TITLE
[eas-cli] Warn about Android simulator parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Warn when starting Android EAS Simulator sessions that support is still in development and iOS parity is coming soon. ([#4320](https://github.com/expo/eas-cli/pull/4320) by [@szdziedzic](https://github.com/szdziedzic))
+
 ## [23.1.0](https://github.com/expo/eas-cli/releases/tag/v23.1.0) - 2026-08-31
 
 ### 🎉 New features

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -614,6 +614,19 @@ describe(Simulator, () => {
     );
   });
 
+  it('warns that Android emulator support is still in development before creating a session', async () => {
+    const { command } = createCommand(['--platform', 'android', '--non-interactive']);
+
+    await command.runAsync();
+
+    expect(Log.warn).toHaveBeenCalledWith(
+      'Android emulator support in EAS Simulator is still in development. Some features available on iOS may not work on Android yet. Full parity with iOS is coming soon.'
+    );
+    expect(jest.mocked(Log.warn).mock.invocationCallOrder[0]).toBeLessThan(
+      mockCreateDeviceRunSessionAsync.mock.invocationCallOrder[0]
+    );
+  });
+
   it.each([
     ['ios', AppPlatform.Ios],
     ['android', AppPlatform.Android],

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -218,6 +218,12 @@ export default class Simulator extends EasCommand {
     }
 
     const platform = await resolvePlatformAsync(flags.platform, nonInteractive);
+    if (platform === AppPlatform.Android) {
+      Log.warn(
+        'Android emulator support in EAS Simulator is still in development. Some features available on iOS may not work on Android yet. Full parity with iOS is coming soon.'
+      );
+      Log.newLine();
+    }
     const expoGoSdkVersion = flags['expo-go']
       ? await resolveExpoGoSdkVersionAsync({ projectDir, sdkVersion: sdkVersionFromFlag })
       : undefined;


### PR DESCRIPTION
# Why

Android emulator support in EAS Simulator is still under active development and does not yet have full feature parity with iOS. The CLI should make that limitation clear before creating an Android session.

Companion website change: https://github.com/expo/universe/pull/30644

Fixes [ENG-26325](https://linear.app/expo/issue/ENG-26325/add-warning-that-android-emulator-is-in-development)

# How

- Warn after the session platform resolves to Android and before sending the session-creation mutation.
- Leave iOS session creation unchanged.
- Add the user-visible change to the changelog.

# Test Plan

CI

