### PR TITLE
[build-tools] set proxy environment variables in the Simulator for local egress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [build-tools] Set proxy environment variables inside the iOS Simulator for `--egress local` sessions, so clients that read them (gRPC, libcurl) also exit from the egress client. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- [build-tools] Set proxy environment variables inside the iOS Simulator for `--egress local` sessions, so clients that read them (gRPC, libcurl) also exit from the egress client. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@brentvatne](https://github.com/brentvatne))
+- [build-tools] Set proxy environment variables inside the iOS Simulator for `--egress local` sessions, so clients that read them (gRPC, libcurl) also exit from the egress client. ([#4390](https://github.com/expo/eas-cli/pull/4390) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
@@ -3,6 +3,7 @@ import spawn from '@expo/turtle-spawn';
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createMockLogger } from '../../../__tests__/utils/logger';
 import { IosSimulatorUtils } from '../../../utils/IosSimulatorUtils';
+import { configureSimulatorProxyEnvironmentAsync } from '../../utils/localEgress';
 import { createStartIosSimulatorBuildFunction } from '../startIosSimulator';
 
 jest.mock('@expo/turtle-spawn', () => ({
@@ -22,8 +23,13 @@ jest.mock('../../../utils/IosSimulatorUtils', () => ({
   },
 }));
 
+jest.mock('../../utils/localEgress', () => ({
+  configureSimulatorProxyEnvironmentAsync: jest.fn(),
+}));
+
 const mockedSpawn = jest.mocked(spawn);
 const mockedUtils = jest.mocked(IosSimulatorUtils);
+const mockedConfigureProxyEnvironment = jest.mocked(configureSimulatorProxyEnvironmentAsync);
 
 function createStep(callInputs?: Record<string, unknown>) {
   const logger = createMockLogger();
@@ -44,6 +50,7 @@ describe(createStartIosSimulatorBuildFunction, () => {
     mockedUtils.startAsync.mockResolvedValue({ udid: 'test-udid' as any });
     mockedUtils.waitForReadyAsync.mockResolvedValue(undefined);
     mockedUtils.disableApsdAsync.mockResolvedValue(undefined);
+    mockedConfigureProxyEnvironment.mockResolvedValue(false);
   });
 
   it('does not enable accessibility settings by default', async () => {
@@ -108,6 +115,27 @@ describe(createStartIosSimulatorBuildFunction, () => {
       udid: 'clone-2',
       env: expect.any(Object),
     });
+  });
+
+  it('configures the local egress proxy environment once each device is ready', async () => {
+    mockedUtils.startAsync
+      .mockResolvedValueOnce({ udid: 'base' as any })
+      .mockResolvedValueOnce({ udid: 'clone-1' as any })
+      .mockResolvedValueOnce({ udid: 'clone-2' as any });
+
+    await createStep({ device_identifier: 'iPhone 15', count: 2 }).executeAsync();
+
+    expect(mockedConfigureProxyEnvironment.mock.calls.map(([{ udid }]) => udid)).toEqual([
+      'base',
+      'clone-1',
+      'clone-2',
+    ]);
+    for (const [callIndex] of mockedConfigureProxyEnvironment.mock.calls.entries()) {
+      const readyCallOrder = mockedUtils.waitForReadyAsync.mock.invocationCallOrder[callIndex];
+      const configureCallOrder =
+        mockedConfigureProxyEnvironment.mock.invocationCallOrder[callIndex];
+      expect(configureCallOrder).toBeGreaterThan(readyCallOrder);
+    }
   });
 
   it('continues when disabling apsd fails', async () => {

--- a/packages/build-tools/src/steps/functions/startIosSimulator.ts
+++ b/packages/build-tools/src/steps/functions/startIosSimulator.ts
@@ -7,6 +7,8 @@ import {
 import spawn from '@expo/turtle-spawn';
 import { minBy } from 'lodash';
 
+import { configureSimulatorProxyEnvironmentAsync } from '../utils/localEgress';
+
 import {
   IosSimulatorName,
   IosSimulatorUtils,
@@ -85,6 +87,7 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
       }
 
       await IosSimulatorUtils.waitForReadyAsync({ udid, env });
+      await configureSimulatorProxyEnvironmentAsync({ udid, env, logger });
 
       logger.info('');
 
@@ -131,6 +134,7 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
             udid: cloneUdid,
             env,
           });
+          await configureSimulatorProxyEnvironmentAsync({ udid: cloneUdid, env, logger });
 
           logger.info(`${cloneDeviceName} is ready.`);
           logger.info('');

--- a/packages/build-tools/src/steps/functions/startLocalEgress.ts
+++ b/packages/build-tools/src/steps/functions/startLocalEgress.ts
@@ -75,9 +75,10 @@ function awaitLocalEgressAcquisitionAsync<T>(
 /**
  * Points the device host's system HTTP(S) proxy at the EAS CLI's egress client.
  * Must run before `eas/start_ios_simulator`: the simulator reads the system proxy
- * at boot. Nothing else on the host changes, so requests from libraries that
- * bypass the system proxy are not covered; the shared session monitor reports
- * them. The shared session cleanup releases the resources started here when
+ * at boot. Once a simulator is ready, `eas/start_ios_simulator` also sets proxy
+ * environment variables inside it for clients that read them (gRPC, libcurl).
+ * Libraries that ignore both are not covered; the shared session monitor
+ * reports them. The shared session cleanup releases the resources started here when
  * the session ends, with a job finalizer as a fallback.
  */
 export function createStartLocalEgressBuildFunction(): BuildFunction {
@@ -183,8 +184,10 @@ export function createStartLocalEgressBuildFunction(): BuildFunction {
         logger.info(
           `Local egress is configured on network service "${service}". HTTP(S) and WebSocket ` +
             'requests that honor the system proxy (WebKit, URLSession and other CFNetwork clients) ' +
-            'fail until the EAS CLI egress client connects, then exit from that machine. Requests ' +
-            'from libraries that bypass the system proxy are not covered and exit from this worker. ' +
+            'fail until the EAS CLI egress client connects, then exit from that machine. Once the ' +
+            'Simulator is ready, proxy environment variables are set inside it for clients that read ' +
+            'them (gRPC, libcurl). Requests from libraries that ignore both are not covered and exit ' +
+            'from this worker. ' +
             'Connection sampling may report these bypasses, but can miss short connections and unconnected UDP traffic.'
         );
       } catch (error) {

--- a/packages/build-tools/src/steps/utils/__tests__/localEgress.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/localEgress.test.ts
@@ -1,4 +1,5 @@
 import { type bunyan } from '@expo/logger';
+import spawn from '@expo/turtle-spawn';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -7,10 +8,13 @@ import { spawnDetached } from '../remoteDeviceRunSession';
 
 import {
   CHISEL_VERSION,
+  LOCAL_EGRESS_NO_PROXY,
   LOCAL_EGRESS_PROXY_PORT,
   buildEgressRemoteConfigFields,
+  buildLocalEgressSimulatorEnvironment,
   buildNetworksetupProxyArgs,
   collectSimulatorProcessIds,
+  configureSimulatorProxyEnvironmentAsync,
   createChiselAuthfileContents,
   getChiselAssetName,
   getChiselDownloadUrl,
@@ -310,6 +314,127 @@ describe('local egress handoff', () => {
     const handoffPath = path.join(tempDir, 'handoff.json');
     await fs.promises.writeFile(handoffPath, JSON.stringify({ url: 'x' }), 'utf8');
     await expect(readLocalEgressHandoffAsync(handoffPath)).rejects.toThrow('malformed');
+  });
+});
+
+describe(buildLocalEgressSimulatorEnvironment, () => {
+  it('points every proxy variable at the loopback port and excludes loopback', () => {
+    expect(buildLocalEgressSimulatorEnvironment(8899)).toEqual({
+      http_proxy: 'http://127.0.0.1:8899',
+      https_proxy: 'http://127.0.0.1:8899',
+      HTTP_PROXY: 'http://127.0.0.1:8899',
+      HTTPS_PROXY: 'http://127.0.0.1:8899',
+      grpc_proxy: 'http://127.0.0.1:8899',
+      no_proxy: LOCAL_EGRESS_NO_PROXY,
+      NO_PROXY: LOCAL_EGRESS_NO_PROXY,
+    });
+  });
+});
+
+describe(configureSimulatorProxyEnvironmentAsync, () => {
+  const mockedSpawn = jest.mocked(spawn);
+  let tempDir: string;
+  let logger: bunyan;
+
+  beforeEach(async () => {
+    mockedSpawn.mockReset();
+    mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'local-egress-env-test-'));
+    logger = { info: jest.fn(), warn: jest.fn() } as unknown as bunyan;
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('does nothing when no local egress session is active', async () => {
+    await expect(
+      configureSimulatorProxyEnvironmentAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+        logger,
+        handoffPath: path.join(tempDir, 'missing.json'),
+      })
+    ).resolves.toBe(false);
+
+    expect(mockedSpawn).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('sets the proxy environment in the simulator when a handoff exists', async () => {
+    const handoffPath = path.join(tempDir, 'handoff.json');
+    await writeLocalEgressHandoffAsync(
+      { url: 'https://egress.example', token: 'pw', fingerprint: 'fp=', port: 8899 },
+      handoffPath
+    );
+
+    await expect(
+      configureSimulatorProxyEnvironmentAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+        logger,
+        handoffPath,
+      })
+    ).resolves.toBe(true);
+
+    const setenvCalls = mockedSpawn.mock.calls.map(([, args]) => args);
+    expect(setenvCalls).toEqual(
+      Object.entries(buildLocalEgressSimulatorEnvironment(8899)).map(([name, value]) => [
+        'simctl',
+        'spawn',
+        'test-udid',
+        'launchctl',
+        'setenv',
+        name,
+        value,
+      ])
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('proxy environment variables set')
+    );
+  });
+
+  it('warns and continues when launchctl fails', async () => {
+    const handoffPath = path.join(tempDir, 'handoff.json');
+    await writeLocalEgressHandoffAsync(
+      { url: 'https://egress.example', token: 'pw', fingerprint: 'fp=', port: 8899 },
+      handoffPath
+    );
+    mockedSpawn.mockRejectedValue(new Error('launchctl failed'));
+
+    await expect(
+      configureSimulatorProxyEnvironmentAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+        logger,
+        handoffPath,
+      })
+    ).resolves.toBe(false);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      expect.stringContaining('will bypass local egress and exit from this worker')
+    );
+  });
+
+  it('warns and continues when the handoff is malformed', async () => {
+    const handoffPath = path.join(tempDir, 'handoff.json');
+    await fs.promises.writeFile(handoffPath, JSON.stringify({ url: 'x' }), 'utf8');
+
+    await expect(
+      configureSimulatorProxyEnvironmentAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+        logger,
+        handoffPath,
+      })
+    ).resolves.toBe(false);
+
+    expect(mockedSpawn).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      expect.stringContaining('could not read the local egress handoff')
+    );
   });
 });
 

--- a/packages/build-tools/src/steps/utils/localEgress.ts
+++ b/packages/build-tools/src/steps/utils/localEgress.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import zlib from 'node:zlib';
 
+import { IosSimulatorUtils, type IosSimulatorUuid } from '../../utils/IosSimulatorUtils';
 import { sleepAsync } from '../../utils/retry';
 
 import { type DetachedProcessHandle, spawnDetached } from './remoteDeviceRunSession';
@@ -342,6 +343,82 @@ export async function configureSystemProxyAsync({
   }
   logger.info(`System proxy for "${service}" set to ${LOCAL_EGRESS_PROXY_HOST}:${port}.`);
   return { service };
+}
+
+export const LOCAL_EGRESS_NO_PROXY = 'localhost,127.0.0.1,::1';
+
+/**
+ * Proxy environment for processes inside the simulator. CFNetwork ignores these
+ * variables and follows the system proxy, but clients with their own network
+ * stack that read them (gRPC and therefore Firestore, libcurl, Go) then send
+ * HTTP CONNECT requests to the same loopback port. Loopback is excluded so the
+ * ports forwarded for `--egress-allow` behave the same on both paths. Lowercase
+ * and uppercase forms are both set because clients differ in which they read.
+ */
+export function buildLocalEgressSimulatorEnvironment(port: number): Record<string, string> {
+  const proxyUrl = `http://${LOCAL_EGRESS_PROXY_HOST}:${port}`;
+  return {
+    http_proxy: proxyUrl,
+    https_proxy: proxyUrl,
+    HTTP_PROXY: proxyUrl,
+    HTTPS_PROXY: proxyUrl,
+    grpc_proxy: proxyUrl,
+    no_proxy: LOCAL_EGRESS_NO_PROXY,
+    NO_PROXY: LOCAL_EGRESS_NO_PROXY,
+  };
+}
+
+/**
+ * Set the local egress proxy environment in a booted simulator when a local
+ * egress session is active. Returns false when local egress is not configured
+ * or the environment could not be set. Failure is a warning, not an error: the
+ * session still works, but clients that read these variables then exit from
+ * this worker instead of the egress client, which the warning spells out.
+ */
+export async function configureSimulatorProxyEnvironmentAsync({
+  udid,
+  env,
+  logger,
+  handoffPath = LOCAL_EGRESS_HANDOFF_PATH,
+}: {
+  udid: IosSimulatorUuid;
+  env: NodeJS.ProcessEnv;
+  logger: bunyan;
+  handoffPath?: string;
+}): Promise<boolean> {
+  let handoff: LocalEgressHandoff | null;
+  try {
+    handoff = await readLocalEgressHandoffAsync(handoffPath);
+  } catch (err) {
+    logger.warn(
+      { err },
+      'Local egress: could not read the local egress handoff, so proxy environment variables were ' +
+        'not set in the Simulator. Clients that read http_proxy/https_proxy (for example gRPC and ' +
+        'libcurl) will bypass local egress and exit from this worker.'
+    );
+    return false;
+  }
+  if (!handoff) {
+    return false;
+  }
+  const variables = buildLocalEgressSimulatorEnvironment(handoff.port);
+  try {
+    await IosSimulatorUtils.setLaunchdEnvironmentAsync({ udid, env, variables });
+  } catch (err) {
+    logger.warn(
+      { err },
+      'Local egress: could not set proxy environment variables in the Simulator. Clients that read ' +
+        'http_proxy/https_proxy (for example gRPC and libcurl) will bypass local egress and exit from ' +
+        'this worker. CFNetwork clients (WebKit, URLSession) still follow the system proxy.'
+    );
+    return false;
+  }
+  logger.info(
+    `Local egress: proxy environment variables set in the Simulator (${Object.keys(variables).join(
+      ', '
+    )}), so clients that read them, such as gRPC and libcurl, also exit from the egress client.`
+  );
+  return true;
 }
 
 export async function writeLocalEgressHandoffAsync(

--- a/packages/build-tools/src/utils/IosSimulatorUtils.ts
+++ b/packages/build-tools/src/utils/IosSimulatorUtils.ts
@@ -285,6 +285,28 @@ export namespace IosSimulatorUtils {
     throw lastError ?? new SystemError('Unable to disable apsd in the Simulator.');
   }
 
+  /**
+   * Set environment variables in the Simulator's launchd. Every process that
+   * launchd spawns afterwards inherits them: apps launched by SpringBoard
+   * (deep links, taps, WebDriverAgent) as well as by `simctl launch`.
+   * Processes that are already running keep their environment.
+   */
+  export async function setLaunchdEnvironmentAsync({
+    udid,
+    env,
+    variables,
+  }: {
+    udid: IosSimulatorUuid;
+    env: NodeJS.ProcessEnv;
+    variables: Record<string, string>;
+  }): Promise<void> {
+    for (const [name, value] of Object.entries(variables)) {
+      await spawn('xcrun', ['simctl', 'spawn', udid, 'launchctl', 'setenv', name, value], {
+        env,
+      });
+    }
+  }
+
   export async function collectLogsAsync({
     deviceIdentifier,
     env,

--- a/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
@@ -340,4 +340,54 @@ describe('IosSimulatorUtils', () => {
       ).rejects.toThrow(SystemError);
     });
   });
+  describe(IosSimulatorUtils.setLaunchdEnvironmentAsync, () => {
+    it('sets each variable in the simulator launchd, in order', async () => {
+      await IosSimulatorUtils.setLaunchdEnvironmentAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+        variables: { https_proxy: 'http://127.0.0.1:8899', no_proxy: 'localhost,127.0.0.1' },
+      });
+
+      expect(mockedSpawn.mock.calls).toEqual([
+        [
+          'xcrun',
+          [
+            'simctl',
+            'spawn',
+            'test-udid',
+            'launchctl',
+            'setenv',
+            'https_proxy',
+            'http://127.0.0.1:8899',
+          ],
+          { env: process.env },
+        ],
+        [
+          'xcrun',
+          [
+            'simctl',
+            'spawn',
+            'test-udid',
+            'launchctl',
+            'setenv',
+            'no_proxy',
+            'localhost,127.0.0.1',
+          ],
+          { env: process.env },
+        ],
+      ]);
+    });
+
+    it('propagates a launchctl failure', async () => {
+      mockedSpawn.mockRejectedValueOnce(new Error('launchctl failed'));
+
+      await expect(
+        IosSimulatorUtils.setLaunchdEnvironmentAsync({
+          udid: 'test-udid' as any,
+          env: process.env,
+          variables: { https_proxy: 'http://127.0.0.1:8899' },
+        })
+      ).rejects.toThrow('launchctl failed');
+    });
+  });
 });

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -139,7 +139,7 @@ export default class Simulator extends EasCommand {
     })(),
     egress: Flags.option({
       description:
-        'With "local", the simulator system proxy points at this machine: HTTP(S) and WebSocket requests that honor it (WebKit, URLSession) exit from this machine and fail while the egress client is disconnected. Requests from libraries that bypass the system proxy are not covered. The egress client must keep running for the life of the session. Only supported with --platform ios.',
+        'With "local", the simulator system proxy points at this machine: HTTP(S) and WebSocket requests that honor it (WebKit, URLSession) and clients that read proxy environment variables (gRPC, libcurl) exit from this machine and fail while the egress client is disconnected. Requests from libraries that ignore both are not covered. The egress client must keep running for the life of the session. Only supported with --platform ios.',
       options: EGRESS_FLAG_VALUES,
     })(),
     'egress-allow': Flags.string({


### PR DESCRIPTION
# Why

`--egress local` points the macOS system proxy at the egress tunnel. That setting is advisory: CFNetwork clients (WebKit, URLSession, and therefore React Native's fetch and WebSocket) follow it, but libraries with their own network stack never consult it and exit from the worker instead. The most common one in Expo apps is gRPC, which is what Firestore uses. gRPC, libcurl, and Go clients do read the standard proxy environment variables, so setting those inside the simulator moves them onto the tunnel with no app changes.

# How

- `IosSimulatorUtils.setLaunchdEnvironmentAsync` runs `simctl spawn <udid> launchctl setenv` for each variable. Every process the simulator's launchd spawns afterwards inherits them, including apps launched by SpringBoard (deep links, taps, WebDriverAgent) and by `simctl launch`. Same mechanism the step already uses to disable apsd.
- `configureSimulatorProxyEnvironmentAsync` in `localEgress.ts` reads the existing handoff file, so it is a no-op when the session has no local egress, and otherwise sets `http_proxy`, `https_proxy`, `HTTP_PROXY`, `HTTPS_PROXY`, and `grpc_proxy` to the loopback egress port, and `no_proxy` / `NO_PROXY` to `localhost,127.0.0.1,::1` so the `--egress-allow` loopback forwards behave the same on both paths. Both cases are set because clients differ in which form they read.
- `start_ios_simulator` calls it right after each device is ready, for the primary device and every clone. A failure logs a warning that names the consequence (those clients exit from the worker) and does not fail the session.
- The egress step's log line, its doc comment, and the `--egress` flag help now say that clients reading proxy environment variables are covered and that libraries ignoring both are not.

Worker-only behavior change; no www or CLI flag changes.

# Test Plan

- Unit tests: `setLaunchdEnvironmentAsync` argument order and error propagation; the environment builder; `configureSimulatorProxyEnvironmentAsync` no-op without a handoff, every setenv call on success, warning-and-continue on launchctl failure and on a malformed handoff; the step calling it after readiness for base and clones. `yarn jest-unit` in build-tools: 127 suites, 1339 tests pass. `tsc` for build-tools and eas-cli, `oxlint` with 0 warnings, `oxfmt`.
- Local, real simulator (iPhone 17, iOS 26.5): ran the compiled function against a booted device with a CONNECT-logging proxy on 8899. All seven variables visible via `simctl spawn <udid> /usr/bin/env`; `simctl spawn <udid> /usr/bin/curl https://example.com` produced `CONNECT example.com:443` at the proxy and returned HTTP 200; curl to `127.0.0.1:1` went direct (no_proxy). Apps opened by URL (SpringBoard path) and by `simctl launch` both inherit launchd env, verified with `ps -Eww`. Host launchd unaffected.
- Staging, worker built from this branch: two `--egress local` sessions. Worker log shows `Local egress: proxy environment variables set in the Simulator (http_proxy, https_proxy, HTTP_PROXY, HTTPS_PROXY, grpc_proxy, no_proxy, NO_PROXY)` at info level right after the simulator is ready, no warnings. Expo Go loaded the app from local Metro through the forwarded loopback port (`iOS Bundled ... 1680 modules`) and rendered; egress client connected and the exit-IP check passed. Staging worker restored from main afterwards.
- Not yet observed end to end: a gRPC client on the worker. gRPC's proxy mapper reads `grpc_proxy`, then `https_proxy`, then `http_proxy` with no Apple/CFStream exclusion, and Firestore's iOS channel setup sets no proxy-related args, so it should follow; a Firestore sample app in a staging build would confirm.

Follow-up: #4393 stacks on this branch and injects a guard into every simulator process that refuses any connection not destined for loopback, so libraries that ignore both the system proxy and these variables fail in-process instead of exiting from the worker. These variables remain the way gRPC, libcurl and Go clients get onto the proxy at all; the guard is what makes bypassing impossible rather than merely discouraged.
