### PR TITLE
[eas-cli] describe the inline egress client instead of asking to start one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Stop telling interactive `eas simulator:start --egress local` users to run `eas simulator:egress` when the egress client already runs in the same terminal. ([#PR_NUMBER](https://github.com/expo/eas-cli/pull/PR_NUMBER) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🧹 Chores
 
 ## [24.1.0](https://github.com/expo/eas-cli/releases/tag/v24.1.0) - 2026-09-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
-- [eas-cli] Stop telling interactive `eas simulator:start --egress local` users to run `eas simulator:egress` when the egress client already runs in the same terminal. ([#PR_NUMBER](https://github.com/expo/eas-cli/pull/PR_NUMBER) by [@brentvatne](https://github.com/brentvatne))
+- [eas-cli] Stop telling interactive `eas simulator:start --egress local` users to run `eas simulator:egress` when the egress client already runs in the same terminal. ([#4382](https://github.com/expo/eas-cli/pull/4382) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🧹 Chores
 

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -419,7 +419,10 @@ export default class Simulator extends EasCommand {
 
     Log.newLine();
     Log.log(
-      formatRemoteSessionInstructions(remoteConfig, flags['out-config-type'], { egressAllow })
+      formatRemoteSessionInstructions(remoteConfig, flags['out-config-type'], {
+        egressAllow,
+        egressClientRunsInline: !nonInteractive,
+      })
     );
     Log.newLine();
 
@@ -444,9 +447,6 @@ export default class Simulator extends EasCommand {
     let egressError: Error | undefined;
     const egressAbortController = new AbortController();
     if (localEgress) {
-      Log.log(
-        "🔀 Running the egress client in this terminal. When connected, proxied HTTP(S) requests can use this machine's network."
-      );
       Log.log('Press Ctrl+C to stop both the egress client and the simulator session.');
       Log.newLine();
       sessionInterrupt.signal.addEventListener(

--- a/packages/eas-cli/src/simulator/__tests__/utils.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/utils.test.ts
@@ -63,10 +63,29 @@ describe('local egress configuration', () => {
     const instructions = formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'dotenv');
     expect(instructions).toContain('eas simulator:egress');
     expect(instructions).toContain('Run the egress client to connect the tunnel');
+    expect(instructions).toContain('Keep it running for the life of the session.');
     expect(instructions).not.toContain('may reach');
     expect(formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'env')).toContain(
       "export EAS_SIMULATOR_EGRESS_ALLOW=''"
     );
+  });
+
+  it('describes the inline egress client instead of asking the reader to start one', () => {
+    const instructions = formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'dotenv', {
+      egressClientRunsInline: true,
+    });
+    expect(instructions).toContain('The egress client runs in this terminal');
+    expect(instructions).toContain(
+      'reconnect the tunnel from another shell with:\n\neas simulator:egress'
+    );
+    expect(instructions).not.toContain('Run the egress client to connect the tunnel');
+    expect(instructions).not.toContain('Keep it running');
+
+    expect(
+      formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'env', {
+        egressClientRunsInline: true,
+      })
+    ).toContain('eas simulator:egress --config-type env');
   });
 
   it('carries the allowed local destinations into the config, env file and instructions', () => {

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -81,6 +81,12 @@ export type LocalEgressConfig = {
 
 export type LocalEgressOptions = {
   egressAllow?: readonly string[];
+  /**
+   * Whether the calling command runs the egress client itself in the current
+   * terminal, as interactive `simulator:start` does. When false the reader must
+   * start `eas simulator:egress` in another process.
+   */
+  egressClientRunsInline?: boolean;
 };
 
 /**
@@ -258,13 +264,15 @@ export function sanitizeRemoteConfigForJson(
 export function formatRemoteSessionInstructions(
   remoteConfig: DeviceRunSessionRemoteConfig,
   configType: RemoteSessionInstructionsConfigType,
-  { egressAllow }: LocalEgressOptions = {}
+  { egressAllow, egressClientRunsInline = false }: LocalEgressOptions = {}
 ): string {
   const instructions = formatControllerInstructions(remoteConfig, configType);
   const egress = getLocalEgressConfig(remoteConfig, egressAllow);
   if (!egress) {
     return instructions;
   }
+  const egressCommand =
+    configType === 'env' ? 'eas simulator:egress --config-type env' : 'eas simulator:egress';
   return [
     instructions,
     '',
@@ -274,11 +282,19 @@ export function formatRemoteSessionInstructions(
           ([key, value]) => `export ${key}='${value}'`
         )
       : []),
-    'Run the egress client to connect the tunnel:',
-    '',
-    configType === 'env' ? 'eas simulator:egress --config-type env' : 'eas simulator:egress',
-    '',
-    'Keep it running for the life of the session.',
+    ...(egressClientRunsInline
+      ? [
+          'The egress client runs in this terminal for the life of the session. If this process exits, reconnect the tunnel from another shell with:',
+          '',
+          egressCommand,
+        ]
+      : [
+          'Run the egress client to connect the tunnel:',
+          '',
+          egressCommand,
+          '',
+          'Keep it running for the life of the session.',
+        ]),
     ...(egress.allow.length > 0
       ? [
           '',


### PR DESCRIPTION
# Why

Interactive `eas simulator:start --egress local` prints a block telling the user to run `eas simulator:egress` and keep it running, then a few lines later starts the egress client in the same terminal. The first block is right for `--non-interactive` and `--out-config-type env`, where the command returns and the user must start the client, but in the interactive case it contradicts what happens next.

# How

- `formatRemoteSessionInstructions` takes an `egressClientRunsInline` option. When set, the middle of the egress block says the client runs in this terminal for the life of the session and that `eas simulator:egress` is how to reconnect from another shell if the process exits. The non-inline wording is unchanged, and the allow-list and loopback-forward lines print in both cases.
- `simulator:start` passes `egressClientRunsInline: !nonInteractive`, and drops its own duplicate "Running the egress client in this terminal" line, keeping the Ctrl+C note. `simulator:get` keeps the non-inline wording since it never runs the client.

# Test Plan

- `yarn jest src/simulator/__tests__/utils.test.ts src/commands/simulator/__tests__/index.test.ts`: 101 passed, including a new case for the inline wording in both config types.
- Lint, format, and typecheck pass for the changed files.
