### PR TITLE
[eas-cli] Add observe:errors command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Add `lcd_width`, `lcd_height`, and `lcd_density` inputs to configure the Android emulator display. ([#4349](https://github.com/expo/eas-cli/pull/4349) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [eas-cli] Add `eas channel:protect` and `eas channel:unprotect` to manage EAS Update channel protection, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))
+- [eas-cli] Add `eas observe:errors` to display error and exception issue groups (grouped by fingerprint), with `--fingerprint <fingerprint>` to drill into a group's individual occurrences and stack traces. ([#4339](https://github.com/expo/eas-cli/pull/4339) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -205,6 +205,7 @@ If you want to enforce the `eas-cli` version for your project, use the `"cli.ver
 * [`eas metadata:pull`](#eas-metadatapull)
 * [`eas metadata:push`](#eas-metadatapush)
 * [`eas new [PATH]`](#eas-new-path)
+* [`eas observe:errors`](#eas-observeerrors)
 * [`eas observe:events [EVENTNAME]`](#eas-observeevents-eventname)
 * [`eas observe:metrics [METRIC]`](#eas-observemetrics-metric)
 * [`eas observe:metrics-summary`](#eas-observemetrics-summary)
@@ -2234,6 +2235,38 @@ DESCRIPTION
 ALIASES
   $ eas new
 ```
+
+## `eas observe:errors`
+
+display error and exception issue groups (grouped by fingerprint) for the app
+
+```
+USAGE
+  $ eas observe:errors [--platform android|ios|ipados|macos|tvos|apple] [--severity fatal|error] [--start <value> |
+    --days <value>] [--end <value> | ] [--app-version <value>] [--build-number <value>] [--update-id <value>]
+    [--environment <value>] [--project-id <value>] [--json] [--non-interactive]
+
+FLAGS
+  --app-version=<value>   Filter by app version
+  --build-number=<value>  Filter by app build number
+  --days=<value>          Show results from the last N days (mutually exclusive with --start/--end)
+  --end=<value>           End of time range (ISO date)
+  --environment=<value>   Filter by environment (e.g. production, development)
+  --json                  Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.
+  --non-interactive       Run the command in non-interactive mode.
+  --platform=<option>     Filter by platform ("apple" covers iOS, iPadOS, tvOS, and macOS)
+                          <options: android|ios|ipados|macos|tvos|apple>
+  --project-id=<value>    EAS project ID (defaults to the project ID of the current directory)
+  --severity=<option>     Filter by severity
+                          <options: fatal|error>
+  --start=<value>         Start of time range (ISO date)
+  --update-id=<value>     Filter by EAS update ID
+
+DESCRIPTION
+  display error and exception issue groups (grouped by fingerprint) for the app
+```
+
+_See code: [packages/eas-cli/src/commands/observe/errors.ts](https://github.com/expo/eas-cli/blob/v23.2.0/packages/eas-cli/src/commands/observe/errors.ts)_
 
 ## `eas observe:events [EVENTNAME]`
 

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -2242,22 +2242,27 @@ display error and exception issue groups (grouped by fingerprint) for the app
 
 ```
 USAGE
-  $ eas observe:errors [--platform android|ios|ipados|macos|tvos|apple] [--severity fatal|error] [--start <value> |
-    --days <value>] [--end <value> | ] [--app-version <value>] [--build-number <value>] [--update-id <value>]
-    [--environment <value>] [--project-id <value>] [--json] [--non-interactive]
+  $ eas observe:errors [--platform android|ios|ipados|macos|tvos|apple] [--fingerprint <value>] [--severity
+    fatal|error] [--after <value>] [--limit <value>] [--start <value> | --days <value>] [--end <value> | ]
+    [--app-version <value>] [--build-number <value>] [--update-id <value>] [--environment <value>] [--project-id
+    <value>] [--json] [--non-interactive]
 
 FLAGS
+  --after=<value>         Cursor for pagination. Use the endCursor from a previous query to fetch the next page.
   --app-version=<value>   Filter by app version
   --build-number=<value>  Filter by app build number
   --days=<value>          Show results from the last N days (mutually exclusive with --start/--end)
   --end=<value>           End of time range (ISO date)
   --environment=<value>   Filter by environment (e.g. production, development)
+  --fingerprint=<value>   Show individual occurrences (with stack traces) for this error group fingerprint instead of
+                          the grouped summary
   --json                  Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.
+  --limit=<value>         The number of items to fetch each query. Defaults to 5 and is capped at 100.
   --non-interactive       Run the command in non-interactive mode.
   --platform=<option>     Filter by platform ("apple" covers iOS, iPadOS, tvOS, and macOS)
                           <options: android|ios|ipados|macos|tvos|apple>
   --project-id=<value>    EAS project ID (defaults to the project ID of the current directory)
-  --severity=<option>     Filter by severity
+  --severity=<option>     Filter by severity (ignored when --fingerprint is set)
                           <options: fatal|error>
   --start=<value>         Start of time range (ISO date)
   --update-id=<value>     Filter by EAS update ID

--- a/packages/eas-cli/README.md
+++ b/packages/eas-cli/README.md
@@ -2257,7 +2257,7 @@ FLAGS
   --fingerprint=<value>   Show individual occurrences (with stack traces) for this error group fingerprint instead of
                           the grouped summary
   --json                  Enable JSON output, non-JSON messages will be printed to stderr. Implies --non-interactive.
-  --limit=<value>         The number of items to fetch each query. Defaults to 5 and is capped at 100.
+  --limit=<value>         The number of items to fetch each query. Defaults to 10 and is capped at 100.
   --non-interactive       Run the command in non-interactive mode.
   --platform=<option>     Filter by platform ("apple" covers iOS, iPadOS, tvOS, and macOS)
                           <options: android|ios|ipados|macos|tvos|apple>

--- a/packages/eas-cli/graphql.schema.json
+++ b/packages/eas-cli/graphql.schema.json
@@ -286,6 +286,226 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AccessibleGitHubAppInstallation",
+        "description": "A GitHub App installation visible to a viewer, not necessarily linked yet.",
+        "fields": [
+          {
+            "name": "account",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AccessibleGitHubAppInstallationAccount",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "installationIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AccessibleGitHubAppInstallationAccount",
+        "description": null,
+        "fields": [
+          {
+            "name": "avatarUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "login",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "GitHubAppInstallationAccountType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AccessibleGitHubRepository",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodeId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AccessibleGitHubRepositoryOwner",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "private",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AccessibleGitHubRepositoryOwner",
+        "description": null,
+        "fields": [
+          {
+            "name": "login",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "Account",
         "description": "An account is a container owning projects, credentials, billing and other organization\ndata and settings. Actors may own and be members of accounts.",
         "fields": [
@@ -418,22 +638,6 @@
                     "ofType": null
                   }
                 }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "aiChatEnabled",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -2535,71 +2739,6 @@
             "deprecationReason": null
           },
           {
-            "name": "viewerDashboardChats",
-            "description": "Most recently active first",
-            "args": [
-              {
-                "name": "after",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "before",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "first",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "last",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DashboardChatConnection",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "viewerNotificationPreferences",
             "description": "Notification preferences of the viewer for this account",
             "args": [],
@@ -4284,55 +4423,6 @@
                   "ofType": {
                     "kind": "ENUM",
                     "name": "Permission",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Account",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "setAiChatEnabled",
-            "description": "Set whether the AI chat is enabled for this account.",
-            "args": [
-              {
-                "name": "accountID",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "aiChatEnabled",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Boolean",
                     "ofType": null
                   }
                 },
@@ -14761,39 +14851,6 @@
             "deprecationReason": "Use userEvents.event, errors.error, or log instead."
           },
           {
-            "name": "customEventCounts",
-            "description": null,
-            "args": [
-              {
-                "name": "input",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "AppObserveCustomEventCountsInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "AppObserveCustomEventCounts",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Unused; no replacement planned."
-          },
-          {
             "name": "customEventList",
             "description": null,
             "args": [
@@ -17005,275 +17062,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "AppObserveCustomEventCountBucket",
-        "description": null,
-        "fields": [
-          {
-            "name": "bucket",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "count",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "AppObserveCustomEventCounts",
-        "description": null,
-        "fields": [
-          {
-            "name": "buckets",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "AppObserveCustomEventCountBucket",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "totalCount",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "AppObserveCustomEventCountsInput",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "appBuildNumber",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "appEasBuildId",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "appUpdateId",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "appVersion",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "bucketIntervalMinutes",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "endTime",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "environment",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "eventName",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "isEmbeddedUpdate",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "platform",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "AppObservePlatform",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "platforms",
-            "description": "Filter to these platforms. Cannot be set together with platform. One of platform or platforms is required.",
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AppObservePlatform",
-                  "ofType": null
-                }
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "startTime",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "AppObserveCustomEventEdge",
         "description": null,
         "fields": [
@@ -17410,6 +17198,42 @@
           },
           {
             "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "countryCode",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceModel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceOsVersion",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -18183,7 +18007,7 @@
       {
         "kind": "OBJECT",
         "name": "AppObserveError",
-        "description": "One unhandled JS error (an app_events exception row).",
+        "description": "One error or crash (an app_events *.exception row).",
         "fields": [
           {
             "name": "appBuildNumber",
@@ -18394,6 +18218,22 @@
             "deprecationReason": null
           },
           {
+            "name": "eventName",
+            "description": "Raw log event name, e.g. exception, js.exception, native.exception.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "expoSdkVersion",
             "description": null,
             "args": [],
@@ -18453,6 +18293,22 @@
               "kind": "SCALAR",
               "name": "Boolean",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveErrorKind",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -18880,7 +18736,7 @@
           },
           {
             "name": "fingerprint",
-            "description": "Stable grouping key (sha256 over error type + entropy-normalized message).",
+            "description": "Stable grouping key (sha256 over error kind + error type + entropy-normalized message).",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -18920,6 +18776,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": "Derived from the event name of the most recent occurrence.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveErrorKind",
                 "ofType": null
               }
             },
@@ -19230,6 +19102,18 @@
             "deprecationReason": null
           },
           {
+            "name": "kind",
+            "description": "Restrict to one error kind (JS errors, native crashes, or other *.exception events).",
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObserveErrorKind",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "platform",
             "description": null,
             "type": {
@@ -19511,6 +19395,18 @@
             "deprecationReason": null
           },
           {
+            "name": "kind",
+            "description": "Restrict to one error kind (JS errors, native crashes, or other *.exception events).",
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObserveErrorKind",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "orderBy",
             "description": null,
             "type": {
@@ -19635,6 +19531,35 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "AppObserveErrorKind",
+        "description": "JS covers both the legacy exception name and js.exception. NATIVE is native.exception. OTHER is any other *.exception event.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "JS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NATIVE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OTHER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "AppObserveErrorOccurrencesFilter",
         "description": null,
@@ -19742,6 +19667,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": "Restrict to one error kind (JS errors, native crashes, or other *.exception events).",
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObserveErrorKind",
               "ofType": null
             },
             "defaultValue": null,
@@ -20237,6 +20174,18 @@
             "deprecationReason": null
           },
           {
+            "name": "kind",
+            "description": "Restrict to one error kind (JS errors, native crashes, or other *.exception events).",
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObserveErrorKind",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "platform",
             "description": null,
             "type": {
@@ -20550,6 +20499,18 @@
             "deprecationReason": null
           },
           {
+            "name": "kind",
+            "description": "Restrict to one error kind (JS errors, native crashes, or other *.exception events).",
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObserveErrorKind",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "platform",
             "description": null,
             "type": {
@@ -20605,7 +20566,7 @@
       {
         "kind": "OBJECT",
         "name": "AppObserveErrors",
-        "description": "Unhandled JS errors: app_events exception rows.",
+        "description": "JS errors and native crashes: app_events *.exception rows.",
         "fields": [
           {
             "name": "breakdown",
@@ -20642,7 +20603,7 @@
           },
           {
             "name": "error",
-            "description": "A single error by id. Null when missing, aged out, or the id belongs to a user-defined event.",
+            "description": "A single error or crash by id. Null when missing, aged out, or the id belongs to a user-defined event.",
             "args": [
               {
                 "name": "id",
@@ -20990,6 +20951,18 @@
             "deprecationReason": null
           },
           {
+            "name": "kind",
+            "description": "Restrict to one error kind (JS errors, native crashes, or other *.exception events).",
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObserveErrorKind",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "platforms",
             "description": "Filter to these platforms.",
             "type": {
@@ -21142,6 +21115,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": "Restrict to one error kind (JS errors, native crashes, or other *.exception events).",
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObserveErrorKind",
               "ofType": null
             },
             "defaultValue": null,
@@ -21320,6 +21305,18 @@
             "deprecationReason": null
           },
           {
+            "name": "kind",
+            "description": "Restrict to one error kind (JS errors, native crashes, or other *.exception events).",
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObserveErrorKind",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "platforms",
             "description": "Filter to these platforms.",
             "type": {
@@ -21472,6 +21469,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "kind",
+            "description": "Restrict to one error kind (JS errors, native crashes, or other *.exception events).",
+            "type": {
+              "kind": "ENUM",
+              "name": "AppObserveErrorKind",
               "ofType": null
             },
             "defaultValue": null,
@@ -28344,6 +28353,394 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AppObserveUserEventBreakdown",
+        "description": null,
+        "fields": [
+          {
+            "name": "buckets",
+            "description": "Buckets ordered by count descending.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveUserEventBreakdownBucket",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isTruncated",
+            "description": "True when more buckets exist than were returned (top-N truncation).",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalBucketCount",
+            "description": "Number of distinct dimension values before truncation.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUserEventBreakdownBucket",
+        "description": null,
+        "fields": [
+          {
+            "name": "count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "key",
+            "description": "Dimension value (app version, OS, device model, country code, or EAS client id). Empty string when unknown.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uniqueUserCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AppObserveUserEventBreakdownDimension",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "APP_VERSION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COUNTRY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DEVICE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OS_VERSION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "USER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveUserEventBreakdownInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "countryCode",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceModel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceOsVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dimension",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppObserveUserEventBreakdownDimension",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "limit",
+            "description": "Maximum buckets to return, 1 to 100. Defaults to 100.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "Event name. The reserved `exception` name is rejected.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AppObserveUserEventConnection",
         "description": null,
         "fields": [
@@ -28390,6 +28787,358 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUserEventCountBucket",
+        "description": null,
+        "fields": [
+          {
+            "name": "bucket",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUserEventCountSeries",
+        "description": null,
+        "fields": [
+          {
+            "name": "buckets",
+            "description": "Buckets with at least one occurrence, ascending. Empty buckets are omitted.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveUserEventCountBucket",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": "Sum of count across all buckets.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppObserveUserEventCounts",
+        "description": null,
+        "fields": [
+          {
+            "name": "series",
+            "description": "One series per requested name, in request order.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppObserveUserEventCountSeries",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppObserveUserEventCountsInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appBuildNumber",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appEasBuildId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appUpdateId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bucketIntervalMinutes",
+            "description": "Bucket width. Defaults to 60. The range must not exceed 2000 buckets.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "countryCode",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceModel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceOsVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "environment",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isEmbeddedUpdate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "names",
+            "description": "Event names to count. At most 10; the reserved `exception` name is rejected.",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": "Filter to these platforms.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppObservePlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startTime",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -28480,6 +29229,42 @@
           },
           {
             "name": "appVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "countryCode",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceModel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "deviceOsVersion",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -29034,6 +29819,72 @@
         "name": "AppObserveUserEvents",
         "description": "User-defined events (`Observe.logEvent`): app_events log rows, excluding errors.",
         "fields": [
+          {
+            "name": "breakdown",
+            "description": "Top values of one dimension (app version, OS, device, user, ...) for a single event name.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveUserEventBreakdownInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveUserEventBreakdown",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "counts",
+            "description": "Time-bucketed occurrence counts, one series per requested event name.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppObserveUserEventCountsInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppObserveUserEventCounts",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "event",
             "description": "A single user-defined event by id. Null when missing, aged out, or the id belongs to an error.",
@@ -29782,16 +30633,12 @@
           },
           {
             "name": "issuerIdentifier",
-            "description": null,
+            "description": "Null for individual (user-scoped) keys, which only support submissions.",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -29939,15 +30786,11 @@
           },
           {
             "name": "issuerIdentifier",
-            "description": null,
+            "description": "Omit for individual (user-scoped) keys, which have no issuer ID and only\nsupport submissions.",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -35347,15 +36190,11 @@
         "inputFields": [
           {
             "name": "issuerIdentifier",
-            "description": null,
+            "description": "Omit for individual (user-scoped) keys, which have no issuer ID.",
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -42278,61 +43117,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "ChatTokenUsage",
-        "description": "A human user's chat token usage over the trailing 30 days, with their fair-usage limit.",
-        "fields": [
-          {
-            "name": "isLimitExceeded",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "limitTokens",
-            "description": "Null when the user's plan has no chat token limit.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "usedTokens",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "ClaudeAuthorization",
         "description": null,
         "fields": [
@@ -45448,6 +46232,18 @@
             "deprecationReason": null
           },
           {
+            "name": "githubAppRegistrationId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "installationIdentifier",
             "description": null,
             "type": {
@@ -47122,849 +47918,6 @@
             "deprecationReason": null
           }
         ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "DashboardChat",
-        "description": "A dashboard AI chat conversation, private to the user who created it.",
-        "fields": [
-          {
-            "name": "account",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Account",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createdAt",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "lastMessageAt",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "messages",
-            "description": "Most recent first",
-            "args": [
-              {
-                "name": "after",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "before",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "first",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "last",
-                "description": null,
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DashboardChatMessageConnection",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "title",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "DashboardChatConnection",
-        "description": null,
-        "fields": [
-          {
-            "name": "edges",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "DashboardChatEdge",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pageInfo",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "DashboardChatEdge",
-        "description": null,
-        "fields": [
-          {
-            "name": "cursor",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DashboardChat",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "DashboardChatMessage",
-        "description": null,
-        "fields": [
-          {
-            "name": "clientMessageId",
-            "description": "Client-supplied; unique per chat, not globally",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "parts",
-            "description": "UIMessage parts, stored verbatim, ordered by index",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "JSONObject",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "role",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "DashboardChatMessageRole",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "status",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "ENUM",
-              "name": "DashboardChatMessageStatus",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "DashboardChatMessageConnection",
-        "description": null,
-        "fields": [
-          {
-            "name": "edges",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "DashboardChatMessageEdge",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pageInfo",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "DashboardChatMessageEdge",
-        "description": null,
-        "fields": [
-          {
-            "name": "cursor",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DashboardChatMessage",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "DashboardChatMessageRole",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "ASSISTANT",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "USER",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "DashboardChatMessageStatus",
-        "description": "Terminal state of an assistant message",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "CANCELED",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "COMPLETED",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ERROR",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "DashboardChatMutation",
-        "description": null,
-        "fields": [
-          {
-            "name": "addUserMessage",
-            "description": "Persist a user message. Idempotent on clientMessageId.",
-            "args": [
-              {
-                "name": "accountID",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "chatID",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "clientMessageId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "parts",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "SCALAR",
-                        "name": "JSONObject",
-                        "ofType": null
-                      }
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DashboardChatMessage",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createChat",
-            "description": "Create a new chat owned by the viewer",
-            "args": [
-              {
-                "name": "accountID",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DashboardChat",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "deleteChat",
-            "description": "Delete a chat and all of its messages",
-            "args": [
-              {
-                "name": "chatID",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DashboardChat",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "renameChat",
-            "description": "Rename a chat",
-            "args": [
-              {
-                "name": "chatID",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "title",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DashboardChat",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "upsertAssistantMessage",
-            "description": "Persist an assistant message, replacing parts when a message with the\nsame clientMessageId already exists.",
-            "args": [
-              {
-                "name": "accountID",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "chatID",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "clientMessageId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "parts",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "SCALAR",
-                        "name": "JSONObject",
-                        "ofType": null
-                      }
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "status",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "DashboardChatMessageStatus",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DashboardChatMessage",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "DashboardChatQuery",
-        "description": null,
-        "fields": [
-          {
-            "name": "byId",
-            "description": "Get dashboard chat by ID - entry point to the graph",
-            "args": [
-              {
-                "name": "id",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "DashboardChat",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -60842,137 +60795,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "GitHubAppInstallationAccessibleRepository",
-        "description": null,
-        "fields": [
-          {
-            "name": "defaultBranch",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nodeId",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "owner",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "GitHubRepositoryOwner",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "private",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "url",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "ENUM",
         "name": "GitHubAppInstallationAccountType",
         "description": null,
@@ -61319,19 +61141,35 @@
       {
         "kind": "OBJECT",
         "name": "GitHubAppRegistration",
-        "description": "A GitHub Enterprise app.",
+        "description": "A GitHub App Expo can act through.",
         "fields": [
           {
             "name": "account",
-            "description": "The Expo account that owns this registration.",
+            "description": "The Expo account that owns this registration, or null for the default github.com app.",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
+              "kind": "OBJECT",
+              "name": "Account",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appInstallationsForViewer",
+            "description": "Installations visible to the viewer's GitHub user, or null when the viewer's GitHub\nauthorization for this registration could not be used. The accompanying error says why.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "Account",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AccessibleGitHubAppInstallation",
+                  "ofType": null
+                }
               }
             },
             "isDeprecated": false,
@@ -61387,7 +61225,7 @@
           },
           {
             "name": "origin",
-            "description": "Origin of the GitHub Enterprise instance, e.g. https://github.example.com or https://example.ghe.com. No trailing slash.",
+            "description": "Origin of the GitHub instance.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -61395,6 +61233,67 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "repositoriesForViewer",
+            "description": "Repositories the viewer's GitHub user can reach through the given installation.",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "installationIdentifier",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubAppRegistrationRepositoriesConnection",
                 "ofType": null
               }
             },
@@ -61593,6 +61492,144 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "GitHubAppRegistrationQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "byId",
+            "description": null,
+            "args": [
+              {
+                "name": "githubAppRegistrationId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubAppRegistration",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubAppRegistrationRepositoriesConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GitHubAppRegistrationRepositoryEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubAppRegistrationRepositoryEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AccessibleGitHubRepository",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "GitHubBuildInput",
         "description": null,
@@ -61693,6 +61730,18 @@
                 "name": "AppPlatform",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "refreshAdHocProvisioningProfile",
+            "description": "Refresh the ad hoc provisioning profile before building. Supported for iOS builds with a build profile that uses internal distribution and remote credentials.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -62589,6 +62638,30 @@
             "deprecationReason": null
           },
           {
+            "name": "branchesForViewer",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createdAt",
             "description": null,
             "args": [],
@@ -63006,132 +63079,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "GitHubRepositoryOwner",
-        "description": null,
-        "fields": [
-          {
-            "name": "avatarUrl",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "login",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "url",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "GitHubRepositoryPaginationResult",
-        "description": null,
-        "fields": [
-          {
-            "name": "repositories",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "GitHubAppInstallationAccessibleRepository",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "totalCount",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "GitHubRepositorySettings",
         "description": null,
         "fields": [
@@ -63365,6 +63312,18 @@
             "deprecationReason": null
           },
           {
+            "name": "registration",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GitHubAppRegistration",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "userActor",
             "description": null,
             "args": [],
@@ -63498,7 +63457,20 @@
           {
             "name": "generateGitHubUserAccessToken",
             "description": "Generate a GitHub User Access Token",
-            "args": [],
+            "args": [
+              {
+                "name": "githubAppRegistrationId",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -68951,55 +68923,6 @@
             "deprecationReason": null
           },
           {
-            "name": "recordChatTokenUsage",
-            "description": "Record chat token usage for the current user.",
-            "args": [
-              {
-                "name": "inputTokens",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "outputTokens",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ChatTokenUsage",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "regenerateSecondFactorBackupCodes",
             "description": "Regenerate backup codes for the current user",
             "args": [
@@ -74198,22 +74121,6 @@
             "deprecationReason": null
           },
           {
-            "name": "dashboardChat",
-            "description": "Mutations for dashboard chats",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DashboardChatMutation",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "deployments",
             "description": null,
             "args": [],
@@ -75602,22 +75509,6 @@
             "deprecationReason": null
           },
           {
-            "name": "dashboardChat",
-            "description": "Top-level query object for querying dashboard chats.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "DashboardChatQuery",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "deployments",
             "description": "Top-level query object for querying Deployments.",
             "args": [],
@@ -75803,6 +75694,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "GitHubAppQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubAppRegistrations",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubAppRegistrationQuery",
                 "ofType": null
               }
             },
@@ -76146,22 +76053,6 @@
               "kind": "OBJECT",
               "name": "User",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "viewerChatTokenUsage",
-            "description": "The current user's chat token usage and limit.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ChatTokenUsage",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -77373,13 +77264,57 @@
             "deprecationReason": null
           },
           {
+            "name": "githubAppRegistrations",
+            "description": "Every GitHub App registration this actor can link a GitHub user through. Includes the default\ngithub.com app. An entry is null when that registration failed to resolve; the accompanying\nerror says why.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "GitHubAppRegistration",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "githubUser",
-            "description": "GitHub account linked to a user",
+            "description": "GitHub.com account linked to a user",
             "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "GitHubUser",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubUsers",
+            "description": "Every GitHub account linked to a user, one per GitHub App registration they have linked\nthrough. Includes githubUser.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GitHubUser",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -88441,13 +88376,57 @@
             "deprecationReason": null
           },
           {
+            "name": "githubAppRegistrations",
+            "description": "Every GitHub App registration this actor can link a GitHub user through. Includes the default\ngithub.com app. An entry is null when that registration failed to resolve; the accompanying\nerror says why.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "GitHubAppRegistration",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "githubUser",
-            "description": "GitHub account linked to a user",
+            "description": "GitHub.com account linked to a user",
             "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "GitHubUser",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubUsers",
+            "description": "Every GitHub account linked to a user, one per GitHub App registration they have linked\nthrough. Includes githubUser.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GitHubUser",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -89243,13 +89222,57 @@
             "deprecationReason": null
           },
           {
+            "name": "githubAppRegistrations",
+            "description": "Every GitHub App registration this actor can link a GitHub user through. Includes the default\ngithub.com app. An entry is null when that registration failed to resolve; the accompanying\nerror says why.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "GitHubAppRegistration",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "githubUser",
-            "description": "GitHub account linked to a user",
+            "description": "GitHub.com account linked to a user",
             "args": [],
             "type": {
               "kind": "OBJECT",
               "name": "GitHubUser",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubUsers",
+            "description": "Every GitHub account linked to a user, one per GitHub App registration they have linked\nthrough. Includes githubUser.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GitHubUser",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/packages/eas-cli/src/commands/observe/__tests__/errors.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/errors.test.ts
@@ -1,0 +1,90 @@
+import { CombinedError } from '@urql/core';
+import { GraphQLError } from 'graphql';
+
+import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
+import { getMockOclifConfig } from '../../../__tests__/commands/utils';
+import { AppObserveErrorSeverity } from '../../../graphql/generated';
+import { fetchObserveErrorGroupsAsync } from '../../../observe/fetchErrors';
+import {
+  buildObserveErrorGroupsJson,
+  buildObserveErrorGroupsTable,
+} from '../../../observe/formatErrors';
+import { EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE } from '../../../observe/planGating';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
+import ObserveErrors from '../errors';
+
+jest.mock('../../../observe/fetchErrors');
+jest.mock('../../../observe/formatErrors', () => ({
+  buildObserveErrorGroupsTable: jest.fn().mockReturnValue('errors-table'),
+  buildObserveErrorGroupsJson: jest.fn().mockReturnValue({ errors: [], isTruncated: false }),
+}));
+jest.mock('../../../log');
+jest.mock('../../../utils/json');
+
+const mockFetchErrorGroupsAsync = jest.mocked(fetchObserveErrorGroupsAsync);
+const mockBuildTable = jest.mocked(buildObserveErrorGroupsTable);
+const mockBuildJson = jest.mocked(buildObserveErrorGroupsJson);
+const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
+const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
+
+describe(ObserveErrors, () => {
+  const graphqlClient = {} as any as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+  const projectId = 'test-project-id';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchErrorGroupsAsync.mockResolvedValue({ groups: [], isTruncated: false });
+  });
+
+  function createCommand(argv: string[]): ObserveErrors {
+    const command = new ObserveErrors(argv, mockConfig);
+    // @ts-expect-error
+    jest.spyOn(command, 'getContextAsync').mockReturnValue({
+      projectId,
+      loggedIn: { graphqlClient },
+    });
+    return command;
+  }
+
+  it('fetches error groups and renders a table by default', async () => {
+    await createCommand([]).runAsync();
+    expect(mockFetchErrorGroupsAsync).toHaveBeenCalledTimes(1);
+    expect(mockBuildTable).toHaveBeenCalledTimes(1);
+    expect(mockEnableJsonOutput).not.toHaveBeenCalled();
+  });
+
+  it('emits JSON with --json', async () => {
+    await createCommand(['--json', '--non-interactive']).runAsync();
+    expect(mockEnableJsonOutput).toHaveBeenCalledTimes(1);
+    expect(mockBuildJson).toHaveBeenCalledTimes(1);
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({ errors: [], isTruncated: false });
+  });
+
+  it('maps the --severity flag to the AppObserveErrorSeverity enum', async () => {
+    await createCommand(['--severity', 'fatal']).runAsync();
+    const options = mockFetchErrorGroupsAsync.mock.calls[0][2];
+    expect(options.severity).toBe(AppObserveErrorSeverity.Fatal);
+  });
+
+  it('surfaces the plan-gate message when errors are not available on the plan', async () => {
+    mockFetchErrorGroupsAsync.mockRejectedValueOnce(
+      new CombinedError({
+        graphQLErrors: [
+          new GraphQLError(
+            'Subscription to EAS is required for this feature.',
+            null,
+            null,
+            null,
+            null,
+            null,
+            {
+              errorCode: EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE,
+            }
+          ),
+        ],
+      })
+    );
+    await expect(createCommand([]).runAsync()).rejects.toThrow(/Subscription to EAS is required/);
+  });
+});

--- a/packages/eas-cli/src/commands/observe/__tests__/errors.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/errors.test.ts
@@ -4,10 +4,15 @@ import { GraphQLError } from 'graphql';
 import { ExpoGraphqlClient } from '../../../commandUtils/context/contextUtils/createGraphqlClient';
 import { getMockOclifConfig } from '../../../__tests__/commands/utils';
 import { AppObserveErrorSeverity } from '../../../graphql/generated';
-import { fetchObserveErrorGroupsAsync } from '../../../observe/fetchErrors';
+import {
+  fetchObserveErrorGroupsAsync,
+  fetchObserveErrorOccurrencesAsync,
+} from '../../../observe/fetchErrors';
 import {
   buildObserveErrorGroupsJson,
   buildObserveErrorGroupsTable,
+  buildObserveErrorOccurrencesJson,
+  buildObserveErrorOccurrencesTable,
 } from '../../../observe/formatErrors';
 import { EAS_OBSERVE_FEATURE_NOT_AVAILABLE_IN_FREE_TIER_ERROR_CODE } from '../../../observe/planGating';
 import { enableJsonOutput, printJsonOnlyOutput } from '../../../utils/json';
@@ -17,13 +22,20 @@ jest.mock('../../../observe/fetchErrors');
 jest.mock('../../../observe/formatErrors', () => ({
   buildObserveErrorGroupsTable: jest.fn().mockReturnValue('errors-table'),
   buildObserveErrorGroupsJson: jest.fn().mockReturnValue({ errors: [], isTruncated: false }),
+  buildObserveErrorOccurrencesTable: jest.fn().mockReturnValue('occurrences-table'),
+  buildObserveErrorOccurrencesJson: jest
+    .fn()
+    .mockReturnValue({ occurrences: [], pageInfo: { hasNextPage: false, endCursor: null } }),
 }));
 jest.mock('../../../log');
 jest.mock('../../../utils/json');
 
 const mockFetchErrorGroupsAsync = jest.mocked(fetchObserveErrorGroupsAsync);
+const mockFetchErrorOccurrencesAsync = jest.mocked(fetchObserveErrorOccurrencesAsync);
 const mockBuildTable = jest.mocked(buildObserveErrorGroupsTable);
 const mockBuildJson = jest.mocked(buildObserveErrorGroupsJson);
+const mockBuildOccurrencesTable = jest.mocked(buildObserveErrorOccurrencesTable);
+const mockBuildOccurrencesJson = jest.mocked(buildObserveErrorOccurrencesJson);
 const mockEnableJsonOutput = jest.mocked(enableJsonOutput);
 const mockPrintJsonOnlyOutput = jest.mocked(printJsonOnlyOutput);
 
@@ -35,6 +47,10 @@ describe(ObserveErrors, () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetchErrorGroupsAsync.mockResolvedValue({ groups: [], isTruncated: false });
+    mockFetchErrorOccurrencesAsync.mockResolvedValue({
+      occurrences: [],
+      pageInfo: { hasNextPage: false, hasPreviousPage: false, endCursor: null } as any,
+    });
   });
 
   function createCommand(argv: string[]): ObserveErrors {
@@ -65,6 +81,25 @@ describe(ObserveErrors, () => {
     await createCommand(['--severity', 'fatal']).runAsync();
     const options = mockFetchErrorGroupsAsync.mock.calls[0][2];
     expect(options.severity).toBe(AppObserveErrorSeverity.Fatal);
+  });
+
+  it('fetches occurrences (not groups) and renders their table when --fingerprint is set', async () => {
+    await createCommand(['--fingerprint', 'fp-1']).runAsync();
+    expect(mockFetchErrorGroupsAsync).not.toHaveBeenCalled();
+    expect(mockFetchErrorOccurrencesAsync).toHaveBeenCalledTimes(1);
+    expect(mockFetchErrorOccurrencesAsync.mock.calls[0][2]).toMatchObject({ fingerprint: 'fp-1' });
+    expect(mockBuildOccurrencesTable).toHaveBeenCalledTimes(1);
+    expect(mockBuildTable).not.toHaveBeenCalled();
+  });
+
+  it('emits occurrences JSON with --fingerprint --json', async () => {
+    await createCommand(['--fingerprint', 'fp-1', '--json', '--non-interactive']).runAsync();
+    expect(mockEnableJsonOutput).toHaveBeenCalledTimes(1);
+    expect(mockBuildOccurrencesJson).toHaveBeenCalledTimes(1);
+    expect(mockPrintJsonOnlyOutput).toHaveBeenCalledWith({
+      occurrences: [],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    });
   });
 
   it('surfaces the plan-gate message when errors are not available on the plan', async () => {

--- a/packages/eas-cli/src/commands/observe/__tests__/errors.test.ts
+++ b/packages/eas-cli/src/commands/observe/__tests__/errors.test.ts
@@ -102,6 +102,29 @@ describe(ObserveErrors, () => {
     });
   });
 
+  it('forwards --limit to the occurrences fetch when --fingerprint is set', async () => {
+    await createCommand(['--fingerprint', 'fp-1', '--limit', '20']).runAsync();
+    expect(mockFetchErrorOccurrencesAsync.mock.calls[0][2]).toMatchObject({
+      fingerprint: 'fp-1',
+      limit: 20,
+    });
+  });
+
+  it('rejects --limit without --fingerprint', async () => {
+    await expect(createCommand(['--limit', '20']).runAsync()).rejects.toThrow(
+      /--after or --limit can only be used in combination with the --fingerprint flag/
+    );
+    expect(mockFetchErrorGroupsAsync).not.toHaveBeenCalled();
+    expect(mockFetchErrorOccurrencesAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects --after without --fingerprint', async () => {
+    await expect(createCommand(['--after', 'cursor-1']).runAsync()).rejects.toThrow(
+      /--after or --limit can only be used in combination with the --fingerprint flag/
+    );
+    expect(mockFetchErrorGroupsAsync).not.toHaveBeenCalled();
+  });
+
   it('surfaces the plan-gate message when errors are not available on the plan', async () => {
     mockFetchErrorGroupsAsync.mockRejectedValueOnce(
       new CombinedError({

--- a/packages/eas-cli/src/commands/observe/errors.ts
+++ b/packages/eas-cli/src/commands/observe/errors.ts
@@ -1,0 +1,105 @@
+import { Flags } from '@oclif/core';
+
+import EasCommand from '../../commandUtils/EasCommand';
+import {
+  EasNonInteractiveAndJsonFlags,
+  resolveNonInteractiveAndJsonFlags,
+} from '../../commandUtils/flags';
+import { AppObserveErrorSeverity } from '../../graphql/generated';
+import Log from '../../log';
+import { fetchObserveErrorGroupsAsync } from '../../observe/fetchErrors';
+import {
+  ObserveAppVersionFlag,
+  ObserveBuildNumberFlag,
+  ObserveEnvironmentFlag,
+  ObservePlatformFlag,
+  ObserveProjectIdFlag,
+  ObserveTimeRangeFlags,
+  ObserveUpdateIdFlag,
+} from '../../observe/flags';
+import {
+  buildObserveErrorGroupsJson,
+  buildObserveErrorGroupsTable,
+} from '../../observe/formatErrors';
+import { withObservePlanGateHandlingAsync } from '../../observe/planGating';
+import { observePlatformsFromFlag } from '../../observe/platforms';
+import { resolveObserveCommandContextAsync } from '../../observe/resolveProjectContext';
+import { resolveTimeRange } from '../../observe/startAndEndTime';
+import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
+
+const SEVERITY_BY_FLAG: Record<string, AppObserveErrorSeverity> = {
+  fatal: AppObserveErrorSeverity.Fatal,
+  error: AppObserveErrorSeverity.Error,
+};
+
+export default class ObserveErrors extends EasCommand {
+  static override description =
+    'display error and exception issue groups (grouped by fingerprint) for the app';
+
+  static override flags = {
+    ...ObservePlatformFlag,
+    severity: Flags.option({
+      description: 'Filter by severity',
+      options: Object.keys(SEVERITY_BY_FLAG),
+      required: false,
+    })(),
+    ...ObserveTimeRangeFlags,
+    ...ObserveAppVersionFlag,
+    ...ObserveBuildNumberFlag,
+    ...ObserveUpdateIdFlag,
+    ...ObserveEnvironmentFlag,
+    ...ObserveProjectIdFlag,
+    ...EasNonInteractiveAndJsonFlags,
+  };
+
+  static override contextDefinition = {
+    ...this.ContextOptions.ProjectId,
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  private static loggedInOnlyContextDefinition = {
+    ...this.ContextOptions.LoggedIn,
+  };
+
+  async runAsync(): Promise<void> {
+    const { flags } = await this.parse(ObserveErrors);
+    const { json, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
+
+    const { projectId, graphqlClient } = await resolveObserveCommandContextAsync({
+      command: this,
+      commandClass: ObserveErrors,
+      loggedInOnlyContextDefinition: ObserveErrors.loggedInOnlyContextDefinition,
+      projectIdOverride: flags['project-id'],
+      nonInteractive,
+    });
+
+    if (json) {
+      enableJsonOutput();
+    }
+
+    const { daysBack, startTime, endTime } = resolveTimeRange(flags);
+
+    const { groups, isTruncated } = await withObservePlanGateHandlingAsync(() =>
+      fetchObserveErrorGroupsAsync(graphqlClient, projectId, {
+        startTime,
+        endTime,
+        platforms: observePlatformsFromFlag(flags.platform),
+        appVersion: flags['app-version'],
+        buildNumber: flags['build-number'],
+        updateId: flags['update-id'],
+        environment: flags.environment,
+        ...(flags.severity && { severity: SEVERITY_BY_FLAG[flags.severity] }),
+      })
+    );
+
+    if (json) {
+      printJsonOnlyOutput(buildObserveErrorGroupsJson(groups, isTruncated));
+    } else {
+      Log.addNewLineIfNone();
+      Log.log(buildObserveErrorGroupsTable(groups, { daysBack, startTime, endTime }));
+      if (isTruncated) {
+        Log.warn('Result is truncated; not all error groups are shown.');
+      }
+    }
+  }
+}

--- a/packages/eas-cli/src/commands/observe/errors.ts
+++ b/packages/eas-cli/src/commands/observe/errors.ts
@@ -5,10 +5,15 @@ import {
   EasNonInteractiveAndJsonFlags,
   resolveNonInteractiveAndJsonFlags,
 } from '../../commandUtils/flags';
+import { getLimitFlagWithCustomValues } from '../../commandUtils/pagination';
 import { AppObserveErrorSeverity } from '../../graphql/generated';
 import Log from '../../log';
-import { fetchObserveErrorGroupsAsync } from '../../observe/fetchErrors';
 import {
+  fetchObserveErrorGroupsAsync,
+  fetchObserveErrorOccurrencesAsync,
+} from '../../observe/fetchErrors';
+import {
+  ObserveAfterFlag,
   ObserveAppVersionFlag,
   ObserveBuildNumberFlag,
   ObserveEnvironmentFlag,
@@ -20,6 +25,8 @@ import {
 import {
   buildObserveErrorGroupsJson,
   buildObserveErrorGroupsTable,
+  buildObserveErrorOccurrencesJson,
+  buildObserveErrorOccurrencesTable,
 } from '../../observe/formatErrors';
 import { withObservePlanGateHandlingAsync } from '../../observe/planGating';
 import { observePlatformsFromFlag } from '../../observe/platforms';
@@ -32,17 +39,29 @@ const SEVERITY_BY_FLAG: Record<string, AppObserveErrorSeverity> = {
   error: AppObserveErrorSeverity.Error,
 };
 
+const DEFAULT_OCCURRENCES_LIMIT = 5;
+
 export default class ObserveErrors extends EasCommand {
   static override description =
     'display error and exception issue groups (grouped by fingerprint) for the app';
 
   static override flags = {
     ...ObservePlatformFlag,
+    fingerprint: Flags.string({
+      description:
+        'Show individual occurrences (with stack traces) for this error group fingerprint instead of the grouped summary',
+      required: false,
+    }),
     severity: Flags.option({
-      description: 'Filter by severity',
+      description: 'Filter by severity (ignored when --fingerprint is set)',
       options: Object.keys(SEVERITY_BY_FLAG),
       required: false,
     })(),
+    ...ObserveAfterFlag,
+    limit: getLimitFlagWithCustomValues({
+      defaultTo: DEFAULT_OCCURRENCES_LIMIT,
+      limit: 100,
+    }),
     ...ObserveTimeRangeFlags,
     ...ObserveAppVersionFlag,
     ...ObserveBuildNumberFlag,
@@ -78,6 +97,38 @@ export default class ObserveErrors extends EasCommand {
     }
 
     const { daysBack, startTime, endTime } = resolveTimeRange(flags);
+
+    if (flags.fingerprint) {
+      const { occurrences, pageInfo } = await withObservePlanGateHandlingAsync(() =>
+        fetchObserveErrorOccurrencesAsync(graphqlClient, projectId, {
+          fingerprint: flags.fingerprint as string,
+          startTime,
+          endTime,
+          platforms: observePlatformsFromFlag(flags.platform),
+          appVersion: flags['app-version'],
+          buildNumber: flags['build-number'],
+          updateId: flags['update-id'],
+          environment: flags.environment,
+          limit: flags.limit ?? DEFAULT_OCCURRENCES_LIMIT,
+          ...(flags.after && { after: flags.after }),
+        })
+      );
+
+      if (json) {
+        printJsonOnlyOutput(buildObserveErrorOccurrencesJson(occurrences, pageInfo));
+      } else {
+        Log.addNewLineIfNone();
+        Log.log(
+          buildObserveErrorOccurrencesTable(occurrences, pageInfo, {
+            fingerprint: flags.fingerprint,
+            daysBack,
+            startTime,
+            endTime,
+          })
+        );
+      }
+      return;
+    }
 
     const { groups, isTruncated } = await withObservePlanGateHandlingAsync(() =>
       fetchObserveErrorGroupsAsync(graphqlClient, projectId, {

--- a/packages/eas-cli/src/commands/observe/errors.ts
+++ b/packages/eas-cli/src/commands/observe/errors.ts
@@ -39,7 +39,7 @@ const SEVERITY_BY_FLAG: Record<string, AppObserveErrorSeverity> = {
   error: AppObserveErrorSeverity.Error,
 };
 
-const DEFAULT_OCCURRENCES_LIMIT = 5;
+const DEFAULT_OCCURRENCES_LIMIT = 10;
 
 export default class ObserveErrors extends EasCommand {
   static override description =
@@ -91,6 +91,12 @@ export default class ObserveErrors extends EasCommand {
       projectIdOverride: flags['project-id'],
       nonInteractive,
     });
+
+    if (!flags.fingerprint && (flags.after || flags.limit)) {
+      throw new Error(
+        '--after or --limit can only be used in combination with the --fingerprint flag.'
+      );
+    }
 
     if (json) {
       enableJsonOutput();

--- a/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
+++ b/packages/eas-cli/src/credentials/ios/actions/AscApiKeyUtils.ts
@@ -304,7 +304,7 @@ export async function resolveAscApiKeyForAppCredentialsAsync({
     ascApiKey: {
       keyP8: fullKey.keyP8,
       keyId: fullKey.keyIdentifier,
-      issuerId: fullKey.issuerIdentifier,
+      issuerId: fullKey.issuerIdentifier ?? '',
     },
     teamId: ascKeyFragment.appleTeam?.appleTeamIdentifier,
     teamName: ascKeyFragment.appleTeam?.appleTeamName ?? undefined,

--- a/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
+++ b/packages/eas-cli/src/credentials/ios/utils/printCredentials.ts
@@ -246,7 +246,9 @@ function displayAscApiKey(
     if (name) {
       fields.push({ label: 'Name', value: name });
     }
-    fields.push({ label: 'Issuer ID', value: issuerIdentifier });
+    if (issuerIdentifier) {
+      fields.push({ label: 'Issuer ID', value: issuerIdentifier });
+    }
     if (roles) {
       fields.push({ label: 'Roles', value: roles.join(',') });
     }

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -74,6 +74,34 @@ export type AccessTokenMutation_SetAccessTokenRevokedArgs = {
   revoked?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+/** A GitHub App installation visible to a viewer, not necessarily linked yet. */
+export type AccessibleGitHubAppInstallation = {
+  __typename?: 'AccessibleGitHubAppInstallation';
+  account: AccessibleGitHubAppInstallationAccount;
+  installationIdentifier: Scalars['Int']['output'];
+};
+
+export type AccessibleGitHubAppInstallationAccount = {
+  __typename?: 'AccessibleGitHubAppInstallationAccount';
+  avatarUrl: Scalars['String']['output'];
+  login: Scalars['String']['output'];
+  type: GitHubAppInstallationAccountType;
+};
+
+export type AccessibleGitHubRepository = {
+  __typename?: 'AccessibleGitHubRepository';
+  id: Scalars['Int']['output'];
+  name: Scalars['String']['output'];
+  nodeId: Scalars['String']['output'];
+  owner: AccessibleGitHubRepositoryOwner;
+  private: Scalars['Boolean']['output'];
+};
+
+export type AccessibleGitHubRepositoryOwner = {
+  __typename?: 'AccessibleGitHubRepositoryOwner';
+  login: Scalars['String']['output'];
+};
+
 /**
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
@@ -86,7 +114,6 @@ export type Account = {
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   /** AI provider connections available to agent sandbox sessions. */
   agentProviderConnections: Array<AgentProviderConnection>;
-  aiChatEnabled: Scalars['Boolean']['output'];
   appCount: Scalars['Int']['output'];
   /** @deprecated Use appStoreConnectApiKeysPaginated */
   appStoreConnectApiKeys: Array<AppStoreConnectApiKey>;
@@ -207,8 +234,6 @@ export type Account = {
   users: Array<UserPermission>;
   /** Vexo account connection for this account */
   vexoAccountConnection?: Maybe<VexoAccountConnection>;
-  /** Most recently active first */
-  viewerDashboardChats: DashboardChatConnection;
   /** Notification preferences of the viewer for this account */
   viewerNotificationPreferences: Array<NotificationPreferenceItem>;
   /** Permission info for the viewer on this account */
@@ -493,18 +518,6 @@ export type Account_TimelineActivityArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
-
-/**
- * An account is a container owning projects, credentials, billing and other organization
- * data and settings. Actors may own and be members of accounts.
- */
-export type Account_ViewerDashboardChatsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
 export type AccountAppStoreConnectApiKeysConnection = {
   __typename?: 'AccountAppStoreConnectApiKeysConnection';
   edges: Array<AccountAppStoreConnectApiKeysEdge>;
@@ -699,8 +712,6 @@ export type AccountMutation = {
   requestRefund?: Maybe<Scalars['Boolean']['output']>;
   /** Revoke specified Permissions for Actor. Actor must already have at least one permission on the account. */
   revokeActorPermissions: Account;
-  /** Set whether the AI chat is enabled for this account. */
-  setAiChatEnabled: Account;
   /** Set the display name for the account. Pass null to clear it and fall back to the account identifier. */
   setDisplayName: Account;
   /** Set whether EAS Observe ingestion is paused for this account. */
@@ -778,12 +789,6 @@ export type AccountMutation_RevokeActorPermissionsArgs = {
   accountID: Scalars['ID']['input'];
   actorID: Scalars['ID']['input'];
   permissions?: InputMaybe<Array<InputMaybe<Permission>>>;
-};
-
-
-export type AccountMutation_SetAiChatEnabledArgs = {
-  accountID: Scalars['ID']['input'];
-  aiChatEnabled: Scalars['Boolean']['input'];
 };
 
 
@@ -2264,8 +2269,6 @@ export type AppObserve = {
    * @deprecated Use userEvents.event, errors.error, or log instead.
    */
   customEvent?: Maybe<AppObserveCustomEvent>;
-  /** @deprecated Unused; no replacement planned. */
-  customEventCounts: AppObserveCustomEventCounts;
   /** @deprecated Use userEvents.list (or errors.occurrences for exceptions) instead. */
   customEventList: AppObserveCustomEventListConnection;
   /** @deprecated Use userEvents.names instead. */
@@ -2369,11 +2372,6 @@ export type AppObserve_AppVersionsArgs = {
 
 export type AppObserve_CustomEventArgs = {
   id: Scalars['ID']['input'];
-};
-
-
-export type AppObserve_CustomEventCountsArgs = {
-  input: AppObserveCustomEventCountsInput;
 };
 
 
@@ -2629,34 +2627,6 @@ export type AppObserveCustomEvent = {
   timestamp: Scalars['DateTime']['output'];
 };
 
-export type AppObserveCustomEventCountBucket = {
-  __typename?: 'AppObserveCustomEventCountBucket';
-  bucket: Scalars['DateTime']['output'];
-  count: Scalars['Int']['output'];
-};
-
-export type AppObserveCustomEventCounts = {
-  __typename?: 'AppObserveCustomEventCounts';
-  buckets: Array<AppObserveCustomEventCountBucket>;
-  totalCount: Scalars['Int']['output'];
-};
-
-export type AppObserveCustomEventCountsInput = {
-  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
-  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
-  appUpdateId?: InputMaybe<Scalars['String']['input']>;
-  appVersion?: InputMaybe<Scalars['String']['input']>;
-  bucketIntervalMinutes?: InputMaybe<Scalars['Int']['input']>;
-  endTime: Scalars['DateTime']['input'];
-  environment?: InputMaybe<Scalars['String']['input']>;
-  eventName: Scalars['String']['input'];
-  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
-  platform?: InputMaybe<AppObservePlatform>;
-  /** Filter to these platforms. Cannot be set together with platform. One of platform or platforms is required. */
-  platforms?: InputMaybe<Array<AppObservePlatform>>;
-  startTime: Scalars['DateTime']['input'];
-};
-
 export type AppObserveCustomEventEdge = {
   __typename?: 'AppObserveCustomEventEdge';
   cursor: Scalars['String']['output'];
@@ -2674,6 +2644,9 @@ export type AppObserveCustomEventListFilter = {
   appEasBuildId?: InputMaybe<Scalars['String']['input']>;
   appUpdateId?: InputMaybe<Scalars['String']['input']>;
   appVersion?: InputMaybe<Scalars['String']['input']>;
+  countryCode?: InputMaybe<Scalars['String']['input']>;
+  deviceModel?: InputMaybe<Scalars['String']['input']>;
+  deviceOsVersion?: InputMaybe<Scalars['String']['input']>;
   easClientId?: InputMaybe<Scalars['String']['input']>;
   endTime?: InputMaybe<Scalars['DateTime']['input']>;
   environment?: InputMaybe<Scalars['String']['input']>;
@@ -2772,7 +2745,7 @@ export type AppObserveEngagementInput = {
   startTime: Scalars['DateTime']['input'];
 };
 
-/** One unhandled JS error (an app_events exception row). */
+/** One error or crash (an app_events *.exception row). */
 export type AppObserveError = AppObserveLog & {
   __typename?: 'AppObserveError';
   appBuildNumber: Scalars['String']['output'];
@@ -2790,11 +2763,14 @@ export type AppObserveError = AppObserveLog & {
   deviceOsVersion: Scalars['String']['output'];
   easClientId: Scalars['String']['output'];
   environment?: Maybe<Scalars['String']['output']>;
+  /** Raw log event name, e.g. exception, js.exception, native.exception. */
+  eventName: Scalars['String']['output'];
   expoSdkVersion?: Maybe<Scalars['String']['output']>;
   fingerprint?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   ingestedAt?: Maybe<Scalars['DateTime']['output']>;
   isFatal?: Maybe<Scalars['Boolean']['output']>;
+  kind: AppObserveErrorKind;
   message?: Maybe<Scalars['String']['output']>;
   properties: Array<AppObserveEventProperty>;
   reactNativeVersion?: Maybe<Scalars['String']['output']>;
@@ -2847,10 +2823,12 @@ export type AppObserveErrorGroup = {
   exceptionMessage?: Maybe<Scalars['String']['output']>;
   /** Error class/type, from the most recent occurrence (e.g. TypeError). */
   exceptionType?: Maybe<Scalars['String']['output']>;
-  /** Stable grouping key (sha256 over error type + entropy-normalized message). */
+  /** Stable grouping key (sha256 over error kind + error type + entropy-normalized message). */
   fingerprint: Scalars['String']['output'];
   firstSeenAt: Scalars['DateTime']['output'];
   isFatal: Scalars['Boolean']['output'];
+  /** Derived from the event name of the most recent occurrence. */
+  kind: AppObserveErrorKind;
   lastSeenAt: Scalars['DateTime']['output'];
   /** Per-platform occurrence and unique-user counts, sorted by eventCount descending. Covers every device OS seen (iOS, Android, iPadOS, ...), so the counts sum to the group totals. */
   platformCounts: Array<AppObserveErrorGroupPlatformCount>;
@@ -2882,6 +2860,8 @@ export type AppObserveErrorGroupBreakdownInput = {
   environment?: InputMaybe<Scalars['String']['input']>;
   fingerprint: Scalars['String']['input'];
   isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Restrict to one error kind (JS errors, native crashes, or other *.exception events). */
+  kind?: InputMaybe<AppObserveErrorKind>;
   platform?: InputMaybe<AppObservePlatform>;
   /** Filter to these platforms. Cannot be set together with platform. */
   platforms?: InputMaybe<Array<AppObservePlatform>>;
@@ -2915,6 +2895,8 @@ export type AppObserveErrorGroupsInput = {
   /** Restrict to a single group, e.g. to fetch one group's header on the detail page. */
   fingerprint?: InputMaybe<Scalars['String']['input']>;
   isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Restrict to one error kind (JS errors, native crashes, or other *.exception events). */
+  kind?: InputMaybe<AppObserveErrorKind>;
   orderBy?: InputMaybe<AppObserveErrorGroupsOrderBy>;
   platform?: InputMaybe<AppObservePlatform>;
   /** Filter to these platforms. Cannot be set together with platform. */
@@ -2933,6 +2915,13 @@ export enum AppObserveErrorGroupsOrderBy {
   MostUsers = 'MOST_USERS'
 }
 
+/** JS covers both the legacy exception name and js.exception. NATIVE is native.exception. OTHER is any other *.exception event. */
+export enum AppObserveErrorKind {
+  Js = 'JS',
+  Native = 'NATIVE',
+  Other = 'OTHER'
+}
+
 export type AppObserveErrorOccurrencesFilter = {
   appBuildNumber?: InputMaybe<Scalars['String']['input']>;
   appEasBuildId?: InputMaybe<Scalars['String']['input']>;
@@ -2944,6 +2933,8 @@ export type AppObserveErrorOccurrencesFilter = {
   /** Restrict to one error group. */
   fingerprint?: InputMaybe<Scalars['String']['input']>;
   isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Restrict to one error kind (JS errors, native crashes, or other *.exception events). */
+  kind?: InputMaybe<AppObserveErrorKind>;
   /** Filter to these platforms. */
   platforms?: InputMaybe<Array<AppObservePlatform>>;
   sessionId?: InputMaybe<Scalars['String']['input']>;
@@ -3007,6 +2998,8 @@ export type AppObserveErrorStatsInput = {
   endTime: Scalars['DateTime']['input'];
   environment?: InputMaybe<Scalars['String']['input']>;
   isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Restrict to one error kind (JS errors, native crashes, or other *.exception events). */
+  kind?: InputMaybe<AppObserveErrorKind>;
   platform?: InputMaybe<AppObservePlatform>;
   /** Filter to these platforms. Cannot be set together with platform. */
   platforms?: InputMaybe<Array<AppObservePlatform>>;
@@ -3045,18 +3038,20 @@ export type AppObserveErrorTimeSeriesInput = {
   /** Restrict to one error group for the detail page's occurrences-over-time chart. Omit for the overview chart. */
   fingerprint?: InputMaybe<Scalars['String']['input']>;
   isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Restrict to one error kind (JS errors, native crashes, or other *.exception events). */
+  kind?: InputMaybe<AppObserveErrorKind>;
   platform?: InputMaybe<AppObservePlatform>;
   /** Filter to these platforms. Cannot be set together with platform. */
   platforms?: InputMaybe<Array<AppObservePlatform>>;
   startTime: Scalars['DateTime']['input'];
 };
 
-/** Unhandled JS errors: app_events exception rows. */
+/** JS errors and native crashes: app_events *.exception rows. */
 export type AppObserveErrors = {
   __typename?: 'AppObserveErrors';
   /** Breaks one error group down by app version, OS, device, or country. */
   breakdown: AppObserveErrorGroupBreakdown;
-  /** A single error by id. Null when missing, aged out, or the id belongs to a user-defined event. */
+  /** A single error or crash by id. Null when missing, aged out, or the id belongs to a user-defined event. */
   error?: Maybe<AppObserveError>;
   /** Distinct error groups (the issues list), grouped by fingerprint. */
   groups: AppObserveErrorGroups;
@@ -3069,25 +3064,25 @@ export type AppObserveErrors = {
 };
 
 
-/** Unhandled JS errors: app_events exception rows. */
+/** JS errors and native crashes: app_events *.exception rows. */
 export type AppObserveErrors_BreakdownArgs = {
   input: AppObserveErrorsBreakdownInput;
 };
 
 
-/** Unhandled JS errors: app_events exception rows. */
+/** JS errors and native crashes: app_events *.exception rows. */
 export type AppObserveErrors_ErrorArgs = {
   id: Scalars['ID']['input'];
 };
 
 
-/** Unhandled JS errors: app_events exception rows. */
+/** JS errors and native crashes: app_events *.exception rows. */
 export type AppObserveErrors_GroupsArgs = {
   input: AppObserveErrorsGroupsInput;
 };
 
 
-/** Unhandled JS errors: app_events exception rows. */
+/** JS errors and native crashes: app_events *.exception rows. */
 export type AppObserveErrors_OccurrencesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
@@ -3098,13 +3093,13 @@ export type AppObserveErrors_OccurrencesArgs = {
 };
 
 
-/** Unhandled JS errors: app_events exception rows. */
+/** JS errors and native crashes: app_events *.exception rows. */
 export type AppObserveErrors_StatsArgs = {
   input: AppObserveErrorsStatsInput;
 };
 
 
-/** Unhandled JS errors: app_events exception rows. */
+/** JS errors and native crashes: app_events *.exception rows. */
 export type AppObserveErrors_TimeSeriesArgs = {
   input: AppObserveErrorsTimeSeriesInput;
 };
@@ -3119,6 +3114,8 @@ export type AppObserveErrorsBreakdownInput = {
   environment?: InputMaybe<Scalars['String']['input']>;
   fingerprint: Scalars['String']['input'];
   isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Restrict to one error kind (JS errors, native crashes, or other *.exception events). */
+  kind?: InputMaybe<AppObserveErrorKind>;
   /** Filter to these platforms. */
   platforms?: InputMaybe<Array<AppObservePlatform>>;
   startTime: Scalars['DateTime']['input'];
@@ -3136,6 +3133,8 @@ export type AppObserveErrorsGroupsInput = {
   /** Restrict to one error group. */
   fingerprint?: InputMaybe<Scalars['String']['input']>;
   isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Restrict to one error kind (JS errors, native crashes, or other *.exception events). */
+  kind?: InputMaybe<AppObserveErrorKind>;
   orderBy?: InputMaybe<AppObserveErrorGroupsOrderBy>;
   /** Filter to these platforms. */
   platforms?: InputMaybe<Array<AppObservePlatform>>;
@@ -3152,6 +3151,8 @@ export type AppObserveErrorsStatsInput = {
   endTime: Scalars['DateTime']['input'];
   environment?: InputMaybe<Scalars['String']['input']>;
   isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Restrict to one error kind (JS errors, native crashes, or other *.exception events). */
+  kind?: InputMaybe<AppObserveErrorKind>;
   /** Filter to these platforms. */
   platforms?: InputMaybe<Array<AppObservePlatform>>;
   startTime: Scalars['DateTime']['input'];
@@ -3168,6 +3169,8 @@ export type AppObserveErrorsTimeSeriesInput = {
   /** Restrict to one error group. */
   fingerprint?: InputMaybe<Scalars['String']['input']>;
   isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Restrict to one error kind (JS errors, native crashes, or other *.exception events). */
+  kind?: InputMaybe<AppObserveErrorKind>;
   /** Filter to these platforms. */
   platforms?: InputMaybe<Array<AppObservePlatform>>;
   startTime: Scalars['DateTime']['input'];
@@ -3969,10 +3972,99 @@ export type AppObserveUserEvent = AppObserveLog & {
   timestamp: Scalars['DateTime']['output'];
 };
 
+export type AppObserveUserEventBreakdown = {
+  __typename?: 'AppObserveUserEventBreakdown';
+  /** Buckets ordered by count descending. */
+  buckets: Array<AppObserveUserEventBreakdownBucket>;
+  /** True when more buckets exist than were returned (top-N truncation). */
+  isTruncated: Scalars['Boolean']['output'];
+  /** Number of distinct dimension values before truncation. */
+  totalBucketCount: Scalars['Int']['output'];
+};
+
+export type AppObserveUserEventBreakdownBucket = {
+  __typename?: 'AppObserveUserEventBreakdownBucket';
+  count: Scalars['Int']['output'];
+  /** Dimension value (app version, OS, device model, country code, or EAS client id). Empty string when unknown. */
+  key: Scalars['String']['output'];
+  uniqueUserCount: Scalars['Int']['output'];
+};
+
+export enum AppObserveUserEventBreakdownDimension {
+  AppVersion = 'APP_VERSION',
+  Country = 'COUNTRY',
+  Device = 'DEVICE',
+  Os = 'OS',
+  OsVersion = 'OS_VERSION',
+  User = 'USER'
+}
+
+export type AppObserveUserEventBreakdownInput = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  countryCode?: InputMaybe<Scalars['String']['input']>;
+  deviceModel?: InputMaybe<Scalars['String']['input']>;
+  deviceOsVersion?: InputMaybe<Scalars['String']['input']>;
+  dimension: AppObserveUserEventBreakdownDimension;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Maximum buckets to return, 1 to 100. Defaults to 100. */
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  /** Event name. The reserved `exception` name is rejected. */
+  name: Scalars['String']['input'];
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  startTime: Scalars['DateTime']['input'];
+};
+
 export type AppObserveUserEventConnection = {
   __typename?: 'AppObserveUserEventConnection';
   edges: Array<AppObserveUserEventEdge>;
   pageInfo: PageInfo;
+};
+
+export type AppObserveUserEventCountBucket = {
+  __typename?: 'AppObserveUserEventCountBucket';
+  bucket: Scalars['DateTime']['output'];
+  count: Scalars['Int']['output'];
+};
+
+export type AppObserveUserEventCountSeries = {
+  __typename?: 'AppObserveUserEventCountSeries';
+  /** Buckets with at least one occurrence, ascending. Empty buckets are omitted. */
+  buckets: Array<AppObserveUserEventCountBucket>;
+  name: Scalars['String']['output'];
+  /** Sum of count across all buckets. */
+  totalCount: Scalars['Int']['output'];
+};
+
+export type AppObserveUserEventCounts = {
+  __typename?: 'AppObserveUserEventCounts';
+  /** One series per requested name, in request order. */
+  series: Array<AppObserveUserEventCountSeries>;
+};
+
+export type AppObserveUserEventCountsInput = {
+  appBuildNumber?: InputMaybe<Scalars['String']['input']>;
+  appEasBuildId?: InputMaybe<Scalars['String']['input']>;
+  appUpdateId?: InputMaybe<Scalars['String']['input']>;
+  appVersion?: InputMaybe<Scalars['String']['input']>;
+  /** Bucket width. Defaults to 60. The range must not exceed 2000 buckets. */
+  bucketIntervalMinutes?: InputMaybe<Scalars['Int']['input']>;
+  countryCode?: InputMaybe<Scalars['String']['input']>;
+  deviceModel?: InputMaybe<Scalars['String']['input']>;
+  deviceOsVersion?: InputMaybe<Scalars['String']['input']>;
+  endTime: Scalars['DateTime']['input'];
+  environment?: InputMaybe<Scalars['String']['input']>;
+  isEmbeddedUpdate?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Event names to count. At most 10; the reserved `exception` name is rejected. */
+  names: Array<Scalars['String']['input']>;
+  /** Filter to these platforms. */
+  platforms?: InputMaybe<Array<AppObservePlatform>>;
+  startTime: Scalars['DateTime']['input'];
 };
 
 export type AppObserveUserEventEdge = {
@@ -3986,6 +4078,9 @@ export type AppObserveUserEventListFilter = {
   appEasBuildId?: InputMaybe<Scalars['String']['input']>;
   appUpdateId?: InputMaybe<Scalars['String']['input']>;
   appVersion?: InputMaybe<Scalars['String']['input']>;
+  countryCode?: InputMaybe<Scalars['String']['input']>;
+  deviceModel?: InputMaybe<Scalars['String']['input']>;
+  deviceOsVersion?: InputMaybe<Scalars['String']['input']>;
   easClientId?: InputMaybe<Scalars['String']['input']>;
   endTime?: InputMaybe<Scalars['DateTime']['input']>;
   environment?: InputMaybe<Scalars['String']['input']>;
@@ -4052,12 +4147,28 @@ export type AppObserveUserEventPropertyFilter = {
 /** User-defined events (`Observe.logEvent`): app_events log rows, excluding errors. */
 export type AppObserveUserEvents = {
   __typename?: 'AppObserveUserEvents';
+  /** Top values of one dimension (app version, OS, device, user, ...) for a single event name. */
+  breakdown: AppObserveUserEventBreakdown;
+  /** Time-bucketed occurrence counts, one series per requested event name. */
+  counts: AppObserveUserEventCounts;
   /** A single user-defined event by id. Null when missing, aged out, or the id belongs to an error. */
   event?: Maybe<AppObserveUserEvent>;
   /** Individual user-defined events. Defaults to newest first. */
   list: AppObserveUserEventConnection;
   /** Distinct event names with counts over the time range. */
   names: AppObserveUserEventNames;
+};
+
+
+/** User-defined events (`Observe.logEvent`): app_events log rows, excluding errors. */
+export type AppObserveUserEvents_BreakdownArgs = {
+  input: AppObserveUserEventBreakdownInput;
+};
+
+
+/** User-defined events (`Observe.logEvent`): app_events log rows, excluding errors. */
+export type AppObserveUserEvents_CountsArgs = {
+  input: AppObserveUserEventCountsInput;
 };
 
 
@@ -4178,7 +4289,8 @@ export type AppStoreConnectApiKey = {
   appleTeam?: Maybe<AppleTeam>;
   createdAt: Scalars['DateTime']['output'];
   id: Scalars['ID']['output'];
-  issuerIdentifier: Scalars['String']['output'];
+  /** Null for individual (user-scoped) keys, which only support submissions. */
+  issuerIdentifier?: Maybe<Scalars['String']['output']>;
   keyIdentifier: Scalars['String']['output'];
   keyP8: Scalars['String']['output'];
   name?: Maybe<Scalars['String']['output']>;
@@ -4194,7 +4306,11 @@ export type AppStoreConnectApiKey_RemoteAppStoreConnectAppsArgs = {
 
 export type AppStoreConnectApiKeyInput = {
   appleTeamId?: InputMaybe<Scalars['ID']['input']>;
-  issuerIdentifier: Scalars['String']['input'];
+  /**
+   * Omit for individual (user-scoped) keys, which have no issuer ID and only
+   * support submissions.
+   */
+  issuerIdentifier?: InputMaybe<Scalars['String']['input']>;
   keyIdentifier: Scalars['String']['input'];
   keyP8: Scalars['String']['input'];
   name?: InputMaybe<Scalars['String']['input']>;
@@ -4977,7 +5093,8 @@ export type ArgentRunSessionRemoteConfig = {
 };
 
 export type AscApiKeyInput = {
-  issuerIdentifier: Scalars['String']['input'];
+  /** Omit for individual (user-scoped) keys, which have no issuer ID. */
+  issuerIdentifier?: InputMaybe<Scalars['String']['input']>;
   keyIdentifier: Scalars['String']['input'];
   keyP8: Scalars['String']['input'];
 };
@@ -5909,15 +6026,6 @@ export type Charge = {
   wasRefunded: Scalars['Boolean']['output'];
 };
 
-/** A human user's chat token usage over the trailing 30 days, with their fair-usage limit. */
-export type ChatTokenUsage = {
-  __typename?: 'ChatTokenUsage';
-  isLimitExceeded: Scalars['Boolean']['output'];
-  /** Null when the user's plan has no chat token limit. */
-  limitTokens?: Maybe<Scalars['Int']['output']>;
-  usedTokens: Scalars['Int']['output'];
-};
-
 export type ClaudeAuthorization = {
   __typename?: 'ClaudeAuthorization';
   authorizationUrl: Scalars['String']['output'];
@@ -6340,6 +6448,7 @@ export type CreateFingerprintInput = {
 
 export type CreateGitHubAppInstallationInput = {
   accountId: Scalars['ID']['input'];
+  githubAppRegistrationId?: InputMaybe<Scalars['ID']['input']>;
   installationIdentifier: Scalars['Int']['input'];
 };
 
@@ -6539,135 +6648,6 @@ export enum CustomDomainStatus {
   Pending = 'PENDING',
   TimedOut = 'TIMED_OUT'
 }
-
-/** A dashboard AI chat conversation, private to the user who created it. */
-export type DashboardChat = {
-  __typename?: 'DashboardChat';
-  account: Account;
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['ID']['output'];
-  lastMessageAt?: Maybe<Scalars['DateTime']['output']>;
-  /** Most recent first */
-  messages: DashboardChatMessageConnection;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
-
-/** A dashboard AI chat conversation, private to the user who created it. */
-export type DashboardChat_MessagesArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-};
-
-export type DashboardChatConnection = {
-  __typename?: 'DashboardChatConnection';
-  edges: Array<DashboardChatEdge>;
-  pageInfo: PageInfo;
-};
-
-export type DashboardChatEdge = {
-  __typename?: 'DashboardChatEdge';
-  cursor: Scalars['String']['output'];
-  node: DashboardChat;
-};
-
-export type DashboardChatMessage = {
-  __typename?: 'DashboardChatMessage';
-  /** Client-supplied; unique per chat, not globally */
-  clientMessageId: Scalars['String']['output'];
-  id: Scalars['ID']['output'];
-  /** UIMessage parts, stored verbatim, ordered by index */
-  parts: Array<Scalars['JSONObject']['output']>;
-  role: DashboardChatMessageRole;
-  status?: Maybe<DashboardChatMessageStatus>;
-};
-
-export type DashboardChatMessageConnection = {
-  __typename?: 'DashboardChatMessageConnection';
-  edges: Array<DashboardChatMessageEdge>;
-  pageInfo: PageInfo;
-};
-
-export type DashboardChatMessageEdge = {
-  __typename?: 'DashboardChatMessageEdge';
-  cursor: Scalars['String']['output'];
-  node: DashboardChatMessage;
-};
-
-export enum DashboardChatMessageRole {
-  Assistant = 'ASSISTANT',
-  User = 'USER'
-}
-
-/** Terminal state of an assistant message */
-export enum DashboardChatMessageStatus {
-  Canceled = 'CANCELED',
-  Completed = 'COMPLETED',
-  Error = 'ERROR'
-}
-
-export type DashboardChatMutation = {
-  __typename?: 'DashboardChatMutation';
-  /** Persist a user message. Idempotent on clientMessageId. */
-  addUserMessage: DashboardChatMessage;
-  /** Create a new chat owned by the viewer */
-  createChat: DashboardChat;
-  /** Delete a chat and all of its messages */
-  deleteChat: DashboardChat;
-  /** Rename a chat */
-  renameChat: DashboardChat;
-  /**
-   * Persist an assistant message, replacing parts when a message with the
-   * same clientMessageId already exists.
-   */
-  upsertAssistantMessage: DashboardChatMessage;
-};
-
-
-export type DashboardChatMutation_AddUserMessageArgs = {
-  accountID: Scalars['ID']['input'];
-  chatID: Scalars['ID']['input'];
-  clientMessageId: Scalars['String']['input'];
-  parts: Array<Scalars['JSONObject']['input']>;
-};
-
-
-export type DashboardChatMutation_CreateChatArgs = {
-  accountID: Scalars['ID']['input'];
-};
-
-
-export type DashboardChatMutation_DeleteChatArgs = {
-  chatID: Scalars['ID']['input'];
-};
-
-
-export type DashboardChatMutation_RenameChatArgs = {
-  chatID: Scalars['ID']['input'];
-  title: Scalars['String']['input'];
-};
-
-
-export type DashboardChatMutation_UpsertAssistantMessageArgs = {
-  accountID: Scalars['ID']['input'];
-  chatID: Scalars['ID']['input'];
-  clientMessageId: Scalars['String']['input'];
-  parts: Array<Scalars['JSONObject']['input']>;
-  status: DashboardChatMessageStatus;
-};
-
-export type DashboardChatQuery = {
-  __typename?: 'DashboardChatQuery';
-  /** Get dashboard chat by ID - entry point to the graph */
-  byId?: Maybe<DashboardChat>;
-};
-
-
-export type DashboardChatQuery_ByIdArgs = {
-  id: Scalars['ID']['input'];
-};
 
 export enum DashboardViewPin {
   Activity = 'ACTIVITY',
@@ -8634,18 +8614,6 @@ export type GitHubAppInstallation = {
   registration?: Maybe<GitHubAppRegistration>;
 };
 
-export type GitHubAppInstallationAccessibleRepository = {
-  __typename?: 'GitHubAppInstallationAccessibleRepository';
-  defaultBranch?: Maybe<Scalars['String']['output']>;
-  description?: Maybe<Scalars['String']['output']>;
-  id: Scalars['Int']['output'];
-  name: Scalars['String']['output'];
-  nodeId: Scalars['String']['output'];
-  owner: GitHubRepositoryOwner;
-  private: Scalars['Boolean']['output'];
-  url: Scalars['String']['output'];
-};
-
 export enum GitHubAppInstallationAccountType {
   Organization = 'ORGANIZATION',
   User = 'USER'
@@ -8709,20 +8677,35 @@ export type GitHubAppQuery_InstallationArgs = {
   id: Scalars['ID']['input'];
 };
 
-/** A GitHub Enterprise app. */
+/** A GitHub App Expo can act through. */
 export type GitHubAppRegistration = {
   __typename?: 'GitHubAppRegistration';
-  /** The Expo account that owns this registration. */
-  account: Account;
+  /** The Expo account that owns this registration, or null for the default github.com app. */
+  account?: Maybe<Account>;
+  /**
+   * Installations visible to the viewer's GitHub user, or null when the viewer's GitHub
+   * authorization for this registration could not be used. The accompanying error says why.
+   */
+  appInstallationsForViewer?: Maybe<Array<AccessibleGitHubAppInstallation>>;
   /** URL of the app's page on its GitHub instance, e.g. https://github.example.com/github-apps/expo. */
   githubAppUrl: Scalars['String']['output'];
   /** Public OAuth client id of the GHE app. */
   githubClientIdentifier: Scalars['String']['output'];
   id: Scalars['ID']['output'];
-  /** Origin of the GitHub Enterprise instance, e.g. https://github.example.com or https://example.ghe.com. No trailing slash. */
+  /** Origin of the GitHub instance. */
   origin: Scalars['String']['output'];
+  /** Repositories the viewer's GitHub user can reach through the given installation. */
+  repositoriesForViewer: GitHubAppRegistrationRepositoriesConnection;
   /** The GHE app slug. */
   slug: Scalars['String']['output'];
+};
+
+
+/** A GitHub App Expo can act through. */
+export type GitHubAppRegistration_RepositoriesForViewerArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  installationIdentifier: Scalars['Int']['input'];
 };
 
 /** Registration data for the GitHub App manifest flow. */
@@ -8768,6 +8751,28 @@ export type GitHubAppRegistrationMutation_StartGitHubAppRegistrationArgs = {
   input: StartGitHubAppRegistrationInput;
 };
 
+export type GitHubAppRegistrationQuery = {
+  __typename?: 'GitHubAppRegistrationQuery';
+  byId: GitHubAppRegistration;
+};
+
+
+export type GitHubAppRegistrationQuery_ByIdArgs = {
+  githubAppRegistrationId: Scalars['ID']['input'];
+};
+
+export type GitHubAppRegistrationRepositoriesConnection = {
+  __typename?: 'GitHubAppRegistrationRepositoriesConnection';
+  edges: Array<GitHubAppRegistrationRepositoryEdge>;
+  pageInfo: PageInfo;
+};
+
+export type GitHubAppRegistrationRepositoryEdge = {
+  __typename?: 'GitHubAppRegistrationRepositoryEdge';
+  cursor: Scalars['String']['output'];
+  node: AccessibleGitHubRepository;
+};
+
 export type GitHubBuildInput = {
   appId: Scalars['ID']['input'];
   autoSubmit?: InputMaybe<Scalars['Boolean']['input']>;
@@ -8776,6 +8781,8 @@ export type GitHubBuildInput = {
   environment?: InputMaybe<Scalars['EnvironmentVariableEnvironment']['input']>;
   gitRef: Scalars['String']['input'];
   platform: AppPlatform;
+  /** Refresh the ad hoc provisioning profile before building. Supported for iOS builds with a build profile that uses internal distribution and remote credentials. */
+  refreshAdHocProvisioningProfile?: InputMaybe<Scalars['Boolean']['input']>;
   submitProfile?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -8900,6 +8907,7 @@ export enum GitHubJobRunTriggerType {
 export type GitHubRepository = {
   __typename?: 'GitHubRepository';
   app: App;
+  branchesForViewer: Array<Scalars['String']['output']>;
   createdAt: Scalars['DateTime']['output'];
   githubAppInstallation: GitHubAppInstallation;
   githubRepositoryIdentifier: Scalars['Int']['output'];
@@ -8954,20 +8962,6 @@ export type GitHubRepositoryMutation_ScheduleGitHubRepositoryDeletionArgs = {
   githubRepositoryId: Scalars['ID']['input'];
 };
 
-export type GitHubRepositoryOwner = {
-  __typename?: 'GitHubRepositoryOwner';
-  avatarUrl: Scalars['String']['output'];
-  id: Scalars['Int']['output'];
-  login: Scalars['String']['output'];
-  url: Scalars['String']['output'];
-};
-
-export type GitHubRepositoryPaginationResult = {
-  __typename?: 'GitHubRepositoryPaginationResult';
-  repositories: Array<GitHubAppInstallationAccessibleRepository>;
-  totalCount: Scalars['Int']['output'];
-};
-
 export type GitHubRepositorySettings = {
   __typename?: 'GitHubRepositorySettings';
   app: App;
@@ -9006,6 +9000,7 @@ export type GitHubUser = {
   githubUserIdentifier: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   metadata?: Maybe<GitHubUserMetadata>;
+  registration?: Maybe<GitHubAppRegistration>;
   userActor: UserActor;
 };
 
@@ -9028,6 +9023,11 @@ export type GitHubUserMutation = {
 
 export type GitHubUserMutation_DeleteGitHubUserArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type GitHubUserMutation_GenerateGitHubUserAccessTokenArgs = {
+  githubAppRegistrationId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type GoogleServiceAccountKey = {
@@ -9729,8 +9729,6 @@ export type MeMutation = {
   leaveAccount: LeaveAccountResult;
   /** Purge unfinished two-factor authentication setup for the current user if not fully-set-up */
   purgeUnfinishedSecondFactorAuthentication: SecondFactorBooleanResult;
-  /** Record chat token usage for the current user. */
-  recordChatTokenUsage: ChatTokenUsage;
   /** Regenerate backup codes for the current user */
   regenerateSecondFactorBackupCodes: SecondFactorRegenerateBackupCodesResult;
   /** Schedule deletion for Account created via createAccount */
@@ -9792,12 +9790,6 @@ export type MeMutation_InitiateSecondFactorAuthenticationArgs = {
 
 export type MeMutation_LeaveAccountArgs = {
   accountId: Scalars['ID']['input'];
-};
-
-
-export type MeMutation_RecordChatTokenUsageArgs = {
-  inputTokens: Scalars['Int']['input'];
-  outputTokens: Scalars['Int']['input'];
 };
 
 
@@ -10504,8 +10496,6 @@ export type RootMutation = {
   convexProject: ConvexProjectMutation;
   convexTeamConnection: ConvexTeamConnectionMutation;
   customDomain: CustomDomainMutation;
-  /** Mutations for dashboard chats */
-  dashboardChat: DashboardChatMutation;
   deployments: DeploymentsMutation;
   /** Mutations that assign or modify DevDomainNames for apps */
   devDomainName: AppDevDomainNameMutation;
@@ -10674,8 +10664,6 @@ export type RootQuery = {
   channels: ChannelQuery;
   /** Top-level query object for querying Convex Integration information. */
   convexIntegration: ConvexIntegrationQuery;
-  /** Top-level query object for querying dashboard chats. */
-  dashboardChat: DashboardChatQuery;
   /** Top-level query object for querying Deployments. */
   deployments: DeploymentQuery;
   deviceRunSessionArtifacts: DeviceRunSessionArtifactQuery;
@@ -10696,6 +10684,7 @@ export type RootQuery = {
   expoGoBuild: ExpoGoBuildQuery;
   /** Top-level query object for querying GitHub App information and resources it has access to. */
   githubApp: GitHubAppQuery;
+  githubAppRegistrations: GitHubAppRegistrationQuery;
   /** Top-level query object for querying Google Service Account Keys. */
   googleServiceAccountKey: GoogleServiceAccountKeyQuery;
   /** Top-level query object for querying Stripe Invoices. */
@@ -10744,8 +10733,6 @@ export type RootQuery = {
    * query object
    */
   viewer?: Maybe<User>;
-  /** The current user's chat token usage and limit. */
-  viewerChatTokenUsage: ChatTokenUsage;
   /** Top-level query object for querying Webhooks. */
   webhook: WebhookQuery;
   workerDeployment: WorkerDeploymentQuery;
@@ -10898,8 +10885,19 @@ export type SsoUser = Actor & UserActor & {
   featureGates: Scalars['JSONObject']['output'];
   firstName?: Maybe<Scalars['String']['output']>;
   fullName?: Maybe<Scalars['String']['output']>;
-  /** GitHub account linked to a user */
+  /**
+   * Every GitHub App registration this actor can link a GitHub user through. Includes the default
+   * github.com app. An entry is null when that registration failed to resolve; the accompanying
+   * error says why.
+   */
+  githubAppRegistrations: Array<Maybe<GitHubAppRegistration>>;
+  /** GitHub.com account linked to a user */
   githubUser?: Maybe<GitHubUser>;
+  /**
+   * Every GitHub account linked to a user, one per GitHub App registration they have linked
+   * through. Includes githubUser.
+   */
+  githubUsers: Array<GitHubUser>;
   id: Scalars['ID']['output'];
   isExpoAdmin: Scalars['Boolean']['output'];
   isStaffModeEnabled: Scalars['Boolean']['output'];
@@ -12458,8 +12456,19 @@ export type User = Actor & UserActor & {
   featureGates: Scalars['JSONObject']['output'];
   firstName?: Maybe<Scalars['String']['output']>;
   fullName?: Maybe<Scalars['String']['output']>;
-  /** GitHub account linked to a user */
+  /**
+   * Every GitHub App registration this actor can link a GitHub user through. Includes the default
+   * github.com app. An entry is null when that registration failed to resolve; the accompanying
+   * error says why.
+   */
+  githubAppRegistrations: Array<Maybe<GitHubAppRegistration>>;
+  /** GitHub.com account linked to a user */
   githubUser?: Maybe<GitHubUser>;
+  /**
+   * Every GitHub account linked to a user, one per GitHub App registration they have linked
+   * through. Includes githubUser.
+   */
+  githubUsers: Array<GitHubUser>;
   hasPassword: Scalars['Boolean']['output'];
   /** Whether this user has any pending user invitations. Only resolves for the viewer. */
   hasPendingUserInvitations: Scalars['Boolean']['output'];
@@ -12556,8 +12565,19 @@ export type UserActor = {
   featureGates: Scalars['JSONObject']['output'];
   firstName?: Maybe<Scalars['String']['output']>;
   fullName?: Maybe<Scalars['String']['output']>;
-  /** GitHub account linked to a user */
+  /**
+   * Every GitHub App registration this actor can link a GitHub user through. Includes the default
+   * github.com app. An entry is null when that registration failed to resolve; the accompanying
+   * error says why.
+   */
+  githubAppRegistrations: Array<Maybe<GitHubAppRegistration>>;
+  /** GitHub.com account linked to a user */
   githubUser?: Maybe<GitHubUser>;
+  /**
+   * Every GitHub account linked to a user, one per GitHub App registration they have linked
+   * through. Includes githubUser.
+   */
+  githubUsers: Array<GitHubUser>;
   id: Scalars['ID']['output'];
   isExpoAdmin: Scalars['Boolean']['output'];
   isStaffModeEnabled: Scalars['Boolean']['output'];
@@ -14902,7 +14922,7 @@ export type CreateAppStoreConnectApiKeyMutationVariables = Exact<{
 }>;
 
 
-export type CreateAppStoreConnectApiKeyMutation = { __typename?: 'RootMutation', appStoreConnectApiKey: { __typename?: 'AppStoreConnectApiKeyMutation', createAppStoreConnectApiKey: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } } };
+export type CreateAppStoreConnectApiKeyMutation = { __typename?: 'RootMutation', appStoreConnectApiKey: { __typename?: 'AppStoreConnectApiKeyMutation', createAppStoreConnectApiKey: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier?: string | null, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } } };
 
 export type DeleteAppStoreConnectApiKeyMutationVariables = Exact<{
   appStoreConnectApiKeyId: Scalars['ID']['input'];
@@ -15075,7 +15095,7 @@ export type CreateIosAppCredentialsMutation = { __typename?: 'RootMutation', ios
            | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?:
                 | { __typename?: 'SSOUser', id: string, username: string }
                 | { __typename?: 'User', id: string, username: string }
-               | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
+               | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier?: string | null, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
 
 export type SetPushKeyMutationVariables = Exact<{
   iosAppCredentialsId: Scalars['ID']['input'];
@@ -15092,7 +15112,7 @@ export type SetPushKeyMutation = { __typename?: 'RootMutation', iosAppCredential
            | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?:
                 | { __typename?: 'SSOUser', id: string, username: string }
                 | { __typename?: 'User', id: string, username: string }
-               | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
+               | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier?: string | null, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
 
 export type SetAppStoreConnectApiKeyForSubmissionsMutationVariables = Exact<{
   iosAppCredentialsId: Scalars['ID']['input'];
@@ -15109,7 +15129,7 @@ export type SetAppStoreConnectApiKeyForSubmissionsMutation = { __typename?: 'Roo
            | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?:
                 | { __typename?: 'SSOUser', id: string, username: string }
                 | { __typename?: 'User', id: string, username: string }
-               | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
+               | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier?: string | null, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null } } };
 
 export type AppStoreConnectApiKeysPaginatedByAccountQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
@@ -15120,7 +15140,7 @@ export type AppStoreConnectApiKeysPaginatedByAccountQueryVariables = Exact<{
 }>;
 
 
-export type AppStoreConnectApiKeysPaginatedByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appStoreConnectApiKeysPaginated: { __typename?: 'AccountAppStoreConnectApiKeysConnection', edges: Array<{ __typename?: 'AccountAppStoreConnectApiKeysEdge', cursor: string, node: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
+export type AppStoreConnectApiKeysPaginatedByAccountQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, appStoreConnectApiKeysPaginated: { __typename?: 'AccountAppStoreConnectApiKeysConnection', edges: Array<{ __typename?: 'AccountAppStoreConnectApiKeysEdge', cursor: string, node: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier?: string | null, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } } };
 
 export type AppleAppIdentifierByBundleIdQueryVariables = Exact<{
   accountName: Scalars['String']['input'];
@@ -15249,7 +15269,7 @@ export type IosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = { __ty
              | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?:
                   | { __typename?: 'SSOUser', id: string, username: string }
                   | { __typename?: 'User', id: string, username: string }
-                 | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null }> } } };
+                 | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier?: string | null, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null }> } } };
 
 export type CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQueryVariables = Exact<{
   projectFullName: Scalars['String']['input'];
@@ -15266,7 +15286,7 @@ export type CommonIosAppCredentialsWithBuildCredentialsByAppIdentifierIdQuery = 
              | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?:
                   | { __typename?: 'SSOUser', id: string, username: string }
                   | { __typename?: 'User', id: string, username: string }
-                 | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null }> } } };
+                 | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier?: string | null, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null }> } } };
 
 export type CreateAppMutationVariables = Exact<{
   appInput: AppInput;
@@ -15893,7 +15913,7 @@ export type AppStoreConnectApiKeyByIdQueryVariables = Exact<{
 }>;
 
 
-export type AppStoreConnectApiKeyByIdQuery = { __typename?: 'RootQuery', appStoreConnectApiKey: { __typename?: 'AppStoreConnectApiKeyQuery', byId: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, keyP8: string } } };
+export type AppStoreConnectApiKeyByIdQuery = { __typename?: 'RootQuery', appStoreConnectApiKey: { __typename?: 'AppStoreConnectApiKeyQuery', byId: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier?: string | null, keyIdentifier: string, keyP8: string } } };
 
 export type LatestAppVersionQueryVariables = Exact<{
   appId: Scalars['String']['input'];
@@ -16820,7 +16840,7 @@ export type AndroidFcmFragment = { __typename?: 'AndroidFcm', id: string, creden
 
 export type AndroidKeystoreFragment = { __typename?: 'AndroidKeystore', id: string, type: AndroidKeystoreType, keystore: string, keystorePassword: string, keyAlias: string, keyPassword?: string | null, md5CertificateFingerprint?: string | null, sha1CertificateFingerprint?: string | null, sha256CertificateFingerprint?: string | null, createdAt: any, updatedAt: any };
 
-export type AppStoreConnectApiKeyFragment = { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null };
+export type AppStoreConnectApiKeyFragment = { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier?: string | null, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null };
 
 export type AppleAppIdentifierFragment = { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string };
 
@@ -16857,7 +16877,7 @@ export type CommonIosAppCredentialsWithoutBuildCredentialsFragment = { __typenam
        | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?:
             | { __typename?: 'SSOUser', id: string, username: string }
             | { __typename?: 'User', id: string, username: string }
-           | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null };
+           | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier?: string | null, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null };
 
 export type CommonIosAppCredentialsFragment = { __typename?: 'IosAppCredentials', id: string, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosDistributionType: IosDistributionType, distributionCertificate?: { __typename?: 'AppleDistributionCertificate', id: string, certificateP12?: string | null, certificatePassword?: string | null, serialNumber: string, developerPortalIdentifier?: string | null, validityNotBefore: any, validityNotAfter: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppBuildCredentialsList: Array<{ __typename?: 'IosAppBuildCredentials', id: string, iosAppCredentials: { __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?:
                 | { __typename?: 'SSOUser', id: string, username: string }
@@ -16868,7 +16888,7 @@ export type CommonIosAppCredentialsFragment = { __typename?: 'IosAppCredentials'
        | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string }, pushKey?: { __typename?: 'ApplePushKey', id: string, keyIdentifier: string, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null, iosAppCredentialsList: Array<{ __typename?: 'IosAppCredentials', id: string, app: { __typename?: 'App', id: string, name: string, fullName: string, slug: string, ownerAccount: { __typename?: 'Account', id: string, name: string, ownerUserActor?:
             | { __typename?: 'SSOUser', id: string, username: string }
             | { __typename?: 'User', id: string, username: string }
-           | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier: string, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null };
+           | null, viewerUserPermission: { __typename?: 'UserPermission', role: Role } }, githubRepository?: { __typename?: 'GitHubRepository', id: string, metadata: { __typename?: 'GitHubRepositoryMetadata', id: string, githubRepoOwnerName: string, githubRepoName: string } } | null }, appleAppIdentifier: { __typename?: 'AppleAppIdentifier', id: string, bundleIdentifier: string } }> } | null, appStoreConnectApiKeyForSubmissions?: { __typename?: 'AppStoreConnectApiKey', id: string, issuerIdentifier?: string | null, keyIdentifier: string, name?: string | null, roles?: Array<AppStoreConnectUserRole> | null, createdAt: any, updatedAt: any, appleTeam?: { __typename?: 'AppleTeam', id: string, appleTeamIdentifier: string, appleTeamName?: string | null } | null } | null };
 
 export type ScheduleUpdateGroupDeletionMutationVariables = Exact<{
   group: Scalars['ID']['input'];

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -16313,6 +16313,14 @@ export type AppObserveNavigationRoutesQueryVariables = Exact<{
 
 export type AppObserveNavigationRoutesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', navigation: { __typename?: 'AppObserveNavigation', routes: { __typename?: 'AppObserveNavigationRoutesConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveNavigationRouteEdge', cursor: string, node: { __typename?: 'AppObserveNavigationRoute', routeName: string, coldTtr: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null }, warmTtr: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null }, tti: { __typename?: 'AppObserveNavigationStat', count: number, median?: number | null, p90?: number | null } } }> } } } } } };
 
+export type AppObserveErrorGroupsQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+  input: AppObserveErrorsGroupsInput;
+}>;
+
+
+export type AppObserveErrorGroupsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', errors: { __typename?: 'AppObserveErrors', groups: { __typename?: 'AppObserveErrorGroups', isTruncated: boolean, groups: Array<{ __typename?: 'AppObserveErrorGroup', fingerprint: string, exceptionType?: string | null, exceptionMessage?: string | null, errorSource?: string | null, severity: AppObserveErrorSeverity, isFatal: boolean, eventCount: number, uniqueUserCount: number, affectedSessionCount: number, firstSeenAt: any, lastSeenAt: any, platforms: Array<string> }> } } } } } };
+
 export type AppObserveSessionEventsQueryVariables = Exact<{
   appId: Scalars['String']['input'];
   id: Scalars['ID']['input'];
@@ -16720,6 +16728,8 @@ export type AppObserveUserEventFragment = { __typename?: 'AppObserveUserEvent', 
 export type AppObserveErrorFragment = { __typename?: 'AppObserveError', id: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, type?: string | null, message?: string | null, source?: string | null, fingerprint?: string | null, isFatal?: boolean | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> };
 
 export type AppObserveMetricFragment = { __typename?: 'AppObserveMetric', id: string, name: string, value: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null, routeName?: string | null };
+
+export type AppObserveErrorGroupFragment = { __typename?: 'AppObserveErrorGroup', fingerprint: string, exceptionType?: string | null, exceptionMessage?: string | null, errorSource?: string | null, severity: AppObserveErrorSeverity, isFatal: boolean, eventCount: number, uniqueUserCount: number, affectedSessionCount: number, firstSeenAt: any, lastSeenAt: any, platforms: Array<string> };
 
 export type AppObserveAppVersionFragment = { __typename?: 'AppObserveAppVersion', appVersion: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, buildNumbers: Array<{ __typename?: 'AppObserveAppBuildNumber', appBuildNumber: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, updates: Array<{ __typename?: 'AppObserveAppUpdate', appUpdateId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number, easBuilds: Array<{ __typename?: 'AppObserveAppEasBuild', easBuildId: string, firstSeenAt: any, eventCount: number, uniqueUserCount: number }> }>, metrics: Array<{ __typename?: 'AppObserveAppVersionMetric', metricName: string, eventCount: number, statistics: { __typename?: 'AppObserveVersionMarkerStatistics', min?: number | null, max?: number | null, median?: number | null, average?: number | null, p80?: number | null, p90?: number | null, p99?: number | null } }> };
 

--- a/packages/eas-cli/src/graphql/generated.ts
+++ b/packages/eas-cli/src/graphql/generated.ts
@@ -16321,6 +16321,17 @@ export type AppObserveErrorGroupsQueryVariables = Exact<{
 
 export type AppObserveErrorGroupsQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', errors: { __typename?: 'AppObserveErrors', groups: { __typename?: 'AppObserveErrorGroups', isTruncated: boolean, groups: Array<{ __typename?: 'AppObserveErrorGroup', fingerprint: string, exceptionType?: string | null, exceptionMessage?: string | null, errorSource?: string | null, severity: AppObserveErrorSeverity, isFatal: boolean, eventCount: number, uniqueUserCount: number, affectedSessionCount: number, firstSeenAt: any, lastSeenAt: any, platforms: Array<string> }> } } } } } };
 
+export type AppObserveErrorOccurrencesQueryVariables = Exact<{
+  appId: Scalars['String']['input'];
+  filter?: InputMaybe<AppObserveErrorOccurrencesFilter>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  orderBy?: InputMaybe<AppObserveErrorOccurrencesOrderBy>;
+}>;
+
+
+export type AppObserveErrorOccurrencesQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, observe: { __typename?: 'AppObserve', errors: { __typename?: 'AppObserveErrors', occurrences: { __typename?: 'AppObserveErrorConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'AppObserveErrorEdge', cursor: string, node: { __typename?: 'AppObserveError', id: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, type?: string | null, message?: string | null, source?: string | null, fingerprint?: string | null, isFatal?: boolean | null, stacktrace?: string | null, body?: string | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> } }> } } } } } };
+
 export type AppObserveSessionEventsQueryVariables = Exact<{
   appId: Scalars['String']['input'];
   id: Scalars['ID']['input'];
@@ -16726,6 +16737,8 @@ export type FingerprintFragment = { __typename?: 'Fingerprint', id: string, hash
 export type AppObserveUserEventFragment = { __typename?: 'AppObserveUserEvent', id: string, name: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> };
 
 export type AppObserveErrorFragment = { __typename?: 'AppObserveError', id: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, type?: string | null, message?: string | null, source?: string | null, fingerprint?: string | null, isFatal?: boolean | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> };
+
+export type AppObserveErrorOccurrenceFragment = { __typename?: 'AppObserveError', id: string, timestamp: any, sessionId?: string | null, severityNumber?: number | null, severityText?: string | null, type?: string | null, message?: string | null, source?: string | null, fingerprint?: string | null, isFatal?: boolean | null, stacktrace?: string | null, body?: string | null, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, appEasBuildId?: string | null, deviceOs: string, deviceOsVersion: string, deviceModel: string, environment?: string | null, easClientId: string, countryCode?: string | null, properties: Array<{ __typename?: 'AppObserveEventProperty', key: string, value: string, type: AppObservePropertyType }> };
 
 export type AppObserveMetricFragment = { __typename?: 'AppObserveMetric', id: string, name: string, value: number, timestamp: any, appVersion: string, appBuildNumber: string, appUpdateId?: string | null, deviceModel: string, deviceOs: string, deviceOsVersion: string, countryCode?: string | null, sessionId?: string | null, easClientId: string, customParams?: any | null, routeName?: string | null };
 

--- a/packages/eas-cli/src/graphql/queries/AppStoreConnectApiKeyQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/AppStoreConnectApiKeyQuery.ts
@@ -12,7 +12,7 @@ export const AppStoreConnectApiKeyQuery = {
     graphqlClient: ExpoGraphqlClient,
     ascApiKeyId: string
   ): Promise<{
-    issuerIdentifier: string;
+    issuerIdentifier: string | null | undefined;
     keyIdentifier: string;
     keyP8: string;
   }> {

--- a/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
@@ -5,6 +5,8 @@ import { withErrorHandlingAsync } from '../client';
 import {
   AppObserveAppVersion,
   AppObserveError,
+  AppObserveErrorGroup,
+  AppObserveErrorsGroupsInput,
   AppObserveLogsOrderBy,
   AppObserveMetric,
   AppObserveMetricsListFilter,
@@ -24,6 +26,7 @@ import { print } from 'graphql';
 import {
   AppObserveAppVersionFragmentNode,
   AppObserveErrorFragmentNode,
+  AppObserveErrorGroupFragmentNode,
   AppObserveMetricFragmentNode,
   AppObserveUserEventFragmentNode,
 } from '../types/Observe';
@@ -154,6 +157,27 @@ type AppObserveNavigationRoutesQueryVariables = {
   first?: number;
   after?: string;
   orderBy?: AppObserveNavigationOrderBy;
+};
+
+type AppObserveErrorGroupsQuery = {
+  app: {
+    byId: {
+      id: string;
+      observe: {
+        errors: {
+          groups: {
+            isTruncated: boolean;
+            groups: AppObserveErrorGroup[];
+          };
+        };
+      };
+    };
+  };
+};
+
+type AppObserveErrorGroupsQueryVariables = {
+  appId: string;
+  input: AppObserveErrorsGroupsInput;
 };
 
 type AppObserveSessionEventsQuery = {
@@ -464,6 +488,41 @@ export const ObserveQuery = {
       routes: edges.map(edge => edge.node),
       pageInfo,
     };
+  },
+
+  async errorGroupsAsync(
+    graphqlClient: ExpoGraphqlClient,
+    { appId, input }: { appId: string; input: AppObserveErrorsGroupsInput }
+  ): Promise<{ groups: AppObserveErrorGroup[]; isTruncated: boolean }> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<AppObserveErrorGroupsQuery, AppObserveErrorGroupsQueryVariables>(
+          gql`
+            query AppObserveErrorGroups($appId: String!, $input: AppObserveErrorsGroupsInput!) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  observe {
+                    errors {
+                      groups(input: $input) {
+                        isTruncated
+                        groups {
+                          ...AppObserveErrorGroupFragment
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            ${print(AppObserveErrorGroupFragmentNode)}
+          `,
+          { appId, input }
+        )
+        .toPromise()
+    );
+
+    return data.app.byId.observe.errors.groups;
   },
 
   async sessionEventsAsync(

--- a/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
+++ b/packages/eas-cli/src/graphql/queries/ObserveQuery.ts
@@ -6,6 +6,8 @@ import {
   AppObserveAppVersion,
   AppObserveError,
   AppObserveErrorGroup,
+  AppObserveErrorOccurrencesFilter,
+  AppObserveErrorOccurrencesOrderBy,
   AppObserveErrorsGroupsInput,
   AppObserveLogsOrderBy,
   AppObserveMetric,
@@ -27,6 +29,7 @@ import {
   AppObserveAppVersionFragmentNode,
   AppObserveErrorFragmentNode,
   AppObserveErrorGroupFragmentNode,
+  AppObserveErrorOccurrenceFragmentNode,
   AppObserveMetricFragmentNode,
   AppObserveUserEventFragmentNode,
 } from '../types/Observe';
@@ -178,6 +181,30 @@ type AppObserveErrorGroupsQuery = {
 type AppObserveErrorGroupsQueryVariables = {
   appId: string;
   input: AppObserveErrorsGroupsInput;
+};
+
+type AppObserveErrorOccurrencesQuery = {
+  app: {
+    byId: {
+      id: string;
+      observe: {
+        errors: {
+          occurrences: {
+            pageInfo: PageInfo;
+            edges: Array<{ cursor: string; node: AppObserveError }>;
+          };
+        };
+      };
+    };
+  };
+};
+
+type AppObserveErrorOccurrencesQueryVariables = {
+  appId: string;
+  filter: AppObserveErrorOccurrencesFilter;
+  first?: number;
+  after?: string;
+  orderBy?: AppObserveErrorOccurrencesOrderBy;
 };
 
 type AppObserveSessionEventsQuery = {
@@ -523,6 +550,64 @@ export const ObserveQuery = {
     );
 
     return data.app.byId.observe.errors.groups;
+  },
+
+  async errorOccurrencesAsync(
+    graphqlClient: ExpoGraphqlClient,
+    variables: AppObserveErrorOccurrencesQueryVariables
+  ): Promise<{ occurrences: AppObserveError[]; pageInfo: PageInfo }> {
+    const data = await withErrorHandlingAsync(
+      graphqlClient
+        .query<AppObserveErrorOccurrencesQuery, AppObserveErrorOccurrencesQueryVariables>(
+          gql`
+            query AppObserveErrorOccurrences(
+              $appId: String!
+              $filter: AppObserveErrorOccurrencesFilter
+              $first: Int
+              $after: String
+              $orderBy: AppObserveErrorOccurrencesOrderBy
+            ) {
+              app {
+                byId(appId: $appId) {
+                  id
+                  observe {
+                    errors {
+                      occurrences(
+                        filter: $filter
+                        first: $first
+                        after: $after
+                        orderBy: $orderBy
+                      ) {
+                        pageInfo {
+                          hasNextPage
+                          hasPreviousPage
+                          endCursor
+                        }
+                        edges {
+                          cursor
+                          node {
+                            id
+                            ...AppObserveErrorOccurrenceFragment
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            ${print(AppObserveErrorOccurrenceFragmentNode)}
+          `,
+          variables
+        )
+        .toPromise()
+    );
+
+    const { edges, pageInfo } = data.app.byId.observe.errors.occurrences;
+    return {
+      occurrences: edges.map(edge => edge.node),
+      pageInfo,
+    };
   },
 
   async sessionEventsAsync(

--- a/packages/eas-cli/src/graphql/types/Observe.ts
+++ b/packages/eas-cli/src/graphql/types/Observe.ts
@@ -56,6 +56,38 @@ export const AppObserveErrorFragmentNode = gql`
   }
 `;
 
+export const AppObserveErrorOccurrenceFragmentNode = gql`
+  fragment AppObserveErrorOccurrenceFragment on AppObserveError {
+    id
+    timestamp
+    sessionId
+    severityNumber
+    severityText
+    type
+    message
+    source
+    fingerprint
+    isFatal
+    stacktrace
+    body
+    properties {
+      key
+      value
+      type
+    }
+    appVersion
+    appBuildNumber
+    appUpdateId
+    appEasBuildId
+    deviceOs
+    deviceOsVersion
+    deviceModel
+    environment
+    easClientId
+    countryCode
+  }
+`;
+
 export const AppObserveMetricFragmentNode = gql`
   fragment AppObserveMetricFragment on AppObserveMetric {
     id

--- a/packages/eas-cli/src/graphql/types/Observe.ts
+++ b/packages/eas-cli/src/graphql/types/Observe.ts
@@ -76,6 +76,23 @@ export const AppObserveMetricFragmentNode = gql`
   }
 `;
 
+export const AppObserveErrorGroupFragmentNode = gql`
+  fragment AppObserveErrorGroupFragment on AppObserveErrorGroup {
+    fingerprint
+    exceptionType
+    exceptionMessage
+    errorSource
+    severity
+    isFatal
+    eventCount
+    uniqueUserCount
+    affectedSessionCount
+    firstSeenAt
+    lastSeenAt
+    platforms
+  }
+`;
+
 export const AppObserveAppVersionFragmentNode = gql`
   fragment AppObserveAppVersionFragment on AppObserveAppVersion {
     appVersion

--- a/packages/eas-cli/src/metadata/auth.ts
+++ b/packages/eas-cli/src/metadata/auth.ts
@@ -105,7 +105,7 @@ async function tryResolveAscApiKeyAsync({
         ascApiKey: {
           keyP8: fullKey.keyP8,
           keyId: fullKey.keyIdentifier,
-          issuerId: fullKey.issuerIdentifier,
+          issuerId: fullKey.issuerIdentifier ?? '',
         },
         teamId: ascKeyFragment.appleTeam?.appleTeamIdentifier,
         teamName: ascKeyFragment.appleTeam?.appleTeamName ?? undefined,

--- a/packages/eas-cli/src/observe/__tests__/formatErrors.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatErrors.test.ts
@@ -1,0 +1,59 @@
+import { AppObserveErrorGroup } from '../../graphql/generated';
+import { buildObserveErrorGroupsJson, buildObserveErrorGroupsTable } from '../formatErrors';
+
+function makeErrorGroup(overrides: Partial<AppObserveErrorGroup> = {}): AppObserveErrorGroup {
+  return {
+    __typename: 'AppObserveErrorGroup' as const,
+    fingerprint: 'fp-1',
+    exceptionType: 'TypeError',
+    exceptionMessage: 'undefined is not a function',
+    errorSource: 'js',
+    severity: 'FATAL',
+    isFatal: true,
+    eventCount: 42,
+    uniqueUserCount: 10,
+    affectedSessionCount: 8,
+    firstSeenAt: '2025-01-01T00:00:00.000Z',
+    lastSeenAt: '2025-01-15T00:00:00.000Z',
+    platforms: ['IOS'],
+    ...overrides,
+  } as AppObserveErrorGroup;
+}
+
+describe(buildObserveErrorGroupsTable, () => {
+  it('renders a placeholder when there are no error groups', () => {
+    expect(buildObserveErrorGroupsTable([])).toContain('No errors found');
+  });
+
+  it('renders the exception type, message, and counts', () => {
+    const output = buildObserveErrorGroupsTable([makeErrorGroup()]);
+    expect(output).toContain('TypeError');
+    expect(output).toContain('undefined is not a function');
+    expect(output).toContain('42');
+  });
+});
+
+describe(buildObserveErrorGroupsJson, () => {
+  it('maps error-group fields into stable JSON keys', () => {
+    const result = buildObserveErrorGroupsJson([makeErrorGroup()], false);
+    expect(result).toEqual({
+      isTruncated: false,
+      errors: [
+        {
+          fingerprint: 'fp-1',
+          type: 'TypeError',
+          message: 'undefined is not a function',
+          source: 'js',
+          severity: 'FATAL',
+          isFatal: true,
+          eventCount: 42,
+          uniqueUserCount: 10,
+          affectedSessionCount: 8,
+          firstSeenAt: '2025-01-01T00:00:00.000Z',
+          lastSeenAt: '2025-01-15T00:00:00.000Z',
+          platforms: ['IOS'],
+        },
+      ],
+    });
+  });
+});

--- a/packages/eas-cli/src/observe/__tests__/formatErrors.test.ts
+++ b/packages/eas-cli/src/observe/__tests__/formatErrors.test.ts
@@ -1,5 +1,10 @@
-import { AppObserveErrorGroup } from '../../graphql/generated';
-import { buildObserveErrorGroupsJson, buildObserveErrorGroupsTable } from '../formatErrors';
+import { AppObserveError, AppObserveErrorGroup, PageInfo } from '../../graphql/generated';
+import {
+  buildObserveErrorGroupsJson,
+  buildObserveErrorGroupsTable,
+  buildObserveErrorOccurrencesJson,
+  buildObserveErrorOccurrencesTable,
+} from '../formatErrors';
 
 function makeErrorGroup(overrides: Partial<AppObserveErrorGroup> = {}): AppObserveErrorGroup {
   return {
@@ -20,16 +25,81 @@ function makeErrorGroup(overrides: Partial<AppObserveErrorGroup> = {}): AppObser
   } as AppObserveErrorGroup;
 }
 
+function makeErrorOccurrence(overrides: Partial<AppObserveError> = {}): AppObserveError {
+  return {
+    __typename: 'AppObserveError' as const,
+    id: 'err-1',
+    type: 'TypeError',
+    message: 'undefined is not a function',
+    source: 'js',
+    fingerprint: 'fp-1',
+    severityText: 'fatal',
+    severityNumber: null,
+    isFatal: true,
+    stacktrace: 'at foo (app.js:1:1)\nat bar (app.js:2:2)',
+    body: null,
+    timestamp: '2025-01-15T10:00:00.000Z',
+    sessionId: 'session-1',
+    appVersion: '1.0.0',
+    appBuildNumber: '42',
+    appUpdateId: null,
+    appEasBuildId: null,
+    deviceModel: 'iPhone 15',
+    deviceOs: 'iOS',
+    deviceOsVersion: '17.0',
+    environment: 'production',
+    easClientId: 'client-1',
+    countryCode: 'US',
+    properties: [],
+    ...overrides,
+  } as AppObserveError;
+}
+
+const noNextPage = {
+  __typename: 'PageInfo' as const,
+  hasNextPage: false,
+  hasPreviousPage: false,
+  endCursor: null,
+} as PageInfo;
+
 describe(buildObserveErrorGroupsTable, () => {
   it('renders a placeholder when there are no error groups', () => {
     expect(buildObserveErrorGroupsTable([])).toContain('No errors found');
   });
 
-  it('renders the exception type, message, and counts', () => {
+  it('renders the fingerprint, exception type, message, and counts', () => {
     const output = buildObserveErrorGroupsTable([makeErrorGroup()]);
+    expect(output).toContain('fp-1');
     expect(output).toContain('TypeError');
     expect(output).toContain('undefined is not a function');
     expect(output).toContain('42');
+    expect(output).toContain('--fingerprint');
+  });
+});
+
+describe(buildObserveErrorOccurrencesTable, () => {
+  it('renders a placeholder when there are no occurrences', () => {
+    const output = buildObserveErrorOccurrencesTable([], noNextPage, { fingerprint: 'fp-1' });
+    expect(output).toContain('No occurrences found');
+    expect(output).toContain('fp-1');
+  });
+
+  it('renders occurrence details including the stack trace', () => {
+    const output = buildObserveErrorOccurrencesTable([makeErrorOccurrence()], noNextPage, {
+      fingerprint: 'fp-1',
+    });
+    expect(output).toContain('Stack trace');
+    expect(output).toContain('at foo (app.js:1:1)');
+    expect(output).toContain('TypeError');
+  });
+});
+
+describe(buildObserveErrorOccurrencesJson, () => {
+  it('includes the stack trace and properties in the JSON', () => {
+    const result = buildObserveErrorOccurrencesJson([makeErrorOccurrence()], noNextPage);
+    expect(result.occurrences[0].stacktrace).toBe('at foo (app.js:1:1)\nat bar (app.js:2:2)');
+    expect(result.occurrences[0].id).toBe('err-1');
+    expect(result.pageInfo).toEqual({ hasNextPage: false, endCursor: null });
   });
 });
 

--- a/packages/eas-cli/src/observe/fetchErrors.ts
+++ b/packages/eas-cli/src/observe/fetchErrors.ts
@@ -1,0 +1,38 @@
+import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
+import {
+  AppObserveErrorGroup,
+  AppObserveErrorSeverity,
+  AppObservePlatform,
+} from '../graphql/generated';
+import { ObserveQuery } from '../graphql/queries/ObserveQuery';
+
+export interface FetchObserveErrorGroupsOptions {
+  startTime: string;
+  endTime: string;
+  platforms?: AppObservePlatform[];
+  appVersion?: string;
+  buildNumber?: string;
+  updateId?: string;
+  environment?: string;
+  severity?: AppObserveErrorSeverity;
+}
+
+export async function fetchObserveErrorGroupsAsync(
+  graphqlClient: ExpoGraphqlClient,
+  appId: string,
+  options: FetchObserveErrorGroupsOptions
+): Promise<{ groups: AppObserveErrorGroup[]; isTruncated: boolean }> {
+  return await ObserveQuery.errorGroupsAsync(graphqlClient, {
+    appId,
+    input: {
+      startTime: options.startTime,
+      endTime: options.endTime,
+      ...(options.platforms?.length && { platforms: options.platforms }),
+      ...(options.appVersion && { appVersion: options.appVersion }),
+      ...(options.buildNumber && { appBuildNumber: options.buildNumber }),
+      ...(options.updateId && { appUpdateId: options.updateId }),
+      ...(options.environment && { environment: options.environment }),
+      ...(options.severity && { severity: options.severity }),
+    },
+  });
+}

--- a/packages/eas-cli/src/observe/fetchErrors.ts
+++ b/packages/eas-cli/src/observe/fetchErrors.ts
@@ -1,8 +1,12 @@
 import { ExpoGraphqlClient } from '../commandUtils/context/contextUtils/createGraphqlClient';
 import {
+  AppObserveError,
   AppObserveErrorGroup,
+  AppObserveErrorOccurrencesOrderByField,
   AppObserveErrorSeverity,
+  AppObserveOrderDirection,
   AppObservePlatform,
+  PageInfo,
 } from '../graphql/generated';
 import { ObserveQuery } from '../graphql/queries/ObserveQuery';
 
@@ -33,6 +37,45 @@ export async function fetchObserveErrorGroupsAsync(
       ...(options.updateId && { appUpdateId: options.updateId }),
       ...(options.environment && { environment: options.environment }),
       ...(options.severity && { severity: options.severity }),
+    },
+  });
+}
+
+export interface FetchObserveErrorOccurrencesOptions {
+  fingerprint: string;
+  startTime: string;
+  endTime: string;
+  platforms?: AppObservePlatform[];
+  appVersion?: string;
+  buildNumber?: string;
+  updateId?: string;
+  environment?: string;
+  limit: number;
+  after?: string;
+}
+
+export async function fetchObserveErrorOccurrencesAsync(
+  graphqlClient: ExpoGraphqlClient,
+  appId: string,
+  options: FetchObserveErrorOccurrencesOptions
+): Promise<{ occurrences: AppObserveError[]; pageInfo: PageInfo }> {
+  return await ObserveQuery.errorOccurrencesAsync(graphqlClient, {
+    appId,
+    filter: {
+      fingerprint: options.fingerprint,
+      startTime: options.startTime,
+      endTime: options.endTime,
+      ...(options.platforms?.length && { platforms: options.platforms }),
+      ...(options.appVersion && { appVersion: options.appVersion }),
+      ...(options.buildNumber && { appBuildNumber: options.buildNumber }),
+      ...(options.updateId && { appUpdateId: options.updateId }),
+      ...(options.environment && { environment: options.environment }),
+    },
+    first: options.limit,
+    ...(options.after && { after: options.after }),
+    orderBy: {
+      field: AppObserveErrorOccurrencesOrderByField.Timestamp,
+      direction: AppObserveOrderDirection.Desc,
     },
   });
 }

--- a/packages/eas-cli/src/observe/formatErrors.ts
+++ b/packages/eas-cli/src/observe/formatErrors.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
 
-import { AppObserveErrorGroup } from '../graphql/generated';
+import { AppObserveError, AppObserveErrorGroup, PageInfo } from '../graphql/generated';
 import renderTextTable from '../utils/renderTextTable';
-import { buildTimeRangeDescription, formatTimestamp } from './formatUtils';
+import { buildTimeRangeDescription, formatLogTimestamp, formatTimestamp } from './formatUtils';
 
 export interface ObserveErrorGroupJson {
   fingerprint: string | null;
@@ -37,8 +37,18 @@ export function buildObserveErrorGroupsTable(
     return chalk.yellow('No errors found.');
   }
 
-  const headers = ['Type', 'Message', 'Severity', 'Events', 'Users', 'Sessions', 'Last Seen'];
+  const headers = [
+    'Fingerprint',
+    'Type',
+    'Message',
+    'Severity',
+    'Events',
+    'Users',
+    'Sessions',
+    'Last Seen',
+  ];
   const rows: string[][] = groups.map(group => [
+    group.fingerprint,
     truncate(group.exceptionType ?? '-', 40),
     truncate(group.exceptionMessage ?? '-', 60),
     group.isFatal ? 'fatal' : (group.severity ?? '-').toString().toLowerCase(),
@@ -54,6 +64,10 @@ export function buildObserveErrorGroupsTable(
     lines.push(chalk.bold(`Errors ${timeDesc}`.trim()), '');
   }
   lines.push(renderTextTable(headers, rows));
+  lines.push(
+    '',
+    'Pass --fingerprint <fingerprint> to see individual occurrences with stack traces.'
+  );
   return lines.join('\n');
 }
 
@@ -78,4 +92,150 @@ export function buildObserveErrorGroupsJson(
     })),
     isTruncated,
   };
+}
+
+export interface ObserveErrorOccurrenceJson {
+  id: string;
+  type: string | null;
+  message: string | null;
+  source: string | null;
+  fingerprint: string | null;
+  severityNumber: number | null;
+  severityText: string | null;
+  isFatal: boolean | null;
+  stacktrace: string | null;
+  body: string | null;
+  timestamp: string;
+  sessionId: string | null;
+  appVersion: string;
+  appBuildNumber: string;
+  appUpdateId: string | null;
+  appEasBuildId: string | null;
+  deviceModel: string;
+  deviceOs: string;
+  deviceOsVersion: string;
+  countryCode: string | null;
+  environment: string | null;
+  easClientId: string;
+  properties: Array<{ key: string; value: string; type: string }>;
+}
+
+export function buildObserveErrorOccurrenceJson(
+  occurrence: AppObserveError
+): ObserveErrorOccurrenceJson {
+  return {
+    id: occurrence.id,
+    type: occurrence.type ?? null,
+    message: occurrence.message ?? null,
+    source: occurrence.source ?? null,
+    fingerprint: occurrence.fingerprint ?? null,
+    severityNumber: occurrence.severityNumber ?? null,
+    severityText: occurrence.severityText ?? null,
+    isFatal: occurrence.isFatal ?? null,
+    stacktrace: occurrence.stacktrace ?? null,
+    body: occurrence.body ?? null,
+    timestamp: occurrence.timestamp,
+    sessionId: occurrence.sessionId ?? null,
+    appVersion: occurrence.appVersion,
+    appBuildNumber: occurrence.appBuildNumber,
+    appUpdateId: occurrence.appUpdateId ?? null,
+    appEasBuildId: occurrence.appEasBuildId ?? null,
+    deviceModel: occurrence.deviceModel,
+    deviceOs: occurrence.deviceOs,
+    deviceOsVersion: occurrence.deviceOsVersion,
+    countryCode: occurrence.countryCode ?? null,
+    environment: occurrence.environment ?? null,
+    easClientId: occurrence.easClientId,
+    properties: occurrence.properties.map(p => ({ key: p.key, value: p.value, type: p.type })),
+  };
+}
+
+export function buildObserveErrorOccurrencesJson(
+  occurrences: AppObserveError[],
+  pageInfo: PageInfo
+): {
+  occurrences: ObserveErrorOccurrenceJson[];
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+} {
+  return {
+    occurrences: occurrences.map(buildObserveErrorOccurrenceJson),
+    pageInfo: {
+      hasNextPage: pageInfo.hasNextPage,
+      endCursor: pageInfo.endCursor ?? null,
+    },
+  };
+}
+
+/**
+ * Render a single error occurrence as a Field/Value detail table followed by
+ * its stack trace (and body, if present), for `eas observe:errors --fingerprint`.
+ */
+function buildObserveErrorOccurrenceDetail(occurrence: AppObserveError): string {
+  const severity = occurrence.isFatal ? 'fatal' : (occurrence.severityText ?? '-');
+  const rows: string[][] = [
+    ['ID', occurrence.id],
+    ['Exception', occurrence.type ?? '-'],
+    ['Message', occurrence.message ?? '-'],
+    ['Source', occurrence.source ?? '-'],
+    ['Severity', severity],
+    ['Timestamp', formatLogTimestamp(occurrence.timestamp)],
+    ['Session ID', occurrence.sessionId ?? '-'],
+    ['App Version', `${occurrence.appVersion} (${occurrence.appBuildNumber})`],
+    ['Update ID', occurrence.appUpdateId ?? '-'],
+    ['Platform', `${occurrence.deviceOs} ${occurrence.deviceOsVersion}`],
+    ['Device', occurrence.deviceModel],
+    ['Country', occurrence.countryCode ?? '-'],
+    ['Environment', occurrence.environment ?? '-'],
+  ];
+  const lines = [renderTextTable(['Field', 'Value'], rows)];
+  if (occurrence.stacktrace) {
+    lines.push('', chalk.bold('Stack trace'), '', occurrence.stacktrace);
+  }
+  if (occurrence.body) {
+    lines.push('', chalk.bold('Body'), '', occurrence.body);
+  }
+  if (occurrence.properties.length > 0) {
+    const propertyRows = occurrence.properties.map(p => [p.key, p.type, p.value]);
+    lines.push(
+      '',
+      chalk.bold('Properties'),
+      '',
+      renderTextTable(['Key', 'Type', 'Value'], propertyRows)
+    );
+  }
+  return lines.join('\n');
+}
+
+export interface BuildErrorOccurrencesOptions {
+  fingerprint: string;
+  daysBack?: number;
+  startTime?: string;
+  endTime?: string;
+}
+
+export function buildObserveErrorOccurrencesTable(
+  occurrences: AppObserveError[],
+  pageInfo: PageInfo,
+  options: BuildErrorOccurrencesOptions
+): string {
+  if (occurrences.length === 0) {
+    return chalk.yellow(`No occurrences found for fingerprint "${options.fingerprint}".`);
+  }
+
+  const timeDesc = buildTimeRangeDescription(options);
+  const lines: string[] = [chalk.bold(`Occurrences of ${options.fingerprint} ${timeDesc}`.trim())];
+  occurrences.forEach((occurrence, index) => {
+    lines.push(
+      '',
+      chalk.bold(`Occurrence ${index + 1}`),
+      '',
+      buildObserveErrorOccurrenceDetail(occurrence)
+    );
+  });
+
+  if (pageInfo.hasNextPage && pageInfo.endCursor) {
+    lines.push('', `Next page: --after ${pageInfo.endCursor}`);
+  }
+
+  return lines.join('\n');
 }

--- a/packages/eas-cli/src/observe/formatErrors.ts
+++ b/packages/eas-cli/src/observe/formatErrors.ts
@@ -1,0 +1,81 @@
+import chalk from 'chalk';
+
+import { AppObserveErrorGroup } from '../graphql/generated';
+import renderTextTable from '../utils/renderTextTable';
+import { buildTimeRangeDescription, formatTimestamp } from './formatUtils';
+
+export interface ObserveErrorGroupJson {
+  fingerprint: string | null;
+  type: string | null;
+  message: string | null;
+  source: string | null;
+  severity: string | null;
+  isFatal: boolean | null;
+  eventCount: number | null;
+  uniqueUserCount: number | null;
+  affectedSessionCount: number | null;
+  firstSeenAt: string | null;
+  lastSeenAt: string | null;
+  platforms: string[];
+}
+
+export interface BuildErrorGroupsTableOptions {
+  daysBack?: number;
+  startTime?: string;
+  endTime?: string;
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+}
+
+export function buildObserveErrorGroupsTable(
+  groups: AppObserveErrorGroup[],
+  options?: BuildErrorGroupsTableOptions
+): string {
+  if (groups.length === 0) {
+    return chalk.yellow('No errors found.');
+  }
+
+  const headers = ['Type', 'Message', 'Severity', 'Events', 'Users', 'Sessions', 'Last Seen'];
+  const rows: string[][] = groups.map(group => [
+    truncate(group.exceptionType ?? '-', 40),
+    truncate(group.exceptionMessage ?? '-', 60),
+    group.isFatal ? 'fatal' : (group.severity ?? '-').toString().toLowerCase(),
+    (group.eventCount ?? 0).toLocaleString(),
+    (group.uniqueUserCount ?? 0).toLocaleString(),
+    (group.affectedSessionCount ?? 0).toLocaleString(),
+    group.lastSeenAt ? formatTimestamp(group.lastSeenAt) : '-',
+  ]);
+
+  const lines: string[] = [];
+  if (options) {
+    const timeDesc = buildTimeRangeDescription(options);
+    lines.push(chalk.bold(`Errors ${timeDesc}`.trim()), '');
+  }
+  lines.push(renderTextTable(headers, rows));
+  return lines.join('\n');
+}
+
+export function buildObserveErrorGroupsJson(
+  groups: AppObserveErrorGroup[],
+  isTruncated: boolean
+): { errors: ObserveErrorGroupJson[]; isTruncated: boolean } {
+  return {
+    errors: groups.map(group => ({
+      fingerprint: group.fingerprint ?? null,
+      type: group.exceptionType ?? null,
+      message: group.exceptionMessage ?? null,
+      source: group.errorSource ?? null,
+      severity: group.severity ?? null,
+      isFatal: group.isFatal ?? null,
+      eventCount: group.eventCount ?? null,
+      uniqueUserCount: group.uniqueUserCount ?? null,
+      affectedSessionCount: group.affectedSessionCount ?? null,
+      firstSeenAt: group.firstSeenAt ?? null,
+      lastSeenAt: group.lastSeenAt ?? null,
+      platforms: group.platforms ?? [],
+    })),
+    isTruncated,
+  };
+}

--- a/packages/eas-cli/src/testflight/app.ts
+++ b/packages/eas-cli/src/testflight/app.ts
@@ -76,7 +76,7 @@ async function findAppWithAccountAscApiKeysAsync({
         token: new Token({
           key: keyP8,
           keyId: keyIdentifier,
-          issuerId: issuerIdentifier,
+          issuerId: issuerIdentifier ?? '',
           duration: ASC_TOKEN_DURATION_SECONDS,
         }),
       };


### PR DESCRIPTION
# Why

A new command is needed to support the display of errors and exceptions in the CLI.

# How

Add `observe:errors` to display error and exception issue groups grouped by fingerprint. Exceptions are now excluded from `observe:events` and surfaced here instead.  Supports the following flags to filter output: `--platform`, `--severity` (fatal|error), time range flags, `--app-version`, `--build-number`, `--update-id`, and `--environment`.

# Test Plan

- New unit tests added
- Tested against real projects in EAS production

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>