### PR TITLE
[eas-cli] Use large runners for Android device sessions

### DIFF
--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -564,11 +564,37 @@ describe(Simulator, () => {
     expect(mockCreateDeviceRunSessionAsync.mock.calls[0][1]).not.toHaveProperty('ios');
   });
 
-  it('omits resourceClass when --resource-class is not set', async () => {
+  it('omits resourceClass for iOS when --resource-class is not set', async () => {
     const { command } = createCommand(['--platform', 'ios', '--non-interactive']);
     await command.runAsync();
 
     expect(mockCreateDeviceRunSessionAsync.mock.calls[0][1]).not.toHaveProperty('resourceClass');
+  });
+
+  it('uses the large resource class for Android by default', async () => {
+    const { command } = createCommand(['--platform', 'android', '--non-interactive']);
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ resourceClass: DeviceRunSessionResourceClass.Large })
+    );
+  });
+
+  it('allows the medium resource class to be selected explicitly for Android', async () => {
+    const { command } = createCommand([
+      '--platform',
+      'android',
+      '--non-interactive',
+      '--resource-class',
+      'medium',
+    ]);
+    await command.runAsync();
+
+    expect(mockCreateDeviceRunSessionAsync).toHaveBeenCalledWith(
+      graphqlClient,
+      expect.objectContaining({ resourceClass: DeviceRunSessionResourceClass.Medium })
+    );
   });
 
   it.each([

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -11,6 +11,7 @@ import {
 } from '../../commandUtils/flags';
 import {
   AppPlatform,
+  DeviceRunSessionResourceClass,
   DeviceRunSessionStatus,
   DeviceRunSessionType,
   JobRunStatus,
@@ -191,10 +192,6 @@ export default class Simulator extends EasCommand {
     const sdkVersionFromFlag = flags['sdk-version']?.trim() || undefined;
     const launchArgs = flags['launch-arg'];
     const openUrl = flags['open-url']?.trim() || undefined;
-    const resourceClass = flags['resource-class']
-      ? DEVICE_RUN_SESSION_RESOURCE_CLASS_BY_FLAG_VALUE[flags['resource-class']]
-      : undefined;
-
     if (sdkVersionFromFlag && !flags['expo-go']) {
       throw new EasCommandError('The --sdk-version flag can only be used with --expo-go.');
     }
@@ -218,6 +215,11 @@ export default class Simulator extends EasCommand {
     }
 
     const platform = await resolvePlatformAsync(flags.platform, nonInteractive);
+    const resourceClass = flags['resource-class']
+      ? DEVICE_RUN_SESSION_RESOURCE_CLASS_BY_FLAG_VALUE[flags['resource-class']]
+      : platform === AppPlatform.Android
+        ? DeviceRunSessionResourceClass.Large
+        : undefined;
     if (platform === AppPlatform.Android) {
       Log.warn(
         'Android emulator support in EAS Simulator is still in development. Some features available on iOS may not work on Android yet. Full parity with iOS is coming soon.'


### PR DESCRIPTION
# Why

Android FPS is roughly halved on medium Linux runners. This complements #4349, which reduces the emulator pixel load.

# How

Default Android device sessions to the large resource class. Explicit overrides still work and iOS behavior is unchanged.

# Test Plan

Simulator command tests, build, typecheck, lint, and format check.