### PR TITLE
[eas-cli] Remove unnecessary confirm_account query param

### DIFF
--- a/packages/eas-cli/src/user/expoBrowserAuthFlowLauncher.ts
+++ b/packages/eas-cli/src/user/expoBrowserAuthFlowLauncher.ts
@@ -79,7 +79,6 @@ export async function getSessionUsingBrowserAuthFlowAsync({ sso = false }): Prom
       `code_challenge=${codeChallenge}`,
       `code_challenge_method=S256`,
       `state=${state}`,
-      `confirm_account=true`,
     ].join('&');
     return `${expoWebsiteUrl}${sso ? '/sso-login' : '/login'}?${params}`;
   };


### PR DESCRIPTION
<!-- You can skip the changelog check by labeling the PR with "no changelog". -->

# Why
On login, eas-cli redirects to the website. Currently, it passes a `confirm_account` query param so that the user can explicitly choose which Expo user to log in as. Now, the website automatically shows an authorize page (that lets users select another user) so the param is no longer necessary.

# How
Removed the `confirm_account` query param

# Test Plan
Ran `yarn run eas login`