### PR TITLE
[eas-cli] Use bunx in simulator tool instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Use `bunx` for Agent Device and Argent commands in EAS Simulator session instructions. ([#4344](https://github.com/expo/eas-cli/pull/4344) by [@szdziedzic](https://github.com/szdziedzic))
+
 ### 🧹 Chores
 
 ## [23.2.0](https://github.com/expo/eas-cli/releases/tag/v23.2.0) - 2026-08-31

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -279,7 +279,7 @@ describe(Simulator, () => {
       [
         '🔑 Run the following to use agent-device with the simulator:',
         '',
-        'eas simulator:exec npx agent-device <command>',
+        'eas simulator:exec bunx agent-device <command>',
         '',
         '🌐 Open the following URL in your browser to preview the simulator:',
         '',

--- a/packages/eas-cli/src/simulator/__tests__/utils.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/utils.test.ts
@@ -19,6 +19,37 @@ const iosAppiumConfig = {
   webPreviewUrl: 'https://preview.example.test',
 };
 
+describe('managed simulator instructions', () => {
+  it('runs agent-device with bunx', () => {
+    const instructions = formatRemoteSessionInstructions(
+      {
+        __typename: 'AgentDeviceRunSessionRemoteConfig',
+        agentDeviceRemoteSessionUrl: 'https://agent.example.test',
+        agentDeviceRemoteSessionToken: 'agent-token',
+      },
+      'dotenv'
+    );
+
+    expect(instructions).toContain('eas simulator:exec bunx agent-device <command>');
+    expect(instructions).not.toContain('npx agent-device');
+  });
+
+  it('runs Argent with bunx', () => {
+    const instructions = formatRemoteSessionInstructions(
+      {
+        __typename: 'ArgentRunSessionRemoteConfig',
+        toolsUrl: 'https://argent.example.test',
+        toolsAuthToken: 'argent-token',
+      },
+      'dotenv'
+    );
+
+    expect(instructions).toContain(
+      "bunx @swmansion/argent link 'https://argent.example.test' --token 'argent-token' --yes"
+    );
+  });
+});
+
 describe('Appium simulator configuration', () => {
   it('maps the appium CLI value to the GraphQL enum', () => {
     expect(DEVICE_RUN_SESSION_TYPE_BY_FLAG_VALUE.appium).toBe(DeviceRunSessionType.Appium);

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -98,7 +98,7 @@ export function formatRemoteSessionInstructions(
           ? [
               '🔑 Run the following to use agent-device with the simulator:',
               '',
-              'eas simulator:exec npx agent-device <command>',
+              'eas simulator:exec bunx agent-device <command>',
             ]
           : [
               '🔑 Run the following in your shell to attach to the agent-device daemon:',
@@ -125,7 +125,8 @@ export function formatRemoteSessionInstructions(
               '🔑 Run the following to link your local Argent client to this simulator session:',
               '',
               [
-                'argent',
+                'bunx',
+                '@swmansion/argent',
                 'link',
                 `'${remoteConfig.toolsUrl}'`,
                 remoteConfig.toolsAuthToken


### PR DESCRIPTION
# Why

EAS Simulator prints commands for attaching Agent Device and Argent clients to managed sessions. Those commands should use Bun's package runner so users do not need a global Argent installation or `npx` for Agent Device.

# How

- Run Agent Device through `bunx agent-device` in the managed simulator command.
- Run Argent through its scoped `bunx @swmansion/argent` package.
- Add focused coverage for both generated commands and update the simulator integration expectation.

# Test Plan

- `yarn build`
- `yarn workspace eas-cli test src/simulator/__tests__/utils.test.ts src/commands/simulator/__tests__/index.test.ts --runInBand`
- `yarn workspace eas-cli typecheck`
- Modified-file Oxlint check
- `yarn fmt:check`
- `bunx agent-device --help`
- `bunx @swmansion/argent link --help`
