### PR TITLE
[eas-cli] Remove obsolete appVersion runtime policy warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Remove the obsolete `appVersion` runtime policy warning that referenced SDK 46 and expo-updates 0.14.4. ([#TBD](https://github.com/expo/eas-cli/pull/TBD) by [@brentvatne](https://github.com/brentvatne))
+
 ## [24.0.0](https://github.com/expo/eas-cli/releases/tag/v24.0.0) - 2026-09-09
 
 ### 🛠 Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
-- [eas-cli] Remove the obsolete `appVersion` runtime policy warning that referenced SDK 46 and expo-updates 0.14.4. ([#TBD](https://github.com/expo/eas-cli/pull/TBD) by [@brentvatne](https://github.com/brentvatne))
+- [eas-cli] Remove the obsolete `appVersion` runtime policy warning that referenced SDK 46 and expo-updates 0.14.4. ([#4375](https://github.com/expo/eas-cli/pull/4375) by [@brentvatne](https://github.com/brentvatne))
 
 ## [24.0.0](https://github.com/expo/eas-cli/releases/tag/v24.0.0) - 2026-09-09
 

--- a/packages/eas-cli/src/build/runBuildAndSubmit.ts
+++ b/packages/eas-cli/src/build/runBuildAndSubmit.ts
@@ -57,7 +57,6 @@ import {
   isExpoUpdatesInstalledAsDevDependency,
   isExpoUpdatesInstalledOrAvailable,
   isUsingEASUpdate,
-  validateAppVersionRuntimePolicySupportAsync,
 } from '../project/projectUtils';
 import {
   ensureAppVersionSourceIsSetAsync,
@@ -481,7 +480,6 @@ async function prepareAndStartBuildAsync({
     }
   }
 
-  await validateAppVersionRuntimePolicySupportAsync(buildCtx.projectDir, buildCtx.exp);
   if (
     easJsonCliConfig?.appVersionSource === undefined &&
     buildProfile.profile.autoIncrement !== 'version'

--- a/packages/eas-cli/src/project/projectUtils.ts
+++ b/packages/eas-cli/src/project/projectUtils.ts
@@ -99,28 +99,6 @@ export async function getExpoUpdatesPackageVersionIfInstalledAsync(
   return version ?? null;
 }
 
-export async function validateAppVersionRuntimePolicySupportAsync(
-  projectDir: string,
-  exp: ExpoConfig
-): Promise<void> {
-  if (typeof exp.runtimeVersion !== 'object' || exp.runtimeVersion?.policy !== 'appVersion') {
-    return;
-  }
-
-  const expoUpdatesPackageVersion = await getExpoUpdatesPackageVersionIfInstalledAsync(projectDir);
-  if (
-    expoUpdatesPackageVersion !== null &&
-    (semver.gte(expoUpdatesPackageVersion, '0.14.4') ||
-      expoUpdatesPackageVersion.includes('canary'))
-  ) {
-    return;
-  }
-
-  Log.warn(
-    `You need to be on SDK 46 or higher, and use expo-updates >= 0.14.4 to use appVersion runtime policy.`
-  );
-}
-
 export async function enforceRollBackToEmbeddedUpdateSupportAsync(
   projectDir: string
 ): Promise<void> {


### PR DESCRIPTION
# Why

`eas build` warns "You need to be on SDK 46 or higher, and use expo-updates >= 0.14.4 to use appVersion runtime policy." whenever a project uses `runtimeVersion: { policy: 'appVersion' }` and the `expo-updates` version lookup fails or returns a version below 0.14.4. SDK 46 is long out of support, so this check no longer catches anything real. In practice it fires when `expo-updates` isn't resolvable from the project directory, and the message about SDK 46 is misleading in that case.

# How

Deleted `validateAppVersionRuntimePolicySupportAsync` from `projectUtils.ts` and its call in `runBuildAndSubmit.ts`. No tests referenced it.

# Test Plan

Ran the `eas-cli` build and project test suites, `tsc`, `yarn lint`, and `yarn fmt:check`. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kNQXnTCUGcsrBvATKdQBg