### PR TITLE
[eas-cli] improve EasCommand test reliability

### DIFF
--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -1,3 +1,4 @@
+import { Config } from '@oclif/core';
 import { v4 as uuidv4 } from 'uuid';
 
 import { AnalyticsWithOrchestration } from '../../analytics/AnalyticsManager';
@@ -24,17 +25,24 @@ jest.mock('../../analytics/AnalyticsManager', () => {
 });
 jest.mock('../../log');
 
-let originalProcessArgv: string[];
 const mockRequestId = uuidv4();
 
-beforeAll(() => {
-  originalProcessArgv = process.argv;
-  process.argv = [];
-});
+/**
+ * A Config that is never loaded. Letting oclif load one discovers and requires
+ * every command in the package, which takes seconds under coverage with a cold
+ * transform cache and has timed out on slow CI runners. Nothing here needs the
+ * command table or hooks.
+ */
+function getMockOclifConfig(): Config {
+  const config = new Config({ root: __dirname });
+  config.runHook = async () => ({
+    failures: [],
+    successes: [],
+  });
+  return config;
+}
 
-afterAll(() => {
-  process.argv = originalProcessArgv;
-});
+const mockConfig = getMockOclifConfig();
 
 const analytics: AnalyticsWithOrchestration = {
   logEvent: jest.fn((): void => {}),
@@ -61,25 +69,18 @@ const createTestEasCommand = (): any => {
 
 describe('EasCommand', () => {
   describe('without exceptions', () => {
-    // The first test in this suite should have an increased timeout
-    // because of the implementation of Command from @oclif/command.
-    // It seems that loading config takes significant amount of time
-    // and I'm not sure how to mock it.
-    //
-    // See https://github.com/oclif/command/blob/master/src/command.ts#L80
-    // and look for "Config.load"
     it('ensures the user data is read', async () => {
       const TestEasCommand = createTestEasCommand();
-      await TestEasCommand.run();
+      await TestEasCommand.run([], mockConfig);
 
       const SessionManager = jest.requireMock('../../user/SessionManager').default;
       const sessionManagerSpy = jest.spyOn(SessionManager.prototype, 'getUserAsync');
       expect(sessionManagerSpy).toBeCalledTimes(1);
-    }, 60_000);
+    });
 
     it('initializes analytics', async () => {
       const TestEasCommand = createTestEasCommand();
-      await TestEasCommand.run();
+      await TestEasCommand.run([], mockConfig);
 
       const { createAnalyticsAsync } = jest.requireMock('../../analytics/AnalyticsManager');
       expect(createAnalyticsAsync).toHaveBeenCalled();
@@ -87,14 +88,14 @@ describe('EasCommand', () => {
 
     it('flushes analytics', async () => {
       const TestEasCommand = createTestEasCommand();
-      await TestEasCommand.run();
+      await TestEasCommand.run([], mockConfig);
 
       expect(analytics.flushAsync).toHaveBeenCalled();
     });
 
     it('flushes Sentry', async () => {
       const TestEasCommand = createTestEasCommand();
-      await TestEasCommand.run();
+      await TestEasCommand.run([], mockConfig);
 
       const Sentry = jest.requireMock('../../sentry').default;
       expect(Sentry.flush).toHaveBeenCalled();
@@ -102,7 +103,7 @@ describe('EasCommand', () => {
 
     it('logs events', async () => {
       const TestEasCommand = createTestEasCommand();
-      await TestEasCommand.run();
+      await TestEasCommand.run([], mockConfig);
 
       expect(analytics.logEvent).toHaveBeenCalledWith('action', {
         action: `eas ${TestEasCommand.id}`,
@@ -114,7 +115,7 @@ describe('EasCommand', () => {
     it('flushes analytics', async () => {
       const TestEasCommand = createTestEasCommand();
       try {
-        await TestEasCommand.run().then(() => {
+        await TestEasCommand.run([], mockConfig).then(() => {
           throw new Error('foo');
         });
       } catch {}
@@ -140,7 +141,7 @@ describe('EasCommand', () => {
         });
 
         try {
-          await TestEasCommand.run();
+          await TestEasCommand.run([], mockConfig);
         } catch {}
 
         expect(sentryScope.setTag).toHaveBeenCalledWith('command', TestEasCommand.id);
@@ -167,7 +168,7 @@ describe('EasCommand', () => {
         });
 
         try {
-          await TestEasCommand.run();
+          await TestEasCommand.run([], mockConfig);
         } catch {}
 
         expect(Sentry.captureException).toHaveBeenCalledTimes(1);
@@ -184,7 +185,7 @@ describe('EasCommand', () => {
           throw error;
         });
         try {
-          await TestEasCommand.run();
+          await TestEasCommand.run([], mockConfig);
         } catch {}
 
         expect(logErrorSpy).toBeCalledWith('Unexpected, internal error message');
@@ -204,7 +205,7 @@ describe('EasCommand', () => {
           throw error;
         });
         try {
-          await TestEasCommand.run();
+          await TestEasCommand.run([], mockConfig);
         } catch {}
 
         expect(logErrorSpy).toBeCalledWith('Unexpected GraphQL error message');
@@ -237,7 +238,7 @@ describe('EasCommand', () => {
           throw error;
         });
         try {
-          await TestEasCommand.run();
+          await TestEasCommand.run([], mockConfig);
         } catch {}
 
         expect(logErrorSpy).toBeCalledWith(
@@ -273,7 +274,7 @@ describe('EasCommand', () => {
           throw error;
         });
         try {
-          await TestEasCommand.run();
+          await TestEasCommand.run([], mockConfig);
         } catch {}
 
         expect(logErrorSpy).toBeCalledWith(
@@ -294,7 +295,7 @@ describe('EasCommand', () => {
           throw new Error('Error message');
         });
         try {
-          await TestEasCommand.run();
+          await TestEasCommand.run([], mockConfig);
         } catch (caughtError) {
           expect(caughtError).toBeInstanceOf(Error);
           expect((caughtError as Error).message).toEqual('testEasCommand command failed.');
@@ -310,7 +311,7 @@ describe('EasCommand', () => {
           throw new CombinedError({ graphQLErrors });
         });
         try {
-          await TestEasCommand.run();
+          await TestEasCommand.run([], mockConfig);
         } catch (caughtError) {
           expect(caughtError).toBeInstanceOf(Error);
           expect((caughtError as Error).message).toEqual('GraphQL request failed.');
@@ -340,7 +341,7 @@ describe('EasCommand', () => {
           throw new CombinedError({ graphQLErrors });
         });
         try {
-          await TestEasCommand.run();
+          await TestEasCommand.run([], mockConfig);
         } catch (caughtError) {
           expect(caughtError).toBeInstanceOf(Error);
           expect((caughtError as Error).message).toEqual('GraphQL request failed.');

--- a/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
+++ b/packages/eas-cli/src/commandUtils/__tests__/EasCommand-test.ts
@@ -42,7 +42,7 @@ function getMockOclifConfig(): Config {
   return config;
 }
 
-const mockConfig = getMockOclifConfig();
+let mockConfig: Config;
 
 const analytics: AnalyticsWithOrchestration = {
   logEvent: jest.fn((): void => {}),
@@ -52,7 +52,16 @@ const analytics: AnalyticsWithOrchestration = {
 
 beforeEach(() => {
   jest.resetAllMocks();
+  mockConfig = getMockOclifConfig();
 });
+
+/**
+ * The config oclif handed to the most recently run command. Command.run returns
+ * a pre-built Config untouched only when it was created by the same @oclif/core
+ * copy the command extends; otherwise it silently builds and fully loads a new
+ * one, bringing back the command discovery this suite avoids.
+ */
+let lastCommandConfig: Config | undefined;
 
 const createTestEasCommand = (): any => {
   const { createAnalyticsAsync } = jest.requireMock('../../analytics/AnalyticsManager');
@@ -60,13 +69,18 @@ const createTestEasCommand = (): any => {
   const EasCommand = require('../EasCommand').default;
 
   class TestEasCommand extends EasCommand {
-    async runAsync(): Promise<void> {}
+    async runAsync(): Promise<void> {
+      lastCommandConfig = this.config;
+    }
   }
 
   TestEasCommand.id = 'testEasCommand'; // normally oclif will assign ids, but b/c this is located outside the commands folder it will not
   return TestEasCommand;
 };
 
+// These tests go through the static Command.run rather than constructing an
+// instance and calling run() like other command tests, because they cover
+// oclif's catch and finally wiring, which only runs inside the static path.
 describe('EasCommand', () => {
   describe('without exceptions', () => {
     it('ensures the user data is read', async () => {
@@ -76,6 +90,14 @@ describe('EasCommand', () => {
       const SessionManager = jest.requireMock('../../user/SessionManager').default;
       const sessionManagerSpy = jest.spyOn(SessionManager.prototype, 'getUserAsync');
       expect(sessionManagerSpy).toBeCalledTimes(1);
+    });
+
+    it('runs with the unloaded config instead of loading one', async () => {
+      const TestEasCommand = createTestEasCommand();
+      await TestEasCommand.run([], mockConfig);
+
+      expect(lastCommandConfig).toBe(mockConfig);
+      expect(mockConfig.plugins.size).toBe(0);
     });
 
     it('initializes analytics', async () => {


### PR DESCRIPTION
# Why

The `Test with Node 20` job on main failed in https://github.com/expo/eas-cli/actions/runs/34530834203 because the first test in `EasCommand-test.ts` exceeded its 60 second timeout. Node 22 and 24 passed the same commit, and every other slow suite in that job ran about ten times slower than usual, so the runner was starved rather than the code broken. The test was still the weak point: it carried a 60 second budget and a comment saying oclif config loading was slow and unmocked.

# How

- Measured where the time goes. Importing `EasCommand` costs about 0.3 seconds. Letting oclif load its `Config` costs 0.7 seconds without coverage and about 10 seconds with coverage and a cold transform cache, because it discovers and requires all 178 command modules and coverage instruments each one. CI always has a cold cache.
- Pass a bare `Config` with stubbed hooks to `TestEasCommand.run([], mockConfig)` instead, the same pattern `src/__tests__/commands/utils.ts` and other command tests already use. Nothing in this suite needs the command table or hooks. A fresh config is created per test so nothing is shared between them.
- The suite keeps going through the static `Command.run` rather than the instance pattern other command tests use, because it covers oclif's `catch` and `finally` wiring, which only runs on the static path. A comment now says so.
- oclif returns a pre-built config untouched only when it came from the same `@oclif/core` copy the command extends; otherwise it silently builds and fully loads a new one, which would bring the slowness back with no obvious cause. A new test asserts the command ran with the exact config it was given and that no plugins were loaded, so that regression fails loudly.
- Removed the custom timeout, the explanatory comment, and the `process.argv` juggling, since `argv` is now passed explicitly.

# What this no longer covers

The old first test was, by accident, the only unit test that loaded the package's real oclif configuration: the commands directory, the plugins, and the manifest. That implicit check is gone. Real invocations and the script tests still boot the CLI for real, and this suite was never meant to be that check, but reviewers should know it was implicit coverage rather than none.

# Test Plan

- `yarn jest src/commandUtils/__tests__/EasCommand-test.ts --coverage --verbose`: 16 passed. The first test went from 12.5 seconds to about 300 milliseconds on a warm cache and 1.6 seconds with `--no-cache`, versus a 60 second budget before. Every other test in the suite stays around a millisecond.
- Lint, format, and typecheck pass for the changed file.
- Test-only change, so this carries the `no changelog` label.
