### PR TITLE
[eas-cli] Keep the branch name in `workflow:run --ref`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
+- [eas-cli] Send the branch or tag name to `eas workflow:run --ref`, instead of resolving it to a commit hash locally, so that runs are labeled with the ref that was requested. ([#4311](https://github.com/expo/eas-cli/issues/4311) by [@dennytosp](https://github.com/dennytosp))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/workflow/__tests__/run.test.ts
+++ b/packages/eas-cli/src/commands/workflow/__tests__/run.test.ts
@@ -3,7 +3,7 @@ import {
   parseJsonInputs,
   parseWorkflowInputsFromYaml,
 } from '../../../commandUtils/workflow/inputs';
-import { resolveWorkflowRunSshInput } from '../run';
+import { resolveWorkflowRunGitRef, resolveWorkflowRunSshInput } from '../run';
 
 describe(resolveWorkflowRunSshInput, () => {
   it('is null when --ssh is not set', () => {
@@ -26,6 +26,124 @@ describe(resolveWorkflowRunSshInput, () => {
     expect(() => resolveWorkflowRunSshInput({ ssh: false, idleTimeoutSeconds: 60 })).toThrow(
       '--ssh-idle-timeout requires --ssh.'
     );
+  });
+});
+
+describe(resolveWorkflowRunGitRef, () => {
+  const commitSha = '0e5c2f18c7e4d0e2f5a1b3c4d5e6f708192a3b4c';
+
+  it('passes a branch name through instead of the commit it points at', () => {
+    expect(
+      resolveWorkflowRunGitRef({
+        requestedRef: 'my-branch',
+        symbolicFullName: 'refs/heads/my-branch',
+        commitSha,
+      })
+    ).toBe('my-branch');
+  });
+
+  it('passes a fully qualified branch name through', () => {
+    expect(
+      resolveWorkflowRunGitRef({
+        requestedRef: 'refs/heads/my-branch',
+        symbolicFullName: 'refs/heads/my-branch',
+        commitSha,
+      })
+    ).toBe('refs/heads/my-branch');
+  });
+
+  it('passes a branch name containing slashes through', () => {
+    expect(
+      resolveWorkflowRunGitRef({
+        requestedRef: 'feat/my-branch',
+        symbolicFullName: 'refs/heads/feat/my-branch',
+        commitSha,
+      })
+    ).toBe('feat/my-branch');
+  });
+
+  it('passes a tag name through', () => {
+    expect(
+      resolveWorkflowRunGitRef({
+        requestedRef: 'v1.0.0',
+        symbolicFullName: 'refs/tags/v1.0.0',
+        commitSha,
+      })
+    ).toBe('v1.0.0');
+  });
+
+  it('passes a fully qualified tag name through', () => {
+    expect(
+      resolveWorkflowRunGitRef({
+        requestedRef: 'refs/tags/v1.0.0',
+        symbolicFullName: 'refs/tags/v1.0.0',
+        commitSha,
+      })
+    ).toBe('refs/tags/v1.0.0');
+  });
+
+  // HEAD resolves to the default branch server-side, so it has to stay a commit.
+  it('resolves HEAD to a commit', () => {
+    expect(
+      resolveWorkflowRunGitRef({
+        requestedRef: 'HEAD',
+        symbolicFullName: 'refs/heads/main',
+        commitSha,
+      })
+    ).toBe(commitSha);
+  });
+
+  it('resolves @ to a commit', () => {
+    expect(
+      resolveWorkflowRunGitRef({
+        requestedRef: '@',
+        symbolicFullName: 'refs/heads/main',
+        commitSha,
+      })
+    ).toBe(commitSha);
+  });
+
+  it('resolves a detached HEAD to a commit', () => {
+    expect(
+      resolveWorkflowRunGitRef({
+        requestedRef: 'HEAD',
+        symbolicFullName: 'HEAD',
+        commitSha,
+      })
+    ).toBe(commitSha);
+  });
+
+  it('resolves a revision expression to a commit', () => {
+    expect(
+      resolveWorkflowRunGitRef({ requestedRef: 'HEAD~2', symbolicFullName: null, commitSha })
+    ).toBe(commitSha);
+  });
+
+  it('resolves a commit hash to a commit', () => {
+    expect(
+      resolveWorkflowRunGitRef({ requestedRef: '0e5c2f1', symbolicFullName: null, commitSha })
+    ).toBe(commitSha);
+  });
+
+  // `origin/my-branch` is a local name for a remote branch; the server would not resolve it.
+  it('resolves a remote-tracking ref to a commit', () => {
+    expect(
+      resolveWorkflowRunGitRef({
+        requestedRef: 'origin/my-branch',
+        symbolicFullName: 'refs/remotes/origin/my-branch',
+        commitSha,
+      })
+    ).toBe(commitSha);
+  });
+
+  it('resolves a partially qualified branch name to a commit', () => {
+    expect(
+      resolveWorkflowRunGitRef({
+        requestedRef: 'heads/my-branch',
+        symbolicFullName: 'refs/heads/my-branch',
+        commitSha,
+      })
+    ).toBe(commitSha);
   });
 });
 

--- a/packages/eas-cli/src/commands/workflow/run.ts
+++ b/packages/eas-cli/src/commands/workflow/run.ts
@@ -91,6 +91,62 @@ export function resolveWorkflowRunSshInput({
   return ssh ? { idleTimeoutSeconds } : null;
 }
 
+const PASSTHROUGH_REF_PREFIXES = ['refs/heads/', 'refs/tags/'];
+
+/**
+ * Pick the value to send as `gitRef` when running a workflow from `--ref`.
+ *
+ * The server resolves the ref itself and records it as the run's `requestedGitRef`,
+ * which is what the website shows in the "Branch" column and offers in the Git branch
+ * filter. Resolving the ref to a commit locally before dispatching therefore throws
+ * away the branch or tag name the user asked for.
+ *
+ * Branch and tag names are passed through untouched, whether they are given in short
+ * (`my-branch`) or fully qualified (`refs/heads/my-branch`) form. Everything else keeps
+ * being sent as the locally resolved commit, because it either has no meaning in the
+ * remote repository or does not mean the same thing there: `HEAD` and `@` resolve to the
+ * default branch server-side, revision expressions such as `HEAD~2` are not refs at all,
+ * and remote-tracking refs like `origin/my-branch` are local names for remote branches.
+ */
+export function resolveWorkflowRunGitRef({
+  requestedRef,
+  symbolicFullName,
+  commitSha,
+}: {
+  requestedRef: string;
+  symbolicFullName: string | null;
+  commitSha: string;
+}): string {
+  const prefix = PASSTHROUGH_REF_PREFIXES.find(candidate =>
+    symbolicFullName?.startsWith(candidate)
+  );
+  if (!symbolicFullName || !prefix) {
+    return commitSha;
+  }
+  const shortName = symbolicFullName.slice(prefix.length);
+  return requestedRef === shortName || requestedRef === symbolicFullName ? requestedRef : commitSha;
+}
+
+/**
+ * Full ref name (e.g. `refs/heads/my-branch`) that `ref` points at, or null when it does
+ * not name a ref (a commit hash, a revision expression, or a detached `HEAD`).
+ */
+async function maybeResolveSymbolicFullNameAsync(
+  ref: string,
+  projectDir: string
+): Promise<string | null> {
+  try {
+    const { output } = await spawnAsync(
+      'git',
+      ['rev-parse', '--symbolic-full-name', '--verify', ref],
+      { cwd: projectDir }
+    );
+    return output[0].trim() || null;
+  } catch {
+    return null;
+  }
+}
+
 export default class WorkflowRun extends EasCommand {
   static override description =
     'run an EAS workflow. The entire local project directory will be packaged and uploaded to EAS servers for the workflow run, unless the --ref flag is used.';
@@ -184,15 +240,26 @@ export default class WorkflowRun extends EasCommand {
       // Run from git ref
       const fileName = path.basename(args.file);
       // Find the real commit, make sure the ref is valid
-      gitRef = (
+      const commitSha = (
         await spawnAsync('git', ['rev-parse', flags.ref], {
           cwd: projectDir,
         })
       ).output[0].trim();
-      if (!gitRef) {
+      if (!commitSha) {
         throw new Error('Failed to resolve git reference');
       }
-      Log.log(`Using workflow file ${fileName} at ${gitRef}`);
+      // Send the branch or tag name the user asked for, so that the server records it as
+      // the run's requested git ref instead of a bare commit hash.
+      gitRef = resolveWorkflowRunGitRef({
+        requestedRef: flags.ref,
+        symbolicFullName: await maybeResolveSymbolicFullNameAsync(flags.ref, projectDir),
+        commitSha,
+      });
+      Log.log(
+        gitRef === commitSha
+          ? `Using workflow file ${fileName} at ${gitRef}`
+          : `Using workflow file ${fileName} at ${gitRef} (${commitSha})`
+      );
       let revisionResult: WorkflowRevision | undefined;
       try {
         revisionResult = await WorkflowRevisionMutation.getOrCreateWorkflowRevisionFromGitRefAsync(


### PR DESCRIPTION
Closes #4311.

### Why

`workflow:run --ref <branch>` resolves the ref with `git rev-parse` and sends the resulting commit hash as `gitRef`, so the branch name never reaches the server. `WorkflowRun` stores `requestedGitRef` and `gitCommitHash` separately — the website's Branch column and its Git-branch filter both read `requestedGitRef` — so a CLI-triggered run is labelled with a 40-character hash while the same workflow started from the dashboard's Run workflow button keeps the branch name. The filter fills with hashes and stops being usable.

This was flagged during review of the PR that added `--ref` (#3203):

> fwiw we might not do that too, one of the first things we're doing in the mutation is resolve the Git ref … (and theoretically it might be that a user's local repo knows of more refs than the remote knows about)

The local `rev-parse` was only meant to support `--ref HEAD`; it ended up applying to every ref.

### What changed

`resolveWorkflowRunGitRef` picks what to send. Branch and tag names go through untouched, in short (`my-branch`) or fully qualified (`refs/heads/my-branch`) form. Everything else keeps being sent as the locally resolved commit, because it either has no meaning in the remote repository or does not mean the same thing there:

| `--ref` | `--symbolic-full-name` | sent |
| --- | --- | --- |
| `my-branch`, `feat/x`, `v1.0`, `refs/heads/…`, `refs/tags/…` | `refs/heads\|tags/…` | **the name** |
| `HEAD`, `@` | `refs/heads/<current>` | commit |
| detached `HEAD` | `HEAD` | commit |
| `HEAD~2`, raw hash | *(empty)* | commit |
| `origin/my-branch` | `refs/remotes/…` | commit |
| `heads/my-branch` | `refs/heads/my-branch` | commit |

`HEAD` deliberately keeps the old behaviour: it resolves to the default branch server-side, so passing it through would silently run against the wrong branch. `rev-parse` is still called, so an invalid ref fails exactly as before, and the log line now shows both (`at my-branch (abc1234…)`).

### Testing

```
yarn typecheck                     # clean
yarn lint                          # 0 warnings, 0 errors
yarn test src/commands/workflow/   # 3 suites, 74 tests passed
```

12 new tests in `run.test.ts`. Red/green: replacing the helper body with the old `return commitSha` fails the 5 pass-through cases with the reported bug (`Expected "my-branch", received "0e5c2f18…"`), while the 7 cases that guard `HEAD`/detached/expression/hash/remote-tracking behaviour pass in both states.

Note: `src/vcs/clients/__tests__/git.test.ts` can hit its 5s per-test timeout under parallel load. That is pre-existing — it reproduces on a clean `main` with these changes stashed.