### PR TITLE
fix(ci): changelog for PRs from forks

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -31,7 +31,9 @@ jobs:
           script: |
             core.setFailed('Please add a changelog entry!')
       - uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
-        if: always()
+        if: >-
+          always() &&
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           message-id: changelog-entry-check
           refresh-message-position: true


### PR DESCRIPTION
# Why

Tokens in forks do not have the write privilege and thus adding the comment will fail.

# How

The added condition skips adding the comment when in a fork, avoiding a failed job even when the changelog was added.

The job still fails when the changelog is missing.

# Test Plan

- Ran `actionlint .github/workflows/changelog.yml`.
- Ran the repository formatter and formatting check.
- Ran `git diff --check`.
