### PR TITLE
[build-tools] Install FFmpeg before Android device hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
+- [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 
 ### 🧹 Chores
 

--- a/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
@@ -9,7 +9,7 @@ import { isProcessDescendantOfAsync } from '../../../utils/processes';
 import { pollArgentArtifactsForUploadAsync } from '../../utils/argentArtifacts';
 import { startArgentEventCollectionAsync } from '../../utils/argentEvents';
 import {
-  ensureFfmpegInstalledAsync,
+  ensureFfmpegInstalledOnceAsync,
   getDeviceRunSessionIdOrThrow,
   getNgrokAuthtokenOrThrow,
   getNgrokTunnelDomainOrThrow,
@@ -42,7 +42,7 @@ jest.mock('../../utils/argentEvents', () => ({
   startArgentEventCollectionAsync: jest.fn(),
 }));
 jest.mock('../../utils/remoteDeviceRunSession', () => ({
-  ensureFfmpegInstalledAsync: jest.fn(),
+  ensureFfmpegInstalledOnceAsync: jest.fn(),
   getDeviceRunSessionIdOrThrow: jest.fn(),
   getNgrokAuthtokenOrThrow: jest.fn(),
   getNgrokTunnelDomainOrThrow: jest.fn(),
@@ -129,12 +129,12 @@ describe('createStartArgentRemoteSessionBuildFunction orchestration', () => {
     );
 
     // (1) FFmpeg setup starts in the background before Argent setup.
-    expect(ensureFfmpegInstalledAsync).toHaveBeenCalledWith({
+    expect(ensureFfmpegInstalledOnceAsync).toHaveBeenCalledWith({
       runtimePlatform: BuildRuntimePlatform.LINUX,
       env: { EXISTING: 'value' },
       logger: expect.anything(),
     });
-    expect(jest.mocked(ensureFfmpegInstalledAsync).mock.invocationCallOrder[0]).toBeLessThan(
+    expect(jest.mocked(ensureFfmpegInstalledOnceAsync).mock.invocationCallOrder[0]).toBeLessThan(
       jest.mocked(spawn).mock.invocationCallOrder[0]
     );
 

--- a/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
@@ -9,6 +9,7 @@ import { isProcessDescendantOfAsync } from '../../../utils/processes';
 import { pollArgentArtifactsForUploadAsync } from '../../utils/argentArtifacts';
 import { startArgentEventCollectionAsync } from '../../utils/argentEvents';
 import {
+  ensureFfmpegInstalledAsync,
   getDeviceRunSessionIdOrThrow,
   getNgrokAuthtokenOrThrow,
   getNgrokTunnelDomainOrThrow,
@@ -127,7 +128,17 @@ describe('createStartArgentRemoteSessionBuildFunction orchestration', () => {
       } as never
     );
 
-    // (1) The event log flag is enabled, before the tool-server is launched.
+    // (1) FFmpeg setup starts in the background before Argent setup.
+    expect(ensureFfmpegInstalledAsync).toHaveBeenCalledWith({
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+      env: { EXISTING: 'value' },
+      logger: expect.anything(),
+    });
+    expect(jest.mocked(ensureFfmpegInstalledAsync).mock.invocationCallOrder[0]).toBeLessThan(
+      jest.mocked(spawn).mock.invocationCallOrder[0]
+    );
+
+    // (2) The event log flag is enabled, before the tool-server is launched.
     const spawnCalls = jest.mocked(spawn).mock.calls;
     const enableEventLogIndex = spawnCalls.findIndex(
       ([command, args]) =>
@@ -138,7 +149,7 @@ describe('createStartArgentRemoteSessionBuildFunction orchestration', () => {
       jest.mocked(spawnDetached).mock.invocationCallOrder[0]
     );
 
-    // (2) The tool-server and the collector are pinned to the exact same event log path.
+    // (3) The tool-server and the collector are pinned to the exact same event log path.
     const serverEnv = jest.mocked(spawnDetached).mock.calls[0][0].env;
     expect(serverEnv.ARGENT_EVENT_LOG).toBe(EXPECTED_EVENT_LOG_PATH);
     expect(serverEnv.EXISTING).toBe('value');
@@ -147,7 +158,7 @@ describe('createStartArgentRemoteSessionBuildFunction orchestration', () => {
       eventLogPath: EXPECTED_EVENT_LOG_PATH,
     });
 
-    // (3) Collection starts (before we wait for the session to stop) and (4) is torn down
+    // (4) Collection starts (before we wait for the session to stop) and (5) is torn down
     // afterwards, exactly once.
     expect(startArgentEventCollectionAsync).toHaveBeenCalledTimes(1);
     expect(mockStopAsync).toHaveBeenCalledTimes(1);

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -101,13 +101,15 @@ export function createStartArgentRemoteSessionBuildFunction(
 
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
         await selectXcodeDeveloperDirectoryAsync({ env, logger });
-      }
 
-      // Argent shells out to ffmpeg to record the screen. Installing it pulls a
-      // large Homebrew dependency tree, so do not block session readiness on it:
-      // the session comes up at its usual speed and only a recording started in
-      // the first moments misses ffmpeg. Never rejects, so `void` is safe.
-      void ensureFfmpegInstalledAsync({ runtimePlatform, env, logger });
+        // Argent shells out to ffmpeg to record the screen. Installing it pulls a
+        // large Homebrew dependency tree, so do not block session readiness on it:
+        // the session comes up at its usual speed and only a recording started in
+        // the first moments misses ffmpeg. On Linux the Android web preview waits
+        // for this installation before launching expo-device-hub instead.
+        // Never rejects, so `void` is safe.
+        void ensureFfmpegInstalledAsync({ runtimePlatform, env, logger });
+      }
 
       logger.info('Enabling the Argent artifacts list endpoint flag.');
       await spawn(

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -101,15 +101,14 @@ export function createStartArgentRemoteSessionBuildFunction(
 
       if (runtimePlatform === BuildRuntimePlatform.DARWIN) {
         await selectXcodeDeveloperDirectoryAsync({ env, logger });
-
-        // Argent shells out to ffmpeg to record the screen. Installing it pulls a
-        // large Homebrew dependency tree, so do not block session readiness on it:
-        // the session comes up at its usual speed and only a recording started in
-        // the first moments misses ffmpeg. On Linux the Android web preview waits
-        // for this installation before launching expo-device-hub instead.
-        // Never rejects, so `void` is safe.
-        void ensureFfmpegInstalledAsync({ runtimePlatform, env, logger });
       }
+
+      // Start the potentially slow installation while Argent is being prepared.
+      // On Linux expo-device-hub calls this again and awaits the same in-flight
+      // setup before launching. On macOS this remains non-blocking, so only a
+      // recording started in the first moments may miss ffmpeg.
+      // Never rejects, so `void` is safe.
+      void ensureFfmpegInstalledAsync({ runtimePlatform, env, logger });
 
       logger.info('Enabling the Argent artifacts list endpoint flag.');
       await spawn(

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -20,7 +20,7 @@ import { sleepAsync } from '../../utils/retry';
 import { pollArgentArtifactsForUploadAsync } from '../utils/argentArtifacts';
 import { ARGENT_EVENT_LOG_FILENAME, startArgentEventCollectionAsync } from '../utils/argentEvents';
 import {
-  ensureFfmpegInstalledAsync,
+  ensureFfmpegInstalledOnceAsync,
   getDeviceRunSessionIdOrThrow,
   getNgrokAuthtokenOrThrow,
   getNgrokTunnelDomainOrThrow,
@@ -108,7 +108,7 @@ export function createStartArgentRemoteSessionBuildFunction(
       // setup before launching. On macOS this remains non-blocking, so only a
       // recording started in the first moments may miss ffmpeg.
       // Never rejects, so `void` is safe.
-      void ensureFfmpegInstalledAsync({ runtimePlatform, env, logger });
+      void ensureFfmpegInstalledOnceAsync({ runtimePlatform, env, logger });
 
       logger.info('Enabling the Argent artifacts list endpoint flag.');
       await spawn(

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -19,6 +19,7 @@ import {
   fetchWebPreviewTurnArgsAsync,
   metricsCorsOriginToServeSimArgs,
   startDeviceWebPreviewWithTunnelAsync,
+  startExpoDeviceHubWithTunnelAsync,
   startNgrokTunnelAsync,
   turnIceServersToWebPreviewArgs,
   waitForDeviceRunSessionStoppedAsync,
@@ -440,6 +441,32 @@ describe(startDeviceWebPreviewWithTunnelAsync, () => {
     expect(args).toEqual(createServeSimArgs({ port, turnArgs, metricsCorsArgs, packageVersion }));
     expect(ngrok.forward).toHaveBeenCalledWith(expect.objectContaining({ addr: port }));
     expect(preview.previewUrl).toBe('https://ios-preview.example.test');
+
+    await preview.stopAsync();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not install ffmpeg before starting expo-device-hub outside Linux', async () => {
+    const close = jest.fn().mockResolvedValue(undefined);
+    jest.mocked(ngrok.forward).mockResolvedValue({
+      url: () => 'https://android-preview.example.test',
+      close,
+    } as never);
+
+    const preview = await startExpoDeviceHubWithTunnelAsync(createCtxMock(), {
+      runtimePlatform: BuildRuntimePlatform.DARWIN,
+      baseDomain,
+      env,
+      logger: createLoggerMock(),
+      timeoutMs: 10_000,
+    });
+
+    expect(jest.mocked(spawn).mock.calls[0][0]).toBe('npx');
+    expect(jest.mocked(spawn)).not.toHaveBeenCalledWith(
+      'ffmpeg',
+      expect.anything(),
+      expect.anything()
+    );
 
     await preview.stopAsync();
     expect(close).toHaveBeenCalledTimes(1);

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -15,7 +15,7 @@ import { sleepAsync } from '../../../utils/retry';
 import {
   createExpoDeviceHubArgs,
   createServeSimArgs,
-  ensureFfmpegInstalledAsync,
+  ensureFfmpegInstalledOnceAsync,
   fetchWebPreviewTurnArgsAsync,
   metricsCorsOriginToServeSimArgs,
   startDeviceWebPreviewWithTunnelAsync,
@@ -840,7 +840,7 @@ describe(waitForDeviceRunSessionStoppedAsync, () => {
   });
 });
 
-describe(ensureFfmpegInstalledAsync, () => {
+describe(ensureFfmpegInstalledOnceAsync, () => {
   const spawnMock = jest.mocked(spawn);
 
   function spawnResolved(): ReturnType<typeof spawn> {
@@ -859,7 +859,7 @@ describe(ensureFfmpegInstalledAsync, () => {
   it('does not install when ffmpeg is on PATH', async () => {
     spawnMock.mockReturnValueOnce(spawnResolved());
 
-    await ensureFfmpegInstalledAsync({
+    await ensureFfmpegInstalledOnceAsync({
       runtimePlatform: BuildRuntimePlatform.DARWIN,
       env: createEnvMock(),
       logger: createLoggerMock(),
@@ -872,7 +872,7 @@ describe(ensureFfmpegInstalledAsync, () => {
   it('installs ffmpeg with Homebrew on darwin when it is missing', async () => {
     spawnMock.mockReturnValueOnce(spawnRejected()).mockReturnValueOnce(spawnResolved());
 
-    await ensureFfmpegInstalledAsync({
+    await ensureFfmpegInstalledOnceAsync({
       runtimePlatform: BuildRuntimePlatform.DARWIN,
       env: createEnvMock(),
       logger: createLoggerMock(),
@@ -893,7 +893,7 @@ describe(ensureFfmpegInstalledAsync, () => {
       .mockReturnValueOnce(spawnResolved()) // apt-get update
       .mockReturnValueOnce(spawnResolved()); // apt-get install
 
-    await ensureFfmpegInstalledAsync({
+    await ensureFfmpegInstalledOnceAsync({
       runtimePlatform: BuildRuntimePlatform.LINUX,
       env: createEnvMock(),
       logger: createLoggerMock(),
@@ -930,11 +930,11 @@ describe(ensureFfmpegInstalledAsync, () => {
       logger: createLoggerMock(),
     };
 
-    const firstSetup = ensureFfmpegInstalledAsync(options);
+    const firstSetup = ensureFfmpegInstalledOnceAsync(options);
     await new Promise<void>(resolve => setImmediate(resolve));
     expect(spawnMock).toHaveBeenCalledTimes(3);
 
-    const secondSetup = ensureFfmpegInstalledAsync(options);
+    const secondSetup = ensureFfmpegInstalledOnceAsync(options);
     expect(spawnMock).toHaveBeenCalledTimes(3);
 
     finishInstall?.();
@@ -949,7 +949,7 @@ describe(ensureFfmpegInstalledAsync, () => {
       .mockReturnValueOnce(spawnResolved()); // apt-get install
     const logger = createLoggerMock();
 
-    await ensureFfmpegInstalledAsync({
+    await ensureFfmpegInstalledOnceAsync({
       runtimePlatform: BuildRuntimePlatform.LINUX,
       env: createEnvMock(),
       logger,
@@ -968,7 +968,7 @@ describe(ensureFfmpegInstalledAsync, () => {
     const logger = createLoggerMock();
 
     await expect(
-      ensureFfmpegInstalledAsync({
+      ensureFfmpegInstalledOnceAsync({
         runtimePlatform: BuildRuntimePlatform.DARWIN,
         env: createEnvMock(),
         logger,
@@ -989,7 +989,7 @@ describe(ensureFfmpegInstalledAsync, () => {
     const logger = createLoggerMock();
 
     await expect(
-      ensureFfmpegInstalledAsync({
+      ensureFfmpegInstalledOnceAsync({
         runtimePlatform: BuildRuntimePlatform.DARWIN,
         env: createEnvMock(),
         logger,

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -915,6 +915,33 @@ describe(ensureFfmpegInstalledAsync, () => {
     );
   });
 
+  it('shares an in-flight ffmpeg setup between callers', async () => {
+    let finishInstall: (() => void) | undefined;
+    const pendingInstall = new Promise<void>(resolve => {
+      finishInstall = resolve;
+    });
+    spawnMock
+      .mockReturnValueOnce(spawnRejected()) // ffmpeg -version
+      .mockReturnValueOnce(spawnResolved()) // apt-get update
+      .mockReturnValueOnce(pendingInstall as unknown as ReturnType<typeof spawn>); // apt-get install
+    const options = {
+      runtimePlatform: BuildRuntimePlatform.LINUX,
+      env: createEnvMock(),
+      logger: createLoggerMock(),
+    };
+
+    const firstSetup = ensureFfmpegInstalledAsync(options);
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(spawnMock).toHaveBeenCalledTimes(3);
+
+    const secondSetup = ensureFfmpegInstalledAsync(options);
+    expect(spawnMock).toHaveBeenCalledTimes(3);
+
+    finishInstall?.();
+    await Promise.all([firstSetup, secondSetup]);
+    expect(spawnMock).toHaveBeenCalledTimes(3);
+  });
+
   it('still installs on linux when the apt index refresh fails', async () => {
     spawnMock
       .mockReturnValueOnce(spawnRejected()) // ffmpeg -version

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -359,13 +359,20 @@ describe(startDeviceWebPreviewWithTunnelAsync, () => {
     });
   });
 
-  it('starts expo-device-hub for Linux and cleans up the preview resources', async () => {
+  it('installs ffmpeg before starting expo-device-hub for Linux', async () => {
     const packageVersion = '1.2.3';
     const close = jest.fn().mockResolvedValue(undefined);
     jest.mocked(ngrok.forward).mockResolvedValue({
       url: () => 'https://android-preview.example.test',
       close,
     } as never);
+    jest
+      .mocked(spawn)
+      .mockReturnValueOnce(
+        Promise.reject(new Error('ffmpeg is missing')) as ReturnType<typeof spawn>
+      )
+      .mockReturnValueOnce(Promise.resolve({}) as unknown as ReturnType<typeof spawn>)
+      .mockReturnValueOnce(Promise.resolve({}) as unknown as ReturnType<typeof spawn>);
 
     const preview = await startDeviceWebPreviewWithTunnelAsync(createCtxMock(), {
       runtimePlatform: BuildRuntimePlatform.LINUX,
@@ -376,7 +383,28 @@ describe(startDeviceWebPreviewWithTunnelAsync, () => {
       packageVersion,
     });
 
-    const [command, args] = jest.mocked(spawn).mock.calls[0];
+    const spawnCalls = jest.mocked(spawn).mock.calls;
+    expect(spawnCalls[0]).toEqual(['ffmpeg', ['-version'], { env }]);
+    expect(spawnCalls[1]).toEqual([
+      'sudo',
+      ['apt-get', 'update'],
+      expect.objectContaining({
+        env: expect.objectContaining({ DEBIAN_FRONTEND: 'noninteractive' }),
+      }),
+    ]);
+    expect(spawnCalls[2]).toEqual([
+      'sudo',
+      ['apt-get', 'install', '-y', 'ffmpeg'],
+      expect.objectContaining({
+        env: expect.objectContaining({ DEBIAN_FRONTEND: 'noninteractive' }),
+      }),
+    ]);
+    const expoDeviceHubCallIndex = spawnCalls.findIndex(([command]) => command === 'npx');
+    expect(expoDeviceHubCallIndex).toBeGreaterThan(2);
+    expect(jest.mocked(spawn).mock.invocationCallOrder[2]).toBeLessThan(
+      jest.mocked(spawn).mock.invocationCallOrder[expoDeviceHubCallIndex]
+    );
+    const [command, args] = spawnCalls[expoDeviceHubCallIndex];
     const port = Number(args[args.indexOf('--port') + 1]);
     expect(port).toBeGreaterThan(0);
     expect(command).toBe('npx');

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -836,12 +836,14 @@ export async function startServeSimWithTunnelAsync(
 export async function startExpoDeviceHubWithTunnelAsync(
   ctx: CustomBuildContext,
   {
+    runtimePlatform,
     baseDomain,
     env,
     logger,
     timeoutMs,
     packageVersion,
   }: {
+    runtimePlatform: BuildRuntimePlatform;
     baseDomain: string;
     env: BuildStepEnv;
     logger: bunyan;
@@ -849,11 +851,9 @@ export async function startExpoDeviceHubWithTunnelAsync(
     packageVersion?: string;
   }
 ): Promise<DeviceWebPreviewHandle> {
-  await ensureFfmpegInstalledAsync({
-    runtimePlatform: BuildRuntimePlatform.LINUX,
-    env,
-    logger,
-  });
+  if (runtimePlatform === BuildRuntimePlatform.LINUX) {
+    await ensureFfmpegInstalledAsync({ runtimePlatform, env, logger });
+  }
   return await startWebPreviewWithTunnelAsync(ctx, {
     baseDomain,
     env,
@@ -883,7 +883,7 @@ export async function startDeviceWebPreviewWithTunnelAsync(
     case BuildRuntimePlatform.DARWIN:
       return await startServeSimWithTunnelAsync(ctx, options);
     case BuildRuntimePlatform.LINUX:
-      return await startExpoDeviceHubWithTunnelAsync(ctx, options);
+      return await startExpoDeviceHubWithTunnelAsync(ctx, { ...options, runtimePlatform });
   }
 }
 

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -332,6 +332,8 @@ async function installFfmpegWithAptAsync({
   await spawn('sudo', ['apt-get', 'install', '-y', 'ffmpeg'], { env: aptEnv, logger });
 }
 
+let ffmpegSetupPromise: Promise<void> | undefined;
+
 /**
  * Install ffmpeg when the runtime does not already provide it. Device-session
  * tools use it for video encoding on macOS (iOS simulators) and Linux (Android
@@ -346,7 +348,7 @@ async function installFfmpegWithAptAsync({
  * `spawn` is not an async function and can throw synchronously, which
  * `asyncResult` cannot catch — it only wraps an already-created promise.
  */
-export async function ensureFfmpegInstalledAsync({
+async function ensureFfmpegInstalledOnceAsync({
   runtimePlatform,
   env,
   logger,
@@ -382,6 +384,31 @@ export async function ensureFfmpegInstalledAsync({
       { err: error },
       'Could not install ffmpeg. FFmpeg-dependent features may not work in this session.'
     );
+  }
+}
+
+export async function ensureFfmpegInstalledAsync({
+  runtimePlatform,
+  env,
+  logger,
+}: {
+  runtimePlatform: BuildRuntimePlatform;
+  env: BuildStepEnv;
+  logger: bunyan;
+}): Promise<void> {
+  if (ffmpegSetupPromise) {
+    await ffmpegSetupPromise;
+    return;
+  }
+
+  const setupPromise = ensureFfmpegInstalledOnceAsync({ runtimePlatform, env, logger });
+  ffmpegSetupPromise = setupPromise;
+  try {
+    await setupPromise;
+  } finally {
+    if (ffmpegSetupPromise === setupPromise) {
+      ffmpegSetupPromise = undefined;
+    }
   }
 }
 

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -348,7 +348,7 @@ let ffmpegSetupPromise: Promise<void> | undefined;
  * `spawn` is not an async function and can throw synchronously, which
  * `asyncResult` cannot catch — it only wraps an already-created promise.
  */
-async function ensureFfmpegInstalledOnceAsync({
+async function ensureFfmpegInstalledAsync({
   runtimePlatform,
   env,
   logger,
@@ -387,7 +387,7 @@ async function ensureFfmpegInstalledOnceAsync({
   }
 }
 
-export async function ensureFfmpegInstalledAsync({
+export async function ensureFfmpegInstalledOnceAsync({
   runtimePlatform,
   env,
   logger,
@@ -401,7 +401,7 @@ export async function ensureFfmpegInstalledAsync({
     return;
   }
 
-  const setupPromise = ensureFfmpegInstalledOnceAsync({ runtimePlatform, env, logger });
+  const setupPromise = ensureFfmpegInstalledAsync({ runtimePlatform, env, logger });
   ffmpegSetupPromise = setupPromise;
   try {
     await setupPromise;
@@ -879,7 +879,7 @@ export async function startExpoDeviceHubWithTunnelAsync(
   }
 ): Promise<DeviceWebPreviewHandle> {
   if (runtimePlatform === BuildRuntimePlatform.LINUX) {
-    await ensureFfmpegInstalledAsync({ runtimePlatform, env, logger });
+    await ensureFfmpegInstalledOnceAsync({ runtimePlatform, env, logger });
   }
   return await startWebPreviewWithTunnelAsync(ctx, {
     baseDomain,

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -297,10 +297,9 @@ async function sleepUntilAbortedAsync(
   }
 }
 
-// Argent encodes screen recordings by piping simulator frames into `ffmpeg`,
-// which it resolves from PATH. The tool-server inherits this step's env, so
-// spawning ffmpeg resolves against the same PATH argent will search: it rejects
-// with ENOENT when the binary is absent, and running it also proves it works.
+// Device-session tools resolve `ffmpeg` from PATH. Spawning it with the step's
+// environment rejects with ENOENT when the binary is absent, and running it also
+// proves that the installed binary works.
 async function isFfmpegAvailableAsync(env: BuildStepEnv): Promise<boolean> {
   return (await asyncResult(spawn('ffmpeg', ['-version'], { env }))).ok;
 }
@@ -334,13 +333,12 @@ async function installFfmpegWithAptAsync({
 }
 
 /**
- * Install ffmpeg when the runtime does not already provide it, so argent's
- * `screen-recording-start` tool can encode a video. The worker images do not
- * ship ffmpeg yet, so without this the tool fails with "`ffmpeg` was not found
- * on PATH" — on macOS (iOS simulators) and Linux (Android emulators) alike.
+ * Install ffmpeg when the runtime does not already provide it. Device-session
+ * tools use it for video encoding on macOS (iOS simulators) and Linux (Android
+ * emulators) alike, but the worker images do not ship it yet.
  *
- * Best-effort by design: screen recording is one optional argent tool, so a
- * failure here is logged and the session continues without it.
+ * Best-effort by design: a failure here is logged and the session continues
+ * without FFmpeg-dependent features.
  *
  * The whole body is wrapped because the caller runs this in the background with
  * `void`. There is no unhandledRejection handler in the worker, so a rejection
@@ -367,7 +365,7 @@ export async function ensureFfmpegInstalledAsync({
     logger.info(
       `ffmpeg is not installed, installing it with ${
         isDarwin ? 'Homebrew' : 'apt'
-      } for argent screen recording.`
+      } for the device session.`
     );
     if (isDarwin) {
       await installFfmpegWithHomebrewAsync({ env, logger });
@@ -377,12 +375,12 @@ export async function ensureFfmpegInstalledAsync({
     logger.info('Installed ffmpeg.');
   } catch (err) {
     const error = err instanceof Error ? err : new Error(String(err));
-    Sentry.capture('Could not install ffmpeg for argent screen recording', error, {
+    Sentry.capture('Could not install ffmpeg for the device session', error, {
       level: 'warning',
     });
     logger.warn(
       { err: error },
-      'Could not install ffmpeg. Argent screen recording will not work in this session.'
+      'Could not install ffmpeg. FFmpeg-dependent features may not work in this session.'
     );
   }
 }
@@ -851,6 +849,11 @@ export async function startExpoDeviceHubWithTunnelAsync(
     packageVersion?: string;
   }
 ): Promise<DeviceWebPreviewHandle> {
+  await ensureFfmpegInstalledAsync({
+    runtimePlatform: BuildRuntimePlatform.LINUX,
+    env,
+    logger,
+  });
   return await startWebPreviewWithTunnelAsync(ctx, {
     baseDomain,
     env,


### PR DESCRIPTION
## Why

`serve-emu` backend used in `expo-device-hub` uses `ffmpeg` for encoding the emulators stream collected using gRPC.

I'm looking into removing the `ffmpeg` dependency, but in the mean time, we need to ensure `ffmpeg` is installed on the host for the better smoother streaming performance we are getting from using gRPC.

## How
 
This PR reused the existing `ffmpeg` install function which was used in `argent` sessions to install `ffmpeg` before starting `expo-device-hub`.