### PR TITLE
[build-tools] Limit simulator recording bitrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Limit iOS Simulator screen recordings to 5 Mbps to keep long device run session artifacts uploadable. ([#4325](https://github.com/expo/eas-cli/pull/4325) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [23.2.0](https://github.com/expo/eas-cli/releases/tag/v23.2.0) - 2026-08-31

--- a/packages/build-tools/src/steps/utils/IosSimulatorRecordingUtils.ts
+++ b/packages/build-tools/src/steps/utils/IosSimulatorRecordingUtils.ts
@@ -16,6 +16,9 @@ const RECORD_SIM_FINISH_TIMEOUT_MS = 70_000;
 const RECORD_SIM_FORCE_STOP_TIMEOUT_MS = 5_000;
 const RECORD_SIM_MAX_ATTEMPTS_PER_BOOT = 3;
 const RECORD_SIM_COMMAND = 'record-sim';
+// A two-hour recording at this target is about 4.5 GB, leaving room below R2's
+// single-part upload limit for MP4 container overhead.
+const RECORD_SIM_BITRATE = '5000000';
 
 type IosSimulatorRecording = {
   id: string;
@@ -241,7 +244,7 @@ async function startIosSimulatorRecordingAsync(
   session.logger.info(`Starting screen recording for ${deviceName}.`);
   const recordingSpawn = spawn(
     session.recordSimCommand,
-    ['--udid', udid, '--output', outputDirectory, '--segment-duration', '0'],
+    createRecordSimArgs({ udid, outputDirectory }),
     {
       env: session.env,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -283,6 +286,25 @@ async function startIosSimulatorRecordingAsync(
     startedAt,
     getOutput,
   });
+}
+
+export function createRecordSimArgs({
+  udid,
+  outputDirectory,
+}: {
+  udid: IosSimulatorUuid;
+  outputDirectory: string;
+}): string[] {
+  return [
+    '--udid',
+    udid,
+    '--output',
+    outputDirectory,
+    '--segment-duration',
+    '0',
+    '--bitrate',
+    RECORD_SIM_BITRATE,
+  ];
 }
 
 async function resolveRecordSimCommandAsync({ env }: { env: Env }): Promise<string | null> {

--- a/packages/build-tools/src/steps/utils/__tests__/IosSimulatorRecordingUtils.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/IosSimulatorRecordingUtils.test.ts
@@ -1,0 +1,22 @@
+import { type IosSimulatorUuid } from '../../../utils/IosSimulatorUtils';
+import { createRecordSimArgs } from '../IosSimulatorRecordingUtils';
+
+describe(createRecordSimArgs, () => {
+  it('limits single-file recordings to 5 Mbps', () => {
+    expect(
+      createRecordSimArgs({
+        udid: '00000000-0000-0000-0000-000000000000' as IosSimulatorUuid,
+        outputDirectory: '/tmp/recording',
+      })
+    ).toEqual([
+      '--udid',
+      '00000000-0000-0000-0000-000000000000',
+      '--output',
+      '/tmp/recording',
+      '--segment-duration',
+      '0',
+      '--bitrate',
+      '5000000',
+    ]);
+  });
+});


### PR DESCRIPTION
# Why

iOS Simulator recordings currently inherit `record-sim`'s 30 Mbps default. Long device run sessions can therefore produce multi-gigabyte artifacts that approach or exceed the single-part upload limit.

Companion WWW change: https://github.com/expo/universe/pull/30668

# How

Pass an explicit 5 Mbps bitrate for device run session recordings. A two-hour recording at that target is about 4.5 GB before MP4 container overhead, leaving headroom below the 4.995 GiB R2 limit while retaining a reasonable H.264 screen-recording bitrate. The standalone `record-sim` default is unchanged.

# Test Plan

CI