### PR TITLE
[build-tools] Add custom log phase helper

### DIFF
--- a/packages/build-tools/src/utils/__tests__/logPhase.test.ts
+++ b/packages/build-tools/src/utils/__tests__/logPhase.test.ts
@@ -1,0 +1,51 @@
+import { BuildPhase, BuildPhaseResult, LogMarker } from '@expo/eas-build-job';
+
+import { withLogPhaseAsync } from '../logPhase';
+
+describe(withLogPhaseAsync.name, () => {
+  const phaseLogger = { info: jest.fn() };
+  const logger = { child: jest.fn(() => phaseLogger) };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the callback result and ends the phase successfully', async () => {
+    const result = await withLogPhaseAsync(logger as any, 'Phase name', async callbackLogger => {
+      expect(callbackLogger).toBe(phaseLogger);
+      return 'result';
+    });
+
+    expect(result).toBe('result');
+    expect(logger.child).toHaveBeenCalledWith({
+      phase: BuildPhase.CUSTOM,
+      buildStepId: expect.stringMatching(/^step-\d{3,}$/),
+      buildStepDisplayName: 'Phase name',
+    });
+    expect(phaseLogger.info).toHaveBeenNthCalledWith(
+      1,
+      { marker: LogMarker.START_PHASE },
+      'Start phase: Phase name'
+    );
+    expect(phaseLogger.info).toHaveBeenNthCalledWith(
+      2,
+      { marker: LogMarker.END_PHASE, result: BuildPhaseResult.SUCCESS },
+      'End phase: Phase name'
+    );
+  });
+
+  it('ends the phase with failure and rethrows the error', async () => {
+    const error = new Error('failed');
+
+    await expect(
+      withLogPhaseAsync(logger as any, 'Phase name', async () => {
+        throw error;
+      })
+    ).rejects.toBe(error);
+
+    expect(phaseLogger.info).toHaveBeenLastCalledWith(
+      { marker: LogMarker.END_PHASE, result: BuildPhaseResult.FAIL },
+      'End phase: Phase name'
+    );
+  });
+});

--- a/packages/build-tools/src/utils/logPhase.ts
+++ b/packages/build-tools/src/utils/logPhase.ts
@@ -1,0 +1,30 @@
+import { BuildPhase, BuildPhaseResult, LogMarker } from '@expo/eas-build-job';
+import { type bunyan } from '@expo/logger';
+import { BuildStep } from '@expo/steps';
+
+export async function withLogPhaseAsync<T>(
+  logger: bunyan,
+  name: string,
+  fn: (logger: bunyan) => Promise<T>
+): Promise<T> {
+  const phaseLogger = logger.child({
+    phase: BuildPhase.CUSTOM,
+    buildStepId: BuildStep.getNewId(),
+    buildStepDisplayName: name,
+  });
+  phaseLogger.info({ marker: LogMarker.START_PHASE }, `Start phase: ${name}`);
+  try {
+    const result = await fn(phaseLogger);
+    phaseLogger.info(
+      { marker: LogMarker.END_PHASE, result: BuildPhaseResult.SUCCESS },
+      `End phase: ${name}`
+    );
+    return result;
+  } catch (error) {
+    phaseLogger.info(
+      { marker: LogMarker.END_PHASE, result: BuildPhaseResult.FAIL },
+      `End phase: ${name}`
+    );
+    throw error;
+  }
+}


### PR DESCRIPTION
# Why

I want a single EAS function to appear as running as two separate phases.

# How

Added `withLogPhaseAsync` which is going to create a logger child with necessary fields overwritten so a new log phase appears.

# Test Plan

CI should pass. Verified locally.

<img width="1343" height="712" alt="Zrzut ekranu 2026-09-4 o 12 17 25" src="https://github.com/user-attachments/assets/f4733c83-3119-42d6-b7dc-fc46aedaf434" />
