### PR TITLE
[eas-cli] Add simulator profiles command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Add `lcd_width`, `lcd_height`, and `lcd_density` inputs to configure the Android emulator display. ([#4349](https://github.com/expo/eas-cli/pull/4349) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [eas-cli] Add `eas channel:protect` and `eas channel:unprotect` to manage EAS Update channel protection, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))
+- [eas-cli] Add `eas simulator:profiles` to list available EAS Simulator device and system image profiles. ([#4323](https://github.com/expo/eas-cli/pull/4323) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/src/commands/simulator/__tests__/profiles.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/profiles.test.ts
@@ -1,0 +1,125 @@
+import { Config } from '@oclif/core';
+import chalk from 'chalk';
+
+import Log from '../../../log';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+import SimulatorProfiles from '../profiles';
+
+jest.mock('../../../log');
+jest.mock('../../../utils/json');
+
+const DEVICES = [
+  'pixel_6',
+  'pixel_6_pro',
+  'pixel_6a',
+  'pixel_7',
+  'pixel_7_pro',
+  'pixel_7a',
+  'pixel_8',
+  'pixel_8_pro',
+  'pixel_8a',
+  'pixel_9',
+  'pixel_9_pro',
+  'pixel_9_pro_xl',
+  'pixel_9a',
+];
+const IMAGES = [
+  'system-images;android-30;default;x86_64',
+  'system-images;android-30;google_apis;x86_64',
+  'system-images;android-32;default;x86_64',
+  'system-images;android-32;google_apis;x86_64',
+  'system-images;android-34;default;x86_64',
+  'system-images;android-34;google_apis;x86_64',
+  'system-images;android-35;default;x86_64',
+  'system-images;android-35;google_apis;x86_64',
+  'system-images;android-36;default;x86_64',
+  'system-images;android-36;google_apis;x86_64',
+];
+const NO_IOS_PROFILES_MESSAGE = 'No simulator profiles are available for iOS yet.';
+
+const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
+const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
+const mockLog = jest.mocked(Log.log);
+
+function getMockOclifConfig(): Config {
+  const config = new Config({ root: __dirname });
+  config.runHook = async () => ({
+    failures: [],
+    successes: [],
+  });
+  return config;
+}
+
+describe(SimulatorProfiles, () => {
+  const mockConfig = getMockOclifConfig();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('emits Android profiles as JSON', async () => {
+    const command = new SimulatorProfiles(['--platform', 'android', '--json'], mockConfig);
+
+    await command.runAsync();
+
+    expect(mockEnableJsonOutput).toHaveBeenCalledTimes(1);
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({ devices: DEVICES, images: IMAGES });
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+
+  it('formats Android profiles and marks the default device', async () => {
+    const command = new SimulatorProfiles(['--platform', 'android'], mockConfig);
+
+    await command.runAsync();
+
+    expect(mockEnableJsonOutput).not.toHaveBeenCalled();
+    expect(mockPrintJsonOnlyOutput).not.toHaveBeenCalled();
+    expect(mockLog).toHaveBeenCalledWith(
+      [
+        chalk.bold('Devices:'),
+        ...DEVICES.map(
+          device =>
+            `  ${device === 'pixel_9' ? chalk.green(device) : device}${
+              device === 'pixel_9' ? ` ${chalk.green('(default)')}` : ''
+            }`
+        ),
+        '',
+        chalk.bold('System images:'),
+        ...IMAGES.map(image => `  ${image}`),
+      ].join('\n')
+    );
+  });
+
+  it('reports that iOS profiles are unavailable', async () => {
+    const command = new SimulatorProfiles(['--platform', 'ios'], mockConfig);
+
+    await command.runAsync();
+
+    expect(mockLog).toHaveBeenCalledWith(NO_IOS_PROFILES_MESSAGE);
+    expect(mockPrintJsonOnlyOutput).not.toHaveBeenCalled();
+  });
+
+  it('reports unavailable iOS profiles as a JSON error', async () => {
+    const command = new SimulatorProfiles(['--platform', 'ios', '--json'], mockConfig);
+
+    await command.runAsync();
+
+    expect(mockEnableJsonOutput).toHaveBeenCalledTimes(1);
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({ error: NO_IOS_PROFILES_MESSAGE });
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+
+  it('requires --platform', async () => {
+    const command = new SimulatorProfiles([], mockConfig);
+
+    await expect(command.runAsync()).rejects.toThrow('Missing required flag platform');
+  });
+
+  it('rejects unsupported platforms', async () => {
+    const command = new SimulatorProfiles(['--platform', 'web'], mockConfig);
+
+    await expect(command.runAsync()).rejects.toThrow(
+      'Expected --platform=web to be one of: android, ios'
+    );
+  });
+});

--- a/packages/eas-cli/src/commands/simulator/profiles.ts
+++ b/packages/eas-cli/src/commands/simulator/profiles.ts
@@ -1,0 +1,93 @@
+import { Flags } from '@oclif/core';
+import chalk from 'chalk';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import { EasJsonOnlyFlag } from '../../commandUtils/flags';
+import Log from '../../log';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+
+const PLATFORM_FLAG_VALUES = ['android', 'ios'] as const;
+const DEVICES = [
+  'pixel_6',
+  'pixel_6_pro',
+  'pixel_6a',
+  'pixel_7',
+  'pixel_7_pro',
+  'pixel_7a',
+  'pixel_8',
+  'pixel_8_pro',
+  'pixel_8a',
+  'pixel_9',
+  'pixel_9_pro',
+  'pixel_9_pro_xl',
+  'pixel_9a',
+] as const;
+const IMAGES = [
+  'system-images;android-30;default;x86_64',
+  'system-images;android-30;google_apis;x86_64',
+  'system-images;android-32;default;x86_64',
+  'system-images;android-32;google_apis;x86_64',
+  'system-images;android-34;default;x86_64',
+  'system-images;android-34;google_apis;x86_64',
+  'system-images;android-35;default;x86_64',
+  'system-images;android-35;google_apis;x86_64',
+  'system-images;android-36;default;x86_64',
+  'system-images;android-36;google_apis;x86_64',
+] as const;
+const DEFAULT_DEVICE: (typeof DEVICES)[number] = 'pixel_9';
+const NO_IOS_PROFILES_MESSAGE = 'No simulator profiles are available for iOS yet.';
+
+export default class SimulatorProfiles extends EasCommand {
+  static override hidden = true;
+  static override aliases = ['sim:profiles'];
+  static override description =
+    '[EXPERIMENTAL] list available device and system image profiles for EAS Simulator';
+
+  static override flags = {
+    platform: Flags.option({
+      char: 'p',
+      description: 'Device platform',
+      options: PLATFORM_FLAG_VALUES,
+      required: true,
+    })(),
+    ...EasJsonOnlyFlag,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(SimulatorProfiles);
+
+    if (flags.json) {
+      enableJsonOutput();
+    }
+
+    if (flags.platform === 'ios') {
+      if (flags.json) {
+        printJsonOnlyOutput({ error: NO_IOS_PROFILES_MESSAGE });
+      } else {
+        Log.log(NO_IOS_PROFILES_MESSAGE);
+      }
+      return;
+    }
+
+    if (flags.json) {
+      printJsonOnlyOutput({ devices: DEVICES, images: IMAGES });
+      return;
+    }
+
+    Log.log(
+      [
+        chalk.bold('Devices:'),
+        ...DEVICES.map(formatDevice),
+        '',
+        chalk.bold('System images:'),
+        ...IMAGES.map(image => `  ${image}`),
+      ].join('\n')
+    );
+  }
+}
+
+function formatDevice(device: (typeof DEVICES)[number]): string {
+  const formattedDevice = device === DEFAULT_DEVICE ? chalk.green(device) : device;
+  const defaultLabel = device === DEFAULT_DEVICE ? ` ${chalk.green('(default)')}` : '';
+  return `  ${formattedDevice}${defaultLabel}`;
+}


### PR DESCRIPTION
# Why

EAS Simulator accepts Android device profile identifiers, but users currently have to guess which profiles are available on the runner. Add a discoverable command for both human workflows and scripts/agents.

# How

- Add `eas simulator:profiles` with the shorter `eas sim:profiles` alias.
- Require `--platform android|ios` and support optional `--json` output.
- Hardcode the Android runner inventory as readonly device and image tuples:
  - Pixel phone profiles from Pixel 6 through Pixel 9, excluding folds, tablets, watches, and TVs.
  - Installed x86_64 `default` and `google_apis` images from API 30 through API 36 (the available APIs are 30, 32, 34, 35, and 36).
- Highlight `pixel_9` in green and label it `(default)` in human-readable output.
- Return a clear no-profiles message for iOS, including an `error` field in JSON mode.

## Usage

```sh
eas sim:profiles --platform android
eas sim:profiles --platform android --json
eas sim:profiles --platform ios
eas sim:profiles --platform ios --json
```

## Human-readable output

```text
Devices:
  pixel_6
  pixel_6_pro
  pixel_6a
  pixel_7
  pixel_7_pro
  pixel_7a
  pixel_8
  pixel_8_pro
  pixel_8a
  pixel_9 (default)
  pixel_9_pro
  pixel_9_pro_xl
  pixel_9a

System images:
  system-images;android-30;default;x86_64
  system-images;android-30;google_apis;x86_64
  system-images;android-32;default;x86_64
  system-images;android-32;google_apis;x86_64
  system-images;android-34;default;x86_64
  system-images;android-34;google_apis;x86_64
  system-images;android-35;default;x86_64
  system-images;android-35;google_apis;x86_64
  system-images;android-36;default;x86_64
  system-images;android-36;google_apis;x86_64
```

For iOS:

```text
No simulator profiles are available for iOS yet.
```

## JSON output

```json
{
  "devices": [
    "pixel_6",
    "pixel_6_pro",
    "pixel_6a",
    "pixel_7",
    "pixel_7_pro",
    "pixel_7a",
    "pixel_8",
    "pixel_8_pro",
    "pixel_8a",
    "pixel_9",
    "pixel_9_pro",
    "pixel_9_pro_xl",
    "pixel_9a"
  ],
  "images": [
    "system-images;android-30;default;x86_64",
    "system-images;android-30;google_apis;x86_64",
    "system-images;android-32;default;x86_64",
    "system-images;android-32;google_apis;x86_64",
    "system-images;android-34;default;x86_64",
    "system-images;android-34;google_apis;x86_64",
    "system-images;android-35;default;x86_64",
    "system-images;android-35;google_apis;x86_64",
    "system-images;android-36;default;x86_64",
    "system-images;android-36;google_apis;x86_64"
  ]
}
```

For iOS:

```json
{
  "error": "No simulator profiles are available for iOS yet."
}
```

# Test Plan

- `mise exec -- yarn workspace eas-cli test src/commands/simulator/__tests__/profiles.test.ts --runInBand`
- `mise exec -- yarn workspace eas-cli typecheck`
- `mise exec -- yarn workspace eas-cli build`
- `mise exec -- yarn lint`
- `mise exec -- yarn fmt:check`
- Ran all four usage examples above against the built CLI and verified the human and JSON output.
