### PR TITLE
[eas-cli] make command descriptions lowercase without trailing periods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🧹 Chores
 
+- [eas-cli] Make command descriptions in `eas --help` consistently lowercase without trailing periods. ([#4385](https://github.com/expo/eas-cli/pull/4385) by [@brentvatne](https://github.com/brentvatne))
+
 ## [24.1.1](https://github.com/expo/eas-cli/releases/tag/v24.1.1) - 2026-09-11
 
 ### 🐛 Bug fixes

--- a/packages/eas-cli/src/commands/browse.ts
+++ b/packages/eas-cli/src/commands/browse.ts
@@ -33,7 +33,7 @@ const PROJECT_PAGES: Record<string, string> = {
 
 export default class Browse extends EasCommand {
   static override description =
-    'Transition from the terminal to the web browser to view and interact with your project on https://expo.dev';
+    'transition from the terminal to the web browser to view and interact with your project on https://expo.dev';
 
   static override args = {
     page: Args.string({

--- a/packages/eas-cli/src/commands/channel/delete.ts
+++ b/packages/eas-cli/src/commands/channel/delete.ts
@@ -13,7 +13,7 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 import { pollForBackgroundJobReceiptAsync } from '../../utils/pollForBackgroundJobReceiptAsync';
 
 export default class ChannelDelete extends EasCommand {
-  static override description = 'Delete a channel';
+  static override description = 'delete a channel';
 
   static override args = {
     name: Args.string({

--- a/packages/eas-cli/src/commands/channel/rollout.ts
+++ b/packages/eas-cli/src/commands/channel/rollout.ts
@@ -50,7 +50,7 @@ type ChannelRolloutArgsAndFlags = {
   Partial<CreateRolloutNonInteractiveOptions>;
 
 export default class ChannelRollout extends EasCommand {
-  static override description = 'Roll a new branch out on a channel incrementally.';
+  static override description = 'roll a new branch out on a channel incrementally';
 
   static override args = {
     channel: Args.string({

--- a/packages/eas-cli/src/commands/credentials/configure-build.ts
+++ b/packages/eas-cli/src/commands/credentials/configure-build.ts
@@ -7,7 +7,7 @@ import { SetUpBuildCredentialsCommandAction } from '../../credentials/manager/Se
 import { selectPlatformAsync } from '../../platform';
 
 export default class InitializeBuildCredentials extends EasCommand {
-  static override description = 'Set up credentials for building your project.';
+  static override description = 'set up credentials for building your project';
 
   static override flags = {
     platform: Flags.option({

--- a/packages/eas-cli/src/commands/deploy/alias/delete.ts
+++ b/packages/eas-cli/src/commands/deploy/alias/delete.ts
@@ -22,7 +22,7 @@ interface DeployAliasDeleteFlags {
 }
 
 export default class WorkerAliasDelete extends EasCommand {
-  static override description = 'Delete deployment aliases.';
+  static override description = 'delete deployment aliases';
   static override aliases = ['worker:alias:delete'];
   static override state = 'preview';
 

--- a/packages/eas-cli/src/commands/deploy/alias/index.ts
+++ b/packages/eas-cli/src/commands/deploy/alias/index.ts
@@ -39,7 +39,7 @@ interface RawDeployAliasFlags {
 }
 
 export default class WorkerAlias extends EasCommand {
-  static override description = 'Assign deployment aliases.';
+  static override description = 'assign deployment aliases';
   static override aliases = ['worker:alias', 'deploy:promote'];
   static override state = 'preview';
 

--- a/packages/eas-cli/src/commands/deploy/delete.ts
+++ b/packages/eas-cli/src/commands/deploy/delete.ts
@@ -23,7 +23,7 @@ interface RawDeployDeleteFlags {
 }
 
 export default class WorkerDelete extends EasCommand {
-  static override description = 'Delete a deployment.';
+  static override description = 'delete a deployment';
   static override aliases = ['worker:delete'];
   static override state = 'preview';
 

--- a/packages/eas-cli/src/commands/go.ts
+++ b/packages/eas-cli/src/commands/go.ts
@@ -99,7 +99,7 @@ async function withSuppressedOutputAsync<T>(fn: () => Promise<T>): Promise<T> {
 /* eslint-enable no-console */
 
 export default class Go extends EasCommand {
-  static override description = 'Create a custom Expo Go and submit to TestFlight';
+  static override description = 'create a custom Expo Go and submit to TestFlight';
   static override hidden = true;
 
   static override flags = {

--- a/packages/eas-cli/src/commands/observe/event.ts
+++ b/packages/eas-cli/src/commands/observe/event.ts
@@ -23,7 +23,7 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class ObserveEvent extends EasCommand {
   static override description =
-    'display a single Observe event (metric, log, or error) by its ID. IDs are included in event data when the `--json` flag is passed to `eas observe:session`, `eas observe:metrics`, or `eas observe:events`.';
+    'display a single Observe event (metric, log, or error) by its ID. IDs are included in event data when the `--json` flag is passed to `eas observe:session`, `eas observe:metrics`, or `eas observe:events`';
 
   static override args = {
     id: Args.string({

--- a/packages/eas-cli/src/commands/observe/events.ts
+++ b/packages/eas-cli/src/commands/observe/events.ts
@@ -37,7 +37,7 @@ const DEFAULT_EVENTS_LIMIT = 10;
 
 export default class ObserveEvents extends EasCommand {
   static override description =
-    'display individual events emitted by the app via `logEvent`, filtered by the event name in the argument. With no arguments, a list of the available event names and associated event counts is returned.';
+    'display individual events emitted by the app via `logEvent`, filtered by the event name in the argument. With no arguments, a list of the available event names and associated event counts is returned';
 
   static override args = {
     eventName: Args.string({

--- a/packages/eas-cli/src/commands/project/new.ts
+++ b/packages/eas-cli/src/commands/project/new.ts
@@ -134,7 +134,7 @@ export default class New extends EasCommand {
   static override aliases = ['new'];
 
   static override description =
-    'Create a new project configured with Expo Application Services (EAS)';
+    'create a new project configured with Expo Application Services (EAS)';
 
   static override args = {
     path: Args.string({

--- a/packages/eas-cli/src/commands/workflow/cancel.ts
+++ b/packages/eas-cli/src/commands/workflow/cancel.ts
@@ -9,7 +9,7 @@ import { promptAsync } from '../../prompts';
 
 export default class WorkflowRunCancel extends EasCommand {
   static override description =
-    'Cancel one or more workflow runs. If no workflow run IDs are provided, you will be prompted to select IN_PROGRESS runs to cancel.';
+    'cancel one or more workflow runs. If no workflow run IDs are provided, you will be prompted to select IN_PROGRESS runs to cancel';
 
   static override strict = false;
 

--- a/packages/eas-cli/src/commands/workflow/list.ts
+++ b/packages/eas-cli/src/commands/workflow/list.ts
@@ -9,7 +9,7 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 export default class WorkflowList extends EasCommand {
   static override hidden = true;
 
-  static override description = 'List workflows for the current project';
+  static override description = 'list workflows for the current project';
 
   static override flags = {
     ...EasJsonOnlyFlag,

--- a/packages/eas-cli/src/commands/workflow/logs.ts
+++ b/packages/eas-cli/src/commands/workflow/logs.ts
@@ -26,7 +26,7 @@ function printLogsForAllSteps(logs: WorkflowLogs): void {
 
 export default class WorkflowLogView extends EasCommand {
   static override description =
-    'view logs for a workflow run, selecting a job and step to view. You can pass in either a workflow run ID or a job ID. If no ID is passed in, you will be prompted to select from recent workflow runs for the current project.';
+    'view logs for a workflow run, selecting a job and step to view. You can pass in either a workflow run ID or a job ID. If no ID is passed in, you will be prompted to select from recent workflow runs for the current project';
 
   static override flags = {
     ...EasJsonOnlyFlag,

--- a/packages/eas-cli/src/commands/workflow/run.ts
+++ b/packages/eas-cli/src/commands/workflow/run.ts
@@ -93,7 +93,7 @@ export function resolveWorkflowRunSshInput({
 
 export default class WorkflowRun extends EasCommand {
   static override description =
-    'run an EAS workflow. The entire local project directory will be packaged and uploaded to EAS servers for the workflow run, unless the --ref flag is used.';
+    'run an EAS workflow. The entire local project directory will be packaged and uploaded to EAS servers for the workflow run, unless the --ref flag is used';
 
   static override args = {
     file: Args.string({

--- a/packages/eas-cli/src/commands/workflow/status.ts
+++ b/packages/eas-cli/src/commands/workflow/status.ts
@@ -32,7 +32,7 @@ import { enableJsonOutput, printJsonOnlyOutput } from '../../utils/json';
 
 export default class WorkflowStatus extends EasCommand {
   static override description =
-    'show the status of an existing workflow run. If no run ID is provided, you will be prompted to select from recent workflow runs for the current project.';
+    'show the status of an existing workflow run. If no run ID is provided, you will be prompted to select from recent workflow runs for the current project';
 
   static override args = {
     WORKFLOW_RUN_ID: Args.string({

--- a/packages/eas-cli/src/commands/workflow/view.ts
+++ b/packages/eas-cli/src/commands/workflow/view.ts
@@ -59,7 +59,7 @@ const processedOutputs: (job: WorkflowJobResult) => FormatFieldsItem[] = job => 
 
 export default class WorkflowView extends EasCommand {
   static override description =
-    'view details for a workflow run, including jobs. If no run ID is provided, you will be prompted to select from recent workflow runs for the current project.';
+    'view details for a workflow run, including jobs. If no run ID is provided, you will be prompted to select from recent workflow runs for the current project';
 
   static override flags = {
     ...EasJsonOnlyFlag,


### PR DESCRIPTION
# Why

`eas --help` mixes styles: most command descriptions start lowercase and end without a period ("start a build", "show the username you are logged in as"), but a handful start with a capital ("Create a new project...", "Transition from the terminal...") or end with a period ("Delete a deployment."). Same for topic-level help such as `eas deploy --help` and `eas workflow --help`.

# How

Across all 150 commands, the description now follows the majority style: lowercase first word unless it is a proper noun, and no trailing period.

- 11 descriptions had a capitalized first word: `browse`, `channel:delete`, `channel:rollout`, `credentials:configure-build`, `deploy:alias`, `deploy:alias:delete`, `deploy:delete`, `go`, `project:new`, `workflow:cancel`, `workflow:list`.
- 12 descriptions ended with a period. For the multi-sentence ones under `observe` and `workflow`, only the final period is dropped.
- Untouched: descriptions that start with a proper noun or `[EXPERIMENTAL]`, and paragraphs after the first line of multi-line descriptions.
- `help` and `autocomplete` come from `@expo/plugin-help` and `@oclif/plugin-autocomplete` and still print "Display ..."; fixing those means changing the plugins.

`README.md` is regenerated from these strings by the `version` script at release time, so it is not updated here.

# Test Plan

- Description strings only. Lint, format, and typecheck pass for the changed files.
- `eas --help` and the affected topic help pages read consistently after `yarn build`.
