### PR TITLE
[build-tools] Upgrade xcpretty to 4.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Update `@expo/xcpretty` to preserve Xcode compiler errors that were missing from formatted build logs. ([#4365](https://github.com/expo/eas-cli/pull/4365) by [@sjchmiela](https://github.com/sjchmiela))
+
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -50,7 +50,7 @@
     "@expo/steps": "23.1.0",
     "@expo/template-file": "23.0.0",
     "@expo/turtle-spawn": "23.1.0",
-    "@expo/xcpretty": "^4.3.1",
+    "@expo/xcpretty": "^4.4.5",
     "@ngrok/ngrok": "1.7.0",
     "@sentry/node": "7.77.0",
     "@urql/core": "^6.0.1",


### PR DESCRIPTION
# Why

Xcode compiler errors can be missing from formatted build logs when diagnostics are indented or omit source lines. `@expo/xcpretty@4.4.5` fixes this in https://github.com/expo/third-party/pull/162.

# How

Raise the `@expo/build-tools` dependency to `^4.4.5` and add a bug fix changelog entry.

# Test Plan

- The release passed all 185 xcpretty tests, build, lint, and formatting checks.
- A smoke test of the packed formatter preserved two compiler errors without source lines, including an indented error.
- Formatted the changed files and checked the diff.
- Pending: Yarn lockfile update and EAS repository checks. npm accepted the release, but `4.4.5` is not yet available from the registry. `yarn install` fails with `No candidates found`. Keep this PR in draft until the version is available and these checks pass.
