### PR TITLE
[build-tools] Allow configuring Android emulator display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [build-tools] Add `lcd_width`, `lcd_height`, and `lcd_density` inputs to configure the Android emulator display. ([#4349](https://github.com/expo/eas-cli/pull/4349) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [eas-cli] Add `eas channel:protect` and `eas channel:unprotect` to manage EAS Update channel protection, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))
 
 ### 🐛 Bug fixes

--- a/packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startAndroidEmulator.test.ts
@@ -83,6 +83,31 @@ describe(createStartAndroidEmulatorBuildFunction, () => {
     mockedMkdtemp.mockRestore();
   });
 
+  it('passes profile and LCD inputs to emulator creation', async () => {
+    const systemImagePackage = 'system-images;android-35;default;x86_64';
+    await createStep({
+      device_identifier: 'medium_phone',
+      system_image_package: systemImagePackage,
+      lcd_width: 720,
+      lcd_height: 1600,
+      lcd_density: 262,
+    }).executeAsync();
+
+    expect(mockedSpawn).toHaveBeenCalledWith('sdkmanager', [systemImagePackage], expect.anything());
+    expect(mockedAndroidUtils.createAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deviceIdentifier: 'medium_phone',
+        systemImagePackage,
+        lcdWidth: 720,
+        lcdHeight: 1600,
+        lcdDensity: 262,
+      })
+    );
+    expect(mockedAndroidUtils.createAsync.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedAndroidUtils.startAsync.mock.invocationCallOrder[0]
+    );
+  });
+
   it('retries base emulator startup with increasing readiness timeouts', async () => {
     mockedAndroidUtils.startAsync
       .mockResolvedValueOnce(createStartResult('emulator-1111'))

--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -147,9 +147,9 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
               deviceName,
               systemImagePackage,
               deviceIdentifier: deviceIdentifier ?? null,
-              lcdWidth,
-              lcdHeight,
-              lcdDensity,
+              lcdWidth: lcdWidth ?? null,
+              lcdHeight: lcdHeight ?? null,
+              lcdDensity: lcdDensity ?? null,
               env,
               logger,
             });

--- a/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
+++ b/packages/build-tools/src/steps/functions/startAndroidEmulator.ts
@@ -47,6 +47,21 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
         allowedValueTypeName: BuildStepInputValueTypeName.STRING,
       }),
       BuildStepInput.createProvider({
+        id: 'lcd_width',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
+      }),
+      BuildStepInput.createProvider({
+        id: 'lcd_height',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
+      }),
+      BuildStepInput.createProvider({
+        id: 'lcd_density',
+        required: false,
+        allowedValueTypeName: BuildStepInputValueTypeName.NUMBER,
+      }),
+      BuildStepInput.createProvider({
         id: 'count',
         required: false,
         defaultValue: 1,
@@ -86,6 +101,9 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
       const systemImagePackage = `${inputs.system_image_package.value}`;
       // We can cast because allowedValueTypeName validated this is a string.
       const deviceIdentifier = inputs.device_identifier.value as AndroidDeviceName | undefined;
+      const lcdWidth = inputs.lcd_width.value as number | undefined;
+      const lcdHeight = inputs.lcd_height.value as number | undefined;
+      const lcdDensity = inputs.lcd_density.value as number | undefined;
       const shouldAdjustAnimationScale =
         env.ANDROID_EMULATOR_ADJUST_ANIMATION_SCALE !== 'false' &&
         env.ANDROID_EMULATOR_ADJUST_ANIMATION_SCALE !== '0';
@@ -129,6 +147,9 @@ export function createStartAndroidEmulatorBuildFunction(): BuildFunction {
               deviceName,
               systemImagePackage,
               deviceIdentifier: deviceIdentifier ?? null,
+              lcdWidth,
+              lcdHeight,
+              lcdDensity,
               env,
               logger,
             });

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -108,9 +108,9 @@ export namespace AndroidEmulatorUtils {
     deviceName: AndroidVirtualDeviceName;
     systemImagePackage: string;
     deviceIdentifier: AndroidDeviceName | null;
-    lcdWidth?: number;
-    lcdHeight?: number;
-    lcdDensity?: number;
+    lcdWidth: number | null;
+    lcdHeight: number | null;
+    lcdDensity: number | null;
     env: NodeJS.ProcessEnv;
     logger: bunyan;
   }): Promise<void> {
@@ -182,7 +182,7 @@ export namespace AndroidEmulatorUtils {
         }
       }
 
-      if (lcdWidth !== undefined && lcdHeight !== undefined && lcdDensity !== undefined) {
+      if (lcdWidth !== null && lcdHeight !== null && lcdDensity !== null) {
         logger.info(
           `Setting screen resolution to ${lcdWidth}x${lcdHeight} and density to ${lcdDensity} ppi.`
         );

--- a/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
+++ b/packages/build-tools/src/utils/AndroidEmulatorUtils.ts
@@ -99,12 +99,18 @@ export namespace AndroidEmulatorUtils {
     deviceName,
     systemImagePackage,
     deviceIdentifier,
+    lcdWidth,
+    lcdHeight,
+    lcdDensity,
     env,
     logger,
   }: {
     deviceName: AndroidVirtualDeviceName;
     systemImagePackage: string;
     deviceIdentifier: AndroidDeviceName | null;
+    lcdWidth?: number;
+    lcdHeight?: number;
+    lcdDensity?: number;
     env: NodeJS.ProcessEnv;
     logger: bunyan;
   }): Promise<void> {
@@ -174,6 +180,13 @@ export namespace AndroidEmulatorUtils {
             configIniFileContent = `${configIniFileContent}\nhw.lcd.height=${1170}\nhw.lcd.width=${540}\nhw.lcd.density=220\n`;
           }
         }
+      }
+
+      if (lcdWidth !== undefined && lcdHeight !== undefined && lcdDensity !== undefined) {
+        logger.info(
+          `Setting screen resolution to ${lcdWidth}x${lcdHeight} and density to ${lcdDensity} ppi.`
+        );
+        configIniFileContent = `${configIniFileContent}\nhw.lcd.height=${lcdHeight}\nhw.lcd.width=${lcdWidth}\nhw.lcd.density=${lcdDensity}\n`;
       }
 
       const shouldAdjustHeapSize =

--- a/packages/build-tools/src/utils/__integration-tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__integration-tests__/AndroidEmulatorUtils.test.ts
@@ -71,6 +71,9 @@ describe('AndroidEmulatorUtils', () => {
         deviceName,
         systemImagePackage: AndroidEmulatorUtils.defaultSystemImagePackage,
         deviceIdentifier: null,
+        lcdWidth: null,
+        lcdHeight: null,
+        lcdDensity: null,
         env: process.env,
         logger: createMockLogger({ logToConsole: true }),
       });
@@ -95,6 +98,9 @@ describe('AndroidEmulatorUtils', () => {
       deviceName,
       systemImagePackage: AndroidEmulatorUtils.defaultSystemImagePackage,
       deviceIdentifier: null,
+      lcdWidth: null,
+      lcdHeight: null,
+      lcdDensity: null,
       env: process.env,
       logger: createMockLogger({ logToConsole: true }),
     });
@@ -158,6 +164,9 @@ describe('AndroidEmulatorUtils', () => {
       deviceName,
       systemImagePackage: AndroidEmulatorUtils.defaultSystemImagePackage,
       deviceIdentifier: null,
+      lcdWidth: null,
+      lcdHeight: null,
+      lcdDensity: null,
       env: process.env,
       logger: createMockLogger({ logToConsole: true }),
     });
@@ -209,6 +218,9 @@ describe('AndroidEmulatorUtils', () => {
             deviceName,
             systemImagePackage: AndroidEmulatorUtils.defaultSystemImagePackage,
             deviceIdentifier: null,
+            lcdWidth: null,
+            lcdHeight: null,
+            lcdDensity: null,
             env: envForAttempt,
             logger: createMockLogger({ logToConsole: true }),
           });
@@ -290,6 +302,9 @@ describe('AndroidEmulatorUtils', () => {
         deviceName,
         systemImagePackage: AndroidEmulatorUtils.defaultSystemImagePackage,
         deviceIdentifier: null,
+        lcdWidth: null,
+        lcdHeight: null,
+        lcdDensity: null,
         env: process.env,
         logger,
       });
@@ -361,6 +376,9 @@ describe('AndroidEmulatorUtils', () => {
       deviceName,
       systemImagePackage: AndroidEmulatorUtils.defaultSystemImagePackage,
       deviceIdentifier: null,
+      lcdWidth: null,
+      lcdHeight: null,
+      lcdDensity: null,
       env: process.env,
       logger: createMockLogger({ logToConsole: true }),
     });

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -139,13 +139,7 @@ describe('AndroidEmulatorUtils', () => {
     it('does not apply an LCD configuration when it is omitted', async () => {
       const deviceName = 'generic-emulator' as AndroidVirtualDeviceName;
       const avdDirectory = `/home/expo/.android/avd/${deviceName}.avd`;
-      const initialConfig = [
-        'hw.lcd.height=2424',
-        'hw.lcd.width=1080',
-        'hw.lcd.density=420',
-        'skin.path=pixel_9',
-        'showDeviceFrame=yes',
-      ].join('\n');
+      const initialConfig = ['skin.path=pixel_9', 'showDeviceFrame=yes'].join('\n');
       await fs.promises.mkdir(avdDirectory, { recursive: true });
       await fs.promises.writeFile(`${avdDirectory}/config.ini`, initialConfig);
       const avdManagerPromise = Promise.resolve({ stdout: '', stderr: '' }) as any;
@@ -168,9 +162,7 @@ describe('AndroidEmulatorUtils', () => {
 
       const config = await fs.promises.readFile(`${avdDirectory}/config.ini`, 'utf8');
       expect(config).toContain(initialConfig);
-      expect(config).not.toContain('hw.lcd.height=1600');
-      expect(config).not.toContain('hw.lcd.width=720');
-      expect(config).not.toContain('hw.lcd.density=262');
+      expect(config).not.toContain('hw.lcd.');
     });
   });
 

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -8,7 +8,11 @@ import path from 'node:path';
 
 import { createMockLogger } from '../../__tests__/utils/logger';
 import { Sentry } from '../../sentry';
-import { AndroidEmulatorUtils, AndroidVirtualDeviceName } from '../AndroidEmulatorUtils';
+import {
+  AndroidDeviceName,
+  AndroidEmulatorUtils,
+  AndroidVirtualDeviceName,
+} from '../AndroidEmulatorUtils';
 import { retryAsync } from '../retry';
 
 jest.mock('@expo/turtle-spawn', () => ({
@@ -46,6 +50,125 @@ describe('AndroidEmulatorUtils', () => {
         await fs.promises.rm(temporaryDirectory, { force: true, recursive: true });
       })
     );
+  });
+
+  describe(AndroidEmulatorUtils.createAsync, () => {
+    it('applies an explicit LCD configuration after screen scaling', async () => {
+      const deviceName = 'eas-simulator' as AndroidVirtualDeviceName;
+      const avdDirectory = `/home/expo/.android/avd/${deviceName}.avd`;
+      await fs.promises.mkdir(avdDirectory, { recursive: true });
+      await fs.promises.writeFile(
+        `${avdDirectory}/config.ini`,
+        [
+          'hw.ramSize=1536',
+          'hw.lcd.height=2424',
+          'hw.lcd.width=1080',
+          'hw.lcd.density=420',
+          'skin.path=pixel_9',
+          'showDeviceFrame=yes',
+        ].join('\n')
+      );
+      const avdManagerPromise = Promise.resolve({ stdout: '', stderr: '' }) as any;
+      const write = jest.fn();
+      const end = jest.fn();
+      avdManagerPromise.child = { stdin: { write, end } };
+      mockedSpawn.mockReturnValue(avdManagerPromise);
+      const logger = createMockLogger();
+
+      await AndroidEmulatorUtils.createAsync({
+        deviceName,
+        systemImagePackage: 'system-images;android-35;default;x86_64',
+        deviceIdentifier: 'medium_phone' as AndroidDeviceName,
+        lcdWidth: 720,
+        lcdHeight: 1600,
+        lcdDensity: 262,
+        env: {
+          HOME: '/home/expo',
+          ANDROID_EMULATOR_ADJUST_SCREEN: '1',
+          ANDROID_EMULATOR_ADJUST_HEAP_SIZE: '0',
+        },
+        logger,
+      });
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        'avdmanager',
+        [
+          'create',
+          'avd',
+          '--name',
+          deviceName,
+          '--package',
+          'system-images;android-35;default;x86_64',
+          '--force',
+          '--device',
+          'medium_phone',
+        ],
+        { env: expect.any(Object), stdio: 'pipe' }
+      );
+      expect(write).toHaveBeenCalledWith('no');
+      expect(end).toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        'Setting scaled screen resolution: hw.lcd.height to 1270 and hw.lcd.width to 566.'
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        'Setting screen resolution to 720x1600 and density to 262 ppi.'
+      );
+      await expect(fs.promises.readFile(`${avdDirectory}/config.ini`, 'utf8')).resolves.toBe(
+        [
+          'hw.ramSize=1536',
+          'hw.lcd.height=2424',
+          'hw.lcd.width=1080',
+          'hw.lcd.density=420',
+          'skin.path=pixel_9',
+          'showDeviceFrame=yes',
+          'hw.ramSize=2048',
+          '',
+          'hw.lcd.density=220',
+          '',
+          'hw.lcd.height=1270',
+          'hw.lcd.width=566',
+          '',
+          'hw.lcd.height=1600',
+          'hw.lcd.width=720',
+          'hw.lcd.density=262',
+          '',
+        ].join('\n')
+      );
+    });
+
+    it('does not apply an LCD configuration when it is omitted', async () => {
+      const deviceName = 'generic-emulator' as AndroidVirtualDeviceName;
+      const avdDirectory = `/home/expo/.android/avd/${deviceName}.avd`;
+      const initialConfig = [
+        'hw.lcd.height=2424',
+        'hw.lcd.width=1080',
+        'hw.lcd.density=420',
+        'skin.path=pixel_9',
+        'showDeviceFrame=yes',
+      ].join('\n');
+      await fs.promises.mkdir(avdDirectory, { recursive: true });
+      await fs.promises.writeFile(`${avdDirectory}/config.ini`, initialConfig);
+      const avdManagerPromise = Promise.resolve({ stdout: '', stderr: '' }) as any;
+      avdManagerPromise.child = { stdin: { write: jest.fn(), end: jest.fn() } };
+      mockedSpawn.mockReturnValue(avdManagerPromise);
+
+      await AndroidEmulatorUtils.createAsync({
+        deviceName,
+        systemImagePackage: AndroidEmulatorUtils.defaultSystemImagePackage,
+        deviceIdentifier: null,
+        env: {
+          HOME: '/home/expo',
+          ANDROID_EMULATOR_ADJUST_HEAP_SIZE: '0',
+        },
+        logger: createMockLogger(),
+      });
+
+      const config = await fs.promises.readFile(`${avdDirectory}/config.ini`, 'utf8');
+      expect(config).toContain(initialConfig);
+      expect(config).not.toContain('hw.lcd.height=1600');
+      expect(config).not.toContain('hw.lcd.width=720');
+      expect(config).not.toContain('hw.lcd.density=262');
+    });
   });
 
   describe(AndroidEmulatorUtils.startAsync, () => {

--- a/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/AndroidEmulatorUtils.test.ts
@@ -156,6 +156,9 @@ describe('AndroidEmulatorUtils', () => {
         deviceName,
         systemImagePackage: AndroidEmulatorUtils.defaultSystemImagePackage,
         deviceIdentifier: null,
+        lcdWidth: null,
+        lcdHeight: null,
+        lcdDensity: null,
         env: {
           HOME: '/home/expo',
           ANDROID_EMULATOR_ADJUST_HEAP_SIZE: '0',


### PR DESCRIPTION
# Why

On a large Linux runner, Pixel 9 rendered 2.618M pixels (1080×2424) at about 30–35 FPS. Medium Phone renders 1.152M pixels (720×1600), 1.466M fewer pixels (~56%), and reaches 50–60 FPS. Medium Linux runners deliver roughly half these frame rates.

# How

Expose lcd_width, lcd_height, and lcd_density inputs for eas/start_android_emulator. So device sessions can set the resolution and density.

# Test Plan

The videos in the comment below show that the emulator runs fast enough to produce 60 fps on large running in the browser `testufo.com` while streaming using `expo-device-hub`. Ofc depending on the running app workload the produced fps can drop.

Focused tests, typecheck, lint, and format check.