### PR TITLE
[build-tools] Reuse simulator-service image devices and cached dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [build-tools] Adopt prewarmed simulators and reuse Expo Go and remote-session tooling from simulator-service images.
 - [build-tools] Add `lcd_width`, `lcd_height`, and `lcd_density` inputs to configure the Android emulator display. ([#4349](https://github.com/expo/eas-cli/pull/4349) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [eas-cli] Add `eas channel:protect` and `eas channel:unprotect` to manage EAS Update channel protection, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))
 - [eas-cli] Add `eas observe:errors` to display error and exception issue groups (grouped by fingerprint), with `--fingerprint <fingerprint>` to drill into a group's individual occurrences and stack traces. ([#4339](https://github.com/expo/eas-cli/pull/4339) by [@douglowder](https://github.com/douglowder))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- [build-tools] Adopt prewarmed simulators and reuse Expo Go and remote-session tooling from simulator-service images.
+- [build-tools] Adopt prewarmed simulators and reuse Expo Go and remote-session tooling from simulator-service images. ([#4372](https://github.com/expo/eas-cli/pull/4372) by [@szdziedzic](https://github.com/szdziedzic))
 - [build-tools] Add `lcd_width`, `lcd_height`, and `lcd_density` inputs to configure the Android emulator display. ([#4349](https://github.com/expo/eas-cli/pull/4349) by [@krystofwoldrich-agent](https://github.com/krystofwoldrich-agent))
 - [eas-cli] Add `eas channel:protect` and `eas channel:unprotect` to manage EAS Update channel protection, and show protection in channel list and view output. ([#4319](https://github.com/expo/eas-cli/pull/4319) by [@sjkim-expo](https://github.com/sjkim-expo))
 - [eas-cli] Add `eas observe:errors` to display error and exception issue groups (grouped by fingerprint), with `--fingerprint <fingerprint>` to drill into a group's individual occurrences and stack traces. ([#4339](https://github.com/expo/eas-cli/pull/4339) by [@douglowder](https://github.com/douglowder))

--- a/packages/build-tools/src/steps/functions/__tests__/downloadBuild.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/downloadBuild.test.ts
@@ -11,7 +11,12 @@ import * as tar from 'tar';
 
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createMockLogger } from '../../../__tests__/utils/logger';
+import { copyImageExpoGoAsync } from '../../utils/simulatorImage';
 import { createDownloadBuildFunction, downloadBuildAsync } from '../downloadBuild';
+
+jest.mock('../../utils/simulatorImage');
+
+beforeEach(() => jest.mocked(copyImageExpoGoAsync).mockResolvedValue(null));
 
 // contains a 'TestApp.app/TestApp' file with 'i am executable' content
 const APP_TAR_GZ_BUFFER = Buffer.from(
@@ -108,6 +113,19 @@ async function createFlatAppTarGzBufferAsync(): Promise<Buffer> {
 }
 
 describe('downloadBuild', () => {
+  it('uses an exact image-cache hit without fetching or extracting an archive', async () => {
+    jest.mocked(copyImageExpoGoAsync).mockResolvedValue('/tmp/job-owned/Expo.app');
+    const result = await downloadBuildAsync({
+      logger: createMockLogger(),
+      applicationArchiveUrl: APPLICATION_ARCHIVE_URL,
+      graphqlClient: createMockGraphqlClient({}),
+      robotAccessToken: null,
+      extensions: ['app'],
+    });
+    expect(result).toEqual({ artifactPath: '/tmp/job-owned/Expo.app' });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('downloads from applicationArchiveUrl returned by GraphQL', async () => {
     const buildId = randomUUID();
     const graphqlClient = createMockGraphqlClient({

--- a/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
@@ -3,12 +3,15 @@ import spawn from '@expo/turtle-spawn';
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createMockLogger } from '../../../__tests__/utils/logger';
 import { IosSimulatorUtils } from '../../../utils/IosSimulatorUtils';
+import { claimImageSimulatorAsync } from '../../utils/simulatorImage';
 import { createStartIosSimulatorBuildFunction } from '../startIosSimulator';
 
 jest.mock('@expo/turtle-spawn', () => ({
   __esModule: true,
   default: jest.fn(),
 }));
+
+jest.mock('../../utils/simulatorImage');
 
 jest.mock('../../../utils/IosSimulatorUtils', () => ({
   IosSimulatorUtils: {
@@ -37,6 +40,7 @@ describe(createStartIosSimulatorBuildFunction, () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
+    jest.mocked(claimImageSimulatorAsync).mockResolvedValue(null);
     mockedUtils.getAvailableDevicesAsync.mockResolvedValue([]);
     mockedUtils.getDeviceAsync.mockResolvedValue(null);
     mockedUtils.cloneAsync.mockResolvedValue(undefined);
@@ -44,6 +48,28 @@ describe(createStartIosSimulatorBuildFunction, () => {
     mockedUtils.startAsync.mockResolvedValue({ udid: 'test-udid' as any });
     mockedUtils.waitForReadyAsync.mockResolvedValue(undefined);
     mockedUtils.disableApsdAsync.mockResolvedValue(undefined);
+  });
+
+  it('adopts a prepared device without shutdown-only accessibility writes or another boot', async () => {
+    jest.mocked(claimImageSimulatorAsync).mockResolvedValue('prepared-udid');
+    await createStep({
+      device_identifier: 'iPhone 17 Pro',
+      enable_accessibility_settings: true,
+    }).executeAsync();
+    expect(mockedUtils.startAsync).not.toHaveBeenCalled();
+    expect(mockedUtils.enableAccessibilitySettingsAsync).not.toHaveBeenCalled();
+  });
+
+  it('does not run a competing normal boot when the image handoff fails', async () => {
+    jest.mocked(claimImageSimulatorAsync).mockRejectedValue(new Error('preparation timeout'));
+    await expect(createStep({ device_identifier: 'iPhone 17' }).executeAsync()).rejects.toThrow();
+    expect(mockedUtils.startAsync).not.toHaveBeenCalled();
+  });
+
+  it('keeps the existing multi-device build path', async () => {
+    await createStep({ device_identifier: 'iPhone 17', count: 2 }).executeAsync();
+    expect(claimImageSimulatorAsync).not.toHaveBeenCalled();
+    expect(mockedUtils.cloneAsync).toHaveBeenCalledTimes(2);
   });
 
   it('does not enable accessibility settings by default', async () => {

--- a/packages/build-tools/src/steps/functions/downloadBuild.ts
+++ b/packages/build-tools/src/steps/functions/downloadBuild.ts
@@ -27,6 +27,7 @@ import { formatBytes } from '../../utils/artifacts';
 import { decompressTarAsync, isFileTarGzAsync } from '../../utils/files';
 import { retryOnDNSFailure } from '../../utils/retryOnDNSFailure';
 import { pluralize } from '../../utils/strings';
+import { copyImageExpoGoAsync } from '../utils/simulatorImage';
 
 const streamPipeline = promisify(stream.pipeline);
 
@@ -185,6 +186,13 @@ export async function downloadBuildAsync(
       'EAS_DOWNLOAD_BUILD_INVALID_SOURCE',
       'Pass buildId or applicationArchiveUrl.'
     );
+  }
+
+  if (params.applicationArchiveUrl && extensions.includes('app')) {
+    const cachedPath = await copyImageExpoGoAsync({ url: downloadUrl, logger });
+    if (cachedPath) {
+      return { artifactPath: cachedPath };
+    }
   }
 
   const downloadDestinationDirectory = await fs.promises.mkdtemp(

--- a/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startAgentDeviceRemoteSession.ts
@@ -16,6 +16,7 @@ import { type CustomBuildContext } from '../../customBuildContext';
 import { Sentry } from '../../sentry';
 import { pollAgentDeviceArtifactsForUploadAsync } from '../utils/agentDeviceArtifacts';
 import { startAgentDeviceEventCollectionAsync } from '../utils/agentDeviceEvents';
+import { getImagePackageAsync } from '../utils/simulatorImage';
 import {
   type DetachedProcessHandle,
   getDeviceRunSessionIdOrThrow,
@@ -209,6 +210,19 @@ async function startAgentDeviceDaemonAsync({
   logger: bunyan;
 }): Promise<DetachedProcessHandle> {
   const packageSpec = createAgentDevicePackageSpec(packageVersion);
+  const imagePackage = await getImagePackageAsync({
+    name: AGENT_DEVICE_PACKAGE_NAME,
+    version: packageVersion,
+    logger,
+  });
+  const imageDaemonPath = imagePackage && path.join(imagePackage, 'dist/src/internal/daemon.js');
+  if (imageDaemonPath && fs.existsSync(imageDaemonPath)) {
+    return spawnDetached({
+      command: 'node',
+      args: [imageDaemonPath],
+      env: { ...env, ...AGENT_DEVICE_DAEMON_ENV },
+    });
+  }
   try {
     logger.info(`Installing ${packageSpec} globally with Bun.`);
     await spawn('bun', ['add', '--global', packageSpec], {

--- a/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
+++ b/packages/build-tools/src/steps/functions/startArgentRemoteSession.ts
@@ -19,6 +19,7 @@ import { isProcessDescendantOfAsync } from '../../utils/processes';
 import { sleepAsync } from '../../utils/retry';
 import { pollArgentArtifactsForUploadAsync } from '../utils/argentArtifacts';
 import { ARGENT_EVENT_LOG_FILENAME, startArgentEventCollectionAsync } from '../utils/argentEvents';
+import { getImagePackageExecutableAsync } from '../utils/simulatorImage';
 import {
   ensureFfmpegInstalledOnceAsync,
   getDeviceRunSessionIdOrThrow,
@@ -110,41 +111,30 @@ export function createStartArgentRemoteSessionBuildFunction(
       // Never rejects, so `void` is safe.
       void ensureFfmpegInstalledOnceAsync({ runtimePlatform, env, logger });
 
+      const imageExecutable = await getImagePackageExecutableAsync({
+        name: ARGENT_PACKAGE_NAME,
+        version: packageVersion,
+        binaryName: 'argent',
+        logger,
+      });
+      const command = imageExecutable ?? 'bun';
+      const prefixArgs = imageExecutable ? [] : ['x', `${ARGENT_PACKAGE_NAME}@${versionSpec}`];
+
       logger.info('Enabling the Argent artifacts list endpoint flag.');
-      await spawn(
-        'bun',
-        [
-          'x',
-          `${ARGENT_PACKAGE_NAME}@${versionSpec}`,
-          'enable',
-          ARGENT_ARTIFACTS_LIST_ENDPOINT_FLAG,
-        ],
-        { env, logger }
-      );
+      await spawn(command, [...prefixArgs, 'enable', ARGENT_ARTIFACTS_LIST_ENDPOINT_FLAG], {
+        env,
+        logger,
+      });
 
       logger.info('Enabling the Argent tool-server event log flag.');
-      await spawn(
-        'bun',
-        ['x', `${ARGENT_PACKAGE_NAME}@${versionSpec}`, 'enable', ARGENT_EVENT_LOG_FLAG],
-        { env, logger }
-      );
+      await spawn(command, [...prefixArgs, 'enable', ARGENT_EVENT_LOG_FLAG], { env, logger });
 
-      logger.info(`Launching ${ARGENT_PACKAGE_NAME}@${versionSpec} tool-server via bun x.`);
-      // Keep Argent itself in foreground mode under the detached bun process. This preserves
-      // the bun -> Argent CLI -> tool-server ancestry used to identify the matching state file.
+      logger.info(`Launching ${ARGENT_PACKAGE_NAME}@${versionSpec} tool-server.`);
+      // Keep Argent in foreground mode under the detached process, preserving the
+      // CLI -> tool-server ancestry used to identify the matching state file.
       const argentServer = spawnDetached({
-        command: 'bun',
-        args: [
-          'x',
-          `${ARGENT_PACKAGE_NAME}@${versionSpec}`,
-          'server',
-          'start',
-          '--port',
-          '0',
-          '--idle-timeout',
-          '0',
-          '--force',
-        ],
+        command,
+        args: [...prefixArgs, 'server', 'start', '--port', '0', '--idle-timeout', '0', '--force'],
         env: { ...env, ARGENT_EVENT_LOG: ARGENT_EVENT_LOG_PATH },
       });
       if (argentServer.pid === undefined) {

--- a/packages/build-tools/src/steps/functions/startIosSimulator.ts
+++ b/packages/build-tools/src/steps/functions/startIosSimulator.ts
@@ -12,6 +12,7 @@ import {
   IosSimulatorUtils,
   IosSimulatorUuid,
 } from '../../utils/IosSimulatorUtils';
+import { claimImageSimulatorAsync } from '../utils/simulatorImage';
 
 export function createStartIosSimulatorBuildFunction(): BuildFunction {
   return new BuildFunction({
@@ -59,6 +60,13 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
         | IosSimulatorUuid
         | IosSimulatorName
         | undefined;
+      const count = Number(inputs.count.value ?? 1);
+      if (
+        count === 1 &&
+        (await claimImageSimulatorAsync({ deviceIdentifier: deviceIdentifierInput, env, logger }))
+      ) {
+        return;
+      }
       const originalDeviceIdentifier =
         deviceIdentifierInput ?? (await findMostGenericIphoneUuidAsync({ env }));
       const enableAccessibilitySettings = Boolean(inputs.enable_accessibility_settings.value);
@@ -92,7 +100,6 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
       const formattedDevice = device?.displayName ?? originalDeviceIdentifier;
       logger.info(`${formattedDevice} is ready.`);
 
-      const count = Number(inputs.count.value ?? 1);
       if (count > 1) {
         logger.info(`Requested ${count} Simulators, shutting down ${formattedDevice} for cloning.`);
         await spawn('xcrun', ['simctl', 'shutdown', originalDeviceIdentifier], {

--- a/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/remoteDeviceRunSession.test.ts
@@ -12,6 +12,7 @@ import { CustomBuildContext } from '../../../customBuildContext';
 import { Sentry } from '../../../sentry';
 import { turtleFetch } from '../../../utils/turtleFetch';
 import { sleepAsync } from '../../../utils/retry';
+import { getImagePackageExecutableAsync } from '../simulatorImage';
 import {
   createExpoDeviceHubArgs,
   createServeSimArgs,
@@ -33,6 +34,9 @@ jest.mock('../../../utils/turtleFetch');
 jest.mock('../../../utils/retry', () => ({ sleepAsync: jest.fn() }));
 jest.mock('../../../sentry');
 jest.mock('@expo/turtle-spawn');
+jest.mock('../simulatorImage');
+
+beforeEach(() => jest.mocked(getImagePackageExecutableAsync).mockResolvedValue(null));
 
 function createLoggerMock(): bunyan {
   return {
@@ -470,6 +474,28 @@ describe(startDeviceWebPreviewWithTunnelAsync, () => {
 
     await preview.stopAsync();
     expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts the baked serve-sim executable with unchanged server arguments', async () => {
+    const executable = '/image/tools/serve-sim/cli.js';
+    jest.mocked(getImagePackageExecutableAsync).mockResolvedValue(executable);
+    jest.mocked(ngrok.forward).mockResolvedValue({
+      url: () => 'https://ios-preview.example.test',
+      close: jest.fn().mockResolvedValue(undefined),
+    } as never);
+    const preview = await startDeviceWebPreviewWithTunnelAsync(createCtxMock(), {
+      runtimePlatform: BuildRuntimePlatform.DARWIN,
+      baseDomain,
+      env,
+      logger: createLoggerMock(),
+      timeoutMs: 10_000,
+    });
+    const [command, args] = jest.mocked(spawn).mock.calls[0];
+    const port = Number(args[args.indexOf('--port') + 1]);
+    expect(command).toBe(executable);
+    expect(args).toEqual(createServeSimArgs({ port, turnArgs, metricsCorsArgs }).slice(2));
+    expect(args).not.toContain('--yes');
+    await preview.stopAsync();
   });
 });
 

--- a/packages/build-tools/src/steps/utils/__tests__/simulatorImage.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/simulatorImage.test.ts
@@ -1,0 +1,206 @@
+import spawn from '@expo/turtle-spawn';
+import { vol } from 'memfs';
+import fetch from 'node-fetch';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { createMockLogger } from '../../../__tests__/utils/logger';
+import {
+  SIMULATOR_IMAGE_DIRECTORY,
+  SIMULATOR_IMAGE_MANIFEST,
+  claimImageSimulatorAsync,
+  copyImageExpoGoAsync,
+  getImagePackageAsync,
+  getImagePackageExecutableAsync,
+} from '../simulatorImage';
+
+jest.mock('@expo/turtle-spawn');
+
+const appPath = '/Users/expo/.expo/ios-simulator-app-cache/Expo-Go-57.0.9.tar.app';
+const appUrl =
+  'https://github.com/expo/expo-go-releases/releases/download/Expo-Go-57.0.9/Expo-Go-57.0.9.tar.gz';
+const packagePath = `${SIMULATOR_IMAGE_DIRECTORY}/tools/agent-device/node_modules/agent-device`;
+const udid = 'B0367AC2-2B04-4C67-B633-A0A2603588D5';
+const logger = createMockLogger();
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+const manifest = {
+  schemaVersion: 1,
+  expoGo: [{ version: '57.0.9', url: appUrl, path: appPath }],
+  packages: [{ name: 'agent-device', version: '1.2.3', path: packagePath }],
+};
+const appInfo = {
+  CFBundleIdentifier: 'host.exp.Exponent',
+  CFBundleShortVersionString: '57.0.9',
+  CFBundleSupportedPlatforms: ['iPhoneSimulator'],
+  CFBundleExecutable: 'Exponent',
+};
+
+function mockOutput(value: unknown): void {
+  jest.mocked(spawn).mockResolvedValue({
+    stdout: JSON.stringify(value),
+    stderr: '',
+    status: 0,
+    signal: null,
+    output: [],
+  });
+}
+
+beforeEach(() => {
+  Object.defineProperty(process, 'platform', { ...originalPlatform, value: 'darwin' });
+  vol.fromJSON({
+    [SIMULATOR_IMAGE_MANIFEST]: JSON.stringify(manifest),
+    [path.join(appPath, 'Info.plist')]: 'validated through plutil',
+    [path.join(appPath, 'Exponent')]: 'simulator executable',
+    [path.join(packagePath, 'package.json')]: JSON.stringify({
+      name: 'agent-device',
+      version: '1.2.3',
+      bin: './cli.js',
+    }),
+    [path.join(packagePath, 'cli.js')]: 'tool executable',
+  });
+  jest.mocked(fetch).mockReset();
+  jest.mocked(spawn).mockReset();
+});
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', originalPlatform);
+  jest.restoreAllMocks();
+});
+
+it('uses the normal path on older images and Linux', async () => {
+  Object.defineProperty(process, 'platform', { ...originalPlatform, value: 'linux' });
+  expect(
+    await claimImageSimulatorAsync({ env: { DEVICE_RUN_SESSION_ID: 'session' }, logger })
+  ).toBeNull();
+  expect(await copyImageExpoGoAsync({ url: appUrl, logger })).toBeNull();
+  Object.defineProperty(process, 'platform', { ...originalPlatform, value: 'darwin' });
+  await fs.promises.unlink(SIMULATOR_IMAGE_MANIFEST);
+  expect(
+    await claimImageSimulatorAsync({ env: { DEVICE_RUN_SESSION_ID: 'session' }, logger })
+  ).toBeNull();
+  expect(spawn).not.toHaveBeenCalled();
+});
+
+it('does not claim devices for ordinary build workflows', async () => {
+  expect(await claimImageSimulatorAsync({ env: {}, logger })).toBeNull();
+  expect(spawn).not.toHaveBeenCalled();
+});
+
+it('claims an explicitly selected device through the locked image helper', async () => {
+  mockOutput({ udid });
+  expect(
+    await claimImageSimulatorAsync({
+      deviceIdentifier: 'iPhone 17 Pro',
+      env: { DEVICE_RUN_SESSION_ID: 'session' },
+      logger,
+    })
+  ).toBe(udid);
+  expect(spawn).toHaveBeenCalledWith(
+    '/opt/homebrew/bin/python3',
+    ['/usr/local/libexec/expo-sim-service/sim_service.py', 'claim', '--device', 'iPhone 17 Pro'],
+    expect.any(Object)
+  );
+});
+
+it('does not bypass a preparation failure, lock timeout, or corrupt image manifest', async () => {
+  jest.mocked(spawn).mockRejectedValue(new Error('preparation lock timeout'));
+  await expect(
+    claimImageSimulatorAsync({ env: { DEVICE_RUN_SESSION_ID: 'session' }, logger })
+  ).rejects.toThrow('lock timeout');
+  await fs.promises.writeFile(SIMULATOR_IMAGE_MANIFEST, '{}');
+  await expect(
+    claimImageSimulatorAsync({ env: { DEVICE_RUN_SESSION_ID: 'session' }, logger })
+  ).rejects.toThrow();
+});
+
+it('rejects malformed claim output', async () => {
+  mockOutput({ udid: 'booted' });
+  await expect(
+    claimImageSimulatorAsync({ env: { DEVICE_RUN_SESSION_ID: 'session' }, logger })
+  ).rejects.toThrow();
+});
+
+it('copies an exact-URL cached bundle to independent job storage without fetching', async () => {
+  mockOutput(appInfo);
+  const result = await copyImageExpoGoAsync({ url: appUrl, logger });
+  expect(result).not.toBeNull();
+  expect(result).not.toBe(appPath);
+  expect(await fs.promises.readFile(path.join(result!, 'Exponent'), 'utf8')).toBe(
+    'simulator executable'
+  );
+  await fs.promises.writeFile(path.join(result!, 'Exponent'), 'job mutation');
+  expect(await fs.promises.readFile(path.join(appPath, 'Exponent'), 'utf8')).toBe(
+    'simulator executable'
+  );
+  expect(fetch).not.toHaveBeenCalled();
+});
+
+it('misses the cache for another origin or patch release', async () => {
+  expect(
+    await copyImageExpoGoAsync({ url: appUrl.replace('github.com', 'example.com'), logger })
+  ).toBeNull();
+  expect(
+    await copyImageExpoGoAsync({ url: appUrl.replaceAll('57.0.9', '57.0.10'), logger })
+  ).toBeNull();
+  expect(spawn).not.toHaveBeenCalled();
+});
+
+it('falls back for a missing executable or mismatched bundle', async () => {
+  mockOutput({ ...appInfo, CFBundleShortVersionString: '57.0.8' });
+  expect(await copyImageExpoGoAsync({ url: appUrl, logger })).toBeNull();
+  mockOutput(appInfo);
+  await fs.promises.unlink(path.join(appPath, 'Exponent'));
+  expect(await copyImageExpoGoAsync({ url: appUrl, logger })).toBeNull();
+});
+
+it('uses an exact pinned tool version without network access', async () => {
+  expect(await getImagePackageAsync({ name: 'agent-device', version: '1.2.3', logger })).toBe(
+    packagePath
+  );
+  expect(fetch).not.toHaveBeenCalled();
+});
+
+it('resolves latest before using the matching baked tool', async () => {
+  jest.mocked(fetch).mockResolvedValue({
+    ok: true,
+    json: async () => ({ name: 'agent-device', version: '1.2.3' }),
+  } as any);
+  expect(await getImagePackageAsync({ name: 'agent-device', logger })).toBe(packagePath);
+  expect(fetch).toHaveBeenCalledWith('https://registry.npmjs.org/agent-device/latest', {
+    timeout: 10_000,
+  });
+});
+
+it('never substitutes a stale baked version for latest', async () => {
+  jest.mocked(fetch).mockResolvedValue({
+    ok: true,
+    json: async () => ({ name: 'agent-device', version: '1.2.4' }),
+  } as any);
+  expect(await getImagePackageAsync({ name: 'agent-device', logger })).toBeNull();
+});
+
+it('falls back to existing installation when npm metadata fails', async () => {
+  jest.mocked(fetch).mockRejectedValue(new Error('offline'));
+  expect(await getImagePackageAsync({ name: 'agent-device', logger })).toBeNull();
+  jest.mocked(fetch).mockResolvedValue({ ok: false, status: 503 } as any);
+  expect(await getImagePackageAsync({ name: 'agent-device', logger })).toBeNull();
+});
+
+it('keeps normal resolution for ranges and missing packages', async () => {
+  expect(
+    await getImagePackageAsync({ name: 'agent-device', version: '^1.2.0', logger })
+  ).toBeNull();
+  expect(await getImagePackageAsync({ name: 'missing', logger })).toBeNull();
+  expect(fetch).not.toHaveBeenCalled();
+});
+
+it('validates the installed package and its executable', async () => {
+  const options = { name: 'agent-device', version: '1.2.3', binaryName: 'agent-device', logger };
+  await fs.promises.chmod(path.join(packagePath, 'cli.js'), 0o755);
+  expect(await getImagePackageExecutableAsync(options)).toBe(path.join(packagePath, 'cli.js'));
+  await fs.promises.writeFile(
+    path.join(packagePath, 'package.json'),
+    JSON.stringify({ name: 'agent-device', version: '1.2.2' })
+  );
+  expect(await getImagePackageExecutableAsync(options)).toBeNull();
+});

--- a/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
+++ b/packages/build-tools/src/steps/utils/remoteDeviceRunSession.ts
@@ -17,6 +17,7 @@ import { CustomBuildContext } from '../../customBuildContext';
 import { Sentry } from '../../sentry';
 import { sleepAsync } from '../../utils/retry';
 import { turtleFetch } from '../../utils/turtleFetch';
+import { getImagePackageExecutableAsync } from './simulatorImage';
 
 const XCODE_DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer';
 const WEB_PREVIEW_HOST = '127.0.0.1';
@@ -785,6 +786,7 @@ async function startWebPreviewWithTunnelAsync(
     serverName,
     packageSpec,
     createArgs,
+    imageExecutable,
   }: {
     baseDomain: string;
     env: BuildStepEnv;
@@ -793,14 +795,17 @@ async function startWebPreviewWithTunnelAsync(
     serverName: string;
     packageSpec: string;
     createArgs: (port: number, turnArgs: string[]) => string[];
+    imageExecutable?: string | null;
   }
 ): Promise<DeviceWebPreviewHandle> {
   const port = await findAvailablePortAsync();
   logger.info(`Launching ${packageSpec} on ${WEB_PREVIEW_HOST}:${port}.`);
   const turnArgs = await fetchWebPreviewTurnArgsAsync(ctx, { env, logger });
+  const args = createArgs(port, turnArgs);
   const previewServer = spawnDetached({
-    command: 'npx',
-    args: createArgs(port, turnArgs),
+    command: imageExecutable ?? 'npx',
+    // createArgs includes npx's --yes and package spec before the server flags.
+    args: imageExecutable ? args.slice(2) : args,
     env,
   });
 
@@ -848,6 +853,12 @@ export async function startServeSimWithTunnelAsync(
   }
 ): Promise<ServeSimPreviewHandle> {
   const metricsCorsArgs = metricsCorsOriginToServeSimArgs(env);
+  const imageExecutable = await getImagePackageExecutableAsync({
+    name: SERVE_SIM_PACKAGE_NAME,
+    version: packageVersion,
+    binaryName: 'serve-sim',
+    logger,
+  });
   return await startWebPreviewWithTunnelAsync(ctx, {
     baseDomain,
     env,
@@ -855,6 +866,7 @@ export async function startServeSimWithTunnelAsync(
     timeoutMs,
     serverName: 'serve-sim',
     packageSpec: createServeSimPackageSpec(packageVersion),
+    imageExecutable,
     createArgs: (port, turnArgs) =>
       createServeSimArgs({ port, turnArgs, metricsCorsArgs, packageVersion }),
   });

--- a/packages/build-tools/src/steps/utils/simulatorImage.ts
+++ b/packages/build-tools/src/steps/utils/simulatorImage.ts
@@ -1,0 +1,188 @@
+import { type bunyan } from '@expo/logger';
+import { type BuildStepEnv } from '@expo/steps';
+import spawn from '@expo/turtle-spawn';
+import fetch from 'node-fetch';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import semver from 'semver';
+import { z } from 'zod';
+
+export const SIMULATOR_IMAGE_DIRECTORY = '/Users/expo/.local/share/eas-simulator';
+export const SIMULATOR_IMAGE_MANIFEST = path.join(SIMULATOR_IMAGE_DIRECTORY, 'manifest.json');
+const SIMULATOR_IMAGE_HELPER = '/usr/local/libexec/expo-sim-service/sim_service.py';
+const EXPO_GO_CACHE = '/Users/expo/.expo/ios-simulator-app-cache';
+
+const ManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  expoGo: z.array(z.object({ url: z.string(), version: z.string(), path: z.string() })),
+  packages: z.array(z.object({ name: z.string(), version: z.string(), path: z.string() })),
+});
+
+async function readManifestAsync(): Promise<z.infer<typeof ManifestSchema> | null> {
+  if (process.platform !== 'darwin' || !fs.existsSync(SIMULATOR_IMAGE_MANIFEST)) {
+    return null;
+  }
+  return ManifestSchema.parse(
+    JSON.parse(await fs.promises.readFile(SIMULATOR_IMAGE_MANIFEST, 'utf8'))
+  );
+}
+
+/** The image owns the preparation lock. Never fall back to a competing boot on failure. */
+export async function claimImageSimulatorAsync({
+  deviceIdentifier,
+  env,
+  logger,
+}: {
+  deviceIdentifier?: string;
+  env: BuildStepEnv;
+  logger: bunyan;
+}): Promise<string | null> {
+  if (!env.DEVICE_RUN_SESSION_ID || !(await readManifestAsync())) {
+    return null;
+  }
+  const { stdout } = await spawn(
+    '/opt/homebrew/bin/python3',
+    [SIMULATOR_IMAGE_HELPER, 'claim', ...(deviceIdentifier ? ['--device', deviceIdentifier] : [])],
+    { env, stdio: 'pipe' }
+  );
+  const { udid } = z.object({ udid: z.string().uuid() }).parse(JSON.parse(stdout));
+  logger.info(`Claimed prepared iOS Simulator ${udid}; other simulators are shut down.`);
+  return udid;
+}
+
+/** Exact URL identity only; copy into job-owned storage to protect the image cache. */
+export async function copyImageExpoGoAsync({
+  url,
+  logger,
+}: {
+  url: string;
+  logger: bunyan;
+}): Promise<string | null> {
+  let copyDirectory: string | undefined;
+  try {
+    const manifest = await readManifestAsync();
+    const entry = manifest?.expoGo.find(entry => entry.url === url);
+    if (
+      !entry ||
+      path.extname(entry.path) !== '.app' ||
+      path.dirname(entry.path) !== EXPO_GO_CACHE
+    ) {
+      return null;
+    }
+    const { stdout } = await spawn(
+      'plutil',
+      ['-convert', 'json', '-o', '-', path.join(entry.path, 'Info.plist')],
+      { stdio: 'pipe' }
+    );
+    const info = z
+      .object({
+        CFBundleIdentifier: z.literal('host.exp.Exponent'),
+        CFBundleShortVersionString: z.literal(entry.version),
+        CFBundleSupportedPlatforms: z
+          .array(z.string())
+          .refine(platforms => platforms.includes('iPhoneSimulator')),
+        CFBundleExecutable: z.string().min(1),
+      })
+      .parse(JSON.parse(stdout));
+    if (path.basename(info.CFBundleExecutable) !== info.CFBundleExecutable) {
+      return null;
+    }
+    await fs.promises.access(path.join(entry.path, info.CFBundleExecutable));
+    copyDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'download_build-image-'));
+    const artifactPath = path.join(copyDirectory, path.basename(entry.path));
+    await fs.promises.cp(entry.path, artifactPath, {
+      recursive: true,
+      mode: fs.constants.COPYFILE_FICLONE,
+    });
+    logger.info(`Using image-cached Expo Go ${entry.version}.`);
+    return artifactPath;
+  } catch (err) {
+    if (copyDirectory) {
+      await fs.promises.rm(copyDirectory, { recursive: true, force: true }).catch(() => {});
+    }
+    logger.warn({ err }, 'Could not use the image Expo Go cache; downloading normally.');
+    return null;
+  }
+}
+
+/** Preserve latest/range semantics: reuse a baked package only for the resolved version. */
+export async function getImagePackageAsync({
+  name,
+  version = 'latest',
+  logger,
+}: {
+  name: string;
+  version?: string;
+  logger: bunyan;
+}): Promise<string | null> {
+  try {
+    const manifest = await readManifestAsync();
+    const entry = manifest?.packages.find(entry => entry.name === name);
+    if (
+      !entry ||
+      path.resolve(entry.path) !== entry.path ||
+      !entry.path.startsWith(`${SIMULATOR_IMAGE_DIRECTORY}/tools/`)
+    ) {
+      return null;
+    }
+    // Arbitrary ranges/tags keep the existing package manager resolution path.
+    let resolved = semver.valid(version);
+    if (version === 'latest') {
+      const response = await fetch(
+        `https://registry.npmjs.org/${encodeURIComponent(name)}/latest`,
+        { timeout: 10_000 }
+      );
+      if (!response.ok) {
+        throw new Error(`npm metadata returned HTTP ${response.status}`);
+      }
+      resolved = z
+        .object({ name: z.literal(name), version: z.string() })
+        .parse(await response.json()).version;
+    }
+    if (!resolved || resolved !== entry.version) {
+      return null;
+    }
+    const installed = JSON.parse(
+      await fs.promises.readFile(path.join(entry.path, 'package.json'), 'utf8')
+    );
+    if (installed.name !== name || installed.version !== resolved) {
+      return null;
+    }
+    logger.info(`Using image-preinstalled ${name}@${resolved}.`);
+    return entry.path;
+  } catch (err) {
+    logger.warn({ err }, `Could not use image-preinstalled ${name}; resolving normally.`);
+    return null;
+  }
+}
+
+export async function getImagePackageExecutableAsync(options: {
+  name: string;
+  version?: string;
+  binaryName: string;
+  logger: bunyan;
+}): Promise<string | null> {
+  const directory = await getImagePackageAsync(options);
+  if (!directory) {
+    return null;
+  }
+  try {
+    const installed = JSON.parse(
+      await fs.promises.readFile(path.join(directory, 'package.json'), 'utf8')
+    );
+    const bin =
+      typeof installed.bin === 'string' ? installed.bin : installed.bin?.[options.binaryName];
+    if (typeof bin !== 'string') {
+      return null;
+    }
+    const executable = path.resolve(directory, bin);
+    if (!executable.startsWith(`${directory}/`)) {
+      return null;
+    }
+    await fs.promises.access(executable, fs.constants.X_OK);
+    return executable;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
# Why

Consume the prewarmed devices, Expo Go cache, and preinstalled tooling in simulator-service images (companion: https://github.com/expo/turtle-v2/pull/2615). Merely booting two simulators or populating the Expo cache does not accelerate the existing EAS workflow safely: several steps target `booted`, and `download_build` previously downloaded every archive.

# How

- Single-device remote sessions claim their selected simulator through the image's locked helper. This waits for launchd, repairs readiness if necessary, and shuts down the spare device. Missing images retain the existing path; a broken handoff fails instead of starting competing preparation.
- Exact Expo Go URL cache hits validate bundle identity/platform/executable and copy the bundle into independent job storage. Misses, invalid caches, and newer releases use the existing downloader. Application installation still runs normally.
- Agent Device, Argent, and serve-sim can use verified preinstalled package paths. Exact versions need no metadata lookup; `latest` resolves current npm metadata and reuses only the matching baked version. Other versions/ranges or unavailable metadata retain existing installation behavior.
- Session credentials, ports, daemon state, tunnels, and artifact/event collection remain per-session. No production image routing changes.

# Test Plan

- Full build-tools unit suite: 123 suites, 1,240 tests, and 35 snapshots passed.
- Package/dependency TypeScript checks passed.
- Type-aware lint and formatting passed for all modified TypeScript files.
- Added coverage for image absence, Linux/general-build fallback, corrupted manifests, handoff failures, preserved multi-device behavior, exact-URL cache reuse, job-owned copies, invalid bundles, latest-version mismatches, metadata failure, and preinstalled preview arguments.

Draft pending a fresh staging simulator-service VM smoke test with the companion image PR. Validate actual launchd adoption, each cached SDK on the image's runtime, controller/native helpers, preview, recording, and timing. This PR alone does not route sessions to the new image.
