### PR TITLE
[eas-cli] fix interpolated workflow URI validation

### DIFF
--- a/packages/eas-cli/src/commandUtils/workflow/__tests__/validation-test.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/__tests__/validation-test.ts
@@ -1,0 +1,62 @@
+import { validateWorkflowStructure } from '../validation';
+
+const workflowSchema = {
+  type: 'object',
+  properties: {
+    jobs: {
+      type: 'object',
+      additionalProperties: {
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              type: { type: 'string', const: 'slack' },
+              params: {
+                type: 'object',
+                properties: {
+                  webhook_url: { type: 'string', format: 'uri' },
+                  message: { type: 'string' },
+                },
+                required: ['webhook_url', 'message'],
+                additionalProperties: false,
+              },
+            },
+            required: ['type', 'params'],
+            additionalProperties: false,
+          },
+        ],
+      },
+    },
+  },
+  required: ['jobs'],
+  additionalProperties: false,
+};
+
+const workflowWithWebhookUrl = (webhookUrl: string): object => ({
+  jobs: {
+    notify: {
+      type: 'slack',
+      params: {
+        webhook_url: webhookUrl,
+        message: 'Build finished',
+      },
+    },
+  },
+});
+
+describe(validateWorkflowStructure, () => {
+  it('allows interpolated values for URI fields', () => {
+    expect(() => {
+      validateWorkflowStructure(
+        workflowWithWebhookUrl('${{ env.SLACK_WEBHOOK_URL }}'),
+        workflowSchema
+      );
+    }).not.toThrow();
+  });
+
+  it('still rejects invalid literal values for URI fields', () => {
+    expect(() => {
+      validateWorkflowStructure(workflowWithWebhookUrl('not a URL'), workflowSchema);
+    }).toThrow('must be a valid URI string');
+  });
+});

--- a/packages/eas-cli/src/commandUtils/workflow/validation.ts
+++ b/packages/eas-cli/src/commandUtils/workflow/validation.ts
@@ -2,6 +2,7 @@ import { InvalidEasJsonError, MissingEasJsonError } from '@expo/eas-json/build/e
 import { CombinedError } from '@urql/core';
 import { promises as fs } from 'fs';
 import path from 'path';
+import addFormats from 'ajv-formats';
 import * as YAML from 'yaml';
 
 import { validateWorkflowLocalCompositeFunctionsAsync } from './compositeFunctions';
@@ -15,9 +16,10 @@ import { ExpoGraphqlClient } from '../context/contextUtils/createGraphqlClient';
 import { parsedYamlFromWorkflowContents } from './parse';
 
 const jobTypesWithBuildProfile = new Set(['build', 'repack']);
+const validateUri = addFormats.get('uri') as (value: string) => boolean;
 
-const buildProfileIsInterpolated = (profileName: string): boolean => {
-  return profileName.includes('${{') && profileName.includes('}}');
+const stringIsInterpolated = (value: string): boolean => {
+  return value.includes('${{') && value.includes('}}');
 };
 
 export async function validateWorkflowFileAsync(
@@ -113,7 +115,7 @@ async function validateWorkflowBuildJobsAsync(parsedYaml: any, projectDir: strin
     job =>
       !buildProfileNames.has(job.value.params.profile) &&
       // If a profile name is interpolated, we can't check if it's valid until the workflow actually runs
-      !buildProfileIsInterpolated(job.value.params.profile)
+      !stringIsInterpolated(job.value.params.profile)
   );
 
   if (invalidBuildJobs.length > 0) {
@@ -139,10 +141,12 @@ function validateWorkflowJobTypes(parsedYaml: any, workflowJsonSchema: any): voi
   }
 }
 
-function validateWorkflowStructure(parsedYaml: any, workflowJsonSchema: any): void {
+export function validateWorkflowStructure(parsedYaml: any, workflowJsonSchema: any): void {
   delete workflowJsonSchema['$schema'];
 
   const ajv = createValidator();
+  // Interpolated values cannot be format-checked until the workflow runs.
+  ajv.addFormat('uri', value => stringIsInterpolated(value) || validateUri(value));
   const validate = ajv.compile(workflowJsonSchema);
   const result = validate(parsedYaml);
 


### PR DESCRIPTION
# Why

A Slack workflow can read its webhook URL from an environment variable:

```yaml
webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
```

EAS CLI checks the workflow before it sends it to Expo's server. At that point, the environment variable has not been replaced with its real value. The local URL checker sees `${{ env.SLACK_WEBHOOK_URL }}` instead of a URL and rejects the workflow.

Expo's server already accepts this workflow. The SDK does not validate Slack webhook URLs, so the bug is in EAS CLI's local check.

The EAS Workflows skill once had its own validator with the same problem. [expo/skills#149](https://github.com/expo/skills/pull/149) removed it and changed the skill to use `eas workflow:validate`. This PR fixes the check in EAS CLI instead of adding the validator back to the skill.

# How

When a URI field contains `${{ ... }}`, EAS CLI now waits for the workflow to resolve that value at runtime instead of trying to validate the unfinished URL.

Literal values still need to be valid URLs. For example, `webhook_url: not a URL` still fails validation. Other workflow and metadata checks do not change.

Fixes ENG-26025

# Test Plan

- Added a test for `${{ env.SLACK_WEBHOOK_URL }}`.
- Added a test that confirms an invalid literal URL still fails.
- Ran the EAS CLI tests and typecheck.
- Ran the repository lint and formatting checks.
- Checked the fix against the current production workflow schema.
