### PR TITLE
[worker] Add MCP server URL to build context

### DIFF
--- a/packages/build-tools/src/__tests__/customBuildContext.test.ts
+++ b/packages/build-tools/src/__tests__/customBuildContext.test.ts
@@ -11,6 +11,19 @@ jest.mock('../utils/stepMetrics');
 const mockUploadStepMetricsToWwwAsync = jest.mocked(uploadStepMetricsToWwwAsync);
 
 describe(CustomBuildContext, () => {
+  it('copies the MCP server URL from the build context', () => {
+    const ctx = new BuildContext(createTestIosJob(), {
+      env: { __API_SERVER_URL: 'http://api.expo.test' },
+      logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+      logger: createMockLogger(),
+      uploadArtifact: jest.fn(),
+      workingdir: '',
+      mcpServerUrl: 'ws://localhost:8787',
+    });
+
+    expect(new CustomBuildContext(ctx).mcpServerUrl).toBe('ws://localhost:8787');
+  });
+
   it('should not lose workflowInterpolationContext', () => {
     const contextUploadArtifact = jest.fn();
     const ctx = new BuildContext(

--- a/packages/build-tools/src/context.ts
+++ b/packages/build-tools/src/context.ts
@@ -68,6 +68,7 @@ export interface BuildContextOptions {
   skipNativeBuild?: boolean;
   metadata?: Metadata;
   expoApiV2BaseUrl?: string;
+  mcpServerUrl?: string;
 }
 
 export class SkipNativeBuildError extends Error {}
@@ -84,6 +85,7 @@ export class BuildContext<TJob extends Job = Job> {
   ) => void;
   public readonly skipNativeBuild?: boolean;
   public readonly expoApiV2BaseUrl?: string;
+  public readonly mcpServerUrl?: string;
   public artifacts: Artifacts = {};
 
   private readonly _isLocal: boolean;
@@ -112,6 +114,7 @@ export class BuildContext<TJob extends Job = Job> {
     this._metadata = options.metadata;
     this.skipNativeBuild = options.skipNativeBuild;
     this.expoApiV2BaseUrl = options.expoApiV2BaseUrl;
+    this.mcpServerUrl = options.mcpServerUrl;
 
     const environmentSecrets = this.getEnvironmentSecrets(job);
     this._env = {

--- a/packages/build-tools/src/customBuildContext.ts
+++ b/packages/build-tools/src/customBuildContext.ts
@@ -63,6 +63,7 @@ export class CustomBuildContext<TJob extends Job = Job> implements ExternalBuild
   public readonly logger: bunyan;
   public readonly graphqlClient: Client;
   public readonly runtimeApi: BuilderRuntimeApi;
+  public readonly mcpServerUrl?: string;
   public job: TJob;
   public metadata?: Metadata;
 
@@ -84,6 +85,7 @@ export class CustomBuildContext<TJob extends Job = Job> implements ExternalBuild
     this.runtimeApi = {
       uploadArtifact: (...args) => buildCtx['uploadArtifact'](...args),
     };
+    this.mcpServerUrl = buildCtx.mcpServerUrl;
     this.expoApiV2BaseUrl = buildCtx.expoApiV2BaseUrl;
     this.startTime = new Date();
   }

--- a/packages/worker/src/__unit__/config.test.ts
+++ b/packages/worker/src/__unit__/config.test.ts
@@ -21,4 +21,18 @@ describe('config', () => {
       expect(config.loggers.http.baseUrl).toBe(expectedBaseUrl);
     });
   });
+
+  it.each([
+    [Environment.DEVELOPMENT, 'ws://localhost:8787'],
+    [Environment.STAGING, 'wss://staging-mcp.expo.dev'],
+    [Environment.PRODUCTION, 'wss://mcp.expo.dev'],
+    [Environment.TEST, 'ws://localhost:8787'],
+  ])('uses the expected MCP server URL in %s', (environment, expectedMcpServerUrl) => {
+    process.env.ENVIRONMENT = environment;
+
+    jest.isolateModules(() => {
+      const config = require('../config').default;
+      expect(config.mcpServerUrl).toBe(expectedMcpServerUrl);
+    });
+  });
 });

--- a/packages/worker/src/__unit__/context.test.ts
+++ b/packages/worker/src/__unit__/context.test.ts
@@ -91,6 +91,19 @@ describe(createBuildContext.name, () => {
     );
   });
 
+  it('adds the MCP server URL to the build context', async () => {
+    const ctx = await createBuildContext({
+      ...baseOptions,
+      job: {
+        platform: Platform.ANDROID,
+        type: Workflow.GENERIC,
+        secrets: { environmentSecrets: [] },
+      } as any,
+    });
+
+    expect(ctx.mcpServerUrl).toBe(config.mcpServerUrl);
+  });
+
   it('routes managed source maps to the source-map uploader', async () => {
     const ctx = await createBuildContext({
       ...baseOptions,

--- a/packages/worker/src/config.ts
+++ b/packages/worker/src/config.ts
@@ -86,4 +86,10 @@ export default {
       : process.env.ENVIRONMENT === 'staging'
         ? 'https://staging-api.expo.dev/v2/'
         : 'https://api.expo.dev/v2/',
+  mcpServerUrl:
+    process.env.ENVIRONMENT === 'development' || process.env.ENVIRONMENT === 'test'
+      ? 'ws://localhost:8787'
+      : process.env.ENVIRONMENT === 'staging'
+        ? 'wss://staging-mcp.expo.dev'
+        : 'wss://mcp.expo.dev',
 };

--- a/packages/worker/src/context.ts
+++ b/packages/worker/src/context.ts
@@ -103,6 +103,7 @@ export async function createBuildContext<TJob extends Job>({
     cacheManager: new GCSCacheManager(),
     metadata,
     expoApiV2BaseUrl: config.wwwApiV2BaseUrl,
+    mcpServerUrl: config.mcpServerUrl,
   });
   return ctx;
 }


### PR DESCRIPTION
# Why

Worker has config for API server URL. I now need MCP server URL too.

# How

Added `mcpServerUrl` in `config` and in contexts.

# Test Plan

CI should pass.