### PR TITLE
[eas-cli] Confirm before creating a PostHog organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [eas-cli] Print the session token in simulator preview links, so they still open once the preview is gated. ([#4312](https://github.com/expo/eas-cli/pull/4312) by [@gwdp](https://github.com/gwdp))
+- [eas-cli] Confirm before `eas integrations:posthog:connect` creates a PostHog organization and project, since the CLI cannot remove them afterwards. ([#4350](https://github.com/expo/eas-cli/pull/4350) by [@LizunovSergey](https://github.com/LizunovSergey))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
@@ -536,12 +536,49 @@ describe(IntegrationsPostHogConnect, () => {
     expect(fs.writeFile).not.toHaveBeenCalled();
   });
 
-  it('does not confirm when reusing an existing organization', async () => {
+  it('does not ask about an organization when one is reused', async () => {
     jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
 
     await createCommand([]).runAsync();
 
     expect(confirmAsync).not.toHaveBeenCalledWith({
+      message: expect.stringContaining('Create a new PostHog organization and project'),
+    });
+    expect(PostHogMutation.setupPostHogProjectAsync).toHaveBeenCalled();
+  });
+
+  it('confirms before creating a project when the organization is reused', async () => {
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+
+    await createCommand([]).runAsync();
+
+    // Reusing an organization still provisions a project, which the CLI cannot remove either.
+    expect(confirmAsync).toHaveBeenCalledWith({
+      message: expect.stringContaining('There is no PostHog project for this app'),
+    });
+  });
+
+  it('creates nothing when the project confirmation is declined', async () => {
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+
+    await createCommand([]).runAsync();
+
+    expect(PostHogMutation.setupPostHogProjectAsync).not.toHaveBeenCalled();
+    expect(spawnAsync).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('asks once, not twice, when it creates both the organization and the project', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+
+    await createCommand(['--region', 'US']).runAsync();
+
+    expect(confirmAsync).toHaveBeenCalledTimes(1);
+    expect(confirmAsync).toHaveBeenCalledWith({
       message: expect.stringContaining('Create a new PostHog organization and project'),
     });
     expect(PostHogMutation.setupPostHogProjectAsync).toHaveBeenCalled();

--- a/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/__tests__/connect.test.ts
@@ -505,6 +505,60 @@ describe(IntegrationsPostHogConnect, () => {
     });
   });
 
+  it('confirms before creating a new organization and project', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+
+    await createCommand(['--region', 'US']).runAsync();
+
+    expect(confirmAsync).toHaveBeenCalledWith({
+      message: expect.stringContaining('Create a new PostHog organization and project'),
+    });
+    expect(PostHogMutation.startPostHogConnectionAsync).toHaveBeenCalled();
+  });
+
+  it('creates nothing when the confirmation is declined', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+    jest.mocked(confirmAsync).mockResolvedValue(false);
+
+    await createCommand(['--region', 'US']).runAsync();
+
+    // The organization cannot be removed by the CLI once it exists, so declining
+    // has to stop before the mutation rather than clean up after it.
+    expect(PostHogMutation.startPostHogConnectionAsync).not.toHaveBeenCalled();
+    expect(PostHogMutation.setupPostHogProjectAsync).not.toHaveBeenCalled();
+    expect(spawnAsync).not.toHaveBeenCalled();
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('does not confirm when reusing an existing organization', async () => {
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+
+    await createCommand([]).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalledWith({
+      message: expect.stringContaining('Create a new PostHog organization and project'),
+    });
+    expect(PostHogMutation.setupPostHogProjectAsync).toHaveBeenCalled();
+  });
+
+  it('provisions non-interactively without a confirmation prompt', async () => {
+    jest
+      .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)
+      .mockResolvedValue(null);
+    jest.mocked(PostHogQuery.getPostHogProjectByAppIdAsync).mockResolvedValue(null);
+
+    await createCommand(['--non-interactive', '--region', 'US']).runAsync();
+
+    expect(confirmAsync).not.toHaveBeenCalled();
+    expect(PostHogMutation.startPostHogConnectionAsync).toHaveBeenCalled();
+  });
+
   it('rethrows a non-dead-end provisioning failure', async () => {
     jest
       .mocked(PostHogQuery.getPostHogOrganizationConnectionByAccountIdAsync)

--- a/packages/eas-cli/src/commands/integrations/posthog/connect.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/connect.ts
@@ -140,6 +140,7 @@ export default class IntegrationsPostHogConnect extends EasCommand {
       graphqlClient,
       account.id
     );
+    let confirmedProvisioning = false;
     if (connection) {
       if (regionFlag && regionFlag !== connection.posthogRegion) {
         Log.warn(
@@ -165,12 +166,26 @@ export default class IntegrationsPostHogConnect extends EasCommand {
         }
       }
       connection = await this.startConnectionAsync(graphqlClient, account, region, nonInteractive);
+      confirmedProvisioning = true;
     }
 
     let project = await PostHogQuery.getPostHogProjectByAppIdAsync(graphqlClient, projectId);
     if (project) {
       Log.withTick(`Using existing PostHog project ${chalk.bold(project.posthogProjectName)}`);
     } else {
+      // Reusing an organization still creates a project, and the CLI cannot remove that either, so
+      // it needs the same confirmation unless the prompt above already covered it.
+      if (!nonInteractive && !confirmedProvisioning) {
+        const confirmed = await confirmAsync({
+          message: `There is no PostHog project for this app in ${chalk.bold(
+            connection.posthogOrganizationName
+          )}. Create one?`,
+        });
+        if (!confirmed) {
+          Log.log('Nothing was created.');
+          return;
+        }
+      }
       const spinner = ora('Setting up PostHog project').start();
       try {
         project = await PostHogMutation.setupPostHogProjectAsync(graphqlClient, {

--- a/packages/eas-cli/src/commands/integrations/posthog/connect.ts
+++ b/packages/eas-cli/src/commands/integrations/posthog/connect.ts
@@ -151,6 +151,19 @@ export default class IntegrationsPostHogConnect extends EasCommand {
       );
     } else {
       const region = await this.resolveRegionAsync(regionFlag, nonInteractive);
+      if (!nonInteractive) {
+        const confirmed = await confirmAsync({
+          message: `The ${chalk.bold(
+            account.name
+          )} account has no PostHog organization. Create a new PostHog organization and project in ${region}?`,
+        });
+        if (!confirmed) {
+          Log.log(
+            'Nothing was created. Connect an existing PostHog organization from the dashboard, or re-run this command to create one.'
+          );
+          return;
+        }
+      }
       connection = await this.startConnectionAsync(graphqlClient, account, region, nonInteractive);
     }
 


### PR DESCRIPTION
# Why

Fixes the first half of #4273.

`eas integrations:posthog:connect` creates a PostHog organization and project as soon as a region is picked. Region selection is the only prompt in front of that, so the first opportunity to stop is the feature prompt that comes *after* — by which point the resources already exist.

That matters more than a typical missing confirmation because the CLI cannot undo it. `eas integrations:posthog:disconnect` removes only the EAS-side link record; the organization then has to be deleted in the PostHog dashboard, under an account auto-created for the Expo account's email — which, as the reporter points out, the developer may not realize exists or have credentials for.

Scope note: #4273 raises two things, and this PR is deliberately only the first. The second — pointing the connection at a **pre-existing** PostHog project — is not fixable from the CLI: `setupPostHogProjectAsync` takes `appId` and `posthogOrganizationConnectionId` and no project selector, so choosing an existing project needs a server-side field first. The reporter wrote that either change would resolve the issue; this is the one that can land in this repo. Happy to follow up on the other if the mutation grows a selector.

# How

One confirmation immediately before the create path, in the branch that runs only when there is no organization to reuse:

```ts
} else {
  const region = await this.resolveRegionAsync(regionFlag, nonInteractive);
  if (!nonInteractive) {
    const confirmed = await confirmAsync({
      message: `The ${chalk.bold(account.name)} account has no PostHog organization. Create a new PostHog organization and project in ${region}?`,
    });
    if (!confirmed) {
      Log.log('Nothing was created. …');
      return;
    }
  }
  connection = await this.startConnectionAsync(...);
}
```

Three things this deliberately does **not** change:

- **Non-interactive runs behave exactly as before.** The prompt is skipped when `nonInteractive` is set, so scripted and CI use is untouched. `--json` implies `nonInteractive` via `resolveNonInteractiveAndJsonFlags`, so JSON output is unaffected too.
- **Reusing an existing organization does not prompt.** Nothing is created on that path, so there is nothing to confirm.
- **The declined path stops before the mutation** rather than creating and cleaning up, since cleanup is exactly what is impossible here.

The prompt sits after the region is resolved so the message can name the region, which is the part that cannot be changed later.

# Test Plan

Four tests added to the existing `connect.test.ts`; the file's `beforeEach` already defaults `confirmAsync` to `true` and to reusing an existing connection, so no existing test needed changing.

```
yarn jest src/commands/integrations/posthog/
Test Suites: 3 passed, 3 total
Tests:       62 passed, 62 total
```

That is 40 pre-existing tests in `connect.test.ts` still green, plus the 4 new ones:

| test | pins |
|---|---|
| `confirms before creating a new organization and project` | the prompt fires on the create path, and provisioning still proceeds on yes |
| `creates nothing when the confirmation is declined` | no org mutation, no project mutation, no install, no file writes |
| `does not confirm when reusing an existing organization` | the reuse path is untouched |
| `provisions non-interactively without a confirmation prompt` | `--non-interactive` behaviour is unchanged |

Each new test was checked against a mutant rather than assumed to discriminate:

| mutant | failing test |
|---|---|
| confirmation block deleted | `confirms before creating…` and `creates nothing when…declined` |
| `if (!nonInteractive)` → always prompt | `provisions non-interactively without a confirmation prompt` |

Repo gates on this branch: `yarn typecheck` clean, `yarn lint` — 0 warnings, 0 errors, `yarn fmt:check` — all matched files correctly formatted.
