### PR TITLE
[eas-build-job] Add sandbox daemon protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-build-job] Add a shared protocol for sandbox daemon commands. ([#4346](https://github.com/expo/eas-cli/pull/4346) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores
@@ -64,7 +66,6 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- [eas-build-job] Add a shared protocol for sandbox daemon commands. ([#4346](https://github.com/expo/eas-cli/pull/4346) by [@sjchmiela](https://github.com/sjchmiela))
 - [build-tools] Add `lcd_width`, `lcd_height`, and `lcd_density` inputs to configure the Android emulator display. ([#4349](https://github.com/expo/eas-cli/pull/4349) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [eas-cli] Add `eas channel:protect` and `eas channel:unprotect` to manage EAS Update channel protection, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))
 - [eas-cli] Add `eas observe:errors` to display error and exception issue groups (grouped by fingerprint), with `--fingerprint <fingerprint>` to drill into a group's individual occurrences and stack traces. ([#4339](https://github.com/expo/eas-cli/pull/4339) by [@douglowder](https://github.com/douglowder))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-build-job] Add a shared protocol for sandbox daemon commands. ([#4346](https://github.com/expo/eas-cli/pull/4346) by [@sjchmiela](https://github.com/sjchmiela))
 - [build-tools] Add `lcd_width`, `lcd_height`, and `lcd_density` inputs to configure the Android emulator display. ([#4349](https://github.com/expo/eas-cli/pull/4349) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [eas-cli] Add `eas channel:protect` and `eas channel:unprotect` to manage EAS Update channel protection, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))
 - [eas-cli] Add `eas observe:errors` to display error and exception issue groups (grouped by fingerprint), with `--fingerprint <fingerprint>` to drill into a group's individual occurrences and stack traces. ([#4339](https://github.com/expo/eas-cli/pull/4339) by [@douglowder](https://github.com/douglowder))

--- a/packages/eas-build-job/src/__tests__/sandbox.test.ts
+++ b/packages/eas-build-job/src/__tests__/sandbox.test.ts
@@ -1,0 +1,66 @@
+import { SandboxDaemonCommands, SandboxDaemonRequestZ, SandboxDaemonResponseZ } from '../sandbox';
+
+describe('sandbox daemon protocol', () => {
+  it('validates command parameters', () => {
+    expect(
+      SandboxDaemonCommands.execCommand.params.parse({
+        cmd: 'pwd',
+        workdir: '/tmp',
+        tty: true,
+        yieldTimeMs: 10,
+      })
+    ).toEqual({ cmd: 'pwd', workdir: '/tmp', tty: true, yieldTimeMs: 10 });
+    expect(
+      SandboxDaemonCommands.writeStdin.params.parse({
+        sessionId: 1,
+        chars: '\u0003',
+        yieldTimeMs: 0,
+      })
+    ).toEqual({ sessionId: 1, chars: '\u0003', yieldTimeMs: 0 });
+  });
+
+  it.each([
+    { output: '', wallTimeSeconds: 0, exitCode: 0 },
+    { output: '', wallTimeSeconds: 0, terminationSignal: 'SIGTERM' },
+    { output: '', wallTimeSeconds: 0, sessionId: 1 },
+  ])('validates a command result with one terminal state', result => {
+    expect(SandboxDaemonCommands.execCommand.result.parse(result)).toEqual(result);
+  });
+
+  it.each([
+    { output: '', wallTimeSeconds: 0 },
+    { output: '', wallTimeSeconds: 0, exitCode: 0, sessionId: 1 },
+  ])('rejects a command result without exactly one terminal state', result => {
+    expect(() => SandboxDaemonCommands.writeStdin.result.parse(result)).toThrow();
+  });
+
+  it('validates success and error response envelopes', () => {
+    expect(
+      SandboxDaemonRequestZ.parse({
+        jsonrpc: '2.0',
+        id: 'request-id',
+        method: 'execCommand',
+        params: { cmd: 'pwd' },
+      })
+    ).toEqual({
+      jsonrpc: '2.0',
+      id: 'request-id',
+      method: 'execCommand',
+      params: { cmd: 'pwd' },
+    });
+    expect(
+      SandboxDaemonResponseZ.parse({ jsonrpc: '2.0', id: 'request-id', result: { output: '' } })
+    ).toEqual({ jsonrpc: '2.0', id: 'request-id', result: { output: '' } });
+    expect(
+      SandboxDaemonResponseZ.parse({
+        jsonrpc: '2.0',
+        id: 'request-id',
+        error: { code: -32603, message: 'Command failed' },
+      })
+    ).toEqual({
+      jsonrpc: '2.0',
+      id: 'request-id',
+      error: { code: -32603, message: 'Command failed' },
+    });
+  });
+});

--- a/packages/eas-build-job/src/index.ts
+++ b/packages/eas-build-job/src/index.ts
@@ -34,6 +34,7 @@ export * from './compositeFunction';
 export * from './submission-config';
 export * from './projectPackage';
 export * from './deviceRunSession';
+export * from './sandbox';
 
 const version = require('../package.json').version;
 export { version };

--- a/packages/eas-build-job/src/sandbox.ts
+++ b/packages/eas-build-job/src/sandbox.ts
@@ -72,7 +72,7 @@ export const SandboxDaemonRequestZ = z.object({
 export type SandboxDaemonRequest = z.output<typeof SandboxDaemonRequestZ>;
 
 export const SandboxDaemonResponseZ = z.union([
-  z.strictObject({ jsonrpc: z.literal('2.0'), id: z.string(), result: z.unknown() }),
+  z.strictObject({ jsonrpc: z.literal('2.0'), id: z.string(), result: z.unknown().nonoptional() }),
   z.strictObject({
     jsonrpc: z.literal('2.0'),
     id: z.string(),

--- a/packages/eas-build-job/src/sandbox.ts
+++ b/packages/eas-build-job/src/sandbox.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+
+export const SandboxDaemonCommands = {
+  execCommand: {
+    params: z.object({
+      cmd: z.string().min(1),
+      workdir: z.string().optional(),
+      tty: z.boolean().optional(),
+      yieldTimeMs: z.number().int().min(0).max(30_000).optional(),
+    }),
+    result: z.union([
+      z.strictObject({
+        output: z.string(),
+        wallTimeSeconds: z.number().nonnegative(),
+        exitCode: z.number().int(),
+      }),
+      z.strictObject({
+        output: z.string(),
+        wallTimeSeconds: z.number().nonnegative(),
+        terminationSignal: z.string().min(1),
+      }),
+      z.strictObject({
+        output: z.string(),
+        wallTimeSeconds: z.number().nonnegative(),
+        sessionId: z.number().int().positive(),
+      }),
+    ]),
+  },
+  writeStdin: {
+    params: z.object({
+      sessionId: z.number().int().positive(),
+      chars: z.string().optional(),
+      yieldTimeMs: z.number().int().min(0).max(30_000).optional(),
+    }),
+    result: z.union([
+      z.strictObject({
+        output: z.string(),
+        wallTimeSeconds: z.number().nonnegative(),
+        exitCode: z.number().int(),
+      }),
+      z.strictObject({
+        output: z.string(),
+        wallTimeSeconds: z.number().nonnegative(),
+        terminationSignal: z.string().min(1),
+      }),
+      z.strictObject({
+        output: z.string(),
+        wallTimeSeconds: z.number().nonnegative(),
+        sessionId: z.number().int().positive(),
+      }),
+    ]),
+  },
+} as const satisfies Record<string, { params: z.ZodType; result: z.ZodType }>;
+
+export type SandboxDaemonMethod = keyof typeof SandboxDaemonCommands;
+
+export type SandboxDaemonCommandParams<Method extends SandboxDaemonMethod> = z.output<
+  (typeof SandboxDaemonCommands)[Method]['params']
+>;
+
+export type SandboxDaemonCommandResult<Method extends SandboxDaemonMethod> = z.output<
+  (typeof SandboxDaemonCommands)[Method]['result']
+>;
+
+export const SandboxDaemonRequestZ = z.object({
+  jsonrpc: z.literal('2.0'),
+  id: z.string(),
+  method: z.string(),
+  params: z.unknown().optional(),
+});
+
+export type SandboxDaemonRequest = z.output<typeof SandboxDaemonRequestZ>;
+
+export const SandboxDaemonResponseZ = z.union([
+  z.strictObject({ jsonrpc: z.literal('2.0'), id: z.string(), result: z.unknown() }),
+  z.strictObject({
+    jsonrpc: z.literal('2.0'),
+    id: z.string(),
+    error: z.strictObject({ code: z.number().int(), message: z.string() }),
+  }),
+]);
+
+export type SandboxDaemonResponse = z.output<typeof SandboxDaemonResponseZ>;


### PR DESCRIPTION
## Why

"sandboxd" from `build-tools` needs to connect to the MCP server in `universe`. They need to be able to talk to each other. I'm thinking it might be nice if they shared an "API protocol"?

## How

Added Zod schema for input and output of to-be-supported messages to `eas-build-job`.

## Test plan

CI should pass. I think I tested this locally too.