### PR TITLE
[build-tools] Skip source refresh for jobs with no sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🐛 Bug fixes
 
+- [build-tools] Skip project source refresh for jobs with no sources. ([#4389](https://github.com/expo/eas-cli/pull/4389) by [@sjchmiela](https://github.com/sjchmiela))
+
 ### 🧹 Chores
 
 ## [24.3.0](https://github.com/expo/eas-cli/releases/tag/v24.3.0) - 2026-09-11

--- a/packages/build-tools/src/common/__tests__/projectSources.test.ts
+++ b/packages/build-tools/src/common/__tests__/projectSources.test.ts
@@ -26,6 +26,38 @@ jest.mock('@expo/downloader');
 jest.mock('@urql/core');
 
 describe('projectSources', () => {
+  it.each(['local-build-plugin', 'eas-build'])(
+    'skips source fetching for NONE without credentials (runner: %s)',
+    async runner => {
+      const ctx = new BuildContext(
+        {
+          triggeredBy: BuildTrigger.EAS_CLI,
+          type: Workflow.MANAGED,
+          mode: BuildMode.BUILD,
+          initiatingUserId: randomUUID(),
+          appId: randomUUID(),
+          platform: Platform.IOS,
+          projectArchive: { type: ArchiveSourceType.NONE },
+          secrets: { environmentSecrets: [] },
+        } as Job,
+        {
+          env: { EAS_BUILD_RUNNER: runner, __API_SERVER_URL: 'https://api.expo.dev' },
+          workingdir: '/workingdir',
+          logger: createMockLogger(),
+          logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
+          uploadArtifact: jest.fn(),
+        }
+      );
+
+      await expect(prepareProjectSourcesAsync(ctx, ctx.buildDirectory)).resolves.toEqual({
+        handled: true,
+      });
+      expect(fetch).not.toHaveBeenCalled();
+      expect(shallowCloneRepositoryAsync).not.toHaveBeenCalled();
+      expect(spawn).not.toHaveBeenCalled();
+    }
+  );
+
   it('makes extracted project sources readable and writable by the worker', async () => {
     const logger = createMockLogger();
 
@@ -629,20 +661,21 @@ describe('local project sources', () => {
     expect(shallowCloneRepositoryAsync).not.toHaveBeenCalled();
   });
 
-  it.each(Object.values(ArchiveSourceType).filter(type => type !== ArchiveSourceType.PATH))(
-    'rejects local %s sources before fetching or unpacking',
-    async type => {
-      const ctx = createContext(type);
-      const result = prepareProjectSourcesAsync(ctx, ctx.buildDirectory);
-      await expect(result).rejects.toBeInstanceOf(SystemError);
-      await expect(result).rejects.toMatchObject({
-        errorCode: 'SERVER_ERROR',
-        trackingCode: 'INVALID_LOCAL_PROJECT_SOURCE',
-        message: `Expected a PATH project source for a local build, received ${type}.`,
-      });
-      expect(fetch).not.toHaveBeenCalled();
-      expect(spawn).not.toHaveBeenCalled();
-      expect(shallowCloneRepositoryAsync).not.toHaveBeenCalled();
-    }
-  );
+  it.each(
+    Object.values(ArchiveSourceType).filter(
+      type => type !== ArchiveSourceType.PATH && type !== ArchiveSourceType.NONE
+    )
+  )('rejects local %s sources before fetching or unpacking', async type => {
+    const ctx = createContext(type);
+    const result = prepareProjectSourcesAsync(ctx, ctx.buildDirectory);
+    await expect(result).rejects.toBeInstanceOf(SystemError);
+    await expect(result).rejects.toMatchObject({
+      errorCode: 'SERVER_ERROR',
+      trackingCode: 'INVALID_LOCAL_PROJECT_SOURCE',
+      message: `Expected a PATH project source for a local build, received ${type}.`,
+    });
+    expect(fetch).not.toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
+    expect(shallowCloneRepositoryAsync).not.toHaveBeenCalled();
+  });
 });

--- a/packages/build-tools/src/common/__tests__/projectSources.test.ts
+++ b/packages/build-tools/src/common/__tests__/projectSources.test.ts
@@ -26,38 +26,6 @@ jest.mock('@expo/downloader');
 jest.mock('@urql/core');
 
 describe('projectSources', () => {
-  it.each(['local-build-plugin', 'eas-build'])(
-    'skips source fetching for NONE without credentials (runner: %s)',
-    async runner => {
-      const ctx = new BuildContext(
-        {
-          triggeredBy: BuildTrigger.EAS_CLI,
-          type: Workflow.MANAGED,
-          mode: BuildMode.BUILD,
-          initiatingUserId: randomUUID(),
-          appId: randomUUID(),
-          platform: Platform.IOS,
-          projectArchive: { type: ArchiveSourceType.NONE },
-          secrets: { environmentSecrets: [] },
-        } as Job,
-        {
-          env: { EAS_BUILD_RUNNER: runner, __API_SERVER_URL: 'https://api.expo.dev' },
-          workingdir: '/workingdir',
-          logger: createMockLogger(),
-          logBuffer: { getLogs: () => [], getPhaseLogs: () => [] },
-          uploadArtifact: jest.fn(),
-        }
-      );
-
-      await expect(prepareProjectSourcesAsync(ctx, ctx.buildDirectory)).resolves.toEqual({
-        handled: true,
-      });
-      expect(fetch).not.toHaveBeenCalled();
-      expect(shallowCloneRepositoryAsync).not.toHaveBeenCalled();
-      expect(spawn).not.toHaveBeenCalled();
-    }
-  );
-
   it('makes extracted project sources readable and writable by the worker', async () => {
     const logger = createMockLogger();
 

--- a/packages/build-tools/src/common/projectSources.ts
+++ b/packages/build-tools/src/common/projectSources.ts
@@ -19,6 +19,10 @@ export async function prepareProjectSourcesAsync<TJob extends Job>(
   destinationDirectory: string
 ): // Return type required to make switch exhaustive.
 Promise<{ handled: boolean }> {
+  if (ctx.job.projectArchive.type === ArchiveSourceType.NONE) {
+    return { handled: true };
+  }
+
   if (ctx.isLocal) {
     if (ctx.job.projectArchive.type !== ArchiveSourceType.PATH) {
       throw new SystemError(


### PR DESCRIPTION
# Why

`workflow-orchestration` tests rightly use `projectArchive.type: NONE`. NONE sources don't need refresh so we can just handle them inline.

# How

If project archive type is NONE, just return, there's nothing to do, refresh, or limit based on job type.

# Test Plan

CI should fix. E2E tests should pass.
