### PR TITLE
[eas-cli] drop the duplicate non-interactive egress hint and the disconnect warning on stop

### DIFF
--- a/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
+++ b/packages/eas-cli/src/commands/simulator/__tests__/index.test.ts
@@ -976,11 +976,17 @@ describe(Simulator, () => {
     await command.runAsync();
     expect(fs.writeFile).not.toHaveBeenCalled();
     expect(Log.log).toHaveBeenCalledWith(
-      expect.stringContaining('Start `eas simulator:egress --config-type env` in another process')
+      expect.stringContaining(
+        'Run the egress client to connect the tunnel:\n\neas simulator:egress --config-type env\n'
+      )
     );
     expect(Log.log).not.toHaveBeenCalledWith(
-      expect.stringContaining('Start `eas simulator:egress` in another process')
+      expect.stringContaining(
+        'Run the egress client to connect the tunnel:\n\neas simulator:egress\n'
+      )
     );
+    // The instructions block is the only place the command is mentioned.
+    expect(Log.log).not.toHaveBeenCalledWith(expect.stringContaining('in another process'));
   });
 
   it.each(localEgressSessions)(

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -430,11 +430,7 @@ export default class Simulator extends EasCommand {
 
     if (nonInteractive) {
       sessionInterrupt.dispose();
-      if (localEgress) {
-        Log.log(
-          `Start \`eas simulator:egress${flags['out-config-type'] === OUT_CONFIG_TYPE_VALUES.Env ? ' --config-type env' : ''}\` in another process to connect the tunnel for proxied HTTP(S) requests.`
-        );
-      }
+      // The instructions above already tell the reader to run eas simulator:egress.
       Log.log(
         `When you are done, stop the session with: eas simulator:stop --id ${deviceRunSessionId}`
       );

--- a/packages/eas-cli/src/simulator/egress.ts
+++ b/packages/eas-cli/src/simulator/egress.ts
@@ -1003,7 +1003,10 @@ export async function runLocalEgressAsync({
         case 'disconnected':
           if (connected) {
             connected = false;
-            onDisconnected?.(line);
+            // A disconnect we caused by stopping is not something to warn about.
+            if (!signal.aborted) {
+              onDisconnected?.(line);
+            }
           }
           break;
         case 'other':


### PR DESCRIPTION
# Why

Follow-up to #4383. Running the built CLI against a real production session, once with a TTY and once without, showed two leftovers in the local egress output.

# How

- **Non-interactive mode printed the same instruction twice.** The instructions block already says to run `eas simulator:egress` and keep it running; the command then printed its own "Start `eas simulator:egress` in another process" line right after. The second line is removed, and the test asserts it stays gone.
- **Ctrl+C logged a reconnect warning for a disconnect we caused.** Stopping the session tears down the tunnel client, and chisel's disconnect line triggered "Egress tunnel disconnected; reconnecting" during "Stopping simulator session...". The client now skips that warning when its own abort signal has fired.

# Test Plan

- `yarn jest src/simulator/__tests__/egress.test.ts src/commands/simulator/__tests__/index.test.ts`: all pass.
- Lint, format, and typecheck pass for the changed files.
- Interactive run under a pseudo-terminal against production with `--egress local --egress-allow localhost:8081`: the banner, "Egress tunnel connected.", and the session spinner printed; Ctrl+C printed "Stopping simulator session..." then "Simulator session stopped" with no reconnect warning, and the session reported `STOPPED`.
- The no-TTY run, which the CLI treats as non-interactive, is what exposed the duplicate line.
