### PR TITLE
[eas-build-job] Remove repository URLs from Git job inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-build-job] Allow Git project sources in remote jobs to omit the repository URL. ([#4360](https://github.com/expo/eas-cli/pull/4360) by [@sjchmiela](https://github.com/sjchmiela))
+
 - [build-tools] Add `lcd_width`, `lcd_height`, and `lcd_density` inputs to configure the Android emulator display. ([#4349](https://github.com/expo/eas-cli/pull/4349) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [eas-cli] Add `eas channel:protect` and `eas channel:unprotect` to manage EAS Update channel protection, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))
 - [eas-cli] Add `eas observe:errors` to display error and exception issue groups (grouped by fingerprint), with `--fingerprint <fingerprint>` to drill into a group's individual occurrences and stack traces. ([#4339](https://github.com/expo/eas-cli/pull/4339) by [@douglowder](https://github.com/douglowder))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-build-job] Remove repository URLs from Git job inputs and fetch them when resolving project sources. ([#4360](https://github.com/expo/eas-cli/pull/4360) by [@sjchmiela](https://github.com/sjchmiela))
 - [eas-cli] Add `eas workflow:insights` to display Workflows Insights for a time range: run counts and success rate compared with the previous period, runs over time, and a per-workflow breakdown, with `--json` output for scripts. ([#4367](https://github.com/expo/eas-cli/pull/4367) by [@hSATAC](https://github.com/hSATAC))
 - [eas-cli] Add `eas workflow:insights:maestro` to display Maestro test insights for a time range: pass and flake rates, a sortable per-flow table, and a single flow's history with error patterns and recent runs, with `--json` output for scripts. ([#4370](https://github.com/expo/eas-cli/pull/4370) by [@hSATAC](https://github.com/hSATAC))
 
@@ -41,8 +42,6 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli][build-tools] Forward `--egress-allow localhost:<port>` and `127.0.0.1:<port>` entries from the simulator host's loopback interface to this machine (like `adb reverse`), so dev server URLs that use `127.0.0.1` work through local egress. ([#4369](https://github.com/expo/eas-cli/pull/4369) by [@brentvatne](https://github.com/brentvatne))
 - [build-tools] Add the `eas/start_local_egress` step for iOS simulator sessions with local egress: the device host's system proxy points at a reverse tunnel to the EAS CLI machine, so HTTP(S) requests that honor it exit from that machine and third parties see its IP. ([#4364](https://github.com/expo/eas-cli/pull/4364) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli] Add `--egress local` to `eas simulator:start` and the `eas simulator:egress` command, which run the local egress client for the session. ([#4364](https://github.com/expo/eas-cli/pull/4364) by [@brentvatne](https://github.com/brentvatne))
-- [eas-build-job] Remove repository URLs from Git job inputs and fetch them when resolving project sources. ([#4360](https://github.com/expo/eas-cli/pull/4360) by [@sjchmiela](https://github.com/sjchmiela))
-
 - [build-tools] Require the serve-sim session token for device run session previews, so the tunnel no longer exposes the shell-exec route. ([#4306](https://github.com/expo/eas-cli/pull/4306) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli][build-tools] Forward `--egress-allow localhost:<port>` and `127.0.0.1:<port>` entries from the simulator host's loopback interface to this machine (like `adb reverse`), so dev server URLs that use `127.0.0.1` work through local egress. ([#4369](https://github.com/expo/eas-cli/pull/4369) by [@brentvatne](https://github.com/brentvatne))
 - [build-tools] Add the `eas/start_local_egress` step for iOS simulator sessions with local egress: the device host's system proxy points at a reverse tunnel to the EAS CLI machine, so HTTP(S) requests that honor it exit from that machine and third parties see its IP. ([#4364](https://github.com/expo/eas-cli/pull/4364) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli] Add `--egress local` to `eas simulator:start` and the `eas simulator:egress` command, which run the local egress client for the session. ([#4364](https://github.com/expo/eas-cli/pull/4364) by [@brentvatne](https://github.com/brentvatne))
+- [eas-build-job] Remove repository URLs from Git job inputs and fetch them when resolving project sources. ([#4360](https://github.com/expo/eas-cli/pull/4360) by [@sjchmiela](https://github.com/sjchmiela))
+
 - [build-tools] Require the serve-sim session token for device run session previews, so the tunnel no longer exposes the shell-exec route. ([#4306](https://github.com/expo/eas-cli/pull/4306) by [@gwdp](https://github.com/gwdp))
 
 ### 🐛 Bug fixes
@@ -54,8 +56,6 @@ This is the log of notable changes to EAS CLI and related packages.
 - [eas-cli] Align the `eas observe:*` commands with the renamed Observe GraphQL schema. `--json` output now uses `name`/`value` instead of `metricName`/`metricValue` (metrics) and `name` instead of `eventName` (log events and event-name summaries), and `eas observe:events` now lists user-defined events only — exceptions moved to the new `eas observe:errors`. ([#4338](https://github.com/expo/eas-cli/pull/4338) by [@douglowder](https://github.com/douglowder))
 
 ### 🎉 New features
-
-- [eas-build-job] Remove repository URLs from Git job inputs and fetch them when resolving project sources. ([#4360](https://github.com/expo/eas-cli/pull/4360) by [@sjchmiela](https://github.com/sjchmiela))
 
 - [build-tools] Add `lcd_width`, `lcd_height`, and `lcd_density` inputs to configure the Android emulator display. ([#4349](https://github.com/expo/eas-cli/pull/4349) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [eas-cli] Add `eas channel:protect` and `eas channel:unprotect` to manage EAS Update channel protection, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- [eas-build-job] Allow Git project sources in remote jobs to omit the repository URL. ([#4360](https://github.com/expo/eas-cli/pull/4360) by [@sjchmiela](https://github.com/sjchmiela))
+- [eas-build-job] Remove repository URLs from Git job inputs and fetch them when resolving project sources. ([#4360](https://github.com/expo/eas-cli/pull/4360) by [@sjchmiela](https://github.com/sjchmiela))
 
 - [build-tools] Add `lcd_width`, `lcd_height`, and `lcd_density` inputs to configure the Android emulator display. ([#4349](https://github.com/expo/eas-cli/pull/4349) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [eas-cli] Add `eas channel:protect` and `eas channel:unprotect` to manage EAS Update channel protection, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))

--- a/packages/build-tools/src/common/__tests__/git.test.ts
+++ b/packages/build-tools/src/common/__tests__/git.test.ts
@@ -1,9 +1,8 @@
-import { ArchiveSourceType, SystemError, UserError } from '@expo/eas-build-job';
+import { UserError } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 import { vol } from 'memfs';
 
-import { createMockLogger } from '../../__tests__/utils/logger';
-import { fetchAndCheckoutRefAsync, shallowCloneRepositoryAsync } from '../git';
+import { fetchAndCheckoutRefAsync } from '../git';
 
 jest.mock('@expo/turtle-spawn');
 
@@ -146,22 +145,5 @@ describe(fetchAndCheckoutRefAsync, () => {
     const error = await promise.catch(err => err);
     expect(error.message).toContain('Failed to fetch and check out ref "main"');
     expect(error.message).not.toContain('ghs_secret123');
-  });
-});
-
-describe(shallowCloneRepositoryAsync, () => {
-  it('rejects Git sources without a URL before starting Git', async () => {
-    await expect(
-      shallowCloneRepositoryAsync({
-        logger: createMockLogger(),
-        destinationDirectory: repositoryDirectory,
-        archiveSource: {
-          type: ArchiveSourceType.GIT,
-          gitRef: null,
-          gitCommitHash: '1234567890',
-        },
-      })
-    ).rejects.toBeInstanceOf(SystemError);
-    expect(spawn).not.toHaveBeenCalled();
   });
 });

--- a/packages/build-tools/src/common/__tests__/git.test.ts
+++ b/packages/build-tools/src/common/__tests__/git.test.ts
@@ -1,8 +1,9 @@
-import { UserError } from '@expo/eas-build-job';
+import { ArchiveSourceType, SystemError, UserError } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
 import { vol } from 'memfs';
 
-import { fetchAndCheckoutRefAsync } from '../git';
+import { createMockLogger } from '../../__tests__/utils/logger';
+import { fetchAndCheckoutRefAsync, shallowCloneRepositoryAsync } from '../git';
 
 jest.mock('@expo/turtle-spawn');
 
@@ -145,5 +146,22 @@ describe(fetchAndCheckoutRefAsync, () => {
     const error = await promise.catch(err => err);
     expect(error.message).toContain('Failed to fetch and check out ref "main"');
     expect(error.message).not.toContain('ghs_secret123');
+  });
+});
+
+describe(shallowCloneRepositoryAsync, () => {
+  it('rejects Git sources without a URL before starting Git', async () => {
+    await expect(
+      shallowCloneRepositoryAsync({
+        logger: createMockLogger(),
+        destinationDirectory: repositoryDirectory,
+        archiveSource: {
+          type: ArchiveSourceType.GIT,
+          gitRef: null,
+          gitCommitHash: '1234567890',
+        },
+      })
+    ).rejects.toBeInstanceOf(SystemError);
+    expect(spawn).not.toHaveBeenCalled();
   });
 });

--- a/packages/build-tools/src/common/__tests__/projectSources.test.ts
+++ b/packages/build-tools/src/common/__tests__/projectSources.test.ts
@@ -115,7 +115,7 @@ describe('projectSources', () => {
     );
   });
 
-  it.each(['http', 'network', 'json', 'schema', 'missing-url'])(
+  it.each(['http', 'network', 'json', 'schema', 'missing-url', 'PATH', 'GCS', 'R2'])(
     'throws a system error if refresh fails (%s)',
     async failure => {
       const robotAccessToken = randomUUID();
@@ -166,6 +166,9 @@ describe('projectSources', () => {
           json: async () => {
             if (failure === 'json') {
               throw cause;
+            }
+            if (['PATH', 'GCS', 'R2'].includes(failure)) {
+              return { data: { type: failure, path: '/project.tar.gz', bucketKey: 'project' } };
             }
             if (failure === 'missing-url') {
               return {

--- a/packages/build-tools/src/common/__tests__/projectSources.test.ts
+++ b/packages/build-tools/src/common/__tests__/projectSources.test.ts
@@ -131,7 +131,6 @@ describe('projectSources', () => {
           appId: randomUUID(),
           projectArchive: {
             type: ArchiveSourceType.GIT,
-            repositoryUrl: 'https://x-access-token:1234567890@github.com/expo/eas-cli.git',
             gitRef: 'refs/heads/main',
             gitCommitHash: randomBytes(20).toString('hex'),
           },
@@ -215,7 +214,6 @@ describe('projectSources', () => {
         appId: randomUUID(),
         projectArchive: {
           type: ArchiveSourceType.GIT,
-          repositoryUrl: 'https://x-access-token:1234567890@github.com/expo/eas-cli.git',
           gitRef: 'refs/heads/main',
           gitCommitHash,
         },
@@ -286,7 +284,6 @@ describe('projectSources', () => {
         appId: randomUUID(),
         projectArchive: {
           type: ArchiveSourceType.GIT,
-          repositoryUrl: 'https://x-access-token:1234567890@github.com/expo/eas-cli.git',
           gitRef: 'refs/heads/main',
           gitCommitHash: randomBytes(20).toString('hex'),
         },

--- a/packages/build-tools/src/common/__tests__/projectSources.test.ts
+++ b/packages/build-tools/src/common/__tests__/projectSources.test.ts
@@ -47,7 +47,7 @@ describe('projectSources', () => {
     expect(logger.info).toHaveBeenCalledWith('Normalizing project source permissions');
   });
 
-  it('uses the refreshed repository URL', async () => {
+  it.each([true, false])('uses the refreshed URL (legacy URL: %s)', async includeRepositoryUrl => {
     const robotAccessToken = randomUUID();
     const buildId = randomUUID();
     await vol.promises.mkdir('/workingdir/environment-secrets/', { recursive: true });
@@ -63,7 +63,9 @@ describe('projectSources', () => {
         appId: randomUUID(),
         projectArchive: {
           type: ArchiveSourceType.GIT,
-          repositoryUrl: 'https://x-access-token:1234567890@github.com/expo/eas-cli.git',
+          ...(includeRepositoryUrl
+            ? { repositoryUrl: 'https://x-access-token:1234567890@github.com/expo/eas-cli.git' }
+            : {}),
           gitRef: 'refs/heads/main',
           gitCommitHash,
         },
@@ -113,7 +115,7 @@ describe('projectSources', () => {
     );
   });
 
-  it.each(['http', 'network', 'json', 'schema'])(
+  it.each(['http', 'network', 'json', 'schema', 'missing-url'])(
     'throws a system error if refresh fails (%s)',
     async failure => {
       const robotAccessToken = randomUUID();
@@ -164,6 +166,15 @@ describe('projectSources', () => {
           json: async () => {
             if (failure === 'json') {
               throw cause;
+            }
+            if (failure === 'missing-url') {
+              return {
+                data: {
+                  type: ArchiveSourceType.GIT,
+                  gitRef: 'refs/heads/main',
+                  gitCommitHash: randomBytes(20).toString('hex'),
+                },
+              };
             }
             return { data: { repository_url: 'https://github.com/expo/eas-cli.git' } };
           },

--- a/packages/build-tools/src/common/git.ts
+++ b/packages/build-tools/src/common/git.ts
@@ -1,4 +1,4 @@
-import { ArchiveSource, ArchiveSourceType, UserError } from '@expo/eas-build-job';
+import { ArchiveSource, ArchiveSourceType, SystemError, UserError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import spawn from '@expo/turtle-spawn';
 import fs from 'fs-extra';
@@ -14,6 +14,9 @@ export async function shallowCloneRepositoryAsync({
   destinationDirectory: string;
 }): Promise<void> {
   const { repositoryUrl } = archiveSource;
+  if (!repositoryUrl) {
+    throw new SystemError('Cannot clone Git sources because the repository URL is missing.');
+  }
   try {
     await spawn('git', ['init'], { cwd: destinationDirectory });
     await spawn('git', ['remote', 'add', 'origin', repositoryUrl], { cwd: destinationDirectory });

--- a/packages/build-tools/src/common/git.ts
+++ b/packages/build-tools/src/common/git.ts
@@ -1,4 +1,4 @@
-import { ArchiveSource, ArchiveSourceType, SystemError, UserError } from '@expo/eas-build-job';
+import { ArchiveSource, ArchiveSourceType, UserError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import spawn from '@expo/turtle-spawn';
 import fs from 'fs-extra';
@@ -10,13 +10,10 @@ export async function shallowCloneRepositoryAsync({
   destinationDirectory,
 }: {
   logger: bunyan;
-  archiveSource: ArchiveSource & { type: ArchiveSourceType.GIT };
+  archiveSource: ArchiveSource & { type: ArchiveSourceType.GIT; repositoryUrl: string };
   destinationDirectory: string;
 }): Promise<void> {
   const { repositoryUrl } = archiveSource;
-  if (!repositoryUrl) {
-    throw new SystemError('Cannot clone Git sources because the repository URL is missing.');
-  }
   try {
     await spawn('git', ['init'], { cwd: destinationDirectory });
     await spawn('git', ['remote', 'add', 'origin', repositoryUrl], { cwd: destinationDirectory });

--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -1,11 +1,5 @@
 import downloadFile from '@expo/downloader';
-import {
-  ArchiveSource,
-  ArchiveSourceSchemaZ,
-  ArchiveSourceType,
-  Job,
-  SystemError,
-} from '@expo/eas-build-job';
+import { ArchiveSourceType, Job, SystemError } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
 import spawn from '@expo/turtle-spawn';
@@ -45,12 +39,6 @@ Promise<{ handled: boolean }> {
   const projectArchive = projectArchiveResult.value;
 
   switch (projectArchive.type) {
-    case ArchiveSourceType.PATH:
-    case ArchiveSourceType.R2:
-    case ArchiveSourceType.GCS: {
-      throw new Error('Remote project sources should be resolved earlier to URL');
-    }
-
     case ArchiveSourceType.NONE: {
       // May be used in no-sources jobs like submission jobs.
       return { handled: true };
@@ -254,7 +242,7 @@ async function uploadProjectMetadataAsync(
   }
 }
 
-async function fetchProjectArchiveSourceAsync(ctx: BuildContext<Job>): Promise<ArchiveSource> {
+async function fetchProjectArchiveSourceAsync(ctx: BuildContext<Job>) {
   const taskId = nullthrows(ctx.env.EAS_BUILD_ID, 'EAS_BUILD_ID is not set');
   const expoApiServerURL = nullthrows(ctx.env.__API_SERVER_URL, '__API_SERVER_URL is not set');
   const robotAccessToken = nullthrows(
@@ -294,10 +282,16 @@ async function fetchProjectArchiveSourceAsync(ctx: BuildContext<Job>): Promise<A
 
   const dataResult = z
     .object({
-      data: ArchiveSourceSchemaZ.refine(
-        source => source.type !== ArchiveSourceType.GIT || source.repositoryUrl !== undefined,
-        { message: 'Refreshed Git sources must include a repository URL' }
-      ),
+      data: z.discriminatedUnion('type', [
+        z.object({
+          type: z.literal(ArchiveSourceType.GIT),
+          repositoryUrl: z.string().url(),
+          gitRef: z.string().nullable(),
+          gitCommitHash: z.string(),
+        }),
+        z.object({ type: z.literal(ArchiveSourceType.URL), url: z.string().url() }),
+        z.object({ type: z.literal(ArchiveSourceType.NONE) }),
+      ]),
     })
     .safeParse(jsonResult.value);
   if (!dataResult.success) {

--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -292,7 +292,14 @@ async function fetchProjectArchiveSourceAsync(ctx: BuildContext<Job>): Promise<A
     );
   }
 
-  const dataResult = z.object({ data: ArchiveSourceSchemaZ }).safeParse(jsonResult.value);
+  const dataResult = z
+    .object({
+      data: ArchiveSourceSchemaZ.refine(
+        source => source.type !== ArchiveSourceType.GIT || source.repositoryUrl !== undefined,
+        { message: 'Refreshed Git sources must include a repository URL' }
+      ),
+    })
+    .safeParse(jsonResult.value);
   if (!dataResult.success) {
     throw new Error(
       `Unexpected data from server (${response.status}): ${z.prettifyError(dataResult.error)}`

--- a/packages/build-tools/src/steps/functions/__tests__/checkout.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/checkout.test.ts
@@ -14,7 +14,6 @@ const projectTargetDirectory = '/workingdir/project';
 
 const GIT_PROJECT_ARCHIVE = {
   type: ArchiveSourceType.GIT,
-  repositoryUrl: 'https://x-access-token:1234567890@github.com/expo/app.git',
   gitRef: 'refs/heads/main',
   gitCommitHash: '0123456789abcdef0123456789abcdef01234567',
 };

--- a/packages/eas-build-job/src/__tests__/android.test.ts
+++ b/packages/eas-build-job/src/__tests__/android.test.ts
@@ -240,7 +240,6 @@ describe('Android.JobSchema', () => {
       username: 'turtle-tutorial',
       projectArchive: {
         type: ArchiveSourceType.GIT,
-        repositoryUrl: 'http://localhost:3000',
         gitRef: 'master',
         gitCommitHash: '1b57db5b1cd12638aba0d12da71a2d691416700d',
       },

--- a/packages/eas-build-job/src/__tests__/common.test.ts
+++ b/packages/eas-build-job/src/__tests__/common.test.ts
@@ -693,12 +693,12 @@ describe('Git archive sources', () => {
     expect(ArchiveSourceSchemaZ.parse(source)).toEqual(source);
   });
 
-  it('strips the repository URL from legacy job sources', () => {
+  it('strips the legacy repository URL with the job validation options', () => {
     const archive = {
       ...source,
       repositoryUrl: 'https://x-access-token:old-token@github.com/expo/eas-cli.git',
     };
-    const result = ArchiveSourceSchema.validate(archive);
+    const result = ArchiveSourceSchema.validate(archive, { stripUnknown: true });
     expect(result.error).toBeUndefined();
     expect(result.value).toEqual(source);
     expect(ArchiveSourceSchemaZ.parse(archive)).toEqual(source);

--- a/packages/eas-build-job/src/__tests__/common.test.ts
+++ b/packages/eas-build-job/src/__tests__/common.test.ts
@@ -1,4 +1,8 @@
 import {
+  ArchiveSource,
+  ArchiveSourceSchema,
+  ArchiveSourceSchemaZ,
+  ArchiveSourceType,
   EasCliVersionsFetchTimeoutError,
   EnvSchema,
   SshSettingsZ,
@@ -672,6 +676,37 @@ describe('fetchEasCliVersionsAsync', () => {
       await assertion;
     } finally {
       jest.useRealTimers();
+    }
+  });
+});
+
+describe('Git archive sources', () => {
+  const source: ArchiveSource = {
+    type: ArchiveSourceType.GIT,
+    gitRef: null,
+    gitCommitHash: '1234567890',
+  };
+
+  it.each([undefined, 'https://github.com/expo/eas-cli.git'])(
+    'accepts a repository URL of %s in both job schemas',
+    repositoryUrl => {
+      const archive = repositoryUrl === undefined ? source : { ...source, repositoryUrl };
+      expect(ArchiveSourceSchema.validate(archive).error).toBeUndefined();
+      expect(ArchiveSourceSchemaZ.parse(archive)).toEqual(archive);
+    }
+  );
+
+  it.each([null, 123, ''])('rejects an invalid repository URL of %s', repositoryUrl => {
+    const archive = { ...source, repositoryUrl };
+    expect(ArchiveSourceSchema.validate(archive).error).toBeDefined();
+    expect(ArchiveSourceSchemaZ.safeParse(archive).success).toBe(false);
+  });
+
+  it('still requires the commit and ref', () => {
+    for (const field of ['gitCommitHash', 'gitRef'] as const) {
+      const archive = { ...source, [field]: undefined };
+      expect(ArchiveSourceSchema.validate(archive).error).toBeDefined();
+      expect(ArchiveSourceSchemaZ.safeParse(archive).success).toBe(false);
     }
   });
 });

--- a/packages/eas-build-job/src/__tests__/common.test.ts
+++ b/packages/eas-build-job/src/__tests__/common.test.ts
@@ -687,19 +687,21 @@ describe('Git archive sources', () => {
     gitCommitHash: '1234567890',
   };
 
-  it.each([undefined, 'https://github.com/expo/eas-cli.git'])(
-    'accepts a repository URL of %s in both job schemas',
-    repositoryUrl => {
-      const archive = repositoryUrl === undefined ? source : { ...source, repositoryUrl };
-      expect(ArchiveSourceSchema.validate(archive).error).toBeUndefined();
-      expect(ArchiveSourceSchemaZ.parse(archive)).toEqual(archive);
-    }
-  );
+  it('accepts Git job sources without a repository URL', () => {
+    expect(ArchiveSourceSchema.validate(source)).toMatchObject({ value: source });
+    expect(ArchiveSourceSchema.validate(source).error).toBeUndefined();
+    expect(ArchiveSourceSchemaZ.parse(source)).toEqual(source);
+  });
 
-  it.each([null, 123, ''])('rejects an invalid repository URL of %s', repositoryUrl => {
-    const archive = { ...source, repositoryUrl };
-    expect(ArchiveSourceSchema.validate(archive).error).toBeDefined();
-    expect(ArchiveSourceSchemaZ.safeParse(archive).success).toBe(false);
+  it('strips the repository URL from legacy job sources', () => {
+    const archive = {
+      ...source,
+      repositoryUrl: 'https://x-access-token:old-token@github.com/expo/eas-cli.git',
+    };
+    const result = ArchiveSourceSchema.validate(archive);
+    expect(result.error).toBeUndefined();
+    expect(result.value).toEqual(source);
+    expect(ArchiveSourceSchemaZ.parse(archive)).toEqual(source);
   });
 
   it('still requires the commit and ref', () => {

--- a/packages/eas-build-job/src/__tests__/generic.test.ts
+++ b/packages/eas-build-job/src/__tests__/generic.test.ts
@@ -9,7 +9,6 @@ describe('Generic.JobZ', () => {
     const job: Generic.Job = {
       projectArchive: {
         type: ArchiveSourceType.GIT,
-        repositoryUrl: 'https://github.com/expo/expo.git',
         gitCommitHash: '1234567890',
         gitRef: null,
       },
@@ -51,7 +50,6 @@ describe('Generic.JobZ', () => {
     const job: Generic.Job = {
       projectArchive: {
         type: ArchiveSourceType.GIT,
-        repositoryUrl: 'https://github.com/expo/expo.git',
         gitCommitHash: '1234567890',
         gitRef: null,
       },
@@ -96,7 +94,6 @@ describe('Generic.JobZ', () => {
     const job: Generic.Job = {
       projectArchive: {
         type: ArchiveSourceType.GIT,
-        repositoryUrl: 'https://github.com/expo/expo.git',
         gitCommitHash: '1234567890',
         gitRef: null,
       },
@@ -131,7 +128,6 @@ describe('Generic.JobZ', () => {
     const job: Generic.Job = {
       projectArchive: {
         type: ArchiveSourceType.GIT,
-        repositoryUrl: 'https://github.com/expo/expo.git',
         gitCommitHash: '1234567890',
         gitRef: null,
       },
@@ -183,7 +179,6 @@ describe('Generic.JobZ', () => {
     const job = {
       projectArchive: {
         type: ArchiveSourceType.GIT,
-        repositoryUrl: 'https://github.com/expo/expo.git',
         gitCommitHash: '1234567890',
         gitRef: null,
       },
@@ -232,7 +227,6 @@ describe('Generic.JobZ', () => {
     const job: Omit<Generic.Job, 'customBuildConfig' | 'steps'> = {
       projectArchive: {
         type: ArchiveSourceType.GIT,
-        repositoryUrl: 'https://github.com/expo/expo.git',
         gitCommitHash: '1234567890',
         gitRef: null,
       },

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -48,8 +48,9 @@ export type ArchiveSource =
       /**
        * Url that can be used to clone repository.
        * It should contain embedded credentials for private registries.
+       * May be omitted in remote jobs, which resolve sources through the API.
        */
-      repositoryUrl: string;
+      repositoryUrl?: string;
       /** A Git ref - points to a branch head, tag head or a branch name. */
       gitRef: string | null;
       /**
@@ -79,7 +80,7 @@ export const ArchiveSourceSchema = Joi.object<ArchiveSource>({
   .when(Joi.object({ type: ArchiveSourceType.GIT }).unknown(), {
     then: Joi.object({
       type: Joi.string().valid(ArchiveSourceType.GIT).required(),
-      repositoryUrl: Joi.string().required(),
+      repositoryUrl: Joi.string(),
       gitCommitHash: Joi.string().required(),
       gitRef: Joi.string().allow(null).required(),
     }),
@@ -94,7 +95,7 @@ export const ArchiveSourceSchema = Joi.object<ArchiveSource>({
 export const ArchiveSourceSchemaZ = z.discriminatedUnion('type', [
   z.object({
     type: z.literal(ArchiveSourceType.GIT),
-    repositoryUrl: z.string().url(),
+    repositoryUrl: z.string().url().optional(),
     gitRef: z.string().nullable(),
     gitCommitHash: z.string(),
   }),

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -45,12 +45,6 @@ export type ArchiveSource =
   | { type: ArchiveSourceType.PATH; path: string }
   | {
       type: ArchiveSourceType.GIT;
-      /**
-       * Url that can be used to clone repository.
-       * It should contain embedded credentials for private registries.
-       * May be omitted in remote jobs, which resolve sources through the API.
-       */
-      repositoryUrl?: string;
       /** A Git ref - points to a branch head, tag head or a branch name. */
       gitRef: string | null;
       /**
@@ -80,7 +74,8 @@ export const ArchiveSourceSchema = Joi.object<ArchiveSource>({
   .when(Joi.object({ type: ArchiveSourceType.GIT }).unknown(), {
     then: Joi.object({
       type: Joi.string().valid(ArchiveSourceType.GIT).required(),
-      repositoryUrl: Joi.string(),
+      // Discard URLs from older job producers. Credentials are fetched from www.
+      repositoryUrl: Joi.any().strip(),
       gitCommitHash: Joi.string().required(),
       gitRef: Joi.string().allow(null).required(),
     }),
@@ -95,7 +90,6 @@ export const ArchiveSourceSchema = Joi.object<ArchiveSource>({
 export const ArchiveSourceSchemaZ = z.discriminatedUnion('type', [
   z.object({
     type: z.literal(ArchiveSourceType.GIT),
-    repositoryUrl: z.string().url().optional(),
     gitRef: z.string().nullable(),
     gitCommitHash: z.string(),
   }),

--- a/packages/eas-build-job/src/common.ts
+++ b/packages/eas-build-job/src/common.ts
@@ -74,8 +74,6 @@ export const ArchiveSourceSchema = Joi.object<ArchiveSource>({
   .when(Joi.object({ type: ArchiveSourceType.GIT }).unknown(), {
     then: Joi.object({
       type: Joi.string().valid(ArchiveSourceType.GIT).required(),
-      // Discard URLs from older job producers. Credentials are fetched from www.
-      repositoryUrl: Joi.any().strip(),
       gitCommitHash: Joi.string().required(),
       gitRef: Joi.string().allow(null).required(),
     }),


### PR DESCRIPTION
# Why

I want the authenticated URL to NOT come through the job payload, but from the www fetch.

# How

Removed `repositoryUrl` from the archive project source schema. Focused the schema we expect www to respond with and adjusted code.

# Test Plan

CI should pass.