### PR TITLE
[eas-cli] Align Observe code with new server schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
+- [eas-cli] Align the `eas observe:*` commands with the renamed Observe GraphQL schema. `--json` output now uses `name`/`value` instead of `metricName`/`metricValue` (metrics) and `name` instead of `eventName` (log events and event-name summaries), and `eas observe:events` now lists user-defined events only — exceptions moved to the new `eas observe:errors`. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@douglowder](https://github.com/douglowder))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🛠 Breaking changes
 
-- [eas-cli] Align the `eas observe:*` commands with the renamed Observe GraphQL schema. `--json` output now uses `name`/`value` instead of `metricName`/`metricValue` (metrics) and `name` instead of `eventName` (log events and event-name summaries), and `eas observe:events` now lists user-defined events only — exceptions moved to the new `eas observe:errors`. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@douglowder](https://github.com/douglowder))
+- [eas-cli] Align the `eas observe:*` commands with the renamed Observe GraphQL schema. `--json` output now uses `name`/`value` instead of `metricName`/`metricValue` (metrics) and `name` instead of `eventName` (log events and event-name summaries), and `eas observe:events` now lists user-defined events only — exceptions moved to the new `eas observe:errors`. ([#4338](https://github.com/expo/eas-cli/pull/4338) by [@douglowder](https://github.com/douglowder))
 
 ### 🎉 New features
 

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -1686,6 +1686,18 @@
             "deprecationReason": null
           },
           {
+            "name": "githubAppRegistration",
+            "description": "GitHub Enterprise app registration for an account",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GitHubAppRegistration",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "googleServiceAccountKeys",
             "description": null,
             "args": [],
@@ -60810,6 +60822,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "registration",
+            "description": "The GitHub Enterprise registration this installation belongs to, or null for the default\ngithub.com app.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GitHubAppRegistration",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -61463,6 +61487,39 @@
         "name": "GitHubAppRegistrationMutation",
         "description": null,
         "fields": [
+          {
+            "name": "deleteGitHubAppRegistration",
+            "description": "Deletes a GitHub Enterprise app registration. Installations of the app and repository links\nmade through it are removed as well. The app itself remains on the GitHub Enterprise instance\nand must be deleted there separately.",
+            "args": [
+              {
+                "name": "githubAppRegistrationId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubAppRegistration",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "finalizeGitHubAppRegistration",
             "description": "Finalizes a GitHub App registration after the GHE instance redirects back with a temporary\ncode. Exchanges the code for the app's credentials and stores the registration.",

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -6544,7 +6544,7 @@
           },
           {
             "name": "webPreviewUrl",
-            "description": "URL of the web preview surface for the session. Null when web previews are\nnot available for the platform (e.g. Android).",
+            "description": "URL of the web preview surface for the session. Null when a web preview is\nnot available for the session.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -14745,8 +14745,8 @@
               "name": "AppObserveCustomEvent",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use userEvents.event, errors.error, or log instead."
           },
           {
             "name": "customEventCounts",
@@ -14778,8 +14778,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Unused; no replacement planned."
           },
           {
             "name": "customEventList",
@@ -14867,8 +14867,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use userEvents.list (or errors.occurrences for exceptions) instead."
           },
           {
             "name": "customEventNames",
@@ -15032,6 +15032,22 @@
                 "ofType": null
               }
             },
+            "isDeprecated": true,
+            "deprecationReason": "Use userEvents.names instead."
+          },
+          {
+            "name": "easUpdates",
+            "description": "Namespaced successor API (ENG-26160). Prefer over the flat `updates` field.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveEasUpdates",
+                "ofType": null
+              }
+            },
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -15146,8 +15162,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use errors.breakdown instead."
           },
           {
             "name": "errorGroups",
@@ -15179,8 +15195,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use errors.groups instead."
           },
           {
             "name": "errorStats",
@@ -15212,8 +15228,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use errors.stats instead."
           },
           {
             "name": "errorTimeSeries",
@@ -15242,6 +15258,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "AppObserveErrorTimeSeries",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use errors.timeSeries instead."
+          },
+          {
+            "name": "errors",
+            "description": "Namespaced successor API (ENG-26160). Prefer over the flat `errorGroups`/`errorStats`/`errorTimeSeries`/`errorGroupBreakdown` fields.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveErrors",
                 "ofType": null
               }
             },
@@ -15274,8 +15306,8 @@
               "name": "AppObserveEvent",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use metrics.metric instead."
           },
           {
             "name": "events",
@@ -15363,8 +15395,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use metrics.list instead."
           },
           {
             "name": "latestExpoSdkVersion",
@@ -15374,6 +15406,67 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "log",
+            "description": "A single log (user-defined event or error) by `event_id`. Null when missing or aged out of retention.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "AppObserveLog",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metrics",
+            "description": "Namespaced successor API (ENG-26160). Prefer over the flat `timeSeries`/`events`/`event` fields.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveMetrics",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "navigation",
+            "description": "Namespaced successor API (ENG-26160). Prefer over the flat `navigationRoutes` field.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveNavigation",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -15468,6 +15561,22 @@
                 "ofType": null
               }
             },
+            "isDeprecated": true,
+            "deprecationReason": "Use navigation.routes instead."
+          },
+          {
+            "name": "overview",
+            "description": "Namespaced successor API (ENG-26160). Prefer over the flat `overview*` fields.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverview",
+                "ofType": null
+              }
+            },
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -15501,8 +15610,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use overview.engagement instead."
           },
           {
             "name": "overviewStability",
@@ -15534,8 +15643,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use overview.stability instead."
           },
           {
             "name": "overviewUpdateComparison",
@@ -15567,8 +15676,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use overview.updateComparison instead."
           },
           {
             "name": "overviewVersionComparison",
@@ -15597,6 +15706,39 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "AppObserveOverviewVersionComparison",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use overview.versionComparison instead."
+          },
+          {
+            "name": "session",
+            "description": "One session's metrics and logs for the timeline (ENG-26160). Unknown session ids yield empty lists.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveSession",
                 "ofType": null
               }
             },
@@ -15633,8 +15775,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use metrics.timeSeries instead."
           },
           {
             "name": "totalEventCount",
@@ -15712,6 +15854,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "AppObserveUpdatesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use easUpdates.list instead."
+          },
+          {
+            "name": "userEvents",
+            "description": "Namespaced successor API (ENG-26160). Prefer over the flat `customEventNames`/`customEventList`/`customEvent` fields.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveUserEvents",
                 "ofType": null
               }
             },
@@ -17691,6 +17849,764 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AppObserveEasUpdates",
+        "description": "EAS Update download activity (app_metrics download samples plus update metadata).",
+        "fields": [
+          {
+            "name": "list",
+            "description": "Updates with download statistics. Forward pagination only. Defaults to newest first.",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveEasUpdatesFilter",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveEasUpdatesOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveUpdatesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveEasUpdatesFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveEasUpdatesOrderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveOrderDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveUpdatesOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveEngagementInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "bucketIntervalMinutes",
+            "description": "Series bucket size. Defaults to one day.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveError",
+        "description": "One unhandled JS error (an app_events exception row).",
+        "fields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "body",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "clientVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "countryCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceLanguageTag",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceModel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceOs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceOsVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "easClientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expoSdkVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fingerprint",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ingestedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isFatal",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "message",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "properties",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveEventProperty",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reactNativeVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sessionId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "severityNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "severityText",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "source",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stacktrace",
+            "description": "Symbolicated when a build with a matching source map exists; otherwise as reported.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "symbolicationBuild",
+            "description": "Build whose uploaded source map symbolicated stacktrace; null when the stack trace is shown as reported.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Build",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "AppObserveLog",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AppObserveErrorBreakdownBucket",
         "description": null,
         "fields": [
@@ -17781,6 +18697,100 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveErrorConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveErrorEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveErrorEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveError",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -18613,6 +19623,229 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveErrorOccurrencesFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "easClientId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fingerprint",
+            "description": "Restrict to one error group.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sessionId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveErrorOccurrencesOrderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveOrderDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveErrorOccurrencesOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppObserveErrorOccurrencesOrderByField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "TIMESTAMP",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "AppObserveErrorPlatformStats",
         "description": "AppObserveErrorStats for one platform; iOS includes iPadOS and tvOS.",
@@ -19319,6 +20552,923 @@
           {
             "name": "platforms",
             "description": "Filter to these platforms. Cannot be set together with platform.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveErrors",
+        "description": "Unhandled JS errors: app_events exception rows.",
+        "fields": [
+          {
+            "name": "breakdown",
+            "description": "Breaks one error group down by app version, OS, device, or country.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveErrorsBreakdownInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveErrorGroupBreakdown",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "A single error by id. Null when missing, aged out, or the id belongs to a user-defined event.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AppObserveError",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "groups",
+            "description": "Distinct error groups (the issues list), grouped by fingerprint.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveErrorsGroupsInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveErrorGroups",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "occurrences",
+            "description": "Individual error occurrences. Defaults to newest first.",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveErrorOccurrencesFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveErrorOccurrencesOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveErrorConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stats",
+            "description": "Headline error stats: crash-free rates and error/affected counts.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveErrorsStatsInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveErrorStats",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timeSeries",
+            "description": "Time-bucketed exception counts split into fatal vs non-fatal.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveErrorsTimeSeriesInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveErrorTimeSeries",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveErrorsBreakdownInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dimension",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveErrorBreakdownDimension",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fingerprint",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveErrorsGroupsInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bucketIntervalMinutes",
+            "description": "Bucket size for each group's timeSeries. Defaults to daily.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fingerprint",
+            "description": "Restrict to one error group.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "orderBy",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObserveErrorGroupsOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "severity",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObserveErrorSeverity",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "source",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveErrorsStatsInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveErrorsTimeSeriesInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bucketIntervalMinutes",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fingerprint",
+            "description": "Restrict to one error group.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
             "type": {
               "kind": "LIST",
               "name": null,
@@ -20238,6 +22388,1931 @@
         "possibleTypes": null
       },
       {
+        "kind": "INTERFACE",
+        "name": "AppObserveLog",
+        "description": "Any app_events log row: a user-defined event or an error.",
+        "fields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "body",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "clientVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "countryCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceLanguageTag",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceModel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceOs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceOsVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "easClientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expoSdkVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ingestedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "properties",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveEventProperty",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reactNativeVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sessionId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "severityNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "severityText",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "AppObserveError",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "AppObserveUserEvent",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveLogConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveLogEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveLogEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "AppObserveLog",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveLogsOrderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveOrderDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveLogsOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppObserveLogsOrderByField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "TIMESTAMP",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveMetric",
+        "description": "One performance-metric sample (a row in app_metrics).",
+        "fields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "clientVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "countryCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "customParams",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceLanguageTag",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceModel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceOs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceOsVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "easClientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventBatchId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expoSdkVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ingestedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "parentSessionId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reactNativeVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "routeName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sessionEventCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sessionId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tags",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userEventCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveMetricConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveMetricEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveMetricEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveMetric",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveMetricTimeSeriesInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bucketIntervalMinutes",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "Metric name, e.g. `expo.app_startup.tti`.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "routeName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveMetrics",
+        "description": "Performance metrics (the app_metrics table): startup, navigation, and update-download samples.",
+        "fields": [
+          {
+            "name": "list",
+            "description": "Individual metric samples. Defaults to newest first.",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveMetricsListFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveMetricsListOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveMetricConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metric",
+            "description": "A single metric sample by id. Null when missing or aged out; sessionEventCount/userEventCount are always null here.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AppObserveMetric",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timeSeries",
+            "description": "Time-bucketed aggregates for one metric, with app-version markers.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveMetricTimeSeriesInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveTimeSeries",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveMetricsListFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": "Filter by the update the device was *running* at sample time (the app_update_id column).",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "downloadedUpdateId",
+            "description": "Filter by the update that was *downloaded* (the expo.update_id tag). Distinct from appUpdateId (running update); the two are not interchangeable.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "easClientId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "Metric name, e.g. `expo.app_startup.tti`.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "routeName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sessionId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveMetricsListOrderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveOrderDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveMetricsListOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppObserveMetricsListOrderByField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "TIMESTAMP",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "VALUE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveNavigation",
+        "description": "Navigation performance per route (app_metrics navigation samples).",
+        "fields": [
+          {
+            "name": "routes",
+            "description": "Per-route navigation summaries.",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveNavigationFilter",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveNavigationOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveNavigationRoutesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveNavigationFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "routeNames",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveNavigationOrderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveOrderDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveNavigationRoutesOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "AppObserveNavigationRoute",
         "description": "Per-route navigation timing breakdown. The \"Navigations\" count shown in the\ndashboard is `coldTtr.count` (one cold-TTR event per user navigation).\nPer-metric `median`/`p90` are null when `count` is 0 so the client can\ndistinguish \"no data\" from \"0ms\".",
@@ -20704,6 +24779,172 @@
               "kind": "SCALAR",
               "name": "Float",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppObserveOrderDirection",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveOverview",
+        "description": "Overview-tab aggregates, across all versions unless a comparison narrows them.",
+        "fields": [
+          {
+            "name": "engagement",
+            "description": "Active users and sessions for the engagement band.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveEngagementInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverviewEngagement",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stability",
+            "description": "Crash-free rates with previous-period comparison for the stability tiles.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveStabilityInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverviewStability",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updateComparison",
+            "description": "Per-update comparison within one app version: the embedded bundle plus each OTA update.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveOverviewUpdateComparisonInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverviewUpdateComparison",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "versionComparison",
+            "description": "Per-version, per-platform metric summaries for the version-comparison matrix.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveOverviewVersionComparisonInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveOverviewVersionComparison",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -22397,6 +26638,274 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AppObserveSession",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "logs",
+            "description": "Logs in the session: user-defined events and errors interleaved.",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveLogsOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveLogConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metrics",
+            "description": "Metric samples in the session.",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveMetricsListOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveMetricConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveStabilityInput",
+        "description": "Stability-tile filters. No release filters: the tiles always span all versions.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "bucketIntervalMinutes",
+            "description": "Series bucket size. Defaults to one day.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AppObserveTimeSeries",
         "description": null,
         "fields": [
@@ -23438,6 +27947,1236 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUserEvent",
+        "description": "One user-defined event (an app_events row that is not an exception).",
+        "fields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "body",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "clientVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "countryCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceLanguageTag",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceModel",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceOs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceOsVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "Human-friendly label from the expo.log.display_name attribute; null when the event was logged without one.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "easClientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "expoSdkVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ingestedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "properties",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveEventProperty",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reactNativeVersion",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sessionId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "severityNumber",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "severityText",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timestamp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "AppObserveLog",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUserEventConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveUserEventEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUserEventEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveUserEvent",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveUserEventListFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "easClientId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "Event name. The reserved `exception` name is rejected; errors live in the errors namespace.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "propertyFilters",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveUserEventPropertyFilter",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sessionId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveUserEventListOrderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveOrderDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveUserEventListOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppObserveUserEventListOrderByField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "TIMESTAMP",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUserEventName",
+        "description": null,
+        "fields": [
+          {
+            "name": "count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUserEventNames",
+        "description": null,
+        "fields": [
+          {
+            "name": "isTruncated",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "names",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveUserEventName",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveUserEventNamesInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "orderBy",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "AppObserveUserEventNamesOrderBy",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveUserEventNamesOrderBy",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "direction",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveOrderDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "field",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveUserEventNamesOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppObserveUserEventNamesOrderByField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "COUNT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NAME",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveUserEventPropertyFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "key",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUserEvents",
+        "description": "User-defined events (`Observe.logEvent`): app_events log rows, excluding errors.",
+        "fields": [
+          {
+            "name": "event",
+            "description": "A single user-defined event by id. Null when missing, aged out, or the id belongs to an error.",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "AppObserveUserEvent",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "list",
+            "description": "Individual user-defined events. Defaults to newest first.",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveUserEventListFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AppObserveUserEventListOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveUserEventConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "names",
+            "description": "Distinct event names with counts over the time range.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveUserEventNamesInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveUserEventNames",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -26731,7 +32470,7 @@
           },
           {
             "name": "webPreviewUrl",
-            "description": "URL of the web preview surface for the session. Null when web previews are\nnot available for the platform (e.g. Android).",
+            "description": "URL of the web preview surface for the session. Null when a web preview is\nnot available for the session.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -29572,7 +35311,7 @@
           },
           {
             "name": "webPreviewUrl",
-            "description": "URL of the web preview surface for the session. Null when web previews are\nnot available for the platform (e.g. Android).",
+            "description": "URL of the web preview surface for the session. Null when a web preview is\nnot available for the session.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -45184,7 +50923,7 @@
           },
           {
             "name": "WEB_PREVIEW_ONLY",
-            "description": "A session accessed only through its web preview. Currently supported on iOS.",
+            "description": "A session accessed only through its web preview.",
             "isDeprecated": false,
             "deprecationReason": null
           }
@@ -53869,6 +59608,49 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "FinalizeGitHubAppRegistrationInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "code",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "state",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "Fingerprint",
         "description": null,
@@ -55498,6 +61280,249 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubAppRegistration",
+        "description": "A GitHub Enterprise app.",
+        "fields": [
+          {
+            "name": "account",
+            "description": "The Expo account that owns this registration.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubAppUrl",
+            "description": "URL of the app's page on its GitHub instance, e.g. https://github.example.com/github-apps/expo.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubClientIdentifier",
+            "description": "Public OAuth client id of the GHE app.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "origin",
+            "description": "Origin of the GitHub Enterprise instance, e.g. https://github.example.com or https://example.ghe.com. No trailing slash.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": "The GHE app slug.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubAppRegistrationManifest",
+        "description": "Registration data for the GitHub App manifest flow.",
+        "fields": [
+          {
+            "name": "githubManifestCreateUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "manifestJson",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "state",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubAppRegistrationMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "finalizeGitHubAppRegistration",
+            "description": "Finalizes a GitHub App registration after the GHE instance redirects back with a temporary\ncode. Exchanges the code for the app's credentials and stores the registration.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "FinalizeGitHubAppRegistrationInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubAppRegistration",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startGitHubAppRegistration",
+            "description": "Starts a GitHub App registration on a GHE instance via the app manifest flow. Returns the\nmanifest for the browser to submit.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "StartGitHubAppRegistrationInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubAppRegistrationManifest",
                 "ofType": null
               }
             },
@@ -68436,6 +74461,22 @@
             "deprecationReason": null
           },
           {
+            "name": "githubAppRegistration",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubAppRegistrationMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "githubBuildTrigger",
             "description": "Mutations for GitHub build triggers",
             "args": [],
@@ -73048,6 +79089,61 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "StartGitHubAppRegistrationInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "accountId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "org",
+            "description": "Organization to register the app under; omit to register under the signed-in user's account.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "origin",
+            "description": "URL of the GitHub Enterprise instance, e.g. https://github.example.com or https://example.ghe.com.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -96271,6 +102367,18 @@
             "deprecationReason": null
           },
           {
+            "name": "displayTitle",
+            "description": "Rendered run_name template. Null falls back to name.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "durationSeconds",
             "description": null,
             "args": [],
@@ -96408,7 +102516,7 @@
           },
           {
             "name": "name",
-            "description": null,
+            "description": "Snapshot of the workflow's name at run creation.",
             "args": [],
             "type": {
               "kind": "NON_NULL",

--- a/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/metrics.test.ts
@@ -4,8 +4,8 @@ import { GraphQLError } from 'graphql';
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { getMockOclifConfig } from '../../../__tests__/commands/utils';
 import {
-  AppObserveEventsOrderByDirection,
-  AppObserveEventsOrderByField,
+  AppObserveMetricsListOrderByField,
+  AppObserveOrderDirection,
   AppObservePlatform,
 } from '../../../graphql/generated';
 import { fetchObserveEventsAsync, resolveOrderBy } from '../../../observe/fetchEvents';
@@ -247,8 +247,8 @@ describe(ObserveMetrics, () => {
     const mockEvents = [
       {
         id: 'evt-1',
-        metricName: 'expo.app_startup.tti',
-        metricValue: 1.23,
+        name: 'expo.app_startup.tti',
+        value: 1.23,
         timestamp: '2025-01-15T10:30:00.000Z',
         appVersion: '1.0.0',
         appBuildNumber: '42',
@@ -290,8 +290,8 @@ describe(ObserveMetrics, () => {
 
     const options = mockFetchObserveEventsAsync.mock.calls[0][2];
     expect(options.orderBy).toEqual({
-      field: AppObserveEventsOrderByField.MetricValue,
-      direction: AppObserveEventsOrderByDirection.Desc,
+      field: AppObserveMetricsListOrderByField.Value,
+      direction: AppObserveOrderDirection.Desc,
     });
   });
 
@@ -315,29 +315,29 @@ describe(ObserveMetrics, () => {
 describe(resolveOrderBy, () => {
   it('resolves lowercase "slowest" to MetricValue DESC', () => {
     expect(resolveOrderBy('slowest')).toEqual({
-      field: AppObserveEventsOrderByField.MetricValue,
-      direction: AppObserveEventsOrderByDirection.Desc,
+      field: AppObserveMetricsListOrderByField.Value,
+      direction: AppObserveOrderDirection.Desc,
     });
   });
 
   it('resolves lowercase "fastest" to MetricValue ASC', () => {
     expect(resolveOrderBy('fastest')).toEqual({
-      field: AppObserveEventsOrderByField.MetricValue,
-      direction: AppObserveEventsOrderByDirection.Asc,
+      field: AppObserveMetricsListOrderByField.Value,
+      direction: AppObserveOrderDirection.Asc,
     });
   });
 
   it('resolves lowercase "newest" to Timestamp DESC', () => {
     expect(resolveOrderBy('newest')).toEqual({
-      field: AppObserveEventsOrderByField.Timestamp,
-      direction: AppObserveEventsOrderByDirection.Desc,
+      field: AppObserveMetricsListOrderByField.Timestamp,
+      direction: AppObserveOrderDirection.Desc,
     });
   });
 
   it('resolves lowercase "oldest" to Timestamp ASC', () => {
     expect(resolveOrderBy('oldest')).toEqual({
-      field: AppObserveEventsOrderByField.Timestamp,
-      direction: AppObserveEventsOrderByDirection.Asc,
+      field: AppObserveMetricsListOrderByField.Timestamp,
+      direction: AppObserveOrderDirection.Asc,
     });
   });
 });

--- a/packages/eas-cli/src/commands/observe/__tests__/session.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/session.test.ts
@@ -56,10 +56,10 @@ const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
 
 function makeMetricEvent(overrides: any = {}): any {
   return {
-    __typename: 'AppObserveEvent',
+    __typename: 'AppObserveMetric',
     id: 'evt-m-1',
-    metricName: 'expo.app_startup.tti',
-    metricValue: 1.23,
+    name: 'expo.app_startup.tti',
+    value: 1.23,
     timestamp: '2025-01-15T10:00:00.000Z',
     appVersion: '1.0.0',
     appBuildNumber: '42',
@@ -78,9 +78,9 @@ function makeMetricEvent(overrides: any = {}): any {
 
 function makeCustomEvent(overrides: any = {}): any {
   return {
-    __typename: 'AppObserveCustomEvent',
+    __typename: 'AppObserveUserEvent',
     id: 'evt-c-1',
-    eventName: 'login_pressed',
+    name: 'login_pressed',
     timestamp: '2025-01-15T10:00:00.000Z',
     sessionId: 'session-log-1',
     severityNumber: null,
@@ -289,9 +289,7 @@ describe(ObserveSession, () => {
 
   it('picker mode without --event-name or --sort prompts for event name, then sort, then event', async () => {
     mockCustomEventNamesAsync.mockResolvedValue({
-      names: [
-        { __typename: 'AppObserveCustomEventName', eventName: 'login_pressed', count: 12 } as any,
-      ],
+      names: [{ __typename: 'AppObserveUserEventName', name: 'login_pressed', count: 12 } as any],
       isTruncated: false,
     });
     // 1) event-name picker → metric choice

--- a/packages/eas-cli/src/commands/observe/session.ts
+++ b/packages/eas-cli/src/commands/observe/session.ts
@@ -287,12 +287,10 @@ async function promptForEventNameAsync({
     })
   );
 
-  const logChoices: ExpoChoice<EventNameChoice>[] = customEventNames.map(
-    ({ eventName, count }) => ({
-      title: `${eventName} (${count} log event${count === 1 ? '' : 's'})`,
-      value: { name: eventName, isMetric: false },
-    })
-  );
+  const logChoices: ExpoChoice<EventNameChoice>[] = customEventNames.map(({ name, count }) => ({
+    title: `${name} (${count} log event${count === 1 ? '' : 's'})`,
+    value: { name, isMetric: false },
+  }));
 
   const choices = [...metricChoices, ...logChoices];
   if (choices.length === 0) {

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -1077,8 +1077,8 @@ export type AgentDeviceRunSessionRemoteConfig = {
   /** Session token gating the web preview. Null when the preview runs ungated. */
   webPreviewToken?: Maybe<Scalars['String']['output']>;
   /**
-   * URL of the web preview surface for the session. Null when web previews are
-   * not available for the platform (e.g. Android).
+   * URL of the web preview surface for the session. Null when a web preview is
+   * not available for the session.
    */
   webPreviewUrl?: Maybe<Scalars['String']['output']>;
 };
@@ -2259,40 +2259,86 @@ export type AppObserve = {
   /**
    * A single custom event by the `id` of an `AppObserveCustomEvent`. Null when the app has no
    * such event, including when it has aged out of retention.
+   * @deprecated Use userEvents.event, errors.error, or log instead.
    */
   customEvent?: Maybe<AppObserveCustomEvent>;
+  /** @deprecated Unused; no replacement planned. */
   customEventCounts: AppObserveCustomEventCounts;
+  /** @deprecated Use userEvents.list (or errors.occurrences for exceptions) instead. */
   customEventList: AppObserveCustomEventListConnection;
+  /** @deprecated Use userEvents.names instead. */
   customEventNames: AppObserveCustomEventNames;
+  /** Namespaced successor API (ENG-26160). Prefer over the flat `updates` field. */
+  easUpdates: AppObserveEasUpdates;
   environments: Array<Scalars['String']['output']>;
-  /** Breaks a single error group down by app version, OS, device, or country (detail page bars). */
+  /**
+   * Breaks a single error group down by app version, OS, device, or country (detail page bars).
+   * @deprecated Use errors.breakdown instead.
+   */
   errorGroupBreakdown: AppObserveErrorGroupBreakdown;
-  /** Distinct unhandled-JS-error groups (the issues list), grouped by fingerprint. */
+  /**
+   * Distinct unhandled-JS-error groups (the issues list), grouped by fingerprint.
+   * @deprecated Use errors.groups instead.
+   */
   errorGroups: AppObserveErrorGroups;
-  /** Headline error stats for the overview: crash-free rates and error/affected counts. */
+  /**
+   * Headline error stats for the overview: crash-free rates and error/affected counts.
+   * @deprecated Use errors.stats instead.
+   */
   errorStats: AppObserveErrorStats;
-  /** Time-bucketed exception counts split into fatal vs non-fatal, for the stacked-bar chart. */
+  /**
+   * Time-bucketed exception counts split into fatal vs non-fatal, for the stacked-bar chart.
+   * @deprecated Use errors.timeSeries instead.
+   */
   errorTimeSeries: AppObserveErrorTimeSeries;
+  /** Namespaced successor API (ENG-26160). Prefer over the flat `errorGroups`/`errorStats`/`errorTimeSeries`/`errorGroupBreakdown` fields. */
+  errors: AppObserveErrors;
   /**
    * A single metric event by the `id` of an `AppObserveEvent`. Null when the app has no such
    * event, including when it has aged out of retention or the id is not one this API issued.
    *
    * `sessionEventCount` and `userEventCount` are always null here: they are aggregates over a
    * time range, and a single event does not supply one.
+   * @deprecated Use metrics.metric instead.
    */
   event?: Maybe<AppObserveEvent>;
+  /** @deprecated Use metrics.list instead. */
   events: AppObserveEventsConnection;
   /** Highest Expo SDK version seen in telemetry over the trailing 30 days; null when none was reported. */
   latestExpoSdkVersion?: Maybe<Scalars['String']['output']>;
+  /** A single log (user-defined event or error) by `event_id`. Null when missing or aged out of retention. */
+  log?: Maybe<AppObserveLog>;
+  /** Namespaced successor API (ENG-26160). Prefer over the flat `timeSeries`/`events`/`event` fields. */
+  metrics: AppObserveMetrics;
+  /** Namespaced successor API (ENG-26160). Prefer over the flat `navigationRoutes` field. */
+  navigation: AppObserveNavigation;
+  /** @deprecated Use navigation.routes instead. */
   navigationRoutes: AppObserveNavigationRoutesConnection;
-  /** Active users and sessions for the Overview engagement band, across all versions. */
+  /** Namespaced successor API (ENG-26160). Prefer over the flat `overview*` fields. */
+  overview: AppObserveOverview;
+  /**
+   * Active users and sessions for the Overview engagement band, across all versions.
+   * @deprecated Use overview.engagement instead.
+   */
   overviewEngagement: AppObserveOverviewEngagement;
-  /** Crash-free rates with previous-period comparison for the Overview stability tiles. */
+  /**
+   * Crash-free rates with previous-period comparison for the Overview stability tiles.
+   * @deprecated Use overview.stability instead.
+   */
   overviewStability: AppObserveOverviewStability;
-  /** Per-update comparison within one app version: the embedded bundle plus each OTA update. */
+  /**
+   * Per-update comparison within one app version: the embedded bundle plus each OTA update.
+   * @deprecated Use overview.updateComparison instead.
+   */
   overviewUpdateComparison: AppObserveOverviewUpdateComparison;
-  /** Per-version, per-platform metric summaries for the Overview version-comparison matrix. */
+  /**
+   * Per-version, per-platform metric summaries for the Overview version-comparison matrix.
+   * @deprecated Use overview.versionComparison instead.
+   */
   overviewVersionComparison: AppObserveOverviewVersionComparison;
+  /** One session's metrics and logs for the timeline (ENG-26160). Unknown session ids yield empty lists. */
+  session: AppObserveSession;
+  /** @deprecated Use metrics.timeSeries instead. */
   timeSeries: AppObserveTimeSeries;
   totalEventCount: Scalars['Int']['output'];
   /**
@@ -2304,8 +2350,13 @@ export type AppObserve = {
    * universe used by `appVersions` headline counts.
    */
   uniqueActiveUserCount: Scalars['Int']['output'];
-  /** Update download activity (the Recent updates list). Not available on the free tier or legacy plans. */
+  /**
+   * Update download activity (the Recent updates list). Not available on the free tier or legacy plans.
+   * @deprecated Use easUpdates.list instead.
+   */
   updates: AppObserveUpdatesConnection;
+  /** Namespaced successor API (ENG-26160). Prefer over the flat `customEventNames`/`customEventList`/`customEvent` fields. */
+  userEvents: AppObserveUserEvents;
 };
 
 
@@ -2392,6 +2443,11 @@ export type AppObserve_EventsArgs = {
 };
 
 
+export type AppObserve_LogArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
 export type AppObserve_NavigationRoutesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
@@ -2419,6 +2475,11 @@ export type AppObserve_OverviewUpdateComparisonArgs = {
 
 export type AppObserve_OverviewVersionComparisonArgs = {
   input: AppObserveOverviewVersionComparisonInput;
+};
+
+
+export type AppObserve_SessionArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -2667,6 +2728,86 @@ export type AppObserveCustomEventPropertyFilter = {
   value: Scalars['String']['input'];
 };
 
+/** EAS Update download activity (app_metrics download samples plus update metadata). */
+export type AppObserveEasUpdates = {
+  __typename?: 'AppObserveEasUpdates';
+  /** Updates with download statistics. Forward pagination only. Defaults to newest first. */
+  list: AppObserveUpdatesConnection;
+};
+
+
+/** EAS Update download activity (app_metrics download samples plus update metadata). */
+export type AppObserveEasUpdates_ListArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  filter: AppObserveEasUpdatesFilter;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AppObserveEasUpdatesOrderBy>;
+};
+
+export type AppObserveEasUpdatesFilter = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  startTime: Scalars['DateTime']['input'];
+};
+
+export type AppObserveEasUpdatesOrderBy = {
+  direction: AppObserveOrderDirection;
+  field: AppObserveUpdatesOrderByField;
+};
+
+export type AppObserveEngagementInput = {
+  /** Series bucket size. Defaults to one day. */
+  bucketIntervalMinutes?: InputMaybe<Scalars['Int']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  startTime: Scalars['DateTime']['input'];
+};
+
+/** One unhandled JS error (an app_events exception row). */
+export type AppObserveError = AppObserveLog & {
+  __typename?: 'AppObserveError';
+  appBuildNumber: Scalars['String']['output'];
+  appEasBuildId?: Maybe<Scalars['String']['output']>;
+  appIdentifier: Scalars['String']['output'];
+  appUpdateId?: Maybe<Scalars['String']['output']>;
+  appUpdateMessage?: Maybe<Scalars['String']['output']>;
+  appVersion: Scalars['String']['output'];
+  body?: Maybe<Scalars['String']['output']>;
+  clientVersion?: Maybe<Scalars['String']['output']>;
+  countryCode?: Maybe<Scalars['String']['output']>;
+  deviceLanguageTag?: Maybe<Scalars['String']['output']>;
+  deviceModel: Scalars['String']['output'];
+  deviceOs: Scalars['String']['output'];
+  deviceOsVersion: Scalars['String']['output'];
+  easClientId: Scalars['String']['output'];
+  environment?: Maybe<Scalars['String']['output']>;
+  expoSdkVersion?: Maybe<Scalars['String']['output']>;
+  fingerprint?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  ingestedAt?: Maybe<Scalars['DateTime']['output']>;
+  isFatal?: Maybe<Scalars['Boolean']['output']>;
+  message?: Maybe<Scalars['String']['output']>;
+  properties: Array<AppObserveEventProperty>;
+  reactNativeVersion?: Maybe<Scalars['String']['output']>;
+  sessionId?: Maybe<Scalars['String']['output']>;
+  severityNumber?: Maybe<Scalars['Int']['output']>;
+  severityText?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  /** Symbolicated when a build with a matching source map exists; otherwise as reported. */
+  stacktrace?: Maybe<Scalars['String']['output']>;
+  /** Build whose uploaded source map symbolicated stacktrace; null when the stack trace is shown as reported. */
+  symbolicationBuild?: Maybe<Build>;
+  timestamp: Scalars['DateTime']['output'];
+  type?: Maybe<Scalars['String']['output']>;
+};
+
 export type AppObserveErrorBreakdownBucket = {
   __typename?: 'AppObserveErrorBreakdownBucket';
   count: Scalars['Int']['output'];
@@ -2681,6 +2822,18 @@ export enum AppObserveErrorBreakdownDimension {
   Device = 'DEVICE',
   Os = 'OS'
 }
+
+export type AppObserveErrorConnection = {
+  __typename?: 'AppObserveErrorConnection';
+  edges: Array<AppObserveErrorEdge>;
+  pageInfo: PageInfo;
+};
+
+export type AppObserveErrorEdge = {
+  __typename?: 'AppObserveErrorEdge';
+  cursor: Scalars['String']['output'];
+  node: AppObserveError;
+};
 
 export type AppObserveErrorGroup = {
   __typename?: 'AppObserveErrorGroup';
@@ -2778,6 +2931,32 @@ export enum AppObserveErrorGroupsOrderBy {
   MostUsers = 'MOST_USERS'
 }
 
+export type AppObserveErrorOccurrencesFilter = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  easClientId?: InputMaybe<Scalars['String']['input']>;
+  endTime?: InputMaybe<Scalars['DateTime']['input']>;
+  environment?: InputMaybe<Scalars['String']['input']>;
+  /** Restrict to one error group. */
+  fingerprint?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  sessionId?: InputMaybe<Scalars['String']['input']>;
+  startTime?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type AppObserveErrorOccurrencesOrderBy = {
+  direction: AppObserveOrderDirection;
+  field: AppObserveErrorOccurrencesOrderByField;
+};
+
+export enum AppObserveErrorOccurrencesOrderByField {
+  Timestamp = 'TIMESTAMP'
+}
+
 /** AppObserveErrorStats for one platform; iOS includes iPadOS and tvOS. */
 export type AppObserveErrorPlatformStats = {
   __typename?: 'AppObserveErrorPlatformStats';
@@ -2866,6 +3045,128 @@ export type AppObserveErrorTimeSeriesInput = {
   isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
   platform?: InputMaybe<AppObservePlatform>;
   /** Filter to these platforms. Cannot be set together with platform. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  startTime: Scalars['DateTime']['input'];
+};
+
+/** Unhandled JS errors: app_events exception rows. */
+export type AppObserveErrors = {
+  __typename?: 'AppObserveErrors';
+  /** Breaks one error group down by app version, OS, device, or country. */
+  breakdown: AppObserveErrorGroupBreakdown;
+  /** A single error by id. Null when missing, aged out, or the id belongs to a user-defined event. */
+  error?: Maybe<AppObserveError>;
+  /** Distinct error groups (the issues list), grouped by fingerprint. */
+  groups: AppObserveErrorGroups;
+  /** Individual error occurrences. Defaults to newest first. */
+  occurrences: AppObserveErrorConnection;
+  /** Headline error stats: crash-free rates and error/affected counts. */
+  stats: AppObserveErrorStats;
+  /** Time-bucketed exception counts split into fatal vs non-fatal. */
+  timeSeries: AppObserveErrorTimeSeries;
+};
+
+
+/** Unhandled JS errors: app_events exception rows. */
+export type AppObserveErrors_BreakdownArgs = {
+  input: AppObserveErrorsBreakdownInput;
+};
+
+
+/** Unhandled JS errors: app_events exception rows. */
+export type AppObserveErrors_ErrorArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+/** Unhandled JS errors: app_events exception rows. */
+export type AppObserveErrors_GroupsArgs = {
+  input: AppObserveErrorsGroupsInput;
+};
+
+
+/** Unhandled JS errors: app_events exception rows. */
+export type AppObserveErrors_OccurrencesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<AppObserveErrorOccurrencesFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AppObserveErrorOccurrencesOrderBy>;
+};
+
+
+/** Unhandled JS errors: app_events exception rows. */
+export type AppObserveErrors_StatsArgs = {
+  input: AppObserveErrorsStatsInput;
+};
+
+
+/** Unhandled JS errors: app_events exception rows. */
+export type AppObserveErrors_TimeSeriesArgs = {
+  input: AppObserveErrorsTimeSeriesInput;
+};
+
+export type AppObserveErrorsBreakdownInput = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  dimension: AppObserveErrorBreakdownDimension;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  fingerprint: Scalars['String']['input'];
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  startTime: Scalars['DateTime']['input'];
+};
+
+export type AppObserveErrorsGroupsInput = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  /** Bucket size for each group's timeSeries. Defaults to daily. */
+  bucketIntervalMinutes?: InputMaybe<Scalars['Int']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  /** Restrict to one error group. */
+  fingerprint?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  orderBy?: InputMaybe<AppObserveErrorGroupsOrderBy>;
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  severity?: InputMaybe<AppObserveErrorSeverity>;
+  source?: InputMaybe<Scalars['String']['input']>;
+  startTime: Scalars['DateTime']['input'];
+};
+
+export type AppObserveErrorsStatsInput = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  startTime: Scalars['DateTime']['input'];
+};
+
+export type AppObserveErrorsTimeSeriesInput = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  bucketIntervalMinutes?: InputMaybe<Scalars['Int']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  /** Restrict to one error group. */
+  fingerprint?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Filter to these platforms. */
   platforms?: InputMaybe<Array<AppObservePlatform>>;
   startTime: Scalars['DateTime']['input'];
 };
@@ -2960,6 +3261,221 @@ export enum AppObserveEventsOrderByField {
   Timestamp = 'TIMESTAMP'
 }
 
+/** Any app_events log row: a user-defined event or an error. */
+export type AppObserveLog = {
+  appBuildNumber: Scalars['String']['output'];
+  appEasBuildId?: Maybe<Scalars['String']['output']>;
+  appIdentifier: Scalars['String']['output'];
+  appUpdateId?: Maybe<Scalars['String']['output']>;
+  appUpdateMessage?: Maybe<Scalars['String']['output']>;
+  appVersion: Scalars['String']['output'];
+  body?: Maybe<Scalars['String']['output']>;
+  clientVersion?: Maybe<Scalars['String']['output']>;
+  countryCode?: Maybe<Scalars['String']['output']>;
+  deviceLanguageTag?: Maybe<Scalars['String']['output']>;
+  deviceModel: Scalars['String']['output'];
+  deviceOs: Scalars['String']['output'];
+  deviceOsVersion: Scalars['String']['output'];
+  easClientId: Scalars['String']['output'];
+  environment?: Maybe<Scalars['String']['output']>;
+  expoSdkVersion?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  ingestedAt?: Maybe<Scalars['DateTime']['output']>;
+  properties: Array<AppObserveEventProperty>;
+  reactNativeVersion?: Maybe<Scalars['String']['output']>;
+  sessionId?: Maybe<Scalars['String']['output']>;
+  severityNumber?: Maybe<Scalars['Int']['output']>;
+  severityText?: Maybe<Scalars['String']['output']>;
+  timestamp: Scalars['DateTime']['output'];
+};
+
+export type AppObserveLogConnection = {
+  __typename?: 'AppObserveLogConnection';
+  edges: Array<AppObserveLogEdge>;
+  pageInfo: PageInfo;
+};
+
+export type AppObserveLogEdge = {
+  __typename?: 'AppObserveLogEdge';
+  cursor: Scalars['String']['output'];
+  node: AppObserveLog;
+};
+
+export type AppObserveLogsOrderBy = {
+  direction: AppObserveOrderDirection;
+  field: AppObserveLogsOrderByField;
+};
+
+export enum AppObserveLogsOrderByField {
+  Timestamp = 'TIMESTAMP'
+}
+
+/** One performance-metric sample (a row in app_metrics). */
+export type AppObserveMetric = {
+  __typename?: 'AppObserveMetric';
+  appBuildNumber: Scalars['String']['output'];
+  appEasBuildId?: Maybe<Scalars['String']['output']>;
+  appIdentifier: Scalars['String']['output'];
+  appName: Scalars['String']['output'];
+  appUpdateId?: Maybe<Scalars['String']['output']>;
+  appUpdateMessage?: Maybe<Scalars['String']['output']>;
+  appVersion: Scalars['String']['output'];
+  clientVersion?: Maybe<Scalars['String']['output']>;
+  countryCode?: Maybe<Scalars['String']['output']>;
+  customParams?: Maybe<Scalars['JSON']['output']>;
+  deviceLanguageTag?: Maybe<Scalars['String']['output']>;
+  deviceModel: Scalars['String']['output'];
+  deviceName?: Maybe<Scalars['String']['output']>;
+  deviceOs: Scalars['String']['output'];
+  deviceOsVersion: Scalars['String']['output'];
+  easClientId: Scalars['String']['output'];
+  environment?: Maybe<Scalars['String']['output']>;
+  eventBatchId: Scalars['ID']['output'];
+  expoSdkVersion?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  ingestedAt?: Maybe<Scalars['DateTime']['output']>;
+  name: Scalars['String']['output'];
+  parentSessionId?: Maybe<Scalars['String']['output']>;
+  reactNativeVersion?: Maybe<Scalars['String']['output']>;
+  routeName?: Maybe<Scalars['String']['output']>;
+  sessionEventCount?: Maybe<Scalars['Int']['output']>;
+  sessionId?: Maybe<Scalars['String']['output']>;
+  tags: Scalars['JSON']['output'];
+  timestamp: Scalars['DateTime']['output'];
+  userEventCount?: Maybe<Scalars['Int']['output']>;
+  value: Scalars['Float']['output'];
+};
+
+export type AppObserveMetricConnection = {
+  __typename?: 'AppObserveMetricConnection';
+  edges: Array<AppObserveMetricEdge>;
+  pageInfo: PageInfo;
+};
+
+export type AppObserveMetricEdge = {
+  __typename?: 'AppObserveMetricEdge';
+  cursor: Scalars['String']['output'];
+  node: AppObserveMetric;
+};
+
+export type AppObserveMetricTimeSeriesInput = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  bucketIntervalMinutes?: InputMaybe<Scalars['Int']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Metric name, e.g. `expo.app_startup.tti`. */
+  name: Scalars['String']['input'];
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  routeName?: InputMaybe<Scalars['String']['input']>;
+  startTime: Scalars['DateTime']['input'];
+};
+
+/** Performance metrics (the app_metrics table): startup, navigation, and update-download samples. */
+export type AppObserveMetrics = {
+  __typename?: 'AppObserveMetrics';
+  /** Individual metric samples. Defaults to newest first. */
+  list: AppObserveMetricConnection;
+  /** A single metric sample by id. Null when missing or aged out; sessionEventCount/userEventCount are always null here. */
+  metric?: Maybe<AppObserveMetric>;
+  /** Time-bucketed aggregates for one metric, with app-version markers. */
+  timeSeries: AppObserveTimeSeries;
+};
+
+
+/** Performance metrics (the app_metrics table): startup, navigation, and update-download samples. */
+export type AppObserveMetrics_ListArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<AppObserveMetricsListFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AppObserveMetricsListOrderBy>;
+};
+
+
+/** Performance metrics (the app_metrics table): startup, navigation, and update-download samples. */
+export type AppObserveMetrics_MetricArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+/** Performance metrics (the app_metrics table): startup, navigation, and update-download samples. */
+export type AppObserveMetrics_TimeSeriesArgs = {
+  input: AppObserveMetricTimeSeriesInput;
+};
+
+export type AppObserveMetricsListFilter = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  /** Filter by the update the device was *running* at sample time (the app_update_id column). */
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  /** Filter by the update that was *downloaded* (the expo.update_id tag). Distinct from appUpdateId (running update); the two are not interchangeable. */
+  downloadedUpdateId?: InputMaybe<Scalars['String']['input']>;
+  easClientId?: InputMaybe<Scalars['String']['input']>;
+  endTime?: InputMaybe<Scalars['DateTime']['input']>;
+  environment?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Metric name, e.g. `expo.app_startup.tti`. */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  routeName?: InputMaybe<Scalars['String']['input']>;
+  sessionId?: InputMaybe<Scalars['String']['input']>;
+  startTime?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type AppObserveMetricsListOrderBy = {
+  direction: AppObserveOrderDirection;
+  field: AppObserveMetricsListOrderByField;
+};
+
+export enum AppObserveMetricsListOrderByField {
+  Timestamp = 'TIMESTAMP',
+  Value = 'VALUE'
+}
+
+/** Navigation performance per route (app_metrics navigation samples). */
+export type AppObserveNavigation = {
+  __typename?: 'AppObserveNavigation';
+  /** Per-route navigation summaries. */
+  routes: AppObserveNavigationRoutesConnection;
+};
+
+
+/** Navigation performance per route (app_metrics navigation samples). */
+export type AppObserveNavigation_RoutesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter: AppObserveNavigationFilter;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AppObserveNavigationOrderBy>;
+};
+
+export type AppObserveNavigationFilter = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  routeNames?: InputMaybe<Array<Scalars['String']['input']>>;
+  startTime: Scalars['DateTime']['input'];
+};
+
+export type AppObserveNavigationOrderBy = {
+  direction: AppObserveOrderDirection;
+  field: AppObserveNavigationRoutesOrderByField;
+};
+
 /**
  * Per-route navigation timing breakdown. The "Navigations" count shown in the
  * dashboard is `coldTtr.count` (one cold-TTR event per user navigation).
@@ -3021,6 +3537,48 @@ export type AppObserveNavigationStat = {
   count: Scalars['Int']['output'];
   median?: Maybe<Scalars['Float']['output']>;
   p90?: Maybe<Scalars['Float']['output']>;
+};
+
+export enum AppObserveOrderDirection {
+  Asc = 'ASC',
+  Desc = 'DESC'
+}
+
+/** Overview-tab aggregates, across all versions unless a comparison narrows them. */
+export type AppObserveOverview = {
+  __typename?: 'AppObserveOverview';
+  /** Active users and sessions for the engagement band. */
+  engagement: AppObserveOverviewEngagement;
+  /** Crash-free rates with previous-period comparison for the stability tiles. */
+  stability: AppObserveOverviewStability;
+  /** Per-update comparison within one app version: the embedded bundle plus each OTA update. */
+  updateComparison: AppObserveOverviewUpdateComparison;
+  /** Per-version, per-platform metric summaries for the version-comparison matrix. */
+  versionComparison: AppObserveOverviewVersionComparison;
+};
+
+
+/** Overview-tab aggregates, across all versions unless a comparison narrows them. */
+export type AppObserveOverview_EngagementArgs = {
+  input: AppObserveEngagementInput;
+};
+
+
+/** Overview-tab aggregates, across all versions unless a comparison narrows them. */
+export type AppObserveOverview_StabilityArgs = {
+  input: AppObserveStabilityInput;
+};
+
+
+/** Overview-tab aggregates, across all versions unless a comparison narrows them. */
+export type AppObserveOverview_UpdateComparisonArgs = {
+  input: AppObserveOverviewUpdateComparisonInput;
+};
+
+
+/** Overview-tab aggregates, across all versions unless a comparison narrows them. */
+export type AppObserveOverview_VersionComparisonArgs = {
+  input: AppObserveOverviewVersionComparisonInput;
 };
 
 export type AppObserveOverviewAllReleases = {
@@ -3230,6 +3788,44 @@ export type AppObserveReleasesInput = {
   startTime: Scalars['DateTime']['input'];
 };
 
+export type AppObserveSession = {
+  __typename?: 'AppObserveSession';
+  id: Scalars['ID']['output'];
+  /** Logs in the session: user-defined events and errors interleaved. */
+  logs: AppObserveLogConnection;
+  /** Metric samples in the session. */
+  metrics: AppObserveMetricConnection;
+};
+
+
+export type AppObserveSession_LogsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AppObserveLogsOrderBy>;
+};
+
+
+export type AppObserveSession_MetricsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AppObserveMetricsListOrderBy>;
+};
+
+/** Stability-tile filters. No release filters: the tiles always span all versions. */
+export type AppObserveStabilityInput = {
+  /** Series bucket size. Defaults to one day. */
+  bucketIntervalMinutes?: InputMaybe<Scalars['Int']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  startTime: Scalars['DateTime']['input'];
+};
+
 export type AppObserveTimeSeries = {
   __typename?: 'AppObserveTimeSeries';
   appVersionMarkers: Array<AppObserveAppVersion>;
@@ -3338,6 +3934,152 @@ export enum AppObserveUpdatesOrderByField {
   MedianDownloadTime = 'MEDIAN_DOWNLOAD_TIME',
   P90DownloadTime = 'P90_DOWNLOAD_TIME'
 }
+
+/** One user-defined event (an app_events row that is not an exception). */
+export type AppObserveUserEvent = AppObserveLog & {
+  __typename?: 'AppObserveUserEvent';
+  appBuildNumber: Scalars['String']['output'];
+  appEasBuildId?: Maybe<Scalars['String']['output']>;
+  appIdentifier: Scalars['String']['output'];
+  appUpdateId?: Maybe<Scalars['String']['output']>;
+  appUpdateMessage?: Maybe<Scalars['String']['output']>;
+  appVersion: Scalars['String']['output'];
+  body?: Maybe<Scalars['String']['output']>;
+  clientVersion?: Maybe<Scalars['String']['output']>;
+  countryCode?: Maybe<Scalars['String']['output']>;
+  deviceLanguageTag?: Maybe<Scalars['String']['output']>;
+  deviceModel: Scalars['String']['output'];
+  deviceOs: Scalars['String']['output'];
+  deviceOsVersion: Scalars['String']['output'];
+  /** Human-friendly label from the expo.log.display_name attribute; null when the event was logged without one. */
+  displayName?: Maybe<Scalars['String']['output']>;
+  easClientId: Scalars['String']['output'];
+  environment?: Maybe<Scalars['String']['output']>;
+  expoSdkVersion?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  ingestedAt?: Maybe<Scalars['DateTime']['output']>;
+  name: Scalars['String']['output'];
+  properties: Array<AppObserveEventProperty>;
+  reactNativeVersion?: Maybe<Scalars['String']['output']>;
+  sessionId?: Maybe<Scalars['String']['output']>;
+  severityNumber?: Maybe<Scalars['Int']['output']>;
+  severityText?: Maybe<Scalars['String']['output']>;
+  timestamp: Scalars['DateTime']['output'];
+};
+
+export type AppObserveUserEventConnection = {
+  __typename?: 'AppObserveUserEventConnection';
+  edges: Array<AppObserveUserEventEdge>;
+  pageInfo: PageInfo;
+};
+
+export type AppObserveUserEventEdge = {
+  __typename?: 'AppObserveUserEventEdge';
+  cursor: Scalars['String']['output'];
+  node: AppObserveUserEvent;
+};
+
+export type AppObserveUserEventListFilter = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  easClientId?: InputMaybe<Scalars['String']['input']>;
+  endTime?: InputMaybe<Scalars['DateTime']['input']>;
+  environment?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Event name. The reserved `exception` name is rejected; errors live in the errors namespace. */
+  name?: InputMaybe<Scalars['String']['input']>;
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  propertyFilters?: InputMaybe<Array<AppObserveUserEventPropertyFilter>>;
+  sessionId?: InputMaybe<Scalars['String']['input']>;
+  startTime?: InputMaybe<Scalars['DateTime']['input']>;
+};
+
+export type AppObserveUserEventListOrderBy = {
+  direction: AppObserveOrderDirection;
+  field: AppObserveUserEventListOrderByField;
+};
+
+export enum AppObserveUserEventListOrderByField {
+  Timestamp = 'TIMESTAMP'
+}
+
+export type AppObserveUserEventName = {
+  __typename?: 'AppObserveUserEventName';
+  count: Scalars['Int']['output'];
+  name: Scalars['String']['output'];
+};
+
+export type AppObserveUserEventNames = {
+  __typename?: 'AppObserveUserEventNames';
+  isTruncated: Scalars['Boolean']['output'];
+  names: Array<AppObserveUserEventName>;
+};
+
+export type AppObserveUserEventNamesInput = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  orderBy?: InputMaybe<AppObserveUserEventNamesOrderBy>;
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  startTime: Scalars['DateTime']['input'];
+};
+
+export type AppObserveUserEventNamesOrderBy = {
+  direction: AppObserveOrderDirection;
+  field: AppObserveUserEventNamesOrderByField;
+};
+
+export enum AppObserveUserEventNamesOrderByField {
+  Count = 'COUNT',
+  Name = 'NAME'
+}
+
+export type AppObserveUserEventPropertyFilter = {
+  key: Scalars['String']['input'];
+  value: Scalars['String']['input'];
+};
+
+/** User-defined events (`Observe.logEvent`): app_events log rows, excluding errors. */
+export type AppObserveUserEvents = {
+  __typename?: 'AppObserveUserEvents';
+  /** A single user-defined event by id. Null when missing, aged out, or the id belongs to an error. */
+  event?: Maybe<AppObserveUserEvent>;
+  /** Individual user-defined events. Defaults to newest first. */
+  list: AppObserveUserEventConnection;
+  /** Distinct event names with counts over the time range. */
+  names: AppObserveUserEventNames;
+};
+
+
+/** User-defined events (`Observe.logEvent`): app_events log rows, excluding errors. */
+export type AppObserveUserEvents_EventArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+/** User-defined events (`Observe.logEvent`): app_events log rows, excluding errors. */
+export type AppObserveUserEvents_ListArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  filter?: InputMaybe<AppObserveUserEventListFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AppObserveUserEventListOrderBy>;
+};
+
+
+/** User-defined events (`Observe.logEvent`): app_events log rows, excluding errors. */
+export type AppObserveUserEvents_NamesArgs = {
+  input: AppObserveUserEventNamesInput;
+};
 
 export type AppObserveVersionMarkerStatistics = {
   __typename?: 'AppObserveVersionMarkerStatistics';
@@ -3816,8 +4558,8 @@ export type AppiumRunSessionRemoteConfig = {
   /** Session token gating the web preview. Null when the preview runs ungated. */
   webPreviewToken?: Maybe<Scalars['String']['output']>;
   /**
-   * URL of the web preview surface for the session. Null when web previews are
-   * not available for the platform (e.g. Android).
+   * URL of the web preview surface for the session. Null when a web preview is
+   * not available for the session.
    */
   webPreviewUrl?: Maybe<Scalars['String']['output']>;
 };
@@ -4226,8 +4968,8 @@ export type ArgentRunSessionRemoteConfig = {
   /** Session token gating the web preview. Null when the preview runs ungated. */
   webPreviewToken?: Maybe<Scalars['String']['output']>;
   /**
-   * URL of the web preview surface for the session. Null when web previews are
-   * not available for the platform (e.g. Android).
+   * URL of the web preview surface for the session. Null when a web preview is
+   * not available for the session.
    */
   webPreviewUrl?: Maybe<Scalars['String']['output']>;
 };
@@ -6399,7 +7141,7 @@ export enum DeviceRunSessionType {
   Argent = 'ARGENT',
   /** @deprecated Use WEB_PREVIEW_ONLY instead. */
   ServeSim = 'SERVE_SIM',
-  /** A session accessed only through its web preview. Currently supported on iOS. */
+  /** A session accessed only through its web preview. */
   WebPreviewOnly = 'WEB_PREVIEW_ONLY'
 }
 
@@ -7736,6 +8478,11 @@ export enum Feature {
   Teams = 'TEAMS'
 }
 
+export type FinalizeGitHubAppRegistrationInput = {
+  code: Scalars['String']['input'];
+  state: Scalars['String']['input'];
+};
+
 export type Fingerprint = {
   __typename?: 'Fingerprint';
   app: App;
@@ -7953,6 +8700,54 @@ export type GitHubAppQuery = {
 
 export type GitHubAppQuery_InstallationArgs = {
   id: Scalars['ID']['input'];
+};
+
+/** A GitHub Enterprise app. */
+export type GitHubAppRegistration = {
+  __typename?: 'GitHubAppRegistration';
+  /** The Expo account that owns this registration. */
+  account: Account;
+  /** URL of the app's page on its GitHub instance, e.g. https://github.example.com/github-apps/expo. */
+  githubAppUrl: Scalars['String']['output'];
+  /** Public OAuth client id of the GHE app. */
+  githubClientIdentifier: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  /** Origin of the GitHub Enterprise instance, e.g. https://github.example.com or https://example.ghe.com. No trailing slash. */
+  origin: Scalars['String']['output'];
+  /** The GHE app slug. */
+  slug: Scalars['String']['output'];
+};
+
+/** Registration data for the GitHub App manifest flow. */
+export type GitHubAppRegistrationManifest = {
+  __typename?: 'GitHubAppRegistrationManifest';
+  githubManifestCreateUrl: Scalars['String']['output'];
+  manifestJson: Scalars['String']['output'];
+  state: Scalars['String']['output'];
+};
+
+export type GitHubAppRegistrationMutation = {
+  __typename?: 'GitHubAppRegistrationMutation';
+  /**
+   * Finalizes a GitHub App registration after the GHE instance redirects back with a temporary
+   * code. Exchanges the code for the app's credentials and stores the registration.
+   */
+  finalizeGitHubAppRegistration: GitHubAppRegistration;
+  /**
+   * Starts a GitHub App registration on a GHE instance via the app manifest flow. Returns the
+   * manifest for the browser to submit.
+   */
+  startGitHubAppRegistration: GitHubAppRegistrationManifest;
+};
+
+
+export type GitHubAppRegistrationMutation_FinalizeGitHubAppRegistrationArgs = {
+  input: FinalizeGitHubAppRegistrationInput;
+};
+
+
+export type GitHubAppRegistrationMutation_StartGitHubAppRegistrationArgs = {
+  input: StartGitHubAppRegistrationInput;
 };
 
 export type GitHubBuildInput = {
@@ -9729,6 +10524,7 @@ export type RootMutation = {
   githubApp: GitHubAppMutation;
   /** Mutations for GitHub App installations */
   githubAppInstallation: GitHubAppInstallationMutation;
+  githubAppRegistration: GitHubAppRegistrationMutation;
   /** Mutations for GitHub build triggers */
   githubBuildTrigger: GitHubBuildTriggerMutation;
   githubJobRunTrigger: GitHubJobRunTriggerMutation;
@@ -10352,6 +11148,14 @@ export enum StandardOffer {
 
 export type StartClaudeConnectionInput = {
   accountId: Scalars['ID']['input'];
+};
+
+export type StartGitHubAppRegistrationInput = {
+  accountId: Scalars['ID']['input'];
+  /** Organization to register the app under; omit to register under the signed-in user's account. */
+  org?: InputMaybe<Scalars['String']['input']>;
+  /** URL of the GitHub Enterprise instance, e.g. https://github.example.com or https://example.ghe.com. */
+  origin: Scalars['String']['input'];
 };
 
 export type StartPostHogConnectionResult = PostHogOrganizationConnection | PostHogPendingConnection;
@@ -13526,6 +14330,8 @@ export type WorkflowRun = ActivityTimelineProjectActivity & {
    */
   cancelReason?: Maybe<WorkflowRunCancelReason>;
   createdAt: Scalars['DateTime']['output'];
+  /** Rendered run_name template. Null falls back to name. */
+  displayTitle?: Maybe<Scalars['String']['output']>;
   durationSeconds?: Maybe<Scalars['Int']['output']>;
   errors: Array<WorkflowRunError>;
   finalizedAt?: Maybe<Scalars['DateTime']['output']>;
@@ -13535,6 +14341,7 @@ export type WorkflowRun = ActivityTimelineProjectActivity & {
   id: Scalars['ID']['output'];
   inputs?: Maybe<Scalars['JSONObject']['output']>;
   jobs: Array<WorkflowJob>;
+  /** Snapshot of the workflow's name at run creation. */
   name: Scalars['String']['output'];
   pullRequestNumber?: Maybe<Scalars['Int']['output']>;
   requestedGitRef?: Maybe<Scalars['String']['output']>;

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -134,6 +134,8 @@ export type Account = {
   environmentVariablesIncludingSensitive: Array<EnvironmentVariableWithSecret>;
   /** GitHub App installations for an account */
   githubAppInstallations: Array<GitHubAppInstallation>;
+  /** GitHub Enterprise app registration for an account */
+  githubAppRegistration?: Maybe<GitHubAppRegistration>;
   /** @deprecated Use googleServiceAccountKeysPaginated */
   googleServiceAccountKeys: Array<GoogleServiceAccountKey>;
   /** Android credentials for account */
@@ -8625,6 +8627,11 @@ export type GitHubAppInstallation = {
   id: Scalars['ID']['output'];
   installationIdentifier: Scalars['Int']['output'];
   metadata: GitHubAppInstallationMetadata;
+  /**
+   * The GitHub Enterprise registration this installation belongs to, or null for the default
+   * github.com app.
+   */
+  registration?: Maybe<GitHubAppRegistration>;
 };
 
 export type GitHubAppInstallationAccessibleRepository = {
@@ -8729,6 +8736,12 @@ export type GitHubAppRegistrationManifest = {
 export type GitHubAppRegistrationMutation = {
   __typename?: 'GitHubAppRegistrationMutation';
   /**
+   * Deletes a GitHub Enterprise app registration. Installations of the app and repository links
+   * made through it are removed as well. The app itself remains on the GitHub Enterprise instance
+   * and must be deleted there separately.
+   */
+  deleteGitHubAppRegistration: GitHubAppRegistration;
+  /**
    * Finalizes a GitHub App registration after the GHE instance redirects back with a temporary
    * code. Exchanges the code for the app's credentials and stores the registration.
    */
@@ -8738,6 +8751,11 @@ export type GitHubAppRegistrationMutation = {
    * manifest for the browser to submit.
    */
   startGitHubAppRegistration: GitHubAppRegistrationManifest;
+};
+
+
+export type GitHubAppRegistrationMutation_DeleteGitHubAppRegistrationArgs = {
+  githubAppRegistrationId: Scalars['ID']['input'];
 };
 
 
@@ -16232,14 +16250,6 @@ export type GoogleServiceAccountKeyByIdQueryVariables = Exact<{
 
 export type GoogleServiceAccountKeyByIdQuery = { __typename?: 'RootQuery', googleServiceAccountKey: { __typename?: 'GoogleServiceAccountKeyQuery', byId: { __typename?: 'GoogleServiceAccountKey', id: string, keyJson: string } } };
 
-export type AppObserveTimeSeriesQueryVariables = Exact<{
-  appId: Scalars['String']['input'];
-  input: AppObserveTimeSeriesInput;
-}>;
-
-
-export type AppObserveTimeSeriesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', timeSeries: { __typename?: 'AppObserveTimeSeries', eventCount: number, appVersionMarkers: Array<{ __typename?: 'AppObserveAppVersion', appVersion: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, buildNumbers: Array<{ __typename?: 'AppObserveAppBuildNumber', appBuildNumber: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, updates: Array<{ __typename?: 'AppObserveAppUpdate', appUpdateId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, metrics: Array<{ __typename?: 'AppObserveAppVersionMetric', metricName: string, eventCount: number, statistics: { __typename?: 'AppObserveVersionMarkerStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } }> }>, statistics: { __typename?: 'AppObserveTimeSeriesStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } } } } } };
-
 export type AppObserveAppVersionsQueryVariables = Exact<{
   appId: Scalars['String']['input'];
   input: AppObserveReleasesInput;
@@ -16248,49 +16258,60 @@ export type AppObserveAppVersionsQueryVariables = Exact<{
 
 export type AppObserveAppVersionsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', appVersions: Array<{ __typename?: 'AppObserveAppVersion', appVersion: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, buildNumbers: Array<{ __typename?: 'AppObserveAppBuildNumber', appBuildNumber: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, updates: Array<{ __typename?: 'AppObserveAppUpdate', appUpdateId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, metrics: Array<{ __typename?: 'AppObserveAppVersionMetric', metricName: string, eventCount: number, statistics: { __typename?: 'AppObserveVersionMarkerStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } }> }> } } } };
 
-export type AppObserveEventsQueryVariables = Exact<{
+export type AppObserveMetricsListQueryVariables = Exact<{
   appId: Scalars['String']['input'];
-  filter?: InputMaybe<AppObserveEventsFilter>;
+  filter?: InputMaybe<AppObserveMetricsListFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   after?: InputMaybe<Scalars['String']['input']>;
-  orderBy?: InputMaybe<AppObserveEventsOrderBy>;
+  orderBy?: InputMaybe<AppObserveMetricsListOrderBy>;
 }>;
 
 
-export type AppObserveEventsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', events: { __typename?: 'AppObserveEventsConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveEventEdge', cursor: string, node: { __typename?: 'AppObserveEvent', id: string, metricName: string, metricValue: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null, routeName?: string | null } }> } } } } };
+export type AppObserveMetricsListQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', metrics: { __typename?: 'AppObserveMetrics', list: { __typename?: 'AppObserveMetricConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveMetricEdge', cursor: string, node: { __typename?: 'AppObserveMetric', id: string, name: string, value: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null, routeName?: string | null } }> } } } } } };
 
-export type AppObserveCustomEventListQueryVariables = Exact<{
+export type AppObserveUserEventListQueryVariables = Exact<{
   appId: Scalars['String']['input'];
-  filter?: InputMaybe<AppObserveCustomEventListFilter>;
+  filter?: InputMaybe<AppObserveUserEventListFilter>;
   first?: InputMaybe<Scalars['Int']['input']>;
   after?: InputMaybe<Scalars['String']['input']>;
-  orderBy?: InputMaybe<AppObserveCustomEventListOrderBy>;
+  orderBy?: InputMaybe<AppObserveUserEventListOrderBy>;
 }>;
 
 
-export type AppObserveCustomEventListQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', customEventList: { __typename?: 'AppObserveCustomEventListConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveCustomEventEdge', cursor: string, node: { __typename?: 'AppObserveCustomEvent', id: string, eventName: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> } }> } } } } };
+export type AppObserveUserEventListQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', userEvents: { __typename?: 'AppObserveUserEvents', list: { __typename?: 'AppObserveUserEventConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveUserEventEdge', cursor: string, node: { __typename?: 'AppObserveUserEvent', id: string, name: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> } }> } } } } } };
 
-export type AppObserveCustomEventNamesQueryVariables = Exact<{
+export type AppObserveUserEventNamesQueryVariables = Exact<{
   appId: Scalars['String']['input'];
-  startTime: Scalars['DateTime']['input'];
-  endTime: Scalars['DateTime']['input'];
-  platforms?: InputMaybe<Array<AppObservePlatform> | AppObservePlatform>;
-  environment?: InputMaybe<Scalars['String']['input']>;
+  input: AppObserveUserEventNamesInput;
 }>;
 
 
-export type AppObserveCustomEventNamesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', customEventNames: { __typename?: 'AppObserveCustomEventNames', isTruncated: boolean, names: Array<{ __typename?: 'AppObserveCustomEventName', eventName: string, count: number }> } } } } };
+export type AppObserveUserEventNamesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', userEvents: { __typename?: 'AppObserveUserEvents', names: { __typename?: 'AppObserveUserEventNames', isTruncated: boolean, names: Array<{ __typename?: 'AppObserveUserEventName', name: string, count: number }> } } } } } };
 
 export type AppObserveNavigationRoutesQueryVariables = Exact<{
   appId: Scalars['String']['input'];
-  filter: AppObserveNavigationRoutesFilter;
+  filter: AppObserveNavigationFilter;
   first?: InputMaybe<Scalars['Int']['input']>;
   after?: InputMaybe<Scalars['String']['input']>;
-  orderBy?: InputMaybe<AppObserveNavigationRoutesOrderBy>;
+  orderBy?: InputMaybe<AppObserveNavigationOrderBy>;
 }>;
 
 
-export type AppObserveNavigationRoutesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', navigationRoutes: { __typename?: 'AppObserveNavigationRoutesConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveNavigationRouteEdge', cursor: string, node: { __typename?: 'AppObserveNavigationRoute', routeName: string, coldTtr: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null }, warmTtr: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null }, tti: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null } } }> } } } } };
+export type AppObserveNavigationRoutesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', navigation: { __typename?: 'AppObserveNavigation', routes: { __typename?: 'AppObserveNavigationRoutesConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveNavigationRouteEdge', cursor: string, node: { __typename?: 'AppObserveNavigationRoute', routeName: string, coldTtr: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null }, warmTtr: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null }, tti: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null } } }> } } } } } };
+
+export type AppObserveSessionEventsQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+  id: Scalars['ID']['input'];
+  first?: InputMaybe<Scalars['Int']['input']>;
+  metricsOrderBy?: InputMaybe<AppObserveMetricsListOrderBy>;
+  logsOrderBy?: InputMaybe<AppObserveLogsOrderBy>;
+}>;
+
+
+export type AppObserveSessionEventsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', session: { __typename?: 'AppObserveSession', id: string, metrics: { __typename?: 'AppObserveMetricConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveMetricEdge', node: { __typename?: 'AppObserveMetric', id: string, name: string, value: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null, routeName?: string | null } }> }, logs: { __typename?: 'AppObserveLogConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveLogEdge', node:
+                | { __typename: 'AppObserveError', id: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, type?: string | null, message?: string | null, source?: string | null, fingerprint?: string | null, isFatal?: boolean | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> }
+                | { __typename: 'AppObserveUserEvent', id: string, name: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> }
+               }> } } } } } };
 
 export type PostHogOrganizationConnectionByAccountIdQueryVariables = Exact<{
   accountId: Scalars['String']['input'];
@@ -16680,11 +16701,11 @@ export type EnvironmentVariableWithSecretFragment = { __typename?: 'EnvironmentV
 
 export type FingerprintFragment = { __typename?: 'Fingerprint', id: string, hash: string, debugInfoUrl?: string | null, builds: { __typename?: 'AppBuildsConnection', edges: Array<{ __typename?: 'AppBuildEdge', node: { __typename?: 'Build', platform: AppPlatform, id: string } }> }, updates: { __typename?: 'AppUpdatesConnection', edges: Array<{ __typename?: 'AppUpdateEdge', node: { __typename?: 'Update', id: string, platform: string } }> } };
 
-export type AppObserveTimeSeriesFragment = { __typename?: 'AppObserveTimeSeries', eventCount: number, appVersionMarkers: Array<{ __typename?: 'AppObserveAppVersion', appVersion: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, buildNumbers: Array<{ __typename?: 'AppObserveAppBuildNumber', appBuildNumber: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, updates: Array<{ __typename?: 'AppObserveAppUpdate', appUpdateId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, metrics: Array<{ __typename?: 'AppObserveAppVersionMetric', metricName: string, eventCount: number, statistics: { __typename?: 'AppObserveVersionMarkerStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } }> }>, statistics: { __typename?: 'AppObserveTimeSeriesStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } };
+export type AppObserveUserEventFragment = { __typename?: 'AppObserveUserEvent', id: string, name: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> };
 
-export type AppObserveCustomEventFragment = { __typename?: 'AppObserveCustomEvent', id: string, eventName: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> };
+export type AppObserveErrorFragment = { __typename?: 'AppObserveError', id: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, type?: string | null, message?: string | null, source?: string | null, fingerprint?: string | null, isFatal?: boolean | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> };
 
-export type AppObserveEventFragment = { __typename?: 'AppObserveEvent', id: string, metricName: string, metricValue: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null, routeName?: string | null };
+export type AppObserveMetricFragment = { __typename?: 'AppObserveMetric', id: string, name: string, value: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null, routeName?: string | null };
 
 export type AppObserveAppVersionFragment = { __typename?: 'AppObserveAppVersion', appVersion: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, buildNumbers: Array<{ __typename?: 'AppObserveAppBuildNumber', appBuildNumber: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, updates: Array<{ __typename?: 'AppObserveAppUpdate', appUpdateId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, metrics: Array<{ __typename?: 'AppObserveAppVersionMetric', metricName: string, eventCount: number, statistics: { __typename?: 'AppObserveVersionMarkerStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } }> };
 

--- a/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
@@ -4,51 +4,34 @@ import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/creat
 import { withErrorHandlingAsync } from '../client';
 import {
   AppObserveAppVersion,
-  AppObserveCustomEvent,
-  AppObserveCustomEventListFilter,
-  AppObserveCustomEventListOrderBy,
-  AppObserveCustomEventName,
-  AppObserveEvent,
-  AppObserveEventsFilter,
-  AppObserveEventsOrderBy,
+  AppObserveError,
+  AppObserveLogsOrderBy,
+  AppObserveMetric,
+  AppObserveMetricsListFilter,
+  AppObserveMetricsListOrderBy,
+  AppObserveNavigationFilter,
+  AppObserveNavigationOrderBy,
   AppObserveNavigationRoute,
-  AppObserveNavigationRoutesFilter,
-  AppObserveNavigationRoutesOrderBy,
   AppObservePlatform,
   AppObserveReleasesInput,
-  AppObserveTimeSeriesInput,
-  AppObserveTimeSeriesStatistics,
+  AppObserveUserEvent,
+  AppObserveUserEventListFilter,
+  AppObserveUserEventListOrderBy,
+  AppObserveUserEventName,
   PageInfo,
 } from '../generated';
 import { print } from 'graphql';
 import {
   AppObserveAppVersionFragmentNode,
-  AppObserveCustomEventFragmentNode,
-  AppObserveEventFragmentNode,
-  AppObserveTimeSeriesFragmentNode,
+  AppObserveErrorFragmentNode,
+  AppObserveMetricFragmentNode,
+  AppObserveUserEventFragmentNode,
 } from '../types/Observe';
 
-export type AppObserveTimeSeriesResult = {
-  appVersionMarkers: AppObserveAppVersion[];
-  eventCount: number;
-  statistics: AppObserveTimeSeriesStatistics;
-};
-
-type AppObserveTimeSeriesQuery = {
-  app: {
-    byId: {
-      id: string;
-      observe: {
-        timeSeries: AppObserveTimeSeriesResult;
-      };
-    };
-  };
-};
-
-type AppObserveTimeSeriesQueryVariables = {
-  appId: string;
-  input: Pick<AppObserveTimeSeriesInput, 'metricName' | 'platform' | 'startTime' | 'endTime'>;
-};
+/** A `session.logs` node is a user event or an error (the `AppObserveLog` interface). */
+export type AppObserveSessionLog =
+  | ({ __typename: 'AppObserveUserEvent' } & AppObserveUserEvent)
+  | ({ __typename: 'AppObserveError' } & AppObserveError);
 
 type AppObserveAppVersionsQuery = {
   app: {
@@ -66,76 +49,84 @@ type AppObserveAppVersionsQueryVariables = {
   input: AppObserveReleasesInput;
 };
 
-type AppObserveEventsQuery = {
+type AppObserveMetricsListQuery = {
   app: {
     byId: {
       id: string;
       observe: {
-        events: {
-          pageInfo: PageInfo;
-          edges: Array<{
-            cursor: string;
-            node: AppObserveEvent;
-          }>;
+        metrics: {
+          list: {
+            pageInfo: PageInfo;
+            edges: Array<{
+              cursor: string;
+              node: AppObserveMetric;
+            }>;
+          };
         };
       };
     };
   };
 };
 
-type AppObserveEventsQueryVariables = {
+type AppObserveMetricsListQueryVariables = {
   appId: string;
-  filter?: AppObserveEventsFilter;
+  filter?: AppObserveMetricsListFilter;
   first?: number;
   after?: string;
-  orderBy?: AppObserveEventsOrderBy;
+  orderBy?: AppObserveMetricsListOrderBy;
 };
 
-type AppObserveCustomEventListQuery = {
+type AppObserveUserEventListQuery = {
   app: {
     byId: {
       id: string;
       observe: {
-        customEventList: {
-          pageInfo: PageInfo;
-          edges: Array<{
-            cursor: string;
-            node: AppObserveCustomEvent;
-          }>;
+        userEvents: {
+          list: {
+            pageInfo: PageInfo;
+            edges: Array<{
+              cursor: string;
+              node: AppObserveUserEvent;
+            }>;
+          };
         };
       };
     };
   };
 };
 
-type AppObserveCustomEventListQueryVariables = {
+type AppObserveUserEventListQueryVariables = {
   appId: string;
-  filter?: AppObserveCustomEventListFilter;
+  filter?: AppObserveUserEventListFilter;
   first?: number;
   after?: string;
-  orderBy?: AppObserveCustomEventListOrderBy;
+  orderBy?: AppObserveUserEventListOrderBy;
 };
 
-type AppObserveCustomEventNamesQuery = {
+type AppObserveUserEventNamesQuery = {
   app: {
     byId: {
       id: string;
       observe: {
-        customEventNames: {
-          isTruncated: boolean;
-          names: AppObserveCustomEventName[];
+        userEvents: {
+          names: {
+            isTruncated: boolean;
+            names: AppObserveUserEventName[];
+          };
         };
       };
     };
   };
 };
 
-type AppObserveCustomEventNamesQueryVariables = {
+type AppObserveUserEventNamesQueryVariables = {
   appId: string;
-  startTime: string;
-  endTime: string;
-  platforms?: AppObservePlatform[];
-  environment?: string;
+  input: {
+    startTime: string;
+    endTime: string;
+    platforms?: AppObservePlatform[];
+    environment?: string;
+  };
 };
 
 type AppObserveNavigationRoutesQuery = {
@@ -143,12 +134,14 @@ type AppObserveNavigationRoutesQuery = {
     byId: {
       id: string;
       observe: {
-        navigationRoutes: {
-          pageInfo: PageInfo;
-          edges: Array<{
-            cursor: string;
-            node: AppObserveNavigationRoute;
-          }>;
+        navigation: {
+          routes: {
+            pageInfo: PageInfo;
+            edges: Array<{
+              cursor: string;
+              node: AppObserveNavigationRoute;
+            }>;
+          };
         };
       };
     };
@@ -157,62 +150,42 @@ type AppObserveNavigationRoutesQuery = {
 
 type AppObserveNavigationRoutesQueryVariables = {
   appId: string;
-  filter: AppObserveNavigationRoutesFilter;
+  filter: AppObserveNavigationFilter;
   first?: number;
   after?: string;
-  orderBy?: AppObserveNavigationRoutesOrderBy;
+  orderBy?: AppObserveNavigationOrderBy;
+};
+
+type AppObserveSessionEventsQuery = {
+  app: {
+    byId: {
+      id: string;
+      observe: {
+        session: {
+          id: string;
+          metrics: {
+            pageInfo: PageInfo;
+            edges: Array<{ node: AppObserveMetric }>;
+          };
+          logs: {
+            pageInfo: PageInfo;
+            edges: Array<{ node: AppObserveSessionLog }>;
+          };
+        };
+      };
+    };
+  };
+};
+
+type AppObserveSessionEventsQueryVariables = {
+  appId: string;
+  id: string;
+  first?: number;
+  metricsOrderBy?: AppObserveMetricsListOrderBy;
+  logsOrderBy?: AppObserveLogsOrderBy;
 };
 
 export const ObserveQuery = {
-  async timeSeriesAsync(
-    graphqlClient: ExpoGraphqlClient,
-    {
-      appId,
-      metricName,
-      platform,
-      startTime,
-      endTime,
-    }: {
-      appId: string;
-      metricName: string;
-      platform: AppObservePlatform;
-      startTime: string;
-      endTime: string;
-    }
-  ): Promise<AppObserveTimeSeriesResult> {
-    const data = await withErrorHandlingAsync(
-      graphqlClient
-        .query<AppObserveTimeSeriesQuery, AppObserveTimeSeriesQueryVariables>(
-          gql`
-            query AppObserveTimeSeries(
-              $appId: String!
-              $input: AppObserveTimeSeriesInput!
-            ) {
-              app {
-                byId(appId: $appId) {
-                  id
-                  observe {
-                    timeSeries(input: $input) {
-                      ...AppObserveTimeSeriesFragment
-                    }
-                  }
-                }
-              }
-            }
-            ${print(AppObserveAppVersionFragmentNode)}
-            ${print(AppObserveTimeSeriesFragmentNode)}
-          `,
-          {
-            appId,
-            input: { metricName, platform, startTime, endTime },
-          }
-        )
-        .toPromise()
-    );
-
-    return data.app.byId.observe.timeSeries;
-  },
-
   async appVersionsAsync(
     graphqlClient: ExpoGraphqlClient,
     {
@@ -235,10 +208,7 @@ export const ObserveQuery = {
       graphqlClient
         .query<AppObserveAppVersionsQuery, AppObserveAppVersionsQueryVariables>(
           gql`
-            query AppObserveAppVersions(
-              $appId: String!
-              $input: AppObserveReleasesInput!
-            ) {
+            query AppObserveAppVersions($appId: String!, $input: AppObserveReleasesInput!) {
               app {
                 byId(appId: $appId) {
                   id
@@ -271,39 +241,36 @@ export const ObserveQuery = {
 
   async eventsAsync(
     graphqlClient: ExpoGraphqlClient,
-    variables: AppObserveEventsQueryVariables
-  ): Promise<{ events: AppObserveEvent[]; pageInfo: PageInfo }> {
+    variables: AppObserveMetricsListQueryVariables
+  ): Promise<{ events: AppObserveMetric[]; pageInfo: PageInfo }> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<AppObserveEventsQuery, AppObserveEventsQueryVariables>(
+        .query<AppObserveMetricsListQuery, AppObserveMetricsListQueryVariables>(
           gql`
-            query AppObserveEvents(
+            query AppObserveMetricsList(
               $appId: String!
-              $filter: AppObserveEventsFilter
+              $filter: AppObserveMetricsListFilter
               $first: Int
               $after: String
-              $orderBy: AppObserveEventsOrderBy
+              $orderBy: AppObserveMetricsListOrderBy
             ) {
               app {
                 byId(appId: $appId) {
                   id
                   observe {
-                    events(
-                      filter: $filter
-                      first: $first
-                      after: $after
-                      orderBy: $orderBy
-                    ) {
-                      pageInfo {
-                        hasNextPage
-                        hasPreviousPage
-                        endCursor
-                      }
-                      edges {
-                        cursor
-                        node {
-                          id
-                          ...AppObserveEventFragment
+                    metrics {
+                      list(filter: $filter, first: $first, after: $after, orderBy: $orderBy) {
+                        pageInfo {
+                          hasNextPage
+                          hasPreviousPage
+                          endCursor
+                        }
+                        edges {
+                          cursor
+                          node {
+                            id
+                            ...AppObserveMetricFragment
+                          }
                         }
                       }
                     }
@@ -311,14 +278,14 @@ export const ObserveQuery = {
                 }
               }
             }
-            ${print(AppObserveEventFragmentNode)}
+            ${print(AppObserveMetricFragmentNode)}
           `,
           variables
         )
         .toPromise()
     );
 
-    const { edges, pageInfo } = data.app.byId.observe.events;
+    const { edges, pageInfo } = data.app.byId.observe.metrics.list;
     return {
       events: edges.map(edge => edge.node),
       pageInfo,
@@ -327,39 +294,36 @@ export const ObserveQuery = {
 
   async customEventListAsync(
     graphqlClient: ExpoGraphqlClient,
-    variables: AppObserveCustomEventListQueryVariables
-  ): Promise<{ events: AppObserveCustomEvent[]; pageInfo: PageInfo }> {
+    variables: AppObserveUserEventListQueryVariables
+  ): Promise<{ events: AppObserveUserEvent[]; pageInfo: PageInfo }> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<AppObserveCustomEventListQuery, AppObserveCustomEventListQueryVariables>(
+        .query<AppObserveUserEventListQuery, AppObserveUserEventListQueryVariables>(
           gql`
-            query AppObserveCustomEventList(
+            query AppObserveUserEventList(
               $appId: String!
-              $filter: AppObserveCustomEventListFilter
+              $filter: AppObserveUserEventListFilter
               $first: Int
               $after: String
-              $orderBy: AppObserveCustomEventListOrderBy
+              $orderBy: AppObserveUserEventListOrderBy
             ) {
               app {
                 byId(appId: $appId) {
                   id
                   observe {
-                    customEventList(
-                      filter: $filter
-                      first: $first
-                      after: $after
-                      orderBy: $orderBy
-                    ) {
-                      pageInfo {
-                        hasNextPage
-                        hasPreviousPage
-                        endCursor
-                      }
-                      edges {
-                        cursor
-                        node {
-                          id
-                          ...AppObserveCustomEventFragment
+                    userEvents {
+                      list(filter: $filter, first: $first, after: $after, orderBy: $orderBy) {
+                        pageInfo {
+                          hasNextPage
+                          hasPreviousPage
+                          endCursor
+                        }
+                        edges {
+                          cursor
+                          node {
+                            id
+                            ...AppObserveUserEventFragment
+                          }
                         }
                       }
                     }
@@ -367,14 +331,14 @@ export const ObserveQuery = {
                 }
               }
             }
-            ${print(AppObserveCustomEventFragmentNode)}
+            ${print(AppObserveUserEventFragmentNode)}
           `,
           variables
         )
         .toPromise()
     );
 
-    const { edges, pageInfo } = data.app.byId.observe.customEventList;
+    const { edges, pageInfo } = data.app.byId.observe.userEvents.list;
     return {
       events: edges.map(edge => edge.node),
       pageInfo,
@@ -396,32 +360,23 @@ export const ObserveQuery = {
       platforms?: AppObservePlatform[];
       environment?: string;
     }
-  ): Promise<{ names: AppObserveCustomEventName[]; isTruncated: boolean }> {
+  ): Promise<{ names: AppObserveUserEventName[]; isTruncated: boolean }> {
     const data = await withErrorHandlingAsync(
       graphqlClient
-        .query<AppObserveCustomEventNamesQuery, AppObserveCustomEventNamesQueryVariables>(
+        .query<AppObserveUserEventNamesQuery, AppObserveUserEventNamesQueryVariables>(
           gql`
-            query AppObserveCustomEventNames(
-              $appId: String!
-              $startTime: DateTime!
-              $endTime: DateTime!
-              $platforms: [AppObservePlatform!]
-              $environment: String
-            ) {
+            query AppObserveUserEventNames($appId: String!, $input: AppObserveUserEventNamesInput!) {
               app {
                 byId(appId: $appId) {
                   id
                   observe {
-                    customEventNames(
-                      startTime: $startTime
-                      endTime: $endTime
-                      platforms: $platforms
-                      environment: $environment
-                    ) {
-                      isTruncated
-                      names {
-                        eventName
-                        count
+                    userEvents {
+                      names(input: $input) {
+                        isTruncated
+                        names {
+                          name
+                          count
+                        }
                       }
                     }
                   }
@@ -431,16 +386,18 @@ export const ObserveQuery = {
           `,
           {
             appId,
-            startTime,
-            endTime,
-            ...(platforms?.length && { platforms }),
-            ...(environment && { environment }),
+            input: {
+              startTime,
+              endTime,
+              ...(platforms?.length && { platforms }),
+              ...(environment && { environment }),
+            },
           }
         )
         .toPromise()
     );
 
-    return data.app.byId.observe.customEventNames;
+    return data.app.byId.observe.userEvents.names;
   },
 
   async navigationRoutesAsync(
@@ -453,39 +410,41 @@ export const ObserveQuery = {
           gql`
             query AppObserveNavigationRoutes(
               $appId: String!
-              $filter: AppObserveNavigationRoutesFilter!
+              $filter: AppObserveNavigationFilter!
               $first: Int
               $after: String
-              $orderBy: AppObserveNavigationRoutesOrderBy
+              $orderBy: AppObserveNavigationOrderBy
             ) {
               app {
                 byId(appId: $appId) {
                   id
                   observe {
-                    navigationRoutes(filter: $filter, first: $first, after: $after, orderBy: $orderBy) {
-                      pageInfo {
-                        hasNextPage
-                        hasPreviousPage
-                        endCursor
-                      }
-                      edges {
-                        cursor
-                        node {
-                          routeName
-                          coldTtr {
-                            count
-                            median
-                            p90
-                          }
-                          warmTtr {
-                            count
-                            median
-                            p90
-                          }
-                          tti {
-                            count
-                            median
-                            p90
+                    navigation {
+                      routes(filter: $filter, first: $first, after: $after, orderBy: $orderBy) {
+                        pageInfo {
+                          hasNextPage
+                          hasPreviousPage
+                          endCursor
+                        }
+                        edges {
+                          cursor
+                          node {
+                            routeName
+                            coldTtr {
+                              count
+                              median
+                              p90
+                            }
+                            warmTtr {
+                              count
+                              median
+                              p90
+                            }
+                            tti {
+                              count
+                              median
+                              p90
+                            }
                           }
                         }
                       }
@@ -500,10 +459,91 @@ export const ObserveQuery = {
         .toPromise()
     );
 
-    const { edges, pageInfo } = data.app.byId.observe.navigationRoutes;
+    const { edges, pageInfo } = data.app.byId.observe.navigation.routes;
     return {
       routes: edges.map(edge => edge.node),
       pageInfo,
+    };
+  },
+
+  async sessionEventsAsync(
+    graphqlClient: ExpoGraphqlClient,
+    variables: AppObserveSessionEventsQueryVariables
+  ): Promise<{
+    metrics: AppObserveMetric[];
+    logs: AppObserveSessionLog[];
+    metricsPageInfo: PageInfo;
+    logsPageInfo: PageInfo;
+  }> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<AppObserveSessionEventsQuery, AppObserveSessionEventsQueryVariables>(
+          gql`
+            query AppObserveSessionEvents(
+              $appId: String!
+              $id: ID!
+              $first: Int
+              $metricsOrderBy: AppObserveMetricsListOrderBy
+              $logsOrderBy: AppObserveLogsOrderBy
+            ) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  observe {
+                    session(id: $id) {
+                      id
+                      metrics(first: $first, orderBy: $metricsOrderBy) {
+                        pageInfo {
+                          hasNextPage
+                          hasPreviousPage
+                          endCursor
+                        }
+                        edges {
+                          node {
+                            id
+                            ...AppObserveMetricFragment
+                          }
+                        }
+                      }
+                      logs(first: $first, orderBy: $logsOrderBy) {
+                        pageInfo {
+                          hasNextPage
+                          hasPreviousPage
+                          endCursor
+                        }
+                        edges {
+                          node {
+                            id
+                            __typename
+                            ... on AppObserveUserEvent {
+                              ...AppObserveUserEventFragment
+                            }
+                            ... on AppObserveError {
+                              ...AppObserveErrorFragment
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            ${print(AppObserveMetricFragmentNode)}
+            ${print(AppObserveUserEventFragmentNode)}
+            ${print(AppObserveErrorFragmentNode)}
+          `,
+          variables
+        )
+        .toPromise()
+    );
+
+    const { metrics, logs } = data.app.byId.observe.session;
+    return {
+      metrics: metrics.edges.map(edge => edge.node),
+      logs: logs.edges.map(edge => edge.node),
+      metricsPageInfo: metrics.pageInfo,
+      logsPageInfo: logs.pageInfo,
     };
   },
 };

--- a/packages/eas-cli/src/graphql/types/Observe.ts
+++ b/packages/eas-cli/src/graphql/types/Observe.ts
@@ -1,27 +1,9 @@
 import gql from 'graphql-tag';
 
-export const AppObserveTimeSeriesFragmentNode = gql`
-  fragment AppObserveTimeSeriesFragment on AppObserveTimeSeries {
-    appVersionMarkers {
-      ...AppObserveAppVersionFragment
-    }
-    eventCount
-    statistics {
-      min
-      max
-      median
-      average
-      p80
-      p90
-      p99
-    }
-  }
-`;
-
-export const AppObserveCustomEventFragmentNode = gql`
-  fragment AppObserveCustomEventFragment on AppObserveCustomEvent {
+export const AppObserveUserEventFragmentNode = gql`
+  fragment AppObserveUserEventFragment on AppObserveUserEvent {
     id
-    eventName
+    name
     timestamp
     sessionId
     severityNumber
@@ -44,11 +26,41 @@ export const AppObserveCustomEventFragmentNode = gql`
   }
 `;
 
-export const AppObserveEventFragmentNode = gql`
-  fragment AppObserveEventFragment on AppObserveEvent {
+export const AppObserveErrorFragmentNode = gql`
+  fragment AppObserveErrorFragment on AppObserveError {
     id
-    metricName
-    metricValue
+    timestamp
+    sessionId
+    severityNumber
+    severityText
+    type
+    message
+    source
+    fingerprint
+    isFatal
+    properties {
+      key
+      value
+      type
+    }
+    appVersion
+    appBuildNumber
+    appUpdateId
+    appEasBuildId
+    deviceOs
+    deviceOsVersion
+    deviceModel
+    environment
+    easClientId
+    countryCode
+  }
+`;
+
+export const AppObserveMetricFragmentNode = gql`
+  fragment AppObserveMetricFragment on AppObserveMetric {
+    id
+    name
+    value
     timestamp
     appVersion
     appBuildNumber

--- a/packages/eas-cli/src/observe/__tests__/fetchCustomEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchCustomEvents.test.ts
@@ -1,14 +1,14 @@
-import { AppObserveCustomEvent, AppObservePlatform } from '../../graphql/generated';
+import { AppObservePlatform, AppObserveUserEvent } from '../../graphql/generated';
 import { ObserveQuery } from '../../graphql/queries/ObserveQuery';
 import { fetchObserveCustomEventsAsync } from '../fetchCustomEvents';
 
 jest.mock('../../graphql/queries/ObserveQuery');
 
-function makeCustomEvent(overrides: Partial<AppObserveCustomEvent> = {}): AppObserveCustomEvent {
+function makeCustomEvent(overrides: Partial<AppObserveUserEvent> = {}): AppObserveUserEvent {
   return {
-    __typename: 'AppObserveCustomEvent' as const,
+    __typename: 'AppObserveUserEvent' as const,
     id: 'evt-1',
-    eventName: 'my_event',
+    name: 'my_event',
     timestamp: '2025-01-01T00:00:00.000Z',
     appVersion: '1.0.0',
     appBuildNumber: '1',
@@ -18,7 +18,7 @@ function makeCustomEvent(overrides: Partial<AppObserveCustomEvent> = {}): AppObs
     easClientId: 'client-1',
     properties: [],
     ...overrides,
-  } as AppObserveCustomEvent;
+  } as AppObserveUserEvent;
 }
 
 describe('fetchObserveCustomEventsAsync', () => {
@@ -57,7 +57,7 @@ describe('fetchObserveCustomEventsAsync', () => {
     });
 
     const filter = mockCustomEventListAsync.mock.calls[0][1].filter;
-    expect(filter?.eventName).toBe('my_event');
+    expect(filter?.name).toBe('my_event');
   });
 
   it('forwards platform, appVersion, and sessionId filters when provided', async () => {
@@ -107,7 +107,7 @@ describe('fetchObserveCustomEventsAsync', () => {
     });
 
     const filter = mockCustomEventListAsync.mock.calls[0][1].filter;
-    expect(filter).not.toHaveProperty('eventName');
+    expect(filter).not.toHaveProperty('name');
     expect(filter).not.toHaveProperty('platform');
     expect(filter).not.toHaveProperty('appVersion');
     expect(filter).not.toHaveProperty('appUpdateId');

--- a/packages/eas-cli/src/observe/__tests__/fetchEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchEvents.test.ts
@@ -2,8 +2,8 @@ import { CombinedError } from '@urql/core';
 import { GraphQLError } from 'graphql';
 
 import {
-  AppObserveEventsOrderByDirection,
-  AppObserveEventsOrderByField,
+  AppObserveMetricsListOrderByField,
+  AppObserveOrderDirection,
   AppObservePlatform,
 } from '../../graphql/generated';
 import { ObserveQuery } from '../../graphql/queries/ObserveQuery';
@@ -25,29 +25,29 @@ function target(platform: AppObservePlatform): ObservePlatformTarget {
 describe(resolveOrderBy, () => {
   it('maps "slowest" to METRIC_VALUE DESC', () => {
     expect(resolveOrderBy(EventsOrderPreset.Slowest)).toEqual({
-      field: AppObserveEventsOrderByField.MetricValue,
-      direction: AppObserveEventsOrderByDirection.Desc,
+      field: AppObserveMetricsListOrderByField.Value,
+      direction: AppObserveOrderDirection.Desc,
     });
   });
 
   it('maps "fastest" to METRIC_VALUE ASC', () => {
     expect(resolveOrderBy(EventsOrderPreset.Fastest)).toEqual({
-      field: AppObserveEventsOrderByField.MetricValue,
-      direction: AppObserveEventsOrderByDirection.Asc,
+      field: AppObserveMetricsListOrderByField.Value,
+      direction: AppObserveOrderDirection.Asc,
     });
   });
 
   it('maps "newest" to TIMESTAMP DESC', () => {
     expect(resolveOrderBy(EventsOrderPreset.Newest)).toEqual({
-      field: AppObserveEventsOrderByField.Timestamp,
-      direction: AppObserveEventsOrderByDirection.Desc,
+      field: AppObserveMetricsListOrderByField.Timestamp,
+      direction: AppObserveOrderDirection.Desc,
     });
   });
 
   it('maps "oldest" to TIMESTAMP ASC', () => {
     expect(resolveOrderBy(EventsOrderPreset.Oldest)).toEqual({
-      field: AppObserveEventsOrderByField.Timestamp,
-      direction: AppObserveEventsOrderByDirection.Asc,
+      field: AppObserveMetricsListOrderByField.Timestamp,
+      direction: AppObserveOrderDirection.Asc,
     });
   });
 });
@@ -69,8 +69,8 @@ describe(fetchObserveEventsAsync, () => {
     await fetchObserveEventsAsync(mockGraphqlClient, 'app-123', {
       metricName: 'expo.app_startup.tti',
       orderBy: {
-        field: AppObserveEventsOrderByField.MetricValue,
-        direction: AppObserveEventsOrderByDirection.Desc,
+        field: AppObserveMetricsListOrderByField.Value,
+        direction: AppObserveOrderDirection.Desc,
       },
       limit: 10,
       startTime: '2025-01-01T00:00:00.000Z',
@@ -81,14 +81,14 @@ describe(fetchObserveEventsAsync, () => {
     expect(mockEventsAsync).toHaveBeenCalledWith(mockGraphqlClient, {
       appId: 'app-123',
       filter: {
-        metricName: 'expo.app_startup.tti',
+        name: 'expo.app_startup.tti',
         startTime: '2025-01-01T00:00:00.000Z',
         endTime: '2025-03-01T00:00:00.000Z',
       },
       first: 10,
       orderBy: {
-        field: AppObserveEventsOrderByField.MetricValue,
-        direction: AppObserveEventsOrderByDirection.Desc,
+        field: AppObserveMetricsListOrderByField.Value,
+        direction: AppObserveOrderDirection.Desc,
       },
     });
   });
@@ -102,8 +102,8 @@ describe(fetchObserveEventsAsync, () => {
     await fetchObserveEventsAsync(mockGraphqlClient, 'app-123', {
       metricName: 'expo.app_startup.tti',
       orderBy: {
-        field: AppObserveEventsOrderByField.MetricValue,
-        direction: AppObserveEventsOrderByDirection.Desc,
+        field: AppObserveMetricsListOrderByField.Value,
+        direction: AppObserveOrderDirection.Desc,
       },
       limit: 5,
       startTime: '2025-01-01T00:00:00.000Z',
@@ -130,8 +130,8 @@ describe(fetchObserveEventsAsync, () => {
     await fetchObserveEventsAsync(mockGraphqlClient, 'app-123', {
       metricName: 'expo.app_startup.tti',
       orderBy: {
-        field: AppObserveEventsOrderByField.MetricValue,
-        direction: AppObserveEventsOrderByDirection.Desc,
+        field: AppObserveMetricsListOrderByField.Value,
+        direction: AppObserveOrderDirection.Desc,
       },
       limit: 10,
       startTime: '2025-01-01T00:00:00.000Z',
@@ -158,8 +158,8 @@ describe(fetchObserveEventsAsync, () => {
     await fetchObserveEventsAsync(mockGraphqlClient, 'app-123', {
       metricName: 'expo.app_startup.tti',
       orderBy: {
-        field: AppObserveEventsOrderByField.MetricValue,
-        direction: AppObserveEventsOrderByDirection.Desc,
+        field: AppObserveMetricsListOrderByField.Value,
+        direction: AppObserveOrderDirection.Desc,
       },
       limit: 10,
       startTime: '2025-01-01T00:00:00.000Z',
@@ -186,8 +186,8 @@ describe(fetchObserveEventsAsync, () => {
     await fetchObserveEventsAsync(mockGraphqlClient, 'app-123', {
       metricName: 'expo.app_startup.tti',
       orderBy: {
-        field: AppObserveEventsOrderByField.MetricValue,
-        direction: AppObserveEventsOrderByDirection.Desc,
+        field: AppObserveMetricsListOrderByField.Value,
+        direction: AppObserveOrderDirection.Desc,
       },
       limit: 10,
       startTime: '2025-01-01T00:00:00.000Z',
@@ -203,10 +203,10 @@ describe(fetchObserveEventsAsync, () => {
   it('returns events and pageInfo from the query result', async () => {
     const mockEvents = [
       {
-        __typename: 'AppObserveEvent' as const,
+        __typename: 'AppObserveMetric' as const,
         id: 'evt-1',
-        metricName: 'expo.app_startup.tti',
-        metricValue: 1.23,
+        name: 'expo.app_startup.tti',
+        value: 1.23,
         timestamp: '2025-01-15T10:30:00.000Z',
         appVersion: '1.0.0',
         appBuildNumber: '42',
@@ -230,8 +230,8 @@ describe(fetchObserveEventsAsync, () => {
     const result = await fetchObserveEventsAsync(mockGraphqlClient, 'app-123', {
       metricName: 'expo.app_startup.tti',
       orderBy: {
-        field: AppObserveEventsOrderByField.MetricValue,
-        direction: AppObserveEventsOrderByDirection.Desc,
+        field: AppObserveMetricsListOrderByField.Value,
+        direction: AppObserveOrderDirection.Desc,
       },
       limit: 10,
       startTime: '2025-01-01T00:00:00.000Z',
@@ -239,7 +239,7 @@ describe(fetchObserveEventsAsync, () => {
     });
 
     expect(result.events).toHaveLength(1);
-    expect(result.events[0].metricValue).toBe(1.23);
+    expect(result.events[0].value).toBe(1.23);
     expect(result.pageInfo.hasNextPage).toBe(true);
   });
 
@@ -252,8 +252,8 @@ describe(fetchObserveEventsAsync, () => {
     await fetchObserveEventsAsync(mockGraphqlClient, 'app-123', {
       metricName: 'expo.app_startup.tti',
       orderBy: {
-        field: AppObserveEventsOrderByField.MetricValue,
-        direction: AppObserveEventsOrderByDirection.Desc,
+        field: AppObserveMetricsListOrderByField.Value,
+        direction: AppObserveOrderDirection.Desc,
       },
       limit: 10,
       after: 'cursor-abc',
@@ -276,8 +276,8 @@ describe(fetchObserveEventsAsync, () => {
     await fetchObserveEventsAsync(mockGraphqlClient, 'app-123', {
       metricName: 'expo.app_startup.tti',
       orderBy: {
-        field: AppObserveEventsOrderByField.MetricValue,
-        direction: AppObserveEventsOrderByDirection.Desc,
+        field: AppObserveMetricsListOrderByField.Value,
+        direction: AppObserveOrderDirection.Desc,
       },
       limit: 10,
       startTime: '2025-01-01T00:00:00.000Z',

--- a/packages/eas-cli/src/observe/__tests__/fetchSessions.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/fetchSessions.test.ts
@@ -1,10 +1,13 @@
 import {
-  AppObserveCustomEvent,
-  AppObserveCustomEventListOrderByField,
-  AppObserveEvent,
-  AppObserveEventsOrderByDirection,
-  AppObserveEventsOrderByField,
+  AppObserveError,
+  AppObserveLogsOrderByField,
+  AppObserveMetric,
+  AppObserveMetricsListOrderByField,
+  AppObserveOrderDirection,
+  AppObserveUserEvent,
+  AppObserveUserEventListOrderByField,
 } from '../../graphql/generated';
+import { AppObserveSessionLog, ObserveQuery } from '../../graphql/queries/ObserveQuery';
 import { fetchObserveCustomEventsAsync } from '../fetchCustomEvents';
 import { fetchObserveEventsAsync } from '../fetchEvents';
 import {
@@ -21,16 +24,20 @@ jest.mock('../fetchEvents', () => {
     fetchObserveEventsAsync: jest.fn(),
   };
 });
+jest.mock('../../graphql/queries/ObserveQuery');
 
 const mockFetchObserveEventsAsync = jest.mocked(fetchObserveEventsAsync);
 const mockFetchObserveCustomEventsAsync = jest.mocked(fetchObserveCustomEventsAsync);
+const mockSessionEventsAsync = jest.mocked(ObserveQuery.sessionEventsAsync);
 
-function makeMetricEvent(overrides: Partial<AppObserveEvent> = {}): AppObserveEvent {
+const noNextPage = { hasNextPage: false, hasPreviousPage: false };
+
+function makeMetricEvent(overrides: Partial<AppObserveMetric> = {}): AppObserveMetric {
   return {
-    __typename: 'AppObserveEvent' as const,
+    __typename: 'AppObserveMetric' as const,
     id: 'evt-m-1',
-    metricName: 'expo.app_startup.tti',
-    metricValue: 0.5,
+    name: 'expo.app_startup.tti',
+    value: 0.5,
     timestamp: '2025-01-15T10:00:00.000Z',
     appVersion: '1.0.0',
     appBuildNumber: '42',
@@ -43,14 +50,14 @@ function makeMetricEvent(overrides: Partial<AppObserveEvent> = {}): AppObserveEv
     easClientId: 'client-1',
     customParams: null,
     ...overrides,
-  } as AppObserveEvent;
+  } as AppObserveMetric;
 }
 
-function makeCustomEvent(overrides: Partial<AppObserveCustomEvent> = {}): AppObserveCustomEvent {
+function makeUserEvent(overrides: Partial<AppObserveUserEvent> = {}): AppObserveUserEvent {
   return {
-    __typename: 'AppObserveCustomEvent' as const,
+    __typename: 'AppObserveUserEvent' as const,
     id: 'evt-c-1',
-    eventName: 'login_pressed',
+    name: 'login_pressed',
     timestamp: '2025-01-15T10:01:00.000Z',
     sessionId: 'session-1',
     severityNumber: null,
@@ -67,7 +74,36 @@ function makeCustomEvent(overrides: Partial<AppObserveCustomEvent> = {}): AppObs
     countryCode: 'US',
     properties: [],
     ...overrides,
-  } as AppObserveCustomEvent;
+  } as AppObserveUserEvent;
+}
+
+function makeUserLog(overrides: Partial<AppObserveUserEvent> = {}): AppObserveSessionLog {
+  return makeUserEvent(overrides) as AppObserveSessionLog;
+}
+
+function makeErrorLog(overrides: Partial<AppObserveError> = {}): AppObserveSessionLog {
+  return {
+    __typename: 'AppObserveError' as const,
+    id: 'err-1',
+    type: 'TypeError',
+    message: 'undefined is not a function',
+    timestamp: '2025-01-15T10:02:00.000Z',
+    sessionId: 'session-1',
+    severityText: 'fatal',
+    severityNumber: null,
+    appVersion: '1.0.0',
+    appBuildNumber: '42',
+    appUpdateId: null,
+    appEasBuildId: null,
+    deviceModel: 'iPhone 15',
+    deviceOs: 'iOS',
+    deviceOsVersion: '17.0',
+    environment: 'production',
+    easClientId: 'client-1',
+    countryCode: 'US',
+    properties: [],
+    ...overrides,
+  } as AppObserveSessionLog;
 }
 
 const baseOptions = {
@@ -77,45 +113,47 @@ const baseOptions = {
 describe('fetchObserveSessionEventsAsync', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockFetchObserveEventsAsync.mockResolvedValue({
-      events: [],
-      pageInfo: { hasNextPage: false, hasPreviousPage: false },
-    });
-    mockFetchObserveCustomEventsAsync.mockResolvedValue({
-      events: [],
-      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    mockSessionEventsAsync.mockResolvedValue({
+      metrics: [],
+      logs: [],
+      metricsPageInfo: noNextPage,
+      logsPageInfo: noNextPage,
     });
   });
 
-  it('forwards sessionId to both event sources and orders metric events oldest-first', async () => {
+  it('queries the session timeline oldest-first for both metrics and logs', async () => {
     await fetchObserveSessionEventsAsync({} as any, 'project-1', {
       ...baseOptions,
       sessionId: 'session-1',
     });
 
-    expect(mockFetchObserveEventsAsync.mock.calls[0][2].sessionId).toBe('session-1');
-    expect(mockFetchObserveEventsAsync.mock.calls[0][2].orderBy).toEqual({
-      field: AppObserveEventsOrderByField.Timestamp,
-      direction: AppObserveEventsOrderByDirection.Asc,
-    });
-    expect(mockFetchObserveCustomEventsAsync.mock.calls[0][2].sessionId).toBe('session-1');
+    expect(mockSessionEventsAsync).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        appId: 'project-1',
+        id: 'session-1',
+        first: 100,
+        metricsOrderBy: {
+          field: AppObserveMetricsListOrderByField.Timestamp,
+          direction: AppObserveOrderDirection.Asc,
+        },
+        logsOrderBy: {
+          field: AppObserveLogsOrderByField.Timestamp,
+          direction: AppObserveOrderDirection.Asc,
+        },
+      })
+    );
   });
 
   it('returns combined entries sorted chronologically, tagged with their source', async () => {
-    mockFetchObserveEventsAsync.mockResolvedValue({
-      events: [makeMetricEvent({ timestamp: '2025-01-15T10:05:00.000Z' })],
-      pageInfo: { hasNextPage: false, hasPreviousPage: false },
-    });
-    mockFetchObserveCustomEventsAsync.mockResolvedValue({
-      events: [
-        makeCustomEvent({ timestamp: '2025-01-15T10:01:00.000Z' }),
-        makeCustomEvent({
-          id: 'evt-c-2',
-          timestamp: '2025-01-15T10:10:00.000Z',
-          eventName: 'logout',
-        }),
+    mockSessionEventsAsync.mockResolvedValue({
+      metrics: [makeMetricEvent({ timestamp: '2025-01-15T10:05:00.000Z' })],
+      logs: [
+        makeUserLog({ timestamp: '2025-01-15T10:01:00.000Z' }),
+        makeUserLog({ id: 'evt-c-2', timestamp: '2025-01-15T10:10:00.000Z', name: 'logout' }),
       ],
-      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      metricsPageInfo: noNextPage,
+      logsPageInfo: noNextPage,
     });
 
     const result = await fetchObserveSessionEventsAsync({} as any, 'project-1', {
@@ -131,30 +169,38 @@ describe('fetchObserveSessionEventsAsync', () => {
     expect(result.entries.map(e => e.source)).toEqual(['log', 'metric', 'log']);
   });
 
-  it('derives session metadata from the entries (first/last timestamps, device, app version)', async () => {
-    mockFetchObserveEventsAsync.mockResolvedValue({
-      events: [
-        makeMetricEvent({
-          timestamp: '2025-01-15T10:00:00.000Z',
-          appVersion: '1.0.0',
-          appBuildNumber: '42',
-          deviceOs: 'iOS',
-          deviceOsVersion: '17.0',
-          deviceModel: 'iPhone 15',
-          appUpdateId: 'update-xyz',
-          countryCode: 'US',
-        }),
+  it('includes error logs as log entries named by their exception type, surfacing message and properties', async () => {
+    mockSessionEventsAsync.mockResolvedValue({
+      metrics: [],
+      logs: [
+        makeErrorLog({
+          properties: [{ key: 'attr', value: 'v', type: 'STRING' }],
+        } as Partial<AppObserveError>),
       ],
-      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      metricsPageInfo: noNextPage,
+      logsPageInfo: noNextPage,
     });
-    mockFetchObserveCustomEventsAsync.mockResolvedValue({
-      events: [
-        makeCustomEvent({
-          timestamp: '2025-01-15T10:05:00.000Z',
-          appUpdateId: 'update-xyz',
-        }),
-      ],
-      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+
+    const result = await fetchObserveSessionEventsAsync({} as any, 'project-1', {
+      ...baseOptions,
+      sessionId: 'session-1',
+    });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].source).toBe('log');
+    expect(result.entries[0].name).toBe('TypeError');
+    expect(result.entries[0].properties).toEqual([
+      { key: 'message', value: 'undefined is not a function', type: 'STRING' },
+      { key: 'attr', value: 'v', type: 'STRING' },
+    ]);
+  });
+
+  it('derives session metadata from the entries (first/last timestamps, device, app version)', async () => {
+    mockSessionEventsAsync.mockResolvedValue({
+      metrics: [makeMetricEvent({ timestamp: '2025-01-15T10:00:00.000Z' })],
+      logs: [makeUserLog({ timestamp: '2025-01-15T10:05:00.000Z', appUpdateId: 'update-xyz' })],
+      metricsPageInfo: noNextPage,
+      logsPageInfo: noNextPage,
     });
 
     const result = await fetchObserveSessionEventsAsync({} as any, 'project-1', {
@@ -184,13 +230,11 @@ describe('fetchObserveSessionEventsAsync', () => {
   });
 
   it('reports hasMore* flags from the underlying page info', async () => {
-    mockFetchObserveEventsAsync.mockResolvedValue({
-      events: [],
-      pageInfo: { hasNextPage: true, hasPreviousPage: false, endCursor: 'cm' },
-    });
-    mockFetchObserveCustomEventsAsync.mockResolvedValue({
-      events: [],
-      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+    mockSessionEventsAsync.mockResolvedValue({
+      metrics: [],
+      logs: [],
+      metricsPageInfo: { hasNextPage: true, hasPreviousPage: false, endCursor: 'cm' },
+      logsPageInfo: noNextPage,
     });
 
     const result = await fetchObserveSessionEventsAsync({} as any, 'project-1', {
@@ -208,7 +252,7 @@ describe('fetchSessionMetricCandidatesAsync', () => {
     jest.clearAllMocks();
     mockFetchObserveEventsAsync.mockResolvedValue({
       events: [],
-      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      pageInfo: noNextPage,
     });
   });
 
@@ -227,8 +271,8 @@ describe('fetchSessionMetricCandidatesAsync', () => {
     expect(options.startTime).toBe('2025-01-01T00:00:00.000Z');
     expect(options.endTime).toBe('2025-02-01T00:00:00.000Z');
     expect(options.orderBy).toEqual({
-      field: AppObserveEventsOrderByField.MetricValue,
-      direction: AppObserveEventsOrderByDirection.Desc,
+      field: AppObserveMetricsListOrderByField.Value,
+      direction: AppObserveOrderDirection.Desc,
     });
   });
 
@@ -239,7 +283,7 @@ describe('fetchSessionMetricCandidatesAsync', () => {
         makeMetricEvent({ id: 'evt-2', sessionId: null }),
         makeMetricEvent({ id: 'evt-3', sessionId: 'session-b' }),
       ],
-      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      pageInfo: noNextPage,
     });
 
     const result = await fetchSessionMetricCandidatesAsync({} as any, 'project-1', {
@@ -259,7 +303,7 @@ describe('fetchSessionLogCandidatesAsync', () => {
     jest.clearAllMocks();
     mockFetchObserveCustomEventsAsync.mockResolvedValue({
       events: [],
-      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      pageInfo: noNextPage,
     });
   });
 
@@ -289,8 +333,8 @@ describe('fetchSessionLogCandidatesAsync', () => {
     });
 
     expect(mockFetchObserveCustomEventsAsync.mock.calls[0][2].orderBy).toEqual({
-      field: AppObserveCustomEventListOrderByField.Timestamp,
-      direction: AppObserveEventsOrderByDirection.Desc,
+      field: AppObserveUserEventListOrderByField.Timestamp,
+      direction: AppObserveOrderDirection.Desc,
     });
   });
 
@@ -304,19 +348,19 @@ describe('fetchSessionLogCandidatesAsync', () => {
     });
 
     expect(mockFetchObserveCustomEventsAsync.mock.calls[0][2].orderBy).toEqual({
-      field: AppObserveCustomEventListOrderByField.Timestamp,
-      direction: AppObserveEventsOrderByDirection.Asc,
+      field: AppObserveUserEventListOrderByField.Timestamp,
+      direction: AppObserveOrderDirection.Asc,
     });
   });
 
   it('preserves the server-provided order (no client-side re-sorting)', async () => {
     mockFetchObserveCustomEventsAsync.mockResolvedValue({
       events: [
-        makeCustomEvent({ id: 'c', timestamp: '2025-01-15T10:10:00.000Z' }),
-        makeCustomEvent({ id: 'b', timestamp: '2025-01-15T10:05:00.000Z' }),
-        makeCustomEvent({ id: 'a', timestamp: '2025-01-15T10:00:00.000Z' }),
+        makeUserEvent({ id: 'c', timestamp: '2025-01-15T10:10:00.000Z' }),
+        makeUserEvent({ id: 'b', timestamp: '2025-01-15T10:05:00.000Z' }),
+        makeUserEvent({ id: 'a', timestamp: '2025-01-15T10:00:00.000Z' }),
       ],
-      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      pageInfo: noNextPage,
     });
 
     const result = await fetchSessionLogCandidatesAsync({} as any, 'project-1', {
@@ -332,10 +376,10 @@ describe('fetchSessionLogCandidatesAsync', () => {
   it('filters out events without a sessionId', async () => {
     mockFetchObserveCustomEventsAsync.mockResolvedValue({
       events: [
-        makeCustomEvent({ id: 'a', sessionId: 'session-a' }),
-        makeCustomEvent({ id: 'b', sessionId: null }),
+        makeUserEvent({ id: 'a', sessionId: 'session-a' }),
+        makeUserEvent({ id: 'b', sessionId: null }),
       ],
-      pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      pageInfo: noNextPage,
     });
 
     const result = await fetchSessionLogCandidatesAsync({} as any, 'project-1', {

--- a/packages/eas-cli/src/observe/__tests__/formatCustomEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatCustomEvents.test.ts
@@ -1,4 +1,4 @@
-import { AppObserveCustomEvent, PageInfo } from '../../graphql/generated';
+import { AppObserveUserEvent, PageInfo } from '../../graphql/generated';
 import {
   buildObserveCustomEventNamesTable,
   buildObserveCustomEventsEmptyWithSuggestionsJson,
@@ -7,11 +7,11 @@ import {
   buildObserveCustomEventsTable,
 } from '../formatCustomEvents';
 
-function makeCustomEvent(overrides: Partial<AppObserveCustomEvent> = {}): AppObserveCustomEvent {
+function makeCustomEvent(overrides: Partial<AppObserveUserEvent> = {}): AppObserveUserEvent {
   return {
-    __typename: 'AppObserveCustomEvent' as const,
+    __typename: 'AppObserveUserEvent' as const,
     id: 'evt-1',
-    eventName: 'my_event',
+    name: 'my_event',
     timestamp: '2025-01-15T10:30:00.000Z',
     appVersion: '1.0.0',
     appBuildNumber: '42',
@@ -21,7 +21,7 @@ function makeCustomEvent(overrides: Partial<AppObserveCustomEvent> = {}): AppObs
     easClientId: 'client-1',
     properties: [],
     ...overrides,
-  } as AppObserveCustomEvent;
+  } as AppObserveUserEvent;
 }
 
 const noNextPage: PageInfo = { hasNextPage: false, hasPreviousPage: false };
@@ -35,7 +35,7 @@ describe(buildObserveCustomEventsTable, () => {
   it('formats events into aligned columns', () => {
     const events = [
       makeCustomEvent({
-        eventName: 'login',
+        name: 'login',
         appVersion: '1.2.0',
         appBuildNumber: '42',
         deviceOs: 'iOS',
@@ -46,7 +46,7 @@ describe(buildObserveCustomEventsTable, () => {
       }),
       makeCustomEvent({
         id: 'evt-2',
-        eventName: 'checkout',
+        name: 'checkout',
         appVersion: '1.1.0',
         appBuildNumber: '38',
         deviceOs: 'Android',
@@ -73,7 +73,7 @@ Jan 14, 2025, 08:15:00.000 AM  checkout  1.1.0 (38)   Android 14  Pixel 8    PL 
   });
 
   it('shows event name in summary header when an event name option is provided', () => {
-    const events = [makeCustomEvent({ eventName: 'login' })];
+    const events = [makeCustomEvent({ name: 'login' })];
     const output = buildObserveCustomEventsTable(events, noNextPage, {
       eventName: 'login',
       daysBack: 30,
@@ -137,7 +137,7 @@ Jan 14, 2025, 08:15:00.000 AM  checkout  1.1.0 (38)   Android 14  Pixel 8    PL 
   });
 
   it('omits the Event column when an event name option is provided (single-event view)', () => {
-    const events = [makeCustomEvent({ eventName: 'login' })];
+    const events = [makeCustomEvent({ name: 'login' })];
     const output = buildObserveCustomEventsTable(events, noNextPage, {
       eventName: 'login',
     });
@@ -212,7 +212,7 @@ describe(buildObserveCustomEventsJson, () => {
     const events = [
       makeCustomEvent({
         id: 'evt-1',
-        eventName: 'login',
+        name: 'login',
         timestamp: '2025-01-15T10:30:00.000Z',
         sessionId: 'session-1',
         severityText: 'INFO',
@@ -239,7 +239,7 @@ describe(buildObserveCustomEventsJson, () => {
       events: [
         {
           id: 'evt-1',
-          eventName: 'login',
+          name: 'login',
           timestamp: '2025-01-15T10:30:00.000Z',
           sessionId: 'session-1',
           severityText: 'INFO',
@@ -299,8 +299,8 @@ describe(buildObserveCustomEventNamesTable, () => {
 
   it('shows event names with counts', () => {
     const output = buildObserveCustomEventNamesTable([
-      { __typename: 'AppObserveCustomEventName', eventName: 'foo', count: 10 },
-      { __typename: 'AppObserveCustomEventName', eventName: 'bar', count: 5 },
+      { __typename: 'AppObserveUserEventName', name: 'foo', count: 10 },
+      { __typename: 'AppObserveUserEventName', name: 'bar', count: 5 },
     ]);
     expect(output).toContain('foo');
     expect(output).toContain('10');
@@ -310,7 +310,7 @@ describe(buildObserveCustomEventNamesTable, () => {
 
   it('appends a truncation notice when isTruncated is true', () => {
     const output = buildObserveCustomEventNamesTable(
-      [{ __typename: 'AppObserveCustomEventName', eventName: 'foo', count: 10 }],
+      [{ __typename: 'AppObserveUserEventName', name: 'foo', count: 10 }],
       { isTruncated: true }
     );
     expect(output).toContain('Result is truncated');
@@ -320,8 +320,8 @@ describe(buildObserveCustomEventNamesTable, () => {
 describe(buildObserveCustomEventsEmptyWithSuggestionsTable, () => {
   it('shows the filtered event name and the available event names', () => {
     const output = buildObserveCustomEventsEmptyWithSuggestionsTable('login', [
-      { __typename: 'AppObserveCustomEventName', eventName: 'foo', count: 10 },
-      { __typename: 'AppObserveCustomEventName', eventName: 'bar', count: 5 },
+      { __typename: 'AppObserveUserEventName', name: 'foo', count: 10 },
+      { __typename: 'AppObserveUserEventName', name: 'bar', count: 5 },
     ]);
 
     expect(output).toContain('No events found matching "login"');
@@ -342,7 +342,7 @@ describe(buildObserveCustomEventsEmptyWithSuggestionsTable, () => {
   it('appends a truncation notice when isTruncated is set', () => {
     const output = buildObserveCustomEventsEmptyWithSuggestionsTable(
       'login',
-      [{ __typename: 'AppObserveCustomEventName', eventName: 'foo', count: 10 }],
+      [{ __typename: 'AppObserveUserEventName', name: 'foo', count: 10 }],
       { isTruncated: true }
     );
 
@@ -352,7 +352,7 @@ describe(buildObserveCustomEventsEmptyWithSuggestionsTable, () => {
   it('includes the time range description in the message when provided', () => {
     const output = buildObserveCustomEventsEmptyWithSuggestionsTable(
       'login',
-      [{ __typename: 'AppObserveCustomEventName', eventName: 'foo', count: 10 }],
+      [{ __typename: 'AppObserveUserEventName', name: 'foo', count: 10 }],
       { daysBack: 7 }
     );
 
@@ -365,8 +365,8 @@ describe(buildObserveCustomEventsEmptyWithSuggestionsJson, () => {
     const result = buildObserveCustomEventsEmptyWithSuggestionsJson(
       'login',
       [
-        { __typename: 'AppObserveCustomEventName', eventName: 'foo', count: 10 },
-        { __typename: 'AppObserveCustomEventName', eventName: 'bar', count: 5 },
+        { __typename: 'AppObserveUserEventName', name: 'foo', count: 10 },
+        { __typename: 'AppObserveUserEventName', name: 'bar', count: 5 },
       ],
       false
     );
@@ -375,8 +375,8 @@ describe(buildObserveCustomEventsEmptyWithSuggestionsJson, () => {
       filteredEventName: 'login',
       events: [],
       availableEventNames: [
-        { eventName: 'foo', count: 10 },
-        { eventName: 'bar', count: 5 },
+        { name: 'foo', count: 10 },
+        { name: 'bar', count: 5 },
       ],
       availableEventNamesIsTruncated: false,
     });

--- a/packages/eas-cli/src/observe/__tests__/formatEvents.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatEvents.test.ts
@@ -1,12 +1,12 @@
-import { AppObserveEvent, PageInfo } from '../../graphql/generated';
+import { AppObserveMetric, PageInfo } from '../../graphql/generated';
 import { buildObserveEventsJson, buildObserveEventsTable } from '../formatEvents';
 
-function createMockEvent(overrides: Partial<AppObserveEvent> = {}): AppObserveEvent {
+function createMockEvent(overrides: Partial<AppObserveMetric> = {}): AppObserveMetric {
   return {
-    __typename: 'AppObserveEvent',
+    __typename: 'AppObserveMetric',
     id: 'evt-1',
-    metricName: 'expo.app_startup.tti',
-    metricValue: 1.23,
+    name: 'expo.app_startup.tti',
+    value: 1.23,
     timestamp: '2025-01-15T10:30:00.000Z',
     appVersion: '1.0.0',
     appBuildNumber: '42',
@@ -35,8 +35,8 @@ describe(buildObserveEventsTable, () => {
   it('formats events into aligned columns', () => {
     const events = [
       createMockEvent({
-        metricName: 'expo.app_startup.tti',
-        metricValue: 1.23,
+        name: 'expo.app_startup.tti',
+        value: 1.23,
         appVersion: '1.2.0',
         appBuildNumber: '42',
         deviceOs: 'iOS',
@@ -47,8 +47,8 @@ describe(buildObserveEventsTable, () => {
       }),
       createMockEvent({
         id: 'evt-2',
-        metricName: 'expo.app_startup.tti',
-        metricValue: 0.85,
+        name: 'expo.app_startup.tti',
+        value: 0.85,
         appVersion: '1.1.0',
         appBuildNumber: '38',
         deviceOs: 'Android',
@@ -76,7 +76,7 @@ describe(buildObserveEventsTable, () => {
   });
 
   it('shows metric name in summary header when options are provided', () => {
-    const events = [createMockEvent({ metricName: 'expo.app_startup.tti' })];
+    const events = [createMockEvent({ name: 'expo.app_startup.tti' })];
     const output = buildObserveEventsTable(events, noNextPage, {
       metricName: 'expo.app_startup.tti',
       daysBack: 30,
@@ -126,8 +126,8 @@ describe(buildObserveEventsJson, () => {
     const events = [
       createMockEvent({
         id: 'evt-1',
-        metricName: 'expo.app_startup.tti',
-        metricValue: 1.23,
+        name: 'expo.app_startup.tti',
+        value: 1.23,
         appVersion: '1.0.0',
         appBuildNumber: '42',
         deviceModel: 'iPhone 15',
@@ -146,8 +146,8 @@ describe(buildObserveEventsJson, () => {
       events: [
         {
           id: 'evt-1',
-          metricName: 'expo.app_startup.tti',
-          metricValue: 1.23,
+          name: 'expo.app_startup.tti',
+          value: 1.23,
           appVersion: '1.0.0',
           appBuildNumber: '42',
           appUpdateId: null,

--- a/packages/eas-cli/src/observe/__tests__/formatSessions.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatSessions.test.ts
@@ -1,4 +1,4 @@
-import { AppObserveCustomEvent, AppObserveEvent } from '../../graphql/generated';
+import { AppObserveMetric, AppObserveUserEvent } from '../../graphql/generated';
 import { SessionEventEntry, SessionMetadata } from '../fetchSessions';
 import {
   buildObserveSessionEventsJson,
@@ -21,8 +21,8 @@ function makeMetricEntry(overrides: Partial<SessionEventEntry> = {}): SessionEve
     deviceOsVersion: '17.0',
     countryCode: 'US',
     easClientId: 'client-1',
-    metricName: 'expo.app_startup.tti',
-    metricValue: 0.8,
+    name: 'expo.app_startup.tti',
+    value: 0.8,
     customParams: null,
     ...overrides,
   };
@@ -41,7 +41,7 @@ function makeLogEntry(overrides: Partial<SessionEventEntry> = {}): SessionEventE
     deviceOsVersion: '17.0',
     countryCode: 'US',
     easClientId: 'client-1',
-    eventName: 'login_pressed',
+    name: 'login_pressed',
     severityText: null,
     severityNumber: null,
     properties: [],
@@ -71,8 +71,8 @@ describe(buildObserveSessionEventsTable, () => {
   it('appends the routeName to navigation metric rows', () => {
     const entries = [
       makeMetricEntry({
-        metricName: 'expo.navigation.tti',
-        metricValue: 0.32,
+        name: 'expo.navigation.tti',
+        value: 0.32,
         routeName: '/home',
       }),
     ];
@@ -150,7 +150,7 @@ describe(buildObserveSessionEventsTable, () => {
 
   it('leaves the Value column as "-" for log entries (metric rows keep their value)', () => {
     const entries = [
-      makeMetricEntry({ metricValue: 0.8 }),
+      makeMetricEntry({ value: 0.8 }),
       makeLogEntry({
         properties: [{ key: 'user_id', value: 'abc', type: 'STRING' }],
       }),
@@ -259,12 +259,12 @@ describe(shortSessionId, () => {
   });
 });
 
-function makeMetricEvent(overrides: Partial<AppObserveEvent> = {}): AppObserveEvent {
+function makeMetricEvent(overrides: Partial<AppObserveMetric> = {}): AppObserveMetric {
   return {
-    __typename: 'AppObserveEvent' as const,
+    __typename: 'AppObserveMetric' as const,
     id: 'evt-m-1',
-    metricName: 'expo.app_startup.tti',
-    metricValue: 1.23,
+    name: 'expo.app_startup.tti',
+    value: 1.23,
     timestamp: '2025-01-15T10:00:00.000Z',
     appVersion: '1.0.0',
     appBuildNumber: '42',
@@ -278,14 +278,14 @@ function makeMetricEvent(overrides: Partial<AppObserveEvent> = {}): AppObserveEv
     customParams: null,
     routeName: null,
     ...overrides,
-  } as AppObserveEvent;
+  } as AppObserveMetric;
 }
 
-function makeCustomEventEvt(overrides: Partial<AppObserveCustomEvent> = {}): AppObserveCustomEvent {
+function makeCustomEventEvt(overrides: Partial<AppObserveUserEvent> = {}): AppObserveUserEvent {
   return {
-    __typename: 'AppObserveCustomEvent' as const,
+    __typename: 'AppObserveUserEvent' as const,
     id: 'evt-c-1',
-    eventName: 'login_pressed',
+    name: 'login_pressed',
     timestamp: '2025-01-15T10:00:00.000Z',
     sessionId: 'session-abcdefgh1234567890',
     severityNumber: null,
@@ -302,7 +302,7 @@ function makeCustomEventEvt(overrides: Partial<AppObserveCustomEvent> = {}): App
     countryCode: 'US',
     properties: [],
     ...overrides,
-  } as AppObserveCustomEvent;
+  } as AppObserveUserEvent;
 }
 
 describe(formatMetricCandidateTitle, () => {

--- a/packages/eas-cli/src/observe/fetchCustomEvents.ts
+++ b/packages/eas-cli/src/observe/fetchCustomEvents.ts
@@ -1,9 +1,9 @@
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import {
-  AppObserveCustomEvent,
-  AppObserveCustomEventListFilter,
-  AppObserveCustomEventListOrderBy,
   AppObservePlatform,
+  AppObserveUserEvent,
+  AppObserveUserEventListFilter,
+  AppObserveUserEventListOrderBy,
   PageInfo,
 } from '../graphql/generated';
 import { ObserveQuery } from '../graphql/queries/ObserveQuery';
@@ -20,11 +20,11 @@ interface FetchCustomEventsOptions {
   updateId?: string;
   sessionId?: string;
   environment?: string;
-  orderBy?: AppObserveCustomEventListOrderBy;
+  orderBy?: AppObserveUserEventListOrderBy;
 }
 
 interface FetchCustomEventsResult {
-  events: AppObserveCustomEvent[];
+  events: AppObserveUserEvent[];
   pageInfo: PageInfo;
 }
 
@@ -33,10 +33,10 @@ export async function fetchObserveCustomEventsAsync(
   appId: string,
   options: FetchCustomEventsOptions
 ): Promise<FetchCustomEventsResult> {
-  const filter: AppObserveCustomEventListFilter = {
+  const filter: AppObserveUserEventListFilter = {
     ...(options.startTime && { startTime: options.startTime }),
     ...(options.endTime && { endTime: options.endTime }),
-    ...(options.eventName && { eventName: options.eventName }),
+    ...(options.eventName && { name: options.eventName }),
     ...(options.platforms?.length && { platforms: options.platforms }),
     ...(options.appVersion && { appVersion: options.appVersion }),
     ...(options.buildNumber && { appBuildNumber: options.buildNumber }),

--- a/packages/eas-cli/src/observe/fetchEvents.ts
+++ b/packages/eas-cli/src/observe/fetchEvents.ts
@@ -1,10 +1,10 @@
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import {
-  AppObserveEvent,
-  AppObserveEventsFilter,
-  AppObserveEventsOrderBy,
-  AppObserveEventsOrderByDirection,
-  AppObserveEventsOrderByField,
+  AppObserveMetric,
+  AppObserveMetricsListFilter,
+  AppObserveMetricsListOrderBy,
+  AppObserveMetricsListOrderByField,
+  AppObserveOrderDirection,
   AppObservePlatform,
   PageInfo,
 } from '../graphql/generated';
@@ -19,35 +19,35 @@ export enum EventsOrderPreset {
   Oldest = 'OLDEST',
 }
 
-export function resolveOrderBy(input: string): AppObserveEventsOrderBy {
+export function resolveOrderBy(input: string): AppObserveMetricsListOrderBy {
   const preset = input.toUpperCase() as EventsOrderPreset;
   switch (preset) {
     case EventsOrderPreset.Slowest:
       return {
-        field: AppObserveEventsOrderByField.MetricValue,
-        direction: AppObserveEventsOrderByDirection.Desc,
+        field: AppObserveMetricsListOrderByField.Value,
+        direction: AppObserveOrderDirection.Desc,
       };
     case EventsOrderPreset.Fastest:
       return {
-        field: AppObserveEventsOrderByField.MetricValue,
-        direction: AppObserveEventsOrderByDirection.Asc,
+        field: AppObserveMetricsListOrderByField.Value,
+        direction: AppObserveOrderDirection.Asc,
       };
     case EventsOrderPreset.Newest:
       return {
-        field: AppObserveEventsOrderByField.Timestamp,
-        direction: AppObserveEventsOrderByDirection.Desc,
+        field: AppObserveMetricsListOrderByField.Timestamp,
+        direction: AppObserveOrderDirection.Desc,
       };
     case EventsOrderPreset.Oldest:
       return {
-        field: AppObserveEventsOrderByField.Timestamp,
-        direction: AppObserveEventsOrderByDirection.Asc,
+        field: AppObserveMetricsListOrderByField.Timestamp,
+        direction: AppObserveOrderDirection.Asc,
       };
   }
 }
 
 interface FetchObserveEventsOptions {
   metricName?: string;
-  orderBy: AppObserveEventsOrderBy;
+  orderBy: AppObserveMetricsListOrderBy;
   limit: number;
   after?: string;
   startTime?: string;
@@ -61,7 +61,7 @@ interface FetchObserveEventsOptions {
 }
 
 interface FetchObserveEventsResult {
-  events: AppObserveEvent[];
+  events: AppObserveMetric[];
   pageInfo: PageInfo;
 }
 
@@ -70,10 +70,10 @@ export async function fetchObserveEventsAsync(
   appId: string,
   options: FetchObserveEventsOptions
 ): Promise<FetchObserveEventsResult> {
-  const filter: AppObserveEventsFilter = {
+  const filter: AppObserveMetricsListFilter = {
     ...(options.startTime && { startTime: options.startTime }),
     ...(options.endTime && { endTime: options.endTime }),
-    ...(options.metricName && { metricName: options.metricName }),
+    ...(options.metricName && { name: options.metricName }),
     ...(options.platforms?.length && { platforms: options.platforms }),
     ...(options.appVersion && { appVersion: options.appVersion }),
     ...(options.buildNumber && { appBuildNumber: options.buildNumber }),

--- a/packages/eas-cli/src/observe/fetchNavigationRoutes.ts
+++ b/packages/eas-cli/src/observe/fetchNavigationRoutes.ts
@@ -1,9 +1,9 @@
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import {
-  AppObserveEventsOrderByDirection,
+  AppObserveNavigationOrderBy,
   AppObserveNavigationRoute,
-  AppObserveNavigationRoutesOrderBy,
   AppObserveNavigationRoutesOrderByField,
+  AppObserveOrderDirection,
   PageInfo,
 } from '../graphql/generated';
 import { ObserveQuery } from '../graphql/queries/ObserveQuery';
@@ -31,7 +31,7 @@ export interface FetchNavigationRoutesOptions {
   buildNumber?: string;
   routeNames?: string[];
   environment?: string;
-  orderBy?: AppObserveNavigationRoutesOrderBy;
+  orderBy?: AppObserveNavigationOrderBy;
 }
 
 export interface FetchNavigationRoutesResult {
@@ -44,9 +44,9 @@ export async function fetchObserveNavigationRoutesAsync(
   appId: string,
   options: FetchNavigationRoutesOptions
 ): Promise<FetchNavigationRoutesResult> {
-  const orderBy: AppObserveNavigationRoutesOrderBy = options.orderBy ?? {
+  const orderBy: AppObserveNavigationOrderBy = options.orderBy ?? {
     field: AppObserveNavigationRoutesOrderByField.NavigationCount,
-    direction: AppObserveEventsOrderByDirection.Desc,
+    direction: AppObserveOrderDirection.Desc,
   };
 
   const queries = options.targets.map(async target => {

--- a/packages/eas-cli/src/observe/fetchSessions.ts
+++ b/packages/eas-cli/src/observe/fetchSessions.ts
@@ -1,11 +1,14 @@
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import {
-  AppObserveCustomEvent,
-  AppObserveCustomEventListOrderByField,
-  AppObserveEvent,
-  AppObserveEventsOrderByDirection,
-  AppObserveEventsOrderByField,
+  AppObserveError,
+  AppObserveLogsOrderByField,
+  AppObserveMetric,
+  AppObserveMetricsListOrderByField,
+  AppObserveOrderDirection,
+  AppObserveUserEvent,
+  AppObserveUserEventListOrderByField,
 } from '../graphql/generated';
+import { AppObserveSessionLog, ObserveQuery } from '../graphql/queries/ObserveQuery';
 import { fetchObserveCustomEventsAsync } from './fetchCustomEvents';
 import { fetchObserveEventsAsync, resolveOrderBy } from './fetchEvents';
 
@@ -13,6 +16,8 @@ export interface SessionEventEntry {
   source: 'metric' | 'log';
   timestamp: string;
   sessionId: string;
+  // Metric name, user-event name, or error type.
+  name: string;
   appVersion: string;
   appBuildNumber: string;
   appUpdateId: string | null;
@@ -22,23 +27,22 @@ export interface SessionEventEntry {
   countryCode: string | null;
   easClientId: string;
   // metric-only fields
-  metricName?: string;
-  metricValue?: number;
+  value?: number;
   customParams?: { [key: string]: any } | null;
   routeName?: string | null;
   // log-only fields
-  eventName?: string;
   severityText?: string | null;
   severityNumber?: number | null;
   properties?: Array<{ key: string; value: string; type: string }>;
   environment?: string | null;
 }
 
-function metricEventToEntry(event: AppObserveEvent): SessionEventEntry {
+function metricEventToEntry(event: AppObserveMetric): SessionEventEntry {
   return {
     source: 'metric',
     timestamp: event.timestamp,
     sessionId: event.sessionId ?? '',
+    name: event.name,
     appVersion: event.appVersion,
     appBuildNumber: event.appBuildNumber,
     appUpdateId: event.appUpdateId ?? null,
@@ -47,18 +51,18 @@ function metricEventToEntry(event: AppObserveEvent): SessionEventEntry {
     deviceOsVersion: event.deviceOsVersion,
     countryCode: event.countryCode ?? null,
     easClientId: event.easClientId,
-    metricName: event.metricName,
-    metricValue: event.metricValue,
+    value: event.value,
     customParams: event.customParams ?? null,
     routeName: event.routeName ?? null,
   };
 }
 
-function customEventToEntry(event: AppObserveCustomEvent): SessionEventEntry {
+function userEventToEntry(event: AppObserveUserEvent): SessionEventEntry {
   return {
     source: 'log',
     timestamp: event.timestamp,
     sessionId: event.sessionId ?? '',
+    name: event.name,
     appVersion: event.appVersion,
     appBuildNumber: event.appBuildNumber,
     appUpdateId: event.appUpdateId ?? null,
@@ -67,12 +71,40 @@ function customEventToEntry(event: AppObserveCustomEvent): SessionEventEntry {
     deviceOsVersion: event.deviceOsVersion,
     countryCode: event.countryCode ?? null,
     easClientId: event.easClientId,
-    eventName: event.eventName,
     severityText: event.severityText ?? null,
     severityNumber: event.severityNumber ?? null,
     properties: event.properties.map(p => ({ key: p.key, value: p.value, type: p.type })),
     environment: event.environment ?? null,
   };
+}
+
+function errorToEntry(event: AppObserveError): SessionEventEntry {
+  const properties = [
+    ...(event.message ? [{ key: 'message', value: event.message, type: 'STRING' }] : []),
+    ...event.properties.map(p => ({ key: p.key, value: p.value, type: p.type })),
+  ];
+  return {
+    source: 'log',
+    timestamp: event.timestamp,
+    sessionId: event.sessionId ?? '',
+    name: event.type ?? 'exception',
+    appVersion: event.appVersion,
+    appBuildNumber: event.appBuildNumber,
+    appUpdateId: event.appUpdateId ?? null,
+    deviceModel: event.deviceModel,
+    deviceOs: event.deviceOs,
+    deviceOsVersion: event.deviceOsVersion,
+    countryCode: event.countryCode ?? null,
+    easClientId: event.easClientId,
+    severityText: event.severityText ?? null,
+    severityNumber: event.severityNumber ?? null,
+    properties,
+    environment: event.environment ?? null,
+  };
+}
+
+function sessionLogToEntry(log: AppObserveSessionLog): SessionEventEntry {
+  return log.__typename === 'AppObserveError' ? errorToEntry(log) : userEventToEntry(log);
 }
 
 export interface SessionMetadata {
@@ -124,25 +156,26 @@ export async function fetchObserveSessionEventsAsync(
   appId: string,
   options: FetchSessionEventsOptions
 ): Promise<FetchSessionEventsResult> {
-  const [metricResult, logResult] = await Promise.all([
-    fetchObserveEventsAsync(graphqlClient, appId, {
-      orderBy: {
-        field: AppObserveEventsOrderByField.Timestamp,
-        direction: AppObserveEventsOrderByDirection.Asc,
+  const { metrics, logs, metricsPageInfo, logsPageInfo } = await ObserveQuery.sessionEventsAsync(
+    graphqlClient,
+    {
+      appId,
+      id: options.sessionId,
+      first: options.limit,
+      metricsOrderBy: {
+        field: AppObserveMetricsListOrderByField.Timestamp,
+        direction: AppObserveOrderDirection.Asc,
       },
-      limit: options.limit,
-      sessionId: options.sessionId,
-    }),
-    fetchObserveCustomEventsAsync(graphqlClient, appId, {
-      limit: options.limit,
-      sessionId: options.sessionId,
-    }),
-  ]);
+      logsOrderBy: {
+        field: AppObserveLogsOrderByField.Timestamp,
+        direction: AppObserveOrderDirection.Asc,
+      },
+    }
+  );
 
-  const entries = [
-    ...metricResult.events.map(metricEventToEntry),
-    ...logResult.events.map(customEventToEntry),
-  ].sort((a, b) => (a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0));
+  const entries = [...metrics.map(metricEventToEntry), ...logs.map(sessionLogToEntry)].sort(
+    (a, b) => (a.timestamp < b.timestamp ? -1 : a.timestamp > b.timestamp ? 1 : 0)
+  );
 
   let metadata: SessionMetadata | null = null;
   if (entries.length > 0) {
@@ -163,8 +196,8 @@ export async function fetchObserveSessionEventsAsync(
   return {
     entries,
     metadata,
-    hasMoreMetricEvents: metricResult.pageInfo.hasNextPage,
-    hasMoreLogEvents: logResult.pageInfo.hasNextPage,
+    hasMoreMetricEvents: metricsPageInfo.hasNextPage,
+    hasMoreLogEvents: logsPageInfo.hasNextPage,
   };
 }
 
@@ -172,7 +205,7 @@ export async function fetchObserveSessionEventsAsync(
  * A metric event that is guaranteed to belong to a session — used as a
  * candidate when picking a session to inspect via `observe:session`.
  */
-export type SessionMetricCandidate = AppObserveEvent & { sessionId: string };
+export type SessionMetricCandidate = AppObserveMetric & { sessionId: string };
 
 export interface FetchSessionMetricCandidatesOptions {
   metricName: string;
@@ -186,7 +219,7 @@ export interface FetchSessionMetricCandidatesOptions {
 
 /**
  * Fetch a page of metric events for the given metricName + window, ordered
- * per `sort`, and filtered to events that have a sessionId. The events query
+ * per `sort`, and filtered to events that have a sessionId. The metrics query
  * supports server-side ordering, so `sort` is passed straight through.
  */
 export async function fetchSessionMetricCandidatesAsync(
@@ -206,10 +239,10 @@ export async function fetchSessionMetricCandidatesAsync(
 }
 
 /**
- * A custom log event that is guaranteed to belong to a session — used as a
- * candidate when picking a session to inspect via `observe:session`.
+ * A user-defined log event that is guaranteed to belong to a session — used as
+ * a candidate when picking a session to inspect via `observe:session`.
  */
-export type SessionLogCandidate = AppObserveCustomEvent & { sessionId: string };
+export type SessionLogCandidate = AppObserveUserEvent & { sessionId: string };
 
 export interface FetchSessionLogCandidatesOptions {
   eventName: string;
@@ -222,8 +255,8 @@ export interface FetchSessionLogCandidatesOptions {
 }
 
 /**
- * Fetch a page of custom log events for the given eventName + window, ordered
- * by timestamp server-side, and filtered to events that have a sessionId.
+ * Fetch a page of user-defined log events for the given eventName + window,
+ * ordered by timestamp server-side, and filtered to events that have a sessionId.
  */
 export async function fetchSessionLogCandidatesAsync(
   graphqlClient: ExpoGraphqlClient,
@@ -237,10 +270,10 @@ export async function fetchSessionLogCandidatesAsync(
     endTime: options.endTime,
     environment: options.environment,
     orderBy: {
-      field: AppObserveCustomEventListOrderByField.Timestamp,
+      field: AppObserveUserEventListOrderByField.Timestamp,
       direction: options.orderAscending
-        ? AppObserveEventsOrderByDirection.Asc
-        : AppObserveEventsOrderByDirection.Desc,
+        ? AppObserveOrderDirection.Asc
+        : AppObserveOrderDirection.Desc,
     },
   });
   return events.filter((e): e is SessionLogCandidate => !!e.sessionId);

--- a/packages/eas-cli/src/observe/formatCustomEvents.ts
+++ b/packages/eas-cli/src/observe/formatCustomEvents.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 
-import { AppObserveCustomEvent, AppObserveCustomEventName, PageInfo } from '../graphql/generated';
+import { AppObserveUserEvent, AppObserveUserEventName, PageInfo } from '../graphql/generated';
 import renderTextTable from '../utils/renderTextTable';
 import { buildTimeRangeDescription, formatLogTimestamp } from './formatUtils';
 
-function formatSeverity(event: AppObserveCustomEvent): string {
+function formatSeverity(event: AppObserveUserEvent): string {
   if (event.severityText) {
     return event.severityText;
   }
@@ -22,7 +22,7 @@ export interface ObserveCustomEventPropertyJson {
 
 export interface ObserveCustomEventJson {
   id: string;
-  eventName: string;
+  name: string;
   timestamp: string;
   sessionId: string | null;
   severityNumber: number | null;
@@ -49,7 +49,7 @@ export interface BuildCustomEventsTableOptions {
 }
 
 export function buildObserveCustomEventsTable(
-  events: AppObserveCustomEvent[],
+  events: AppObserveUserEvent[],
   pageInfo: PageInfo,
   options?: BuildCustomEventsTableOptions
 ): string {
@@ -72,7 +72,7 @@ export function buildObserveCustomEventsTable(
 
   const rows: string[][] = events.map(event => [
     formatLogTimestamp(event.timestamp),
-    ...(showEventName ? [event.eventName] : []),
+    ...(showEventName ? [event.name] : []),
     ...(hasSeverity ? [formatSeverity(event)] : []),
     `${event.appVersion} (${event.appBuildNumber})`,
     `${event.deviceOs} ${event.deviceOsVersion}`,
@@ -102,7 +102,7 @@ export function buildObserveCustomEventsTable(
 }
 
 export function buildObserveCustomEventsJson(
-  events: AppObserveCustomEvent[],
+  events: AppObserveUserEvent[],
   pageInfo: PageInfo
 ): {
   events: ObserveCustomEventJson[];
@@ -111,7 +111,7 @@ export function buildObserveCustomEventsJson(
   return {
     events: events.map(event => ({
       id: event.id,
-      eventName: event.eventName,
+      name: event.name,
       timestamp: event.timestamp,
       sessionId: event.sessionId ?? null,
       severityNumber: event.severityNumber ?? null,
@@ -148,7 +148,7 @@ export interface BuildEmptyCustomEventsWithSuggestionsOptions {
 
 export function buildObserveCustomEventsEmptyWithSuggestionsTable(
   eventName: string,
-  names: AppObserveCustomEventName[],
+  names: AppObserveUserEventName[],
   options?: BuildEmptyCustomEventsWithSuggestionsOptions
 ): string {
   const lines: string[] = [];
@@ -163,7 +163,7 @@ export function buildObserveCustomEventsEmptyWithSuggestionsTable(
   lines.push('', 'Available event names in this time range:', '');
 
   const headers = ['Event Name', 'Count'];
-  const rows: string[][] = names.map(n => [n.eventName, n.count.toLocaleString()]);
+  const rows: string[][] = names.map(n => [n.name, n.count.toLocaleString()]);
   lines.push(renderTextTable(headers, rows));
 
   if (options?.isTruncated) {
@@ -175,18 +175,18 @@ export function buildObserveCustomEventsEmptyWithSuggestionsTable(
 
 export function buildObserveCustomEventsEmptyWithSuggestionsJson(
   eventName: string,
-  names: AppObserveCustomEventName[],
+  names: AppObserveUserEventName[],
   isTruncated: boolean
 ): {
   filteredEventName: string;
   events: [];
-  availableEventNames: Array<{ eventName: string; count: number }>;
+  availableEventNames: Array<{ name: string; count: number }>;
   availableEventNamesIsTruncated: boolean;
 } {
   return {
     filteredEventName: eventName,
     events: [],
-    availableEventNames: names.map(n => ({ eventName: n.eventName, count: n.count })),
+    availableEventNames: names.map(n => ({ name: n.name, count: n.count })),
     availableEventNamesIsTruncated: isTruncated,
   };
 }
@@ -199,7 +199,7 @@ export interface BuildCustomEventNamesTableOptions {
 }
 
 export function buildObserveCustomEventNamesTable(
-  names: AppObserveCustomEventName[],
+  names: AppObserveUserEventName[],
   options?: BuildCustomEventNamesTableOptions
 ): string {
   if (names.length === 0) {
@@ -207,7 +207,7 @@ export function buildObserveCustomEventNamesTable(
   }
 
   const headers = ['Event Name', 'Count'];
-  const rows: string[][] = names.map(n => [n.eventName, n.count.toLocaleString()]);
+  const rows: string[][] = names.map(n => [n.name, n.count.toLocaleString()]);
 
   const lines: string[] = [];
 
@@ -227,11 +227,11 @@ export function buildObserveCustomEventNamesTable(
 }
 
 export function buildObserveCustomEventNamesJson(
-  names: AppObserveCustomEventName[],
+  names: AppObserveUserEventName[],
   isTruncated: boolean
-): { names: Array<{ eventName: string; count: number }>; isTruncated: boolean } {
+): { names: Array<{ name: string; count: number }>; isTruncated: boolean } {
   return {
-    names: names.map(n => ({ eventName: n.eventName, count: n.count })),
+    names: names.map(n => ({ name: n.name, count: n.count })),
     isTruncated,
   };
 }

--- a/packages/eas-cli/src/observe/formatEvents.ts
+++ b/packages/eas-cli/src/observe/formatEvents.ts
@@ -1,14 +1,14 @@
 import chalk from 'chalk';
 
-import { AppObserveEvent, PageInfo } from '../graphql/generated';
+import { AppObserveMetric, PageInfo } from '../graphql/generated';
 import renderTextTable from '../utils/renderTextTable';
 import { buildTimeRangeDescription, formatTimestamp } from './formatUtils';
 import { getMetricDisplayName } from './metricNames';
 
 export interface ObserveEventJson {
   id: string;
-  metricName: string;
-  metricValue: number;
+  name: string;
+  value: number;
   appVersion: string;
   appBuildNumber: string;
   appUpdateId: string | null;
@@ -23,7 +23,7 @@ export interface ObserveEventJson {
   routeName: string | null;
 }
 
-function resolveCustomParams(event: AppObserveEvent): { [key: string]: any } | null {
+function resolveCustomParams(event: AppObserveMetric): { [key: string]: any } | null {
   return event.customParams ?? null;
 }
 
@@ -36,7 +36,7 @@ export interface BuildEventsTableOptions {
 }
 
 export function buildObserveEventsTable(
-  events: AppObserveEvent[],
+  events: AppObserveMetric[],
   pageInfo: PageInfo,
   options?: BuildEventsTableOptions
 ): string {
@@ -57,7 +57,7 @@ export function buildObserveEventsTable(
   ];
 
   const rows: string[][] = events.map(event => [
-    `${event.metricValue.toFixed(2)}s`,
+    `${event.value.toFixed(2)}s`,
     `${event.appVersion} (${event.appBuildNumber})`,
     ...(hasUpdates ? [event.appUpdateId ?? '-'] : []),
     `${event.deviceOs} ${event.deviceOsVersion}`,
@@ -88,14 +88,14 @@ export function buildObserveEventsTable(
 }
 
 export function buildObserveEventsJson(
-  events: AppObserveEvent[],
+  events: AppObserveMetric[],
   pageInfo: PageInfo
 ): { events: ObserveEventJson[]; pageInfo: { hasNextPage: boolean; endCursor: string | null } } {
   return {
     events: events.map(event => ({
       id: event.id,
-      metricName: event.metricName,
-      metricValue: event.metricValue,
+      name: event.name,
+      value: event.value,
       appVersion: event.appVersion,
       appBuildNumber: event.appBuildNumber,
       appUpdateId: event.appUpdateId ?? null,

--- a/packages/eas-cli/src/observe/formatSessions.ts
+++ b/packages/eas-cli/src/observe/formatSessions.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import { AppObserveCustomEvent, AppObserveEvent } from '../graphql/generated';
+import { AppObserveMetric, AppObserveUserEvent } from '../graphql/generated';
 import { SessionEventEntry, SessionMetadata } from './fetchSessions';
 import { formatLogTimestamp } from './formatUtils';
 import { getMetricDisplayName } from './metricNames';
@@ -13,16 +13,16 @@ export interface BuildSessionEventsOptions {
 }
 
 function formatEntryName(entry: SessionEventEntry): string {
-  if (entry.source === 'metric' && entry.metricName) {
-    const name = getMetricDisplayName(entry.metricName);
+  if (entry.source === 'metric') {
+    const name = getMetricDisplayName(entry.name);
     return entry.routeName ? `${name} · ${entry.routeName}` : name;
   }
-  return entry.eventName ?? '-';
+  return entry.name;
 }
 
 function formatMetricEntryValue(entry: SessionEventEntry): string {
-  if (typeof entry.metricValue === 'number') {
-    return `${entry.metricValue.toFixed(2)}s`;
+  if (typeof entry.value === 'number') {
+    return `${entry.value.toFixed(2)}s`;
   }
   return '-';
 }
@@ -159,9 +159,9 @@ export function shortSessionId(sessionId: string): string {
  * One-line title for a metric event shown in the observe:session candidate
  * picker, e.g. `Jan 15, 10:00:00.000 AM · Startup TTI 1.23s · 1.0.0 · iOS 17.0 · session abc…1234`.
  */
-export function formatMetricCandidateTitle(event: AppObserveEvent): string {
-  const displayName = getMetricDisplayName(event.metricName);
-  const value = `${event.metricValue.toFixed(2)}s`;
+export function formatMetricCandidateTitle(event: AppObserveMetric): string {
+  const displayName = getMetricDisplayName(event.name);
+  const value = `${event.value.toFixed(2)}s`;
   const timestamp = formatLogTimestamp(event.timestamp);
   const shortSession = shortSessionId(event.sessionId ?? '');
   const device = `${event.deviceOs} ${event.deviceOsVersion}`;
@@ -172,11 +172,11 @@ export function formatMetricCandidateTitle(event: AppObserveEvent): string {
  * One-line title for a custom log event shown in the observe:session
  * candidate picker.
  */
-export function formatLogCandidateTitle(event: AppObserveCustomEvent): string {
+export function formatLogCandidateTitle(event: AppObserveUserEvent): string {
   const timestamp = formatLogTimestamp(event.timestamp);
   const severity =
     event.severityText ?? (event.severityNumber != null ? String(event.severityNumber) : '-');
   const shortSession = shortSessionId(event.sessionId ?? '');
   const device = `${event.deviceOs} ${event.deviceOsVersion}`;
-  return `${timestamp} · ${event.eventName} · ${severity} · ${event.appVersion} · ${device} · session ${shortSession}`;
+  return `${timestamp} · ${event.name} · ${severity} · ${event.appVersion} · ${device} · session ${shortSession}`;
 }


### PR DESCRIPTION
# Why

We need to adjust the Observe commands and queries to use the new GraphQL schema from the server.

# How

Rework all the commands to use the new schema. Results from commands using the `--json` flag will change slightly, with the `metricName` and `eventName` properties replaced by `name`.

# Test Plan

- CI and unit tests should pass.
- Tested locally against real EAS projects in production.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>