### PR TITLE
[eas-cli] Record a cached build under the flag its lookup searches by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This is the log of notable changes to EAS CLI and related packages.
 ### 🐛 Bug fixes
 
 - [build-tools] Report a system error when project source refresh fails for a remote build. ([#4359](https://github.com/expo/eas-cli/pull/4359) by [@sjchmiela](https://github.com/sjchmiela))
+- [eas-cli] Record a build uploaded to the build cache under the same development-client value its lookup searches by, so a locally built dev client is found again instead of missing the cache forever. Adds `--dev-client` / `--no-dev-client` to `eas upload`. ([#4377](https://github.com/expo/eas-cli/pull/4377) by [@LizunovSergey](https://github.com/LizunovSergey))
 
 ### 🧹 Chores
 

--- a/packages/eas-build-cache-provider/jest.config.ts
+++ b/packages/eas-build-cache-provider/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from '@jest/types';
+
+import baseConfig from '../../jest/jest.shared.config';
+
+const config: Config.InitialOptions = {
+  ...baseConfig,
+  rootDir: __dirname,
+  roots: ['src'],
+  testRegex: '/__tests__/.*(test|spec)\\.[jt]sx?$',
+};
+
+export default config;

--- a/packages/eas-build-cache-provider/src/__tests__/index.test.ts
+++ b/packages/eas-build-cache-provider/src/__tests__/index.test.ts
@@ -33,7 +33,9 @@ describe('uploadBuildCache', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.mocked(fs.exists).mockResolvedValue(true as never);
-    jest.mocked(spawnAsync).mockResolvedValue({ stdout: '{"url":"https://expo.dev/build"}' } as never);
+    jest
+      .mocked(spawnAsync)
+      .mockResolvedValue({ stdout: '{"url":"https://expo.dev/build"}' } as never);
   });
 
   it('records the build as a dev client when the project builds one', async () => {

--- a/packages/eas-build-cache-provider/src/__tests__/index.test.ts
+++ b/packages/eas-build-cache-provider/src/__tests__/index.test.ts
@@ -1,0 +1,71 @@
+import { UploadBuildCacheProps, getPackageJson } from '@expo/config';
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs-extra';
+
+import EASBuildCacheProvider from '../index';
+
+// The plugin type is a union of the current and the deprecated shape; this
+// package implements the current one.
+const provider = EASBuildCacheProvider as {
+  uploadBuildCache: (props: UploadBuildCacheProps, options: unknown) => Promise<string | null>;
+  resolveBuildCache: (props: UploadBuildCacheProps, options: unknown) => Promise<string | null>;
+};
+
+jest.mock('@expo/spawn-async');
+jest.mock('fs-extra');
+jest.mock('@expo/config', () => ({ getPackageJson: jest.fn() }));
+
+describe('uploadBuildCache', () => {
+  function uploadProps(): UploadBuildCacheProps {
+    return {
+      projectRoot: '/app',
+      buildPath: '/app/android/app/build/outputs/apk/debug/app-debug.apk',
+      fingerprintHash: 'abc123',
+      platform: 'android',
+      runOptions: { variant: 'debug' },
+    } as UploadBuildCacheProps;
+  }
+
+  function uploadArgs(): string[] {
+    return jest.mocked(spawnAsync).mock.calls[0][1] as string[];
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.mocked(fs.exists).mockResolvedValue(true as never);
+    jest.mocked(spawnAsync).mockResolvedValue({ stdout: '{"url":"https://expo.dev/build"}' } as never);
+  });
+
+  it('records the build as a dev client when the project builds one', async () => {
+    jest.mocked(getPackageJson).mockReturnValue({ dependencies: { 'expo-dev-client': '^6.0.0' } });
+
+    await provider.uploadBuildCache(uploadProps(), undefined);
+
+    // resolveBuildCache searches with --dev-client for this same project, so an
+    // upload recorded under the other value can never be found again.
+    expect(uploadArgs()).toContain('--dev-client');
+  });
+
+  it('records a plain build when the project has no dev client', async () => {
+    jest.mocked(getPackageJson).mockReturnValue({});
+
+    await provider.uploadBuildCache(uploadProps(), undefined);
+
+    expect(uploadArgs()).toContain('--no-dev-client');
+  });
+
+  it('agrees with the lookup it will be searched by', async () => {
+    jest.mocked(getPackageJson).mockReturnValue({ dependencies: { 'expo-dev-client': '^6.0.0' } });
+
+    await provider.uploadBuildCache(uploadProps(), undefined);
+    await provider.resolveBuildCache(uploadProps(), undefined);
+
+    const [uploadArgv, resolveArgv] = jest
+      .mocked(spawnAsync)
+      .mock.calls.map(call => call[1] as string[]);
+    const devClientArg = (argv: string[]): string | undefined =>
+      argv.find(arg => arg === '--dev-client' || arg === '--no-dev-client');
+
+    expect(devClientArg(uploadArgv)).toBe(devClientArg(resolveArgv));
+  });
+});

--- a/packages/eas-build-cache-provider/src/index.ts
+++ b/packages/eas-build-cache-provider/src/index.ts
@@ -67,6 +67,7 @@ async function uploadBuildCacheAsync({
   platform,
   fingerprintHash,
   buildPath,
+  runOptions,
 }: UploadBuildCacheProps): Promise<string | null> {
   const easJsonPath = path.join(projectRoot, 'eas.json');
   if (!(await fs.exists(easJsonPath))) {
@@ -84,6 +85,11 @@ async function uploadBuildCacheAsync({
         `--platform=${platform}`,
         `--fingerprint=${fingerprintHash}`,
         buildPath ? `--build-path=${buildPath}` : '',
+        // Record the build under the same predicate `resolveBuildCacheAsync` searches
+        // with. Letting `eas-cli upload` infer it from the archive instead makes the
+        // two halves of this cache disagree, and an upload filed under the other
+        // value is never found again.
+        isDevClientBuild({ runOptions, projectRoot }) ? '--dev-client' : '--no-dev-client',
         '--non-interactive',
         '--json',
       ],

--- a/packages/eas-cli/src/commands/__tests__/upload.test.ts
+++ b/packages/eas-cli/src/commands/__tests__/upload.test.ts
@@ -1,0 +1,84 @@
+import { Platform } from '@expo/eas-build-job';
+import { vol } from 'memfs';
+import StreamZip from 'node-stream-zip';
+
+import { getMockOclifConfig } from '../../__tests__/commands/utils';
+import { ExpoGraphqlClient } from '../../commandUtils/context/contextUtils/createGraphqlClient';
+import { testProjectId } from '../../credentials/__tests__/fixtures-constants';
+import { LocalBuildMutation } from '../../graphql/mutations/LocalBuildMutation';
+import { uploadFileAtPathToGCSAsync } from '../../uploads';
+import BuildUpload from '../upload';
+
+jest.mock('fs');
+jest.mock('fs/promises');
+jest.mock('../../log');
+jest.mock('../../uploads');
+jest.mock('../../graphql/mutations/LocalBuildMutation');
+jest.mock('../../graphql/mutations/FingerprintMutation');
+jest.mock('node-stream-zip');
+
+const BUILD_PATH = '/app/android/app/build/outputs/apk/debug/app-debug.apk';
+
+describe(BuildUpload, () => {
+  const graphqlClient = {} as ExpoGraphqlClient;
+  const mockConfig = getMockOclifConfig();
+
+  function createCommand(argv: string[]): BuildUpload {
+    const command = new BuildUpload([...argv, '--platform=android', '--non-interactive'], mockConfig);
+    jest.spyOn(command as any, 'getContextAsync').mockResolvedValue({
+      projectId: testProjectId,
+      loggedIn: { graphqlClient },
+    } as never);
+    return command;
+  }
+
+  function recordedDevelopmentClient(): boolean {
+    const calls = jest.mocked(LocalBuildMutation.createLocalBuildAsync).mock.calls;
+    expect(calls).toHaveLength(1);
+    return (calls[0][4] as { developmentClient: boolean }).developmentClient;
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    vol.reset();
+    vol.fromJSON({ [BUILD_PATH]: 'not-a-real-apk' });
+
+    // An APK carrying no dev menu marker: what the probe sees for an Android
+    // build produced by `expo run:android`.
+    jest.mocked(StreamZip.async).mockImplementation(
+      () =>
+        ({
+          entry: jest.fn().mockResolvedValue(null),
+          entryData: jest.fn(),
+          entries: jest.fn().mockResolvedValue({}),
+          close: jest.fn().mockResolvedValue(undefined),
+        }) as never
+    );
+    jest.mocked(uploadFileAtPathToGCSAsync).mockResolvedValue('bucket-key');
+    jest.mocked(LocalBuildMutation.createLocalBuildAsync).mockResolvedValue({
+      id: 'build-id',
+      platform: Platform.ANDROID,
+      app: { slug: 'testapp', ownerAccount: { name: 'testuser' } },
+    } as never);
+  });
+
+  it('falls back to what the archive shows when neither flag is passed', async () => {
+    await createCommand([`--build-path=${BUILD_PATH}`]).runAsync();
+
+    expect(recordedDevelopmentClient()).toBe(false);
+  });
+
+  it('records a development client when --dev-client is passed', async () => {
+    await createCommand([`--build-path=${BUILD_PATH}`, '--dev-client']).runAsync();
+
+    // The archive probe alone files this build as a plain one, and
+    // `build:download --dev-client` then never finds it again.
+    expect(recordedDevelopmentClient()).toBe(true);
+  });
+
+  it('records a plain build when --no-dev-client is passed', async () => {
+    await createCommand([`--build-path=${BUILD_PATH}`, '--no-dev-client']).runAsync();
+
+    expect(recordedDevelopmentClient()).toBe(false);
+  });
+});

--- a/packages/eas-cli/src/commands/__tests__/upload.test.ts
+++ b/packages/eas-cli/src/commands/__tests__/upload.test.ts
@@ -24,7 +24,10 @@ describe(BuildUpload, () => {
   const mockConfig = getMockOclifConfig();
 
   function createCommand(argv: string[]): BuildUpload {
-    const command = new BuildUpload([...argv, '--platform=android', '--non-interactive'], mockConfig);
+    const command = new BuildUpload(
+      [...argv, '--platform=android', '--non-interactive'],
+      mockConfig
+    );
     jest.spyOn(command as any, 'getContextAsync').mockResolvedValue({
       projectId: testProjectId,
       loggedIn: { graphqlClient },

--- a/packages/eas-cli/src/commands/upload.ts
+++ b/packages/eas-cli/src/commands/upload.ts
@@ -48,6 +48,11 @@ export default class BuildUpload extends EasCommand {
     fingerprint: Flags.string({
       description: 'Fingerprint hash of the local build',
     }),
+    'dev-client': Flags.boolean({
+      description:
+        'Record the build as a development client build. Overrides what is detected from the build archive.',
+      allowNo: true,
+    }),
     ...EasNonInteractiveAndJsonFlags,
   };
 
@@ -58,7 +63,11 @@ export default class BuildUpload extends EasCommand {
 
   async runAsync(): Promise<void> {
     const { flags } = await this.parse(BuildUpload);
-    const { 'build-path': buildPath, fingerprint: manualFingerprintHash } = flags;
+    const {
+      'build-path': buildPath,
+      fingerprint: manualFingerprintHash,
+      'dev-client': developmentClientOverride,
+    } = flags;
     const { json: jsonFlag, nonInteractive } = resolveNonInteractiveAndJsonFlags(flags);
     const {
       projectId,
@@ -80,10 +89,15 @@ export default class BuildUpload extends EasCommand {
 
     const {
       fingerprintHash: buildFingerprintHash,
-      developmentClient,
+      developmentClient: detectedDevelopmentClient,
       simulator,
       ...otherMetadata
     } = await extractAppMetadataAsync(localBuildPath, platform);
+    // The archive probe below only recognizes a dev client by a file the dev menu
+    // leaves in the build, so a caller that already knows what it built has to be
+    // able to say so — `build:download --dev-client` filters on this same field,
+    // and a build recorded under the other value can never be found again.
+    const developmentClient = developmentClientOverride ?? detectedDevelopmentClient;
 
     let fingerprint = manualFingerprintHash ?? buildFingerprintHash;
     if (fingerprint) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/eas-cli/issues/4373.

The EAS build cache writes and reads the same build under two different definitions of "development client", so a locally-built Android dev client uploads successfully and is then never found again.

- The lookup, `resolveBuildCacheAsync`, passes `--dev-client` when `isDevClientBuild({ runOptions, projectRoot })` says so — that reads `expo-dev-client` from the project's `package.json` and the run variant.
- The upload was given no such input. `eas-cli upload` derived the value on its own, in `extractAppMetadataAsync`, from whether the archive contains the dev menu marker: `assets/EXDevMenuApp.android.js` on Android, `EXDevMenu.bundle/` on iOS.

Nothing keeps those two in agreement. When they disagree the upload succeeds and a finished build is recorded, but every later `build:download --fingerprint=… --dev-client` filters it out, so the cache misses forever on an unchanged project — the symptom in the issue.

The reporter's investigation holds up, and the Android half is worse than "they can disagree": `EXDevMenuApp.android.js` is not produced anywhere in current `expo`. `expo-dev-menu`'s Android side is a Compose UI, and neither `packages/expo-dev-menu/android/build.gradle` nor `packages/expo-dev-launcher/android/build.gradle` bundles a JS asset — the only mention left in the monorepo is a stale comment in `eslint-config-expo` about a build intermediate. The iOS `EXDevMenu.bundle` is still real (it is in `expo-dev-menu.podspec`'s `resource_bundles`), so only the Android branch of the probe is dead, and on Android every upload is currently recorded as `developmentClient: false`.

# How

Rather than teach the probe a new Android marker — which would only move the guess, and would drift again the next time the dev menu is repackaged — the caller that already knows what it built now says so.

- `eas upload` takes `--dev-client` / `--no-dev-client`, mirroring the flag `build:download` already filters by (`allowNo: true`, same wording). The archive probe stays as the default when neither flag is passed, so direct users of `eas upload` see no change.
- `uploadBuildCacheAsync` passes the verdict it already computes for the lookup. `runOptions` was already on `UploadBuildCacheProps`; it was simply not destructured.

Both halves of the cache now use one predicate, so they cannot disagree by construction.

# Test Plan

Automated, and both suites are new — neither file had tests before.

`packages/eas-cli/src/commands/__tests__/upload.test.ts` drives the command through `runAsync` with a mocked archive that carries no dev menu marker, and asserts what reaches `LocalBuildMutation.createLocalBuildAsync`:

```
PASS src/commands/__tests__/upload.test.ts
  ✓ falls back to what the archive shows when neither flag is passed
  ✓ records a development client when --dev-client is passed
  ✓ records a plain build when --no-dev-client is passed
```

`packages/eas-build-cache-provider/src/__tests__/index.test.ts` (with a `jest.config.ts` mirroring `packages/eas-json`'s — the package had `"test": "jest --passWithNoTests"` and no config) asserts the argv the provider builds, including that the two halves agree:

```
PASS src/__tests__/index.test.ts
  ✓ records the build as a dev client when the project builds one
  ✓ records a plain build when the project has no dev client
  ✓ agrees with the lookup it will be searched by
```

Both are witnesses, checked by mutation. Reducing the override to `detectedDevelopmentClient` fails "records a development client when --dev-client is passed"; forcing the provider's ternary to `'--no-dev-client'` fails two of the three provider tests, including "agrees with the lookup it will be searched by".

Repo gates: `yarn lint` and `yarn fmt:check` clean; `packages/eas-build-cache-provider` typechecks clean. `packages/eas-cli` `yarn typecheck` reports the same two pre-existing `TS2322`s in `credentials/ios/appstore/authenticate.ts` and `testflight/app.ts` that `origin/main` reports on a clean tree — none from this change. Full `packages/eas-cli` suite on this branch: 2532 passed, 0 failed; on `origin/main` in the same environment: 2528 passed, 1 failed, with ~26 suites failing to compile against the locally-resolved `@expo/apple-utils` type declarations either way.

Not verified: I did not build an Android dev client APK to confirm first-hand that one lacks `assets/EXDevMenuApp.android.js`. That claim rests on the reporter's observation plus the absence of any producer for that file in current `expo`, cited above. The fix does not depend on it — it removes the disagreement rather than re-tuning the probe.
