### PR TITLE
[eas-cli] Say why reading the app config failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This is the log of notable changes to EAS CLI and related packages.
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [eas-cli] Print the session token in simulator preview links, so they still open once the preview is gated. ([#4312](https://github.com/expo/eas-cli/pull/4312) by [@gwdp](https://github.com/gwdp))
+- [eas-cli] Report the Expo CLI's own error when reading the app config fails, instead of only its exit code. ([#4354](https://github.com/expo/eas-cli/pull/4354) by [@LizunovSergey](https://github.com/LizunovSergey))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/project/__tests__/expoConfig.test.ts
+++ b/packages/eas-cli/src/project/__tests__/expoConfig.test.ts
@@ -1,12 +1,16 @@
 import { getConfigFilePaths, modifyConfigAsync } from '@expo/config';
 import JsonFile from '@expo/json-file';
-import { writeFileSync } from 'fs-extra';
+import fs, { writeFileSync } from 'fs-extra';
 
-import { createOrModifyExpoConfigAsync } from '../expoConfig';
+import { createOrModifyExpoConfigAsync, getPrivateExpoConfigAsync } from '../expoConfig';
+import { isExpoInstalled } from '../projectUtils';
+import { spawnExpoCommand } from '../../utils/expoCli';
 
 jest.mock('fs-extra');
 jest.mock('@expo/config');
 jest.mock('@expo/json-file');
+jest.mock('../projectUtils');
+jest.mock('../../utils/expoCli');
 
 beforeEach(() => {
   jest.resetAllMocks();
@@ -45,6 +49,60 @@ describe('expoConfig', () => {
 
       await createOrModifyExpoConfigAsync('/app', { owner: 'ccheever' });
       expect(modifyConfigAsync).toHaveBeenCalledWith('/app', { owner: 'ccheever' });
+    });
+  });
+
+  describe('getPrivateExpoConfigAsync', () => {
+    function mockExpoCommandFailure(stderr: string): void {
+      jest.mocked(isExpoInstalled).mockReturnValue(true);
+      jest
+        .mocked(spawnExpoCommand)
+        .mockRejectedValue(
+          Object.assign(
+            new Error('/app/node_modules/expo/bin/cli config --json exited with non-zero code: 1'),
+            { stdout: '', stderr, status: 1 }
+          ) as any
+        );
+    }
+
+    it('surfaces the stderr of a failed expo config command', async () => {
+      mockExpoCommandFailure('Something went wrong reading app.config.ts');
+      jest.mocked(fs.existsSync).mockReturnValue(true);
+
+      // Without this the caller only sees "exited with non-zero code: 1" and the
+      // reason the CLI printed is dropped.
+      await expect(getPrivateExpoConfigAsync('/app')).rejects.toThrow(
+        'Something went wrong reading app.config.ts'
+      );
+    });
+
+    it('points at the dependencies when the expo config command cannot resolve a module', async () => {
+      mockExpoCommandFailure("Error: Cannot find module 'expo-updates'");
+      jest.mocked(fs.existsSync).mockReturnValue(true);
+
+      await expect(getPrivateExpoConfigAsync('/app')).rejects.toThrow(
+        'dependencies look missing or incomplete'
+      );
+    });
+
+    it('points at the dependencies when node_modules is absent, whatever the CLI printed', async () => {
+      mockExpoCommandFailure('some unrelated failure');
+      jest.mocked(fs.existsSync).mockReturnValue(false);
+
+      await expect(getPrivateExpoConfigAsync('/app')).rejects.toThrow(
+        'dependencies look missing or incomplete'
+      );
+    });
+
+    it('does not blame the dependencies when they are installed and the failure is unrelated', async () => {
+      mockExpoCommandFailure('some unrelated failure');
+      jest.mocked(fs.existsSync).mockReturnValue(true);
+
+      await expect(getPrivateExpoConfigAsync('/app')).rejects.toThrow(
+        expect.objectContaining({
+          message: expect.not.stringContaining('dependencies look missing or incomplete'),
+        }) as Error
+      );
     });
   });
 });

--- a/packages/eas-cli/src/project/__tests__/expoConfig.test.ts
+++ b/packages/eas-cli/src/project/__tests__/expoConfig.test.ts
@@ -53,16 +53,14 @@ describe('expoConfig', () => {
   });
 
   describe('getPrivateExpoConfigAsync', () => {
-    function mockExpoCommandFailure(stderr: string): void {
+    function mockExpoCommandFailure(stderr: string): Error {
       jest.mocked(isExpoInstalled).mockReturnValue(true);
-      jest
-        .mocked(spawnExpoCommand)
-        .mockRejectedValue(
-          Object.assign(
-            new Error('/app/node_modules/expo/bin/cli config --json exited with non-zero code: 1'),
-            { stdout: '', stderr, status: 1 }
-          ) as any
-        );
+      const cause = Object.assign(
+        new Error('/app/node_modules/expo/bin/cli config --json exited with non-zero code: 1'),
+        { stdout: '', stderr, status: 1 }
+      );
+      jest.mocked(spawnExpoCommand).mockRejectedValue(cause as any);
+      return cause;
     }
 
     it('surfaces the stderr of a failed expo config command', async () => {
@@ -101,6 +99,20 @@ describe('expoConfig', () => {
       await expect(getPrivateExpoConfigAsync('/app')).rejects.toThrow(
         expect.objectContaining({
           message: expect.not.stringContaining('dependencies look missing or incomplete'),
+        }) as Error
+      );
+    });
+
+    it('keeps the original spawn failure as the cause', async () => {
+      const cause = mockExpoCommandFailure('some unrelated failure');
+      jest.mocked(fs.existsSync).mockReturnValue(true);
+
+      // The rewritten message is for the user; logs and debuggers still need the
+      // stack and the stdout/stderr/status the spawn rejection carried.
+      await expect(getPrivateExpoConfigAsync('/app')).rejects.toThrow(
+        expect.objectContaining({
+          message: expect.stringMatching(/Failed to read the app config from the Expo CLI/),
+          cause,
         }) as Error
       );
     });

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -53,15 +53,20 @@ async function getExpoConfigInternalAsync(
 
     let exp: ExpoConfig;
     if (isExpoInstalled(projectDir)) {
-      const { stdout } = await spawnExpoCommand(
-        projectDir,
-        ['config', '--json', ...(opts.isPublicConfig ? ['--type', 'public'] : [])],
-        {
-          env: {
-            EXPO_NO_DOTENV: '1',
-          },
-        }
-      );
+      let stdout: string;
+      try {
+        ({ stdout } = await spawnExpoCommand(
+          projectDir,
+          ['config', '--json', ...(opts.isPublicConfig ? ['--type', 'public'] : [])],
+          {
+            env: {
+              EXPO_NO_DOTENV: '1',
+            },
+          }
+        ));
+      } catch (error: any) {
+        throw new Error(expoConfigCommandFailedMessage(projectDir, error));
+      }
       exp = JSON.parse(stdout);
     } else {
       exp = getConfig(projectDir, {
@@ -82,6 +87,28 @@ async function getExpoConfigInternalAsync(
   } finally {
     process.env = originalProcessEnv;
   }
+}
+
+/**
+ * The Expo CLI prints the reason it failed on stderr, but a rejected spawn only carries
+ * "exited with non-zero code", so surface the output and name the usual cause: dependencies that
+ * are missing or half-installed.
+ */
+function expoConfigCommandFailedMessage(projectDir: string, error: any): string {
+  const stderr = typeof error?.stderr === 'string' ? error.stderr.trim() : '';
+  const parts = ['Failed to read the app config from the Expo CLI.'];
+  if (stderr) {
+    parts.push(stderr);
+  }
+  const dependenciesUnresolved =
+    /Cannot find module|MODULE_NOT_FOUND/.test(stderr) ||
+    !fs.existsSync(path.join(projectDir, 'node_modules'));
+  if (dependenciesUnresolved) {
+    parts.push(
+      'The project dependencies look missing or incomplete. Install them and run this command again.'
+    );
+  }
+  return parts.join('\n\n');
 }
 
 const MinimalAppConfigSchema = Joi.object({

--- a/packages/eas-cli/src/project/expoConfig.ts
+++ b/packages/eas-cli/src/project/expoConfig.ts
@@ -65,7 +65,7 @@ async function getExpoConfigInternalAsync(
           }
         ));
       } catch (error: any) {
-        throw new Error(expoConfigCommandFailedMessage(projectDir, error));
+        throw new Error(expoConfigCommandFailedMessage(projectDir, error), { cause: error });
       }
       exp = JSON.parse(stdout);
     } else {


### PR DESCRIPTION
# Why

Fixes #4213.

Reading the app config shells out to the versioned Expo CLI, and when that exits non-zero the rejected spawn carries only:

```
/Users/brent/code/mac-migration/node_modules/expo/bin/cli config --json exited with non-zero code: 1
    Error: update:configure command failed.
```

The child's stderr holds the actual reason and is thrown away, so the user is left with an exit code and a path. In the reported case the cause was dependencies that were missing or half-installed — the CLI had almost certainly printed `Cannot find module …`, and none of it reached the surface.

Worth noting where the existing guards stop: `isExpoInstalled` already returns `false` when `expo/bin/cli` cannot be resolved at all, and `spawnExpoCommand` already turns a `MODULE_NOT_FOUND` on that resolution into a good message. Neither covers this case, because here `expo/bin/cli` **does** resolve — it just fails to run.

# How

Wrap the `spawnExpoCommand` call and build a message from what the child actually said:

- Always include the CLI's stderr, when there is any.
- Add a dependency hint when the stderr points at unresolved modules (`Cannot find module` / `MODULE_NOT_FOUND`), or when the project has no `node_modules` directory at all — the second covers a CLI that fails before it can print anything useful.
- Say nothing about dependencies when they are installed and the failure is unrelated, so an app-config error is not misattributed.

This is the same treatment `expoUpdatesCommandAsync` already gives the expo-updates CLI in `utils/expoUpdatesCli.ts`, which reads `e.stderr` and rethrows it rather than letting the bare exit code escape.

Before:

```
/app/node_modules/expo/bin/cli config --json exited with non-zero code: 1
```

After:

```
Failed to read the app config from the Expo CLI.

Error: Cannot find module 'expo-updates'

The project dependencies look missing or incomplete. Install them and run this command again.
```

# Test Plan

Four tests added to `src/project/__tests__/expoConfig.test.ts`, which previously covered only `createOrModifyExpoConfigAsync`.

```
yarn jest src/project/__tests__/expoConfig.test.ts
Tests:       7 passed, 7 total
```

Whole package, to check nothing else depended on the old behaviour:

```
yarn jest
Test Suites: 305 passed, 305 total
Tests:       4 skipped, 2662 passed, 2666 total
```

Each new test was checked against a mutant rather than assumed to discriminate:

| mutant | failing test |
|---|---|
| stderr no longer appended | `surfaces the stderr of a failed expo config command` |
| `Cannot find module` / `MODULE_NOT_FOUND` check removed | `points at the dependencies when the expo config command cannot resolve a module` |
| `node_modules` existence check inverted | `points at the dependencies when node_modules is absent…` and `does not blame the dependencies…` |
| hint added unconditionally | `does not blame the dependencies when they are installed and the failure is unrelated` |

Removing the `node_modules` check outright is not expressible: it is the only use of `projectDir`, so the compiler rejects it with `TS6133` before any test runs.

`yarn typecheck`, `yarn lint` (0 warnings, 0 errors) and `yarn fmt:check` are clean on this branch.

One note in the interest of not overclaiming: on the first full-suite run `src/vcs/clients/__tests__/git.test.ts` failed. It passes on a clean `main` tree, passes twice in isolation with this branch applied, and passes on a repeat full run — it does real git work in temp directories and looks parallelism-sensitive, not related to this change.
