### PR TITLE
[build-tools] Require PATH sources for local builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [build-tools] Require PATH project sources for local builds. ([#4362](https://github.com/expo/eas-cli/pull/4362) by [@sjchmiela](https://github.com/sjchmiela))
+
 ## [24.1.2](https://github.com/expo/eas-cli/releases/tag/v24.1.2) - 2026-09-11
 
 ### 🐛 Bug fixes

--- a/packages/build-tools/src/common/__tests__/projectSources.test.ts
+++ b/packages/build-tools/src/common/__tests__/projectSources.test.ts
@@ -6,6 +6,7 @@ import {
   Job,
   Platform,
   SystemError,
+  UserError,
   Workflow,
 } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
@@ -622,9 +623,12 @@ describe('local project sources', () => {
     'rejects local %s sources before fetching or unpacking',
     async type => {
       const ctx = createContext(type);
-      await expect(prepareProjectSourcesAsync(ctx, ctx.buildDirectory)).rejects.toThrow(
-        'Local builds require a PATH project source'
-      );
+      const result = prepareProjectSourcesAsync(ctx, ctx.buildDirectory);
+      await expect(result).rejects.toBeInstanceOf(UserError);
+      await expect(result).rejects.toMatchObject({
+        errorCode: 'INVALID_LOCAL_PROJECT_SOURCE',
+        message: 'Local builds require a PATH project source.',
+      });
       expect(fetch).not.toHaveBeenCalled();
       expect(spawn).not.toHaveBeenCalled();
       expect(shallowCloneRepositoryAsync).not.toHaveBeenCalled();

--- a/packages/build-tools/src/common/__tests__/projectSources.test.ts
+++ b/packages/build-tools/src/common/__tests__/projectSources.test.ts
@@ -47,7 +47,7 @@ describe('projectSources', () => {
     expect(logger.info).toHaveBeenCalledWith('Normalizing project source permissions');
   });
 
-  it.each([false, true])('uses the correct repository URL (local: %s)', async isLocal => {
+  it('uses the refreshed repository URL', async () => {
     const robotAccessToken = randomUUID();
     const buildId = randomUUID();
     await vol.promises.mkdir('/workingdir/environment-secrets/', { recursive: true });
@@ -78,7 +78,7 @@ describe('projectSources', () => {
           __API_SERVER_URL: 'https://api.expo.dev',
           EXPO_TOKEN: robotAccessToken,
           EAS_BUILD_ID: buildId,
-          EAS_BUILD_RUNNER: isLocal ? 'local-build-plugin' : 'eas-build',
+          EAS_BUILD_RUNNER: 'eas-build',
         },
         workingdir: '/workingdir',
         logger: createMockLogger(),
@@ -107,15 +107,10 @@ describe('projectSources', () => {
       expect.objectContaining({
         archiveSource: {
           ...ctx.job.projectArchive,
-          repositoryUrl: isLocal
-            ? 'https://x-access-token:1234567890@github.com/expo/eas-cli.git'
-            : 'https://x-access-token:qwerty@github.com/expo/eas-cli.git',
+          repositoryUrl: 'https://x-access-token:qwerty@github.com/expo/eas-cli.git',
         },
       })
     );
-    if (isLocal) {
-      expect(fetchMock).not.toHaveBeenCalled();
-    }
   });
 
   it.each(['http', 'network', 'json', 'schema'])(
@@ -587,4 +582,52 @@ describe('projectSources', () => {
       );
     });
   });
+});
+
+describe('local project sources', () => {
+  function createContext(type: ArchiveSourceType): BuildContext<Job> {
+    return new BuildContext(
+      {
+        platform: Platform.IOS,
+        projectArchive: { type, path: '/source.tar.gz' },
+      } as Job,
+      {
+        env: { EAS_BUILD_RUNNER: 'local-build-plugin', __API_SERVER_URL: 'https://api.expo.dev' },
+        workingdir: '/workingdir',
+        logger: createMockLogger(),
+        logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+        uploadArtifact: jest.fn(),
+      }
+    );
+  }
+
+  it('copies and unpacks a PATH source without fetching from www', async () => {
+    await vol.promises.mkdir('/workingdir', { recursive: true });
+    await vol.promises.writeFile('/source.tar.gz', 'local archive');
+    const ctx = createContext(ArchiveSourceType.PATH);
+    await expect(prepareProjectSourcesAsync(ctx, ctx.buildDirectory)).resolves.toEqual({
+      handled: true,
+    });
+    expect(await vol.promises.readFile('/workingdir/project.tar.gz', 'utf8')).toBe('local archive');
+    expect(spawn).toHaveBeenCalledWith(
+      'tar',
+      ['-C', ctx.buildDirectory, '--strip-components', '1', '-zxf', '/workingdir/project.tar.gz'],
+      { logger: ctx.logger }
+    );
+    expect(fetch).not.toHaveBeenCalled();
+    expect(shallowCloneRepositoryAsync).not.toHaveBeenCalled();
+  });
+
+  it.each(Object.values(ArchiveSourceType).filter(type => type !== ArchiveSourceType.PATH))(
+    'rejects local %s sources before fetching or unpacking',
+    async type => {
+      const ctx = createContext(type);
+      await expect(prepareProjectSourcesAsync(ctx, ctx.buildDirectory)).rejects.toThrow(
+        'Local builds require a PATH project source'
+      );
+      expect(fetch).not.toHaveBeenCalled();
+      expect(spawn).not.toHaveBeenCalled();
+      expect(shallowCloneRepositoryAsync).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/packages/build-tools/src/common/__tests__/projectSources.test.ts
+++ b/packages/build-tools/src/common/__tests__/projectSources.test.ts
@@ -6,7 +6,6 @@ import {
   Job,
   Platform,
   SystemError,
-  UserError,
   Workflow,
 } from '@expo/eas-build-job';
 import spawn from '@expo/turtle-spawn';
@@ -624,10 +623,11 @@ describe('local project sources', () => {
     async type => {
       const ctx = createContext(type);
       const result = prepareProjectSourcesAsync(ctx, ctx.buildDirectory);
-      await expect(result).rejects.toBeInstanceOf(UserError);
+      await expect(result).rejects.toBeInstanceOf(SystemError);
       await expect(result).rejects.toMatchObject({
-        errorCode: 'INVALID_LOCAL_PROJECT_SOURCE',
-        message: 'Local builds require a PATH project source.',
+        errorCode: 'SERVER_ERROR',
+        trackingCode: 'INVALID_LOCAL_PROJECT_SOURCE',
+        message: `Expected a PATH project source for a local build, received ${type}.`,
       });
       expect(fetch).not.toHaveBeenCalled();
       expect(spawn).not.toHaveBeenCalled();

--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -9,6 +9,7 @@ import {
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
 import spawn from '@expo/turtle-spawn';
+import assert from 'assert';
 import fs from 'fs/promises';
 import { graphql } from 'gql.tada';
 import fetch from 'node-fetch';
@@ -25,30 +26,28 @@ export async function prepareProjectSourcesAsync<TJob extends Job>(
   destinationDirectory: string
 ): // Return type required to make switch exhaustive.
 Promise<{ handled: boolean }> {
-  let projectArchive: ArchiveSource = ctx.job.projectArchive;
   if (ctx.isLocal) {
-    console.warn('Local build, skipping project archive refresh');
-  } else {
-    const projectArchiveResult = await asyncResult(fetchProjectArchiveSourceAsync(ctx));
-
-    if (!projectArchiveResult.ok) {
-      throw new SystemError('Failed to fetch project sources. Re-run the job.', {
-        cause: projectArchiveResult.reason,
-      });
-    }
-
-    projectArchive = projectArchiveResult.value;
+    assert(
+      ctx.job.projectArchive.type === ArchiveSourceType.PATH,
+      'Local builds require a PATH project source'
+    );
+    await prepareProjectSourcesLocallyAsync(ctx, ctx.job.projectArchive.path, destinationDirectory);
+    return { handled: true };
   }
 
+  const projectArchiveResult = await asyncResult(fetchProjectArchiveSourceAsync(ctx));
+  if (!projectArchiveResult.ok) {
+    throw new SystemError('Failed to fetch project sources. Re-run the job.', {
+      cause: projectArchiveResult.reason,
+    });
+  }
+  const projectArchive = projectArchiveResult.value;
+
   switch (projectArchive.type) {
+    case ArchiveSourceType.PATH:
     case ArchiveSourceType.R2:
     case ArchiveSourceType.GCS: {
       throw new Error('Remote project sources should be resolved earlier to URL');
-    }
-
-    case ArchiveSourceType.PATH: {
-      await prepareProjectSourcesLocallyAsync(ctx, projectArchive.path, destinationDirectory); // used in eas build --local
-      return { handled: true };
     }
 
     case ArchiveSourceType.NONE: {

--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -5,11 +5,11 @@ import {
   ArchiveSourceType,
   Job,
   SystemError,
+  UserError,
 } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
 import spawn from '@expo/turtle-spawn';
-import assert from 'assert';
 import fs from 'fs/promises';
 import { graphql } from 'gql.tada';
 import fetch from 'node-fetch';
@@ -27,10 +27,12 @@ export async function prepareProjectSourcesAsync<TJob extends Job>(
 ): // Return type required to make switch exhaustive.
 Promise<{ handled: boolean }> {
   if (ctx.isLocal) {
-    assert(
-      ctx.job.projectArchive.type === ArchiveSourceType.PATH,
-      'Local builds require a PATH project source'
-    );
+    if (ctx.job.projectArchive.type !== ArchiveSourceType.PATH) {
+      throw new UserError(
+        'INVALID_LOCAL_PROJECT_SOURCE',
+        'Local builds require a PATH project source.'
+      );
+    }
     await prepareProjectSourcesLocallyAsync(ctx, ctx.job.projectArchive.path, destinationDirectory);
     return { handled: true };
   }

--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -5,7 +5,6 @@ import {
   ArchiveSourceType,
   Job,
   SystemError,
-  UserError,
 } from '@expo/eas-build-job';
 import { bunyan } from '@expo/logger';
 import { asyncResult } from '@expo/results';
@@ -28,9 +27,9 @@ export async function prepareProjectSourcesAsync<TJob extends Job>(
 Promise<{ handled: boolean }> {
   if (ctx.isLocal) {
     if (ctx.job.projectArchive.type !== ArchiveSourceType.PATH) {
-      throw new UserError(
-        'INVALID_LOCAL_PROJECT_SOURCE',
-        'Local builds require a PATH project source.'
+      throw new SystemError(
+        `Expected a PATH project source for a local build, received ${ctx.job.projectArchive.type}.`,
+        { trackingCode: 'INVALID_LOCAL_PROJECT_SOURCE' }
       );
     }
     await prepareProjectSourcesLocallyAsync(ctx, ctx.job.projectArchive.path, destinationDirectory);


### PR DESCRIPTION
# Why

I want to simplify how we handle project archive source. We can expect local builds to only run with `PATH` sources.

# How

Adjusted code and validation.

# Test Plan

CI should pass.