### PR TITLE
[build-tools] Use `bun x` to start Argent remote sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Start Argent remote sessions with `bun x` so they work when the `bunx` symlink is missing. ([491b372a](https://github.com/expo/eas-cli/commit/491b372a) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - [build-tools] Reduce `expo-device-hub` preview resolution from 1280 px to 960 px to match `serve-sim` and lower streaming bandwidth. ([#4326](https://github.com/expo/eas-cli/pull/4326) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [build-tools] Install FFmpeg before launching `expo-device-hub` in Android device sessions. ([#4332](https://github.com/expo/eas-cli/pull/4332) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 

--- a/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
@@ -139,10 +139,38 @@ describe('createStartArgentRemoteSessionBuildFunction orchestration', () => {
     );
 
     // (2) The event log flag is enabled, before the tool-server is launched.
+    expect(spawn).toHaveBeenNthCalledWith(
+      1,
+      'bun',
+      ['x', '@swmansion/argent@latest', 'enable', 'artifacts-list-endpoint'],
+      expect.objectContaining({ env: { EXISTING: 'value' } })
+    );
+    expect(spawn).toHaveBeenNthCalledWith(
+      2,
+      'bun',
+      ['x', '@swmansion/argent@latest', 'enable', 'tool-server-event-log'],
+      expect.objectContaining({ env: { EXISTING: 'value' } })
+    );
+    expect(spawnDetached).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'bun',
+        args: [
+          'x',
+          '@swmansion/argent@latest',
+          'server',
+          'start',
+          '--port',
+          '0',
+          '--idle-timeout',
+          '0',
+          '--force',
+        ],
+      })
+    );
     const spawnCalls = jest.mocked(spawn).mock.calls;
     const enableEventLogIndex = spawnCalls.findIndex(
       ([command, args]) =>
-        command === 'bunx' && Array.isArray(args) && args.includes('tool-server-event-log')
+        command === 'bun' && Array.isArray(args) && args.includes('tool-server-event-log')
     );
     expect(enableEventLogIndex).toBeGreaterThanOrEqual(0);
     expect(jest.mocked(spawn).mock.invocationCallOrder[enableEventLogIndex]).toBeLessThan(

--- a/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession-orchestration.test.ts
@@ -139,38 +139,13 @@ describe('createStartArgentRemoteSessionBuildFunction orchestration', () => {
     );
 
     // (2) The event log flag is enabled, before the tool-server is launched.
-    expect(spawn).toHaveBeenNthCalledWith(
-      1,
-      'bun',
-      ['x', '@swmansion/argent@latest', 'enable', 'artifacts-list-endpoint'],
-      expect.objectContaining({ env: { EXISTING: 'value' } })
-    );
-    expect(spawn).toHaveBeenNthCalledWith(
-      2,
-      'bun',
-      ['x', '@swmansion/argent@latest', 'enable', 'tool-server-event-log'],
-      expect.objectContaining({ env: { EXISTING: 'value' } })
-    );
-    expect(spawnDetached).toHaveBeenCalledWith(
-      expect.objectContaining({
-        command: 'bun',
-        args: [
-          'x',
-          '@swmansion/argent@latest',
-          'server',
-          'start',
-          '--port',
-          '0',
-          '--idle-timeout',
-          '0',
-          '--force',
-        ],
-      })
-    );
     const spawnCalls = jest.mocked(spawn).mock.calls;
     const enableEventLogIndex = spawnCalls.findIndex(
       ([command, args]) =>
-        command === 'bun' && Array.isArray(args) && args.includes('tool-server-event-log')
+        command === 'bun' &&
+        Array.isArray(args) &&
+        args[0] === 'x' &&
+        args.includes('tool-server-event-log')
     );
     expect(enableEventLogIndex).toBeGreaterThanOrEqual(0);
     expect(jest.mocked(spawn).mock.invocationCallOrder[enableEventLogIndex]).toBeLessThan(

--- a/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startArgentRemoteSession.test.ts
@@ -74,7 +74,7 @@ describe(warnIfArgentPackageVersionCannotBeVerified, () => {
     ).not.toThrow();
     expect(warn).toHaveBeenCalledTimes(2);
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('Continuing and letting bunx resolve it.')
+      expect.stringContaining('Continuing and letting bun x resolve it.')
     );
   });
 });

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -112,24 +112,30 @@ export function createStartArgentRemoteSessionBuildFunction(
 
       logger.info('Enabling the Argent artifacts list endpoint flag.');
       await spawn(
-        'bunx',
-        [`${ARGENT_PACKAGE_NAME}@${versionSpec}`, 'enable', ARGENT_ARTIFACTS_LIST_ENDPOINT_FLAG],
+        'bun',
+        [
+          'x',
+          `${ARGENT_PACKAGE_NAME}@${versionSpec}`,
+          'enable',
+          ARGENT_ARTIFACTS_LIST_ENDPOINT_FLAG,
+        ],
         { env, logger }
       );
 
       logger.info('Enabling the Argent tool-server event log flag.');
       await spawn(
-        'bunx',
-        [`${ARGENT_PACKAGE_NAME}@${versionSpec}`, 'enable', ARGENT_EVENT_LOG_FLAG],
+        'bun',
+        ['x', `${ARGENT_PACKAGE_NAME}@${versionSpec}`, 'enable', ARGENT_EVENT_LOG_FLAG],
         { env, logger }
       );
 
-      logger.info(`Launching ${ARGENT_PACKAGE_NAME}@${versionSpec} tool-server via bunx.`);
-      // Keep Argent itself in foreground mode under the detached bunx process. This preserves
-      // the bunx -> Argent CLI -> tool-server ancestry used to identify the matching state file.
+      logger.info(`Launching ${ARGENT_PACKAGE_NAME}@${versionSpec} tool-server via bun x.`);
+      // Keep Argent itself in foreground mode under the detached bun process. This preserves
+      // the bun -> Argent CLI -> tool-server ancestry used to identify the matching state file.
       const argentServer = spawnDetached({
-        command: 'bunx',
+        command: 'bun',
         args: [
+          'x',
           `${ARGENT_PACKAGE_NAME}@${versionSpec}`,
           'server',
           'start',
@@ -294,7 +300,7 @@ export function warnIfArgentPackageVersionCannotBeVerified({
     logger.warn(
       `Argent remote simulator sessions require ${ARGENT_PACKAGE_NAME}@${MIN_ARGENT_REMOTE_SESSION_VERSION} or newer, ` +
         `but package_version "${packageVersion}" is not an exact semver version that EAS can verify. ` +
-        `Continuing and letting bunx resolve it.`
+        `Continuing and letting bun x resolve it.`
     );
     return;
   }


### PR DESCRIPTION
# Why

Argent remote sessions can fail with `spawn bunx ENOENT` even when Bun itself is installed. Bun's installer creates the `bunx` symlink indirectly by invoking `bun completions`.

The installer skips that invocation when both conditions hold:

1. `command -v bun` fails in the installer's current `PATH`, even after downloading the executable.
2. `basename "$SHELL"` is neither `bash`, `zsh`, nor `fish` (for example, `SHELL=/bin/sh`).

The unsupported-shell branch prints manual PATH instructions and completes successfully without creating `bunx`. Executing the installer with Bash does not necessarily change the `$SHELL` environment variable.

Source references for Bun 1.3.14:

- [Existing-Bun PATH check and completions invocation](https://github.com/oven-sh/bun/blob/bun-v1.3.14/src/cli/install.sh#L174-L181).
- [Shell-specific branches and unsupported-shell fallback](https://github.com/oven-sh/bun/blob/bun-v1.3.14/src/cli/install.sh#L194-L316).
- [The completions command calls the symlink installer](https://github.com/oven-sh/bun/blob/bun-v1.3.14/src/cli/install_completions_command.zig#L153), whose [POSIX implementation creates `bunx` beside Bun](https://github.com/oven-sh/bun/blob/bun-v1.3.14/src/cli/install_completions_command.zig#L6-L46).

This behavior is not caused by specifying a version: the same installer branching is present in the checked versions 1.0.14, 1.2.20, 1.3.13, and 1.3.14. The missing-launcher behavior was reproduced in an isolated installation; the failing cloud VM itself has not been inspected.

# How

Invoke `bun x` instead of `bunx` for both feature-flag commands and the detached Argent server. Update the logs and process ancestry comment to match. The existing orchestration check now matches the event-log flag command using `bun` with `x` as its first argument.

The companion image fix, https://github.com/expo/turtle-v2/pull/2614, ensures the symlink exists in Linux images. macOS already has a working `bunx` installation. This EAS change also works with existing images that already have Bun but lack the symlink.

Authored by Codex (GPT-6).


