### PR TITLE
[eas-cli] add --egress-allow to reach local dev servers through local egress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [eas-cli] Add `--egress-allow <host:port>` to `eas simulator:start` so local egress sessions can reach dev servers on this machine or its network. ([#4369](https://github.com/expo/eas-cli/pull/4369) by [@brentvatne](https://github.com/brentvatne))
 - [build-tools] Add the `eas/start_local_egress` step for iOS simulator sessions with local egress: the device host's system proxy points at a reverse tunnel to the EAS CLI machine, so HTTP(S) requests that honor it exit from that machine and third parties see its IP. ([#4364](https://github.com/expo/eas-cli/pull/4364) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli] Add `--egress local` to `eas simulator:start` and the `eas simulator:egress` command, which run the local egress client for the session. ([#4364](https://github.com/expo/eas-cli/pull/4364) by [@brentvatne](https://github.com/brentvatne))
 - [build-tools] Require the serve-sim session token for device run session previews, so the tunnel no longer exposes the shell-exec route. ([#4306](https://github.com/expo/eas-cli/pull/4306) by [@gwdp](https://github.com/gwdp))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🎉 New features
 
 - [eas-cli] Add `--egress-allow <host:port>` to `eas simulator:start` so local egress sessions can reach dev servers on this machine or its network. ([#4369](https://github.com/expo/eas-cli/pull/4369) by [@brentvatne](https://github.com/brentvatne))
+- [eas-cli][build-tools] Forward `--egress-allow localhost:<port>` and `127.0.0.1:<port>` entries from the simulator host's loopback interface to this machine (like `adb reverse`), so dev server URLs that use `127.0.0.1` work through local egress. ([#4369](https://github.com/expo/eas-cli/pull/4369) by [@brentvatne](https://github.com/brentvatne))
 - [build-tools] Add the `eas/start_local_egress` step for iOS simulator sessions with local egress: the device host's system proxy points at a reverse tunnel to the EAS CLI machine, so HTTP(S) requests that honor it exit from that machine and third parties see its IP. ([#4364](https://github.com/expo/eas-cli/pull/4364) by [@brentvatne](https://github.com/brentvatne))
 - [eas-cli] Add `--egress local` to `eas simulator:start` and the `eas simulator:egress` command, which run the local egress client for the session. ([#4364](https://github.com/expo/eas-cli/pull/4364) by [@brentvatne](https://github.com/brentvatne))
 - [build-tools] Require the serve-sim session token for device run session previews, so the tunnel no longer exposes the shell-exec route. ([#4306](https://github.com/expo/eas-cli/pull/4306) by [@gwdp](https://github.com/gwdp))

--- a/packages/eas-cli/src/commands/simulator/__tests__/egress.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/egress.test.ts
@@ -17,6 +17,7 @@ jest.mock('../../../simulator/egress', () => ({
 
 const shellSession = {
   EAS_SIMULATOR_SESSION_ID: 'session-b',
+  EAS_SIMULATOR_EGRESS_ALLOW: '',
   EAS_SIMULATOR_EGRESS_URL: 'https://egress-b.example.test',
   EAS_SIMULATOR_EGRESS_TOKEN: 'token-b',
   EAS_SIMULATOR_EGRESS_FINGERPRINT: 'fingerprint-b',
@@ -24,6 +25,7 @@ const shellSession = {
 };
 const fileSession = {
   EAS_SIMULATOR_SESSION_ID: 'session-a',
+  EAS_SIMULATOR_EGRESS_ALLOW: 'localhost:3000',
   EAS_SIMULATOR_EGRESS_URL: 'https://egress-a.example.test',
   EAS_SIMULATOR_EGRESS_TOKEN: 'token-a',
   EAS_SIMULATOR_EGRESS_FINGERPRINT: 'fingerprint-a',
@@ -71,6 +73,7 @@ describe(SimulatorEgress, () => {
         token: shellSession.EAS_SIMULATOR_EGRESS_TOKEN,
         fingerprint: shellSession.EAS_SIMULATOR_EGRESS_FINGERPRINT,
         port: 8899,
+        allow: [],
       })
     );
     expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('session-b'));
@@ -91,6 +94,7 @@ describe(SimulatorEgress, () => {
           token: fileSession.EAS_SIMULATOR_EGRESS_TOKEN,
           fingerprint: fileSession.EAS_SIMULATOR_EGRESS_FINGERPRINT,
           port: 8898,
+          allow: ['localhost:3000'],
         })
       );
       expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('session-a'));

--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -53,7 +53,10 @@ jest.mock('../../../simulator/env', () => ({
 }));
 jest.mock('../../../simulator/expoGo');
 jest.mock('../../../prompts');
-jest.mock('../../../simulator/egress');
+jest.mock('../../../simulator/egress', () => ({
+  ...jest.requireActual('../../../simulator/egress'),
+  runLocalEgressAsync: jest.fn(),
+}));
 jest.mock('../../../ora', () => ({
   ora: jest.fn(() => {
     const spinner = {
@@ -1028,6 +1031,65 @@ describe(Simulator, () => {
       expect(process.listeners('SIGINT')).toEqual(listeners);
     }
   );
+
+  it('passes normalized --egress-allow destinations to the egress client', async () => {
+    const session = makeDeviceRunSession({
+      remoteConfig: {
+        __typename: 'AgentDeviceRunSessionRemoteConfig',
+        agentDeviceRemoteSessionUrl: 'https://agent.example.com',
+        agentDeviceRemoteSessionToken: 'token',
+        egressUrl: 'https://egress.example.com',
+        egressToken: 'pw',
+        egressFingerprint: 'fp',
+        egressPort: 8899,
+      },
+    });
+    mockByIdAsync
+      .mockResolvedValueOnce(session)
+      .mockResolvedValueOnce({ ...session, status: DeviceRunSessionStatus.Stopped });
+    jest.mocked(runLocalEgressAsync).mockResolvedValueOnce(undefined);
+
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--egress',
+      'local',
+      '--egress-allow',
+      'localhost:3000',
+      '--egress-allow',
+      'LOCALHOST:3000',
+      '--egress-allow',
+      '192.168.1.20:8080',
+    ]);
+    await command.runAsync();
+
+    expect(runLocalEgressAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ allow: ['localhost:3000', '192.168.1.20:8080'] })
+    );
+  });
+
+  it('rejects malformed --egress-allow values before creating a session', async () => {
+    // If validation were skipped, fail fast instead of polling a live session.
+    mockByIdAsync.mockResolvedValue(
+      makeDeviceRunSession({ status: DeviceRunSessionStatus.Stopped })
+    );
+    const { command } = createCommand([
+      '--platform',
+      'ios',
+      '--egress',
+      'local',
+      '--egress-allow',
+      'localhost',
+    ]);
+    await expect(command.runAsync()).rejects.toThrow('Invalid --egress-allow value "localhost"');
+    expect(mockCreateDeviceRunSessionAsync).not.toHaveBeenCalled();
+  });
+
+  it('requires --egress for --egress-allow', async () => {
+    const { command } = createCommand(['--platform', 'ios', '--egress-allow', 'localhost:3000']);
+    await expect(command.runAsync()).rejects.toThrow(/--egress/);
+    expect(mockCreateDeviceRunSessionAsync).not.toHaveBeenCalled();
+  });
 
   it('prompts to select the platform when --platform is omitted', async () => {
     mockPromptAsync.mockResolvedValueOnce({ selectedPlatform: AppPlatform.Android });

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -22,7 +22,7 @@ import { DeviceRunSessionQuery } from '../../graphql/queries/DeviceRunSessionQue
 import Log, { link } from '../../log';
 import { ora } from '../../ora';
 import { promptAsync } from '../../prompts';
-import { runLocalEgressAsync } from '../../simulator/egress';
+import { parseEgressAllowList, runLocalEgressAsync } from '../../simulator/egress';
 import {
   EAS_SIMULATOR_SESSION_ID,
   SIMULATOR_DOTENV_FILE_NAME,
@@ -142,6 +142,12 @@ export default class Simulator extends EasCommand {
         'With "local", the simulator system proxy points at this machine: HTTP(S) and WebSocket requests that honor it (WebKit, URLSession) exit from this machine and fail while the egress client is disconnected. Requests from libraries that bypass the system proxy are not covered. The egress client must keep running for the life of the session. Only supported with --platform ios.',
       options: EGRESS_FLAG_VALUES,
     })(),
+    'egress-allow': Flags.string({
+      description:
+        'Destination on this machine or its network that the simulator may reach through local egress, as an exact host:port (for example localhost:3000). Repeat for multiple destinations. Requires --egress local.',
+      multiple: true,
+      dependsOn: ['egress'],
+    }),
     force: Flags.boolean({
       description:
         '[default: true] Create a new simulator session even when an existing simulator session is present in the environment.',
@@ -231,6 +237,12 @@ export default class Simulator extends EasCommand {
     const egress = flags.egress === 'local' ? DeviceRunSessionEgress.Local : undefined;
     if (egress && platform !== AppPlatform.Ios) {
       throw new EasCommandError('--egress local is only supported with --platform ios.');
+    }
+    let egressAllow: string[] = [];
+    try {
+      egressAllow = parseEgressAllowList(flags['egress-allow'] ?? []);
+    } catch (err) {
+      throw new EasCommandError(err instanceof Error ? err.message : String(err));
     }
     if (platform === AppPlatform.Android) {
       Log.warn(
@@ -377,7 +389,7 @@ export default class Simulator extends EasCommand {
 
     if (flags['out-config-type'] === OUT_CONFIG_TYPE_VALUES.Dotenv) {
       await writeSimulatorEnvSafelyAsync(projectDir, {
-        ...getRemoteSessionEnvironmentVariables(remoteConfig),
+        ...getRemoteSessionEnvironmentVariables(remoteConfig, { egressAllow }),
         [EAS_SIMULATOR_SESSION_ID]: deviceRunSessionId,
       });
     }
@@ -406,10 +418,12 @@ export default class Simulator extends EasCommand {
     }
 
     Log.newLine();
-    Log.log(formatRemoteSessionInstructions(remoteConfig, flags['out-config-type']));
+    Log.log(
+      formatRemoteSessionInstructions(remoteConfig, flags['out-config-type'], { egressAllow })
+    );
     Log.newLine();
 
-    const localEgress = getLocalEgressConfig(remoteConfig);
+    const localEgress = getLocalEgressConfig(remoteConfig, egressAllow);
 
     if (nonInteractive) {
       sessionInterrupt.dispose();

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -144,7 +144,7 @@ export default class Simulator extends EasCommand {
     })(),
     'egress-allow': Flags.string({
       description:
-        'Destination on this machine or its network that the simulator may reach through local egress, as an exact host:port (for example localhost:3000). Repeat for multiple destinations. Requires --egress local.',
+        'Destination on this machine or its network that the simulator may reach through local egress, as an exact host:port (for example localhost:3000). Repeat for multiple destinations. A localhost or 127.0.0.1 entry also forwards that port from the simulator host to this machine (like adb reverse), so dev server URLs that use 127.0.0.1 work. Requires --egress local.',
       multiple: true,
       dependsOn: ['egress'],
     }),

--- a/packages/eas-cli/src/simulator/__tests__/egress.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/egress.test.ts
@@ -12,6 +12,7 @@ import {
   classifyChiselClientLogLine,
   createEgressTargetResolver,
   getChiselAssetName,
+  isChiselRemoteRejectionLine,
   isForbiddenEgressAddress,
   orderEgressAddresses,
   parseEgressAllowList,
@@ -142,6 +143,39 @@ describe(buildChiselClientArgs, () => {
       'https://egress-abc.eas-simulator.ngrok.dev',
       'R:127.0.0.1:8899:127.0.0.1:8899',
     ]);
+  });
+
+  it('adds one loopback reverse remote per forwarded port after the proxy remote', () => {
+    expect(
+      buildChiselClientArgs({
+        url: 'https://egress-abc.eas-simulator.ngrok.dev',
+        fingerprint: 'fp=',
+        port: 8899,
+        localPort: 51000,
+        forwardPorts: [3000, 8082],
+      }).slice(-3)
+    ).toEqual([
+      'R:127.0.0.1:8899:127.0.0.1:51000',
+      'R:127.0.0.1:3000:127.0.0.1:3000',
+      'R:127.0.0.1:8082:127.0.0.1:8082',
+    ]);
+  });
+});
+
+describe(isChiselRemoteRejectionLine, () => {
+  it('recognizes denied and unbindable reverse remotes', () => {
+    expect(
+      isChiselRemoteRejectionLine("2026/09/10 client: access to 'R:127.0.0.1:8082' denied")
+    ).toBe(true);
+    expect(
+      isChiselRemoteRejectionLine(
+        '2026/09/10 client: Connection error: listen tcp 127.0.0.1:8082: bind: address already in use'
+      )
+    ).toBe(true);
+    expect(isChiselRemoteRejectionLine('2026/09/10 client: Connected (Latency 41ms)')).toBe(false);
+    expect(
+      isChiselRemoteRejectionLine('2026/09/10 client: Connection error: websocket: bad handshake')
+    ).toBe(false);
   });
 });
 
@@ -806,6 +840,43 @@ describe(runLocalEgressAsync, () => {
       expect(spawnAsync).not.toHaveBeenCalled();
     } finally {
       exists.mockReset();
+    }
+  });
+
+  it('opens a loopback reverse remote for each forwarded --egress-allow port', async () => {
+    jest.mocked(fs.pathExists).mockResolvedValue(true as never);
+    let child: ChildProcess | undefined;
+    jest.mocked(spawnAsync).mockImplementation(() => {
+      child = new ChildProcess();
+      const promise = new Promise<never>((_resolve, reject) => {
+        child!.kill = jest.fn(signal => {
+          Object.defineProperty(child, 'signalCode', { value: signal, configurable: true });
+          reject(new Error('terminated'));
+          return true;
+        });
+      });
+      return Object.assign(promise, { child });
+    });
+    const controller = new AbortController();
+    const running = runLocalEgressAsync({
+      url: 'https://example.test',
+      token: 'pw',
+      fingerprint: 'fp',
+      port: 8899,
+      allow: ['localhost:8082', '127.0.0.1:3000', 'localhost:80', '192.168.1.20:8080'],
+      signal: controller.signal,
+    });
+    try {
+      await waitForAsync(() => child !== undefined);
+      const args = jest.mocked(spawnAsync).mock.calls[0][1] ?? [];
+      expect(args.slice(-3)).toEqual([
+        expect.stringMatching(/^R:127\.0\.0\.1:8899:127\.0\.0\.1:\d+$/),
+        'R:127.0.0.1:3000:127.0.0.1:3000',
+        'R:127.0.0.1:8082:127.0.0.1:8082',
+      ]);
+    } finally {
+      controller.abort();
+      await running;
     }
   });
 

--- a/packages/eas-cli/src/simulator/__tests__/egress.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/egress.test.ts
@@ -1,6 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
 import * as fs from 'fs-extra';
 import { ChildProcess } from 'node:child_process';
+import dns from 'node:dns/promises';
 import { once } from 'node:events';
 import http from 'node:http';
 import net from 'node:net';
@@ -9,9 +10,11 @@ import {
   EgressPolicyError,
   buildChiselClientArgs,
   classifyChiselClientLogLine,
+  createEgressTargetResolver,
   getChiselAssetName,
   isForbiddenEgressAddress,
   orderEgressAddresses,
+  parseEgressAllowList,
   readLocalEgressConfigFromEnv,
   resolveEgressTargetAsync,
   runLocalEgressAsync,
@@ -79,15 +82,31 @@ describe(isForbiddenEgressAddress, () => {
 });
 
 describe(resolveEgressTargetAsync, () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it.each(['localhost', 'LOCALHOST', 'api.localhost', 'printer.local', '127.0.0.1', '[::1]'])(
     'refuses %s without resolving it',
     async host => {
-      await expect(resolveEgressTargetAsync(host)).rejects.toBeInstanceOf(EgressPolicyError);
+      await expect(resolveEgressTargetAsync(host, 443)).rejects.toBeInstanceOf(EgressPolicyError);
     }
   );
 
   it('returns a public IP literal unchanged', async () => {
-    await expect(resolveEgressTargetAsync('1.1.1.1')).resolves.toEqual(['1.1.1.1']);
+    await expect(resolveEgressTargetAsync('1.1.1.1', 443)).resolves.toEqual(['1.1.1.1']);
+  });
+
+  it('refuses a DNS name if any record is private', async () => {
+    const lookup = jest.spyOn(dns, 'lookup').mockResolvedValue([
+      { address: '1.1.1.1', family: 4 },
+      { address: '192.168.1.10', family: 4 },
+    ] as never);
+    await expect(resolveEgressTargetAsync('mixed.example', 443)).rejects.toBeInstanceOf(
+      EgressPolicyError
+    );
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(lookup).toHaveBeenCalledWith('mixed.example', { all: true, verbatim: true });
   });
 });
 
@@ -167,13 +186,101 @@ describe(readLocalEgressConfigFromEnv, () => {
       token: 'pw',
       fingerprint: 'fp=',
       port: 8899,
+      allow: [],
     });
+  });
+
+  it('reads the allowed local destinations written by --egress-allow', () => {
+    expect(
+      readLocalEgressConfigFromEnv({
+        EAS_SIMULATOR_EGRESS_URL: 'https://egress-abc.eas-simulator.ngrok.dev',
+        EAS_SIMULATOR_EGRESS_TOKEN: 'pw',
+        EAS_SIMULATOR_EGRESS_FINGERPRINT: 'fp=',
+        EAS_SIMULATOR_EGRESS_PORT: '8899',
+        EAS_SIMULATOR_EGRESS_ALLOW: 'localhost:3000, 192.168.1.20:8080',
+      }).allow
+    ).toEqual(['localhost:3000', '192.168.1.20:8080']);
   });
 
   it('explains how to start a session with egress when the variables are missing', () => {
     expect(() => readLocalEgressConfigFromEnv({ EAS_SIMULATOR_SESSION_ID: 'abc' })).toThrow(
       'was not started with local egress'
     );
+  });
+});
+
+describe(parseEgressAllowList, () => {
+  it('normalizes exact host and port pairs and drops duplicates', () => {
+    expect(
+      parseEgressAllowList([
+        'localhost:3000',
+        ' LOCALHOST:3000 ',
+        '192.168.1.20:8080',
+        '[::1]:3000',
+        '[0:0:0:0:0:0:0:1]:3000',
+        'dev-box.lan:443',
+      ])
+    ).toEqual(['localhost:3000', '192.168.1.20:8080', '[::1]:3000', 'dev-box.lan:443']);
+  });
+
+  it.each([
+    'localhost',
+    'localhost:0',
+    'localhost:70000',
+    '*.test:80',
+    '10.0.0.0/8:80',
+    'http://localhost:3000',
+    '[not-an-ip]:3000',
+    ':3000',
+    ',localhost:3000',
+    'localhost,:3000',
+    'user@localhost:3000',
+    'localhost#ignored:3000',
+    'localhost?ignored:3000',
+    "local'host:3000",
+    'local\\host:3000',
+  ])('rejects %s', entry => {
+    expect(() => parseEgressAllowList([entry])).toThrow('Invalid --egress-allow value');
+  });
+
+  it('normalizes IDN hostnames containing combining marks', () => {
+    expect(parseEgressAllowList(['cafe\u0301.example:3000'])).toEqual(['xn--caf-dma.example:3000']);
+  });
+});
+
+describe(createEgressTargetResolver, () => {
+  it.each([
+    ['[0:0:0:0:0:0:0:1]:3000', '[::1]', '::1'],
+    ['127.1:3000', '127.0.0.1', '127.0.0.1'],
+    ['[::ffff:127.0.0.1]:3000', '[::ffff:7f00:1]', '::ffff:7f00:1'],
+  ])('matches %s after HTTP URL normalization', async (entry, hostname, address) => {
+    const resolve = createEgressTargetResolver({ allow: parseEgressAllowList([entry]) });
+    await expect(resolve(hostname, 3000)).resolves.toEqual([address]);
+    await expect(resolve(hostname, 3001)).rejects.toBeInstanceOf(EgressPolicyError);
+    await expect(resolve('localhost', 3000)).rejects.toBeInstanceOf(EgressPolicyError);
+  });
+
+  it('returns the default policy when nothing is allowed', () => {
+    expect(createEgressTargetResolver({ allow: [] })).toBe(resolveEgressTargetAsync);
+  });
+
+  it('maps an allowed localhost destination to loopback and reports it', async () => {
+    const allowed: string[] = [];
+    const resolve = createEgressTargetResolver({
+      allow: ['localhost:3000', '192.168.1.20:8080'],
+      onAllowed: destination => allowed.push(destination),
+    });
+    await expect(resolve('LocalHost', 3000)).resolves.toEqual(['127.0.0.1', '::1']);
+    await expect(resolve('192.168.1.20', 8080)).resolves.toEqual(['192.168.1.20']);
+    expect(allowed).toEqual(['localhost:3000', '192.168.1.20:8080']);
+  });
+
+  it('keeps refusing the same host on other ports and unlisted private addresses', async () => {
+    const resolve = createEgressTargetResolver({ allow: ['localhost:3000'] });
+    await expect(resolve('localhost', 3001)).rejects.toBeInstanceOf(EgressPolicyError);
+    await expect(resolve('127.0.0.1', 3000)).rejects.toBeInstanceOf(EgressPolicyError);
+    await expect(resolve('192.168.1.20', 8080)).rejects.toBeInstanceOf(EgressPolicyError);
+    await expect(resolve('93.184.216.34', 443)).resolves.toEqual(['93.184.216.34']);
   });
 });
 
@@ -314,6 +421,43 @@ describe(startLocalEgressProxyServerAsync, () => {
       'GET http://internal.example/ HTTP/1.1\r\nHost: internal.example\r\nConnection: close\r\n\r\n'
     );
     expect(httpResponse).toContain('HTTP/1.1 403');
+  });
+
+  it('reaches an allowed local destination and keeps refusing the rest', async () => {
+    const allowedProxy = await startLocalEgressProxyServerAsync({
+      port: 0,
+      resolveTargetAsync: createEgressTargetResolver({ allow: [`localhost:${targetHttpPort}`] }),
+    });
+    const requestAsync = (request: string): Promise<string> =>
+      new Promise((resolve, reject) => {
+        const socket = net.connect({ host: '127.0.0.1', port: allowedProxy.port });
+        let response = '';
+        socket.on('data', chunk => (response += chunk.toString()));
+        socket.on('end', () => {
+          resolve(response);
+        });
+        socket.on('error', reject);
+        socket.on('connect', () => socket.write(request));
+      });
+    try {
+      const allowedResponse = await requestAsync(
+        `GET http://localhost:${targetHttpPort}/allowed HTTP/1.1\r\nHost: localhost:${targetHttpPort}\r\nConnection: close\r\n\r\n`
+      );
+      expect(allowedResponse).toContain('HTTP/1.1 200');
+      expect(allowedResponse).toContain('hello from GET /allowed');
+
+      const otherPortResponse = await requestAsync(
+        `CONNECT localhost:${targetEchoPort} HTTP/1.1\r\nHost: localhost\r\n\r\n`
+      );
+      expect(otherPortResponse).toContain('HTTP/1.1 403');
+
+      const ipResponse = await requestAsync(
+        `GET http://127.0.0.1:${targetHttpPort}/ HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n`
+      );
+      expect(ipResponse).toContain('HTTP/1.1 403');
+    } finally {
+      await allowedProxy.closeAsync();
+    }
   });
 
   it('rejects requests without an absolute URL', async () => {

--- a/packages/eas-cli/src/simulator/__tests__/egressControllers.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/egressControllers.test.ts
@@ -1,0 +1,85 @@
+import { parse as parseDotenv } from 'dotenv';
+import * as fs from 'fs-extra';
+
+import { readLocalEgressConfigFromEnv } from '../egress';
+import { writeSimulatorEnvAsync } from '../env';
+import {
+  DeviceRunSessionRemoteConfig,
+  formatRemoteSessionInstructions,
+  getRemoteSessionEnvironmentVariables,
+} from '../utils';
+
+jest.mock('fs-extra');
+
+const configs: DeviceRunSessionRemoteConfig[] = [
+  {
+    __typename: 'AgentDeviceRunSessionRemoteConfig',
+    agentDeviceRemoteSessionUrl: 'https://agent.example.test',
+    agentDeviceRemoteSessionToken: 'agent-token',
+  },
+  { __typename: 'ArgentRunSessionRemoteConfig', toolsUrl: 'https://argent.example.test' },
+  {
+    __typename: 'AppiumRunSessionRemoteConfig',
+    appiumUrl: 'https://appium.example.test',
+    capabilities: { platformName: 'iOS' },
+  },
+  {
+    __typename: 'WebPreviewOnlyRunSessionRemoteConfig',
+    previewUrl: 'https://preview.example.test',
+  },
+  { __typename: 'ServeSimRunSessionRemoteConfig', previewUrl: 'https://preview.example.test' },
+];
+
+const egressFields = {
+  egressUrl: 'https://egress.example.test',
+  egressToken: 'test-egress-token',
+  egressFingerprint: 'test-fingerprint',
+  egressPort: 8899,
+};
+
+describe('egress exceptions across simulator controllers', () => {
+  beforeEach(() => {
+    jest.mocked(fs.writeFile).mockResolvedValue(undefined as never);
+  });
+
+  it.each(configs)('persists only the requested exceptions for $__typename', async config => {
+    const remoteConfig = { ...config, ...egressFields };
+    const egressAllow = ['localhost:3000', '[::1]:4000'];
+    const environment = getRemoteSessionEnvironmentVariables(remoteConfig, { egressAllow });
+    await writeSimulatorEnvAsync('/test/project', environment);
+    const content = String(jest.mocked(fs.writeFile).mock.calls.at(-1)?.[1]);
+    expect(readLocalEgressConfigFromEnv(parseDotenv(content))).toEqual({
+      url: egressFields.egressUrl,
+      token: egressFields.egressToken,
+      fingerprint: egressFields.egressFingerprint,
+      port: 8899,
+      allow: egressAllow,
+    });
+    const instructions = formatRemoteSessionInstructions(remoteConfig, 'dotenv', { egressAllow });
+    expect(instructions).toContain('eas simulator:egress');
+    expect(instructions).toContain('localhost:3000, [::1]:4000');
+  });
+
+  it.each(configs)(
+    'explicitly clears exceptions for $__typename when none are requested',
+    config => {
+      const environment = getRemoteSessionEnvironmentVariables({ ...config, ...egressFields });
+      expect(environment.EAS_SIMULATOR_EGRESS_ALLOW).toBe('');
+      expect(
+        readLocalEgressConfigFromEnv({
+          EAS_SIMULATOR_EGRESS_ALLOW: 'localhost:9999',
+          ...environment,
+        }).allow
+      ).toEqual([]);
+    }
+  );
+
+  it.each(configs)('does not grant exceptions without an egress tunnel for $__typename', config => {
+    expect(
+      getRemoteSessionEnvironmentVariables(config, { egressAllow: ['localhost:3000'] })
+    ).not.toHaveProperty('EAS_SIMULATOR_EGRESS_ALLOW');
+    expect(
+      formatRemoteSessionInstructions(config, 'dotenv', { egressAllow: ['localhost:3000'] })
+    ).not.toContain('localhost:3000');
+  });
+});

--- a/packages/eas-cli/src/simulator/__tests__/env.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/env.test.ts
@@ -1,13 +1,23 @@
 import * as fs from 'fs-extra';
 import { parse as parseDotenv } from 'dotenv';
+import * as realFs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
+  EAS_SIMULATOR_EGRESS_ALLOW,
+  EAS_SIMULATOR_EGRESS_FINGERPRINT,
+  EAS_SIMULATOR_EGRESS_PORT,
+  EAS_SIMULATOR_EGRESS_TOKEN,
+  EAS_SIMULATOR_EGRESS_URL,
   EAS_SIMULATOR_SESSION_ID,
   SIMULATOR_DOTENV_FILE_HEADER,
   getSimulatorEnvFilePath,
+  loadSimulatorEnvAsync,
   resetSimulatorEnvAsync,
   writeSimulatorEnvAsync,
 } from '../env';
+import { readLocalEgressConfigFromEnv } from '../egress';
 
 jest.mock('fs-extra');
 
@@ -61,6 +71,124 @@ describe(resetSimulatorEnvAsync, () => {
       'permission denied'
     );
   });
+});
+
+describe(loadSimulatorEnvAsync, () => {
+  let projectDir: string;
+  let previousEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    previousEnv = { ...process.env };
+    projectDir = await realFs.mkdtemp(path.join(os.tmpdir(), 'eas-simulator-env-'));
+    jest.mocked(fs.readFile).mockImplementation(jest.requireActual('fs-extra').readFile);
+    process.env[EAS_SIMULATOR_EGRESS_ALLOW] = 'localhost:3000';
+    process.env[EAS_SIMULATOR_SESSION_ID] = 'session-a';
+    process.env[EAS_SIMULATOR_EGRESS_URL] = 'https://session-a.example.test';
+    process.env[EAS_SIMULATOR_EGRESS_TOKEN] = 'session-a-token';
+    process.env[EAS_SIMULATOR_EGRESS_FINGERPRINT] = 'session-a-fingerprint';
+    process.env[EAS_SIMULATOR_EGRESS_PORT] = '8899';
+    process.env.AGENT_DEVICE_DAEMON_BASE_URL = 'https://agent-a.example.test';
+    process.env.AGENT_DEVICE_DAEMON_AUTH_TOKEN = 'agent-a-token';
+    process.env.EAS_SIMULATOR_ENV_TEST_UNRELATED = 'keep-this';
+  });
+
+  afterEach(async () => {
+    process.env = previousEnv;
+    await realFs.rm(projectDir, { recursive: true, force: true });
+    jest.resetAllMocks();
+  });
+
+  it.each(['', `${EAS_SIMULATOR_EGRESS_ALLOW}=''\n`])(
+    "does not inherit another session's exceptions when the file has no exceptions (%j)",
+    async allowLine => {
+      await realFs.writeFile(
+        getSimulatorEnvFilePath(projectDir),
+        `${EAS_SIMULATOR_SESSION_ID}='session-b'\n` +
+          `${EAS_SIMULATOR_EGRESS_URL}='https://session-b.example.test'\n` +
+          allowLine
+      );
+
+      await loadSimulatorEnvAsync(projectDir);
+
+      expect(process.env[EAS_SIMULATOR_SESSION_ID]).toBe('session-b');
+      expect(process.env[EAS_SIMULATOR_EGRESS_ALLOW]).toBe('');
+    }
+  );
+
+  it('preserves shell-exported exceptions when there is no simulator file', async () => {
+    await loadSimulatorEnvAsync(projectDir);
+
+    expect(process.env[EAS_SIMULATOR_EGRESS_ALLOW]).toBe('localhost:3000');
+    expect(process.env[EAS_SIMULATOR_EGRESS_URL]).toBe('https://session-a.example.test');
+    expect(process.env.AGENT_DEVICE_DAEMON_BASE_URL).toBe('https://agent-a.example.test');
+    expect(process.env.AGENT_DEVICE_DAEMON_AUTH_TOKEN).toBe('agent-a-token');
+    expect(process.env.EAS_SIMULATOR_ENV_TEST_UNRELATED).toBe('keep-this');
+  });
+
+  it('loads the file credentials and exceptions together over inherited values', async () => {
+    await realFs.writeFile(
+      getSimulatorEnvFilePath(projectDir),
+      `${EAS_SIMULATOR_SESSION_ID}='session-b'\n` +
+        "AGENT_DEVICE_DAEMON_BASE_URL='https://agent-b.example.test'\n" +
+        "AGENT_DEVICE_DAEMON_AUTH_TOKEN='agent-b-token'\n" +
+        `${EAS_SIMULATOR_EGRESS_URL}='https://session-b.example.test'\n` +
+        `${EAS_SIMULATOR_EGRESS_TOKEN}='session-b-token'\n` +
+        `${EAS_SIMULATOR_EGRESS_FINGERPRINT}='session-b-fingerprint'\n` +
+        `${EAS_SIMULATOR_EGRESS_PORT}='8900'\n` +
+        `${EAS_SIMULATOR_EGRESS_ALLOW}='localhost:4000'\n`
+    );
+
+    await loadSimulatorEnvAsync(projectDir);
+
+    expect(readLocalEgressConfigFromEnv(process.env)).toEqual({
+      url: 'https://session-b.example.test',
+      token: 'session-b-token',
+      fingerprint: 'session-b-fingerprint',
+      port: 8900,
+      allow: ['localhost:4000'],
+    });
+    expect(process.env[EAS_SIMULATOR_SESSION_ID]).toBe('session-b');
+    expect(process.env.AGENT_DEVICE_DAEMON_BASE_URL).toBe('https://agent-b.example.test');
+    expect(process.env.AGENT_DEVICE_DAEMON_AUTH_TOKEN).toBe('agent-b-token');
+    expect(process.env.EAS_SIMULATOR_ENV_TEST_UNRELATED).toBe('keep-this');
+  });
+
+  it('replaces an inherited agent session with an Appium session without mixing controls', async () => {
+    const capabilities = JSON.stringify({ platformName: 'iOS' });
+    await realFs.writeFile(
+      getSimulatorEnvFilePath(projectDir),
+      `${EAS_SIMULATOR_SESSION_ID}='session-b'\n` +
+        "APPIUM_URL='https://appium-b.example.test'\n" +
+        `APPIUM_CAPS='${capabilities}'\n`
+    );
+
+    await loadSimulatorEnvAsync(projectDir);
+
+    expect(process.env[EAS_SIMULATOR_SESSION_ID]).toBe('session-b');
+    expect(process.env.APPIUM_URL).toBe('https://appium-b.example.test');
+    expect(process.env.APPIUM_CAPS).toBe(capabilities);
+    expect(process.env.AGENT_DEVICE_DAEMON_BASE_URL).toBeUndefined();
+    expect(process.env.AGENT_DEVICE_DAEMON_AUTH_TOKEN).toBeUndefined();
+    expect(process.env[EAS_SIMULATOR_EGRESS_URL]).toBeUndefined();
+    expect(process.env[EAS_SIMULATOR_EGRESS_ALLOW]).toBe('');
+    expect(process.env.EAS_SIMULATOR_ENV_TEST_UNRELATED).toBe('keep-this');
+  });
+
+  it.each(['', `${EAS_SIMULATOR_EGRESS_URL}='https://session-b.example.test'\n`])(
+    'does not fill missing file credentials from a previous session (%j)',
+    async egressLine => {
+      await realFs.writeFile(
+        getSimulatorEnvFilePath(projectDir),
+        `${EAS_SIMULATOR_SESSION_ID}='session-b'\n${egressLine}`
+      );
+
+      await loadSimulatorEnvAsync(projectDir);
+
+      expect(process.env[EAS_SIMULATOR_EGRESS_TOKEN]).toBeUndefined();
+      expect(process.env[EAS_SIMULATOR_EGRESS_ALLOW]).toBe('');
+      expect(() => readLocalEgressConfigFromEnv(process.env)).toThrow('no egress client to run');
+    }
+  );
 });
 
 describe(writeSimulatorEnvAsync, () => {

--- a/packages/eas-cli/src/simulator/__tests__/utils.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/utils.test.ts
@@ -6,10 +6,12 @@ import {
   DeviceRunSessionRemoteConfig,
   EAS_SIMULATOR_WAITLIST_URL,
   deviceRunSessionTypeToFlagValue,
+  formatLoopbackForwardNotice,
   formatPreviewUrl,
   formatRemoteSessionInstructions,
   formatSimulatorUnavailableMessage,
   getLocalEgressConfig,
+  getLoopbackForwardPlan,
   getRemoteSessionEnvironmentVariables,
   sanitizeRemoteConfigForJson,
 } from '../utils';
@@ -78,11 +80,56 @@ describe('local egress configuration', () => {
     expect(
       getRemoteSessionEnvironmentVariables(agentDeviceConfig, { egressAllow })
     ).not.toHaveProperty('EAS_SIMULATOR_EGRESS_ALLOW');
-    expect(
-      formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'dotenv', { egressAllow })
-    ).toContain(
+    const instructions = formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'dotenv', {
+      egressAllow,
+    });
+    expect(instructions).toContain(
       "The simulator may reach localhost:3000, 192.168.1.20:8080 on this machine's network."
     );
+    expect(instructions).toContain(
+      '127.0.0.1:3000 in the simulator reaches the same port on this machine (like adb reverse)'
+    );
+  });
+
+  it('omits the loopback forwarding notice when no allowed destination is loopback', () => {
+    expect(
+      formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'dotenv', {
+        egressAllow: ['192.168.1.20:8080'],
+      })
+    ).not.toContain('adb reverse');
+  });
+});
+
+describe(getLoopbackForwardPlan, () => {
+  it('forwards unprivileged localhost and 127.0.0.1 ports once each, in order', () => {
+    expect(
+      getLoopbackForwardPlan(
+        ['localhost:8082', '127.0.0.1:3000', 'localhost:3000', '192.168.1.20:8080', '[::1]:4000'],
+        8899
+      )
+    ).toEqual({ ports: [3000, 8082], skipped: [] });
+  });
+
+  it('skips privileged ports and the proxy port, which the device host does not forward', () => {
+    expect(
+      getLoopbackForwardPlan(['localhost:80', '127.0.0.1:8899', 'localhost:1024'], 8899)
+    ).toEqual({ ports: [1024], skipped: ['localhost:80', '127.0.0.1:8899'] });
+  });
+
+  it('returns an empty plan without allow entries', () => {
+    expect(getLoopbackForwardPlan([], 8899)).toEqual({ ports: [], skipped: [] });
+  });
+});
+
+describe(formatLoopbackForwardNotice, () => {
+  it('describes forwarded ports and name-only entries', () => {
+    expect(formatLoopbackForwardNotice({ ports: [3000, 8082], skipped: ['localhost:80'] })).toEqual(
+      [
+        '127.0.0.1:3000, 127.0.0.1:8082 in the simulator reach the same ports on this machine (like adb reverse), so dev server URLs that use 127.0.0.1 work.',
+        'localhost:80 is reachable by name only: privileged ports and the egress proxy port are not forwarded to 127.0.0.1 in the simulator.',
+      ]
+    );
+    expect(formatLoopbackForwardNotice({ ports: [], skipped: [] })).toEqual([]);
   });
 });
 

--- a/packages/eas-cli/src/simulator/__tests__/utils.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/utils.test.ts
@@ -47,6 +47,7 @@ describe('local egress configuration', () => {
       token: 'egress-secret',
       fingerprint: 'fp=',
       port: 8899,
+      allow: [],
     });
     expect(getRemoteSessionEnvironmentVariables(agentDeviceConfigWithEgress)).toEqual({
       AGENT_DEVICE_DAEMON_BASE_URL: 'https://agent-device.example.test',
@@ -55,10 +56,33 @@ describe('local egress configuration', () => {
       EAS_SIMULATOR_EGRESS_TOKEN: 'egress-secret',
       EAS_SIMULATOR_EGRESS_FINGERPRINT: 'fp=',
       EAS_SIMULATOR_EGRESS_PORT: '8899',
+      EAS_SIMULATOR_EGRESS_ALLOW: '',
     });
     const instructions = formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'dotenv');
     expect(instructions).toContain('eas simulator:egress');
     expect(instructions).toContain('Run the egress client to connect the tunnel');
+    expect(instructions).not.toContain('may reach');
+    expect(formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'env')).toContain(
+      "export EAS_SIMULATOR_EGRESS_ALLOW=''"
+    );
+  });
+
+  it('carries the allowed local destinations into the config, env file and instructions', () => {
+    const egressAllow = ['localhost:3000', '192.168.1.20:8080'];
+    expect(getLocalEgressConfig(agentDeviceConfigWithEgress, egressAllow)?.allow).toEqual(
+      egressAllow
+    );
+    expect(
+      getRemoteSessionEnvironmentVariables(agentDeviceConfigWithEgress, { egressAllow })
+    ).toMatchObject({ EAS_SIMULATOR_EGRESS_ALLOW: 'localhost:3000,192.168.1.20:8080' });
+    expect(
+      getRemoteSessionEnvironmentVariables(agentDeviceConfig, { egressAllow })
+    ).not.toHaveProperty('EAS_SIMULATOR_EGRESS_ALLOW');
+    expect(
+      formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'dotenv', { egressAllow })
+    ).toContain(
+      "The simulator may reach localhost:3000, 192.168.1.20:8080 on this machine's network."
+    );
   });
 });
 
@@ -368,17 +392,18 @@ describe.each(controllerConfigs)('$__typename local egress', remoteConfig => {
       EAS_SIMULATOR_EGRESS_TOKEN: egress.egressToken,
       EAS_SIMULATOR_EGRESS_FINGERPRINT: egress.egressFingerprint,
       EAS_SIMULATOR_EGRESS_PORT: '8899',
+      EAS_SIMULATOR_EGRESS_ALLOW: '',
     });
     expect(getLocalEgressConfig(withEgress)).toEqual({
       url: egress.egressUrl,
       token: egress.egressToken,
       fingerprint: egress.egressFingerprint,
       port: 8899,
+      allow: [],
     });
     const dotenvInstructions = formatRemoteSessionInstructions(withEgress, 'dotenv');
     expect(dotenvInstructions).toContain('eas simulator:egress');
     expect(dotenvInstructions).not.toContain(egress.egressToken);
-    expect(dotenvInstructions).not.toContain('--config-type env');
     expect(formatRemoteSessionInstructions(withEgress, 'env')).toContain(
       'eas simulator:egress --config-type env'
     );

--- a/packages/eas-cli/src/simulator/egress.ts
+++ b/packages/eas-cli/src/simulator/egress.ts
@@ -11,6 +11,7 @@ import { Duplex } from 'node:stream';
 import zlib from 'node:zlib';
 
 import {
+  EAS_SIMULATOR_EGRESS_ALLOW,
   EAS_SIMULATOR_EGRESS_FINGERPRINT,
   EAS_SIMULATOR_EGRESS_PORT,
   EAS_SIMULATOR_EGRESS_TOKEN,
@@ -36,6 +37,11 @@ import { getCacheDirectory } from '../utils/paths';
  *    that port, so requests that honor it (WebKit, URLSession and other CFNetwork
  *    clients) arrive here. Requests from libraries that bypass the system proxy
  *    never reach this client and exit from the device host instead.
+ *
+ * `--egress-allow host:port` names destinations on the developer's machine or
+ * network that the proxy may connect to despite the local-network refusal, so a
+ * dev server on `localhost:3000` is reachable from the remote simulator the way
+ * it is from a local one. Entries are exact host and port pairs, never ranges.
  */
 
 export const LOCAL_EGRESS_PROXY_HOST = '127.0.0.1';
@@ -83,7 +89,10 @@ export function readLocalEgressConfigFromEnv(env: NodeJS.ProcessEnv): LocalEgres
         '`eas simulator:start --platform ios --egress local`.'
     );
   }
-  return { url, token, fingerprint, port };
+  const allow = parseEgressAllowList(
+    (env[EAS_SIMULATOR_EGRESS_ALLOW] ?? '').split(',').filter(entry => entry.trim().length > 0)
+  );
+  return { url, token, fingerprint, port, allow };
 }
 
 // ---------------------------------------------------------------------------
@@ -184,7 +193,7 @@ export function isForbiddenEgressAddress(address: string): boolean {
   }
 }
 
-export type EgressTargetResolver = (hostname: string) => Promise<string[]>;
+export type EgressTargetResolver = (hostname: string, port: number) => Promise<string[]>;
 
 /**
  * IPv4 first. Developer networks often have broken or slow IPv6, and a hung
@@ -230,6 +239,96 @@ export const resolveEgressTargetAsync: EgressTargetResolver = async hostname => 
   }
   return orderEgressAddresses(addresses);
 };
+
+// ---------------------------------------------------------------------------
+// Allowed local destinations (--egress-allow)
+// ---------------------------------------------------------------------------
+
+function formatEgressDestination(host: string, port: number): string {
+  return `${net.isIPv6(host) ? `[${host}]` : host}:${port}`;
+}
+
+function normalizeEgressHostname(hostname: string): string {
+  const host = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (net.isIPv6(host)) {
+    // URL canonicalizes IPv6 but does not accept interface zone identifiers.
+    const [address, zone] = host.split('%');
+    const normalized = new URL(`http://[${address}]`).hostname.slice(1, -1);
+    return zone ? `${normalized}%${zone}` : normalized;
+  }
+  if (!/^[\p{L}\p{M}\p{N}_.-]+$/u.test(host)) {
+    throw new Error(`Invalid destination hostname "${hostname}".`);
+  }
+  // Match absolute-form HTTP URL parsing, including IPv4 and IDN normalization.
+  return new URL(`http://${host}`).hostname;
+}
+
+/**
+ * Parse one `--egress-allow` value into its normalized `host:port` form. Only an
+ * exact host and port pair is accepted. Web pages and SDKs inside the simulator
+ * can use the proxy too, so nothing here opens a range or a wildcard.
+ */
+export function parseEgressAllowEntry(entry: string): string {
+  const match = /^(\[[^\]]+\]|[^\s:/[\]*]+):(\d{1,5})$/.exec(entry.trim());
+  const host = match ? match[1].replace(/^\[|\]$/g, '').toLowerCase() : '';
+  const port = match ? Number(match[2]) : 0;
+  const bracketed = match ? match[1].startsWith('[') : false;
+  if (!match || port <= 0 || port > 65535 || (bracketed && !net.isIPv6(host))) {
+    throw new Error(
+      `Invalid --egress-allow value "${entry}". Use an exact host and port, for example ` +
+        'localhost:3000, 192.168.1.20:8080, or [::1]:3000. Wildcards and address ranges are not accepted.'
+    );
+  }
+  try {
+    return formatEgressDestination(normalizeEgressHostname(host), port);
+  } catch {
+    throw new Error(
+      `Invalid --egress-allow value "${entry}". Use an exact hostname or IP address and port.`
+    );
+  }
+}
+
+export function parseEgressAllowList(entries: readonly string[]): string[] {
+  return [...new Set(entries.map(parseEgressAllowEntry))];
+}
+
+/**
+ * Wrap the default destination policy with the `--egress-allow` list. A listed
+ * destination connects to this machine's loopback or network exactly as named;
+ * every other destination keeps the default refusals. `localhost` maps to the
+ * loopback addresses directly and never goes through DNS.
+ */
+export function createEgressTargetResolver({
+  allow,
+  onAllowed,
+}: {
+  allow: readonly string[];
+  onAllowed?: (destination: string) => void;
+}): EgressTargetResolver {
+  const allowed = new Set(allow);
+  if (allowed.size === 0) {
+    return resolveEgressTargetAsync;
+  }
+  return async (hostname, port) => {
+    const host = normalizeEgressHostname(hostname);
+    const destination = formatEgressDestination(host, port);
+    if (!allowed.has(destination)) {
+      return await resolveEgressTargetAsync(hostname, port);
+    }
+    onAllowed?.(destination);
+    if (host === 'localhost') {
+      return ['127.0.0.1', '::1'];
+    }
+    if (net.isIP(host)) {
+      return [host];
+    }
+    const addresses = await dns.lookup(host, { all: true, verbatim: true });
+    if (addresses.length === 0) {
+      throw new Error(`Could not resolve ${host}.`);
+    }
+    return orderEgressAddresses(addresses);
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Proxy server
@@ -402,7 +501,7 @@ export async function startLocalEgressProxyServerAsync({
     targetPort: number,
     signal: AbortSignal
   ): Promise<net.Socket> => {
-    const addresses = await resolveTargetAsync(hostname);
+    const addresses = await resolveTargetAsync(hostname, targetPort);
     // DNS lookup itself cannot be canceled, but a late answer must never open a socket.
     signal.throwIfAborted();
     return await connectUpstreamAsync({
@@ -786,11 +885,14 @@ export async function runLocalEgressAsync({
   token,
   fingerprint,
   port,
+  allow = [],
   localPort = 0,
   signal,
   onConnected,
   onDisconnected,
-}: LocalEgressConfig & {
+}: Omit<LocalEgressConfig, 'allow'> & {
+  /** Normalized `--egress-allow` destinations; see createEgressTargetResolver. */
+  allow?: readonly string[];
   /** Defaults to an available ephemeral port; the remote worker port stays fixed. */
   localPort?: number;
   signal: AbortSignal;
@@ -821,7 +923,23 @@ export async function runLocalEgressAsync({
     signal.throwIfAborted();
     const chiselPath = await ensureChiselBinaryAsync({ signal });
     signal.throwIfAborted();
-    proxy = await startLocalEgressProxyServerAsync({ port: localPort });
+    const reportedAllowed = new Set<string>();
+    const resolveAllowedTarget = createEgressTargetResolver({
+      allow,
+      onAllowed: destination => {
+        if (reportedAllowed.has(destination)) {
+          Log.debug(`[egress] ${destination} allowed by --egress-allow`);
+          return;
+        }
+        reportedAllowed.add(destination);
+        Log.log(`The simulator reached ${destination} on this machine's network.`);
+      },
+    });
+    proxy = await startLocalEgressProxyServerAsync({
+      port: localPort,
+      resolveTargetAsync: async (hostname, targetPort) =>
+        await resolveAllowedTarget(hostname, targetPort),
+    });
     signal.throwIfAborted();
     Log.debug(`[egress] proxy listening on ${LOCAL_EGRESS_PROXY_HOST}:${proxy.port}`);
     const chisel = spawnAsync(

--- a/packages/eas-cli/src/simulator/egress.ts
+++ b/packages/eas-cli/src/simulator/egress.ts
@@ -17,7 +17,7 @@ import {
   EAS_SIMULATOR_EGRESS_TOKEN,
   EAS_SIMULATOR_EGRESS_URL,
 } from './env';
-import { LocalEgressConfig } from './utils';
+import { LocalEgressConfig, getLoopbackForwardPlan } from './utils';
 import fetch from '../fetch';
 import Log from '../log';
 import { getCacheDirectory } from '../utils/paths';
@@ -844,6 +844,7 @@ export function buildChiselClientArgs({
   fingerprint,
   port,
   localPort = port,
+  forwardPorts = [],
 }: {
   url: string;
   fingerprint: string;
@@ -851,8 +852,17 @@ export function buildChiselClientArgs({
   port: number;
   /** Port the proxy listens on here; independent of the worker's listening port. */
   localPort?: number;
+  /**
+   * Loopback ports to forward from the device host to the same port here, one
+   * reverse remote each; see getLoopbackForwardPlan.
+   */
+  forwardPorts?: readonly number[];
 }): string[] {
   const remote = `R:${LOCAL_EGRESS_PROXY_HOST}:${port}:${LOCAL_EGRESS_PROXY_HOST}:${localPort}`;
+  const forwards = forwardPorts.map(
+    forwardPort =>
+      `R:${LOCAL_EGRESS_PROXY_HOST}:${forwardPort}:${LOCAL_EGRESS_PROXY_HOST}:${forwardPort}`
+  );
   return [
     'client',
     '--fingerprint',
@@ -863,7 +873,17 @@ export function buildChiselClientArgs({
     '-1',
     url,
     remote,
+    ...forwards,
   ];
+}
+
+/**
+ * The device host refuses a reverse remote it does not permit, or one whose
+ * port is already in use there. chisel then drops the whole connection and
+ * retries, so proxied requests stay unavailable until the entry is removed.
+ */
+export function isChiselRemoteRejectionLine(line: string): boolean {
+  return /access to '[^']*' denied|address already in use|bind:/i.test(line);
 }
 
 export function classifyChiselClientLogLine(line: string): 'connected' | 'disconnected' | 'other' {
@@ -942,9 +962,21 @@ export async function runLocalEgressAsync({
     });
     signal.throwIfAborted();
     Log.debug(`[egress] proxy listening on ${LOCAL_EGRESS_PROXY_HOST}:${proxy.port}`);
+    const forwards = getLoopbackForwardPlan(allow, port);
+    for (const forwardPort of forwards.ports) {
+      Log.debug(
+        `[egress] forwarding ${LOCAL_EGRESS_PROXY_HOST}:${forwardPort} on the device host to this machine`
+      );
+    }
     const chisel = spawnAsync(
       chiselPath,
-      buildChiselClientArgs({ url, fingerprint, port, localPort: proxy.port }),
+      buildChiselClientArgs({
+        url,
+        fingerprint,
+        port,
+        localPort: proxy.port,
+        forwardPorts: forwards.ports,
+      }),
       {
         // Stream diagnostics without retaining the entire session's logs in spawnAsync.
         ignoreStdio: true,
@@ -956,6 +988,13 @@ export async function runLocalEgressAsync({
     let connected = false;
     const handleLine = (line: string): void => {
       Log.debug(`[egress] ${line}`);
+      if (isChiselRemoteRejectionLine(line)) {
+        Log.warn(
+          `The device host rejected a forwarded loopback port, so the tunnel cannot connect: ${line}\n` +
+            'Remove the --egress-allow localhost/127.0.0.1 entry for that port, or check that the ' +
+            'session runs a worker that permits loopback port forwarding.'
+        );
+      }
       switch (classifyChiselClientLogLine(line)) {
         case 'connected':
           connected = true;

--- a/packages/eas-cli/src/simulator/env.ts
+++ b/packages/eas-cli/src/simulator/env.ts
@@ -12,6 +12,8 @@ export const EAS_SIMULATOR_EGRESS_URL = 'EAS_SIMULATOR_EGRESS_URL';
 export const EAS_SIMULATOR_EGRESS_TOKEN = 'EAS_SIMULATOR_EGRESS_TOKEN';
 export const EAS_SIMULATOR_EGRESS_FINGERPRINT = 'EAS_SIMULATOR_EGRESS_FINGERPRINT';
 export const EAS_SIMULATOR_EGRESS_PORT = 'EAS_SIMULATOR_EGRESS_PORT';
+// Comma-separated host:port destinations from `--egress-allow`.
+export const EAS_SIMULATOR_EGRESS_ALLOW = 'EAS_SIMULATOR_EGRESS_ALLOW';
 export const SIMULATOR_DOTENV_FILE_HEADER =
   '# Do not commit this file.\n# Do not modify these values manually. They are managed by eas-cli.\n# It holds configuration only for the current simulator session.\n\n';
 
@@ -23,6 +25,38 @@ export async function loadSimulatorEnvAsync(projectDir: string): Promise<void> {
   const simulatorDotenvFilePath = getSimulatorEnvFilePath(projectDir);
 
   loadProjectEnv(projectDir, { silent: true });
+  try {
+    const simulatorEnv = parseDotenv(await fs.readFile(simulatorDotenvFilePath, 'utf8'));
+    if (simulatorEnv[EAS_SIMULATOR_SESSION_ID] || simulatorEnv[EAS_SIMULATOR_EGRESS_URL]) {
+      // loadEnvFiles never replaces existing variables, even with force: true.
+      // Keep this session's credentials and destination policy together rather
+      // than combining them with values exported for an older session.
+      for (const key of [
+        EAS_SIMULATOR_SESSION_ID,
+        'AGENT_DEVICE_DAEMON_BASE_URL',
+        'AGENT_DEVICE_DAEMON_AUTH_TOKEN',
+        'ARGENT_TOOLS_URL',
+        'ARGENT_AUTH_TOKEN',
+        'APPIUM_URL',
+        'APPIUM_CAPS',
+        EAS_SIMULATOR_EGRESS_URL,
+        EAS_SIMULATOR_EGRESS_TOKEN,
+        EAS_SIMULATOR_EGRESS_FINGERPRINT,
+        EAS_SIMULATOR_EGRESS_PORT,
+      ]) {
+        if (simulatorEnv[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = simulatorEnv[key];
+        }
+      }
+      process.env[EAS_SIMULATOR_EGRESS_ALLOW] = simulatorEnv[EAS_SIMULATOR_EGRESS_ALLOW] ?? '';
+    }
+  } catch (err) {
+    if (!(typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOENT')) {
+      throw err;
+    }
+  }
   loadEnvFiles([simulatorDotenvFilePath], { force: true });
 }
 

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -5,6 +5,7 @@ import {
 } from '../graphql/generated';
 import { link } from '../log';
 import {
+  EAS_SIMULATOR_EGRESS_ALLOW,
   EAS_SIMULATOR_EGRESS_FINGERPRINT,
   EAS_SIMULATOR_EGRESS_PORT,
   EAS_SIMULATOR_EGRESS_TOKEN,
@@ -71,20 +72,37 @@ export type LocalEgressConfig = {
   token: string;
   fingerprint: string;
   port: number;
+  /**
+   * Normalized `host:port` destinations on the developer's machine or network
+   * that the simulator may reach through the proxy (`--egress-allow`).
+   */
+  allow: string[];
+};
+
+export type LocalEgressOptions = {
+  egressAllow?: readonly string[];
 };
 
 /**
  * Connection details for the local egress client, present only for sessions
- * started with `--egress local`.
+ * started with `--egress local`. `allow` comes from the developer's flags, not
+ * from the worker.
  */
 export function getLocalEgressConfig(
-  remoteConfig: DeviceRunSessionRemoteConfig
+  remoteConfig: DeviceRunSessionRemoteConfig,
+  allow: readonly string[] = []
 ): LocalEgressConfig | null {
   const { egressUrl, egressToken, egressFingerprint, egressPort } = remoteConfig;
   if (!egressUrl || !egressToken || !egressFingerprint || egressPort == null) {
     return null;
   }
-  return { url: egressUrl, token: egressToken, fingerprint: egressFingerprint, port: egressPort };
+  return {
+    url: egressUrl,
+    token: egressToken,
+    fingerprint: egressFingerprint,
+    port: egressPort,
+    allow: [...allow],
+  };
 }
 
 export function getLocalEgressEnvironmentVariables(
@@ -98,15 +116,17 @@ export function getLocalEgressEnvironmentVariables(
     [EAS_SIMULATOR_EGRESS_TOKEN]: egress.token,
     [EAS_SIMULATOR_EGRESS_FINGERPRINT]: egress.fingerprint,
     [EAS_SIMULATOR_EGRESS_PORT]: String(egress.port),
+    [EAS_SIMULATOR_EGRESS_ALLOW]: egress.allow.join(','),
   };
 }
 
 export function getRemoteSessionEnvironmentVariables(
-  remoteConfig: DeviceRunSessionRemoteConfig
+  remoteConfig: DeviceRunSessionRemoteConfig,
+  { egressAllow }: LocalEgressOptions = {}
 ): Record<string, string> {
   return {
     ...getControllerEnvironmentVariables(remoteConfig),
-    ...getLocalEgressEnvironmentVariables(getLocalEgressConfig(remoteConfig)),
+    ...getLocalEgressEnvironmentVariables(getLocalEgressConfig(remoteConfig, egressAllow)),
   };
 }
 
@@ -180,10 +200,11 @@ export function sanitizeRemoteConfigForJson(
 
 export function formatRemoteSessionInstructions(
   remoteConfig: DeviceRunSessionRemoteConfig,
-  configType: RemoteSessionInstructionsConfigType
+  configType: RemoteSessionInstructionsConfigType,
+  { egressAllow }: LocalEgressOptions = {}
 ): string {
   const instructions = formatControllerInstructions(remoteConfig, configType);
-  const egress = getLocalEgressConfig(remoteConfig);
+  const egress = getLocalEgressConfig(remoteConfig, egressAllow);
   if (!egress) {
     return instructions;
   }
@@ -201,6 +222,9 @@ export function formatRemoteSessionInstructions(
     configType === 'env' ? 'eas simulator:egress --config-type env' : 'eas simulator:egress',
     '',
     'Keep it running for the life of the session.',
+    ...(egress.allow.length > 0
+      ? ['', `The simulator may reach ${egress.allow.join(', ')} on this machine's network.`]
+      : []),
   ].join('\n');
 }
 

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -105,6 +105,63 @@ export function getLocalEgressConfig(
   };
 }
 
+export type LoopbackForwardPlan = {
+  /** Ports the tunnel client forwards on the device host's loopback interface. */
+  ports: number[];
+  /** Loopback allow entries that stay reachable by name through the proxy only. */
+  skipped: string[];
+};
+
+/**
+ * Which `--egress-allow` entries also become loopback port forwards. iOS never
+ * sends loopback-literal requests to the system proxy, and Expo CLI rewrites
+ * `localhost` to `127.0.0.1` in manifests, so the proxy alone cannot serve a dev
+ * server allowed as `localhost:<port>`. For each entry naming `localhost` or
+ * `127.0.0.1`, the tunnel client opens a reverse remote that makes
+ * `127.0.0.1:<port>` on the device host reach the same port here, like
+ * `adb reverse`. The device host only permits unprivileged ports, and the proxy
+ * port is already taken by the tunnel server, so those entries are skipped.
+ */
+export function getLoopbackForwardPlan(
+  allow: readonly string[],
+  proxyPort: number
+): LoopbackForwardPlan {
+  const ports = new Set<number>();
+  const skipped: string[] = [];
+  for (const destination of allow) {
+    const match = /^(?:localhost|127\.0\.0\.1):(\d+)$/.exec(destination);
+    if (!match) {
+      continue;
+    }
+    const port = Number(match[1]);
+    if (port < 1024 || port === proxyPort) {
+      skipped.push(destination);
+      continue;
+    }
+    ports.add(port);
+  }
+  return { ports: [...ports].sort((a, b) => a - b), skipped };
+}
+
+export function formatLoopbackForwardNotice({ ports, skipped }: LoopbackForwardPlan): string[] {
+  const lines: string[] = [];
+  if (ports.length > 0) {
+    const addresses = ports.map(port => `127.0.0.1:${port}`).join(', ');
+    lines.push(
+      `${addresses} in the simulator ${ports.length === 1 ? 'reaches' : 'reach'} the same ` +
+        `${ports.length === 1 ? 'port' : 'ports'} on this machine (like adb reverse), so dev server ` +
+        'URLs that use 127.0.0.1 work.'
+    );
+  }
+  if (skipped.length > 0) {
+    lines.push(
+      `${skipped.join(', ')} ${skipped.length === 1 ? 'is' : 'are'} reachable by name only: ` +
+        'privileged ports and the egress proxy port are not forwarded to 127.0.0.1 in the simulator.'
+    );
+  }
+  return lines;
+}
+
 export function getLocalEgressEnvironmentVariables(
   egress: LocalEgressConfig | null
 ): Record<string, string> {
@@ -223,7 +280,11 @@ export function formatRemoteSessionInstructions(
     '',
     'Keep it running for the life of the session.',
     ...(egress.allow.length > 0
-      ? ['', `The simulator may reach ${egress.allow.join(', ')} on this machine's network.`]
+      ? [
+          '',
+          `The simulator may reach ${egress.allow.join(', ')} on this machine's network.`,
+          ...formatLoopbackForwardNotice(getLoopbackForwardPlan(egress.allow, egress.port)),
+        ]
       : []),
   ].join('\n');
 }


### PR DESCRIPTION
# Why

The local-egress proxy blocks private/local destinations by default. Developers need explicit access to dev servers such as `localhost:3000`. This PR is stacked on https://github.com/expo/eas-cli/pull/4364.

# How

- Adds repeatable `--egress-allow host:port`, requiring `--egress local`. Entries are normalized and deduplicated; wildcards, ranges, and malformed values are rejected before session creation.
- Exceptions match the exact host and port. Allowing `localhost:3000` does not allow another port or the separately named `127.0.0.1`. Unlisted destinations retain the default policy.
- Persists exceptions in session configuration and displays them when starting or reconnecting. All iOS controllers are supported through the base PR, including Argent and Appium; tests cover exception propagation and stale-value clearing across all five remoteConfig variants.
- Forwards loopback entries like `adb reverse`. iOS never sends `127.0.0.1` requests to the system proxy, and Expo CLI rewrites `localhost` to `127.0.0.1` in manifests, so a proxy-only allow entry could not serve an Expo Go or dev client bundle. For each `localhost:<port>` or `127.0.0.1:<port>` entry, the egress client opens one chisel reverse remote so `127.0.0.1:<port>` on the simulator host reaches the same port on this machine. Privileged ports and the proxy port stay name-only. The base PR’s worker permits these remotes; a rejected remote is surfaced with a hint instead of looping silently. Reverse-remote traffic does not pass through the proxy’s per-request check or logging: the entry itself is the decision, and the forward can only reach that one port.

# Test Plan

- Local validation: 196 CLI tests across the simulator suites pass, including parsing, exact matching, live proxy requests, controller configuration, dotenv/environment isolation, the loopback forward plan, and the chisel remote arguments. CLI typecheck, lint, and format checks pass.
- Real-worker validation on staging (worker built from the base branch, Expo Go session, agent-device controller, Metro on port 8082 on the developer machine):
  - With `--egress-allow localhost:8082` only, `exp://localhost:8082` in Expo Go fetched the manifest through the proxy and loaded the bundle from `127.0.0.1:8082` through the forwarded port. Metro logged the bundle build and the app rendered.
  - Fast Refresh works: with Metro in watch mode, editing `src/app/index.tsx` updated the running app in the simulator within seconds and without a manual reload. The dev server WebSocket rides the forwarded loopback port like the bundle does.
  - Safari in the simulator reached `http://127.0.0.1:8082/status` on the developer machine. `http://127.0.0.1:8081`, a port the developer machine was also serving but had not allowed, stayed unreachable.
  - Before the forward existed, the same `localhost:8082` entry loaded the manifest but the bundle request to `127.0.0.1:8082` never reached the proxy and failed on the worker’s loopback, which is the failure this change fixes.
  - Unlisted private destinations such as `localhost:8081` and a LAN address on an unlisted port were refused with the documented message. Proxied requests failed while the egress client was stopped and recovered when it restarted.
