### PR TITLE
[build-tools] raise the remote session startup timeout to 200 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
+- [build-tools] Raise the remote session startup timeout from 60s to 200s so a slow npm install does not fail the session. ([#4341](https://github.com/expo/eas-cli/pull/4341) by [@gwdp](https://github.com/gwdp))
 
 ### 🧹 Chores
 

--- a/packages/build-tools/src/steps/functions/__tests__/startWebPreviewRemoteSession.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startWebPreviewRemoteSession.test.ts
@@ -64,7 +64,7 @@ describe(createStartWebPreviewRemoteSessionBuildFunction, () => {
       baseDomain: 'tunnel.example.com',
       env,
       logger,
-      timeoutMs: 60_000,
+      timeoutMs: 200_000,
       packageVersion: '1.2.3',
     });
     expect(uploadRemoteSessionConfigAsync).toHaveBeenCalledWith({

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -35,7 +35,7 @@ const AGENT_DEVICE_REPO_URL = 'https://github.com/callstack/agent-device.git';
 const SRC_DIR = '/tmp/agent-device-src';
 const AGENT_DEVICE_STATE_DIR = path.join(os.homedir(), '.agent-device');
 const DAEMON_JSON_PATH = path.join(AGENT_DEVICE_STATE_DIR, 'daemon.json');
-const STARTUP_TIMEOUT_MS = 60_000;
+const STARTUP_TIMEOUT_MS = 200_000;
 const AGENT_DEVICE_DAEMON_ENV = {
   AGENT_DEVICE_DAEMON_SERVER_MODE: 'http',
   AGENT_DEVICE_RETAIN_ARTIFACTS: '1',

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -44,7 +44,7 @@ const ARGENT_STATE_DIR = path.join(os.homedir(), '.argent');
 // ARGENT_EVENT_LOG) and the collector, so an ambient ARGENT_EVENT_LOG or a future change to
 // Argent's default can never make the two disagree.
 const ARGENT_EVENT_LOG_PATH = path.join(ARGENT_STATE_DIR, ARGENT_EVENT_LOG_FILENAME);
-const STARTUP_TIMEOUT_MS = 60_000;
+const STARTUP_TIMEOUT_MS = 200_000;
 
 const ArgentToolServerStateSchema = z.object({
   port: z.number(),

--- a/packages/build-tools/src/steps/functions/startWebPreviewRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startWebPreviewRemoteSession.ts
@@ -15,7 +15,7 @@ import {
   waitForDeviceRunSessionStoppedAsync,
 } from '../utils/remoteDeviceRunSession';
 
-const STARTUP_TIMEOUT_MS = 60_000;
+const STARTUP_TIMEOUT_MS = 200_000;
 
 export function createStartWebPreviewRemoteSessionBuildFunction(
   ctx: CustomBuildContext


### PR DESCRIPTION
# Why

Simulator sessions have been failing to start. The "Start serve-sim" step times out after 60 seconds with `Last output: <empty>`. npm has been slow because its audit endpoint hangs 


# How

Raise `STARTUP_TIMEOUT_MS` from 60s to 200s

# Test plan
CI