### PR TITLE
[eas-cli] shorten the local egress banner and drop the run-it-yourself instruction in interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [eas-cli] Shorten the local egress banner printed by `eas simulator:start` and stop mentioning `eas simulator:egress` in interactive mode, where the client runs in the same terminal. ([#4383](https://github.com/expo/eas-cli/pull/4383) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🧹 Chores
 
 ## [24.1.1](https://github.com/expo/eas-cli/releases/tag/v24.1.1) - 2026-09-11

--- a/packages/eas-cli/src/commands/simulator/egress.ts
+++ b/packages/eas-cli/src/commands/simulator/egress.ts
@@ -59,9 +59,7 @@ export default class SimulatorEgress extends EasCommand {
         ...egress,
         signal: abortController.signal,
         onConnected: () => {
-          Log.succeed(
-            "Egress tunnel connected. Proxied HTTP(S) requests can use this machine's network."
-          );
+          Log.succeed('Egress tunnel connected.');
         },
         onDisconnected: () => {
           Log.warn(

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -447,8 +447,6 @@ export default class Simulator extends EasCommand {
     let egressError: Error | undefined;
     const egressAbortController = new AbortController();
     if (localEgress) {
-      Log.log('Press Ctrl+C to stop both the egress client and the simulator session.');
-      Log.newLine();
       sessionInterrupt.signal.addEventListener(
         'abort',
         () => {

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -458,9 +458,7 @@ export default class Simulator extends EasCommand {
         ...localEgress,
         signal: egressAbortController.signal,
         onConnected: () => {
-          Log.succeed(
-            "Egress tunnel connected. Proxied HTTP(S) requests can use this machine's network."
-          );
+          Log.succeed('Egress tunnel connected.');
         },
         onDisconnected: () => {
           Log.warn(

--- a/packages/eas-cli/src/simulator/__tests__/utils.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/utils.test.ts
@@ -61,33 +61,35 @@ describe('local egress configuration', () => {
       EAS_SIMULATOR_EGRESS_ALLOW: '',
     });
     const instructions = formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'dotenv');
-    expect(instructions).toContain('eas simulator:egress');
+    expect(instructions).toContain(
+      "🔀 Local egress: the simulator's HTTP(S) traffic exits from this machine.\n"
+    );
     expect(instructions).toContain('Run the egress client to connect the tunnel');
+    expect(instructions).toContain('eas simulator:egress');
     expect(instructions).toContain('Keep it running for the life of the session.');
-    expect(instructions).not.toContain('may reach');
+    expect(instructions).not.toContain('It can also reach');
     expect(formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'env')).toContain(
       "export EAS_SIMULATOR_EGRESS_ALLOW=''"
     );
   });
 
-  it('describes the inline egress client instead of asking the reader to start one', () => {
-    const instructions = formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'dotenv', {
-      egressClientRunsInline: true,
-    });
-    expect(instructions).toContain(
-      'The egress client runs in this terminal. Press Ctrl+C to stop it together with the simulator session.'
-    );
-    expect(instructions).toContain(
-      'If this terminal closes any other way, the session keeps running. Reconnect the tunnel from another shell with:\n\neas simulator:egress\n\nor stop the session with eas simulator:stop.'
-    );
-    expect(instructions).not.toContain('Run the egress client to connect the tunnel');
-    expect(instructions).not.toContain('Keep it running');
-
-    expect(
-      formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'env', {
-        egressClientRunsInline: true,
-      })
-    ).toContain('eas simulator:egress --config-type env');
+  it('says nothing about starting the client when it runs inline', () => {
+    for (const configType of ['dotenv', 'env'] as const) {
+      const instructions = formatRemoteSessionInstructions(
+        agentDeviceConfigWithEgress,
+        configType,
+        {
+          egressClientRunsInline: true,
+        }
+      );
+      expect(instructions).toContain(
+        "🔀 Local egress: the simulator's HTTP(S) traffic exits from this machine."
+      );
+      expect(instructions).not.toContain('eas simulator:egress');
+      expect(instructions).not.toContain('Run the egress client');
+      expect(instructions).not.toContain('Keep it running');
+      expect(instructions).not.toContain('export EAS_SIMULATOR_EGRESS');
+    }
   });
 
   it('carries the allowed local destinations into the config, env file and instructions', () => {
@@ -105,19 +107,19 @@ describe('local egress configuration', () => {
       egressAllow,
     });
     expect(instructions).toContain(
-      "The simulator may reach localhost:3000, 192.168.1.20:8080 on this machine's network."
+      "🔀 Local egress: the simulator's HTTP(S) traffic exits from this machine. It can also reach localhost:3000, 192.168.1.20:8080."
     );
-    expect(instructions).toContain(
-      '127.0.0.1:3000 in the simulator reaches the same port on this machine (like adb reverse)'
-    );
+    expect(instructions).not.toContain('reachable by name only');
   });
 
-  it('omits the loopback forwarding notice when no allowed destination is loopback', () => {
+  it('warns only about loopback entries the device host will not forward', () => {
     expect(
       formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'dotenv', {
-        egressAllow: ['192.168.1.20:8080'],
+        egressAllow: ['localhost:80', 'localhost:3000'],
       })
-    ).not.toContain('adb reverse');
+    ).toContain(
+      'localhost:80 is reachable by name only: privileged ports and the egress proxy port are not forwarded to 127.0.0.1 in the simulator.'
+    );
   });
 });
 
@@ -143,13 +145,13 @@ describe(getLoopbackForwardPlan, () => {
 });
 
 describe(formatLoopbackForwardNotice, () => {
-  it('describes forwarded ports and name-only entries', () => {
+  it('describes name-only entries and stays silent about forwarded ports', () => {
     expect(formatLoopbackForwardNotice({ ports: [3000, 8082], skipped: ['localhost:80'] })).toEqual(
       [
-        '127.0.0.1:3000, 127.0.0.1:8082 in the simulator reach the same ports on this machine (like adb reverse), so dev server URLs that use 127.0.0.1 work.',
         'localhost:80 is reachable by name only: privileged ports and the egress proxy port are not forwarded to 127.0.0.1 in the simulator.',
       ]
     );
+    expect(formatLoopbackForwardNotice({ ports: [3000], skipped: [] })).toEqual([]);
     expect(formatLoopbackForwardNotice({ ports: [], skipped: [] })).toEqual([]);
   });
 });

--- a/packages/eas-cli/src/simulator/__tests__/utils.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/utils.test.ts
@@ -74,9 +74,11 @@ describe('local egress configuration', () => {
     const instructions = formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'dotenv', {
       egressClientRunsInline: true,
     });
-    expect(instructions).toContain('The egress client runs in this terminal');
     expect(instructions).toContain(
-      'reconnect the tunnel from another shell with:\n\neas simulator:egress'
+      'The egress client runs in this terminal. Press Ctrl+C to stop it together with the simulator session.'
+    );
+    expect(instructions).toContain(
+      'If this terminal closes any other way, the session keeps running. Reconnect the tunnel from another shell with:\n\neas simulator:egress\n\nor stop the session with eas simulator:stop.'
     );
     expect(instructions).not.toContain('Run the egress client to connect the tunnel');
     expect(instructions).not.toContain('Keep it running');

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -284,9 +284,12 @@ export function formatRemoteSessionInstructions(
       : []),
     ...(egressClientRunsInline
       ? [
-          'The egress client runs in this terminal for the life of the session. If this process exits, reconnect the tunnel from another shell with:',
+          'The egress client runs in this terminal. Press Ctrl+C to stop it together with the simulator session.',
+          'If this terminal closes any other way, the session keeps running. Reconnect the tunnel from another shell with:',
           '',
           egressCommand,
+          '',
+          'or stop the session with eas simulator:stop.',
         ]
       : [
           'Run the egress client to connect the tunnel:',

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -149,23 +149,18 @@ export function getLoopbackForwardPlan(
   return { ports: [...ports].sort((a, b) => a - b), skipped };
 }
 
-export function formatLoopbackForwardNotice({ ports, skipped }: LoopbackForwardPlan): string[] {
-  const lines: string[] = [];
-  if (ports.length > 0) {
-    const addresses = ports.map(port => `127.0.0.1:${port}`).join(', ');
-    lines.push(
-      `${addresses} in the simulator ${ports.length === 1 ? 'reaches' : 'reach'} the same ` +
-        `${ports.length === 1 ? 'port' : 'ports'} on this machine (like adb reverse), so dev server ` +
-        'URLs that use 127.0.0.1 work.'
-    );
+/**
+ * Only the exception is worth a line: forwarded ports just work, but an entry
+ * the device host will not forward changes what the reader would expect.
+ */
+export function formatLoopbackForwardNotice({ skipped }: LoopbackForwardPlan): string[] {
+  if (skipped.length === 0) {
+    return [];
   }
-  if (skipped.length > 0) {
-    lines.push(
-      `${skipped.join(', ')} ${skipped.length === 1 ? 'is' : 'are'} reachable by name only: ` +
-        'privileged ports and the egress proxy port are not forwarded to 127.0.0.1 in the simulator.'
-    );
-  }
-  return lines;
+  return [
+    `${skipped.join(', ')} ${skipped.length === 1 ? 'is' : 'are'} reachable by name only: ` +
+      'privileged ports and the egress proxy port are not forwarded to 127.0.0.1 in the simulator.',
+  ];
 }
 
 export function getLocalEgressEnvironmentVariables(
@@ -273,38 +268,30 @@ export function formatRemoteSessionInstructions(
   }
   const egressCommand =
     configType === 'env' ? 'eas simulator:egress --config-type env' : 'eas simulator:egress';
+  const summary =
+    "🔀 Local egress: the simulator's HTTP(S) traffic exits from this machine." +
+    (egress.allow.length > 0 ? ` It can also reach ${egress.allow.join(', ')}.` : '');
   return [
     instructions,
     '',
-    '🔀 This session can route proxied HTTP(S) requests through this machine.',
-    ...(configType === 'env'
-      ? Object.entries(getLocalEgressEnvironmentVariables(egress)).map(
-          ([key, value]) => `export ${key}='${value}'`
-        )
-      : []),
+    summary,
+    ...formatLoopbackForwardNotice(getLoopbackForwardPlan(egress.allow, egress.port)),
+    // In interactive mode the client starts in this terminal once the session is
+    // ready and stops with it, so there is nothing for the reader to run.
     ...(egressClientRunsInline
-      ? [
-          'The egress client runs in this terminal. Press Ctrl+C to stop it together with the simulator session.',
-          'If this terminal closes any other way, the session keeps running. Reconnect the tunnel from another shell with:',
-          '',
-          egressCommand,
-          '',
-          'or stop the session with eas simulator:stop.',
-        ]
+      ? []
       : [
+          ...(configType === 'env'
+            ? Object.entries(getLocalEgressEnvironmentVariables(egress)).map(
+                ([key, value]) => `export ${key}='${value}'`
+              )
+            : []),
           'Run the egress client to connect the tunnel:',
           '',
           egressCommand,
           '',
           'Keep it running for the life of the session.',
         ]),
-    ...(egress.allow.length > 0
-      ? [
-          '',
-          `The simulator may reach ${egress.allow.join(', ')} on this machine's network.`,
-          ...formatLoopbackForwardNotice(getLoopbackForwardPlan(egress.allow, egress.port)),
-        ]
-      : []),
   ].join('\n');
 }
 


### PR DESCRIPTION
# Why

Follow-up to #4382, which shipped in 24.1.1. The interactive `eas simulator:start --egress local` banner still told the user to run `eas simulator:egress` "if this process exits", which contradicts Ctrl+C ending the session, and the rest of the egress output restated the same fact three times and explained the loopback-forwarding mechanism to people who only need to know their dev server is reachable.

# How

- Interactive mode no longer mentions `eas simulator:egress` at all. The client starts and stops with the session in the same terminal, and the spinner that follows already says to press Ctrl+C, so there is nothing for the reader to run.
- Both modes open with one summary line that names the allowed destinations. In non-interactive and `--out-config-type env` mode the existing "run `eas simulator:egress` and keep it running" instruction still follows, since there the user really must run it. The separate "start `eas simulator:egress` in another process" line that used to print after that block is gone, since the block already says it.
- The "like `adb reverse`" mechanism sentence leaves the banner; it stays in the `--egress-allow` flag help. Only an entry the device host will not forward, a privileged port or the proxy port, still gets a warning line.
- The tunnel-connected message in `simulator:start` and `simulator:egress` is now just "Egress tunnel connected."
- Stopping with Ctrl+C no longer logs "Egress tunnel disconnected; reconnecting" for the disconnect the stop itself caused.

# Test Plan

- `yarn jest src/simulator/__tests__/utils.test.ts src/commands/simulator/__tests__/index.test.ts src/commands/simulator/__tests__/egress.test.ts`: all pass, including cases for the inline wording in both config types, the destination list, the name-only warning, and the absence of the duplicate non-interactive hint.
- Lint, format, and typecheck pass for the changed files.
- Ran the built CLI from this branch against production from a fresh project, interactively under a pseudo-terminal, with `--egress local --egress-allow localhost:8081`. Output after the preview URL, exactly as printed:

  ```
  🔀 Local egress: the simulator's HTTP(S) traffic exits from this machine. It can also reach localhost:8081.

  ✔ Egress tunnel connected.
  ⠋ Simulator session active — press Ctrl+C to stop, or run `eas simulator:stop --id …` from another shell
  ```

  Ctrl+C printed "Stopping simulator session..." then "✔ Simulator session stopped", with no reconnect warning, and the session showed `STOPPED` afterwards.

- The same command without a TTY, which the CLI treats as non-interactive, printed the summary line followed by the "Run the egress client to connect the tunnel / `eas simulator:egress` / Keep it running for the life of the session" block. That run is what exposed the duplicate "start `eas simulator:egress` in another process" line, which is now removed; the unit test asserts it no longer prints.
