### PR TITLE
[build-tools] inject a guard into simulator processes that refuses connections bypassing the local egress proxy

### DIFF
--- a/.github/workflows/test-egress-guard.yml
+++ b/.github/workflows/test-egress-guard.yml
@@ -1,0 +1,31 @@
+name: test-egress-guard
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - packages/build-tools/resources/egress-guard/**
+      - packages/build-tools/src/steps/utils/localEgressGuard.ts
+      - packages/build-tools/src/steps/utils/__tests__/localEgressGuard*.ts
+      - packages/build-tools/src/steps/functions/startIosSimulator.ts
+      - packages/worker/.eas/workflows/test-egress-guard.yml
+      - .github/workflows/test-egress-guard.yml
+
+jobs:
+  test-egress-guard:
+    # The simulator tests need macOS with Xcode, which the EAS macOS workers have.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: ./.github/actions/setup-mise
+      - name: Install eas-cli
+        run: npm install --global eas-cli@latest
+      - name: Run the test-egress-guard EAS workflow on macOS
+        working-directory: packages/worker
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_DEV_EXPO_GITHUB_ROBOT_ACCESS_TOKEN }}
+        run: |
+          eas workflow:run test-egress-guard.yml \
+            --ref ${{ github.event.pull_request.head.sha || github.sha }} \
+            --non-interactive \
+            --wait

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- [build-tools] Inject a guard into every iOS Simulator process during `--egress local` sessions that refuses connections which bypass the system proxy and reports them, with the calling frameworks, in the session log. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@brentvatne](https://github.com/brentvatne))
+- [build-tools] Inject a guard into every iOS Simulator process during `--egress local` sessions that refuses connections which bypass the system proxy and reports them, with the calling frameworks, in the session log. ([#4393](https://github.com/expo/eas-cli/pull/4393) by [@brentvatne](https://github.com/brentvatne))
 - [build-tools] Set proxy environment variables inside the iOS Simulator for `--egress local` sessions, so clients that read them (gRPC, libcurl) also exit from the egress client. ([#4390](https://github.com/expo/eas-cli/pull/4390) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [build-tools] Set proxy environment variables inside the iOS Simulator for `--egress local` sessions, so clients that read them (gRPC, libcurl) also exit from the egress client. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@brentvatne](https://github.com/brentvatne))
+
 ### 🐛 Bug fixes
 
 ### 🧹 Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
+- [build-tools] Inject a guard into every iOS Simulator process during `--egress local` sessions that refuses connections which bypass the system proxy and reports them, with the calling frameworks, in the session log. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@brentvatne](https://github.com/brentvatne))
 - [build-tools] Set proxy environment variables inside the iOS Simulator for `--egress local` sessions, so clients that read them (gRPC, libcurl) also exit from the egress client. ([#4390](https://github.com/expo/eas-cli/pull/4390) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is the log of notable changes to EAS CLI and related packages.
 
 ### 🎉 New features
 
-- [build-tools] Set proxy environment variables inside the iOS Simulator for `--egress local` sessions, so clients that read them (gRPC, libcurl) also exit from the egress client. ([#XXXX](https://github.com/expo/eas-cli/pull/XXXX) by [@brentvatne](https://github.com/brentvatne))
+- [build-tools] Set proxy environment variables inside the iOS Simulator for `--egress local` sessions, so clients that read them (gRPC, libcurl) also exit from the egress client. ([#4390](https://github.com/expo/eas-cli/pull/4390) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/packages/build-tools/.gitignore
+++ b/packages/build-tools/.gitignore
@@ -9,3 +9,4 @@ bin/record-sim
 src/graphql-env.d.ts
 schema.graphql
 bin/egress-guard.dylib
+bin/egress-guard-check

--- a/packages/build-tools/.gitignore
+++ b/packages/build-tools/.gitignore
@@ -8,3 +8,4 @@ bin/record-sim
 
 src/graphql-env.d.ts
 schema.graphql
+bin/egress-guard.dylib

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -24,6 +24,8 @@
     "prebuild": "yarn gql",
     "build": "tsc",
     "build:record-sim": "mkdir -p bin && record_sim_bin_path=$(swift build -c release --package-path resources/record-sim --build-path resources/record-sim/.build --show-bin-path) && swift build -c release --package-path resources/record-sim --build-path resources/record-sim/.build && cp \"$record_sim_bin_path/record-sim\" bin/record-sim && chmod +x bin/record-sim",
+    "build:egress-guard": "resources/egress-guard/build.sh",
+    "test:egress-guard": "resources/egress-guard/tests/run-policy-tests.sh",
     "typecheck": "tsc",
     "generate-appium-commands": "mise exec node@22.22.0 -- node scripts/generate-appium-commands.js",
     "prepack": "rimraf dist \"*.tsbuildinfo\" && yarn gql && tsc -p tsconfig.build.json",

--- a/packages/build-tools/resources/egress-guard/README.md
+++ b/packages/build-tools/resources/egress-guard/README.md
@@ -33,10 +33,22 @@ Layout:
 - `policy.c` / `policy.h`: classification, mode, formatting, per-process
   dedupe. Pure C, host-testable.
 - `guard.c`: the interposers and the constructor that reads the environment.
+- `check.c`: `egress-guard-check`, run inside the simulator right after the
+  guard is installed. Exits non-zero unless the library is loaded in a fresh
+  process and behaves as the mode says; the worker fails the session on that.
 - `tests/policy_test.c`: host unit tests, `tests/run-policy-tests.sh`.
 - `tests/nettest.swift`: probe binary the simulator end-to-end test runs inside
   a device; exercises URLSession, Network.framework, BSD TCP and UDP, DNS.
 - `build.sh`: universal simulator dylib into `packages/build-tools/bin/`.
 
-The dylib is built by `packages/worker/package.sh` for the iOS worker tarball
-and by the `test-egress-guard` EAS workflow, not committed.
+Installation order matters: the worker sets the launchd environment right
+after `simctl boot` returns, when launchd is up but nothing else has started,
+so every process the boot then spawns inherits the guard. The self-check runs
+once boot completes. Both the dylib and the check binary are built by
+`packages/worker/package.sh` for the iOS worker tarball and by the
+`test-egress-guard` EAS workflow, not committed.
+
+Failure semantics: a missing library, a failed `launchctl setenv`, or a failed
+self-check fails the session, since a `--egress local` session without the
+guard would silently leak. Only an unwritable event log is a warning, because
+refusals still happen and only the reporting is lost.

--- a/packages/build-tools/resources/egress-guard/README.md
+++ b/packages/build-tools/resources/egress-guard/README.md
@@ -41,10 +41,14 @@ Layout:
   a device; exercises URLSession, Network.framework, BSD TCP and UDP, DNS.
 - `build.sh`: universal simulator dylib into `packages/build-tools/bin/`.
 
-Installation order matters: the worker sets the launchd environment right
-after `simctl boot` returns, when launchd is up but nothing else has started,
-so every process the boot then spawns inherits the guard. The self-check runs
-once boot completes. Both the dylib and the check binary are built by
+Installation order matters. `simctl` forwards every `SIMCTL_CHILD_`-prefixed
+variable of its own environment to the process it starts, and for `simctl
+boot` that process is the simulator's launchd, so the worker boots with the
+guard and proxy variables in that form and every process of the boot inherits
+them (measured: 176 of 176). `launchctl setenv` after boot is kept for a
+device that was already booted, but by then the boot's own processes have
+started without it. The self-check runs once boot completes and is followed
+by a coverage report from `lsof`, listing any process without the library. Both the dylib and the check binary are built by
 `packages/worker/package.sh` for the iOS worker tarball and by the
 `test-egress-guard` EAS workflow, not committed.
 

--- a/packages/build-tools/resources/egress-guard/README.md
+++ b/packages/build-tools/resources/egress-guard/README.md
@@ -1,0 +1,42 @@
+# egress-guard
+
+A small dylib injected into every process the iOS Simulator launches during a
+`--egress local` session. It interposes the socket calls that open outbound
+traffic (`connect`, `connectx`, `sendto`, `sendmsg`) and refuses any
+destination that is not loopback. The system proxy and the `--egress-allow`
+forwards live on loopback, so everything that honors the proxy keeps working
+and everything that bypasses it fails with `ECONNREFUSED` in the process that
+tried, with the calling frameworks recorded.
+
+Why interposing: simulator processes share the worker's uid, so a packet
+filter cannot tell them apart from the worker's own traffic. dyld interposing
+from an inserted library reaches calls made inside Apple's own frameworks
+(CFNetwork, Network.framework), and `launchctl setenv DYLD_INSERT_LIBRARIES`
+inside the simulator makes launchd hand the library to every process it
+spawns. The simulator does not enforce library validation, which is what makes
+this possible there and nowhere else.
+
+Configuration comes from the environment the simulator's launchd provides:
+
+- `EAS_EGRESS_GUARD_LOG`: file the guard appends events to (host path).
+- `EAS_EGRESS_GUARD_MODE`: `block` (default, and what any unknown value means)
+  or `log` (observe only).
+
+Each event is one tab-separated line:
+
+```
+eas-egress-guard\t<process>\t<pid>\t<function>\t<blocked|logged>\t<peer>\t<caller>,<caller>...
+```
+
+Layout:
+
+- `policy.c` / `policy.h`: classification, mode, formatting, per-process
+  dedupe. Pure C, host-testable.
+- `guard.c`: the interposers and the constructor that reads the environment.
+- `tests/policy_test.c`: host unit tests, `tests/run-policy-tests.sh`.
+- `tests/nettest.swift`: probe binary the simulator end-to-end test runs inside
+  a device; exercises URLSession, Network.framework, BSD TCP and UDP, DNS.
+- `build.sh`: universal simulator dylib into `packages/build-tools/bin/`.
+
+The dylib is built by `packages/worker/package.sh` for the iOS worker tarball
+and by the `test-egress-guard` EAS workflow, not committed.

--- a/packages/build-tools/resources/egress-guard/build.sh
+++ b/packages/build-tools/resources/egress-guard/build.sh
@@ -17,3 +17,14 @@ for arch in arm64 x86_64; do
 done
 lipo -create -output "$bin_dir/egress-guard.dylib" "$out/egress-guard-arm64.dylib" "$out/egress-guard-x86_64.dylib"
 lipo -info "$bin_dir/egress-guard.dylib"
+
+# The self-check the worker runs inside the simulator after installing the guard.
+for arch in arm64 x86_64; do
+  xcrun --sdk iphonesimulator clang \
+    -std=c11 -Wall -Wextra -Werror -O2 \
+    -target "$arch-apple-ios15.0-simulator" -isysroot "$sdk" \
+    -o "$out/egress-guard-check-$arch" check.c
+done
+lipo -create -output "$bin_dir/egress-guard-check" "$out/egress-guard-check-arm64" "$out/egress-guard-check-x86_64"
+chmod +x "$bin_dir/egress-guard-check"
+lipo -info "$bin_dir/egress-guard-check"

--- a/packages/build-tools/resources/egress-guard/build.sh
+++ b/packages/build-tools/resources/egress-guard/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Builds the guard as a universal (arm64 + x86_64) iOS Simulator dylib into
+# packages/build-tools/bin/egress-guard.dylib. Requires Xcode.
+set -euo pipefail
+cd "$(dirname "$0")"
+# Output directory; defaults to packages/build-tools/bin.
+bin_dir="${1:-../../bin}"
+mkdir -p "$bin_dir"
+out=$(mktemp -d)
+sdk=$(xcrun --sdk iphonesimulator --show-sdk-path)
+for arch in arm64 x86_64; do
+  xcrun --sdk iphonesimulator clang \
+    -std=c11 -Wall -Wextra -Werror -O2 \
+    -target "$arch-apple-ios15.0-simulator" -isysroot "$sdk" \
+    -dynamiclib -install_name @rpath/egress-guard.dylib \
+    -o "$out/egress-guard-$arch.dylib" policy.c guard.c
+done
+lipo -create -output "$bin_dir/egress-guard.dylib" "$out/egress-guard-arm64.dylib" "$out/egress-guard-x86_64.dylib"
+lipo -info "$bin_dir/egress-guard.dylib"

--- a/packages/build-tools/resources/egress-guard/check.c
+++ b/packages/build-tools/resources/egress-guard/check.c
@@ -1,0 +1,77 @@
+// Self-check run inside a simulator right after the guard is installed:
+// proves the guard library is loaded in a freshly spawned process and that it
+// behaves as the requested mode says. Exit 0 on success; 2 when the library is
+// not loaded; 3 when it is loaded but did not behave; 1 on usage errors.
+//
+//   egress-guard-check --mode block|log
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <mach-o/dyld.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+// TEST-NET-1 (RFC 5737): never routed, so without the guard a non-blocking
+// connect reports EINPROGRESS and nothing ever answers.
+#define PROBE_ADDRESS "192.0.2.1"
+#define PROBE_PORT 9
+
+static int guard_loaded(void) {
+  for (uint32_t i = 0; i < _dyld_image_count(); i++) {
+    const char *name = _dyld_get_image_name(i);
+    if (name != NULL && strstr(name, "egress-guard.dylib") != NULL) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  const char *mode = "block";
+  if (argc == 3 && strcmp(argv[1], "--mode") == 0) {
+    mode = argv[2];
+  } else if (argc != 1) {
+    fprintf(stderr, "usage: egress-guard-check [--mode block|log]\n");
+    return 1;
+  }
+  if (!guard_loaded()) {
+    printf("egress-guard-check: the guard library is not loaded in this process\n");
+    return 2;
+  }
+
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) {
+    printf("egress-guard-check: socket() failed: %s\n", strerror(errno));
+    return 3;
+  }
+  fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
+  struct sockaddr_in to;
+  memset(&to, 0, sizeof to);
+  to.sin_family = AF_INET;
+  to.sin_len = sizeof to;
+  to.sin_port = htons(PROBE_PORT);
+  inet_pton(AF_INET, PROBE_ADDRESS, &to.sin_addr);
+  int rc = connect(fd, (struct sockaddr *)&to, sizeof to);
+  int err = errno;
+  close(fd);
+
+  if (strcmp(mode, "block") == 0) {
+    if (rc == -1 && err == ECONNREFUSED) {
+      printf("egress-guard-check: guard loaded; non-loopback connections are refused\n");
+      return 0;
+    }
+    printf("egress-guard-check: guard loaded but a non-loopback connect was not refused (rc=%d, errno=%d %s)\n",
+           rc, err, strerror(err));
+    return 3;
+  }
+  if (rc == 0 || (rc == -1 && err == EINPROGRESS)) {
+    printf("egress-guard-check: guard loaded in log mode; connections pass through\n");
+    return 0;
+  }
+  printf("egress-guard-check: guard loaded in log mode but connect failed (errno=%d %s)\n", err,
+         strerror(err));
+  return 3;
+}

--- a/packages/build-tools/resources/egress-guard/guard.c
+++ b/packages/build-tools/resources/egress-guard/guard.c
@@ -1,0 +1,154 @@
+// The local egress guard: interposes the calls that open outbound traffic in
+// every simulator process it is inserted into, refuses non-loopback
+// destinations in block mode, and records one event per destination per
+// process. See README.md and policy.h.
+#include "policy.h"
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <execinfo.h>
+#include <fcntl.h>
+#include <os/lock.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define EG_LOG_ENV "EAS_EGRESS_GUARD_LOG"
+#define EG_MODE_ENV "EAS_EGRESS_GUARD_MODE"
+#define EG_MAX_CALLERS 6
+#define EG_CALLER_LENGTH 64
+
+static int eg_initialized = 0;
+static int eg_log_fd = -1;
+static eg_mode_t eg_mode = EG_MODE_BLOCK;
+static eg_seen_t eg_seen;
+static os_unfair_lock eg_lock = OS_UNFAIR_LOCK_INIT;
+
+static void eg_init(void) {
+  if (eg_initialized) {
+    return;
+  }
+  eg_mode = eg_parse_mode(getenv(EG_MODE_ENV));
+  const char *log_path = getenv(EG_LOG_ENV);
+  if (log_path != NULL && log_path[0] != '\0') {
+    // O_APPEND keeps whole lines intact across processes writing concurrently.
+    eg_log_fd = open(log_path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0644);
+  }
+  eg_initialized = 1;
+}
+
+__attribute__((constructor)) static void eg_constructor(void) { eg_init(); }
+
+// Image names of the frames above the interposer, innermost first, with
+// consecutive repeats collapsed: "Network,CFNetwork,MyApp".
+__attribute__((noinline)) static int eg_collect_callers(char names[EG_MAX_CALLERS][EG_CALLER_LENGTH]) {
+  void *frames[EG_MAX_CALLERS + 4];
+  int frame_count = backtrace(frames, EG_MAX_CALLERS + 4);
+  int count = 0;
+  // frames[0] is this function, frames[1] eg_handle, frames[2] the interposer.
+  for (int i = 3; i < frame_count && count < EG_MAX_CALLERS; i++) {
+    Dl_info info;
+    const char *image = "?";
+    if (dladdr(frames[i], &info) && info.dli_fname != NULL) {
+      const char *slash = strrchr(info.dli_fname, '/');
+      image = slash ? slash + 1 : info.dli_fname;
+    }
+    if (count > 0 && strcmp(names[count - 1], image) == 0) {
+      continue;
+    }
+    strncpy(names[count], image, EG_CALLER_LENGTH - 1);
+    names[count][EG_CALLER_LENGTH - 1] = '\0';
+    count++;
+  }
+  return count;
+}
+
+// Returns 1 when the call must be refused.
+__attribute__((noinline)) static int eg_handle(const char *function, const struct sockaddr *sa,
+                                              socklen_t len) {
+  eg_class_t cls = eg_classify(sa, len);
+  if (cls != EG_REMOTE) {
+    return 0;
+  }
+  eg_init();
+  int deny = eg_should_deny(eg_mode, cls);
+
+  char peer[96];
+  if (eg_format_peer(sa, len, peer, sizeof peer) != 0) {
+    strncpy(peer, "?", sizeof peer);
+  }
+  char key[EG_SEEN_KEY_LENGTH];
+  snprintf(key, sizeof key, "%s %s", function, peer);
+  os_unfair_lock_lock(&eg_lock);
+  int fresh = eg_seen_insert(&eg_seen, key);
+  os_unfair_lock_unlock(&eg_lock);
+
+  if (fresh && eg_log_fd >= 0) {
+    char names[EG_MAX_CALLERS][EG_CALLER_LENGTH];
+    int caller_count = eg_collect_callers(names);
+    const char *callers[EG_MAX_CALLERS];
+    for (int i = 0; i < caller_count; i++) {
+      callers[i] = names[i];
+    }
+    char line[1024];
+    int n = eg_format_event(line, sizeof line, getprogname(), getpid(), function,
+                            deny ? "blocked" : "logged", peer, callers, caller_count);
+    if (n > 0) {
+      (void)write(eg_log_fd, line, (size_t)n);
+    }
+  }
+  return deny;
+}
+
+static int eg_connect(int fd, const struct sockaddr *sa, socklen_t len) {
+  if (eg_handle("connect", sa, len)) {
+    errno = ECONNREFUSED;
+    return -1;
+  }
+  return connect(fd, sa, len);
+}
+
+static int eg_connectx(int s, const sa_endpoints_t *endpoints, sae_associd_t associd,
+                       unsigned int flags, const struct iovec *iov, unsigned int iovcnt,
+                       size_t *len, sae_connid_t *connid) {
+  if (endpoints != NULL && endpoints->sae_dstaddr != NULL &&
+      eg_handle("connectx", endpoints->sae_dstaddr, endpoints->sae_dstaddrlen)) {
+    errno = ECONNREFUSED;
+    return -1;
+  }
+  return connectx(s, endpoints, associd, flags, iov, iovcnt, len, connid);
+}
+
+static ssize_t eg_sendto(int fd, const void *buf, size_t n, int flags, const struct sockaddr *sa,
+                         socklen_t len) {
+  if (sa != NULL && eg_handle("sendto", sa, len)) {
+    errno = ECONNREFUSED;
+    return -1;
+  }
+  return sendto(fd, buf, n, flags, sa, len);
+}
+
+static ssize_t eg_sendmsg(int fd, const struct msghdr *msg, int flags) {
+  if (msg != NULL && msg->msg_name != NULL && msg->msg_namelen > 0 &&
+      eg_handle("sendmsg", (const struct sockaddr *)msg->msg_name, msg->msg_namelen)) {
+    errno = ECONNREFUSED;
+    return -1;
+  }
+  return sendmsg(fd, msg, flags);
+}
+
+// dyld applies these to every image in the process, including the shared
+// cache, which is how calls made inside CFNetwork and Network.framework are
+// caught.
+__attribute__((used)) static const struct {
+  const void *replacement;
+  const void *original;
+} eg_interposers[] __attribute__((section("__DATA,__interpose"))) = {
+    {(const void *)eg_connect, (const void *)connect},
+    {(const void *)eg_connectx, (const void *)connectx},
+    {(const void *)eg_sendto, (const void *)sendto},
+    {(const void *)eg_sendmsg, (const void *)sendmsg},
+};

--- a/packages/build-tools/resources/egress-guard/policy.c
+++ b/packages/build-tools/resources/egress-guard/policy.c
@@ -1,0 +1,147 @@
+#include "policy.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int is_v4_local(uint32_t host_order) {
+  return (host_order >> 24) == 127 || host_order == 0;
+}
+
+eg_class_t eg_classify(const struct sockaddr *sa, socklen_t len) {
+  if (sa == NULL || len < 2) {
+    return EG_PASSTHROUGH;
+  }
+  if (sa->sa_family == AF_INET) {
+    if (len < sizeof(struct sockaddr_in)) {
+      return EG_PASSTHROUGH;
+    }
+    const struct sockaddr_in *in = (const struct sockaddr_in *)sa;
+    return is_v4_local(ntohl(in->sin_addr.s_addr)) ? EG_LOOPBACK : EG_REMOTE;
+  }
+  if (sa->sa_family == AF_INET6) {
+    if (len < sizeof(struct sockaddr_in6)) {
+      return EG_PASSTHROUGH;
+    }
+    const struct in6_addr *a6 = &((const struct sockaddr_in6 *)sa)->sin6_addr;
+    if (IN6_IS_ADDR_LOOPBACK(a6) || IN6_IS_ADDR_UNSPECIFIED(a6)) {
+      return EG_LOOPBACK;
+    }
+    if (IN6_IS_ADDR_V4MAPPED(a6)) {
+      uint32_t v4;
+      memcpy(&v4, &a6->s6_addr[12], sizeof v4);
+      return is_v4_local(ntohl(v4)) ? EG_LOOPBACK : EG_REMOTE;
+    }
+    return EG_REMOTE;
+  }
+  return EG_PASSTHROUGH;
+}
+
+eg_mode_t eg_parse_mode(const char *value) {
+  if (value != NULL && strcmp(value, "log") == 0) {
+    return EG_MODE_LOG;
+  }
+  return EG_MODE_BLOCK;
+}
+
+int eg_should_deny(eg_mode_t mode, eg_class_t cls) {
+  return mode == EG_MODE_BLOCK && cls == EG_REMOTE;
+}
+
+int eg_format_peer(const struct sockaddr *sa, socklen_t len, char *out, size_t n) {
+  char ip[INET6_ADDRSTRLEN];
+  int written;
+  if (sa == NULL) {
+    return -1;
+  }
+  if (sa->sa_family == AF_INET && len >= sizeof(struct sockaddr_in)) {
+    const struct sockaddr_in *in = (const struct sockaddr_in *)sa;
+    if (inet_ntop(AF_INET, &in->sin_addr, ip, sizeof ip) == NULL) {
+      return -1;
+    }
+    written = snprintf(out, n, "%s:%d", ip, ntohs(in->sin_port));
+  } else if (sa->sa_family == AF_INET6 && len >= sizeof(struct sockaddr_in6)) {
+    const struct sockaddr_in6 *in6 = (const struct sockaddr_in6 *)sa;
+    if (inet_ntop(AF_INET6, &in6->sin6_addr, ip, sizeof ip) == NULL) {
+      return -1;
+    }
+    written = snprintf(out, n, "[%s]:%d", ip, ntohs(in6->sin6_port));
+  } else {
+    return -1;
+  }
+  return (written < 0 || (size_t)written >= n) ? -1 : 0;
+}
+
+int eg_seen_insert(eg_seen_t *seen, const char *key) {
+  for (int i = 0; i < seen->count; i++) {
+    if (strncmp(seen->keys[i], key, EG_SEEN_KEY_LENGTH - 1) == 0) {
+      return 0;
+    }
+  }
+  if (seen->count >= EG_SEEN_CAPACITY) {
+    seen->overflow++;
+    return 0;
+  }
+  strncpy(seen->keys[seen->count], key, EG_SEEN_KEY_LENGTH - 1);
+  seen->keys[seen->count][EG_SEEN_KEY_LENGTH - 1] = '\0';
+  seen->count++;
+  return 1;
+}
+
+// Append `text` to out[*pos], replacing field separators; returns 0 when it fit.
+static int append_field(char *out, size_t n, size_t *pos, const char *text) {
+  for (const char *c = text; *c; c++) {
+    if (*pos + 1 >= n) {
+      return -1;
+    }
+    out[(*pos)++] = (*c == '\t' || *c == '\n' || *c == '\r') ? ' ' : *c;
+  }
+  return 0;
+}
+
+static int append_raw(char *out, size_t n, size_t *pos, const char *text) {
+  size_t len = strlen(text);
+  if (*pos + len + 1 > n) {
+    return -1;
+  }
+  memcpy(out + *pos, text, len);
+  *pos += len;
+  return 0;
+}
+
+int eg_format_event(char *out, size_t n, const char *progname, int pid, const char *function,
+                    const char *action, const char *peer, const char *const *callers,
+                    int caller_count) {
+  size_t pos = 0;
+  char pid_text[16];
+  snprintf(pid_text, sizeof pid_text, "%d", pid);
+  if (append_raw(out, n, &pos, EG_EVENT_PREFIX "\t") != 0 ||
+      append_field(out, n, &pos, progname ? progname : "?") != 0 ||
+      append_raw(out, n, &pos, "\t") != 0 || append_raw(out, n, &pos, pid_text) != 0 ||
+      append_raw(out, n, &pos, "\t") != 0 || append_field(out, n, &pos, function) != 0 ||
+      append_raw(out, n, &pos, "\t") != 0 || append_field(out, n, &pos, action) != 0 ||
+      append_raw(out, n, &pos, "\t") != 0 || append_field(out, n, &pos, peer) != 0 ||
+      append_raw(out, n, &pos, "\t") != 0) {
+    return -1;
+  }
+  for (int i = 0; i < caller_count && callers != NULL; i++) {
+    if (i > 0 && append_raw(out, n, &pos, ",") != 0) {
+      return -1;
+    }
+    // Commas separate callers, so they cannot appear inside one.
+    for (const char *c = callers[i]; *c; c++) {
+      char ch = (*c == ',' || *c == '\t' || *c == '\n' || *c == '\r') ? ' ' : *c;
+      if (pos + 1 >= n) {
+        return -1;
+      }
+      out[pos++] = ch;
+    }
+  }
+  if (append_raw(out, n, &pos, "\n") != 0) {
+    return -1;
+  }
+  out[pos] = '\0';
+  return (int)pos;
+}

--- a/packages/build-tools/resources/egress-guard/policy.h
+++ b/packages/build-tools/resources/egress-guard/policy.h
@@ -1,0 +1,56 @@
+// Policy and formatting for the local egress guard. Pure functions with no
+// interposing, so they compile and test on macOS as well as in the simulator.
+#ifndef EAS_EGRESS_GUARD_POLICY_H
+#define EAS_EGRESS_GUARD_POLICY_H
+
+#include <stddef.h>
+#include <sys/socket.h>
+
+// What a destination address is, as far as the guard cares.
+typedef enum {
+  EG_PASSTHROUGH = 0,  // not an internet address (unix sockets, NULL, short); never touched
+  EG_LOOPBACK = 1,     // 127.0.0.0/8, ::1, ::ffff:127.x, unspecified; the proxy and forwards live here
+  EG_REMOTE = 2,       // anything else, including link-local and multicast
+} eg_class_t;
+
+typedef enum {
+  EG_MODE_BLOCK = 0,  // refuse EG_REMOTE with ECONNREFUSED
+  EG_MODE_LOG = 1,    // observe only
+} eg_mode_t;
+
+eg_class_t eg_classify(const struct sockaddr *sa, socklen_t len);
+
+// "block" or unset selects block; "log" selects log. Anything else is block:
+// an unknown mode must fail closed.
+eg_mode_t eg_parse_mode(const char *value);
+
+int eg_should_deny(eg_mode_t mode, eg_class_t cls);
+
+// Writes "1.2.3.4:443" or "[2001:db8::1]:443". Returns 0 on success.
+int eg_format_peer(const struct sockaddr *sa, socklen_t len, char *out, size_t n);
+
+// Fixed-capacity set of strings, so a retrying client logs a destination once
+// per process instead of once per attempt.
+#define EG_SEEN_CAPACITY 128
+#define EG_SEEN_KEY_LENGTH 192
+typedef struct {
+  char keys[EG_SEEN_CAPACITY][EG_SEEN_KEY_LENGTH];
+  int count;
+  int overflow;  // insertions refused because the table was full
+} eg_seen_t;
+
+// 1 when the key was not present and was inserted; 0 when already present or
+// when the table is full (counted in overflow).
+int eg_seen_insert(eg_seen_t *seen, const char *key);
+
+#define EG_EVENT_PREFIX "eas-egress-guard"
+
+// One tab-separated line, newline terminated:
+//   eas-egress-guard\t<progname>\t<pid>\t<function>\t<action>\t<peer>\t<caller>,<caller>...\n
+// Tabs and newlines inside fields are replaced with spaces. Returns the length
+// written, or -1 when it does not fit.
+int eg_format_event(char *out, size_t n, const char *progname, int pid, const char *function,
+                    const char *action, const char *peer, const char *const *callers,
+                    int caller_count);
+
+#endif

--- a/packages/build-tools/resources/egress-guard/tests/nettest.swift
+++ b/packages/build-tools/resources/egress-guard/tests/nettest.swift
@@ -1,0 +1,122 @@
+// Probe run inside a simulator by the egress guard end-to-end test. Exercises
+// every outbound path the guard must cover and prints one JSON object.
+//
+//   nettest --proxy-port <port> --udp-port <port>
+//
+// proxy-port: a CONNECT proxy on the host's loopback, standing in for the
+// egress proxy. udp-port: a UDP echo on loopback.
+import Foundation
+import Network
+
+var results: [String: String] = [:]
+let args = CommandLine.arguments
+func arg(_ name: String) -> Int {
+  guard let i = args.firstIndex(of: name), i + 1 < args.count else { return 0 }
+  return Int(args[i + 1]) ?? 0
+}
+let proxyPort = arg("--proxy-port")
+let udpPort = arg("--udp-port")
+let remoteHost = "example.com"
+let remotePort = 443
+
+func classify(_ error: Error?) -> String {
+  guard let e = error as NSError? else { return "ok" }
+  if e.domain == NSURLErrorDomain && e.code == NSURLErrorCannotConnectToHost { return "refused" }
+  if e.domain == NSPOSIXErrorDomain && e.code == Int(ECONNREFUSED) { return "refused" }
+  return "error(\(e.domain):\(e.code))"
+}
+
+// 1. URLSession straight to the internet. Blocked by the guard.
+func urlSessionDirect() {
+  let g = DispatchGroup(); g.enter()
+  let c = URLSessionConfiguration.ephemeral; c.timeoutIntervalForRequest = 10
+  c.connectionProxyDictionary = [:]  // explicitly no proxy, even if the host has one
+  URLSession(configuration: c).dataTask(with: URL(string: "https://\(remoteHost)/")!) { _, r, e in
+    results["urlsessionDirect"] = e == nil ? "ok(\((r as? HTTPURLResponse)?.statusCode ?? 0))" : classify(e); g.leave()
+  }.resume(); g.wait()
+}
+
+// 2. URLSession through a CONNECT proxy on loopback. Allowed: the guard only
+// sees a loopback connect.
+func urlSessionProxied() {
+  let g = DispatchGroup(); g.enter()
+  let c = URLSessionConfiguration.ephemeral; c.timeoutIntervalForRequest = 15
+  // The kCFNetworkProxies* constants are not exposed to Swift on iOS; these are their values.
+  c.connectionProxyDictionary = ["HTTPSEnable": 1, "HTTPSProxy": "127.0.0.1", "HTTPSPort": proxyPort]
+  URLSession(configuration: c).dataTask(with: URL(string: "https://\(remoteHost)/")!) { _, r, e in
+    results["urlsessionProxied"] = e == nil ? "ok(\((r as? HTTPURLResponse)?.statusCode ?? 0))" : classify(e); g.leave()
+  }.resume(); g.wait()
+}
+
+// 3. Network.framework connection straight out. Blocked.
+func nwConnectionDirect() {
+  let g = DispatchGroup(); g.enter()
+  let p = NWParameters.tls; p.preferNoProxies = true
+  let c = NWConnection(host: NWEndpoint.Host(remoteHost), port: NWEndpoint.Port(integerLiteral: UInt16(remotePort)), using: p)
+  var done = false
+  c.stateUpdateHandler = { s in
+    guard !done else { return }
+    switch s {
+    case .ready: done = true; results["nwconnectionDirect"] = "ok"; c.cancel(); g.leave()
+    case .failed(let e): done = true; results["nwconnectionDirect"] = classify(e); g.leave()
+    case .waiting(let e): done = true; results["nwconnectionDirect"] = "waiting(" + classify(e) + ")"; c.cancel(); g.leave()
+    default: break
+    }
+  }
+  c.start(queue: .global())
+  _ = g.wait(timeout: .now() + 15)
+  if results["nwconnectionDirect"] == nil { results["nwconnectionDirect"] = "timeout"; c.cancel() }
+}
+
+// 4. Plain BSD TCP connect to a resolved address. Blocked.
+func bsdConnectDirect() {
+  var hints = addrinfo(); hints.ai_socktype = SOCK_STREAM; hints.ai_family = AF_INET
+  var info: UnsafeMutablePointer<addrinfo>? = nil
+  guard getaddrinfo(remoteHost, "443", &hints, &info) == 0, let ai = info else { results["bsdConnectDirect"] = "dns-failed"; return }
+  results["dns"] = "ok"
+  let fd = socket(ai.pointee.ai_family, ai.pointee.ai_socktype, ai.pointee.ai_protocol)
+  let rc = connect(fd, ai.pointee.ai_addr, ai.pointee.ai_addrlen)
+  results["bsdConnectDirect"] = rc == 0 ? "ok" : (errno == ECONNREFUSED ? "refused" : "errno(\(errno))")
+  close(fd); freeaddrinfo(info)
+}
+
+// 5. UDP datagram straight out. Blocked. 6. UDP datagram to loopback echo. Allowed.
+func udp(_ key: String, _ host: String, _ port: Int, expectEcho: Bool) {
+  let fd = socket(AF_INET, SOCK_DGRAM, 0)
+  var to = sockaddr_in(); to.sin_family = sa_family_t(AF_INET); to.sin_port = in_port_t(UInt16(port)).bigEndian
+  inet_pton(AF_INET, host, &to.sin_addr)
+  var payload: [UInt8] = Array("ping".utf8)
+  let sent = withUnsafePointer(to: &to) { p in p.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+    sendto(fd, &payload, payload.count, 0, sa, socklen_t(MemoryLayout<sockaddr_in>.size)) } }
+  if sent < 0 { results[key] = errno == ECONNREFUSED ? "refused" : "errno(\(errno))"; close(fd); return }
+  if expectEcho {
+    var tv = timeval(tv_sec: 3, tv_usec: 0); setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+    var buf = [UInt8](repeating: 0, count: 16)
+    let n = recv(fd, &buf, buf.count, 0)
+    results[key] = n > 0 ? "ok" : "no-echo"
+  } else { results[key] = "sent" }
+  close(fd)
+}
+
+urlSessionDirect()
+urlSessionProxied()
+nwConnectionDirect()
+bsdConnectDirect()
+udp("udpDirect", "8.8.8.8", 53, expectEcho: false)
+udp("udpLoopback", "127.0.0.1", udpPort, expectEcho: true)
+
+// 7. The same literal destination twice: the guard must log it once per process.
+func bsdConnectLiteral(_ key: String) {
+  var to = sockaddr_in(); to.sin_family = sa_family_t(AF_INET); to.sin_port = in_port_t(UInt16(443)).bigEndian
+  inet_pton(AF_INET, "1.1.1.1", &to.sin_addr)
+  let fd = socket(AF_INET, SOCK_STREAM, 0)
+  let rc = withUnsafePointer(to: &to) { p in p.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+    connect(fd, sa, socklen_t(MemoryLayout<sockaddr_in>.size)) } }
+  results[key] = rc == 0 ? "ok" : (errno == ECONNREFUSED ? "refused" : "errno(\(errno))")
+  close(fd)
+}
+bsdConnectLiteral("literalFirst")
+bsdConnectLiteral("literalSecond")
+
+let json = try! JSONSerialization.data(withJSONObject: results, options: [.sortedKeys])
+print(String(data: json, encoding: .utf8)!)

--- a/packages/build-tools/resources/egress-guard/tests/policy_test.c
+++ b/packages/build-tools/resources/egress-guard/tests/policy_test.c
@@ -1,0 +1,120 @@
+// Host-runnable tests for the guard's policy and formatting. Build and run
+// with tests/run-policy-tests.sh; every failure prints the failing line.
+#include "../policy.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/un.h>
+
+static int failures = 0;
+#define CHECK(cond)                                                     \
+  do {                                                                  \
+    if (!(cond)) {                                                      \
+      failures++;                                                       \
+      fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);   \
+    }                                                                   \
+  } while (0)
+
+static struct sockaddr_in v4(const char *ip, int port) {
+  struct sockaddr_in a; memset(&a, 0, sizeof a);
+  a.sin_family = AF_INET; a.sin_len = sizeof a; a.sin_port = htons(port);
+  inet_pton(AF_INET, ip, &a.sin_addr);
+  return a;
+}
+static struct sockaddr_in6 v6(const char *ip, int port) {
+  struct sockaddr_in6 a; memset(&a, 0, sizeof a);
+  a.sin6_family = AF_INET6; a.sin6_len = sizeof a; a.sin6_port = htons(port);
+  inet_pton(AF_INET6, ip, &a.sin6_addr);
+  return a;
+}
+
+static void test_classify(void) {
+  struct sockaddr_in a4; struct sockaddr_in6 a6; struct sockaddr_un un;
+
+  a4 = v4("127.0.0.1", 8899); CHECK(eg_classify((struct sockaddr *)&a4, sizeof a4) == EG_LOOPBACK);
+  a4 = v4("127.42.0.9", 80);  CHECK(eg_classify((struct sockaddr *)&a4, sizeof a4) == EG_LOOPBACK);
+  a4 = v4("0.0.0.0", 80);     CHECK(eg_classify((struct sockaddr *)&a4, sizeof a4) == EG_LOOPBACK);
+  a4 = v4("93.184.216.34", 443); CHECK(eg_classify((struct sockaddr *)&a4, sizeof a4) == EG_REMOTE);
+  a4 = v4("192.168.1.10", 8081); CHECK(eg_classify((struct sockaddr *)&a4, sizeof a4) == EG_REMOTE);
+  a4 = v4("169.254.1.1", 80);    CHECK(eg_classify((struct sockaddr *)&a4, sizeof a4) == EG_REMOTE);
+  a4 = v4("224.0.0.251", 5353);  CHECK(eg_classify((struct sockaddr *)&a4, sizeof a4) == EG_REMOTE);
+
+  a6 = v6("::1", 8899);                CHECK(eg_classify((struct sockaddr *)&a6, sizeof a6) == EG_LOOPBACK);
+  a6 = v6("::", 80);                   CHECK(eg_classify((struct sockaddr *)&a6, sizeof a6) == EG_LOOPBACK);
+  a6 = v6("::ffff:127.0.0.1", 8899);   CHECK(eg_classify((struct sockaddr *)&a6, sizeof a6) == EG_LOOPBACK);
+  a6 = v6("::ffff:93.184.216.34", 443); CHECK(eg_classify((struct sockaddr *)&a6, sizeof a6) == EG_REMOTE);
+  a6 = v6("2606:4700::1", 443);        CHECK(eg_classify((struct sockaddr *)&a6, sizeof a6) == EG_REMOTE);
+  a6 = v6("fe80::1", 443);             CHECK(eg_classify((struct sockaddr *)&a6, sizeof a6) == EG_REMOTE);
+
+  memset(&un, 0, sizeof un); un.sun_family = AF_UNIX; strcpy(un.sun_path, "/var/run/mDNSResponder");
+  CHECK(eg_classify((struct sockaddr *)&un, sizeof un) == EG_PASSTHROUGH);
+  CHECK(eg_classify(NULL, 0) == EG_PASSTHROUGH);
+  a4 = v4("93.184.216.34", 443); CHECK(eg_classify((struct sockaddr *)&a4, 4) == EG_PASSTHROUGH);  // too short to read
+}
+
+static void test_mode(void) {
+  CHECK(eg_parse_mode(NULL) == EG_MODE_BLOCK);
+  CHECK(eg_parse_mode("") == EG_MODE_BLOCK);
+  CHECK(eg_parse_mode("block") == EG_MODE_BLOCK);
+  CHECK(eg_parse_mode("log") == EG_MODE_LOG);
+  CHECK(eg_parse_mode("LOG") == EG_MODE_BLOCK);
+  CHECK(eg_parse_mode("permissive") == EG_MODE_BLOCK);
+
+  CHECK(eg_should_deny(EG_MODE_BLOCK, EG_REMOTE) == 1);
+  CHECK(eg_should_deny(EG_MODE_BLOCK, EG_LOOPBACK) == 0);
+  CHECK(eg_should_deny(EG_MODE_BLOCK, EG_PASSTHROUGH) == 0);
+  CHECK(eg_should_deny(EG_MODE_LOG, EG_REMOTE) == 0);
+}
+
+static void test_format_peer(void) {
+  char out[64];
+  struct sockaddr_in a4 = v4("93.184.216.34", 443);
+  CHECK(eg_format_peer((struct sockaddr *)&a4, sizeof a4, out, sizeof out) == 0);
+  CHECK(strcmp(out, "93.184.216.34:443") == 0);
+  struct sockaddr_in6 a6 = v6("2606:4700::1", 443);
+  CHECK(eg_format_peer((struct sockaddr *)&a6, sizeof a6, out, sizeof out) == 0);
+  CHECK(strcmp(out, "[2606:4700::1]:443") == 0);
+  CHECK(eg_format_peer((struct sockaddr *)&a4, sizeof a4, out, 8) != 0);
+  struct sockaddr_un un; memset(&un, 0, sizeof un); un.sun_family = AF_UNIX;
+  CHECK(eg_format_peer((struct sockaddr *)&un, sizeof un, out, sizeof out) != 0);
+}
+
+static void test_seen(void) {
+  static eg_seen_t seen; memset(&seen, 0, sizeof seen);
+  CHECK(eg_seen_insert(&seen, "connect 1.1.1.1:443") == 1);
+  CHECK(eg_seen_insert(&seen, "connect 1.1.1.1:443") == 0);
+  CHECK(eg_seen_insert(&seen, "sendto 1.1.1.1:443") == 1);
+  CHECK(seen.count == 2);
+  char key[64];
+  for (int i = 0; i < EG_SEEN_CAPACITY + 5; i++) { snprintf(key, sizeof key, "k%d", i); eg_seen_insert(&seen, key); }
+  CHECK(seen.count == EG_SEEN_CAPACITY);
+  CHECK(seen.overflow == 7);  // 2 + 128 + 5 attempts, 128 fit
+  CHECK(eg_seen_insert(&seen, "k0") == 0);  // still remembered
+}
+
+static void test_format_event(void) {
+  char out[512];
+  const char *callers[] = {"Network", "CFNetwork", "MyApp"};
+  int n = eg_format_event(out, sizeof out, "MyApp", 4242, "connect", "blocked", "93.184.216.34:443", callers, 3);
+  CHECK(n > 0);
+  CHECK(strcmp(out, "eas-egress-guard\tMyApp\t4242\tconnect\tblocked\t93.184.216.34:443\tNetwork,CFNetwork,MyApp\n") == 0);
+
+  const char *tabbed[] = {"a\tb"};
+  n = eg_format_event(out, sizeof out, "we\nird\tname", 1, "sendto", "logged", "1.2.3.4:53", tabbed, 1);
+  CHECK(n > 0);
+  CHECK(strcmp(out, "eas-egress-guard\twe ird name\t1\tsendto\tlogged\t1.2.3.4:53\ta b\n") == 0);
+
+  n = eg_format_event(out, sizeof out, "NoCallers", 7, "connectx", "blocked", "[::2]:80", NULL, 0);
+  CHECK(n > 0 && strcmp(out, "eas-egress-guard\tNoCallers\t7\tconnectx\tblocked\t[::2]:80\t\n") == 0);
+
+  CHECK(eg_format_event(out, 16, "MyApp", 4242, "connect", "blocked", "93.184.216.34:443", callers, 3) == -1);
+}
+
+int main(void) {
+  test_classify(); test_mode(); test_format_peer(); test_seen(); test_format_event();
+  if (failures) { fprintf(stderr, "%d failure(s)\n", failures); return 1; }
+  printf("egress-guard policy tests: all passed\n");
+  return 0;
+}

--- a/packages/build-tools/resources/egress-guard/tests/run-policy-tests.sh
+++ b/packages/build-tools/resources/egress-guard/tests/run-policy-tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Builds the policy unit tests for the host (macOS) and runs them.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+out=$(mktemp -d)
+clang -std=c11 -Wall -Wextra -Werror -o "$out/policy_test" policy.c tests/policy_test.c
+"$out/policy_test"

--- a/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
@@ -4,6 +4,7 @@ import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createMockLogger } from '../../../__tests__/utils/logger';
 import { IosSimulatorUtils } from '../../../utils/IosSimulatorUtils';
 import { configureSimulatorProxyEnvironmentAsync } from '../../utils/localEgress';
+import { installLocalEgressGuardAsync } from '../../utils/localEgressGuard';
 import { createStartIosSimulatorBuildFunction } from '../startIosSimulator';
 
 jest.mock('@expo/turtle-spawn', () => ({
@@ -26,10 +27,14 @@ jest.mock('../../../utils/IosSimulatorUtils', () => ({
 jest.mock('../../utils/localEgress', () => ({
   configureSimulatorProxyEnvironmentAsync: jest.fn(),
 }));
+jest.mock('../../utils/localEgressGuard', () => ({
+  installLocalEgressGuardAsync: jest.fn(),
+}));
 
 const mockedSpawn = jest.mocked(spawn);
 const mockedUtils = jest.mocked(IosSimulatorUtils);
 const mockedConfigureProxyEnvironment = jest.mocked(configureSimulatorProxyEnvironmentAsync);
+const mockedInstallGuard = jest.mocked(installLocalEgressGuardAsync);
 
 function createStep(callInputs?: Record<string, unknown>) {
   const logger = createMockLogger();
@@ -51,6 +56,7 @@ describe(createStartIosSimulatorBuildFunction, () => {
     mockedUtils.waitForReadyAsync.mockResolvedValue(undefined);
     mockedUtils.disableApsdAsync.mockResolvedValue(undefined);
     mockedConfigureProxyEnvironment.mockResolvedValue(false);
+    mockedInstallGuard.mockResolvedValue(false);
   });
 
   it('does not enable accessibility settings by default', async () => {
@@ -117,7 +123,7 @@ describe(createStartIosSimulatorBuildFunction, () => {
     });
   });
 
-  it('configures the local egress proxy environment once each device is ready', async () => {
+  it('configures the local egress proxy environment and guard as soon as each device boots, before readiness', async () => {
     mockedUtils.startAsync
       .mockResolvedValueOnce({ udid: 'base' as any })
       .mockResolvedValueOnce({ udid: 'clone-1' as any })
@@ -125,16 +131,20 @@ describe(createStartIosSimulatorBuildFunction, () => {
 
     await createStep({ device_identifier: 'iPhone 15', count: 2 }).executeAsync();
 
-    expect(mockedConfigureProxyEnvironment.mock.calls.map(([{ udid }]) => udid)).toEqual([
-      'base',
-      'clone-1',
-      'clone-2',
-    ]);
-    for (const [callIndex] of mockedConfigureProxyEnvironment.mock.calls.entries()) {
-      const readyCallOrder = mockedUtils.waitForReadyAsync.mock.invocationCallOrder[callIndex];
-      const configureCallOrder =
-        mockedConfigureProxyEnvironment.mock.invocationCallOrder[callIndex];
-      expect(configureCallOrder).toBeGreaterThan(readyCallOrder);
+    const udids = ['base', 'clone-1', 'clone-2'];
+    expect(mockedConfigureProxyEnvironment.mock.calls.map(([{ udid }]) => udid)).toEqual(udids);
+    expect(mockedInstallGuard.mock.calls.map(([{ udid }]) => udid)).toEqual(udids);
+    for (const [callIndex] of udids.entries()) {
+      const startOrder = mockedUtils.startAsync.mock.invocationCallOrder[callIndex];
+      const configureOrder = mockedConfigureProxyEnvironment.mock.invocationCallOrder[callIndex];
+      const guardOrder = mockedInstallGuard.mock.invocationCallOrder[callIndex];
+      const readyOrder = mockedUtils.waitForReadyAsync.mock.invocationCallOrder[callIndex];
+      // Daemons launched during boot inherit launchd's environment, so both run
+      // right after the boot returns and before anything else waits.
+      expect(configureOrder).toBeGreaterThan(startOrder);
+      expect(guardOrder).toBeGreaterThan(startOrder);
+      expect(configureOrder).toBeLessThan(readyOrder);
+      expect(guardOrder).toBeLessThan(readyOrder);
     }
   });
 

--- a/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
@@ -4,7 +4,10 @@ import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createMockLogger } from '../../../__tests__/utils/logger';
 import { IosSimulatorUtils } from '../../../utils/IosSimulatorUtils';
 import { configureSimulatorProxyEnvironmentAsync } from '../../utils/localEgress';
-import { installLocalEgressGuardAsync } from '../../utils/localEgressGuard';
+import {
+  installLocalEgressGuardAsync,
+  verifyLocalEgressGuardAsync,
+} from '../../utils/localEgressGuard';
 import { createStartIosSimulatorBuildFunction } from '../startIosSimulator';
 
 jest.mock('@expo/turtle-spawn', () => ({
@@ -18,6 +21,8 @@ jest.mock('../../../utils/IosSimulatorUtils', () => ({
     getDeviceAsync: jest.fn(),
     cloneAsync: jest.fn(),
     enableAccessibilitySettingsAsync: jest.fn(),
+    resolveUdidAsync: jest.fn(),
+    bootAsync: jest.fn(),
     startAsync: jest.fn(),
     waitForReadyAsync: jest.fn(),
     disableApsdAsync: jest.fn(),
@@ -29,12 +34,21 @@ jest.mock('../../utils/localEgress', () => ({
 }));
 jest.mock('../../utils/localEgressGuard', () => ({
   installLocalEgressGuardAsync: jest.fn(),
+  verifyLocalEgressGuardAsync: jest.fn(),
 }));
 
 const mockedSpawn = jest.mocked(spawn);
 const mockedUtils = jest.mocked(IosSimulatorUtils);
 const mockedConfigureProxyEnvironment = jest.mocked(configureSimulatorProxyEnvironmentAsync);
 const mockedInstallGuard = jest.mocked(installLocalEgressGuardAsync);
+const mockedVerifyGuard = jest.mocked(verifyLocalEgressGuardAsync);
+
+// Names resolve to udids the way the step expects; udids pass through.
+const UDIDS: Record<string, string> = {
+  'iPhone 15': 'base',
+  'eas-simulator-1': 'clone-1',
+  'eas-simulator-2': 'clone-2',
+};
 
 function createStep(callInputs?: Record<string, unknown>) {
   const logger = createMockLogger();
@@ -52,29 +66,39 @@ describe(createStartIosSimulatorBuildFunction, () => {
     mockedUtils.getDeviceAsync.mockResolvedValue(null);
     mockedUtils.cloneAsync.mockResolvedValue(undefined);
     mockedUtils.enableAccessibilitySettingsAsync.mockResolvedValue(undefined);
-    mockedUtils.startAsync.mockResolvedValue({ udid: 'test-udid' as any });
+    mockedUtils.resolveUdidAsync.mockImplementation(
+      async ({ deviceIdentifier }) => (UDIDS[deviceIdentifier] ?? deviceIdentifier) as any
+    );
+    mockedUtils.bootAsync.mockResolvedValue(undefined);
+    mockedUtils.startAsync.mockImplementation(async ({ deviceIdentifier }) => ({
+      udid: deviceIdentifier as any,
+    }));
     mockedUtils.waitForReadyAsync.mockResolvedValue(undefined);
     mockedUtils.disableApsdAsync.mockResolvedValue(undefined);
     mockedConfigureProxyEnvironment.mockResolvedValue(false);
     mockedInstallGuard.mockResolvedValue(false);
+    mockedVerifyGuard.mockResolvedValue(undefined);
   });
 
   it('does not enable accessibility settings by default', async () => {
     await createStep({ device_identifier: 'iPhone 15' }).executeAsync();
 
     expect(mockedUtils.enableAccessibilitySettingsAsync).not.toHaveBeenCalled();
-    expect(mockedUtils.startAsync).toHaveBeenCalledWith({
+    expect(mockedUtils.resolveUdidAsync).toHaveBeenCalledWith({
       deviceIdentifier: 'iPhone 15',
+      env: expect.any(Object),
+    });
+    expect(mockedUtils.bootAsync).toHaveBeenCalledWith({
+      deviceIdentifier: 'base',
+      env: expect.any(Object),
+    });
+    expect(mockedUtils.startAsync).toHaveBeenCalledWith({
+      deviceIdentifier: 'base',
       env: expect.any(Object),
     });
   });
 
   it('enables accessibility settings before starting the main device and every clone when requested', async () => {
-    mockedUtils.startAsync
-      .mockResolvedValueOnce({ udid: 'base' as any })
-      .mockResolvedValueOnce({ udid: 'clone-1' as any })
-      .mockResolvedValueOnce({ udid: 'clone-2' as any });
-
     await createStep({
       device_identifier: 'iPhone 15',
       count: 2,
@@ -102,11 +126,6 @@ describe(createStartIosSimulatorBuildFunction, () => {
   });
 
   it('disables apsd on the main device and every clone', async () => {
-    mockedUtils.startAsync
-      .mockResolvedValueOnce({ udid: 'base' as any })
-      .mockResolvedValueOnce({ udid: 'clone-1' as any })
-      .mockResolvedValueOnce({ udid: 'clone-2' as any });
-
     await createStep({ device_identifier: 'iPhone 15', count: 2 }).executeAsync();
 
     expect(mockedUtils.disableApsdAsync).toHaveBeenCalledWith({
@@ -123,29 +142,56 @@ describe(createStartIosSimulatorBuildFunction, () => {
     });
   });
 
-  it('configures the local egress proxy environment and guard as soon as each device boots, before readiness', async () => {
-    mockedUtils.startAsync
-      .mockResolvedValueOnce({ udid: 'base' as any })
-      .mockResolvedValueOnce({ udid: 'clone-1' as any })
-      .mockResolvedValueOnce({ udid: 'clone-2' as any });
+  it('installs the proxy environment and guard between boot and boot completion, then verifies the guard', async () => {
+    mockedInstallGuard.mockResolvedValue(true);
 
     await createStep({ device_identifier: 'iPhone 15', count: 2 }).executeAsync();
 
     const udids = ['base', 'clone-1', 'clone-2'];
+    expect(
+      mockedUtils.bootAsync.mock.calls.map(([{ deviceIdentifier }]) => deviceIdentifier)
+    ).toEqual(udids);
     expect(mockedConfigureProxyEnvironment.mock.calls.map(([{ udid }]) => udid)).toEqual(udids);
     expect(mockedInstallGuard.mock.calls.map(([{ udid }]) => udid)).toEqual(udids);
+    expect(mockedVerifyGuard.mock.calls.map(([{ udid }]) => udid)).toEqual(udids);
     for (const [callIndex] of udids.entries()) {
-      const startOrder = mockedUtils.startAsync.mock.invocationCallOrder[callIndex];
+      const bootOrder = mockedUtils.bootAsync.mock.invocationCallOrder[callIndex];
       const configureOrder = mockedConfigureProxyEnvironment.mock.invocationCallOrder[callIndex];
       const guardOrder = mockedInstallGuard.mock.invocationCallOrder[callIndex];
+      const bootCompleteOrder = mockedUtils.startAsync.mock.invocationCallOrder[callIndex];
+      const verifyOrder = mockedVerifyGuard.mock.invocationCallOrder[callIndex];
       const readyOrder = mockedUtils.waitForReadyAsync.mock.invocationCallOrder[callIndex];
-      // Daemons launched during boot inherit launchd's environment, so both run
-      // right after the boot returns and before anything else waits.
-      expect(configureOrder).toBeGreaterThan(startOrder);
-      expect(guardOrder).toBeGreaterThan(startOrder);
-      expect(configureOrder).toBeLessThan(readyOrder);
-      expect(guardOrder).toBeLessThan(readyOrder);
+      // launchd is up when boot returns and has spawned nothing yet: that is the
+      // only moment at which its environment reaches every process of the boot.
+      expect(configureOrder).toBeGreaterThan(bootOrder);
+      expect(guardOrder).toBeGreaterThan(bootOrder);
+      expect(configureOrder).toBeLessThan(bootCompleteOrder);
+      expect(guardOrder).toBeLessThan(bootCompleteOrder);
+      // The self-check needs a completed boot and runs before anything else.
+      expect(verifyOrder).toBeGreaterThan(bootCompleteOrder);
+      expect(verifyOrder).toBeLessThan(readyOrder);
     }
+  });
+
+  it('skips the guard verification when no local egress session is active', async () => {
+    mockedInstallGuard.mockResolvedValue(false);
+
+    await createStep({ device_identifier: 'iPhone 15' }).executeAsync();
+
+    expect(mockedVerifyGuard).not.toHaveBeenCalled();
+  });
+
+  it('fails the step when the guard cannot be installed or verified', async () => {
+    mockedInstallGuard.mockRejectedValueOnce(new Error('guard library missing'));
+    await expect(createStep({ device_identifier: 'iPhone 15' }).executeAsync()).rejects.toThrow(
+      'guard library missing'
+    );
+
+    mockedInstallGuard.mockResolvedValue(true);
+    mockedVerifyGuard.mockRejectedValueOnce(new Error('self-check failed'));
+    await expect(createStep({ device_identifier: 'iPhone 15' }).executeAsync()).rejects.toThrow(
+      'self-check failed'
+    );
   });
 
   it('continues when disabling apsd fails', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
@@ -6,6 +6,7 @@ import { IosSimulatorUtils } from '../../../utils/IosSimulatorUtils';
 import { configureSimulatorProxyEnvironmentAsync } from '../../utils/localEgress';
 import {
   installLocalEgressGuardAsync,
+  resolveLocalEgressBootEnvironmentAsync,
   verifyLocalEgressGuardAsync,
 } from '../../utils/localEgressGuard';
 import { createStartIosSimulatorBuildFunction } from '../startIosSimulator';
@@ -34,6 +35,7 @@ jest.mock('../../utils/localEgress', () => ({
 }));
 jest.mock('../../utils/localEgressGuard', () => ({
   installLocalEgressGuardAsync: jest.fn(),
+  resolveLocalEgressBootEnvironmentAsync: jest.fn(),
   verifyLocalEgressGuardAsync: jest.fn(),
 }));
 
@@ -42,6 +44,7 @@ const mockedUtils = jest.mocked(IosSimulatorUtils);
 const mockedConfigureProxyEnvironment = jest.mocked(configureSimulatorProxyEnvironmentAsync);
 const mockedInstallGuard = jest.mocked(installLocalEgressGuardAsync);
 const mockedVerifyGuard = jest.mocked(verifyLocalEgressGuardAsync);
+const mockedResolveBootEnvironment = jest.mocked(resolveLocalEgressBootEnvironmentAsync);
 
 // Names resolve to udids the way the step expects; udids pass through.
 const UDIDS: Record<string, string> = {
@@ -78,6 +81,7 @@ describe(createStartIosSimulatorBuildFunction, () => {
     mockedConfigureProxyEnvironment.mockResolvedValue(false);
     mockedInstallGuard.mockResolvedValue(false);
     mockedVerifyGuard.mockResolvedValue(undefined);
+    mockedResolveBootEnvironment.mockResolvedValue(null);
   });
 
   it('does not enable accessibility settings by default', async () => {
@@ -91,6 +95,7 @@ describe(createStartIosSimulatorBuildFunction, () => {
     expect(mockedUtils.bootAsync).toHaveBeenCalledWith({
       deviceIdentifier: 'base',
       env: expect.any(Object),
+      launchdEnvironment: {},
     });
     expect(mockedUtils.startAsync).toHaveBeenCalledWith({
       deviceIdentifier: 'base',
@@ -170,6 +175,33 @@ describe(createStartIosSimulatorBuildFunction, () => {
       expect(verifyOrder).toBeGreaterThan(bootCompleteOrder);
       expect(verifyOrder).toBeLessThan(readyOrder);
     }
+  });
+
+  it('boots with the local egress environment so the first processes inherit it', async () => {
+    mockedResolveBootEnvironment.mockResolvedValue({
+      DYLD_INSERT_LIBRARIES: '/w/bin/egress-guard.dylib',
+      https_proxy: 'http://127.0.0.1:8899',
+    });
+
+    await createStep({ device_identifier: 'iPhone 15', count: 2 }).executeAsync();
+
+    for (const [{ deviceIdentifier, launchdEnvironment }] of mockedUtils.bootAsync.mock.calls) {
+      expect(['base', 'clone-1', 'clone-2']).toContain(deviceIdentifier);
+      expect(launchdEnvironment).toEqual({
+        DYLD_INSERT_LIBRARIES: '/w/bin/egress-guard.dylib',
+        https_proxy: 'http://127.0.0.1:8899',
+      });
+    }
+  });
+
+  it('boots with an empty launchd environment when no local egress session is active', async () => {
+    await createStep({ device_identifier: 'iPhone 15' }).executeAsync();
+
+    expect(mockedUtils.bootAsync).toHaveBeenCalledWith({
+      deviceIdentifier: 'base',
+      env: expect.any(Object),
+      launchdEnvironment: {},
+    });
   });
 
   it('skips the guard verification when no local egress session is active', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
@@ -163,10 +163,9 @@ describe(createStartIosSimulatorBuildFunction, () => {
       const readyOrder = mockedUtils.waitForReadyAsync.mock.invocationCallOrder[callIndex];
       // launchd is up when boot returns and has spawned nothing yet: that is the
       // only moment at which its environment reaches every process of the boot.
-      expect(configureOrder).toBeGreaterThan(bootOrder);
       expect(guardOrder).toBeGreaterThan(bootOrder);
+      expect(configureOrder).toBeGreaterThan(guardOrder);
       expect(configureOrder).toBeLessThan(bootCompleteOrder);
-      expect(guardOrder).toBeLessThan(bootCompleteOrder);
       // The self-check needs a completed boot and runs before anything else.
       expect(verifyOrder).toBeGreaterThan(bootCompleteOrder);
       expect(verifyOrder).toBeLessThan(readyOrder);

--- a/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startIosSimulator.test.ts
@@ -3,6 +3,7 @@ import spawn from '@expo/turtle-spawn';
 import { createGlobalContextMock } from '../../../__tests__/utils/context';
 import { createMockLogger } from '../../../__tests__/utils/logger';
 import { IosSimulatorUtils } from '../../../utils/IosSimulatorUtils';
+import { configureSimulatorProxyEnvironmentAsync } from '../../utils/localEgress';
 import { createStartIosSimulatorBuildFunction } from '../startIosSimulator';
 
 jest.mock('@expo/turtle-spawn', () => ({
@@ -22,8 +23,13 @@ jest.mock('../../../utils/IosSimulatorUtils', () => ({
   },
 }));
 
+jest.mock('../../utils/localEgress', () => ({
+  configureSimulatorProxyEnvironmentAsync: jest.fn(),
+}));
+
 const mockedSpawn = jest.mocked(spawn);
 const mockedUtils = jest.mocked(IosSimulatorUtils);
+const mockedConfigureProxyEnvironment = jest.mocked(configureSimulatorProxyEnvironmentAsync);
 
 function createStep(callInputs?: Record<string, unknown>) {
   const logger = createMockLogger();
@@ -44,6 +50,7 @@ describe(createStartIosSimulatorBuildFunction, () => {
     mockedUtils.startAsync.mockResolvedValue({ udid: 'test-udid' as any });
     mockedUtils.waitForReadyAsync.mockResolvedValue(undefined);
     mockedUtils.disableApsdAsync.mockResolvedValue(undefined);
+    mockedConfigureProxyEnvironment.mockResolvedValue(false);
   });
 
   it('does not enable accessibility settings by default', async () => {
@@ -108,6 +115,27 @@ describe(createStartIosSimulatorBuildFunction, () => {
       udid: 'clone-2',
       env: expect.any(Object),
     });
+  });
+
+  it('configures the local egress proxy environment once each device is ready', async () => {
+    mockedUtils.startAsync
+      .mockResolvedValueOnce({ udid: 'base' as any })
+      .mockResolvedValueOnce({ udid: 'clone-1' as any })
+      .mockResolvedValueOnce({ udid: 'clone-2' as any });
+
+    await createStep({ device_identifier: 'iPhone 15', count: 2 }).executeAsync();
+
+    expect(mockedConfigureProxyEnvironment.mock.calls.map(([{ udid }]) => udid)).toEqual([
+      'base',
+      'clone-1',
+      'clone-2',
+    ]);
+    for (const [callIndex] of mockedConfigureProxyEnvironment.mock.calls.entries()) {
+      const readyCallOrder = mockedUtils.waitForReadyAsync.mock.invocationCallOrder[callIndex];
+      const configureCallOrder =
+        mockedConfigureProxyEnvironment.mock.invocationCallOrder[callIndex];
+      expect(configureCallOrder).toBeGreaterThan(readyCallOrder);
+    }
   });
 
   it('continues when disabling apsd fails', async () => {

--- a/packages/build-tools/src/steps/functions/__tests__/startLocalEgress.test.ts
+++ b/packages/build-tools/src/steps/functions/__tests__/startLocalEgress.test.ts
@@ -20,6 +20,9 @@ jest.mock('../../utils/localEgress', () => ({
   startChiselServerAsync: jest.fn(),
   writeLocalEgressHandoffAsync: jest.fn(),
 }));
+jest.mock('../../utils/localEgressGuard', () => ({
+  stopLocalEgressGuardRelaysAsync: jest.fn().mockResolvedValue(undefined),
+}));
 jest.mock('../../utils/remoteDeviceRunSession', () => ({
   findAvailablePortAsync: jest.fn(),
   startNgrokTunnelAsync: jest.fn(),

--- a/packages/build-tools/src/steps/functions/startIosSimulator.ts
+++ b/packages/build-tools/src/steps/functions/startIosSimulator.ts
@@ -4,11 +4,15 @@ import {
   BuildStepInput,
   BuildStepInputValueTypeName,
 } from '@expo/steps';
+import { type bunyan } from '@expo/logger';
 import spawn from '@expo/turtle-spawn';
 import { minBy } from 'lodash';
 
 import { configureSimulatorProxyEnvironmentAsync } from '../utils/localEgress';
-import { installLocalEgressGuardAsync } from '../utils/localEgressGuard';
+import {
+  installLocalEgressGuardAsync,
+  verifyLocalEgressGuardAsync,
+} from '../utils/localEgressGuard';
 
 import {
   IosSimulatorName,
@@ -76,14 +80,11 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
           env,
         });
       }
-      const { udid } = await IosSimulatorUtils.startAsync({
+      const udid = await bootWithLocalEgressAsync({
         deviceIdentifier: originalDeviceIdentifier,
         env,
+        logger,
       });
-      // Right after boot, before anything else waits: processes launched from
-      // here on inherit launchd's environment, so the earlier the better.
-      await configureSimulatorProxyEnvironmentAsync({ udid, env, logger });
-      await installLocalEgressGuardAsync({ udid, env, logger });
 
       try {
         await IosSimulatorUtils.disableApsdAsync({ udid, env });
@@ -123,12 +124,11 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
               env,
             });
           }
-          const { udid: cloneUdid } = await IosSimulatorUtils.startAsync({
+          const cloneUdid = await bootWithLocalEgressAsync({
             deviceIdentifier: cloneDeviceName,
             env,
+            logger,
           });
-          await configureSimulatorProxyEnvironmentAsync({ udid: cloneUdid, env, logger });
-          await installLocalEgressGuardAsync({ udid: cloneUdid, env, logger });
 
           try {
             await IosSimulatorUtils.disableApsdAsync({ udid: cloneUdid, env });
@@ -147,6 +147,35 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
       }
     },
   });
+}
+
+/**
+ * Boot a device with the local egress environment in place before anything
+ * inside it starts. `simctl boot` returns once the simulator's launchd is up
+ * and before it has spawned anything else, which is the only moment at which
+ * launchd environment reaches every process of the boot. The proxy variables
+ * and the guard are set in that gap; then the boot is waited for and the
+ * guard is verified in a fresh process. Nothing here applies when no local
+ * egress session is active.
+ */
+async function bootWithLocalEgressAsync({
+  deviceIdentifier,
+  env,
+  logger,
+}: {
+  deviceIdentifier: IosSimulatorUuid | IosSimulatorName;
+  env: BuildStepEnv;
+  logger: bunyan;
+}): Promise<IosSimulatorUuid> {
+  const udid = await IosSimulatorUtils.resolveUdidAsync({ deviceIdentifier, env });
+  await IosSimulatorUtils.bootAsync({ deviceIdentifier: udid, env });
+  await configureSimulatorProxyEnvironmentAsync({ udid, env, logger });
+  const guardInstalled = await installLocalEgressGuardAsync({ udid, env, logger });
+  await IosSimulatorUtils.startAsync({ deviceIdentifier: udid, env });
+  if (guardInstalled) {
+    await verifyLocalEgressGuardAsync({ udid, env, logger });
+  }
+  return udid;
 }
 
 async function findMostGenericIphoneUuidAsync({

--- a/packages/build-tools/src/steps/functions/startIosSimulator.ts
+++ b/packages/build-tools/src/steps/functions/startIosSimulator.ts
@@ -7,6 +7,8 @@ import {
 import spawn from '@expo/turtle-spawn';
 import { minBy } from 'lodash';
 
+import { configureSimulatorProxyEnvironmentAsync } from '../utils/localEgress';
+
 import {
   IosSimulatorName,
   IosSimulatorUtils,
@@ -85,6 +87,7 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
       }
 
       await IosSimulatorUtils.waitForReadyAsync({ udid, env });
+      await configureSimulatorProxyEnvironmentAsync({ udid, env, logger });
 
       logger.info('');
 
@@ -131,6 +134,7 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
             udid: cloneUdid,
             env,
           });
+          await configureSimulatorProxyEnvironmentAsync({ udid: cloneUdid, env, logger });
 
           logger.info(`${cloneDeviceName} is ready.`);
           logger.info('');

--- a/packages/build-tools/src/steps/functions/startIosSimulator.ts
+++ b/packages/build-tools/src/steps/functions/startIosSimulator.ts
@@ -11,6 +11,7 @@ import { minBy } from 'lodash';
 import { configureSimulatorProxyEnvironmentAsync } from '../utils/localEgress';
 import {
   installLocalEgressGuardAsync,
+  resolveLocalEgressBootEnvironmentAsync,
   verifyLocalEgressGuardAsync,
 } from '../utils/localEgressGuard';
 
@@ -168,9 +169,15 @@ async function bootWithLocalEgressAsync({
   logger: bunyan;
 }): Promise<IosSimulatorUuid> {
   const udid = await IosSimulatorUtils.resolveUdidAsync({ deviceIdentifier, env });
-  await IosSimulatorUtils.bootAsync({ deviceIdentifier: udid, env });
-  // The guard goes first: it is the enforcement, and every process launchd
-  // spawns from here on must inherit it. The proxy variables follow.
+  // The guard and proxy variables ride the boot itself, so launchd has them
+  // before it spawns its first process.
+  const launchdEnvironment = await resolveLocalEgressBootEnvironmentAsync();
+  await IosSimulatorUtils.bootAsync({
+    deviceIdentifier: udid,
+    env,
+    launchdEnvironment: launchdEnvironment ?? {},
+  });
+  // Also set them through launchctl, for a device that was already booted.
   const guardInstalled = await installLocalEgressGuardAsync({ udid, env, logger });
   await configureSimulatorProxyEnvironmentAsync({ udid, env, logger });
   await IosSimulatorUtils.startAsync({ deviceIdentifier: udid, env });

--- a/packages/build-tools/src/steps/functions/startIosSimulator.ts
+++ b/packages/build-tools/src/steps/functions/startIosSimulator.ts
@@ -169,8 +169,10 @@ async function bootWithLocalEgressAsync({
 }): Promise<IosSimulatorUuid> {
   const udid = await IosSimulatorUtils.resolveUdidAsync({ deviceIdentifier, env });
   await IosSimulatorUtils.bootAsync({ deviceIdentifier: udid, env });
-  await configureSimulatorProxyEnvironmentAsync({ udid, env, logger });
+  // The guard goes first: it is the enforcement, and every process launchd
+  // spawns from here on must inherit it. The proxy variables follow.
   const guardInstalled = await installLocalEgressGuardAsync({ udid, env, logger });
+  await configureSimulatorProxyEnvironmentAsync({ udid, env, logger });
   await IosSimulatorUtils.startAsync({ deviceIdentifier: udid, env });
   if (guardInstalled) {
     await verifyLocalEgressGuardAsync({ udid, env, logger });

--- a/packages/build-tools/src/steps/functions/startIosSimulator.ts
+++ b/packages/build-tools/src/steps/functions/startIosSimulator.ts
@@ -8,6 +8,7 @@ import spawn from '@expo/turtle-spawn';
 import { minBy } from 'lodash';
 
 import { configureSimulatorProxyEnvironmentAsync } from '../utils/localEgress';
+import { installLocalEgressGuardAsync } from '../utils/localEgressGuard';
 
 import {
   IosSimulatorName,
@@ -79,6 +80,10 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
         deviceIdentifier: originalDeviceIdentifier,
         env,
       });
+      // Right after boot, before anything else waits: processes launched from
+      // here on inherit launchd's environment, so the earlier the better.
+      await configureSimulatorProxyEnvironmentAsync({ udid, env, logger });
+      await installLocalEgressGuardAsync({ udid, env, logger });
 
       try {
         await IosSimulatorUtils.disableApsdAsync({ udid, env });
@@ -87,7 +92,6 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
       }
 
       await IosSimulatorUtils.waitForReadyAsync({ udid, env });
-      await configureSimulatorProxyEnvironmentAsync({ udid, env, logger });
 
       logger.info('');
 
@@ -123,6 +127,8 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
             deviceIdentifier: cloneDeviceName,
             env,
           });
+          await configureSimulatorProxyEnvironmentAsync({ udid: cloneUdid, env, logger });
+          await installLocalEgressGuardAsync({ udid: cloneUdid, env, logger });
 
           try {
             await IosSimulatorUtils.disableApsdAsync({ udid: cloneUdid, env });
@@ -134,7 +140,6 @@ export function createStartIosSimulatorBuildFunction(): BuildFunction {
             udid: cloneUdid,
             env,
           });
-          await configureSimulatorProxyEnvironmentAsync({ udid: cloneUdid, env, logger });
 
           logger.info(`${cloneDeviceName} is ready.`);
           logger.info('');

--- a/packages/build-tools/src/steps/functions/startLocalEgress.ts
+++ b/packages/build-tools/src/steps/functions/startLocalEgress.ts
@@ -75,9 +75,10 @@ function awaitLocalEgressAcquisitionAsync<T>(
 /**
  * Points the device host's system HTTP(S) proxy at the EAS CLI's egress client.
  * Must run before `eas/start_ios_simulator`: the simulator reads the system proxy
- * at boot. Nothing else on the host changes, so requests from libraries that
- * bypass the system proxy are not covered; the shared session monitor reports
- * them. The shared session cleanup releases the resources started here when
+ * at boot. Once a simulator is ready, `eas/start_ios_simulator` also sets proxy
+ * environment variables inside it for clients that read them (gRPC, libcurl).
+ * Libraries that ignore both are not covered; the shared session monitor
+ * reports them. The shared session cleanup releases the resources started here when
  * the session ends, with a job finalizer as a fallback.
  */
 export function createStartLocalEgressBuildFunction(): BuildFunction {
@@ -183,8 +184,10 @@ export function createStartLocalEgressBuildFunction(): BuildFunction {
         logger.info(
           `Local egress is configured on network service "${service}". HTTP(S) and WebSocket ` +
             'requests that honor the system proxy (WebKit, URLSession and other CFNetwork clients) ' +
-            'fail until the EAS CLI egress client connects, then exit from that machine. Requests ' +
-            'from libraries that bypass the system proxy are not covered and exit from this worker. ' +
+            'fail until the EAS CLI egress client connects, then exit from that machine. Once the ' +
+            'Simulator is ready, proxy environment variables are set inside it for clients that read ' +
+            'them (gRPC, libcurl). Requests from libraries that ignore both are not covered and exit ' +
+            'from this worker. ' +
             'Connection sampling may report these bypasses, but can miss short connections and unconnected UDP traffic.'
         );
       } catch (error) {

--- a/packages/build-tools/src/steps/functions/startLocalEgress.ts
+++ b/packages/build-tools/src/steps/functions/startLocalEgress.ts
@@ -17,6 +17,7 @@ import {
   stopLocalEgressResourcesAsync,
   writeLocalEgressHandoffAsync,
 } from '../utils/localEgress';
+import { stopLocalEgressGuardRelaysAsync } from '../utils/localEgressGuard';
 import {
   type DetachedProcessHandle,
   type NgrokTunnelHandle,
@@ -75,10 +76,10 @@ function awaitLocalEgressAcquisitionAsync<T>(
 /**
  * Points the device host's system HTTP(S) proxy at the EAS CLI's egress client.
  * Must run before `eas/start_ios_simulator`: the simulator reads the system proxy
- * at boot. Once a simulator is ready, `eas/start_ios_simulator` also sets proxy
- * environment variables inside it for clients that read them (gRPC, libcurl).
- * Libraries that ignore both are not covered; the shared session monitor
- * reports them. The shared session cleanup releases the resources started here when
+ * at boot. Once a simulator boots, `eas/start_ios_simulator` also sets proxy
+ * environment variables inside it for clients that read them (gRPC, libcurl)
+ * and installs the local egress guard, which refuses connections that ignore
+ * both. The shared session cleanup releases the resources started here when
  * the session ends, with a job finalizer as a fallback.
  */
 export function createStartLocalEgressBuildFunction(): BuildFunction {
@@ -103,6 +104,7 @@ export function createStartLocalEgressBuildFunction(): BuildFunction {
       const lifetimeSignal = registerLocalEgressResources(async () => {
         await setupFinished;
         const results = await Promise.allSettled([
+          Promise.resolve().then(() => stopLocalEgressGuardRelaysAsync(logger)),
           Promise.resolve().then(() => tunnel?.stopAsync()),
           Promise.resolve().then(() => server?.stopAsync()),
         ]);
@@ -185,10 +187,9 @@ export function createStartLocalEgressBuildFunction(): BuildFunction {
           `Local egress is configured on network service "${service}". HTTP(S) and WebSocket ` +
             'requests that honor the system proxy (WebKit, URLSession and other CFNetwork clients) ' +
             'fail until the EAS CLI egress client connects, then exit from that machine. Once the ' +
-            'Simulator is ready, proxy environment variables are set inside it for clients that read ' +
-            'them (gRPC, libcurl). Requests from libraries that ignore both are not covered and exit ' +
-            'from this worker. ' +
-            'Connection sampling may report these bypasses, but can miss short connections and unconnected UDP traffic.'
+            'Simulator boots, proxy environment variables are set inside it for clients that read ' +
+            'them (gRPC, libcurl), and the local egress guard is installed so that connections which ' +
+            'ignore both are refused in the process that makes them and reported here.'
         );
       } catch (error) {
         finishSetup();

--- a/packages/build-tools/src/steps/utils/__tests__/localEgress.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/localEgress.test.ts
@@ -377,18 +377,16 @@ describe(configureSimulatorProxyEnvironmentAsync, () => {
       })
     ).resolves.toBe(true);
 
-    const setenvCalls = mockedSpawn.mock.calls.map(([, args]) => args);
-    expect(setenvCalls).toEqual(
-      Object.entries(buildLocalEgressSimulatorEnvironment(8899)).map(([name, value]) => [
+    expect(mockedSpawn.mock.calls.map(([, args]) => args)).toEqual([
+      [
         'simctl',
         'spawn',
         'test-udid',
         'launchctl',
         'setenv',
-        name,
-        value,
-      ])
-    );
+        ...Object.entries(buildLocalEgressSimulatorEnvironment(8899)).flat(),
+      ],
+    ]);
     expect(logger.info).toHaveBeenCalledWith(
       expect.stringContaining('proxy environment variables set')
     );

--- a/packages/build-tools/src/steps/utils/__tests__/localEgress.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/localEgress.test.ts
@@ -1,4 +1,5 @@
 import { type bunyan } from '@expo/logger';
+import spawn from '@expo/turtle-spawn';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -7,10 +8,13 @@ import { spawnDetached } from '../remoteDeviceRunSession';
 
 import {
   CHISEL_VERSION,
+  LOCAL_EGRESS_NO_PROXY,
   LOCAL_EGRESS_PROXY_PORT,
   buildEgressRemoteConfigFields,
+  buildLocalEgressSimulatorEnvironment,
   buildNetworksetupProxyArgs,
   collectSimulatorProcessIds,
+  configureSimulatorProxyEnvironmentAsync,
   createChiselAuthfileContents,
   getChiselAssetName,
   getChiselDownloadUrl,
@@ -310,6 +314,127 @@ describe('local egress handoff', () => {
     const handoffPath = path.join(tempDir, 'handoff.json');
     await fs.promises.writeFile(handoffPath, JSON.stringify({ url: 'x' }), 'utf8');
     await expect(readLocalEgressHandoffAsync(handoffPath)).rejects.toThrow('malformed');
+  });
+});
+
+describe(buildLocalEgressSimulatorEnvironment, () => {
+  it('points every proxy variable at the loopback port and excludes loopback', () => {
+    expect(buildLocalEgressSimulatorEnvironment(8899)).toEqual({
+      http_proxy: 'http://127.0.0.1:8899',
+      https_proxy: 'http://127.0.0.1:8899',
+      HTTP_PROXY: 'http://127.0.0.1:8899',
+      HTTPS_PROXY: 'http://127.0.0.1:8899',
+      grpc_proxy: 'http://127.0.0.1:8899',
+      no_proxy: LOCAL_EGRESS_NO_PROXY,
+      NO_PROXY: LOCAL_EGRESS_NO_PROXY,
+    });
+  });
+});
+
+describe(configureSimulatorProxyEnvironmentAsync, () => {
+  const mockedSpawn = jest.mocked(spawn);
+  let tempDir: string;
+  let logger: bunyan;
+
+  beforeEach(async () => {
+    mockedSpawn.mockReset();
+    mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'local-egress-env-test-'));
+    logger = { info: jest.fn(), warn: jest.fn() } as unknown as bunyan;
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('does nothing when no local egress session is active', async () => {
+    await expect(
+      configureSimulatorProxyEnvironmentAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+        logger,
+        handoffPath: path.join(tempDir, 'missing.json'),
+      })
+    ).resolves.toBe(false);
+
+    expect(mockedSpawn).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('sets the proxy environment in the simulator when a handoff exists', async () => {
+    const handoffPath = path.join(tempDir, 'handoff.json');
+    await writeLocalEgressHandoffAsync(
+      { url: 'https://egress.example', token: 'pw', fingerprint: 'fp=', port: 8899 },
+      handoffPath
+    );
+
+    await expect(
+      configureSimulatorProxyEnvironmentAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+        logger,
+        handoffPath,
+      })
+    ).resolves.toBe(true);
+
+    const setenvCalls = mockedSpawn.mock.calls.map(([, args]) => args);
+    expect(setenvCalls).toEqual(
+      Object.entries(buildLocalEgressSimulatorEnvironment(8899)).map(([name, value]) => [
+        'simctl',
+        'spawn',
+        'test-udid',
+        'launchctl',
+        'setenv',
+        name,
+        value,
+      ])
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('proxy environment variables set')
+    );
+  });
+
+  it('warns and continues when launchctl fails', async () => {
+    const handoffPath = path.join(tempDir, 'handoff.json');
+    await writeLocalEgressHandoffAsync(
+      { url: 'https://egress.example', token: 'pw', fingerprint: 'fp=', port: 8899 },
+      handoffPath
+    );
+    mockedSpawn.mockRejectedValue(new Error('launchctl failed'));
+
+    await expect(
+      configureSimulatorProxyEnvironmentAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+        logger,
+        handoffPath,
+      })
+    ).resolves.toBe(false);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      expect.stringContaining('will bypass local egress and exit from this worker')
+    );
+  });
+
+  it('warns and continues when the handoff is malformed', async () => {
+    const handoffPath = path.join(tempDir, 'handoff.json');
+    await fs.promises.writeFile(handoffPath, JSON.stringify({ url: 'x' }), 'utf8');
+
+    await expect(
+      configureSimulatorProxyEnvironmentAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+        logger,
+        handoffPath,
+      })
+    ).resolves.toBe(false);
+
+    expect(mockedSpawn).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      expect.stringContaining('could not read the local egress handoff')
+    );
   });
 });
 

--- a/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ios.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ios.ts
@@ -19,8 +19,10 @@ import {
   type GuardEvent,
   installLocalEgressGuardAsync,
   parseGuardLogLine,
+  resolveEgressGuardCheckAsync,
   resolveEgressGuardLibraryAsync,
   stopLocalEgressGuardRelaysAsync,
+  verifyLocalEgressGuardAsync,
 } from '../localEgressGuard';
 
 jest.unmock('fs');
@@ -76,6 +78,7 @@ describeE2E('local egress guard in a booted simulator', () => {
   let udid: IosSimulatorUuid;
   let bootedByTest = false;
   let libraryPath: string;
+  let checkPath: string;
   let nettestPath: string;
   let handoffPath: string;
   let proxyServer: http.Server;
@@ -85,7 +88,7 @@ describeE2E('local egress guard in a booted simulator', () => {
   const logger = createLogger();
 
   async function installAsync(mode: 'block' | 'log', logPath: string): Promise<boolean> {
-    return await installLocalEgressGuardAsync({
+    const installed = await installLocalEgressGuardAsync({
       udid,
       env,
       logger,
@@ -95,6 +98,9 @@ describeE2E('local egress guard in a booted simulator', () => {
       mode,
       tailIntervalMs: 100,
     });
+    // The same self-check the worker runs once boot completes.
+    await verifyLocalEgressGuardAsync({ udid, env, logger, mode, checkPath });
+    return installed;
   }
 
   async function runNettestAsync(): Promise<Record<string, string>> {
@@ -129,6 +135,11 @@ describeE2E('local egress guard in a booted simulator', () => {
       throw new Error('egress-guard.dylib is not available and could not be built.');
     }
     libraryPath = resolved;
+    const resolvedCheck = await resolveEgressGuardCheckAsync();
+    if (!resolvedCheck) {
+      throw new Error('egress-guard-check is not available and could not be built.');
+    }
+    checkPath = resolvedCheck;
 
     // The probe binary, compiled for the simulator running on this host.
     nettestPath = path.join(workDir, 'nettest');
@@ -313,6 +324,24 @@ describeE2E('local egress guard in a booted simulator', () => {
     const events = (await readEventsAsync(logPath)).filter(e => e.process === 'nettest');
     expect(events.length).toBeGreaterThan(0);
     expect(events.every(e => e.action === 'logged')).toBe(true);
+  });
+
+  it('reports a missing guard through the self-check', async () => {
+    // Point launchd at a library path that does not exist: dyld ignores it, so
+    // a fresh process runs unguarded, which the check must catch.
+    await IosSimulatorUtils.setLaunchdEnvironmentAsync({
+      udid,
+      env,
+      variables: { DYLD_INSERT_LIBRARIES: path.join(workDir, 'missing.dylib') },
+    });
+    await expect(
+      verifyLocalEgressGuardAsync({ udid, env, logger, mode: 'block', checkPath })
+    ).rejects.toThrow(/not in effect/);
+    await IosSimulatorUtils.setLaunchdEnvironmentAsync({
+      udid,
+      env,
+      variables: { DYLD_INSERT_LIBRARIES: libraryPath },
+    });
   });
 
   it('keeps refusing when the log file cannot be written', async () => {

--- a/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ios.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ios.ts
@@ -1,0 +1,328 @@
+/**
+ * End-to-end test of the local egress guard against a real iOS Simulator.
+ * Needs Xcode with a simulator runtime and network access. Opt in with
+ * EAS_LOCAL_EGRESS_E2E=1; the test-egress-guard EAS workflow runs it on macOS.
+ */
+import { type bunyan } from '@expo/logger';
+import spawn from '@expo/turtle-spawn';
+import dgram from 'node:dgram';
+import fs from 'node:fs';
+import http from 'node:http';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { IosSimulatorUtils, type IosSimulatorUuid } from '../../../utils/IosSimulatorUtils';
+import { writeLocalEgressHandoffAsync } from '../localEgress';
+import {
+  type GuardEvent,
+  installLocalEgressGuardAsync,
+  parseGuardLogLine,
+  resolveEgressGuardLibraryAsync,
+  stopLocalEgressGuardRelaysAsync,
+} from '../localEgressGuard';
+
+jest.unmock('fs');
+jest.unmock('node:fs');
+jest.unmock('fs/promises');
+jest.unmock('node:fs/promises');
+jest.setTimeout(15 * 60 * 1000);
+
+const enabled = process.platform === 'darwin' && process.env.EAS_LOCAL_EGRESS_E2E === '1';
+const describeE2E = enabled ? describe : describe.skip;
+
+const GUARD_DIR = path.join(__dirname, '..', '..', '..', '..', 'resources', 'egress-guard');
+const env = process.env;
+
+function createLogger(): bunyan & { lines: string[] } {
+  const lines: string[] = [];
+  const record = (a: unknown, b?: unknown) => {
+    lines.push(typeof a === 'string' ? a : String(b));
+  };
+  return { info: record, warn: record, debug: record, lines } as any;
+}
+
+async function readEventsAsync(logPath: string): Promise<GuardEvent[]> {
+  let raw = '';
+  try {
+    raw = await fs.promises.readFile(logPath, 'utf8');
+  } catch {
+    return [];
+  }
+  return raw
+    .split('\n')
+    .map(parseGuardLogLine)
+    .filter((e): e is GuardEvent => e !== null);
+}
+
+async function waitForAsync<T>(
+  probe: () => Promise<T | undefined>,
+  { timeoutMs, intervalMs = 1000 }: { timeoutMs: number; intervalMs?: number }
+): Promise<T | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await probe();
+    if (value !== undefined) {
+      return value;
+    }
+    await sleep(intervalMs);
+  }
+  return undefined;
+}
+
+describeE2E('local egress guard in a booted simulator', () => {
+  let workDir: string;
+  let udid: IosSimulatorUuid;
+  let bootedByTest = false;
+  let libraryPath: string;
+  let nettestPath: string;
+  let handoffPath: string;
+  let proxyServer: http.Server;
+  let proxyPort: number;
+  let udpServer: dgram.Socket;
+  let udpPort: number;
+  const logger = createLogger();
+
+  async function installAsync(mode: 'block' | 'log', logPath: string): Promise<boolean> {
+    return await installLocalEgressGuardAsync({
+      udid,
+      env,
+      logger,
+      handoffPath,
+      libraryPath,
+      logPath,
+      mode,
+      tailIntervalMs: 100,
+    });
+  }
+
+  async function runNettestAsync(): Promise<Record<string, string>> {
+    const result = await spawn(
+      'xcrun',
+      [
+        'simctl',
+        'spawn',
+        udid,
+        nettestPath,
+        '--proxy-port',
+        String(proxyPort),
+        '--udp-port',
+        String(udpPort),
+      ],
+      { env, stdio: 'pipe' }
+    );
+    const last = result.stdout.trim().split('\n').at(-1) ?? '{}';
+    return JSON.parse(last);
+  }
+
+  beforeAll(async () => {
+    workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'egress-guard-e2e-'));
+
+    // The guard library, built on demand.
+    let resolved = await resolveEgressGuardLibraryAsync();
+    if (!resolved) {
+      await spawn('bash', [path.join(GUARD_DIR, 'build.sh')], { env, stdio: 'pipe' });
+      resolved = await resolveEgressGuardLibraryAsync();
+    }
+    if (!resolved) {
+      throw new Error('egress-guard.dylib is not available and could not be built.');
+    }
+    libraryPath = resolved;
+
+    // The probe binary, compiled for the simulator running on this host.
+    nettestPath = path.join(workDir, 'nettest');
+    await spawn(
+      'xcrun',
+      [
+        '-sdk',
+        'iphonesimulator',
+        'swiftc',
+        '-target',
+        `${process.arch === 'arm64' ? 'arm64' : 'x86_64'}-apple-ios15.0-simulator`,
+        path.join(GUARD_DIR, 'tests', 'nettest.swift'),
+        '-o',
+        nettestPath,
+      ],
+      { env, stdio: 'pipe' }
+    );
+
+    // A device. Reuse a booted iPhone when there is one; otherwise boot one and
+    // shut it down afterwards. Never delete anything.
+    const booted = await IosSimulatorUtils.getAvailableDevicesAsync({ env, filter: 'booted' });
+    const bootedIphone = booted.find(d => /^iPhone/.test(d.name));
+    if (bootedIphone) {
+      udid = bootedIphone.udid;
+    } else {
+      const available = await IosSimulatorUtils.getAvailableDevicesAsync({
+        env,
+        filter: 'available',
+      });
+      const iphone =
+        available.find(d => /^iPhone \d/.test(d.name)) ??
+        available.find(d => /^iPhone/.test(d.name));
+      if (!iphone) {
+        throw new Error('No iPhone simulator is available.');
+      }
+      udid = iphone.udid;
+      await spawn('xcrun', ['simctl', 'boot', udid], { env, stdio: 'pipe' });
+      bootedByTest = true;
+    }
+    await IosSimulatorUtils.startAsync({ deviceIdentifier: udid, env });
+
+    // Loopback stand-ins for the egress proxy and for a local UDP service.
+    proxyServer = http.createServer((_req, res) => {
+      res.writeHead(502);
+      res.end();
+    });
+    proxyServer.on('connect', (req, socket, head) => {
+      const [host, port] = String(req.url).split(':');
+      const upstream = net.connect(Number(port) || 443, host, () => {
+        socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+        if (head.length) {
+          upstream.write(new Uint8Array(head));
+        }
+        upstream.pipe(socket);
+        socket.pipe(upstream);
+      });
+      upstream.on('error', () => socket.destroy());
+      socket.on('error', () => upstream.destroy());
+    });
+    await new Promise<void>(resolve => proxyServer.listen(0, '127.0.0.1', () => resolve()));
+    proxyPort = (proxyServer.address() as net.AddressInfo).port;
+
+    udpServer = dgram.createSocket('udp4');
+    udpServer.on('message', (msg, rinfo) =>
+      udpServer.send(new Uint8Array(msg), rinfo.port, rinfo.address)
+    );
+    await new Promise<void>(resolve => udpServer.bind(0, '127.0.0.1', () => resolve()));
+    udpPort = udpServer.address().port;
+
+    handoffPath = path.join(workDir, 'handoff.json');
+    await writeLocalEgressHandoffAsync(
+      { url: 'https://egress.example', token: 'pw', fingerprint: 'fp=', port: 8899 },
+      handoffPath
+    );
+  });
+
+  afterAll(async () => {
+    await stopLocalEgressGuardRelaysAsync(logger);
+    proxyServer?.close();
+    udpServer?.close();
+    if (bootedByTest && udid) {
+      await spawn('xcrun', ['simctl', 'shutdown', udid], { env, stdio: 'pipe' }).catch(() => {});
+    }
+    if (workDir) {
+      await fs.promises.rm(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses every direct path and leaves loopback and DNS alone', async () => {
+    const logPath = path.join(workDir, 'block.log');
+    expect(await installAsync('block', logPath)).toBe(true);
+
+    const results = await runNettestAsync();
+
+    expect(results).toMatchObject({
+      urlsessionDirect: 'refused',
+      urlsessionProxied: 'ok(200)',
+      bsdConnectDirect: 'refused',
+      dns: 'ok',
+      udpDirect: 'refused',
+      udpLoopback: 'ok',
+      literalFirst: 'refused',
+      literalSecond: 'refused',
+    });
+    expect(results.nwconnectionDirect).not.toMatch(/^ok|^timeout/);
+
+    const events = (await readEventsAsync(logPath)).filter(e => e.process === 'nettest');
+    expect(events.length).toBeGreaterThanOrEqual(4);
+    expect(events.every(e => e.action === 'blocked')).toBe(true);
+    // URLSession and Network.framework connects are caught inside Apple's frameworks.
+    expect(
+      events.some(e => e.function === 'connect' && e.callers.some(c => /CFNetwork/.test(c)))
+    ).toBe(true);
+    expect(
+      events.some(
+        e =>
+          e.function === 'connect' && e.callers.some(c => /Network/.test(c) && !/CFNetwork/.test(c))
+      )
+    ).toBe(true);
+    // UDP is covered.
+    expect(events.some(e => e.function === 'sendto' && e.peer === '8.8.8.8:53')).toBe(true);
+    // One line per destination per process, even when the process retries.
+    expect(events.filter(e => e.function === 'connect' && e.peer === '1.1.1.1:443')).toHaveLength(
+      1
+    );
+    // Nothing on loopback is ever reported.
+    expect(events.some(e => /^127\./.test(e.peer))).toBe(false);
+  });
+
+  it('guards processes the simulator launches on its own', async () => {
+    const logPath = path.join(workDir, 'daemons.log');
+    expect(await installAsync('block', logPath)).toBe(true);
+
+    await spawn('xcrun', ['simctl', 'openurl', udid, 'https://example.net/'], {
+      env,
+      stdio: 'pipe',
+    });
+
+    const daemonEvent = await waitForAsync(
+      async () =>
+        (await readEventsAsync(logPath)).find(
+          e => e.process !== 'nettest' && e.action === 'blocked'
+        ),
+      { timeoutMs: 60_000 }
+    );
+    expect(daemonEvent).toBeDefined();
+  });
+
+  it('does not interfere with the simulator tooling the worker relies on', async () => {
+    const screenshot = path.join(workDir, 'screenshot.png');
+    for (const args of [
+      ['simctl', 'spawn', udid, 'launchctl', 'list'],
+      [
+        'simctl',
+        'spawn',
+        udid,
+        'defaults',
+        'write',
+        'dev.expo.egress-guard-test',
+        'key',
+        '-string',
+        'value',
+      ],
+      ['simctl', 'spawn', udid, '/usr/bin/env'],
+      ['simctl', 'launch', udid, 'com.apple.Preferences'],
+      ['simctl', 'io', udid, 'screenshot', screenshot],
+    ]) {
+      await expect(spawn('xcrun', args, { env, stdio: 'pipe' })).resolves.toBeDefined();
+    }
+    expect(fs.existsSync(screenshot)).toBe(true);
+  });
+
+  it('observes without refusing in log mode', async () => {
+    const logPath = path.join(workDir, 'log-mode.log');
+    expect(await installAsync('log', logPath)).toBe(true);
+
+    const results = await runNettestAsync();
+
+    expect(results.urlsessionDirect).toBe('ok(200)');
+    expect(results.bsdConnectDirect).toBe('ok');
+    expect(results.udpDirect).toBe('sent');
+    const events = (await readEventsAsync(logPath)).filter(e => e.process === 'nettest');
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.every(e => e.action === 'logged')).toBe(true);
+  });
+
+  it('keeps refusing when the log file cannot be written', async () => {
+    const logPath = path.join(workDir, 'no-such-dir', 'guard.log');
+    expect(await installAsync('block', logPath)).toBe(true);
+
+    const results = await runNettestAsync();
+
+    expect(results.urlsessionDirect).toBe('refused');
+    expect(results.bsdConnectDirect).toBe('refused');
+    expect(results.urlsessionProxied).toBe('ok(200)');
+  });
+});

--- a/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ios.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ios.ts
@@ -1,7 +1,11 @@
 /**
  * End-to-end test of the local egress guard against a real iOS Simulator.
- * Needs Xcode with a simulator runtime and network access. Opt in with
- * EAS_LOCAL_EGRESS_E2E=1; the test-egress-guard EAS workflow runs it on macOS.
+ * Needs Xcode with a simulator runtime, a shut-down iPhone simulator, and
+ * network access. Opt in with EAS_LOCAL_EGRESS_E2E=1; the test-egress-guard
+ * EAS workflow runs it on macOS.
+ *
+ * Variables handed to launchd at boot cannot be changed afterwards with
+ * `launchctl setenv`, so each configuration gets its own boot.
  */
 import { type bunyan } from '@expo/logger';
 import spawn from '@expo/turtle-spawn';
@@ -19,8 +23,10 @@ import {
   type GuardEvent,
   installLocalEgressGuardAsync,
   parseGuardLogLine,
+  reportLocalEgressGuardCoverageAsync,
   resolveEgressGuardCheckAsync,
   resolveEgressGuardLibraryAsync,
+  resolveLocalEgressBootEnvironmentAsync,
   stopLocalEgressGuardRelaysAsync,
   verifyLocalEgressGuardAsync,
 } from '../localEgressGuard';
@@ -73,10 +79,9 @@ async function waitForAsync<T>(
   return undefined;
 }
 
-describeE2E('local egress guard in a booted simulator', () => {
+describeE2E('local egress guard in a simulator', () => {
   let workDir: string;
   let udid: IosSimulatorUuid;
-  let bootedByTest = false;
   let libraryPath: string;
   let checkPath: string;
   let nettestPath: string;
@@ -87,20 +92,27 @@ describeE2E('local egress guard in a booted simulator', () => {
   let udpPort: number;
   const logger = createLogger();
 
-  async function installAsync(mode: 'block' | 'log', logPath: string): Promise<boolean> {
-    const installed = await installLocalEgressGuardAsync({
-      udid,
-      env,
-      logger,
+  /** Shut the device down and boot it again with the given launchd environment. */
+  async function rebootAsync(launchdEnvironment: Record<string, string>): Promise<void> {
+    await spawn('xcrun', ['simctl', 'shutdown', udid], { env, stdio: 'pipe' }).catch(() => {});
+    await IosSimulatorUtils.bootAsync({ deviceIdentifier: udid, env, launchdEnvironment });
+    await IosSimulatorUtils.startAsync({ deviceIdentifier: udid, env });
+  }
+
+  async function bootEnvironmentAsync(
+    mode: 'block' | 'log',
+    logPath: string
+  ): Promise<Record<string, string>> {
+    const variables = await resolveLocalEgressBootEnvironmentAsync({
       handoffPath,
       libraryPath,
       logPath,
       mode,
-      tailIntervalMs: 100,
     });
-    // The same self-check the worker runs once boot completes.
-    await verifyLocalEgressGuardAsync({ udid, env, logger, mode, checkPath });
-    return installed;
+    if (!variables) {
+      throw new Error('The handoff was not written.');
+    }
+    return variables;
   }
 
   async function runNettestAsync(): Promise<Record<string, string>> {
@@ -125,7 +137,7 @@ describeE2E('local egress guard in a booted simulator', () => {
   beforeAll(async () => {
     workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'egress-guard-e2e-'));
 
-    // The guard library, built on demand.
+    // The guard library and self-check, built on demand.
     let resolved = await resolveEgressGuardLibraryAsync();
     if (!resolved) {
       await spawn('bash', [path.join(GUARD_DIR, 'build.sh')], { env, stdio: 'pipe' });
@@ -158,28 +170,28 @@ describeE2E('local egress guard in a booted simulator', () => {
       { env, stdio: 'pipe' }
     );
 
-    // A device. Reuse a booted iPhone when there is one; otherwise boot one and
-    // shut it down afterwards. Never delete anything.
-    const booted = await IosSimulatorUtils.getAvailableDevicesAsync({ env, filter: 'booted' });
-    const bootedIphone = booted.find(d => /^iPhone/.test(d.name));
-    if (bootedIphone) {
-      udid = bootedIphone.udid;
-    } else {
-      const available = await IosSimulatorUtils.getAvailableDevicesAsync({
-        env,
-        filter: 'available',
-      });
-      const iphone =
-        available.find(d => /^iPhone \d/.test(d.name)) ??
-        available.find(d => /^iPhone/.test(d.name));
-      if (!iphone) {
-        throw new Error('No iPhone simulator is available.');
-      }
-      udid = iphone.udid;
-      await spawn('xcrun', ['simctl', 'boot', udid], { env, stdio: 'pipe' });
-      bootedByTest = true;
+    handoffPath = path.join(workDir, 'handoff.json');
+    await writeLocalEgressHandoffAsync(
+      { url: 'https://egress.example', token: 'pw', fingerprint: 'fp=', port: 8899 },
+      handoffPath
+    );
+
+    // A shut-down iPhone the test can boot as many times as it needs. A device
+    // someone else booted is left alone. Nothing is ever deleted.
+    const booted = new Set(
+      (await IosSimulatorUtils.getAvailableDevicesAsync({ env, filter: 'booted' })).map(d => d.udid)
+    );
+    const available = await IosSimulatorUtils.getAvailableDevicesAsync({
+      env,
+      filter: 'available',
+    });
+    const iphone =
+      available.find(d => /^iPhone \d/.test(d.name) && !booted.has(d.udid)) ??
+      available.find(d => /^iPhone/.test(d.name) && !booted.has(d.udid));
+    if (!iphone) {
+      throw new Error('No shut-down iPhone simulator is available for the test to boot.');
     }
-    await IosSimulatorUtils.startAsync({ deviceIdentifier: udid, env });
+    udid = iphone.udid;
 
     // Loopback stand-ins for the egress proxy and for a local UDP service.
     proxyServer = http.createServer((_req, res) => {
@@ -208,19 +220,13 @@ describeE2E('local egress guard in a booted simulator', () => {
     );
     await new Promise<void>(resolve => udpServer.bind(0, '127.0.0.1', () => resolve()));
     udpPort = udpServer.address().port;
-
-    handoffPath = path.join(workDir, 'handoff.json');
-    await writeLocalEgressHandoffAsync(
-      { url: 'https://egress.example', token: 'pw', fingerprint: 'fp=', port: 8899 },
-      handoffPath
-    );
   });
 
   afterAll(async () => {
     await stopLocalEgressGuardRelaysAsync(logger);
     proxyServer?.close();
     udpServer?.close();
-    if (bootedByTest && udid) {
+    if (udid) {
       await spawn('xcrun', ['simctl', 'shutdown', udid], { env, stdio: 'pipe' }).catch(() => {});
     }
     if (workDir) {
@@ -228,130 +234,186 @@ describeE2E('local egress guard in a booted simulator', () => {
     }
   });
 
-  it('refuses every direct path and leaves loopback and DNS alone', async () => {
-    const logPath = path.join(workDir, 'block.log');
-    expect(await installAsync('block', logPath)).toBe(true);
+  describe('booted with the guard in launchd, as the worker boots', () => {
+    let logPath: string;
 
-    const results = await runNettestAsync();
-
-    expect(results).toMatchObject({
-      urlsessionDirect: 'refused',
-      urlsessionProxied: 'ok(200)',
-      bsdConnectDirect: 'refused',
-      dns: 'ok',
-      udpDirect: 'refused',
-      udpLoopback: 'ok',
-      literalFirst: 'refused',
-      literalSecond: 'refused',
-    });
-    expect(results.nwconnectionDirect).not.toMatch(/^ok|^timeout/);
-
-    const events = (await readEventsAsync(logPath)).filter(e => e.process === 'nettest');
-    expect(events.length).toBeGreaterThanOrEqual(4);
-    expect(events.every(e => e.action === 'blocked')).toBe(true);
-    // URLSession and Network.framework connects are caught inside Apple's frameworks.
-    expect(
-      events.some(e => e.function === 'connect' && e.callers.some(c => /CFNetwork/.test(c)))
-    ).toBe(true);
-    expect(
-      events.some(
-        e =>
-          e.function === 'connect' && e.callers.some(c => /Network/.test(c) && !/CFNetwork/.test(c))
-      )
-    ).toBe(true);
-    // UDP is covered.
-    expect(events.some(e => e.function === 'sendto' && e.peer === '8.8.8.8:53')).toBe(true);
-    // One line per destination per process, even when the process retries.
-    expect(events.filter(e => e.function === 'connect' && e.peer === '1.1.1.1:443')).toHaveLength(
-      1
-    );
-    // Nothing on loopback is ever reported.
-    expect(events.some(e => /^127\./.test(e.peer))).toBe(false);
-  });
-
-  it('guards processes the simulator launches on its own', async () => {
-    const logPath = path.join(workDir, 'daemons.log');
-    expect(await installAsync('block', logPath)).toBe(true);
-
-    await spawn('xcrun', ['simctl', 'openurl', udid, 'https://example.net/'], {
-      env,
-      stdio: 'pipe',
+    beforeAll(async () => {
+      logPath = path.join(workDir, 'boot.log');
+      await rebootAsync(await bootEnvironmentAsync('block', logPath));
+      await verifyLocalEgressGuardAsync({ udid, env, logger, mode: 'block', checkPath });
     });
 
-    const daemonEvent = await waitForAsync(
-      async () =>
-        (await readEventsAsync(logPath)).find(
-          e => e.process !== 'nettest' && e.action === 'blocked'
-        ),
-      { timeoutMs: 60_000 }
-    );
-    expect(daemonEvent).toBeDefined();
-  });
-
-  it('does not interfere with the simulator tooling the worker relies on', async () => {
-    const screenshot = path.join(workDir, 'screenshot.png');
-    for (const args of [
-      ['simctl', 'spawn', udid, 'launchctl', 'list'],
-      [
-        'simctl',
-        'spawn',
-        udid,
-        'defaults',
-        'write',
-        'dev.expo.egress-guard-test',
-        'key',
-        '-string',
-        'value',
-      ],
-      ['simctl', 'spawn', udid, '/usr/bin/env'],
-      ['simctl', 'launch', udid, 'com.apple.Preferences'],
-      ['simctl', 'io', udid, 'screenshot', screenshot],
-    ]) {
-      await expect(spawn('xcrun', args, { env, stdio: 'pipe' })).resolves.toBeDefined();
-    }
-    expect(fs.existsSync(screenshot)).toBe(true);
-  });
-
-  it('observes without refusing in log mode', async () => {
-    const logPath = path.join(workDir, 'log-mode.log');
-    expect(await installAsync('log', logPath)).toBe(true);
-
-    const results = await runNettestAsync();
-
-    expect(results.urlsessionDirect).toBe('ok(200)');
-    expect(results.bsdConnectDirect).toBe('ok');
-    expect(results.udpDirect).toBe('sent');
-    const events = (await readEventsAsync(logPath)).filter(e => e.process === 'nettest');
-    expect(events.length).toBeGreaterThan(0);
-    expect(events.every(e => e.action === 'logged')).toBe(true);
-  });
-
-  it('reports a missing guard through the self-check', async () => {
-    // Point launchd at a library path that does not exist: dyld ignores it, so
-    // a fresh process runs unguarded, which the check must catch.
-    await IosSimulatorUtils.setLaunchdEnvironmentAsync({
-      udid,
-      env,
-      variables: { DYLD_INSERT_LIBRARIES: path.join(workDir, 'missing.dylib') },
+    it('covers every process of the boot', async () => {
+      const coverage = await reportLocalEgressGuardCoverageAsync({ env, logger });
+      expect(coverage).not.toBeNull();
+      expect(coverage!.covered.length).toBeGreaterThan(50);
+      expect(coverage!.uncovered).toEqual([]);
+      // Refusals were recorded by processes that started during the boot, before
+      // any launchctl call could have reached them.
+      expect((await readEventsAsync(logPath)).length).toBeGreaterThan(0);
     });
-    await expect(
-      verifyLocalEgressGuardAsync({ udid, env, logger, mode: 'block', checkPath })
-    ).rejects.toThrow(/not in effect/);
-    await IosSimulatorUtils.setLaunchdEnvironmentAsync({
-      udid,
-      env,
-      variables: { DYLD_INSERT_LIBRARIES: libraryPath },
+
+    it('refuses every direct path and leaves loopback and DNS alone', async () => {
+      const results = await runNettestAsync();
+
+      expect(results).toMatchObject({
+        urlsessionDirect: 'refused',
+        urlsessionProxied: 'ok(200)',
+        bsdConnectDirect: 'refused',
+        dns: 'ok',
+        udpDirect: 'refused',
+        udpLoopback: 'ok',
+        literalFirst: 'refused',
+        literalSecond: 'refused',
+      });
+      expect(results.nwconnectionDirect).not.toMatch(/^ok|^timeout/);
+
+      const events = (await readEventsAsync(logPath)).filter(e => e.process === 'nettest');
+      expect(events.length).toBeGreaterThanOrEqual(4);
+      expect(events.every(e => e.action === 'blocked')).toBe(true);
+      // URLSession and Network.framework connects are caught inside Apple's frameworks.
+      expect(
+        events.some(e => e.function === 'connect' && e.callers.some(c => /CFNetwork/.test(c)))
+      ).toBe(true);
+      expect(
+        events.some(
+          e =>
+            e.function === 'connect' &&
+            e.callers.some(c => /Network/.test(c) && !/CFNetwork/.test(c))
+        )
+      ).toBe(true);
+      // UDP is covered.
+      expect(events.some(e => e.function === 'sendto' && e.peer === '8.8.8.8:53')).toBe(true);
+      // One line per destination per process, even when the process retries.
+      expect(events.filter(e => e.function === 'connect' && e.peer === '1.1.1.1:443')).toHaveLength(
+        1
+      );
+      // Nothing on loopback is ever reported.
+      expect(events.some(e => /^127\./.test(e.peer))).toBe(false);
+    });
+
+    it('guards processes the simulator launches on its own', async () => {
+      await spawn('xcrun', ['simctl', 'openurl', udid, 'https://example.net/'], {
+        env,
+        stdio: 'pipe',
+      });
+      const daemonEvent = await waitForAsync(
+        async () =>
+          (await readEventsAsync(logPath)).find(
+            e => e.process !== 'nettest' && e.action === 'blocked'
+          ),
+        { timeoutMs: 60_000 }
+      );
+      expect(daemonEvent).toBeDefined();
+    });
+
+    it('does not interfere with the simulator tooling the worker relies on', async () => {
+      const screenshot = path.join(workDir, 'screenshot.png');
+      for (const args of [
+        ['simctl', 'spawn', udid, 'launchctl', 'list'],
+        [
+          'simctl',
+          'spawn',
+          udid,
+          'defaults',
+          'write',
+          'dev.expo.egress-guard-test',
+          'key',
+          '-string',
+          'value',
+        ],
+        ['simctl', 'spawn', udid, '/usr/bin/env'],
+        ['simctl', 'launch', udid, 'com.apple.Preferences'],
+        ['simctl', 'io', udid, 'screenshot', screenshot],
+      ]) {
+        await expect(spawn('xcrun', args, { env, stdio: 'pipe' })).resolves.toBeDefined();
+      }
+      expect(fs.existsSync(screenshot)).toBe(true);
     });
   });
 
-  it('keeps refusing when the log file cannot be written', async () => {
-    const logPath = path.join(workDir, 'no-such-dir', 'guard.log');
-    expect(await installAsync('block', logPath)).toBe(true);
+  describe('booted in log mode', () => {
+    let logPath: string;
 
-    const results = await runNettestAsync();
+    beforeAll(async () => {
+      logPath = path.join(workDir, 'log-mode.log');
+      await rebootAsync(await bootEnvironmentAsync('log', logPath));
+      await verifyLocalEgressGuardAsync({ udid, env, logger, mode: 'log', checkPath });
+    });
 
-    expect(results.urlsessionDirect).toBe('refused');
-    expect(results.bsdConnectDirect).toBe('refused');
-    expect(results.urlsessionProxied).toBe('ok(200)');
+    it('observes without refusing', async () => {
+      const results = await runNettestAsync();
+
+      expect(results.urlsessionDirect).toBe('ok(200)');
+      expect(results.bsdConnectDirect).toBe('ok');
+      expect(results.udpDirect).toBe('sent');
+      const events = (await readEventsAsync(logPath)).filter(e => e.process === 'nettest');
+      expect(events.length).toBeGreaterThan(0);
+      expect(events.every(e => e.action === 'logged')).toBe(true);
+    });
+  });
+
+  describe('booted without the guard, as a device that was already running', () => {
+    beforeAll(async () => {
+      await rebootAsync({});
+    });
+
+    it('is reported as not in effect by the self-check', async () => {
+      await expect(
+        verifyLocalEgressGuardAsync({ udid, env, logger, mode: 'block', checkPath })
+      ).rejects.toThrow(/not in effect/);
+    });
+
+    it('can be installed after boot through launchctl for processes started from then on', async () => {
+      const logPath = path.join(workDir, 'install.log');
+      expect(
+        await installLocalEgressGuardAsync({
+          udid,
+          env,
+          logger,
+          handoffPath,
+          libraryPath,
+          logPath,
+          mode: 'block',
+          tailIntervalMs: 100,
+        })
+      ).toBe(true);
+      await verifyLocalEgressGuardAsync({ udid, env, logger, mode: 'block', checkPath });
+
+      const results = await runNettestAsync();
+      expect(results.urlsessionDirect).toBe('refused');
+      expect(results.bsdConnectDirect).toBe('refused');
+
+      // The relay turns the guard's events into session log lines.
+      const relayed = await waitForAsync(
+        async () =>
+          logger.lines.find(l =>
+            /refused connect from nettest \(pid \d+\) to 1\.1\.1\.1:443/.test(l)
+          ),
+        { timeoutMs: 5_000, intervalMs: 200 }
+      );
+      expect(relayed).toBeDefined();
+
+      // Processes from before the install are the uncovered set the coverage
+      // report names; nettest itself was covered.
+      const coverage = await reportLocalEgressGuardCoverageAsync({ env, logger });
+      expect(coverage!.uncovered.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('booted with an unwritable event log', () => {
+    beforeAll(async () => {
+      await rebootAsync(
+        await bootEnvironmentAsync('block', path.join(workDir, 'no-such-dir', 'guard.log'))
+      );
+    });
+
+    it('still refuses', async () => {
+      await verifyLocalEgressGuardAsync({ udid, env, logger, mode: 'block', checkPath });
+      const results = await runNettestAsync();
+      expect(results.urlsessionDirect).toBe('refused');
+      expect(results.bsdConnectDirect).toBe('refused');
+      expect(results.urlsessionProxied).toBe('ok(200)');
+    });
   });
 });

--- a/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ts
@@ -15,6 +15,7 @@ import {
   GuardLogTailer,
   buildGuardLaunchdEnvironment,
   installLocalEgressGuardAsync,
+  parseGuardCoverage,
   parseGuardLogLine,
   resolveEgressGuardLibraryAsync,
   stopLocalEgressGuardRelaysAsync,
@@ -355,6 +356,34 @@ describe(installLocalEgressGuardAsync, () => {
   });
 });
 
+describe(parseGuardCoverage, () => {
+  const ps = [
+    '    1     0 /sbin/launchd',
+    ' 4000     1 /Runtimes/x/sbin/launchd_sim',
+    ' 4001  4000 /Runtimes/x/System/Library/CoreServices/SpringBoard.app/SpringBoard',
+    ' 4002  4000 /Runtimes/x/usr/libexec/backboardd',
+    ' 4003  4001 /Containers/Bundle/Application/1/Expo Go.app/Expo Go',
+    ' 3758     1 node',
+  ].join('\n');
+  const lsof = [
+    'p4001',
+    'n/Runtimes/x/System/Library/CoreServices/SpringBoard.app/SpringBoard',
+    'n/usr/lib/dyld',
+    'p4003',
+    'n/Containers/Bundle/Application/1/Expo Go.app/Expo Go',
+    'n/Users/expo/build-tools/bin/egress-guard.dylib',
+    'p3758',
+    'n/usr/local/bin/node',
+  ].join('\n');
+
+  it('splits simulator processes by whether the guard library is mapped', () => {
+    expect(parseGuardCoverage(ps, lsof)).toEqual({
+      covered: ['Expo Go'],
+      uncovered: ['SpringBoard', 'backboardd'],
+    });
+  });
+});
+
 describe(verifyLocalEgressGuardAsync, () => {
   let logger: ReturnType<typeof createLogger>;
   beforeEach(() => {
@@ -363,10 +392,12 @@ describe(verifyLocalEgressGuardAsync, () => {
   });
 
   it('runs the packaged self-check inside the simulator and logs its verdict', async () => {
-    mockedSpawn.mockResolvedValue({
-      stdout: 'egress-guard-check: guard loaded; non-loopback connections are refused\n',
-      stderr: '',
-    } as any);
+    mockedSpawn
+      .mockResolvedValueOnce({
+        stdout: 'egress-guard-check: guard loaded; non-loopback connections are refused\n',
+        stderr: '',
+      } as any)
+      .mockResolvedValue({ stdout: '', stderr: '' } as any);
 
     await verifyLocalEgressGuardAsync({
       udid: 'u' as any,
@@ -380,9 +411,11 @@ describe(verifyLocalEgressGuardAsync, () => {
       ['simctl', 'spawn', 'u', '/w/bin/egress-guard-check', '--mode', 'block'],
       expect.objectContaining({ stdio: 'pipe' })
     );
-    expect(logger.lines.at(-1)?.msg).toContain(
-      'verified in the Simulator: egress-guard-check: guard loaded'
-    );
+    expect(
+      logger.lines.some(l =>
+        /verified in the Simulator: egress-guard-check: guard loaded/.test(l.msg)
+      )
+    ).toBe(true);
   });
 
   it('fails the session with the self-check output when the check fails', async () => {

--- a/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ts
@@ -1,4 +1,6 @@
+import { SystemError } from '@expo/eas-build-job';
 import { type bunyan } from '@expo/logger';
+import spawn from '@expo/turtle-spawn';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -16,6 +18,7 @@ import {
   parseGuardLogLine,
   resolveEgressGuardLibraryAsync,
   stopLocalEgressGuardRelaysAsync,
+  verifyLocalEgressGuardAsync,
 } from '../localEgressGuard';
 
 jest.mock('@expo/turtle-spawn');
@@ -24,6 +27,7 @@ jest.mock('../../../utils/IosSimulatorUtils', () => ({
 }));
 
 const mockedSetEnv = jest.mocked(IosSimulatorUtils.setLaunchdEnvironmentAsync);
+const mockedSpawn = jest.mocked(spawn);
 
 function createLogger(): bunyan & { lines: { level: string; msg: string }[] } {
   const lines: { level: string; msg: string }[] = [];
@@ -126,6 +130,14 @@ describe(GuardEventRelay, () => {
     expect(relay.summary()).toEqual({ blocked: 0, logged: 2, distinct: 2, suppressed: 1 });
   });
 
+  it('ignores the self-check probe, which trips the guard on purpose', () => {
+    const logger = createLogger();
+    const relay = new GuardEventRelay(logger);
+    relay.handle(blocked('egress-guard-check', '192.0.2.1:9'));
+    expect(logger.lines).toHaveLength(0);
+    expect(relay.summary()).toEqual({ blocked: 0, logged: 0, distinct: 0, suppressed: 0 });
+  });
+
   it('writes a summary line', () => {
     const logger = createLogger();
     const relay = new GuardEventRelay(logger);
@@ -206,6 +218,8 @@ describe(installLocalEgressGuardAsync, () => {
   beforeEach(async () => {
     mockedSetEnv.mockReset();
     mockedSetEnv.mockResolvedValue(undefined);
+    mockedSpawn.mockReset();
+    mockedSpawn.mockResolvedValue({ stdout: '', stderr: '' } as any);
     dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'guard-install-'));
     logger = createLogger();
   });
@@ -228,7 +242,7 @@ describe(installLocalEgressGuardAsync, () => {
     expect(mockedSetEnv).not.toHaveBeenCalled();
   });
 
-  it('warns and continues when the library is not available', async () => {
+  it('fails the session when the library is not available', async () => {
     const handoffPath = path.join(dir, 'handoff.json');
     await writeLocalEgressHandoffAsync(handoff, handoffPath);
     await expect(
@@ -240,9 +254,42 @@ describe(installLocalEgressGuardAsync, () => {
         libraryPath: null,
         logPath: path.join(dir, 'guard.log'),
       })
-    ).resolves.toBe(false);
+    ).rejects.toThrow(SystemError);
     expect(mockedSetEnv).not.toHaveBeenCalled();
-    expect(logger.lines.some(l => l.level === 'warn' && /not available/.test(l.msg))).toBe(true);
+  });
+
+  it('logs the simulator processes that were already running and are not covered', async () => {
+    const handoffPath = path.join(dir, 'handoff.json');
+    await writeLocalEgressHandoffAsync(handoff, handoffPath);
+    const libraryPath = path.join(dir, 'egress-guard.dylib');
+    await fs.promises.writeFile(libraryPath, '');
+    mockedSpawn.mockResolvedValue({
+      stdout: [
+        '    1     0 /sbin/launchd',
+        ' 4000     1 /Library/Developer/CoreSimulator/Volumes/iOS/Runtimes/x/sbin/launchd_sim',
+        ' 4001  4000 /Library/Developer/CoreSimulator/Volumes/iOS/Runtimes/x/System/Library/CoreServices/SpringBoard.app/SpringBoard',
+        ' 4002  4000 /Library/Developer/CoreSimulator/Volumes/iOS/Runtimes/x/usr/libexec/backboardd',
+        ' 3758     1 node',
+      ].join('\n'),
+      stderr: '',
+    } as any);
+
+    await installLocalEgressGuardAsync({
+      udid: 'u' as any,
+      env: process.env,
+      logger,
+      handoffPath,
+      libraryPath,
+      logPath: path.join(dir, 'guard.log'),
+    });
+
+    expect(
+      logger.lines.some(l =>
+        /2 simulator process\(es\) were already running .* not covered by it: SpringBoard, backboardd\./.test(
+          l.msg
+        )
+      )
+    ).toBe(true);
   });
 
   it('sets the launchd environment, creates the log file, and relays events into the session log', async () => {
@@ -288,7 +335,7 @@ describe(installLocalEgressGuardAsync, () => {
     expect(logger.lines.at(-1)?.msg).toContain('refused 1 connection attempt(s)');
   });
 
-  it('warns and continues when launchctl fails', async () => {
+  it('fails the session when launchctl fails', async () => {
     const handoffPath = path.join(dir, 'handoff.json');
     await writeLocalEgressHandoffAsync(handoff, handoffPath);
     const libraryPath = path.join(dir, 'egress-guard.dylib');
@@ -304,9 +351,63 @@ describe(installLocalEgressGuardAsync, () => {
         libraryPath,
         logPath: path.join(dir, 'guard.log'),
       })
-    ).resolves.toBe(false);
-    expect(logger.lines.some(l => l.level === 'warn' && /could not install/.test(l.msg))).toBe(
-      true
+    ).rejects.toThrow(/Could not install the local egress guard/);
+  });
+});
+
+describe(verifyLocalEgressGuardAsync, () => {
+  let logger: ReturnType<typeof createLogger>;
+  beforeEach(() => {
+    mockedSpawn.mockReset();
+    logger = createLogger();
+  });
+
+  it('runs the packaged self-check inside the simulator and logs its verdict', async () => {
+    mockedSpawn.mockResolvedValue({
+      stdout: 'egress-guard-check: guard loaded; non-loopback connections are refused\n',
+      stderr: '',
+    } as any);
+
+    await verifyLocalEgressGuardAsync({
+      udid: 'u' as any,
+      env: process.env,
+      logger,
+      checkPath: '/w/bin/egress-guard-check',
+    });
+
+    expect(mockedSpawn).toHaveBeenCalledWith(
+      'xcrun',
+      ['simctl', 'spawn', 'u', '/w/bin/egress-guard-check', '--mode', 'block'],
+      expect.objectContaining({ stdio: 'pipe' })
     );
+    expect(logger.lines.at(-1)?.msg).toContain(
+      'verified in the Simulator: egress-guard-check: guard loaded'
+    );
+  });
+
+  it('fails the session with the self-check output when the check fails', async () => {
+    mockedSpawn.mockRejectedValue(
+      Object.assign(new Error('exited with non-zero code: 2'), {
+        status: 2,
+        stdout: 'egress-guard-check: the guard library is not loaded in this process\n',
+        stderr: '',
+      })
+    );
+
+    await expect(
+      verifyLocalEgressGuardAsync({
+        udid: 'u' as any,
+        env: process.env,
+        logger,
+        checkPath: '/w/bin/egress-guard-check',
+      })
+    ).rejects.toThrow(/not in effect .*\(exit 2\).*guard library is not loaded/);
+  });
+
+  it('fails the session when the self-check binary is missing', async () => {
+    await expect(
+      verifyLocalEgressGuardAsync({ udid: 'u' as any, env: process.env, logger, checkPath: null })
+    ).rejects.toThrow(/self-check is not available/);
+    expect(mockedSpawn).not.toHaveBeenCalled();
   });
 });

--- a/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ts
@@ -15,9 +15,11 @@ import {
   GuardLogTailer,
   buildGuardLaunchdEnvironment,
   installLocalEgressGuardAsync,
+  mergeGuardCoverageSamples,
   parseGuardCoverage,
   parseGuardLogLine,
   resolveEgressGuardLibraryAsync,
+  resolveLocalEgressBootEnvironmentAsync,
   stopLocalEgressGuardRelaysAsync,
   verifyLocalEgressGuardAsync,
 } from '../localEgressGuard';
@@ -356,6 +358,54 @@ describe(installLocalEgressGuardAsync, () => {
   });
 });
 
+describe(resolveLocalEgressBootEnvironmentAsync, () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'guard-bootenv-'));
+  });
+  afterEach(async () => {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns null without a local egress session', async () => {
+    await expect(
+      resolveLocalEgressBootEnvironmentAsync({ handoffPath: path.join(dir, 'missing.json') })
+    ).resolves.toBeNull();
+  });
+
+  it('fails when the guard library is not available', async () => {
+    const handoffPath = path.join(dir, 'handoff.json');
+    await writeLocalEgressHandoffAsync(handoff, handoffPath);
+    await expect(
+      resolveLocalEgressBootEnvironmentAsync({ handoffPath, libraryPath: null })
+    ).rejects.toThrow(SystemError);
+  });
+
+  it('combines the guard variables with the proxy variables for the handoff port', async () => {
+    const handoffPath = path.join(dir, 'handoff.json');
+    await writeLocalEgressHandoffAsync({ ...handoff, port: 8899 }, handoffPath);
+    await expect(
+      resolveLocalEgressBootEnvironmentAsync({
+        handoffPath,
+        libraryPath: '/w/bin/egress-guard.dylib',
+        logPath: '/tmp/guard.log',
+        mode: 'block',
+      })
+    ).resolves.toEqual({
+      DYLD_INSERT_LIBRARIES: '/w/bin/egress-guard.dylib',
+      [EGRESS_GUARD_LOG_ENV]: '/tmp/guard.log',
+      [EGRESS_GUARD_MODE_ENV]: 'block',
+      http_proxy: 'http://127.0.0.1:8899',
+      https_proxy: 'http://127.0.0.1:8899',
+      HTTP_PROXY: 'http://127.0.0.1:8899',
+      HTTPS_PROXY: 'http://127.0.0.1:8899',
+      grpc_proxy: 'http://127.0.0.1:8899',
+      no_proxy: 'localhost,127.0.0.1,::1',
+      NO_PROXY: 'localhost,127.0.0.1,::1',
+    });
+  });
+});
+
 describe(parseGuardCoverage, () => {
   const ps = [
     '    1     0 /sbin/launchd',
@@ -380,7 +430,30 @@ describe(parseGuardCoverage, () => {
     expect(parseGuardCoverage(ps, lsof)).toEqual({
       covered: ['Expo Go'],
       uncovered: ['SpringBoard', 'backboardd'],
+      uncoveredPids: [4001, 4002],
     });
+  });
+
+  it('only keeps processes uncovered in both samples, so exec-in-progress ones drop out', () => {
+    const first = parseGuardCoverage(ps, lsof);
+    const secondPs = ps + '\n 4009  4000 /Runtimes/x/usr/libexec/newlystarted';
+    const second = parseGuardCoverage(
+      secondPs,
+      lsof + '\np4002\nn/Users/expo/bin/egress-guard.dylib'
+    );
+    expect(mergeGuardCoverageSamples(first, second)).toEqual({
+      covered: ['Expo Go', 'backboardd'],
+      uncovered: ['SpringBoard'],
+      uncoveredPids: [4001],
+    });
+  });
+
+  it("ignores launchd's exec trampoline, which has nothing mapped yet", () => {
+    const withTrampoline = ps + '\n 4004  4000 /Runtimes/x/usr/libexec/xpcproxy_sim';
+    expect(parseGuardCoverage(withTrampoline, lsof).uncovered).toEqual([
+      'SpringBoard',
+      'backboardd',
+    ]);
   });
 });
 

--- a/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ts
@@ -18,6 +18,7 @@ import {
   mergeGuardCoverageSamples,
   parseGuardCoverage,
   parseGuardLogLine,
+  rebindLocalEgressGuardRelays,
   resolveEgressGuardLibraryAsync,
   resolveLocalEgressBootEnvironmentAsync,
   stopLocalEgressGuardRelaysAsync,
@@ -336,6 +337,36 @@ describe(installLocalEgressGuardAsync, () => {
 
     await stopLocalEgressGuardRelaysAsync(logger);
     expect(logger.lines.at(-1)?.msg).toContain('refused 1 connection attempt(s)');
+  });
+
+  it('attributes later events and the summary to a rebound logger', async () => {
+    const handoffPath = path.join(dir, 'handoff.json');
+    await writeLocalEgressHandoffAsync(handoff, handoffPath);
+    const libraryPath = path.join(dir, 'egress-guard.dylib');
+    await fs.promises.writeFile(libraryPath, '');
+    const logPath = path.join(dir, 'guard.log');
+    await installLocalEgressGuardAsync({
+      udid: 'u' as any,
+      env: process.env,
+      logger,
+      handoffPath,
+      libraryPath,
+      logPath,
+      tailIntervalMs: 20,
+    });
+
+    const sessionLogger = createLogger();
+    rebindLocalEgressGuardRelays(sessionLogger);
+    await fs.promises.appendFile(
+      logPath,
+      'eas-egress-guard\tMyApp\t4242\tconnect\tblocked\t1.1.1.1:443\tNetwork\n'
+    );
+    await sleep(80);
+    expect(sessionLogger.lines.some(l => /refused connect from MyApp/.test(l.msg))).toBe(true);
+    expect(logger.lines.some(l => /refused connect from MyApp/.test(l.msg))).toBe(false);
+
+    await stopLocalEgressGuardRelaysAsync(logger);
+    expect(sessionLogger.lines.at(-1)?.msg).toContain('refused 1 connection attempt(s)');
   });
 
   it('fails the session when launchctl fails', async () => {

--- a/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ts
+++ b/packages/build-tools/src/steps/utils/__tests__/localEgressGuard.test.ts
@@ -1,0 +1,312 @@
+import { type bunyan } from '@expo/logger';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+import { IosSimulatorUtils } from '../../../utils/IosSimulatorUtils';
+import { writeLocalEgressHandoffAsync } from '../localEgress';
+import {
+  EGRESS_GUARD_LOG_ENV,
+  EGRESS_GUARD_MODE_ENV,
+  GuardEventRelay,
+  GuardLogTailer,
+  buildGuardLaunchdEnvironment,
+  installLocalEgressGuardAsync,
+  parseGuardLogLine,
+  resolveEgressGuardLibraryAsync,
+  stopLocalEgressGuardRelaysAsync,
+} from '../localEgressGuard';
+
+jest.mock('@expo/turtle-spawn');
+jest.mock('../../../utils/IosSimulatorUtils', () => ({
+  IosSimulatorUtils: { setLaunchdEnvironmentAsync: jest.fn() },
+}));
+
+const mockedSetEnv = jest.mocked(IosSimulatorUtils.setLaunchdEnvironmentAsync);
+
+function createLogger(): bunyan & { lines: { level: string; msg: string }[] } {
+  const lines: { level: string; msg: string }[] = [];
+  const record = (level: string) => (a: unknown, b?: unknown) =>
+    lines.push({ level, msg: typeof a === 'string' ? a : String(b) });
+  return { info: record('info'), warn: record('warn'), debug: record('debug'), lines } as any;
+}
+
+const handoff = { url: 'https://egress.example', token: 'pw', fingerprint: 'fp=', port: 8899 };
+
+describe(buildGuardLaunchdEnvironment, () => {
+  it('inserts the library and passes the log path and mode', () => {
+    expect(
+      buildGuardLaunchdEnvironment({
+        libraryPath: '/w/bin/egress-guard.dylib',
+        logPath: '/tmp/guard.log',
+        mode: 'block',
+      })
+    ).toEqual({
+      DYLD_INSERT_LIBRARIES: '/w/bin/egress-guard.dylib',
+      [EGRESS_GUARD_LOG_ENV]: '/tmp/guard.log',
+      [EGRESS_GUARD_MODE_ENV]: 'block',
+    });
+  });
+});
+
+describe(parseGuardLogLine, () => {
+  it('parses a blocked event with callers', () => {
+    expect(
+      parseGuardLogLine(
+        'eas-egress-guard\tMyApp\t4242\tconnect\tblocked\t93.184.216.34:443\tNetwork,CFNetwork,MyApp'
+      )
+    ).toEqual({
+      process: 'MyApp',
+      pid: 4242,
+      function: 'connect',
+      action: 'blocked',
+      peer: '93.184.216.34:443',
+      callers: ['Network', 'CFNetwork', 'MyApp'],
+    });
+  });
+
+  it('parses a logged event without callers and IPv6 peers', () => {
+    expect(
+      parseGuardLogLine('eas-egress-guard\tdaemon\t7\tsendto\tlogged\t[2606:4700::1]:53\t')
+    ).toEqual({
+      process: 'daemon',
+      pid: 7,
+      function: 'sendto',
+      action: 'logged',
+      peer: '[2606:4700::1]:53',
+      callers: [],
+    });
+  });
+
+  it('ignores lines that are not guard events', () => {
+    expect(parseGuardLogLine('')).toBeNull();
+    expect(parseGuardLogLine('something else\ta\tb')).toBeNull();
+    expect(
+      parseGuardLogLine('eas-egress-guard\tMyApp\tnot-a-pid\tconnect\tblocked\t1.1.1.1:443\t')
+    ).toBeNull();
+    expect(
+      parseGuardLogLine('eas-egress-guard\tMyApp\t1\tconnect\tmaybe\t1.1.1.1:443\t')
+    ).toBeNull();
+  });
+});
+
+describe(GuardEventRelay, () => {
+  const blocked = (process: string, peer: string, pid = 1) => ({
+    process,
+    pid,
+    function: 'connect',
+    action: 'blocked' as const,
+    peer,
+    callers: ['Network', 'CFNetwork'],
+  });
+
+  it('logs the first sighting of a process and destination, then only counts', () => {
+    const logger = createLogger();
+    const relay = new GuardEventRelay(logger);
+    relay.handle(blocked('MyApp', '1.1.1.1:443'));
+    relay.handle(blocked('MyApp', '1.1.1.1:443', 2));
+    relay.handle(blocked('MyApp', '2.2.2.2:443'));
+    expect(logger.lines.map(l => l.msg)).toEqual([
+      expect.stringContaining(
+        'refused connect from MyApp (pid 1) to 1.1.1.1:443; callers: Network, CFNetwork'
+      ),
+      expect.stringContaining('refused connect from MyApp (pid 1) to 2.2.2.2:443'),
+    ]);
+    expect(relay.summary()).toEqual({ blocked: 3, logged: 0, distinct: 2, suppressed: 0 });
+  });
+
+  it('words observed events differently and stops logging past the limit', () => {
+    const logger = createLogger();
+    const relay = new GuardEventRelay(logger, /* limit */ 1);
+    relay.handle({ ...blocked('MyApp', '1.1.1.1:443'), action: 'logged' });
+    relay.handle({ ...blocked('MyApp', '2.2.2.2:443'), action: 'logged' });
+    expect(logger.lines).toHaveLength(1);
+    expect(logger.lines[0].msg).toContain('observed connect from MyApp');
+    expect(relay.summary()).toEqual({ blocked: 0, logged: 2, distinct: 2, suppressed: 1 });
+  });
+
+  it('writes a summary line', () => {
+    const logger = createLogger();
+    const relay = new GuardEventRelay(logger);
+    relay.handle(blocked('MyApp', '1.1.1.1:443'));
+    relay.handle(blocked('MyApp', '1.1.1.1:443'));
+    relay.handle(blocked('daemon', '3.3.3.3:443', 9));
+    relay.logSummary();
+    expect(logger.lines.at(-1)?.msg).toContain(
+      'refused 3 connection attempt(s) to 2 distinct destination(s) from 2 process(es)'
+    );
+  });
+});
+
+describe(GuardLogTailer, () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'guard-tailer-'));
+  });
+  afterEach(async () => {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  });
+
+  it('delivers whole lines as they are appended, keeps partial lines, and survives truncation', async () => {
+    const file = path.join(dir, 'guard.log');
+    const lines: string[] = [];
+    const tailer = new GuardLogTailer({ path: file, onLine: l => lines.push(l), intervalMs: 20 });
+    tailer.start();
+    await sleep(50); // file does not exist yet; must not throw
+    await fs.promises.writeFile(file, 'first\nsecond\npart', 'utf8');
+    await sleep(80);
+    expect(lines).toEqual(['first', 'second']);
+    await fs.promises.appendFile(file, 'ial\n', 'utf8');
+    await sleep(80);
+    expect(lines).toEqual(['first', 'second', 'partial']);
+    await fs.promises.writeFile(file, 'after-truncate\n', 'utf8');
+    await sleep(80);
+    expect(lines).toEqual(['first', 'second', 'partial', 'after-truncate']);
+    await tailer.stopAsync();
+    await fs.promises.appendFile(file, 'late\n', 'utf8');
+    await sleep(60);
+    expect(lines).not.toContain('late');
+  });
+
+  it('flushes what is already in the file when stopped', async () => {
+    const file = path.join(dir, 'guard.log');
+    const lines: string[] = [];
+    const tailer = new GuardLogTailer({
+      path: file,
+      onLine: l => lines.push(l),
+      intervalMs: 10_000,
+    });
+    tailer.start();
+    await fs.promises.writeFile(file, 'only\n', 'utf8');
+    await tailer.stopAsync();
+    expect(lines).toEqual(['only']);
+  });
+});
+
+describe(resolveEgressGuardLibraryAsync, () => {
+  it('returns null when the library is not built', async () => {
+    await expect(
+      resolveEgressGuardLibraryAsync(path.join(os.tmpdir(), 'no-such-dir'))
+    ).resolves.toBeNull();
+  });
+
+  it('returns the packaged path when present', async () => {
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'guard-bin-'));
+    const lib = path.join(dir, 'egress-guard.dylib');
+    await fs.promises.writeFile(lib, '');
+    await expect(resolveEgressGuardLibraryAsync(dir)).resolves.toBe(lib);
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  });
+});
+
+describe(installLocalEgressGuardAsync, () => {
+  let dir: string;
+  let logger: ReturnType<typeof createLogger>;
+  beforeEach(async () => {
+    mockedSetEnv.mockReset();
+    mockedSetEnv.mockResolvedValue(undefined);
+    dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'guard-install-'));
+    logger = createLogger();
+  });
+  afterEach(async () => {
+    await stopLocalEgressGuardRelaysAsync(logger);
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  });
+
+  it('does nothing without a local egress session', async () => {
+    await expect(
+      installLocalEgressGuardAsync({
+        udid: 'u' as any,
+        env: process.env,
+        logger,
+        handoffPath: path.join(dir, 'missing.json'),
+        libraryPath: path.join(dir, 'egress-guard.dylib'),
+        logPath: path.join(dir, 'guard.log'),
+      })
+    ).resolves.toBe(false);
+    expect(mockedSetEnv).not.toHaveBeenCalled();
+  });
+
+  it('warns and continues when the library is not available', async () => {
+    const handoffPath = path.join(dir, 'handoff.json');
+    await writeLocalEgressHandoffAsync(handoff, handoffPath);
+    await expect(
+      installLocalEgressGuardAsync({
+        udid: 'u' as any,
+        env: process.env,
+        logger,
+        handoffPath,
+        libraryPath: null,
+        logPath: path.join(dir, 'guard.log'),
+      })
+    ).resolves.toBe(false);
+    expect(mockedSetEnv).not.toHaveBeenCalled();
+    expect(logger.lines.some(l => l.level === 'warn' && /not available/.test(l.msg))).toBe(true);
+  });
+
+  it('sets the launchd environment, creates the log file, and relays events into the session log', async () => {
+    const handoffPath = path.join(dir, 'handoff.json');
+    await writeLocalEgressHandoffAsync(handoff, handoffPath);
+    const libraryPath = path.join(dir, 'egress-guard.dylib');
+    await fs.promises.writeFile(libraryPath, '');
+    const logPath = path.join(dir, 'guard.log');
+
+    await expect(
+      installLocalEgressGuardAsync({
+        udid: 'u' as any,
+        env: process.env,
+        logger,
+        handoffPath,
+        libraryPath,
+        logPath,
+        mode: 'block',
+        tailIntervalMs: 20,
+      })
+    ).resolves.toBe(true);
+
+    expect(mockedSetEnv).toHaveBeenCalledWith({
+      udid: 'u',
+      env: process.env,
+      variables: buildGuardLaunchdEnvironment({ libraryPath, logPath, mode: 'block' }),
+    });
+    expect(fs.existsSync(logPath)).toBe(true);
+    expect(logger.lines.some(l => /guard installed/.test(l.msg) && /block/.test(l.msg))).toBe(true);
+
+    await fs.promises.appendFile(
+      logPath,
+      'eas-egress-guard\tMyApp\t4242\tconnect\tblocked\t1.1.1.1:443\tNetwork\n'
+    );
+    await sleep(80);
+    expect(
+      logger.lines.some(l =>
+        /refused connect from MyApp \(pid 4242\) to 1\.1\.1\.1:443/.test(l.msg)
+      )
+    ).toBe(true);
+
+    await stopLocalEgressGuardRelaysAsync(logger);
+    expect(logger.lines.at(-1)?.msg).toContain('refused 1 connection attempt(s)');
+  });
+
+  it('warns and continues when launchctl fails', async () => {
+    const handoffPath = path.join(dir, 'handoff.json');
+    await writeLocalEgressHandoffAsync(handoff, handoffPath);
+    const libraryPath = path.join(dir, 'egress-guard.dylib');
+    await fs.promises.writeFile(libraryPath, '');
+    mockedSetEnv.mockRejectedValue(new Error('launchctl failed'));
+
+    await expect(
+      installLocalEgressGuardAsync({
+        udid: 'u' as any,
+        env: process.env,
+        logger,
+        handoffPath,
+        libraryPath,
+        logPath: path.join(dir, 'guard.log'),
+      })
+    ).resolves.toBe(false);
+    expect(logger.lines.some(l => l.level === 'warn' && /could not install/.test(l.msg))).toBe(
+      true
+    );
+  });
+});

--- a/packages/build-tools/src/steps/utils/localEgress.ts
+++ b/packages/build-tools/src/steps/utils/localEgress.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import zlib from 'node:zlib';
 
+import { IosSimulatorUtils, type IosSimulatorUuid } from '../../utils/IosSimulatorUtils';
 import { sleepAsync } from '../../utils/retry';
 
 import { type DetachedProcessHandle, spawnDetached } from './remoteDeviceRunSession';
@@ -342,6 +343,82 @@ export async function configureSystemProxyAsync({
   }
   logger.info(`System proxy for "${service}" set to ${LOCAL_EGRESS_PROXY_HOST}:${port}.`);
   return { service };
+}
+
+export const LOCAL_EGRESS_NO_PROXY = 'localhost,127.0.0.1,::1';
+
+/**
+ * Proxy environment for processes inside the simulator. CFNetwork ignores these
+ * variables and follows the system proxy, but clients with their own network
+ * stack that read them (gRPC and therefore Firestore, libcurl, Go) then send
+ * HTTP CONNECT requests to the same loopback port. Loopback is excluded so the
+ * ports forwarded for `--egress-allow` behave the same on both paths. Lowercase
+ * and uppercase forms are both set because clients differ in which they read.
+ */
+export function buildLocalEgressSimulatorEnvironment(port: number): Record<string, string> {
+  const proxyUrl = `http://${LOCAL_EGRESS_PROXY_HOST}:${port}`;
+  return {
+    http_proxy: proxyUrl,
+    https_proxy: proxyUrl,
+    HTTP_PROXY: proxyUrl,
+    HTTPS_PROXY: proxyUrl,
+    grpc_proxy: proxyUrl,
+    no_proxy: LOCAL_EGRESS_NO_PROXY,
+    NO_PROXY: LOCAL_EGRESS_NO_PROXY,
+  };
+}
+
+/**
+ * Set the local egress proxy environment in a booted simulator when a local
+ * egress session is active. Returns false when local egress is not configured
+ * or the environment could not be set. Failure is a warning, not an error: the
+ * session still works, but clients that read these variables then exit from
+ * this worker instead of the egress client, which the warning spells out.
+ */
+export async function configureSimulatorProxyEnvironmentAsync({
+  udid,
+  env,
+  logger,
+  handoffPath = LOCAL_EGRESS_HANDOFF_PATH,
+}: {
+  udid: IosSimulatorUuid;
+  env: NodeJS.ProcessEnv;
+  logger: bunyan;
+  handoffPath?: string;
+}): Promise<boolean> {
+  let handoff: LocalEgressHandoff | null;
+  try {
+    handoff = await readLocalEgressHandoffAsync(handoffPath);
+  } catch (err) {
+    logger.warn(
+      { err },
+      'Local egress: could not read the local egress handoff, so proxy environment variables were ' +
+        'not set in the Simulator. Clients that read http_proxy/https_proxy (for example gRPC and ' +
+        'libcurl) will bypass local egress and exit from this worker.'
+    );
+    return false;
+  }
+  if (!handoff) {
+    return false;
+  }
+  const variables = buildLocalEgressSimulatorEnvironment(handoff.port);
+  try {
+    await IosSimulatorUtils.setLaunchdEnvironmentAsync({ udid, env, variables });
+  } catch (err) {
+    logger.warn(
+      { err },
+      'Local egress: could not set proxy environment variables in the Simulator. Clients that read ' +
+        'http_proxy/https_proxy (for example gRPC and libcurl) will bypass local egress and exit from ' +
+        'this worker. CFNetwork clients (WebKit, URLSession) still follow the system proxy.'
+    );
+    return false;
+  }
+  logger.info(
+    `Local egress: proxy environment variables set in the Simulator (${Object.keys(variables).join(
+      ', '
+    )}), so clients that read them, such as gRPC and libcurl, also exit from the egress client.`
+  );
+  return true;
 }
 
 export async function writeLocalEgressHandoffAsync(

--- a/packages/build-tools/src/steps/utils/localEgressGuard.ts
+++ b/packages/build-tools/src/steps/utils/localEgressGuard.ts
@@ -9,6 +9,7 @@ import { IosSimulatorUtils, type IosSimulatorUuid } from '../../utils/IosSimulat
 
 import {
   LOCAL_EGRESS_HANDOFF_PATH,
+  buildLocalEgressSimulatorEnvironment,
   collectSimulatorProcessIds,
   readLocalEgressHandoffAsync,
 } from './localEgress';
@@ -253,6 +254,45 @@ export class GuardLogTailer {
   }
 }
 
+/**
+ * The environment the simulator's launchd must have from its first process:
+ * the guard and the proxy variables. Pass it to `IosSimulatorUtils.bootAsync`,
+ * which hands it to launchd before anything is spawned; `launchctl setenv`
+ * after boot only reaches later processes. Returns null when no local egress
+ * session is active. Throws when the guard library is not packaged, since a
+ * local egress session without it would silently leak.
+ */
+export async function resolveLocalEgressBootEnvironmentAsync({
+  handoffPath = LOCAL_EGRESS_HANDOFF_PATH,
+  libraryPath,
+  logPath = LOCAL_EGRESS_GUARD_LOG_PATH,
+  mode = 'block',
+}: {
+  handoffPath?: string;
+  /** Explicit library path, `null` for "not available"; resolved from the package when omitted. */
+  libraryPath?: string | null;
+  logPath?: string;
+  mode?: EgressGuardMode;
+} = {}): Promise<Record<string, string> | null> {
+  const handoff = await readLocalEgressHandoffAsync(handoffPath);
+  if (!handoff) {
+    return null;
+  }
+  const resolvedLibrary =
+    libraryPath === undefined ? await resolveEgressGuardLibraryAsync() : libraryPath;
+  if (!resolvedLibrary) {
+    throw new SystemError(
+      'The local egress guard library is not available on this device host, so this local egress session ' +
+        'cannot guarantee that connections bypassing the system proxy are refused. The device host image is ' +
+        'missing bin/egress-guard.dylib; this is a service problem, please contact support.'
+    );
+  }
+  return {
+    ...buildGuardLaunchdEnvironment({ libraryPath: resolvedLibrary, logPath, mode }),
+    ...buildLocalEgressSimulatorEnvironment(handoff.port),
+  };
+}
+
 type ActiveRelay = { tailer: GuardLogTailer; relay: GuardEventRelay };
 const activeRelays = new Map<string, ActiveRelay>();
 
@@ -407,11 +447,19 @@ async function logAlreadyRunningProcessesAsync({
   );
 }
 
+/**
+ * launchd's trampoline exists for milliseconds between fork and exec of the
+ * real service, with nothing mapped yet; it never makes a connection itself.
+ */
+const COVERAGE_IGNORED_PROCESSES = new Set(['xpcproxy_sim']);
+
 export type GuardCoverage = {
   /** Simulator processes with the guard library mapped. */
   covered: string[];
   /** Simulator processes without it: started before the guard was installed. */
   uncovered: string[];
+  /** Pids behind `uncovered`, for comparing samples. */
+  uncoveredPids: number[];
 };
 
 /**
@@ -439,13 +487,44 @@ export function parseGuardCoverage(psOutput: string, lsofOutput: string): GuardC
   }
   const covered: string[] = [];
   const uncovered: string[] = [];
+  const uncoveredPids: number[] = [];
   for (const simulatorPid of simulatorPids) {
     const name = commandsByPid.get(simulatorPid) ?? String(simulatorPid);
-    (loaded.has(simulatorPid) ? covered : uncovered).push(name);
+    if (COVERAGE_IGNORED_PROCESSES.has(name)) {
+      continue;
+    }
+    if (loaded.has(simulatorPid)) {
+      covered.push(name);
+    } else {
+      uncovered.push(name);
+      uncoveredPids.push(simulatorPid);
+    }
   }
   covered.sort();
   uncovered.sort();
-  return { covered, uncovered };
+  return { covered, uncovered, uncoveredPids };
+}
+
+/**
+ * A process caught between fork and exec has nothing mapped yet and looks
+ * uncovered for an instant. Two samples a moment apart separate those from
+ * processes that really run without the guard: only pids uncovered in both
+ * count, reported with the later sample's names.
+ */
+export function mergeGuardCoverageSamples(
+  first: GuardCoverage,
+  second: GuardCoverage
+): GuardCoverage {
+  const persistent = new Set(first.uncoveredPids.filter(pid => second.uncoveredPids.includes(pid)));
+  const uncovered: string[] = [];
+  const uncoveredPids: number[] = [];
+  second.uncoveredPids.forEach((pid, index) => {
+    if (persistent.has(pid)) {
+      uncovered.push(second.uncovered[index]);
+      uncoveredPids.push(pid);
+    }
+  });
+  return { covered: second.covered, uncovered, uncoveredPids };
 }
 
 /**
@@ -456,9 +535,39 @@ export function parseGuardCoverage(psOutput: string, lsofOutput: string): GuardC
 export async function reportLocalEgressGuardCoverageAsync({
   env,
   logger,
+  sampleIntervalMs = 1_000,
 }: {
   env: NodeJS.ProcessEnv;
   logger: bunyan;
+  sampleIntervalMs?: number;
+}): Promise<GuardCoverage | null> {
+  const first = await sampleGuardCoverageAsync({ env });
+  if (!first) {
+    return null;
+  }
+  await new Promise(resolve => setTimeout(resolve, sampleIntervalMs));
+  const second = await sampleGuardCoverageAsync({ env });
+  const coverage = second ? mergeGuardCoverageSamples(first, second) : first;
+  const total = coverage.covered.length + coverage.uncovered.length;
+  if (coverage.uncovered.length === 0) {
+    logger.info(
+      `Local egress guard coverage: all ${total} simulator process(es) have the guard loaded.`
+    );
+  } else {
+    const shown =
+      coverage.uncovered.slice(0, 20).join(', ') +
+      (coverage.uncovered.length > 20 ? `, and ${coverage.uncovered.length - 20} more` : '');
+    logger.info(
+      `Local egress guard coverage: ${coverage.covered.length} of ${total} simulator process(es) have the guard loaded. Not covered, started before the guard was installed: ${shown}.`
+    );
+  }
+  return coverage;
+}
+
+async function sampleGuardCoverageAsync({
+  env,
+}: {
+  env: NodeJS.ProcessEnv;
 }): Promise<GuardCoverage | null> {
   let psOutput: string;
   try {
@@ -486,21 +595,7 @@ export async function reportLocalEgressGuardCoverageAsync({
     }
     lsofOutput = result.stdout ?? '';
   }
-  const coverage = parseGuardCoverage(psOutput, lsofOutput);
-  const total = coverage.covered.length + coverage.uncovered.length;
-  if (coverage.uncovered.length === 0) {
-    logger.info(
-      `Local egress guard coverage: all ${total} simulator process(es) have the guard loaded.`
-    );
-  } else {
-    const shown =
-      coverage.uncovered.slice(0, 20).join(', ') +
-      (coverage.uncovered.length > 20 ? `, and ${coverage.uncovered.length - 20} more` : '');
-    logger.info(
-      `Local egress guard coverage: ${coverage.covered.length} of ${total} simulator process(es) have the guard loaded. Not covered, started before the guard was installed: ${shown}.`
-    );
-  }
-  return coverage;
+  return parseGuardCoverage(psOutput, lsofOutput);
 }
 
 /**

--- a/packages/build-tools/src/steps/utils/localEgressGuard.ts
+++ b/packages/build-tools/src/steps/utils/localEgressGuard.ts
@@ -407,6 +407,102 @@ async function logAlreadyRunningProcessesAsync({
   );
 }
 
+export type GuardCoverage = {
+  /** Simulator processes with the guard library mapped. */
+  covered: string[];
+  /** Simulator processes without it: started before the guard was installed. */
+  uncovered: string[];
+};
+
+/**
+ * Which simulator processes have the guard library mapped, from
+ * `ps -axo pid=,ppid=,comm=` and `lsof -nP -a -p <pids> -d txt -F pn` output.
+ * A process is covered when any of its mapped images is the guard library.
+ */
+export function parseGuardCoverage(psOutput: string, lsofOutput: string): GuardCoverage {
+  const simulatorPids = new Set(collectSimulatorProcessIds(psOutput));
+  const commandsByPid = new Map<number, string>();
+  for (const line of psOutput.split('\n')) {
+    const match = /^\s*(\d+)\s+\d+\s+(\S.*)$/.exec(line);
+    if (match) {
+      commandsByPid.set(Number(match[1]), path.basename(match[2].trim()));
+    }
+  }
+  const loaded = new Set<number>();
+  let pid: number | null = null;
+  for (const line of lsofOutput.split('\n')) {
+    if (line[0] === 'p') {
+      pid = Number(line.slice(1));
+    } else if (line[0] === 'n' && pid !== null && line.endsWith(EGRESS_GUARD_LIBRARY_FILE)) {
+      loaded.add(pid);
+    }
+  }
+  const covered: string[] = [];
+  const uncovered: string[] = [];
+  for (const simulatorPid of simulatorPids) {
+    const name = commandsByPid.get(simulatorPid) ?? String(simulatorPid);
+    (loaded.has(simulatorPid) ? covered : uncovered).push(name);
+  }
+  covered.sort();
+  uncovered.sort();
+  return { covered, uncovered };
+}
+
+/**
+ * Measure and log guard coverage across the simulator's processes. Observation
+ * only: the uncovered set is whatever started before the guard was installed,
+ * which is nothing when installation runs right after `simctl boot`.
+ */
+export async function reportLocalEgressGuardCoverageAsync({
+  env,
+  logger,
+}: {
+  env: NodeJS.ProcessEnv;
+  logger: bunyan;
+}): Promise<GuardCoverage | null> {
+  let psOutput: string;
+  try {
+    psOutput = (await spawn('ps', ['-axo', 'pid=,ppid=,comm='], { env, stdio: 'pipe' })).stdout;
+  } catch {
+    return null;
+  }
+  const pids = collectSimulatorProcessIds(psOutput);
+  if (pids.length === 0) {
+    return null;
+  }
+  let lsofOutput: string;
+  try {
+    lsofOutput = (
+      await spawn('lsof', ['-nP', '-a', '-p', pids.join(','), '-d', 'txt', '-F', 'pn'], {
+        env,
+        stdio: 'pipe',
+      })
+    ).stdout;
+  } catch (err) {
+    // lsof exits 1 when some listed pid has already exited; stdout is still valid.
+    const result = err as { status?: number | null; stdout?: string };
+    if (result.status !== 1) {
+      return null;
+    }
+    lsofOutput = result.stdout ?? '';
+  }
+  const coverage = parseGuardCoverage(psOutput, lsofOutput);
+  const total = coverage.covered.length + coverage.uncovered.length;
+  if (coverage.uncovered.length === 0) {
+    logger.info(
+      `Local egress guard coverage: all ${total} simulator process(es) have the guard loaded.`
+    );
+  } else {
+    const shown =
+      coverage.uncovered.slice(0, 20).join(', ') +
+      (coverage.uncovered.length > 20 ? `, and ${coverage.uncovered.length - 20} more` : '');
+    logger.info(
+      `Local egress guard coverage: ${coverage.covered.length} of ${total} simulator process(es) have the guard loaded. Not covered, started before the guard was installed: ${shown}.`
+    );
+  }
+  return coverage;
+}
+
 /**
  * Run the packaged self-check inside the simulator: it must find the guard
  * loaded in a fresh process and see it behave as `mode` says. Throws when the
@@ -453,6 +549,7 @@ export async function verifyLocalEgressGuardAsync({
     );
   }
   logger.info(`Local egress guard verified in the Simulator: ${output || 'self-check passed'}.`);
+  await reportLocalEgressGuardCoverageAsync({ env, logger });
 }
 
 /** Stop relaying and write each relay's summary; called from the session cleanup. */

--- a/packages/build-tools/src/steps/utils/localEgressGuard.ts
+++ b/packages/build-tools/src/steps/utils/localEgressGuard.ts
@@ -1,11 +1,17 @@
+import { SystemError } from '@expo/eas-build-job';
 import { type bunyan } from '@expo/logger';
+import spawn from '@expo/turtle-spawn';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
 import { IosSimulatorUtils, type IosSimulatorUuid } from '../../utils/IosSimulatorUtils';
 
-import { LOCAL_EGRESS_HANDOFF_PATH, readLocalEgressHandoffAsync } from './localEgress';
+import {
+  LOCAL_EGRESS_HANDOFF_PATH,
+  collectSimulatorProcessIds,
+  readLocalEgressHandoffAsync,
+} from './localEgress';
 
 /**
  * Worker side of the local egress guard: a dylib injected into every process
@@ -17,6 +23,7 @@ import { LOCAL_EGRESS_HANDOFF_PATH, readLocalEgressHandoffAsync } from './localE
  */
 
 export const EGRESS_GUARD_LIBRARY_FILE = 'egress-guard.dylib';
+export const EGRESS_GUARD_CHECK_FILE = 'egress-guard-check';
 export const EGRESS_GUARD_LOG_ENV = 'EAS_EGRESS_GUARD_LOG';
 export const EGRESS_GUARD_MODE_ENV = 'EAS_EGRESS_GUARD_MODE';
 export const LOCAL_EGRESS_GUARD_LOG_PATH = path.join(os.tmpdir(), 'eas-local-egress-guard.log');
@@ -73,17 +80,30 @@ export function parseGuardLogLine(line: string): GuardEvent | null {
   };
 }
 
-/** The packaged library, next to the compiled package like record-sim. */
-export async function resolveEgressGuardLibraryAsync(
-  binDir: string = path.join(__dirname, '..', '..', '..', 'bin')
-): Promise<string | null> {
-  const libraryPath = path.join(binDir, EGRESS_GUARD_LIBRARY_FILE);
+const PACKAGED_BIN_DIR = path.join(__dirname, '..', '..', '..', 'bin');
+
+async function resolvePackagedFileAsync(binDir: string, file: string): Promise<string | null> {
+  const filePath = path.join(binDir, file);
   try {
-    await fs.promises.access(libraryPath);
-    return libraryPath;
+    await fs.promises.access(filePath);
+    return filePath;
   } catch {
     return null;
   }
+}
+
+/** The packaged library, next to the compiled package like record-sim. */
+export async function resolveEgressGuardLibraryAsync(
+  binDir: string = PACKAGED_BIN_DIR
+): Promise<string | null> {
+  return await resolvePackagedFileAsync(binDir, EGRESS_GUARD_LIBRARY_FILE);
+}
+
+/** The packaged self-check binary, built alongside the library. */
+export async function resolveEgressGuardCheckAsync(
+  binDir: string = PACKAGED_BIN_DIR
+): Promise<string | null> {
+  return await resolvePackagedFileAsync(binDir, EGRESS_GUARD_CHECK_FILE);
 }
 
 /**
@@ -105,6 +125,10 @@ export class GuardEventRelay {
   ) {}
 
   handle(event: GuardEvent): void {
+    if (event.process === EGRESS_GUARD_CHECK_FILE) {
+      // The self-check deliberately trips the guard once; not a bypass.
+      return;
+    }
     if (event.action === 'blocked') {
       this.blocked++;
     } else {
@@ -233,11 +257,16 @@ type ActiveRelay = { tailer: GuardLogTailer; relay: GuardEventRelay };
 const activeRelays = new Map<string, ActiveRelay>();
 
 /**
- * Install the guard into a booted simulator when a local egress session is
- * active, and start relaying its events into the session log. Returns false
- * when there is no local egress session, the library is not packaged, or
- * launchd could not be configured. Every failure is a warning that names the
- * consequence; the session itself is never failed here.
+ * Install the guard into a simulator when a local egress session is active,
+ * and start relaying its events into the session log. Returns false when
+ * there is no local egress session. Throws when the library is not packaged
+ * or launchd could not be configured: a local egress session without the
+ * guard would silently leak, so it must not start. Only an unwritable event
+ * log is a warning, since refusals still happen and only reporting is lost.
+ *
+ * Call this as soon as `simctl boot` returns: launchd is up and nothing else
+ * has started, so every process the boot spawns inherits the guard. Verify
+ * with `verifyLocalEgressGuardAsync` once boot completes.
  */
 export async function installLocalEgressGuardAsync({
   udid,
@@ -277,12 +306,14 @@ export async function installLocalEgressGuardAsync({
   const resolvedLibrary =
     libraryPath === undefined ? await resolveEgressGuardLibraryAsync() : libraryPath;
   if (!resolvedLibrary) {
-    logger.warn(
-      'Local egress guard: the guard library is not available on this device host, so connections that ' +
-        'bypass the system proxy will not be refused; they exit from this worker. The session is otherwise unaffected.'
+    throw new SystemError(
+      'The local egress guard library is not available on this device host, so this local egress session ' +
+        'cannot guarantee that connections bypassing the system proxy are refused. The device host image is ' +
+        'missing bin/egress-guard.dylib; this is a service problem, please contact support.'
     );
-    return false;
   }
+
+  await logAlreadyRunningProcessesAsync({ env, logger });
 
   let logWritable = true;
   try {
@@ -303,12 +334,12 @@ export async function installLocalEgressGuardAsync({
       variables: buildGuardLaunchdEnvironment({ libraryPath: resolvedLibrary, logPath, mode }),
     });
   } catch (err) {
-    logger.warn(
-      { err },
-      'Local egress guard: could not install the guard in the Simulator, so connections that bypass the ' +
-        'system proxy will not be refused; they exit from this worker. The session is otherwise unaffected.'
+    throw new SystemError(
+      'Could not install the local egress guard in the Simulator (launchctl setenv failed), so this local ' +
+        'egress session cannot guarantee that connections bypassing the system proxy are refused. Retry the ' +
+        'session; if it keeps failing, please contact support.',
+      { cause: err }
     );
-    return false;
   }
 
   if (logWritable && !activeRelays.has(logPath)) {
@@ -333,6 +364,95 @@ export async function installLocalEgressGuardAsync({
     } in the process that makes them and reported here as they happen.`
   );
   return true;
+}
+
+/**
+ * Processes the simulator already runs when the guard is installed never get
+ * it. Right after `simctl boot` that is nothing; later it is SpringBoard and
+ * the early daemons, which follow the system proxy anyway. Log them so the
+ * uncovered set is visible rather than assumed.
+ */
+async function logAlreadyRunningProcessesAsync({
+  env,
+  logger,
+}: {
+  env: NodeJS.ProcessEnv;
+  logger: bunyan;
+}): Promise<void> {
+  let psOutput = '';
+  try {
+    psOutput = (await spawn('ps', ['-axo', 'pid=,ppid=,comm='], { env, stdio: 'pipe' })).stdout;
+  } catch {
+    return;
+  }
+  const pids = new Set(collectSimulatorProcessIds(psOutput));
+  const names = new Set<string>();
+  for (const line of psOutput.split('\n')) {
+    const match = /^\s*(\d+)\s+\d+\s+(\S.*)$/.exec(line);
+    if (match && pids.has(Number(match[1]))) {
+      names.add(path.basename(match[2].trim()));
+    }
+  }
+  if (names.size === 0) {
+    logger.info(
+      'Local egress guard: no simulator process was running before the guard was installed.'
+    );
+    return;
+  }
+  const listed = [...names].sort();
+  const shown =
+    listed.slice(0, 20).join(', ') + (listed.length > 20 ? `, and ${listed.length - 20} more` : '');
+  logger.info(
+    `Local egress guard: ${names.size} simulator process(es) were already running before the guard was installed and are not covered by it: ${shown}.`
+  );
+}
+
+/**
+ * Run the packaged self-check inside the simulator: it must find the guard
+ * loaded in a fresh process and see it behave as `mode` says. Throws when the
+ * check binary is missing or the check fails, which fails the session.
+ */
+export async function verifyLocalEgressGuardAsync({
+  udid,
+  env,
+  logger,
+  mode = 'block',
+  checkPath,
+}: {
+  udid: IosSimulatorUuid;
+  env: NodeJS.ProcessEnv;
+  logger: bunyan;
+  mode?: EgressGuardMode;
+  /** Explicit check binary path, `null` for "not available"; resolved from the package when omitted. */
+  checkPath?: string | null;
+}): Promise<void> {
+  const resolvedCheck = checkPath === undefined ? await resolveEgressGuardCheckAsync() : checkPath;
+  if (!resolvedCheck) {
+    throw new SystemError(
+      'The local egress guard self-check is not available on this device host, so this session cannot ' +
+        'verify that the guard is in effect. The device host image is missing bin/egress-guard-check; ' +
+        'this is a service problem, please contact support.'
+    );
+  }
+  let output: string;
+  try {
+    const result = await spawn('xcrun', ['simctl', 'spawn', udid, resolvedCheck, '--mode', mode], {
+      env,
+      stdio: 'pipe',
+    });
+    output = result.stdout.trim();
+  } catch (err) {
+    const failed = err as { status?: number | null; stdout?: string; stderr?: string };
+    const detail = [failed.stdout, failed.stderr].filter(Boolean).join('\n').trim();
+    throw new SystemError(
+      'The local egress guard is not in effect in the Simulator: the self-check run right after boot ' +
+        `failed${failed.status != null ? ` (exit ${failed.status})` : ''}. Connections that bypass the ` +
+        'system proxy would leave from the device host, so the session was stopped. Retry the session; if it ' +
+        `keeps failing, please contact support.${detail ? ` Self-check output: ${detail}` : ''}`,
+      { cause: err }
+    );
+  }
+  logger.info(`Local egress guard verified in the Simulator: ${output || 'self-check passed'}.`);
 }
 
 /** Stop relaying and write each relay's summary; called from the session cleanup. */

--- a/packages/build-tools/src/steps/utils/localEgressGuard.ts
+++ b/packages/build-tools/src/steps/utils/localEgressGuard.ts
@@ -119,11 +119,23 @@ export class GuardEventRelay {
   private blocked = 0;
   private logged = 0;
   private suppressed = 0;
+  private logger: bunyan;
 
   constructor(
-    private readonly logger: bunyan,
+    logger: bunyan,
     private readonly limit: number = GUARD_RELAY_LOG_LIMIT
-  ) {}
+  ) {
+    this.logger = logger;
+  }
+
+  /**
+   * Log through a different step's logger from now on. Refusals happen for
+   * the life of the session, so they belong to the step that runs the
+   * session, not the one that booted the simulator minutes earlier.
+   */
+  setLogger(logger: bunyan): void {
+    this.logger = logger;
+  }
 
   handle(event: GuardEvent): void {
     if (event.process === EGRESS_GUARD_CHECK_FILE) {
@@ -645,6 +657,19 @@ export async function verifyLocalEgressGuardAsync({
   }
   logger.info(`Local egress guard verified in the Simulator: ${output || 'self-check passed'}.`);
   await reportLocalEgressGuardCoverageAsync({ env, logger });
+}
+
+/**
+ * Attribute guard events to the step that runs the session from now on. The
+ * relay starts under the simulator boot step's logger; once the session step
+ * takes over, its lines should appear under that step in the job log, next
+ * to the rest of the session's output, rather than under a step that already
+ * finished.
+ */
+export function rebindLocalEgressGuardRelays(logger: bunyan): void {
+  for (const { relay } of activeRelays.values()) {
+    relay.setLogger(logger);
+  }
 }
 
 /** Stop relaying and write each relay's summary; called from the session cleanup. */

--- a/packages/build-tools/src/steps/utils/localEgressGuard.ts
+++ b/packages/build-tools/src/steps/utils/localEgressGuard.ts
@@ -1,0 +1,353 @@
+import { type bunyan } from '@expo/logger';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { IosSimulatorUtils, type IosSimulatorUuid } from '../../utils/IosSimulatorUtils';
+
+import { LOCAL_EGRESS_HANDOFF_PATH, readLocalEgressHandoffAsync } from './localEgress';
+
+/**
+ * Worker side of the local egress guard: a dylib injected into every process
+ * the simulator launches, which refuses connections that do not go to
+ * loopback (where the proxy and the `--egress-allow` forwards live) and
+ * records one event per destination per process. This module installs it
+ * through the simulator's launchd environment and relays its events into the
+ * session log. See resources/egress-guard/README.md.
+ */
+
+export const EGRESS_GUARD_LIBRARY_FILE = 'egress-guard.dylib';
+export const EGRESS_GUARD_LOG_ENV = 'EAS_EGRESS_GUARD_LOG';
+export const EGRESS_GUARD_MODE_ENV = 'EAS_EGRESS_GUARD_MODE';
+export const LOCAL_EGRESS_GUARD_LOG_PATH = path.join(os.tmpdir(), 'eas-local-egress-guard.log');
+const GUARD_EVENT_PREFIX = 'eas-egress-guard';
+const GUARD_RELAY_LOG_LIMIT = 200;
+const GUARD_TAIL_INTERVAL_MS = 1_000;
+
+export type EgressGuardMode = 'block' | 'log';
+
+export function buildGuardLaunchdEnvironment({
+  libraryPath,
+  logPath,
+  mode,
+}: {
+  libraryPath: string;
+  logPath: string;
+  mode: EgressGuardMode;
+}): Record<string, string> {
+  return {
+    DYLD_INSERT_LIBRARIES: libraryPath,
+    [EGRESS_GUARD_LOG_ENV]: logPath,
+    [EGRESS_GUARD_MODE_ENV]: mode,
+  };
+}
+
+export type GuardEvent = {
+  process: string;
+  pid: number;
+  function: string;
+  action: 'blocked' | 'logged';
+  peer: string;
+  /** Image names above the interposer, innermost first. */
+  callers: string[];
+};
+
+/** One tab-separated line written by the guard; see policy.h for the format. */
+export function parseGuardLogLine(line: string): GuardEvent | null {
+  const fields = line.split('\t');
+  if (fields.length < 7 || fields[0] !== GUARD_EVENT_PREFIX) {
+    return null;
+  }
+  const [, process, pidText, fn, action, peer, callerText] = fields;
+  const pid = Number(pidText);
+  if (!Number.isInteger(pid) || (action !== 'blocked' && action !== 'logged') || !fn || !peer) {
+    return null;
+  }
+  return {
+    process,
+    pid,
+    function: fn,
+    action,
+    peer,
+    callers: callerText ? callerText.split(',').filter(Boolean) : [],
+  };
+}
+
+/** The packaged library, next to the compiled package like record-sim. */
+export async function resolveEgressGuardLibraryAsync(
+  binDir: string = path.join(__dirname, '..', '..', '..', 'bin')
+): Promise<string | null> {
+  const libraryPath = path.join(binDir, EGRESS_GUARD_LIBRARY_FILE);
+  try {
+    await fs.promises.access(libraryPath);
+    return libraryPath;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Turns guard events into session log lines: one line the first time a
+ * process reaches a destination through a given call, counts after that, and
+ * a summary at the end.
+ */
+export class GuardEventRelay {
+  private readonly seen = new Set<string>();
+  private readonly peers = new Set<string>();
+  private readonly processes = new Set<string>();
+  private blocked = 0;
+  private logged = 0;
+  private suppressed = 0;
+
+  constructor(
+    private readonly logger: bunyan,
+    private readonly limit: number = GUARD_RELAY_LOG_LIMIT
+  ) {}
+
+  handle(event: GuardEvent): void {
+    if (event.action === 'blocked') {
+      this.blocked++;
+    } else {
+      this.logged++;
+    }
+    this.peers.add(event.peer);
+    this.processes.add(event.process);
+    const key = `${event.process}|${event.function}|${event.peer}`;
+    if (this.seen.has(key)) {
+      return;
+    }
+    this.seen.add(key);
+    if (this.seen.size > this.limit) {
+      this.suppressed++;
+      return;
+    }
+    const verb = event.action === 'blocked' ? 'refused' : 'observed';
+    const callers = event.callers.length ? `; callers: ${event.callers.join(', ')}` : '';
+    this.logger.info(
+      `Local egress guard: ${verb} ${event.function} from ${event.process} (pid ${event.pid}) to ${event.peer}${callers}`
+    );
+  }
+
+  summary(): { blocked: number; logged: number; distinct: number; suppressed: number } {
+    return {
+      blocked: this.blocked,
+      logged: this.logged,
+      distinct: this.peers.size,
+      suppressed: this.suppressed,
+    };
+  }
+
+  logSummary(): void {
+    const { blocked, logged, distinct, suppressed } = this.summary();
+    const observed = logged ? ` and observed ${logged} more without refusing` : '';
+    const dropped = suppressed
+      ? ` ${suppressed} further distinct destination(s) were not logged individually.`
+      : '';
+    this.logger.info(
+      `Local egress guard: refused ${blocked} connection attempt(s) to ${distinct} distinct destination(s) from ${this.processes.size} process(es)${observed}.${dropped}`
+    );
+  }
+}
+
+/**
+ * Polls a file the simulator processes append to and delivers whole lines.
+ * Tolerates the file not existing yet, partial trailing lines, and truncation.
+ */
+export class GuardLogTailer {
+  private readonly path: string;
+  private readonly onLine: (line: string) => void;
+  private readonly intervalMs: number;
+  private offset = 0;
+  private partial = '';
+  private timer: NodeJS.Timeout | undefined;
+  private reading: Promise<void> = Promise.resolve();
+
+  constructor({
+    path: filePath,
+    onLine,
+    intervalMs = GUARD_TAIL_INTERVAL_MS,
+  }: {
+    path: string;
+    onLine: (line: string) => void;
+    intervalMs?: number;
+  }) {
+    this.path = filePath;
+    this.onLine = onLine;
+    this.intervalMs = intervalMs;
+  }
+
+  start(): void {
+    this.timer = setInterval(() => {
+      this.reading = this.reading.then(() => this.readAsync()).catch(() => {});
+    }, this.intervalMs);
+    this.timer.unref();
+  }
+
+  async stopAsync(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+    await this.reading.catch(() => {});
+    await this.readAsync().catch(() => {});
+  }
+
+  private async readAsync(): Promise<void> {
+    let handle: fs.promises.FileHandle;
+    try {
+      handle = await fs.promises.open(this.path, 'r');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return;
+      }
+      throw err;
+    }
+    try {
+      const { size } = await handle.stat();
+      if (size < this.offset) {
+        // Truncated or replaced; start over.
+        this.offset = 0;
+        this.partial = '';
+      }
+      if (size === this.offset) {
+        return;
+      }
+      const buffer = new Uint8Array(size - this.offset);
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, this.offset);
+      this.offset += bytesRead;
+      const text = this.partial + Buffer.from(buffer.buffer, 0, bytesRead).toString('utf8');
+      const lines = text.split('\n');
+      this.partial = lines.pop() ?? '';
+      for (const line of lines) {
+        if (line.length > 0) {
+          this.onLine(line);
+        }
+      }
+    } finally {
+      await handle.close();
+    }
+  }
+}
+
+type ActiveRelay = { tailer: GuardLogTailer; relay: GuardEventRelay };
+const activeRelays = new Map<string, ActiveRelay>();
+
+/**
+ * Install the guard into a booted simulator when a local egress session is
+ * active, and start relaying its events into the session log. Returns false
+ * when there is no local egress session, the library is not packaged, or
+ * launchd could not be configured. Every failure is a warning that names the
+ * consequence; the session itself is never failed here.
+ */
+export async function installLocalEgressGuardAsync({
+  udid,
+  env,
+  logger,
+  handoffPath = LOCAL_EGRESS_HANDOFF_PATH,
+  libraryPath,
+  logPath = LOCAL_EGRESS_GUARD_LOG_PATH,
+  mode = 'block',
+  tailIntervalMs,
+}: {
+  udid: IosSimulatorUuid;
+  env: NodeJS.ProcessEnv;
+  logger: bunyan;
+  handoffPath?: string;
+  /** Explicit library path, `null` for "not available"; resolved from the package when omitted. */
+  libraryPath?: string | null;
+  logPath?: string;
+  mode?: EgressGuardMode;
+  tailIntervalMs?: number;
+}): Promise<boolean> {
+  let handoff;
+  try {
+    handoff = await readLocalEgressHandoffAsync(handoffPath);
+  } catch (err) {
+    logger.warn(
+      { err },
+      'Local egress guard: could not read the local egress handoff, so the guard was not installed. ' +
+        'Connections that bypass the proxy will exit from this worker.'
+    );
+    return false;
+  }
+  if (!handoff) {
+    return false;
+  }
+
+  const resolvedLibrary =
+    libraryPath === undefined ? await resolveEgressGuardLibraryAsync() : libraryPath;
+  if (!resolvedLibrary) {
+    logger.warn(
+      'Local egress guard: the guard library is not available on this device host, so connections that ' +
+        'bypass the system proxy will not be refused; they exit from this worker. The session is otherwise unaffected.'
+    );
+    return false;
+  }
+
+  let logWritable = true;
+  try {
+    await fs.promises.mkdir(path.dirname(logPath), { recursive: true });
+    await fs.promises.appendFile(logPath, '');
+  } catch (err) {
+    logWritable = false;
+    logger.warn(
+      { err },
+      `Local egress guard: could not create ${logPath}, so refused connections will not be reported in this log. They are still refused.`
+    );
+  }
+
+  try {
+    await IosSimulatorUtils.setLaunchdEnvironmentAsync({
+      udid,
+      env,
+      variables: buildGuardLaunchdEnvironment({ libraryPath: resolvedLibrary, logPath, mode }),
+    });
+  } catch (err) {
+    logger.warn(
+      { err },
+      'Local egress guard: could not install the guard in the Simulator, so connections that bypass the ' +
+        'system proxy will not be refused; they exit from this worker. The session is otherwise unaffected.'
+    );
+    return false;
+  }
+
+  if (logWritable && !activeRelays.has(logPath)) {
+    const relay = new GuardEventRelay(logger);
+    const tailer = new GuardLogTailer({
+      path: logPath,
+      intervalMs: tailIntervalMs,
+      onLine: line => {
+        const event = parseGuardLogLine(line);
+        if (event) {
+          relay.handle(event);
+        }
+      },
+    });
+    tailer.start();
+    activeRelays.set(logPath, { tailer, relay });
+  }
+
+  logger.info(
+    `Local egress guard installed in the Simulator (mode ${mode}): connections that bypass the system proxy are ${
+      mode === 'block' ? 'refused' : 'observed'
+    } in the process that makes them and reported here as they happen.`
+  );
+  return true;
+}
+
+/** Stop relaying and write each relay's summary; called from the session cleanup. */
+export async function stopLocalEgressGuardRelaysAsync(logger: bunyan): Promise<void> {
+  const relays = [...activeRelays.values()];
+  activeRelays.clear();
+  for (const { tailer, relay } of relays) {
+    try {
+      await tailer.stopAsync();
+    } catch (err) {
+      logger.warn(
+        { err },
+        'Local egress guard: could not read the last events from the guard log.'
+      );
+    }
+    relay.logSummary();
+  }
+}

--- a/packages/build-tools/src/steps/utils/localEgressSession.ts
+++ b/packages/build-tools/src/steps/utils/localEgressSession.ts
@@ -6,6 +6,7 @@ import {
   readLocalEgressHandoffAsync,
   stopLocalEgressResourcesAsync,
 } from './localEgress';
+import { rebindLocalEgressGuardRelays } from './localEgressGuard';
 import { uploadRemoteSessionConfigAsync } from './remoteDeviceRunSession';
 
 /** Release the pre-boot egress resources even if controller startup or teardown fails. */
@@ -39,6 +40,9 @@ export async function uploadRemoteSessionConfigWithLocalEgressAsync({
     remoteConfig: { ...options.remoteConfig, ...buildEgressRemoteConfigFields(localEgress) },
   });
   if (localEgress && !signal?.aborted) {
+    // Guard refusals from here on show up under this step in the job log,
+    // alongside the monitor's reports, instead of under the boot step.
+    rebindLocalEgressGuardRelays(options.logger);
     options.logger.info(
       'Local egress: waiting for the EAS CLI egress client to connect. Proxied HTTP(S) ' +
         'requests are unavailable until it does.'

--- a/packages/build-tools/src/utils/IosSimulatorUtils.ts
+++ b/packages/build-tools/src/utils/IosSimulatorUtils.ts
@@ -351,11 +351,15 @@ export namespace IosSimulatorUtils {
     env: NodeJS.ProcessEnv;
     variables: Record<string, string>;
   }): Promise<void> {
-    for (const [name, value] of Object.entries(variables)) {
-      await spawn('xcrun', ['simctl', 'spawn', udid, 'launchctl', 'setenv', name, value], {
-        env,
-      });
+    // One invocation for every variable: each `simctl spawn` costs a few
+    // hundred milliseconds on a device host, and this runs in the window
+    // between `simctl boot` returning and launchd spawning the boot's
+    // processes, which must inherit these.
+    const pairs = Object.entries(variables).flat();
+    if (pairs.length === 0) {
+      return;
     }
+    await spawn('xcrun', ['simctl', 'spawn', udid, 'launchctl', 'setenv', ...pairs], { env });
   }
 
   export async function collectLogsAsync({

--- a/packages/build-tools/src/utils/IosSimulatorUtils.ts
+++ b/packages/build-tools/src/utils/IosSimulatorUtils.ts
@@ -285,6 +285,28 @@ export namespace IosSimulatorUtils {
     throw lastError ?? new SystemError('Unable to disable apsd in the Simulator.');
   }
 
+  /**
+   * Set environment variables in the Simulator's launchd. Every process that
+   * launchd spawns afterwards inherits them: apps launched by SpringBoard
+   * (deep links, taps, WebDriverAgent) as well as by `simctl launch`.
+   * Processes that are already running keep their environment.
+   */
+  export async function setLaunchdEnvironmentAsync({
+    udid,
+    env,
+    variables,
+  }: {
+    udid: IosSimulatorUuid;
+    env: NodeJS.ProcessEnv;
+    variables: Record<string, string>;
+  }): Promise<void> {
+    for (const [name, value] of Object.entries(variables)) {
+      await spawn('xcrun', ['simctl', 'spawn', udid, 'launchctl', 'setenv', name, value], {
+        env,
+      });
+    }
+  }
+
   export async function collectLogsAsync({
     deviceIdentifier,
     env,

--- a/packages/build-tools/src/utils/IosSimulatorUtils.ts
+++ b/packages/build-tools/src/utils/IosSimulatorUtils.ts
@@ -185,6 +185,57 @@ export namespace IosSimulatorUtils {
     }
   }
 
+  const UDID_PATTERN = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
+
+  /**
+   * The UDID for a device name or UDID. A name picks the first available
+   * device with that name, as `simctl` itself does.
+   */
+  export async function resolveUdidAsync({
+    deviceIdentifier,
+    env,
+  }: {
+    deviceIdentifier: IosSimulatorUuid | IosSimulatorName;
+    env: NodeJS.ProcessEnv;
+  }): Promise<IosSimulatorUuid> {
+    if (UDID_PATTERN.test(deviceIdentifier)) {
+      return deviceIdentifier as IosSimulatorUuid;
+    }
+    const devices = await getAvailableDevicesAsync({ env, filter: 'available' });
+    const device = devices.find(candidate => candidate.name === deviceIdentifier);
+    if (!device) {
+      throw new UserError(
+        'EAS_IOS_SIMULATOR_NOT_FOUND',
+        `No available iOS Simulator is named "${deviceIdentifier}". Run \`xcrun simctl list devices available\` on the device host to see the devices it offers.`
+      );
+    }
+    return device.udid;
+  }
+
+  /**
+   * Start booting without waiting for boot to complete. Returns as soon as the
+   * simulator's launchd is up, before it has spawned anything else, which is
+   * the moment to set launchd environment that every later process must
+   * inherit. Follow with `startAsync` to wait for the boot to finish.
+   */
+  export async function bootAsync({
+    deviceIdentifier,
+    env,
+  }: {
+    deviceIdentifier: IosSimulatorUuid | IosSimulatorName;
+    env: NodeJS.ProcessEnv;
+  }): Promise<void> {
+    try {
+      await spawn('xcrun', ['simctl', 'boot', deviceIdentifier], { env, stdio: 'pipe' });
+    } catch (err) {
+      const failed = err as { stderr?: string };
+      if (/current state: Booted/.test(failed.stderr ?? '')) {
+        return;
+      }
+      throw err;
+    }
+  }
+
   export async function startAsync({
     deviceIdentifier,
     env,

--- a/packages/build-tools/src/utils/IosSimulatorUtils.ts
+++ b/packages/build-tools/src/utils/IosSimulatorUtils.ts
@@ -213,20 +213,30 @@ export namespace IosSimulatorUtils {
   }
 
   /**
-   * Start booting without waiting for boot to complete. Returns as soon as the
-   * simulator's launchd is up, before it has spawned anything else, which is
-   * the moment to set launchd environment that every later process must
-   * inherit. Follow with `startAsync` to wait for the boot to finish.
+   * Start booting without waiting for boot to complete; follow with
+   * `startAsync` to wait for it. `launchdEnvironment` is handed to the
+   * simulator's launchd before it spawns anything: `simctl` forwards every
+   * `SIMCTL_CHILD_`-prefixed variable of its own environment to the process
+   * it starts, and for `boot` that process is launchd itself. This is the only
+   * way to give the first processes of a boot an environment; `launchctl
+   * setenv` after boot only reaches processes started later. A device that is
+   * already booted keeps its environment.
    */
   export async function bootAsync({
     deviceIdentifier,
     env,
+    launchdEnvironment = {},
   }: {
     deviceIdentifier: IosSimulatorUuid | IosSimulatorName;
     env: NodeJS.ProcessEnv;
+    launchdEnvironment?: Record<string, string>;
   }): Promise<void> {
+    const bootEnv = { ...env };
+    for (const [name, value] of Object.entries(launchdEnvironment)) {
+      bootEnv[`SIMCTL_CHILD_${name}`] = value;
+    }
     try {
-      await spawn('xcrun', ['simctl', 'boot', deviceIdentifier], { env, stdio: 'pipe' });
+      await spawn('xcrun', ['simctl', 'boot', deviceIdentifier], { env: bootEnv, stdio: 'pipe' });
     } catch (err) {
       const failed = err as { stderr?: string };
       if (/current state: Booted/.test(failed.stderr ?? '')) {

--- a/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
@@ -340,4 +340,54 @@ describe('IosSimulatorUtils', () => {
       ).rejects.toThrow(SystemError);
     });
   });
+  describe(IosSimulatorUtils.setLaunchdEnvironmentAsync, () => {
+    it('sets each variable in the simulator launchd, in order', async () => {
+      await IosSimulatorUtils.setLaunchdEnvironmentAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+        variables: { https_proxy: 'http://127.0.0.1:8899', no_proxy: 'localhost,127.0.0.1' },
+      });
+
+      expect(mockedSpawn.mock.calls).toEqual([
+        [
+          'xcrun',
+          [
+            'simctl',
+            'spawn',
+            'test-udid',
+            'launchctl',
+            'setenv',
+            'https_proxy',
+            'http://127.0.0.1:8899',
+          ],
+          { env: process.env },
+        ],
+        [
+          'xcrun',
+          [
+            'simctl',
+            'spawn',
+            'test-udid',
+            'launchctl',
+            'setenv',
+            'no_proxy',
+            'localhost,127.0.0.1',
+          ],
+          { env: process.env },
+        ],
+      ]);
+    });
+
+    it('propagates a launchctl failure', async () => {
+      mockedSpawn.mockRejectedValueOnce(new Error('launchctl failed'));
+
+      await expect(
+        IosSimulatorUtils.setLaunchdEnvironmentAsync({
+          udid: 'test-udid' as any,
+          env: process.env,
+          variables: { https_proxy: 'http://127.0.0.1:8899' },
+        })
+      ).rejects.toThrow('launchctl failed');
+    });
+  });
 });

--- a/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
@@ -452,5 +452,24 @@ describe('IosSimulatorUtils', () => {
         IosSimulatorUtils.bootAsync({ deviceIdentifier: 'AAAA' as any, env: process.env })
       ).rejects.toThrow('boot failed');
     });
+
+    it('hands launchd environment to the boot through SIMCTL_CHILD_ variables', async () => {
+      await IosSimulatorUtils.bootAsync({
+        deviceIdentifier: 'AAAA' as any,
+        env: { PATH: '/usr/bin' },
+        launchdEnvironment: {
+          DYLD_INSERT_LIBRARIES: '/w/guard.dylib',
+          https_proxy: 'http://127.0.0.1:8899',
+        },
+      });
+      expect(mockedSpawn).toHaveBeenCalledWith('xcrun', ['simctl', 'boot', 'AAAA'], {
+        env: {
+          PATH: '/usr/bin',
+          SIMCTL_CHILD_DYLD_INSERT_LIBRARIES: '/w/guard.dylib',
+          SIMCTL_CHILD_https_proxy: 'http://127.0.0.1:8899',
+        },
+        stdio: 'pipe',
+      });
+    });
   });
 });

--- a/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
@@ -341,7 +341,7 @@ describe('IosSimulatorUtils', () => {
     });
   });
   describe(IosSimulatorUtils.setLaunchdEnvironmentAsync, () => {
-    it('sets each variable in the simulator launchd, in order', async () => {
+    it('sets every variable in the simulator launchd with one invocation', async () => {
       await IosSimulatorUtils.setLaunchdEnvironmentAsync({
         udid: 'test-udid' as any,
         env: process.env,
@@ -359,23 +359,21 @@ describe('IosSimulatorUtils', () => {
             'setenv',
             'https_proxy',
             'http://127.0.0.1:8899',
-          ],
-          { env: process.env },
-        ],
-        [
-          'xcrun',
-          [
-            'simctl',
-            'spawn',
-            'test-udid',
-            'launchctl',
-            'setenv',
             'no_proxy',
             'localhost,127.0.0.1',
           ],
           { env: process.env },
         ],
       ]);
+    });
+
+    it('does nothing for an empty variable set', async () => {
+      await IosSimulatorUtils.setLaunchdEnvironmentAsync({
+        udid: 'test-udid' as any,
+        env: process.env,
+        variables: {},
+      });
+      expect(mockedSpawn).not.toHaveBeenCalled();
     });
 
     it('propagates a launchctl failure', async () => {
@@ -390,6 +388,7 @@ describe('IosSimulatorUtils', () => {
       ).rejects.toThrow('launchctl failed');
     });
   });
+
   describe(IosSimulatorUtils.resolveUdidAsync, () => {
     it('passes a udid through without listing devices', async () => {
       await expect(

--- a/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
+++ b/packages/build-tools/src/utils/__tests__/IosSimulatorUtils.test.ts
@@ -390,4 +390,68 @@ describe('IosSimulatorUtils', () => {
       ).rejects.toThrow('launchctl failed');
     });
   });
+  describe(IosSimulatorUtils.resolveUdidAsync, () => {
+    it('passes a udid through without listing devices', async () => {
+      await expect(
+        IosSimulatorUtils.resolveUdidAsync({
+          deviceIdentifier: '8027F627-9534-4679-85BF-0F14AFF228E8' as any,
+          env: process.env,
+        })
+      ).resolves.toBe('8027F627-9534-4679-85BF-0F14AFF228E8');
+      expect(mockedSpawn).not.toHaveBeenCalled();
+    });
+
+    it('resolves a device name to the first available device with that name', async () => {
+      mockedSpawn.mockResolvedValue({
+        stdout: JSON.stringify({
+          devices: {
+            'com.apple.CoreSimulator.SimRuntime.iOS-26-5': [
+              { udid: 'AAAA', name: 'iPhone 17', isAvailable: true, state: 'Shutdown' },
+              { udid: 'BBBB', name: 'iPhone Air', isAvailable: true, state: 'Shutdown' },
+            ],
+          },
+        }),
+        stderr: '',
+      } as any);
+
+      await expect(
+        IosSimulatorUtils.resolveUdidAsync({
+          deviceIdentifier: 'iPhone Air' as any,
+          env: process.env,
+        })
+      ).resolves.toBe('BBBB');
+      await expect(
+        IosSimulatorUtils.resolveUdidAsync({
+          deviceIdentifier: 'iPhone 99' as any,
+          env: process.env,
+        })
+      ).rejects.toThrow(UserError);
+    });
+  });
+
+  describe(IosSimulatorUtils.bootAsync, () => {
+    it('boots without waiting and tolerates an already booted device', async () => {
+      await IosSimulatorUtils.bootAsync({ deviceIdentifier: 'AAAA' as any, env: process.env });
+      expect(mockedSpawn).toHaveBeenCalledWith('xcrun', ['simctl', 'boot', 'AAAA'], {
+        env: process.env,
+        stdio: 'pipe',
+      });
+
+      mockedSpawn.mockRejectedValueOnce(
+        Object.assign(new Error('boot failed'), {
+          stderr: 'Unable to boot device in current state: Booted',
+        })
+      );
+      await expect(
+        IosSimulatorUtils.bootAsync({ deviceIdentifier: 'AAAA' as any, env: process.env })
+      ).resolves.toBeUndefined();
+
+      mockedSpawn.mockRejectedValueOnce(
+        Object.assign(new Error('boot failed'), { stderr: 'other' })
+      );
+      await expect(
+        IosSimulatorUtils.bootAsync({ deviceIdentifier: 'AAAA' as any, env: process.env })
+      ).rejects.toThrow('boot failed');
+    });
+  });
 });

--- a/packages/eas-cli/src/commands/simulator/get.ts
+++ b/packages/eas-cli/src/commands/simulator/get.ts
@@ -111,7 +111,11 @@ export default class SimulatorGet extends EasCommand {
     if (session.status === DeviceRunSessionStatus.InProgress) {
       Log.newLine();
       if (session.remoteConfig) {
-        Log.log(formatRemoteSessionInstructions(session.remoteConfig, 'env'));
+        Log.log(
+          formatRemoteSessionInstructions(session.remoteConfig, 'env', {
+            sessionUrl: deviceRunSessionUrl,
+          })
+        );
       } else {
         Log.log(
           '⏳ Session is starting up — remote config is not available yet. Re-run this command in a moment.'

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -139,7 +139,7 @@ export default class Simulator extends EasCommand {
     })(),
     egress: Flags.option({
       description:
-        'With "local", the simulator system proxy points at this machine: HTTP(S) and WebSocket requests that honor it (WebKit, URLSession) and clients that read proxy environment variables (gRPC, libcurl) exit from this machine and fail while the egress client is disconnected. Connections that ignore both are refused inside the simulator and reported in the session log. The egress client must keep running for the life of the session. Only supported with --platform ios.',
+        'With "local", the simulator system proxy points at this machine: HTTP(S) and WebSocket requests that honor it (WebKit, URLSession) and clients that read proxy environment variables (gRPC, libcurl) exit from this machine and fail while the egress client is disconnected. Connections that ignore both are refused inside the simulator and listed, with the library that tried, in the Logs section of the session page on expo.dev. The egress client must keep running for the life of the session. Only supported with --platform ios.',
       options: EGRESS_FLAG_VALUES,
     })(),
     'egress-allow': Flags.string({
@@ -422,6 +422,7 @@ export default class Simulator extends EasCommand {
       formatRemoteSessionInstructions(remoteConfig, flags['out-config-type'], {
         egressAllow,
         egressClientRunsInline: !nonInteractive,
+        sessionUrl: deviceRunSessionUrl,
       })
     );
     Log.newLine();

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -139,7 +139,7 @@ export default class Simulator extends EasCommand {
     })(),
     egress: Flags.option({
       description:
-        'With "local", the simulator system proxy points at this machine: HTTP(S) and WebSocket requests that honor it (WebKit, URLSession) exit from this machine and fail while the egress client is disconnected. Requests from libraries that bypass the system proxy are not covered. The egress client must keep running for the life of the session. Only supported with --platform ios.',
+        'With "local", the simulator system proxy points at this machine: HTTP(S) and WebSocket requests that honor it (WebKit, URLSession) and clients that read proxy environment variables (gRPC, libcurl) exit from this machine and fail while the egress client is disconnected. Requests from libraries that ignore both are not covered. The egress client must keep running for the life of the session. Only supported with --platform ios.',
       options: EGRESS_FLAG_VALUES,
     })(),
     'egress-allow': Flags.string({

--- a/packages/eas-cli/src/commands/simulator/index.ts
+++ b/packages/eas-cli/src/commands/simulator/index.ts
@@ -139,7 +139,7 @@ export default class Simulator extends EasCommand {
     })(),
     egress: Flags.option({
       description:
-        'With "local", the simulator system proxy points at this machine: HTTP(S) and WebSocket requests that honor it (WebKit, URLSession) and clients that read proxy environment variables (gRPC, libcurl) exit from this machine and fail while the egress client is disconnected. Requests from libraries that ignore both are not covered. The egress client must keep running for the life of the session. Only supported with --platform ios.',
+        'With "local", the simulator system proxy points at this machine: HTTP(S) and WebSocket requests that honor it (WebKit, URLSession) and clients that read proxy environment variables (gRPC, libcurl) exit from this machine and fail while the egress client is disconnected. Connections that ignore both are refused inside the simulator and reported in the session log. The egress client must keep running for the life of the session. Only supported with --platform ios.',
       options: EGRESS_FLAG_VALUES,
     })(),
     'egress-allow': Flags.string({

--- a/packages/eas-cli/src/simulator/__tests__/utils.test.ts
+++ b/packages/eas-cli/src/simulator/__tests__/utils.test.ts
@@ -68,9 +68,26 @@ describe('local egress configuration', () => {
     expect(instructions).toContain('eas simulator:egress');
     expect(instructions).toContain('Keep it running for the life of the session.');
     expect(instructions).not.toContain('It can also reach');
+    expect(instructions).toContain(
+      'Connections that bypass the proxy are refused inside the simulator. The Logs section of the session page lists what was refused and which library tried.'
+    );
     expect(formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'env')).toContain(
       "export EAS_SIMULATOR_EGRESS_ALLOW=''"
     );
+  });
+
+  it('links the session page when it is known, so refusals can be found', () => {
+    const instructions = formatRemoteSessionInstructions(agentDeviceConfigWithEgress, 'dotenv', {
+      sessionUrl: 'https://expo.dev/accounts/a/projects/p/simulator-sessions/s',
+    });
+    // The link is rendered with terminal styling, so check the phrase and the URL apart.
+    expect(instructions).toContain('lists what was refused and which library tried: ');
+    expect(instructions).toContain('https://expo.dev/accounts/a/projects/p/simulator-sessions/s');
+    expect(
+      formatRemoteSessionInstructions(agentDeviceConfig, 'dotenv', {
+        sessionUrl: 'https://expo.dev/x',
+      })
+    ).not.toContain('refused');
   });
 
   it('says nothing about starting the client when it runs inline', () => {

--- a/packages/eas-cli/src/simulator/utils.ts
+++ b/packages/eas-cli/src/simulator/utils.ts
@@ -82,6 +82,12 @@ export type LocalEgressConfig = {
 export type LocalEgressOptions = {
   egressAllow?: readonly string[];
   /**
+   * Link to the session on expo.dev. Its Logs section lists every connection
+   * the local egress guard refused inside the simulator, with the process and
+   * the calling frameworks, so the banner points readers there.
+   */
+  sessionUrl?: string;
+  /**
    * Whether the calling command runs the egress client itself in the current
    * terminal, as interactive `simulator:start` does. When false the reader must
    * start `eas simulator:egress` in another process.
@@ -259,7 +265,7 @@ export function sanitizeRemoteConfigForJson(
 export function formatRemoteSessionInstructions(
   remoteConfig: DeviceRunSessionRemoteConfig,
   configType: RemoteSessionInstructionsConfigType,
-  { egressAllow, egressClientRunsInline = false }: LocalEgressOptions = {}
+  { egressAllow, egressClientRunsInline = false, sessionUrl }: LocalEgressOptions = {}
 ): string {
   const instructions = formatControllerInstructions(remoteConfig, configType);
   const egress = getLocalEgressConfig(remoteConfig, egressAllow);
@@ -271,10 +277,14 @@ export function formatRemoteSessionInstructions(
   const summary =
     "🔀 Local egress: the simulator's HTTP(S) traffic exits from this machine." +
     (egress.allow.length > 0 ? ` It can also reach ${egress.allow.join(', ')}.` : '');
+  const guardNotice =
+    'Connections that bypass the proxy are refused inside the simulator. The Logs section of the ' +
+    `session page lists what was refused and which library tried${sessionUrl ? `: ${link(sessionUrl)}` : '.'}`;
   return [
     instructions,
     '',
     summary,
+    guardNotice,
     ...formatLoopbackForwardNotice(getLoopbackForwardPlan(egress.allow, egress.port)),
     // In interactive mode the client starts in this terminal once the session is
     // ready and stops with it, so there is nothing for the reader to run.

--- a/packages/worker/.eas/workflows/test-egress-guard.yml
+++ b/packages/worker/.eas/workflows/test-egress-guard.yml
@@ -15,16 +15,16 @@ jobs:
       - name: Build build-tools and its workspace dependencies
         run: yarn run -T lerna run build --scope @expo/build-tools --include-dependencies
       - name: Build the guard library
-        working_directory: packages/build-tools
+        working_directory: ../build-tools
         run: yarn build:egress-guard
       - name: Run the guard policy unit tests
-        working_directory: packages/build-tools
+        working_directory: ../build-tools
         run: yarn test:egress-guard
       - name: Run the guard unit tests
-        working_directory: packages/build-tools
+        working_directory: ../build-tools
         run: yarn jest-unit src/steps/utils/__tests__/localEgressGuard.test.ts src/steps/functions/__tests__/startIosSimulator.test.ts
       - name: Run the simulator end-to-end tests
-        working_directory: packages/build-tools
+        working_directory: ../build-tools
         env:
           EAS_LOCAL_EGRESS_E2E: '1'
         run: yarn jest-unit src/steps/utils/__tests__/localEgressGuard.test.ios.ts

--- a/packages/worker/.eas/workflows/test-egress-guard.yml
+++ b/packages/worker/.eas/workflows/test-egress-guard.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - uses: eas/checkout
       - uses: eas/install_node_modules
-      - name: Build workspace packages
-        run: yarn build
+      - name: Build build-tools and its workspace dependencies
+        run: yarn run -T lerna run build --scope @expo/build-tools --include-dependencies
       - name: Build the guard library
         working_directory: packages/build-tools
         run: yarn build:egress-guard

--- a/packages/worker/.eas/workflows/test-egress-guard.yml
+++ b/packages/worker/.eas/workflows/test-egress-guard.yml
@@ -1,0 +1,30 @@
+name: Test egress guard
+defaults:
+  tools:
+    corepack: true
+on:
+  workflow_dispatch: {}
+jobs:
+  test_egress_guard:
+    name: Test egress guard on a macOS simulator
+    runs_on: macos-medium
+    image: latest
+    steps:
+      - uses: eas/checkout
+      - uses: eas/install_node_modules
+      - name: Build workspace packages
+        run: yarn build
+      - name: Build the guard library
+        working_directory: packages/build-tools
+        run: yarn build:egress-guard
+      - name: Run the guard policy unit tests
+        working_directory: packages/build-tools
+        run: yarn test:egress-guard
+      - name: Run the guard unit tests
+        working_directory: packages/build-tools
+        run: yarn jest-unit src/steps/utils/__tests__/localEgressGuard.test.ts src/steps/functions/__tests__/startIosSimulator.test.ts
+      - name: Run the simulator end-to-end tests
+        working_directory: packages/build-tools
+        env:
+          EAS_LOCAL_EGRESS_E2E: '1'
+        run: yarn jest-unit src/steps/utils/__tests__/localEgressGuard.test.ios.ts

--- a/packages/worker/package.sh
+++ b/packages/worker/package.sh
@@ -99,6 +99,7 @@ popd >/dev/null 2>&1
 
 if [[ "$PLATFORM" != "ios" ]]; then
   rm -f "$target_root_dir/packages/build-tools/bin/record-sim"
+  rm -f "$target_root_dir/packages/build-tools/bin/egress-guard.dylib"
 fi
 
 if [[ "$PLATFORM" == "ios" ]]; then
@@ -116,6 +117,10 @@ if [[ "$PLATFORM" == "ios" ]]; then
     --build-path "$record_sim_build_dir"
   cp "$record_sim_bin_path/record-sim" "$record_sim_bin_dir/record-sim"
   chmod +x "$record_sim_bin_dir/record-sim"
+
+  # The local egress guard, injected into simulator processes; see
+  # packages/build-tools/resources/egress-guard/README.md.
+  "$ROOT_DIR/packages/build-tools/resources/egress-guard/build.sh" "$record_sim_bin_dir"
 
   # build plugin
   pushd "$ROOT_DIR/packages/expo-cocoapods-proxy" >/dev/null 2>&1


### PR DESCRIPTION
# Why

`--egress local` points the simulator's system proxy at the egress tunnel, and #4390 sets proxy environment variables for clients that read them. Both are conventions: a library with its own socket layer still exits from the worker, silently. A packet filter cannot help, since simulator processes share the worker's uid. This PR makes the guarantee structural: a dylib injected into every simulator process refuses any connection that is not destined for loopback, in the process that made it, and reports which library tried. The proxy is the only way a request ends up on loopback, so this refuses everything that does not use it.

# How

- `resources/egress-guard/`: a small C dylib. `guard.c` interposes `connect`, `connectx`, `sendto`, `sendmsg` and their `$NOCANCEL` variants through dyld's `__DATA,__interpose`, which reaches calls made inside CFNetwork and Network.framework. Remote destinations get `ECONNREFUSED`; each process logs one event per destination with the calling image names. `policy.c` classifies destinations, including a sockaddr left as `AF_UNSPEC`, which the kernel connects as the family its length implies. `check.c` is a self-check run inside the simulator after boot.
- Recording is best-effort and cannot hurt the process: the log is opened per event rather than held as a descriptor, the dedupe lock is a bounded trylock so signal re-entry or a fork child skips the event instead of aborting, and a process that lists 128 destinations writes one `overflow` line and keeps refusing.
- Injection rides the boot: `simctl boot` forwards `SIMCTL_CHILD_` variables to the simulator's launchd, so every process of the boot inherits the guard. `launchctl setenv` cannot change variables given at boot and only reaches later processes, so it is used only for a device that was already booted.
- `localEgressGuard.ts` resolves the boot environment from the local egress handoff, relays refusals into the session log under the session step, runs the self-check once boot completes, and reports coverage from `lsof`. The self-check proves in a fresh process that the guard is loaded and behaves as the mode says on `connect`, `connect$NOCANCEL` and an `AF_UNSPEC` connect.
- Fail closed: a missing library, a failed `launchctl setenv`, or a failed self-check fails the session. An unwritable event log is a warning.
- The `simulator:start` banner and `--egress` help say that bypassing connections are refused and link the session page, where the job log lists them.
- Built into `bin/` by `package.sh` for the iOS worker tarball; the `test-egress-guard` EAS workflow runs the host suites, unit tests and simulator e2e on pull requests touching the guard.

Not covered: DNS names still resolve through the system resolver (metadata only; direct DNS is refused), and a hostile app with the worker's uid could unload the guard or make raw syscalls. The target is accidental bypass by libraries.

# Test Plan

- `yarn test:egress-guard`: `policy_test.c` covers classification, mode parsing, peer and event formatting, the dedupe table. `guard_test.c` compiles `guard.c` in and forces signal re-entry, fork with a held lock, and eight-thread contention. `guard_insert_test.c` loads the built dylib and checks descriptor reuse, closed stdout, `$NOCANCEL` refusal, every `AF_UNSPEC` shape, the UDP disconnect, caller attribution, and the overflow line. No test opens a socket to a non-loopback address. Both suites also pass as x86_64 under Rosetta.
- Unit tests for the boot environment, log parser, relay, tailer, coverage parsing, installer outcomes, and the simulator step ordering. `oxlint` and `tsc` clean.
- Simulator e2e (`EAS_LOCAL_EGRESS_E2E=1`, iOS 26.5): every process of the boot covered; URLSession, Network.framework, BSD TCP and UDP, `AF_UNSPEC` connect and `sendto$NOCANCEL` refused while proxied URLSession, loopback UDP, UDP disconnect and DNS work; one event per destination per process; daemons the simulator launches are guarded; simctl tooling unaffected; log mode observes without refusing; a device booted without the guard fails the self-check and can be covered afterwards through `launchctl`; an unwritable log still refuses. 8 of 8 pass locally and in the EAS workflow.
- Staging: sessions on a worker built from this branch (tarball hash-matched to the promotion) showed the guard installed at boot, the self-check passing, all simulator processes covered, system daemons' direct connections refused with callers attributed, and Safari rendering a page through the egress client. Without the client connected the same page failed closed.
